### PR TITLE
Cleanup warning messages related to redundant cast

### DIFF
--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/breakpoints/PersistenceManager.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/breakpoints/PersistenceManager.java
@@ -161,7 +161,7 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
             }
         }
         bs = new Breakpoint [bb.size ()];
-        return (Breakpoint[]) bb.toArray (bs);
+        return bb.toArray(bs);
     }
 }
 

--- a/enterprise/api.web.webmodule/src/org/netbeans/modules/web/api/webmodule/WebModule.java
+++ b/enterprise/api.web.webmodule/src/org/netbeans/modules/web/api/webmodule/WebModule.java
@@ -107,7 +107,7 @@ public final class WebModule {
         Parameters.notNull("file", file); // NOI18N
         Iterator<WebModuleProvider> it = implementations.allInstances().iterator();
         while (it.hasNext()) {
-            WebModuleProvider impl = (WebModuleProvider)it.next();
+            WebModuleProvider impl = it.next();
             WebModule wm = impl.findWebModule (file);
             if (wm != null) {
                 return wm;

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/DomainEditor.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/DomainEditor.java
@@ -516,13 +516,13 @@ public class DomainEditor {
             }
         } // connection-pool properties
 
-        pValues.put(CONST_LOWER_DATABASE_NAME, (String) map.get(CONST_LOWER_DATABASE_NAME));
-        pValues.put(CONST_PORT_NUMBER, (String) map.get(CONST_PORT_NUMBER));
-        pValues.put(CONST_LOWER_PORT_NUMBER, (String) map.get(CONST_LOWER_PORT_NUMBER));
-        pValues.put(CONST_DATABASE_NAME, (String) map.get(CONST_DATABASE_NAME));
-        pValues.put(CONST_SID, (String) map.get(CONST_SID));
-        pValues.put(CONST_DRIVER_CLASS, (String) map.get(CONST_DRIVER_CLASS));
-        pValues.put(CONST_DERBY_CONN_ATTRS, (String) map.get(CONST_DERBY_CONN_ATTRS));
+        pValues.put(CONST_LOWER_DATABASE_NAME, map.get(CONST_LOWER_DATABASE_NAME));
+        pValues.put(CONST_PORT_NUMBER, map.get(CONST_PORT_NUMBER));
+        pValues.put(CONST_LOWER_PORT_NUMBER, map.get(CONST_LOWER_PORT_NUMBER));
+        pValues.put(CONST_DATABASE_NAME, map.get(CONST_DATABASE_NAME));
+        pValues.put(CONST_SID, map.get(CONST_SID));
+        pValues.put(CONST_DRIVER_CLASS, map.get(CONST_DRIVER_CLASS));
+        pValues.put(CONST_DERBY_CONN_ATTRS, map.get(CONST_DERBY_CONN_ATTRS));
         if (dsClassName != null) {
             pValues.put("dsClassName", dsClassName.getNodeValue());
         }

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/response/RestXMLResponseParser.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/response/RestXMLResponseParser.java
@@ -120,7 +120,7 @@ public class RestXMLResponseParser extends RestResponseParser {
         HashMap<String, String> entryMap = new HashMap<>();
         Iterator<Attribute> iter = entry.getAttributes();
         while (iter.hasNext()) {
-            Attribute att = (Attribute) iter.next();
+            Attribute att = iter.next();
             entryMap.put(att.getName().getLocalPart(), att.getValue());
         }
         return entryMap;

--- a/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/ejbjar/ProjectCarProvider.java
+++ b/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/ejbjar/ProjectCarProvider.java
@@ -33,7 +33,7 @@ public class ProjectCarProvider implements CarProvider {
     public org.netbeans.modules.j2ee.api.ejbjar.Car findCar (org.openide.filesystems.FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
         if (project != null) {
-            CarProvider provider = (CarProvider) project.getLookup ().lookup (CarProvider.class);
+            CarProvider provider = project.getLookup().lookup(CarProvider.class);
             if (provider != null) {
                 return provider.findCar(file);
             }

--- a/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/ejbjar/ProjectEarProvider.java
+++ b/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/ejbjar/ProjectEarProvider.java
@@ -33,7 +33,7 @@ public class ProjectEarProvider implements EarProvider {
     public org.netbeans.modules.j2ee.api.ejbjar.Ear findEar (org.openide.filesystems.FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
         if (project != null) {
-            EarProvider provider = (EarProvider) project.getLookup ().lookup (EarProvider.class);
+            EarProvider provider = project.getLookup().lookup(EarProvider.class);
             if (provider != null) {
                 return provider.findEar (file);
             }

--- a/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/ejbjar/ProjectEjbJarProvider.java
+++ b/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/ejbjar/ProjectEjbJarProvider.java
@@ -33,7 +33,7 @@ public class ProjectEjbJarProvider implements EjbJarProvider {
     public org.netbeans.modules.j2ee.api.ejbjar.EjbJar findEjbJar (org.openide.filesystems.FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
         if (project != null) {
-            EjbJarProvider provider = (EjbJarProvider) project.getLookup ().lookup (EjbJarProvider.class);
+            EjbJarProvider provider = project.getLookup().lookup(EjbJarProvider.class);
             if (provider != null) {
                 return provider.findEjbJar (file);
             }

--- a/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/spi/ejbjar/support/J2eeProjectView.java
+++ b/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/spi/ejbjar/support/J2eeProjectView.java
@@ -72,7 +72,7 @@ public final class J2eeProjectView {
      */
     public static EjbNodesFactory getEjbNodesFactory () {
         if (factoryInstance == null) {
-            factoryInstance = (EjbNodesFactory) Lookup.getDefault().lookup(EjbNodesFactory.class);
+            factoryInstance = Lookup.getDefault().lookup(EjbNodesFactory.class);
         }
         if (factoryInstance == null) {
             Logger.getLogger("global").log(Level.INFO, "No EjbNodesFactory instance available: Enterprise Beans nodes cannot be creater");

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/LibrariesNodeFactory.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/LibrariesNodeFactory.java
@@ -61,7 +61,7 @@ public final class LibrariesNodeFactory implements NodeFactory {
     }
 
     public NodeList createNodes(Project p) {
-        AppClientProject project = (AppClientProject)p.getLookup().lookup(AppClientProject.class);
+        AppClientProject project = p.getLookup().lookup(AppClientProject.class);
         assert project != null;
         return new LibrariesNodeList(project);
     }
@@ -82,7 +82,7 @@ public final class LibrariesNodeFactory implements NodeFactory {
         LibrariesNodeList(AppClientProject proj) {
             project = proj;
             testSources = project.getTestSourceRoots();
-            AppClientLogicalViewProvider logView = (AppClientLogicalViewProvider)project.getLookup().lookup(AppClientLogicalViewProvider.class);
+            AppClientLogicalViewProvider logView = project.getLookup().lookup(AppClientLogicalViewProvider.class);
             assert logView != null;
             evaluator = project.evaluator();
             helper = project.getUpdateHelper();

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/SetupDirNodeFactory.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/SetupDirNodeFactory.java
@@ -45,7 +45,7 @@ public final class SetupDirNodeFactory implements NodeFactory {
     }
 
     public NodeList createNodes(Project p) {
-        AppClientProject project = (AppClientProject) p.getLookup().lookup(AppClientProject.class);
+        AppClientProject project = p.getLookup().lookup(AppClientProject.class);
         assert project != null;
         return new SetupDirNodeList(project);
     }
@@ -58,7 +58,7 @@ public final class SetupDirNodeFactory implements NodeFactory {
 
         SetupDirNodeList(AppClientProject proj) {
             project = proj;
-            AppClientLogicalViewProvider logView = (AppClientLogicalViewProvider) project.getLookup().lookup(AppClientLogicalViewProvider.class);
+            AppClientLogicalViewProvider logView = project.getLookup().lookup(AppClientLogicalViewProvider.class);
             assert logView != null;
         }
         

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/AppClientCompositePanelProvider.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/AppClientCompositePanelProvider.java
@@ -99,7 +99,7 @@ public class AppClientCompositePanelProvider implements ProjectCustomizer.Compos
                     null,
                     (ProjectCustomizer.Category[]) null );
         } else if (WEBSERVICESCATEGORY.equals(name)) {
-            AppClientProject project = (AppClientProject) context.lookup(AppClientProject.class);
+            AppClientProject project = context.lookup(AppClientProject.class);
             List serviceClientsSettings = null;
             WebServicesClientSupport clientSupport = WebServicesClientSupport.getWebServicesClientSupport(project.getProjectDirectory());
             if (clientSupport != null) {

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/AppClientProjectProperties.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/AppClientProjectProperties.java
@@ -550,7 +550,7 @@ public final class AppClientProjectProperties {
         updateHelper.putProperties( AntProjectHelper.PROJECT_PROPERTIES_PATH, projectProperties );
         updateHelper.putProperties( AntProjectHelper.PRIVATE_PROPERTIES_PATH, privateProperties );        
         
-        String value = (String)additionalProperties.get(SOURCE_ENCODING);
+        String value = additionalProperties.get(SOURCE_ENCODING);
         if (value != null) {
             try {
                 FileEncodingQuery.setDefaultEncoding(Charset.forName(value));
@@ -602,7 +602,7 @@ public final class AppClientProjectProperties {
         // 1. first remove all project references. The method will modify
         // project property files, so it must be done separately
         for (Iterator<ClassPathSupport.Item> it = removed.iterator(); it.hasNext(); ) {
-            ClassPathSupport.Item item = (ClassPathSupport.Item)it.next();
+            ClassPathSupport.Item item = it.next();
             if ( item.getType() == ClassPathSupport.Item.TYPE_ARTIFACT ||
                     item.getType() == ClassPathSupport.Item.TYPE_JAR ) {
                 refHelper.destroyReference(item.getReference());
@@ -617,7 +617,7 @@ public final class AppClientProjectProperties {
         boolean changed = false;
         
         for (Iterator<ClassPathSupport.Item> it = removed.iterator(); it.hasNext(); ) {
-            ClassPathSupport.Item item = (ClassPathSupport.Item)it.next();
+            ClassPathSupport.Item item = it.next();
             if (item.getType() == ClassPathSupport.Item.TYPE_LIBRARY) {
                 // remove helper property pointing to library jar if there is any
                 String prop = item.getReference();

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/CustomizerLibraries.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/CustomizerLibraries.java
@@ -237,7 +237,7 @@ public class CustomizerLibraries extends JPanel implements HelpCtx.Provider, Lis
            };
         for (int i = 0; i < models.length; i++) {
             for (Iterator<ClassPathSupport.Item> it = ClassPathUiSupport.getIterator(models[i]); it.hasNext();) {
-                ClassPathSupport.Item itm = (ClassPathSupport.Item) it.next();
+                ClassPathSupport.Item itm = it.next();
                 if (itm.getType() == ClassPathSupport.Item.TYPE_LIBRARY) {
                     itm.reassignLibraryManager(man);
                 }
@@ -264,7 +264,7 @@ public class CustomizerLibraries extends JPanel implements HelpCtx.Provider, Lis
         
         for( int i = 0; i < models.length; i++ ) {
             for (Iterator<ClassPathSupport.Item> it = ClassPathUiSupport.getIterator( models[i] ); it.hasNext(); ) {
-                if ( ((ClassPathSupport.Item)it.next()).isBroken() ) {
+                if (it.next().isBroken()) {
                     broken = true;
                     break;
                 }

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/CustomizerProviderImpl.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/CustomizerProviderImpl.java
@@ -87,7 +87,7 @@ public class CustomizerProviderImpl implements CustomizerProvider, ProjectSharab
             return;
         }
         else {
-            AppClientProjectProperties uiProperties = new AppClientProjectProperties( (AppClientProject)project, updateHelper, evaluator, refHelper, genFileHelper );        
+            AppClientProjectProperties uiProperties = new AppClientProjectProperties(project, updateHelper, evaluator, refHelper, genFileHelper);        
             Lookup context = Lookups.fixed(new Object[] {
                 project,
                 uiProperties,

--- a/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/DatasourceCustomizer.java
+++ b/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/DatasourceCustomizer.java
@@ -62,7 +62,7 @@ class DatasourceCustomizer extends javax.swing.JPanel {
         if (datasources != null) { // transform Set to Map for faster searching
             this.datasources = new HashMap<String, Datasource>();
             for (Iterator<Datasource> it = datasources.iterator(); it.hasNext();) {
-                Datasource ds = (Datasource) it.next();
+                Datasource ds = it.next();
                 if (ds.getJndiName() != null)
                     this.datasources.put(ds.getJndiName(), ds);
             }

--- a/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/BrokenDatasourceSupport.java
+++ b/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/BrokenDatasourceSupport.java
@@ -123,8 +123,7 @@ public class BrokenDatasourceSupport {
      * @return Set<Datasource>  returns a set of data sources that don't have corresponding database connections
      */
     public static Set<Datasource> getBrokenDatasources(Project project) {
-        J2eeModuleProvider jmp =
-                (J2eeModuleProvider)project.getLookup().lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider jmp = project.getLookup().lookup(J2eeModuleProvider.class);
         
         Set<Datasource> dss = null;
         try {
@@ -136,7 +135,7 @@ public class BrokenDatasourceSupport {
         Set<Datasource> brokenDatasources = new HashSet<Datasource>();
         Iterator<Datasource> it = dss.iterator();
         while (it.hasNext()) {
-            Datasource ds = (Datasource)it.next();
+            Datasource ds = it.next();
             if(!isFound(ds)){
                 brokenDatasources.add(ds);
             }

--- a/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/BrokenServerLibrarySupport.java
+++ b/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/BrokenServerLibrarySupport.java
@@ -96,7 +96,7 @@ public final class BrokenServerLibrarySupport {
 
                 @Override
                 public void run() {
-                    J2eeModuleProvider jmp = (J2eeModuleProvider)project.getLookup().lookup(J2eeModuleProvider.class);
+                    J2eeModuleProvider jmp = project.getLookup().lookup(J2eeModuleProvider.class);
                     String serverInstanceID = jmp.getServerInstanceID();
                     ServerInstance inst = Deployment.getDefault().getServerInstance(serverInstanceID);
                     try {
@@ -123,8 +123,7 @@ public final class BrokenServerLibrarySupport {
     }
 
     public static Set<ServerLibraryDependency> getMissingServerLibraries(Project project) {
-        J2eeModuleProvider jmp =
-                (J2eeModuleProvider)project.getLookup().lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider jmp = project.getLookup().lookup(J2eeModuleProvider.class);
         Set<ServerLibraryDependency> deps = getDependencies(jmp);
 
         String serverInstanceID = jmp.getServerInstanceID();
@@ -143,8 +142,7 @@ public final class BrokenServerLibrarySupport {
     }
 
     public static Set<ServerLibraryDependency> getDeployableServerLibraries(Project project) {
-        J2eeModuleProvider jmp =
-                (J2eeModuleProvider)project.getLookup().lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider jmp = project.getLookup().lookup(J2eeModuleProvider.class);
         Set<ServerLibraryDependency> deps = getDependencies(jmp);
 
         String serverInstanceID = jmp.getServerInstanceID();

--- a/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/NoSelectedServerWarning.java
+++ b/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/NoSelectedServerWarning.java
@@ -98,7 +98,7 @@ final class NoSelectedServerWarning extends JPanel {
                 types.add(type);
             }
         }
-        return selectServerDialog((J2eeModule.Type[]) types.toArray(new J2eeModule.Type[types.size()]),
+        return selectServerDialog(types.toArray(new J2eeModule.Type[types.size()]),
                 Profile.fromPropertiesString(j2eeSpec), title, description);
     }
 

--- a/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/api/webservices/DDProvider.java
+++ b/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/api/webservices/DDProvider.java
@@ -141,7 +141,7 @@ public final class DDProvider {
     }
 
     private WebServicesProxy getFromCache (FileObject fo) {
-         return (WebServicesProxy) ddMap.get(fo);
+         return ddMap.get(fo);
     }
     
     /**

--- a/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/impl/commonws/ComponentBeanMultiple.java
+++ b/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/impl/commonws/ComponentBeanMultiple.java
@@ -89,7 +89,7 @@ public abstract class ComponentBeanMultiple extends DescriptionBeanMultiple impl
             Iterator<String> keys = displayNames.keySet().iterator();
             int i=0;
             while (keys.hasNext()) {
-                String key = (String) keys.next();
+                String key = keys.next();
                 addDisplayName((String)displayNames.get(key));
                 setDisplayNameXmlLang(i++, key);
             }
@@ -335,6 +335,6 @@ public abstract class ComponentBeanMultiple extends DescriptionBeanMultiple impl
             }
         }
         Iterator<Icon> it = iconList.iterator();
-        while(it.hasNext()) removeIcon((org.netbeans.modules.j2ee.dd.api.common.Icon)it.next());
+        while(it.hasNext()) removeIcon(it.next());
     }
 }

--- a/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/impl/commonws/DescriptionBeanMultiple.java
+++ b/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/impl/commonws/DescriptionBeanMultiple.java
@@ -81,7 +81,7 @@ public abstract class DescriptionBeanMultiple extends EnclosingBean implements D
             Iterator<String> keys = descriptions.keySet().iterator();
             int i=0;
             while (keys.hasNext()) {
-                String key = (String) keys.next();
+                String key = keys.next();
                 addDescription((String)descriptions.get(key));
                 setDescriptionXmlLang(i++, key);
             }

--- a/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/impl/webservices/WebServicesProxy.java
+++ b/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/impl/webservices/WebServicesProxy.java
@@ -71,7 +71,7 @@ public class WebServicesProxy implements Webservices {
                 new java.beans.PropertyChangeEvent(this, PROPERTY_VERSION, version, value);
             version = value;
             for (int i=0;i<listeners.size();i++) {
-                ((java.beans.PropertyChangeListener)listeners.get(i)).propertyChange(evt);
+                listeners.get(i).propertyChange(evt);
             }
         }
     }
@@ -95,7 +95,7 @@ public class WebServicesProxy implements Webservices {
                         ddStatus, value);
             ddStatus = value;
             for (int i=0;i<listeners.size();i++) {
-                ((java.beans.PropertyChangeListener)listeners.get(i)).propertyChange(evt);
+                listeners.get(i).propertyChange(evt);
             }
         }
     }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/application/DDProvider.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/application/DDProvider.java
@@ -187,7 +187,7 @@ public final class DDProvider {
     }
 
     private ApplicationProxy getFromCache (FileObject fo) {
-        return (ApplicationProxy) ddMap.get(fo);
+        return ddMap.get(fo);
     }
     
     /**

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/web/DDProvider.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/web/DDProvider.java
@@ -112,7 +112,7 @@ public final class DDProvider {
                     }
                 } else {
                     version = original.getVersion();
-                    error = (SAXParseException) errorMap.get(fo.toURL());
+                    error = errorMap.get(fo.toURL());
                 }
             }
             if (version != null) {

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/ApplicationProxy.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/ApplicationProxy.java
@@ -71,7 +71,7 @@ public class ApplicationProxy implements Application {
                 new java.beans.PropertyChangeEvent(this, PROPERTY_VERSION, version, value);
             version=value;
             for (int i=0;i<listeners.size();i++) {
-                ((java.beans.PropertyChangeListener)listeners.get(i)).propertyChange(evt);
+                listeners.get(i).propertyChange(evt);
             }
         }
     }
@@ -200,7 +200,7 @@ public class ApplicationProxy implements Application {
                 new java.beans.PropertyChangeEvent(this, PROPERTY_STATUS, ddStatus, value);
             ddStatus=value;
             for (int i=0;i<listeners.size();i++) {
-                ((java.beans.PropertyChangeListener)listeners.get(i)).propertyChange(evt);
+                listeners.get(i).propertyChange(evt);
             }
         }
     }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/client/AppClientProxy.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/client/AppClientProxy.java
@@ -61,7 +61,7 @@ public class AppClientProxy implements AppClient {
     public void setOriginal(AppClient app) {
         if (this.app != app) {
             for (Iterator<PropertyChangeListener> i = listeners.iterator(); i.hasNext();) {
-                PropertyChangeListener pcl = (PropertyChangeListener) i.next();
+                PropertyChangeListener pcl = i.next();
                 if (this.app != null) this.app.removePropertyChangeListener(pcl);
                 if (app != null) app.addPropertyChangeListener(pcl);
                 
@@ -84,7 +84,7 @@ public class AppClientProxy implements AppClient {
                     new java.beans.PropertyChangeEvent(this, PROPERTY_VERSION, version, value);
             version=value;
             for (Iterator<PropertyChangeListener> i = listeners.iterator(); i.hasNext();) {
-                ((PropertyChangeListener) i.next()).propertyChange(evt);
+                i.next().propertyChange(evt);
             }
         }
     }
@@ -189,7 +189,7 @@ public class AppClientProxy implements AppClient {
                     new java.beans.PropertyChangeEvent(this, PROPERTY_STATUS, ddStatus, value);
             ddStatus=value;
             for (Iterator<PropertyChangeListener> i = listeners.iterator(); i.hasNext();) {
-                ((PropertyChangeListener) i.next()).propertyChange(evt);
+                i.next().propertyChange(evt);
             }
         }
     }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/ComponentBeanMultiple.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/ComponentBeanMultiple.java
@@ -97,7 +97,7 @@ public abstract class ComponentBeanMultiple extends DescriptionBeanMultiple impl
             Iterator<Map.Entry> entries = displayNames.entrySet().iterator();
             int i=0;
             while (entries.hasNext()) {
-                Map.Entry entry = (Map.Entry) entries.next();
+                Map.Entry entry = entries.next();
                 String key = (String) entry.getKey();
                 addDisplayName((String) entry.getValue());
                 setDisplayNameXmlLang(i++, key);

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/DescriptionBeanMultiple.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/DescriptionBeanMultiple.java
@@ -87,7 +87,7 @@ public abstract class DescriptionBeanMultiple extends EnclosingBean implements D
             Iterator<String> keys = descriptions.keySet().iterator();
             int i=0;
             while (keys.hasNext()) {
-                String key = (String) keys.next();
+                String key = keys.next();
                 addDescription((String)descriptions.get(key));
                 setDescriptionXmlLang(i++, key);
             }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/EjbJarProxy.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/EjbJarProxy.java
@@ -82,7 +82,7 @@ public class EjbJarProxy implements EjbJar {
                     new java.beans.PropertyChangeEvent(this, PROPERTY_VERSION, version, value);
             version = value;
             for (int i = 0; i < listeners.size(); i++) {
-                ((java.beans.PropertyChangeListener) listeners.get(i)).propertyChange(evt);
+                listeners.get(i).propertyChange(evt);
             }
         }
     }
@@ -166,7 +166,7 @@ public class EjbJarProxy implements EjbJar {
                 new java.beans.PropertyChangeEvent(this, PROPERTY_STATUS, ddStatus, value);
             ddStatus=value;
             for (int i=0;i<listeners.size();i++) {
-                ((java.beans.PropertyChangeListener)listeners.get(i)).propertyChange(evt);
+                listeners.get(i).propertyChange(evt);
             }
         }
     }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/WebAppProxy.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/WebAppProxy.java
@@ -79,7 +79,7 @@ public class WebAppProxy implements WebApp {
                 new java.beans.PropertyChangeEvent(this, PROPERTY_VERSION, version, value);
             version=value;
             for (int i=0;i<listeners.size();i++) {
-                ((java.beans.PropertyChangeListener)listeners.get(i)).propertyChange(evt);
+                listeners.get(i).propertyChange(evt);
             }
         }
     }
@@ -105,7 +105,7 @@ public class WebAppProxy implements WebApp {
                 new java.beans.PropertyChangeEvent(this, PROPERTY_STATUS, ddStatus, value);
             ddStatus=value;
             for (int i=0;i<listeners.size();i++) {
-                ((java.beans.PropertyChangeListener)listeners.get(i)).propertyChange(evt);
+                listeners.get(i).propertyChange(evt);
             }
         }
     }

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataNode.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataNode.java
@@ -91,7 +91,7 @@ public final class EarDataNode extends DataNode {
                 }
                 actions.add(origActions[i]);
             }
-            filteredActions = (Action[]) actions.toArray(new Action[actions.size()]);
+            filteredActions = actions.toArray(new Action[actions.size()]);
         }
         return filteredActions;
     }

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataObject.java
@@ -168,7 +168,7 @@ public class EarDataObject extends DD2beansDataObject
                 }
             }
         }
-        srcRoots = (FileObject []) srcRootList.toArray (new FileObject [srcRootList.size ()]);
+        srcRoots = srcRootList.toArray(new FileObject[srcRootList.size ()]);
     }
     
     private String getPackageName (FileObject clazz) {
@@ -487,7 +487,7 @@ public class EarDataObject extends DD2beansDataObject
             return;
        
         if (evt.getType () != DDChangeEvent.EJB_ADDED) {
-            updateDD(evt.getOldValue(), (String)evt.getNewValue (), evt.getType());
+            updateDD(evt.getOldValue(), evt.getNewValue (), evt.getType());
         }
     }
 
@@ -519,7 +519,7 @@ public class EarDataObject extends DD2beansDataObject
                             if (index>0) deletedName = deletedServletName.substring(index+1);
                             boolean found = false;
                             for (int j=0;j<newFileNames.size();j++) {
-                                String newFileName = (String)newFileNames.get(j);
+                                String newFileName = newFileNames.get(j);
                                 String newName = newFileName;
                                 int ind = newFileName.lastIndexOf("."); //NOI18N
                                 if (ind>0) newName = newFileName.substring(ind+1);

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/client/ClientDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/client/ClientDataObject.java
@@ -133,7 +133,7 @@ public class ClientDataObject extends  DDMultiViewDataObject
                 }
             }
         }
-        srcRoots = (FileObject []) srcRootList.toArray(new FileObject [srcRootList.size()]);
+        srcRoots = srcRootList.toArray(new FileObject[srcRootList.size()]);
     }
 
     @Override

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/DD2beansDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/DD2beansDataObject.java
@@ -73,7 +73,7 @@ public abstract class DD2beansDataObject extends XMLJ2eeDataObject implements or
                             XMLJ2eeUtils.replaceDocument(doc, newDoc, prefixMark);
                             setDocumentValid(true);
                             if (saveAfterNodeChanges) {
-                                SaveCookie savec = (SaveCookie) getCookie(SaveCookie.class);
+                                SaveCookie savec = getCookie(SaveCookie.class);
                                 if (savec != null) {
                                     savec.save();
                                 }

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/xmlutils/XMLJ2eeDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/xmlutils/XMLJ2eeDataObject.java
@@ -300,7 +300,7 @@ public abstract class XMLJ2eeDataObject extends XMLDataObject implements CookieS
             OutputWriter outputWriter = inOut.getOut();
             int line   = Math.max(0,error.getErrorLine());
             
-            LineCookie cookie = (LineCookie)getCookie(LineCookie.class);
+            LineCookie cookie = getCookie(LineCookie.class);
             // getting Line object
             Line xline = cookie.getLineSet ().getCurrent(line==0?0:line-1);
             // attaching Annotation

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/xmlutils/XMLJ2eeEditorSupport.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/xmlutils/XMLJ2eeEditorSupport.java
@@ -365,7 +365,7 @@ public class XMLJ2eeEditorSupport extends DataEditorSupport
          * @return the editor support
          */
         public CloneableOpenSupport findCloneableOpenSupport () {
-            return (XMLJ2eeEditorSupport) getDataObject ().getCookie (XMLJ2eeEditorSupport.class);
+            return getDataObject().getCookie(XMLJ2eeEditorSupport.class);
         }
     }
 }

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/xmlutils/XMLJ2eeUtils.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/xmlutils/XMLJ2eeUtils.java
@@ -308,7 +308,7 @@ public class XMLJ2eeUtils {
         int elementIndex=-1; 
         while (it.hasNext()){
             elementIndex=-1;
-            ElementAttrInfo info = (ElementAttrInfo)it.next();
+            ElementAttrInfo info = it.next();
             String attributeName = info.getAttributeName();
             String attributeValue = info.getAttributeValue();
             NodeList nodeList = element.getElementsByTagName(info.getElementName());
@@ -361,7 +361,7 @@ public class XMLJ2eeUtils {
         int elementIndex=-1;
         while (it.hasNext()){
             elementIndex=-1;
-            ElementAttrInfo info = (ElementAttrInfo)it.next();
+            ElementAttrInfo info = it.next();
             String attributeName = info.getAttributeName();
             String attributeValue = info.getAttributeValue();
             NodeList nodeList = element.getElementsByTagName(info.getElementName());
@@ -406,7 +406,7 @@ public class XMLJ2eeUtils {
         Element parent = null;
         Element element = root;
         while (it.hasNext()){
-            ElementAttrInfo info = (ElementAttrInfo)it.next();
+            ElementAttrInfo info = it.next();
             String attributeName = info.getAttributeName();
             String attributeValue = info.getAttributeValue();
             NodeList nodeList = element.getElementsByTagName(info.getElementName());
@@ -463,7 +463,7 @@ public class XMLJ2eeUtils {
         Iterator<ElementAttrInfo> it = elementPath.iterator();
         Element element = root;
         while (it.hasNext()){
-            ElementAttrInfo info = (ElementAttrInfo)it.next();
+            ElementAttrInfo info = it.next();
             String attributeName = info.getAttributeName();
             String attributeValue = info.getAttributeValue();
             NodeList nodeList = element.getElementsByTagName(info.getElementName());
@@ -557,7 +557,7 @@ public class XMLJ2eeUtils {
         Element element = root;
         
         while (it.hasNext()){
-            ElementAttrInfo info = (ElementAttrInfo)it.next();
+            ElementAttrInfo info = it.next();
             String attributeName = info.getAttributeName();
             String attributeValue = info.getAttributeValue();
             NodeList nodeList = element.getElementsByTagName(info.getElementName());
@@ -633,7 +633,7 @@ public class XMLJ2eeUtils {
         Element parent = null;
         Element element = root;
         while (it.hasNext()){
-            ElementAttrInfo info = (ElementAttrInfo)it.next();
+            ElementAttrInfo info = it.next();
             String attributeName = info.getAttributeName();
             String attributeValue = info.getAttributeValue();
             NodeList nodeList = element.getElementsByTagName(info.getElementName());

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EjbJarMultiViewDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EjbJarMultiViewDataObject.java
@@ -307,7 +307,7 @@ public class EjbJarMultiViewDataObject extends DDMultiViewDataObject
                 public void run() {
                     if (deletedEjbNames != null) {
                         for (int i = 0; i < deletedEjbNames.size(); i++) {
-                            String deletedServletName = (String) deletedEjbNames.get(i);
+                            String deletedServletName = deletedEjbNames.get(i);
                             String deletedName = deletedServletName;
                             int index = deletedServletName.lastIndexOf("."); //NOI18N
                             if (index > 0) {
@@ -315,7 +315,7 @@ public class EjbJarMultiViewDataObject extends DDMultiViewDataObject
                             }
                             boolean found = false;
                             for (int j = 0; j < newFileNames.size(); j++) {
-                                String newFileName = (String) newFileNames.get(j);
+                                String newFileName = newFileNames.get(j);
                                 String newName = newFileName;
                                 int ind = newFileName.lastIndexOf("."); //NOI18N
                                 if (ind > 0) {

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EntityAndSessionHelper.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EntityAndSessionHelper.java
@@ -92,7 +92,7 @@ public abstract class EntityAndSessionHelper implements PropertyChangeListener, 
     
     protected void firePropertyChange(PropertyChangeEvent evt) {
         for (Iterator<PropertyChangeListener> iterator = listeners.iterator(); iterator.hasNext();) {
-            ((PropertyChangeListener) iterator.next()).propertyChange(evt);
+            iterator.next().propertyChange(evt);
         }
     }
     

--- a/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/EarActionProvider.java
+++ b/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/EarActionProvider.java
@@ -247,7 +247,7 @@ public class EarActionProvider implements ActionProvider {
                 final Set s = spp.getSubprojects();
                 Iterator<Project> iter = s.iterator();
                 while (iter.hasNext()) {
-                    Project proj = (Project) iter.next();
+                    Project proj = iter.next();
                     WebModuleProvider wmp = proj.getLookup().lookup(WebModuleProvider.class);
                     if (null != wmp) {
                         WebModule wm = wmp.findWebModule(proj.getProjectDirectory());
@@ -280,7 +280,7 @@ public class EarActionProvider implements ActionProvider {
                 final Set s = spp.getSubprojects();
                 Iterator<Project> iter = s.iterator();
                 while (iter.hasNext()) {
-                    Project proj = (Project) iter.next();
+                    Project proj = iter.next();
                     WebModuleProvider wmp = proj.getLookup().lookup(WebModuleProvider.class);
                     if (null != wmp) {
                         WebModule wm = wmp.findWebModule(proj.getProjectDirectory());

--- a/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/EarProject.java
+++ b/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/EarProject.java
@@ -428,7 +428,7 @@ public final class EarProject implements Project, AntProjectListener {
         protected void projectOpened() {
             helper.getStandardPropertyEvaluator().addPropertyChangeListener(EarProject.this.appModule);
 
-            J2eeArchiveLogicalViewProvider logicalViewProvider = (J2eeArchiveLogicalViewProvider) EarProject.this.getLookup().lookup (J2eeArchiveLogicalViewProvider.class);
+            J2eeArchiveLogicalViewProvider logicalViewProvider = EarProject.this.getLookup().lookup(J2eeArchiveLogicalViewProvider.class);
             if (logicalViewProvider != null) {
                 logicalViewProvider.initialize();
             }

--- a/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/classpath/ClassPathProviderImpl.java
+++ b/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/classpath/ClassPathProviderImpl.java
@@ -64,7 +64,7 @@ public final class ClassPathProviderImpl implements ClassPathProvider, PropertyC
         return ProjectManager.mutex().readAccess(new Mutex.Action<FileObject>() {
             public FileObject run() {
                 synchronized (ClassPathProviderImpl.this) {
-                    FileObject fo = (FileObject) ClassPathProviderImpl.this.dirCache.get (propname);
+                    FileObject fo = ClassPathProviderImpl.this.dirCache.get(propname);
                     if (fo == null ||  !fo.isValid()) {
                         String prop = evaluator.getProperty(propname);
                         if (prop != null) {

--- a/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ui/customizer/CustomizerLibraries.java
+++ b/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ui/customizer/CustomizerLibraries.java
@@ -102,7 +102,7 @@ public final class CustomizerLibraries extends JPanel implements HelpCtx.Provide
         
         for( int i = 0; i < models.length; i++ ) {
             for (Iterator<ClassPathSupport.Item> it = ClassPathUiSupport.getIterator( models[i] ); it.hasNext(); ) {
-                if ( ((ClassPathSupport.Item)it.next()).isBroken() ) {
+                if (it.next().isBroken()) {
                     broken = true;
                     break;
                 }
@@ -158,7 +158,7 @@ public final class CustomizerLibraries extends JPanel implements HelpCtx.Provide
            };
         for (int i = 0; i < models.length; i++) {
             for (Iterator<ClassPathSupport.Item> it = ClassPathUiSupport.getIterator(models[i]); it.hasNext();) {
-                ClassPathSupport.Item itm = (ClassPathSupport.Item) it.next();
+                ClassPathSupport.Item itm = it.next();
                 if (itm.getType() == ClassPathSupport.Item.TYPE_LIBRARY) {
                     itm.reassignLibraryManager(man);
                 }

--- a/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ui/customizer/EarProjectProperties.java
+++ b/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ui/customizer/EarProjectProperties.java
@@ -254,15 +254,15 @@ public final class EarProjectProperties {
         }
         EditableProperties projectProperties = updateHelper.getProperties( AntProjectHelper.PROJECT_PROPERTIES_PATH );                
         EditableProperties privateProperties = updateHelper.getProperties( AntProjectHelper.PRIVATE_PROPERTIES_PATH );
-        DEBUG_CLASSPATH_MODEL = ClassPathUiSupport.createListModel( cs.itemsIterator( (String)projectProperties.get( ProjectProperties.RUN_CLASSPATH ), null ) );
-        ENDORSED_CLASSPATH_MODEL = ClassPathUiSupport.createListModel( cs.itemsIterator( (String)projectProperties.get( ProjectProperties.ENDORSED_CLASSPATH ), null ) );
+        DEBUG_CLASSPATH_MODEL = ClassPathUiSupport.createListModel( cs.itemsIterator(projectProperties.get( ProjectProperties.RUN_CLASSPATH ), null ) );
+        ENDORSED_CLASSPATH_MODEL = ClassPathUiSupport.createListModel( cs.itemsIterator(projectProperties.get( ProjectProperties.ENDORSED_CLASSPATH ), null ) );
         CLASS_PATH_LIST_RENDERER = ClassPathListCellRenderer.createClassPathListRenderer(evaluator, project.getProjectDirectory());
 
         // CustomizerJarContent
         ARCHIVE_COMPRESS_MODEL = projectGroup.createToggleButtonModel( evaluator, JAR_COMPRESS );
         ARCHIVE_NAME_MODEL = projectGroup.createStringDocument( evaluator, JAR_NAME );
         BUILD_CLASSES_EXCLUDES_MODEL = projectGroup.createStringDocument( evaluator, BUILD_CLASSES_EXCLUDES );
-        EAR_CONTENT_ADDITIONAL_MODEL = AdditionalContentTableModel.createTableModel( cs.itemsIterator( (String)projectProperties.get( JAR_CONTENT_ADDITIONAL ), TAG_WEB_MODULE__ADDITIONAL_LIBRARIES) );
+        EAR_CONTENT_ADDITIONAL_MODEL = AdditionalContentTableModel.createTableModel( cs.itemsIterator(projectProperties.get( JAR_CONTENT_ADDITIONAL ), TAG_WEB_MODULE__ADDITIONAL_LIBRARIES) );
         EAR_CONTENT_ADDITIONAL_MODEL.getDefaultListModel().addListDataListener(new ListDataListener() {
             public void intervalAdded(ListDataEvent e) {
                 CLIENT_MODULE_MODEL.refresh(ClassPathUiSupport.getList( EAR_CONTENT_ADDITIONAL_MODEL.getDefaultListModel()));

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/action/SendJMSGenerator.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/action/SendJMSGenerator.java
@@ -327,7 +327,7 @@ public final class SendJMSGenerator {
                 workingCopy.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
                 TypeElement typeElement = workingCopy.getElements().getTypeElement(className);
                 MethodTree methodTree = MethodModelSupport.createMethodTree(workingCopy, methodModel);
-                methodTree = (MethodTree) GeneratorUtilities.get(workingCopy).importFQNs(methodTree);
+                methodTree = GeneratorUtilities.get(workingCopy).importFQNs(methodTree);
                 ClassTree classTree = workingCopy.getTrees().getTree(typeElement);
                 ClassTree newClassTree = workingCopy.getTreeMaker().addClassMember(classTree, methodTree);
                 workingCopy.rewrite(classTree, newClassTree);
@@ -395,7 +395,7 @@ public final class SendJMSGenerator {
                 workingCopy.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
                 TypeElement typeElement = workingCopy.getElements().getTypeElement(className);
                 MethodTree methodTree = MethodModelSupport.createMethodTree(workingCopy, methodModel);
-                methodTree = (MethodTree) GeneratorUtilities.get(workingCopy).importFQNs(methodTree);
+                methodTree = GeneratorUtilities.get(workingCopy).importFQNs(methodTree);
                 ClassTree classTree = workingCopy.getTrees().getTree(typeElement);
                 ClassTree newClassTree = workingCopy.getTreeMaker().addClassMember(classTree, methodTree);
                 workingCopy.rewrite(classTree, newClassTree);

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/action/UseDatabaseGenerator.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/action/UseDatabaseGenerator.java
@@ -218,7 +218,7 @@ public final class UseDatabaseGenerator {
                         Collections.singleton(Modifier.PRIVATE)
                         );
                 MethodTree methodTree = MethodModelSupport.createMethodTree(workingCopy, methodModel);
-                methodTree = (MethodTree) GeneratorUtilities.get(workingCopy).importFQNs(methodTree);
+                methodTree = GeneratorUtilities.get(workingCopy).importFQNs(methodTree);
                 ClassTree classTree = workingCopy.getTrees().getTree(typeElement);
                 ClassTree modifiedClassTree = workingCopy.getTreeMaker().addClassMember(classTree, methodTree);
                 workingCopy.rewrite(classTree, modifiedClassTree);

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/CallEjbGenerator.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/CallEjbGenerator.java
@@ -383,7 +383,7 @@ public class CallEjbGenerator {
                         '{' + MessageFormat.format(JNDI_LOOKUP_EJB3_JAVAEE5, new Object[] { name, homeFieldName }) + '}',
                         null
                         );
-                methodTree = (MethodTree) GeneratorUtilities.get(workingCopy).importFQNs(methodTree);
+                methodTree = GeneratorUtilities.get(workingCopy).importFQNs(methodTree);
                 newClassTree = treeMaker.insertClassMember(newClassTree, 3, methodTree);
                 
                 workingCopy.rewrite(classTree, newClassTree);
@@ -439,7 +439,7 @@ public class CallEjbGenerator {
             Iterator<String> exIt = exceptions.iterator();
             StringBuffer catchBody = new StringBuffer("try {\n" + body + "}\n"); // NOI18N
             while (exIt.hasNext()) {
-                String exceptionName = (String) exIt.next();
+                String exceptionName = exIt.next();
                 catchBody.append("catch("); // NOI18N
                 catchBody.append(exceptionName);
                 catchBody.append(' ');  //NOI18N
@@ -520,7 +520,7 @@ public class CallEjbGenerator {
             Iterator<String> exIt = exceptions.iterator();
             StringBuffer catchBody = new StringBuffer("try {\n" + body + "\n}"); // NOI18N
             while (exIt.hasNext()) {
-                String exceptionName = (String) exIt.next();
+                String exceptionName = exIt.next();
                 catchBody.append(" catch("); // NOI18N
                 catchBody.append(exceptionName);
                 catchBody.append(' ');  //NOI18N

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGenerator.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGenerator.java
@@ -112,8 +112,9 @@ public final class MessageGenerator {
         this.jmsSupport = jmsSupport;
         boolean useMappedName = useMappedName();
         if (profile != null && profile.isAtLeast(Profile.JAVA_EE_7_WEB) && jmsSupport.useDestinationLookup()) {
-            String destination = properties.get(ActivationConfigProperties.DESTINATION_LOOKUP) == null || ((String) properties.get(ActivationConfigProperties.DESTINATION_LOOKUP)).isEmpty() ?
-                    messageDestination.getName() : properties.get(ActivationConfigProperties.DESTINATION_LOOKUP);
+            String destination = properties.get(ActivationConfigProperties.DESTINATION_LOOKUP) == null ||
+                    properties.get(ActivationConfigProperties.DESTINATION_LOOKUP).isEmpty() ?
+                                   messageDestination.getName() : properties.get(ActivationConfigProperties.DESTINATION_LOOKUP);
             properties.put(DESTINATION_LOOKUP, destination);
         } else {
             if (!useMappedName) {

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/MultiTargetChooserPanel.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/MultiTargetChooserPanel.java
@@ -202,7 +202,7 @@ public final class MultiTargetChooserPanel implements WizardDescriptor.Panel, Ch
         ChangeEvent e = new ChangeEvent(this);
         Iterator<ChangeListener> it = listeners.iterator();
         while (it.hasNext()) {
-            ((ChangeListener)it.next()).stateChanged(e);
+            it.next().stateChanged(e);
         }
     }
 

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/cmp/CMPMapping.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/cmp/CMPMapping.java
@@ -48,11 +48,11 @@ public class CMPMapping implements OriginalCMPMapping {
     }
     
     public String getFieldColumn(String cmpFieldName) {
-        return (String) model.getCMPFieldMapping().get(cmpFieldName);
+        return model.getCMPFieldMapping().get(cmpFieldName);
     }
     
     public String[] getRelationshipColumn(String cmrFieldName) {
-        ColumnData[] columns =  (ColumnData[]) model.getCmrFieldMapping().get(cmrFieldName);
+        ColumnData[] columns =  model.getCmrFieldMapping().get(cmrFieldName);
         String[] names = new String[columns.length];
         for(int i = 0; i < columns.length; i ++) {
             names[i] = columns[i].getColumnName();
@@ -73,7 +73,7 @@ public class CMPMapping implements OriginalCMPMapping {
     }
     
     public String getRelationshipJoinTable(String cmrFieldName) {
-        return (String) model.getJoinTableMapping().get(cmrFieldName);
+        return model.getJoinTableMapping().get(cmrFieldName);
     }
     
     public CMPMappingModel getMappingModel() {

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/ServiceLocatorStrategy.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/ServiceLocatorStrategy.java
@@ -95,8 +95,7 @@ public class ServiceLocatorStrategy {
     private ClassPath buildClassPathFromImportedProject(FileObject fileObject) {
         Project project = FileOwnerQuery.getOwner(fileObject);
         assert project != null : "cannot find project for file";
-        ClassPathProvider cpp = (ClassPathProvider)
-            project.getLookup().lookup(ClassPathProvider.class);
+        ClassPathProvider cpp = project.getLookup().lookup(ClassPathProvider.class);
         assert cpp != null: "project doesn't have class path provider";
         Sources sources = ProjectUtils.getSources(project);
         SourceGroup[] groups = sources.getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA);

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarJPAModuleInfo.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarJPAModuleInfo.java
@@ -52,7 +52,7 @@ class EjbJarJPAModuleInfo implements JPAModuleInfo {
 
     @Override
     public Boolean isJPAVersionSupported(String version) {
-        J2eeModuleProvider j2eeModuleProvider = (J2eeModuleProvider) project.getLookup().lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider j2eeModuleProvider = project.getLookup().lookup(J2eeModuleProvider.class);
         J2eePlatform platform  = Deployment.getDefault().getJ2eePlatform(j2eeModuleProvider.getServerInstanceID());
         
         if (platform == null) {

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/UpdateProjectImpl.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/UpdateProjectImpl.java
@@ -196,7 +196,7 @@ public class UpdateProjectImpl implements UpdateImplementation {
                                 ArrayList<FileObject> files = new ArrayList<FileObject>();
                                 ArrayList<FileObject> dirs = new ArrayList<FileObject>();
                                 for (Iterator<URL> it = roots.iterator(); it.hasNext();) {
-                                    URL rootUrl = (URL) it.next();
+                                    URL rootUrl = it.next();
                                     FileObject root = org.openide.filesystems.URLMapper.findFileObject (rootUrl);
                                     if ("jar".equals(rootUrl.getProtocol())) {  //NOI18N
                                         root = FileUtil.getArchiveFile (root);

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/Utils.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/Utils.java
@@ -107,7 +107,7 @@ public class Utils {
         Set globalPath = GlobalPathRegistry.getDefault().getSourceRoots();
         Iterator<FileObject> iter = globalPath.iterator();
         while (iter.hasNext()) {
-            FileObject sourceRoot = (FileObject)iter.next();
+            FileObject sourceRoot = iter.next();
             Project project = FileOwnerQuery.getOwner(sourceRoot);
             if (project != null) {
                 Object j2eeAppProvider = project.getLookup().lookup(J2eeApplicationProvider.class);

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/CustomizerLibraries.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/CustomizerLibraries.java
@@ -206,7 +206,7 @@ public class CustomizerLibraries extends JPanel implements HelpCtx.Provider, Lis
            };
         for (int i = 0; i < models.length; i++) {
             for (Iterator<ClassPathSupport.Item> it = ClassPathUiSupport.getIterator(models[i]); it.hasNext();) {
-                ClassPathSupport.Item itm = (ClassPathSupport.Item) it.next();
+                ClassPathSupport.Item itm = it.next();
                 if (itm.getType() == ClassPathSupport.Item.TYPE_LIBRARY) {
                     itm.reassignLibraryManager(man);
                 }
@@ -232,7 +232,7 @@ public class CustomizerLibraries extends JPanel implements HelpCtx.Provider, Lis
         
         for( int i = 0; i < models.length; i++ ) {
             for( Iterator<ClassPathSupport.Item> it = ClassPathUiSupport.getIterator( models[i] ); it.hasNext(); ) {
-                if ( ((ClassPathSupport.Item)it.next()).isBroken() ) {
+                if (it.next().isBroken()) {
                     broken = true;
                     break;
                 }

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/CustomizerProviderImpl.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/CustomizerProviderImpl.java
@@ -85,7 +85,7 @@ public class CustomizerProviderImpl implements CustomizerProvider2, ProjectShara
             return;
         }
         else {
-            EjbJarProjectProperties uiProperties = new EjbJarProjectProperties( (EjbJarProject)project, updateHelper, evaluator, refHelper );        
+            EjbJarProjectProperties uiProperties = new EjbJarProjectProperties(project, updateHelper, evaluator, refHelper);        
             Lookup context = Lookups.fixed(new Object[] {
                 project,
                 uiProperties,

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/CustomizerSources.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/CustomizerSources.java
@@ -76,8 +76,8 @@ public class CustomizerSources extends javax.swing.JPanel implements HelpCtx.Pro
         jTextFieldConfigFilesFolder.setDocument(uiProperties.META_INF_MODEL);
         
         SourceRootsUi.EditMediator emSR = SourceRootsUi.registerEditMediator(
-                (EjbJarProject)uiProperties.getProject(),
-                ((EjbJarProject)uiProperties.getProject()).getSourceRoots(),
+                uiProperties.getProject(),
+                uiProperties.getProject().getSourceRoots(),
                 sourceRoots,
                 addSourceRoot,
                 removeSourceRoot,
@@ -85,8 +85,8 @@ public class CustomizerSources extends javax.swing.JPanel implements HelpCtx.Pro
                 downSourceRoot,null,false);
         
         SourceRootsUi.EditMediator emTSR = SourceRootsUi.registerEditMediator(
-                (EjbJarProject)uiProperties.getProject(),
-                ((EjbJarProject)uiProperties.getProject()).getTestSourceRoots(),
+                uiProperties.getProject(),
+                uiProperties.getProject().getTestSourceRoots(),
                 testRoots,
                 addTestRoot,
                 removeTestRoot,
@@ -111,7 +111,7 @@ public class CustomizerSources extends javax.swing.JPanel implements HelpCtx.Pro
             }
         });
         enableSourceLevel();
-        this.originalEncoding = ((EjbJarProject)uiProperties.getProject()).evaluator().getProperty(EjbJarProjectProperties.SOURCE_ENCODING);
+        this.originalEncoding = uiProperties.getProject().evaluator().getProperty(EjbJarProjectProperties.SOURCE_ENCODING);
         if (this.originalEncoding == null) {
             this.originalEncoding = Charset.defaultCharset().name();
         }

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/EjbJarProjectProperties.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/EjbJarProjectProperties.java
@@ -566,7 +566,7 @@ public final class EjbJarProjectProperties {
             Deployment.getDefault().disableCompileOnSaveSupport(project.getEjbModule());
         }
         
-        String value = (String)additionalProperties.get(SOURCE_ENCODING);
+        String value = additionalProperties.get(SOURCE_ENCODING);
         if (value != null) {
             try {
                 FileEncodingQuery.setDefaultEncoding(Charset.forName(value));
@@ -607,7 +607,7 @@ public final class EjbJarProjectProperties {
         // 1. first remove all project references. The method will modify
         // project property files, so it must be done separately
         for (Iterator<ClassPathSupport.Item> it = removed.iterator(); it.hasNext(); ) {
-            ClassPathSupport.Item item = (ClassPathSupport.Item)it.next();
+            ClassPathSupport.Item item = it.next();
             if ( item.getType() == ClassPathSupport.Item.TYPE_ARTIFACT ||
                     item.getType() == ClassPathSupport.Item.TYPE_JAR ) {
                 refHelper.destroyReference(item.getReference());
@@ -622,7 +622,7 @@ public final class EjbJarProjectProperties {
         boolean changed = false;
         
         for (Iterator<ClassPathSupport.Item> it = removed.iterator(); it.hasNext(); ) {
-            ClassPathSupport.Item item = (ClassPathSupport.Item)it.next();
+            ClassPathSupport.Item item = it.next();
             if (item.getType() == ClassPathSupport.Item.TYPE_LIBRARY) {
                 // remove helper property pointing to library jar if there is any
                 String prop = item.getReference();

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/refactor/MicronautRefactoringFactory.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/refactor/MicronautRefactoringFactory.java
@@ -237,7 +237,7 @@ public class MicronautRefactoringFactory implements RefactoringPluginFactory {
             try {
                 DataObject dobj = DataObject.find(getParentFile());
                 if (dobj != null) {
-                    EditorCookie.Observable obs = (EditorCookie.Observable)dobj.getCookie(EditorCookie.Observable.class);
+                    EditorCookie.Observable obs = dobj.getCookie(EditorCookie.Observable.class);
                     if (obs != null && obs instanceof CloneableEditorSupport) {
                         CloneableEditorSupport supp = (CloneableEditorSupport)obs;
                         return new PositionBounds(supp.createPositionRef(startOffset, Position.Bias.Forward), supp.createPositionRef(Math.max(startOffset, endOffset), Position.Bias.Forward));

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/ui/JavaSEPlatformPanel.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/ui/JavaSEPlatformPanel.java
@@ -134,7 +134,7 @@ public class JavaSEPlatformPanel extends JPanel {
             Iterator<FileObject> platformIterator
                     = selectedPlatform.getInstallFolders().iterator();
             if (platformIterator.hasNext()) {
-                selectedJavaHome = (FileObject)platformIterator.next();
+                selectedJavaHome = platformIterator.next();
             }
         }
         if (selectedJavaHome != null && panel.updateProperties()) {

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/DomainEditor.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/DomainEditor.java
@@ -510,12 +510,12 @@ public class DomainEditor {
             }
         } // connection-pool properties
 
-        pValues.put(CONST_LOWER_DATABASE_NAME, (String) map.get(CONST_LOWER_DATABASE_NAME));
-        pValues.put(CONST_PORT_NUMBER, (String) map.get(CONST_PORT_NUMBER));
-        pValues.put(CONST_LOWER_PORT_NUMBER, (String) map.get(CONST_LOWER_PORT_NUMBER));
-        pValues.put(CONST_DATABASE_NAME, (String) map.get(CONST_DATABASE_NAME));
-        pValues.put(CONST_SID, (String) map.get(CONST_SID));
-        pValues.put(CONST_DRIVER_CLASS, (String) map.get(CONST_DRIVER_CLASS));
+        pValues.put(CONST_LOWER_DATABASE_NAME, map.get(CONST_LOWER_DATABASE_NAME));
+        pValues.put(CONST_PORT_NUMBER, map.get(CONST_PORT_NUMBER));
+        pValues.put(CONST_LOWER_PORT_NUMBER, map.get(CONST_LOWER_PORT_NUMBER));
+        pValues.put(CONST_DATABASE_NAME, map.get(CONST_DATABASE_NAME));
+        pValues.put(CONST_SID, map.get(CONST_SID));
+        pValues.put(CONST_DRIVER_CLASS, map.get(CONST_DRIVER_CLASS));
         if (dsClassName != null) {
             pValues.put("dsClassName", dsClassName.getNodeValue());
         }

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/JDBCDriverDeployHelper.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/JDBCDriverDeployHelper.java
@@ -164,7 +164,7 @@ public class JDBCDriverDeployHelper {
             if (jdbcDriverURLs.size() > 0) {
                 boolean success = true;
                 for (int i = 0; i < jdbcDriverURLs.size(); i++) {
-                    URL jarUrl = (URL) jdbcDriverURLs.get(i);
+                    URL jarUrl = jdbcDriverURLs.get(i);
                     File libsDir = driverLoc;
                     try {
                         File toJar = new File(libsDir, new File(jarUrl.toURI()).getName());

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/ProgressEventSupport.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/ProgressEventSupport.java
@@ -106,7 +106,7 @@ public class ProgressEventSupport {
 
 	if (targets != null) {
 	    for (int i = 0; i < targets.size(); i++) {
-	        ProgressListener target = (ProgressListener)targets.elementAt(i);
+	        ProgressListener target = targets.elementAt(i);
 	        target.handleProgressEvent (evt);
 	    }
 	}

--- a/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/DeployOnSaveManager.java
+++ b/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/DeployOnSaveManager.java
@@ -549,7 +549,7 @@ public final class DeployOnSaveManager {
                     if (checkFile != null && file != null) {
                         String relative = FileUtil.getRelativePath(contentDirectory, checkFile);
                         if (relative != null) {
-                            FileObject targetFO = (FileObject) destMap.get(relative);
+                            FileObject targetFO = destMap.get(relative);
                             if (file.isFolder()) {
                                 destMap.remove(relative);
                                 //continue;

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/completion/CompletionContext.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/completion/CompletionContext.java
@@ -282,7 +282,7 @@ public class CompletionContext {
     public List<String> getExistingAttributes() {
         if (existingAttributes == null) {
             try {
-                existingAttributes = (List<String>)support.runWithSequence(
+                existingAttributes = support.runWithSequence(
                         documentContext.getCurrentTokenOffset(),
                         this::getExistingAttributesLocked
                 );

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/FieldInjectionPointLogic.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/FieldInjectionPointLogic.java
@@ -543,8 +543,7 @@ abstract class FieldInjectionPointLogic {
             WebBeansModelImplementation modelImpl, TypeElement typeElement, AtomicBoolean cancel )
     {
         Set<TypeElement> result = new HashSet<TypeElement>();
-        ElementHandle<TypeElement> handle = ElementHandle
-                .create((TypeElement) typeElement);
+        ElementHandle<TypeElement> handle = ElementHandle.create(typeElement);
         ClassIndex classIndex = modelImpl
                 .getHelper().getClasspathInfo().getClassIndex();
         if(cancel.get()) {

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/InjectablesModel.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/InjectablesModel.java
@@ -248,9 +248,9 @@ public final class InjectablesModel extends DefaultTreeModel
                     .create(element), controller.getClasspathInfo());
             // Type declaration
             TypeTreeNode node = new TypeTreeNode(fileObject,
-                    (TypeElement) element, disabledBeans.contains( element),
+                    element, disabledBeans.contains( element),
                     controller);
-            insertTreeNode(elementMap, (TypeElement) element, node, root, 
+            insertTreeNode(elementMap, element, node, root, 
                     disabledBeans.contains(element), controller);
         }
         

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/xml/WebBeansModelFactory.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/xml/WebBeansModelFactory.java
@@ -46,7 +46,7 @@ public class WebBeansModelFactory extends AbstractModelFactory<WebBeansModel> {
     
     @Override
     public WebBeansModel getModel(ModelSource source) {
-        return (WebBeansModel) super.getModel(source);
+        return super.getModel(source);
     }
     
     private static final WebBeansModelFactory INSTANCE = new WebBeansModelFactory();

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/xml/impl/WebBeansComponentImpl.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/xml/impl/WebBeansComponentImpl.java
@@ -73,8 +73,7 @@ abstract class WebBeansComponentImpl extends
             for (int i = 0; i < nl.getLength(); i++) {
                 Node n = nl.item(i);
                 if (n instanceof Element) {
-                    WebBeansComponent comp = (WebBeansComponent) getModel().getFactory()
-                            .createComponent((Element) n, this);
+                    WebBeansComponent comp = getModel().getFactory().createComponent((Element) n, this);
                     if (comp != null) {
                         children.add(comp);
                     }

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebFreeFormActionProvider.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebFreeFormActionProvider.java
@@ -248,7 +248,7 @@ public class WebFreeFormActionProvider implements ActionProvider {
         if (properties != null) {
             Iterator<Element> propertiesIt = XMLUtil.findSubElements(properties).iterator();
             while (propertiesIt.hasNext()) {
-                Element el = (Element) propertiesIt.next();
+                Element el = propertiesIt.next();
                 Element nue = script.getOwnerDocument().createElement("property"); // NOI18N
                 if (el.getLocalName().equals("property")) { // NOI18N
                     String name = el.getAttribute("name"); // NOI18N
@@ -594,7 +594,7 @@ public class WebFreeFormActionProvider implements ActionProvider {
         } catch (DataObjectNotFoundException e) {
             throw new AssertionError(e);
         }
-        LineCookie lines = (LineCookie) fileDO.getCookie(LineCookie.class);
+        LineCookie lines = fileDO.getCookie(LineCookie.class);
         if (lines != null) {
             try {
                 lines.getLineSet().getCurrent(line).show(ShowOpenType.OPEN, ShowVisibilityType.FOCUS);
@@ -620,7 +620,7 @@ public class WebFreeFormActionProvider implements ActionProvider {
             throw new AssertionError(e);
         }
         
-        EditCookie edit = (EditCookie)fileDO.getCookie(EditCookie.class);
+        EditCookie edit = fileDO.getCookie(EditCookie.class);
         if (edit != null) {
             edit.edit();
         }
@@ -665,7 +665,7 @@ public class WebFreeFormActionProvider implements ActionProvider {
         Element foldersEl = XMLUtil.findElement(data, "folders", Util.NAMESPACE); // NOI18N
         if (foldersEl != null) {
             for (Iterator<Element> i = XMLUtil.findSubElements(foldersEl).iterator(); i.hasNext();) {
-                Element sourceFolderEl = (Element)i.next();
+                Element sourceFolderEl = i.next();
                 Element typeEl = XMLUtil.findElement(sourceFolderEl , "type", Util.NAMESPACE); // NOI18N
                 if (typeEl == null || !XMLUtil.findText(typeEl).equals(type))
                     continue;

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebModules.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebModules.java
@@ -152,7 +152,7 @@ public class WebModules implements WebModuleProvider, AntProjectListener, ClassP
         List<Element> webModules = XMLUtil.findSubElements(web);
         Iterator<Element> it = webModules.iterator();
         while (it.hasNext()) {
-            Element webModulesEl = (Element)it.next();
+            Element webModulesEl = it.next();
             assert webModulesEl.getLocalName().equals("web-module") : webModulesEl;
             FileObject docRootFO = getFile (webModulesEl, "doc-root"); //NOI18N
             Element j2eeSpecEl = XMLUtil.findElement (webModulesEl, "j2ee-spec-level", WebProjectNature.NS_WEB_2);

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebProjectGenerator.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebProjectGenerator.java
@@ -198,7 +198,7 @@ public class WebProjectGenerator {
             WebModule wm = new WebModule();
             Iterator<Element> it2 = XMLUtil.findSubElements(wmEl).iterator();
             while (it2.hasNext()) {
-                Element el = (Element)it2.next();
+                Element el = it2.next();
                 if (el.getLocalName().equals("doc-root")) { // NOI18N
                     wm.docRoot = XMLUtil.findText(el);
                     continue;

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/WebClasspathPanel.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/WebClasspathPanel.java
@@ -356,7 +356,7 @@ public class WebClasspathPanel extends javax.swing.JPanel implements HelpCtx.Pro
     public String getClasspath(){
         StringBuffer sf = new StringBuffer();
         for (int i = 1; i < listModel.getSize(); i++){
-            String path = (String)listModel.get(i);
+            String path = listModel.get(i);
             sf.append(path);
             if (i < listModel.getSize()-1)
                 sf.append(File.pathSeparatorChar);
@@ -385,7 +385,7 @@ public class WebClasspathPanel extends javax.swing.JPanel implements HelpCtx.Pro
                 AuxiliaryConfiguration aux = Util.getAuxiliaryConfiguration(projectHelper);
                 List<WebProjectGenerator.WebModule> l = WebProjectGenerator.getWebmodules(projectHelper, aux);
                 if (l != null){
-                    WebProjectGenerator.WebModule wm = (WebProjectGenerator.WebModule)l.get(0);
+                    WebProjectGenerator.WebModule wm = l.get(0);
                     wm.classpath = getClasspath();
                     WebProjectGenerator.putWebModules(projectHelper, aux, l);
                 }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/ConfigurationUtils.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/ConfigurationUtils.java
@@ -160,7 +160,7 @@ public class ConfigurationUtils {
                     files.add(file);
                 }
             }
-            return (FileObject[])files.toArray(new FileObject[files.size()]);
+            return files.toArray(new FileObject[files.size()]);
         }
         return new FileObject [0];
     }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/editor/JsfFacesComponentsProvider.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/editor/JsfFacesComponentsProvider.java
@@ -85,7 +85,7 @@ public class JsfFacesComponentsProvider {
                             // @FacesComponent to be used as a tag in the facelet can be defined by annotation only for now.
                             if (component instanceof ComponentImpl) {
                                 ComponentImpl facesComponent = (ComponentImpl) component;
-                                includeComponentIntoLibraries(libraries, (ComponentImpl) facesComponent);
+                                includeComponentIntoLibraries(libraries, facesComponent);
                             }
                         }
                         return libraries.values();

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/facesmodel/JSFConfigModelFactory.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/facesmodel/JSFConfigModelFactory.java
@@ -42,7 +42,7 @@ public class JSFConfigModelFactory extends AbstractModelFactory<JSFConfigModel>{
     }
     
     public JSFConfigModel getModel(ModelSource source) {
-        return (JSFConfigModel) super.getModel(source);
+        return super.getModel(source);
     }
     
     private static final JSFConfigModelFactory INSTANCE = new JSFConfigModelFactory();

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/dialogs/AddNavigationCaseDialog.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/dialogs/AddNavigationCaseDialog.java
@@ -50,7 +50,7 @@ public class AddNavigationCaseDialog extends javax.swing.JPanel implements Valid
         modelT.addElement("");
         Iterator<NavigationRule> iter = facesConfig.getNavigationRules().iterator();
         while (iter.hasNext()) {
-            String fromViewID=((NavigationRule)iter.next()).getFromViewId();
+            String fromViewID=iter.next().getFromViewId();
             if (fromViewID != null && fromViewID.trim().length() > 0){
                 modelF.addElement(fromViewID);
                 modelT.addElement(fromViewID);

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/JSFConfigurationPanelVisual.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/JSFConfigurationPanelVisual.java
@@ -1599,7 +1599,7 @@ private void serverLibrariesActionPerformed(java.awt.event.ActionEvent evt) {//G
         }
 
         private JSFComponentModelItem getItem(int index) {
-            return (JSFComponentModelItem) model.get(index);
+            return model.get(index);
         }
 
         public void addItem(JSFComponentModelItem item){

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/Controller.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/Controller.java
@@ -961,7 +961,7 @@ class Controller  {
             public void run() {
                 for (Iterator<FileObject> it = fileObjectsToDelete.iterator(); it.hasNext(); ) {
                     try {
-                        ((FileObject) it.next()).delete();
+                        it.next().delete();
                     } catch (IOException e) {
                         Logger.getLogger("global").log(Level.INFO, null, e);
                     }
@@ -972,7 +972,7 @@ class Controller  {
 	numtns = nodes.size();
  	tns = new TransactionNode[numtns]; 
 	for(int i=0;i<numtns;++i) 
-	    tns[i] = (TransactionNode)nodes.elementAt(i);
+	    tns[i] = nodes.elementAt(i);
 	currTrans.add(tns);
 
 
@@ -995,7 +995,7 @@ class Controller  {
 	numtns = nodes.size();
 	tns = new TransactionNode[numtns]; 
 	for(int i=0;i<numtns;++i) {
-	    tns[i] = (TransactionNode)nodes.elementAt(i);
+	    tns[i] = nodes.elementAt(i);
 	    if(debug) 
 		log("Adding saved node" + tns[i].toString()); //NOI18N 
 		    

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/DisplayTableSorter.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/DisplayTableSorter.java
@@ -72,7 +72,7 @@ public class DisplayTableSorter extends AbstractTableModel implements
 	}
 
 	resetIndices();
-	sort((int[])index.clone(), index, 0, index.length);
+	sort(index.clone(), index, 0, index.length);
 	 
 	if(debug) {
 	    StringBuffer buf = 
@@ -119,7 +119,6 @@ public class DisplayTableSorter extends AbstractTableModel implements
 
     public int compare(int row1, int row2) {
 
-	 
 	String str1 = (String)model.getValueAt(row1, 0);
 	String str2 = (String)model.getValueAt(row2, 0);
 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/EditPanel.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/EditPanel.java
@@ -119,7 +119,7 @@ class EditPanel extends javax.swing.JPanel implements
 	MonitorData md = null;	    
         // We retrieve the data from the file system, not from the 
         // cache
-        md = Controller.getInstance().getMonitorData((TransactionNode)node, 
+        md = Controller.getInstance().getMonitorData(node, 
                                                      false,  // from file
                                                      false); // don't cache
         if (md == null) {

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/TransactionView.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/TransactionView.java
@@ -587,7 +587,7 @@ class TransactionView extends TopComponent implements ExplorerManager.Provider,
 	splitPanel.setDividerLocation((int)(logD.getWidth()));
 
 	try { 
-	    Container o = (Container)this.getParent(); 
+	    Container o = this.getParent(); 
 	    while(true) { 
 		if(o instanceof JFrame) { 
 		    JFrame parent = (JFrame)o; 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/RequestData.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/RequestData.java
@@ -294,7 +294,7 @@ public class RequestData extends BaseBean {
 	int numCookies = cookies.size();
 	Param[] params = new Param[numCookies]; 
 	for(int k=0; k<numCookies; ++k) 
-	    params[k] = (Param)cookies.elementAt(k);
+	    params[k] = cookies.elementAt(k);
 	
 	return params;
     }

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/ReflectionHelper.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/ReflectionHelper.java
@@ -697,7 +697,7 @@ public class ReflectionHelper {
                  */
                 Class classToAdd = null;
                 if (null != parameterList && ii < parameterList.size()) {
-                    JavaParameter actualParameter = (JavaParameter) parameterList.get(ii);
+                    JavaParameter actualParameter = parameterList.get(ii);
                     String formalName = actualParameter.getType().getFormalName();
                     if (isPrimitiveClass(formalName)) {
                         classToAdd = referenceClass2PrimitiveClass(paramValues[ii].getClass());

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/client/RESTExplorerPanel.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/client/RESTExplorerPanel.java
@@ -191,8 +191,7 @@ public class RESTExplorerPanel extends JPanel implements ExplorerManager.Provide
          */
         @Override
         public Node createNode( Project project ) {
-            LogicalViewProvider logicalProvider = (LogicalViewProvider)project.
-                getLookup().lookup(LogicalViewProvider.class);
+            LogicalViewProvider logicalProvider = project.getLookup().lookup(LogicalViewProvider.class);
             if (logicalProvider!=null) {
                 Node rootNode = logicalProvider.createLogicalView();
                 Node restResourcesNode = RESTResourcesView.

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/nodes/OpenCookieFactory.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/nodes/OpenCookieFactory.java
@@ -98,13 +98,11 @@ public class OpenCookieFactory {
                             
                             @Override
                             public void run() {
-                                OpenCookie oc = (OpenCookie) dataObj.getCookie(
-                                        OpenCookie.class);
+                                OpenCookie oc = dataObj.getCookie(OpenCookie.class);
                                 if (oc != null) {
                                     oc.open();
                                 }
-                                LineCookie lc = (LineCookie) dataObj.getCookie(
-                                        LineCookie.class);
+                                LineCookie lc = dataObj.getCookie(LineCookie.class);
                                 if (lc != null) {
                                     Line line = lc.getLineSet().getOriginal(
                                             (int) position[0]);

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/JavaSourceHelper.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/JavaSourceHelper.java
@@ -637,7 +637,7 @@ public class JavaSourceHelper {
         List<ExpressionTree> typeArgTrees = new ArrayList<ExpressionTree>();
 
         for (String arg : typeArgs) {
-            typeArgTrees.add((ExpressionTree) createTypeTree(copy, arg));
+            typeArgTrees.add(createTypeTree(copy, arg));
         }
 
         return maker.ParameterizedType(typeTree, typeArgTrees);

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java
@@ -79,7 +79,7 @@ public class SourceGroupSupport {
                 result.add(sourceGroups[i]);
             }
         }
-        return (SourceGroup[]) result.toArray(new SourceGroup[result.size()]);
+        return result.toArray(new SourceGroup[result.size()]);
     }
 
     public static boolean isValidPackageName(String packageName) {
@@ -197,7 +197,7 @@ public class SourceGroupSupport {
         List<SourceGroup> result = new ArrayList<>();
         List<FileObject> sourceRoots = getFileObjects(rootURLs, true);
         for (int i = 0; i < sourceRoots.size(); i++) {
-            FileObject sourceRoot = (FileObject) sourceRoots.get(i);
+            FileObject sourceRoot = sourceRoots.get(i);
             SourceGroup srcGroup = (SourceGroup) foldersToSourceGroupsMap.get(sourceRoot);
             if (srcGroup != null) {
                 result.add(srcGroup);

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/TestRestTargetPanel.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/TestRestTargetPanel.java
@@ -226,8 +226,7 @@ public class TestRestTargetPanel extends javax.swing.JPanel {
          */
         @Override
         public Node createNode( Project project ) {
-            LogicalViewProvider logicalProvider = (LogicalViewProvider)project.
-                getLookup().lookup(LogicalViewProvider.class);
+            LogicalViewProvider logicalProvider = project.getLookup().lookup(LogicalViewProvider.class);
             RestSupport support = project.getLookup().lookup(RestSupport.class);
             SourceGroup[] sourceGroups = ProjectUtils.getSources(project).
                 getSourceGroups(WebProjectConstants.TYPE_DOC_ROOT);

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/Utils.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/Utils.java
@@ -105,13 +105,13 @@ public class Utils {
             
             // Force a save to make sure to make sure the line position in
             // the editor is in sync with the java source.
-            SaveCookie sc = (SaveCookie) dataObj.getCookie(SaveCookie.class);
+            SaveCookie sc = dataObj.getCookie(SaveCookie.class);
      
             if (sc != null) {
                 sc.save();
             }
             
-            LineCookie lc = (LineCookie) dataObj.getCookie(LineCookie.class);
+            LineCookie lc = dataObj.getCookie(LineCookie.class);
             
             if (lc != null) {
                 final long[] position = JavaSourceHelper.getPosition(javaSource, methodName);

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/wizard/PatternResourcesSetupPanel.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/wizard/PatternResourcesSetupPanel.java
@@ -237,7 +237,7 @@ final class PatternResourcesSetupPanel extends AbstractPanel {
 
         @Override
         public boolean valid(WizardDescriptor wizard) {
-            boolean isValid = ((AbstractPanel.Settings)mainPanel).valid(wizard);
+            boolean isValid = mainPanel.valid(wizard);
             if ( isValid && hasJaxRsConfigurationPanel() ){
                 return jaxRsConfigurationPanel.valid(wizard);
             }

--- a/extide/gradle/src/org/netbeans/modules/gradle/customizer/BuildActionsCustomizer.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/customizer/BuildActionsCustomizer.java
@@ -531,7 +531,7 @@ public class BuildActionsCustomizer extends javax.swing.JPanel {
             // try to insert at the same position:
             List<String> items = new ArrayList<>();
             for (int i = 1; i < availableActionsModel.getSize(); i++) {
-                items.add((String)availableActionsModel.getElementAt(i));
+                items.add(availableActionsModel.getElementAt(i));
             }
             items.add(action);
             Collections.sort(items);

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/PathFinderVisitor.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/PathFinderVisitor.java
@@ -790,7 +790,7 @@ public class PathFinderVisitor extends ClassCodeVisitorSupport {
                 List<Statement> statements = block.getStatements();
                 if (statements != null && !statements.isEmpty()) {
                     if (code.getLineNumber() < 0 && code.getColumnNumber() < 0) {
-                        Statement first = (Statement) statements.get(0);
+                        Statement first = statements.get(0);
                         code.setLineNumber(first.getLineNumber());
                         code.setColumnNumber(first.getColumnNumber());
                     }

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/actions/singlefilerun/JPDAStart.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/actions/singlefilerun/JPDAStart.java
@@ -83,7 +83,7 @@ public class JPDAStart implements Runnable {
                 ListeningConnector lc = null;
                 Iterator<ListeningConnector> i = Bootstrap.virtualMachineManager().listeningConnectors().iterator();
                 for (; i.hasNext();) {
-                    lc = (ListeningConnector) i.next();
+                    lc = i.next();
                     Transport t = lc.transport();
                     if (t != null && t.name().equals(getTransport())) {
                         break;

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/AddQueryParameterDlg.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/AddQueryParameterDlg.java
@@ -151,9 +151,9 @@ public class AddQueryParameterDlg extends JPanel {
 
         // Append criterion value or parameter
         if ( parmRadioBtn.isSelected() ) {
-            criteriaStringBuffer.append ((String) parmTxtField.getText());
+            criteriaStringBuffer.append(parmTxtField.getText());
         } else if ( valueRadioBtn.isSelected() )
-            criteriaStringBuffer.append ((String) valueTxtField.getText());
+            criteriaStringBuffer.append(valueTxtField.getText());
 
         /* Ask Jeff how to handle this ?
            criteriaStringBuffer.append ((String) defaultValTxtField.getText());

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilder.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilder.java
@@ -792,7 +792,7 @@ public class QueryBuilder extends TopComponent
                 List<Column> fromColumns = new ArrayList<>();
                 ( (JoinTable) fromTables.get(i) ).getReferencedColumns(fromColumns);
                 for ( int j = 0; j < fromColumns.size(); j++ ) {
-                    Column fromColumn = (Column) fromColumns.get(j);
+                    Column fromColumn = fromColumns.get(j);
                     if (! checkTableColumnName( fromColumn)) {
                         showTableColumnNameError(  fromColumn.getColumnName() );
                         return false;
@@ -892,7 +892,7 @@ public class QueryBuilder extends TopComponent
     private boolean checkColumns(List<Column> columns)  throws SQLException {
 	Log.getLogger().entering("QueryBuilder", "checkColumns"); // NOI18N
         for ( int i = 0; i < columns.size(); i++ ) {
-            Column column = (Column) columns.get(i);
+            Column column = columns.get(i);
             String columnTableSpec = column.getTableSpec();
             String columnFullTableName = column.getFullTableName();
 
@@ -1147,7 +1147,7 @@ public class QueryBuilder extends TopComponent
                 String[] values = new String[list.size()];
 
                 for (int i = 0; i < parameters.length; i++) {
-                    parameters[i] = new String((String) list.get(i));
+                    parameters[i] = new String(list.get(i));
                 }
                 ParameterizedQueryDialog pqDlg =
 		    new ParameterizedQueryDialog( parameters, true);

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryModel.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryModel.java
@@ -208,7 +208,7 @@ class QueryModel {
         List<Column> columns = new ArrayList<>();
         _query.getSelect().getReferencedColumns(columns);
         for (int i=0; i<columns.size(); i++) {
-            Column col = (Column)columns.get(i);
+            Column col = columns.get(i);
             if (col.matches(tableSpec, columnName))
                 return col;
         }

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/FromNode.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/FromNode.java
@@ -143,7 +143,7 @@ public class FromNode implements From {
 
     public String getFullTableName(String corrName) {
         for (int i=0; i<_tableList.size(); i++) {
-            JoinTable jt = (JoinTable) _tableList.get(i);
+            JoinTable jt = _tableList.get(i);
             String cn=jt.getTableSpec();
             if ((cn!=null) && (cn.equals(corrName)))
                 return jt.getFullTableName();
@@ -153,7 +153,7 @@ public class FromNode implements From {
 
     public String getTableSpec(String fullTableName) {
         for (int i=0; i<_tableList.size(); i++) {
-            JoinTable jt = (JoinTable) _tableList.get(i);
+            JoinTable jt = _tableList.get(i);
             String cn=jt.getFullTableName();
             if ((cn!=null) && (cn.equals(fullTableName)))
                 return jt.getTableSpec();

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/OrderByNode.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/OrderByNode.java
@@ -53,11 +53,11 @@ public class OrderByNode implements OrderBy {
         String res = "";    // NOI18N
         if (_sortSpecificationList != null && _sortSpecificationList.size() > 0) {
 
-            res = " ORDER BY " + ((SortSpecification)_sortSpecificationList.get(0)).genText(quoter);  // NOI18N
+            res = " ORDER BY " + _sortSpecificationList.get(0).genText(quoter);  // NOI18N
 
             for (int i=1; i<_sortSpecificationList.size(); i++) {
                 res += ", " + "                    " +    // NOI18N
-                  ((SortSpecification)_sortSpecificationList.get(i)).genText(quoter);
+                  _sortSpecificationList.get(i).genText(quoter);
             }
         }
 
@@ -73,14 +73,14 @@ public class OrderByNode implements OrderBy {
     void renameTableSpec(String oldTableSpec, String corrName) {
         if (_sortSpecificationList != null) {
             for (int i=0; i<_sortSpecificationList.size(); i++)
-                ((SortSpecification)_sortSpecificationList.get(i)).renameTableSpec(oldTableSpec, corrName);
+                _sortSpecificationList.get(i).renameTableSpec(oldTableSpec, corrName);
         }
     }
 
     public void removeSortSpecification(String tableSpec) {
         if (_sortSpecificationList != null) {
             for (int i=0; i<_sortSpecificationList.size(); i++) {
-                ColumnNode col = (ColumnNode)((SortSpecification)_sortSpecificationList.get(i)).getColumn();
+                ColumnNode col = (ColumnNode)_sortSpecificationList.get(i).getColumn();
                 if (col.getTableSpec().equals(tableSpec))
                 {
                     _sortSpecificationList.remove(i);
@@ -96,7 +96,7 @@ public class OrderByNode implements OrderBy {
     public void removeSortSpecification(String tableSpec, String columnName) {
         if (_sortSpecificationList != null) {
             for (int i=0; i<_sortSpecificationList.size(); i++) {
-                ColumnNode col = (ColumnNode)((SortSpecification)_sortSpecificationList.get(i)).getColumn();
+                ColumnNode col = (ColumnNode)_sortSpecificationList.get(i).getColumn();
                 if (col.matches(tableSpec, columnName))
                 {
                     _sortSpecificationList.remove(i);
@@ -122,13 +122,13 @@ public class OrderByNode implements OrderBy {
     }
 
     public SortSpecification getSortSpecification(int i) {
-        return (_sortSpecificationList != null) ? ((SortSpecification)_sortSpecificationList.get(i)) : null;
+        return (_sortSpecificationList != null) ? _sortSpecificationList.get(i) : null;
     }
 
     public void  getReferencedColumns (Collection columns) {
         if (_sortSpecificationList != null) {
             for (int i = 0; i < _sortSpecificationList.size(); i++)
-                ((SortSpecification)_sortSpecificationList.get(i)).getReferencedColumns(columns);
+                _sortSpecificationList.get(i).getReferencedColumns(columns);
         }
     }
 

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/QueryNode.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/QueryNode.java
@@ -183,7 +183,7 @@ public class QueryNode implements Query {
                 String tableName=tbl.getTableName();
                 String schemaName=tbl.getSchemaName();
                 for (int j=0; j<columnNames.size(); j++) {
-                    String columnName = (String) columnNames.get(j);
+                    String columnName = columnNames.get(j);
                     columns.add(new ColumnNode(tableName, columnName, corrName, schemaName));
                 }
             }

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/WhereNode.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/WhereNode.java
@@ -86,7 +86,7 @@ public class WhereNode implements Where {
             List<Column> column = new ArrayList<>();
             _cond.getReferencedColumns(column);
             for (int i = 0; i < column.size(); i++) {
-                Column col = (Column)column.get(i);
+                Column col = column.get(i);
                 if (col.matches(tableSpec)) {
                     _cond = null;
                 }

--- a/ide/db/src/org/netbeans/modules/db/explorer/action/GrabTableHelper.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/action/GrabTableHelper.java
@@ -135,8 +135,7 @@ public class GrabTableHelper {
         Map cprops = connector.getDatabaseSpecification().getCommandProperties(
                 Specification.CREATE_TABLE);
         Map<String, String> bindmap = (Map) cprops.get("Binding");                     // NOI18N
-        String tname = (String) bindmap.get(TableColumn.COLUMN);
-        column.setFormat((String) ((Map) props.get(tname)).get(
-                "Format"));                                             //NOI18N
+        String tname = bindmap.get(TableColumn.COLUMN);
+        column.setFormat((String)props.get(tname).get( "Format"));                     //NOI18N
     }
 }

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
@@ -571,7 +571,7 @@ public final class AddDriverDialog extends javax.swing.JPanel {
 
                 for (int i = 0; i < dlm.size(); i++) {
                     try {
-                        String file  = (String)dlm.get(i);
+                        String file  = dlm.get(i);
                         JarFile jf = new JarFile(file);
                         try {
                             Enumeration entries = jf.entries();

--- a/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatter.java
+++ b/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatter.java
@@ -176,7 +176,7 @@ public class ExtFormatter extends Formatter implements FormatLayer {
     public synchronized boolean replaceFormatLayer(String layerName, FormatLayer layer) {
         int cnt = formatLayerList.size();
         for (int i = 0; i < cnt; i++) {
-            if (layerName.equals(((FormatLayer)formatLayerList.get(i)).getName())) {
+            if (layerName.equals(formatLayerList.get(i).getName())) {
                 formatLayerList.set(i, layer);
                 return true;
             }

--- a/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/CaretFoldExpanderImpl.java
+++ b/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/CaretFoldExpanderImpl.java
@@ -59,7 +59,7 @@ public final class CaretFoldExpanderImpl extends CaretFoldExpander {
                     Fold lastFold;
                     boolean lastFoldExpandAdded = false;
                     if (collapsedFoldIterator.hasNext()) {
-                        lastFold = (Fold) collapsedFoldIterator.next();
+                        lastFold = collapsedFoldIterator.next();
                         foldsToExpand = new ArrayList<>(2);
                     } else {
                         lastFold = null;
@@ -71,7 +71,7 @@ public final class CaretFoldExpanderImpl extends CaretFoldExpander {
                             if (offset >= lastFold.getEndOffset()) {
                                 // Fetch next fold
                                 if (collapsedFoldIterator.hasNext()) {
-                                    lastFold = (Fold) collapsedFoldIterator.next();
+                                    lastFold = collapsedFoldIterator.next();
                                     lastFoldExpandAdded = false;
                                 } else {
                                     break;
@@ -108,7 +108,7 @@ public final class CaretFoldExpanderImpl extends CaretFoldExpander {
             int offset = c.viewToModel(p);
             Iterator<Fold> collapsedFoldIterator = FoldUtilities.collapsedFoldIterator(foldHierarchy, offset, offset);
             if (collapsedFoldIterator.hasNext()) {
-                Fold fold = (Fold) collapsedFoldIterator.next();
+                Fold fold = collapsedFoldIterator.next();
                 // Expand even if the offset is at fold's begining/end because that's what viewToModel() will return
                 if (offset >= fold.getStartOffset() && offset <= fold.getEndOffset()) {
                     foldHierarchy.expand(fold);

--- a/ide/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/TableSorter.java
+++ b/ide/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/TableSorter.java
@@ -132,7 +132,7 @@ public class TableSorter extends AbstractTableModel {
 
     private Directive getDirective(int column) {
         for (int i = 0; i < sortingColumns.size(); i++) {
-            Directive directive = (Directive) sortingColumns.get(i);
+            Directive directive = sortingColumns.get(i);
             if (directive.column == column) {
                 return directive;
             }
@@ -197,7 +197,7 @@ public class TableSorter extends AbstractTableModel {
 
     protected Comparator getComparator(int column) {
         Class columnType = tableModel.getColumnClass(column);
-        Comparator comparator = (Comparator) columnComparators.get(columnType);
+        Comparator comparator = columnComparators.get(columnType);
         if (comparator != null) {
             return comparator;
         }

--- a/ide/project.ant/src/org/netbeans/spi/project/support/ant/ReferenceHelper.java
+++ b/ide/project.ant/src/org/netbeans/spi/project/support/ant/ReferenceHelper.java
@@ -1707,7 +1707,7 @@ public final class ReferenceHelper {
             }
             String[] values = new String[6];
             for (int i = 0; i < 6; i++) {
-                Element el = (Element)nl.get(i);
+                Element el = nl.get(i);
                 if (!REFS_NS2.equals(el.getNamespaceURI())) {
                     throw new IllegalArgumentException("bad subelement ns: " + el); // NOI18N
                 }
@@ -1727,7 +1727,7 @@ public final class ReferenceHelper {
             }
             Properties props = new Properties();
             if (nl.size() == 7) {
-                Element el = (Element)nl.get(6);
+                Element el = nl.get(6);
                 if (!REFS_NS2.equals(el.getNamespaceURI())) {
                     throw new IllegalArgumentException("bad subelement ns: " + el); // NOI18N
                 }

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/ContentModel.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/ContentModel.java
@@ -102,9 +102,9 @@ abstract class ContentModel {
         // create models
 
         if (type == '|') {
-            model = new Choice((ContentModel[])models.toArray(new ContentModel[0]));
+            model = new Choice(models.toArray(new ContentModel[0]));
         } else if (type == ',') {
-            model = new Sequence((ContentModel[])models.toArray(new ContentModel[0]));
+            model = new Sequence(models.toArray(new ContentModel[0]));
         } else {
             // note model contains last Element
         }
@@ -133,7 +133,7 @@ abstract class ContentModel {
             if(models.size() == 1) {
                 //there is just one model inside (the mentioned case)
                 //so we can return it
-                return (ContentModel)models.get(0);
+                return models.get(0);
             }
         }
 
@@ -586,7 +586,7 @@ abstract class ContentModel {
             if (hasNext() == false) {
                 throw new IllegalStateException();
             } else {
-                String next  = (String) list.get(current);
+                String next  = list.get(current);
                 current++;
                 return next;
             }

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
@@ -205,7 +205,7 @@ class DTDGrammar implements ExtendedGrammarQuery {
             }
             // simple fallback
             if (elements == null) {
-                elements = (Set) elementDecls.get(el.getTagName());
+                elements = elementDecls.get(el.getTagName());
             }
         } else if (node instanceof Document) {
             elements = elementDecls.keySet();  //??? should be one from DOCTYPE if exist
@@ -267,14 +267,14 @@ class DTDGrammar implements ExtendedGrammarQuery {
             
             String elementName = element.getNodeName();
             String key = elementName + " " + attributeName;
-            List values = (List) attrEnumerations.get(key);
+            List values = attrEnumerations.get(key);
             if (values == null) return org.openide.util.Enumerations.empty();
             
             String prefix = ctx.getCurrentPrefix();
             LinkedList en = new LinkedList ();
             Iterator<String> it = values.iterator();
             while (it.hasNext()) {
-                String next = (String) it.next();
+                String next = it.next();
                 if (next.startsWith(prefix)) {
                     en.add(new MyText(next, next));
                 }
@@ -302,7 +302,7 @@ class DTDGrammar implements ExtendedGrammarQuery {
             String elementName = element.getNodeName();
             String attributeName = attr.getNodeName();
             String key = elementName + " " + attributeName;                 // NOI18N
-            String def = (String) defaultAttributeValues.get(key);
+            String def = defaultAttributeValues.get(key);
             if (def == null) return null;
             return new MyText(def, def);
         }

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionNodeView.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionNodeView.java
@@ -108,7 +108,7 @@ public abstract class SectionNodeView extends SectionView {
     }
 
     public SectionNode retrieveSectionNode(SectionNode node) {
-        SectionNode sectionNode = (SectionNode) nodes.get(node);
+        SectionNode sectionNode = nodes.get(node);
         return sectionNode == null ? rootNode : sectionNode;
     }
 

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionView.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionView.java
@@ -86,7 +86,7 @@ public class SectionView extends PanelView implements SectionFocusCookie, Contai
     }
     
     protected void openSection(Node node){
-        NodeSectionPanel panel = (NodeSectionPanel) map.get(node);
+        NodeSectionPanel panel = map.get(node);
         if (panel != null) {
             focusSection(panel);
         }
@@ -122,7 +122,7 @@ public class SectionView extends PanelView implements SectionFocusCookie, Contai
      * @return the corresponding panel or null.
      */
     public NodeSectionPanel getSection(Node key){
-        return (NodeSectionPanel)map.get(key);
+        return map.get(key);
     }
     
     /**
@@ -281,7 +281,7 @@ public class SectionView extends PanelView implements SectionFocusCookie, Contai
     public SectionPanel findSectionPanel(Object key) {
         java.util.Enumeration en = map.keys();
         while (en.hasMoreElements()) {
-            NodeSectionPanel pan = (NodeSectionPanel)map.get(en.nextElement());
+            NodeSectionPanel pan = map.get(en.nextElement());
             if (pan instanceof SectionPanel) {
                 SectionPanel p = (SectionPanel)pan;
                 if (key==p.getKey()) {

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreePanelView.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreePanelView.java
@@ -57,7 +57,7 @@ public class TreePanelView extends PanelView {
     
     protected void showPanel(TreeNode node) {
         String panelId = node.getPanelId();
-        TreePanel treePanel = (TreePanel)map.get(panelId);
+        TreePanel treePanel = map.get(panelId);
         if (treePanel==null) {
             treePanel = node.getPanel();
             map.put(panelId,treePanel);

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
@@ -149,7 +149,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
         short acceptPolicy = acceptRadioButton.isSelected() ?
             TreeNodeFilter.ACCEPT_TYPES :
             TreeNodeFilter.REJECT_TYPES;
-        Class[] nodeTypes = (Class[])nodeTypesList.toArray (new Class[0]);
+        Class[] nodeTypes = nodeTypesList.toArray(new Class[0]);
 
         return new TreeNodeFilter (nodeTypes, acceptPolicy);
     }
@@ -383,7 +383,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
 	/**
 	 */
         public Object getValueAt (int row, int column) {
-            Object retVal = new Item (new NamedClass ((Class)nodeTypesList.get (row)));
+            Object retVal = new Item (new NamedClass (nodeTypesList.get (row)));
 
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("<-- getValue: row    = " + row); // NOI18N
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("<-- getValue: column = " + column); // NOI18N
@@ -468,7 +468,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
         /**
          */
         public String toString () {
-            String name = (String)publicNodeTypeNamesMap.get (clazz);
+            String name = publicNodeTypeNamesMap.get (clazz);
 
             if ( name == null ) {
                 name = clazz.getName();

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookieImpl.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookieImpl.java
@@ -335,7 +335,7 @@ public class TreeEditorCookieImpl implements TreeEditorCookie, UpdateDocumentCoo
             
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("PARSING: " + input.getSystemId()); // NOI18N
 
-            TreeDocumentRoot doc = (TreeDocumentRoot) parser.parse(input);
+            TreeDocumentRoot doc = parser.parse(input);
             
             annotation = Util.THIS.getString ("MSG_Unexpected_exception_in_merge");
             setTreeAndStatus (doc, STATUS_OK);
@@ -418,7 +418,7 @@ public class TreeEditorCookieImpl implements TreeEditorCookie, UpdateDocumentCoo
     // it MUST respect synchronization atomicity
     public void updateDocumentRoot() {
 
-        TreeDocumentCookie cookie = (TreeDocumentCookie) xmlDO.getCookie(TreeDocumentCookie.class);
+        TreeDocumentCookie cookie = xmlDO.getCookie(TreeDocumentCookie.class);
         if (cookie != null && cookie.getDocumentRoot() != null) {
             Task task = new Task( new Runnable() {
                 public void run() {

--- a/ide/xml/src/org/netbeans/modules/xml/actions/CollectSystemAction.java
+++ b/ide/xml/src/org/netbeans/modules/xml/actions/CollectSystemAction.java
@@ -120,7 +120,7 @@ public abstract class CollectSystemAction extends SystemAction implements Presen
 
         Iterator<SystemAction> it = coll.iterator();
         while (it.hasNext ()) {
-            SystemAction a = (SystemAction) it.next();
+            SystemAction a = it.next();
             
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug (
                 "-*- CollectSystemAction.createMenu: next action " + a +

--- a/ide/xml/src/org/netbeans/modules/xml/sync/SyncSupport.java
+++ b/ide/xml/src/org/netbeans/modules/xml/sync/SyncSupport.java
@@ -190,7 +190,7 @@ public abstract class SyncSupport {
             }
             
             if (modified.size() > 1) {
-                master = selectMasterRepresentation((Representation[])modified.toArray(new Representation[0]));
+                master = selectMasterRepresentation(modified.toArray(new Representation[0]));
             }
 
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("\t" + System.identityHashCode(this) + " master: " + master); // NOI18N

--- a/ide/xsl/src/org/netbeans/modules/xsl/grammar/ResultNode.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/grammar/ResultNode.java
@@ -239,7 +239,7 @@ public class ResultNode implements Node {
         }
         
         public Node item(int index) {
-            return (Node)nodeVector.elementAt(index);
+            return nodeVector.elementAt(index);
         }
     }
     

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
@@ -852,7 +852,7 @@ public class AntDebugger extends ActionsProviderSupport {
             if (ll == null) {
                 continue;
             }
-            TargetOriginating to = (TargetOriginating) ll.getLast();
+            TargetOriginating to = ll.getLast();
             if (to.getOriginatingTarget() == null) {
                 to.setOriginatingTarget(t);
             } else {
@@ -907,12 +907,12 @@ public class AntDebugger extends ActionsProviderSupport {
             }
             nameToTargetByFiles.put(file, nameToTarget);
         }
-        TargetLister.Target target = (TargetLister.Target) nameToTarget.get(name);
+        TargetLister.Target target = nameToTarget.get(name);
         if (target == null) {
-            String projName = (String) projectNamesByFiles.get(file);
+            String projName = projectNamesByFiles.get(file);
             if (name.startsWith(projName+".")) {
                 name = name.substring(projName.length() + 1);
-                target = (TargetLister.Target) nameToTarget.get(name);
+                target = nameToTarget.get(name);
             }
         }
         return target;

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
@@ -297,12 +297,12 @@ public class DebuggerAntLogger extends AntLogger {
     private void finishDebugging (
         AntDebugger debugger
     ) {
-        AntSession session = (AntSession) runningDebuggers2.remove (debugger);
+        AntSession session = runningDebuggers2.remove (debugger);
         runningDebuggers.remove (session);
     }
     
     private AntDebugger getDebugger (AntSession s, AntEvent antEvent) {
-        AntDebugger d = (AntDebugger) runningDebuggers.get (s);
+        AntDebugger d = runningDebuggers.get(s);
         if (d != null) return d;
         
         if (!filesToDebug.contains (s.getOriginatingScript ())) 

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointAnnotationListener.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointAnnotationListener.java
@@ -99,13 +99,9 @@ implements PropertyChangeListener {
     }
     
     private void removeAnnotation (Breakpoint b) {
-        DebuggerBreakpointAnnotation annotation = (DebuggerBreakpointAnnotation) 
-            breakpointToAnnotation.remove (b);
+        DebuggerBreakpointAnnotation annotation = breakpointToAnnotation.remove(b);
         if (annotation == null) return;
         annotation.detach ();
-        b.removePropertyChangeListener (
-            Breakpoint.PROP_ENABLED, 
-            this
-        );
+        b.removePropertyChangeListener(Breakpoint.PROP_ENABLED, this);
     }
 }

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointsReader.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointsReader.java
@@ -77,7 +77,7 @@ public class BreakpointsReader implements Properties.Reader {
     @Override
     public void write (Object object, Properties properties) {
         AntBreakpoint b = (AntBreakpoint) object;
-        FileObject fo = (FileObject) b.getLine ().getLookup ().
+        FileObject fo = b.getLine().getLookup().
             lookup (FileObject.class);
             properties.setString("url", fo.toURL().toString());
             properties.setInt (

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/PersistenceManager.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/PersistenceManager.java
@@ -141,7 +141,7 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
             if (bs[i] instanceof AntBreakpoint)
                 bb.add (bs [i]);
         bs = new Breakpoint [bb.size ()];
-        return (Breakpoint[]) bb.toArray (bs);
+        return bb.toArray(bs);
     }
 }
 

--- a/java/beans/src/org/netbeans/modules/beans/IdxPropertyPatternPanel.java
+++ b/java/beans/src/org/netbeans/modules/beans/IdxPropertyPatternPanel.java
@@ -627,7 +627,7 @@ public final class IdxPropertyPatternPanel extends javax.swing.JPanel
                 String type = st.nextToken().trim();
                 l.add(type);
             }
-            TYPES = (String[]) l.toArray(new String[l.size()]);
+            TYPES = l.toArray(new String[l.size()]);
         }
         return TYPES;
     }

--- a/java/beans/src/org/netbeans/modules/beans/PropertyPatternPanel.java
+++ b/java/beans/src/org/netbeans/modules/beans/PropertyPatternPanel.java
@@ -524,7 +524,7 @@ public final class PropertyPatternPanel extends javax.swing.JPanel
                 String type = st.nextToken().trim();
                 l.add(type);
             }
-            TYPES = (String[]) l.toArray(new String[l.size()]);
+            TYPES = l.toArray(new String[l.size()]);
         }
         return TYPES;
     }

--- a/java/dbschema/src/org/netbeans/modules/dbschema/SchemaElement.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/SchemaElement.java
@@ -172,7 +172,7 @@ public class SchemaElement extends DBElement implements Node.Cookie {
             return se;
         else
             synchronized (schemaCache) {
-                se = (SchemaElement) schemaCache.get(name);
+                se = schemaCache.get(name);
                 if (se != null)
                     return se;
                 

--- a/java/dbschema/src/org/netbeans/modules/dbschema/SchemaElementUtil.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/SchemaElementUtil.java
@@ -61,9 +61,9 @@ public class SchemaElementUtil {
                     tempURL = schemaFO.toURL().toString();
                 
                 if (schemaFO == null)
-                    se = (SchemaElement) SchemaElement.schemaCache.get(name);
+                    se = SchemaElement.schemaCache.get(name);
                 else
-                    se = (SchemaElement) SchemaElement.schemaCache.get(name + "#" + tempURL); //NOI18N
+                    se = SchemaElement.schemaCache.get(name + "#" + tempURL); //NOI18N
                 if (se != null)
                     return se;
 

--- a/java/dbschema/src/org/netbeans/modules/dbschema/TableElement.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/TableElement.java
@@ -398,7 +398,7 @@ public final class TableElement extends DBElement implements ColumnElementHolder
 
 		int count = keys.size();
 
-		return ((ForeignKeyElement[]) keys.toArray(new ForeignKeyElement[count]));
+		return (keys.toArray(new ForeignKeyElement[count]));
 	}
 
 	/** Finds a foreign key by name.
@@ -428,7 +428,7 @@ public final class TableElement extends DBElement implements ColumnElementHolder
 		if (keys == null)
             return null;
 
-		return ((UniqueKeyElement[]) keys.toArray(new UniqueKeyElement[keys.size()]));
+		return (keys.toArray(new UniqueKeyElement[keys.size()]));
 	}
 
 	/** Finds a unique key by name.

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ForeignKeyElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/ForeignKeyElementImpl.java
@@ -44,7 +44,7 @@ public class ForeignKeyElementImpl  extends KeyElementImpl implements ForeignKey
   
     public ColumnPairElement[] getColumnPairs() {
         DBElement[] dbe = getColumnCollection().getElements();
-        return (ColumnPairElement[]) Arrays.asList(dbe).toArray(new ColumnPairElement[dbe.length]);
+        return Arrays.asList(dbe).toArray(new ColumnPairElement[dbe.length]);
     }
     
     public ColumnPairElement getColumnPair(DBIdentifier name) {

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/IndexElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/IndexElementImpl.java
@@ -84,7 +84,7 @@ public class IndexElementImpl extends DBMemberElementImpl implements IndexElemen
      */
     public ColumnElement[] getColumns() {
         DBElement[] dbe = columns.getElements();
-        return (ColumnElement[]) Arrays.asList(dbe).toArray(new ColumnElement[dbe.length]);
+        return Arrays.asList(dbe).toArray(new ColumnElement[dbe.length]);
     }
   
     /** Find a column by name.

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/KeyElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/KeyElementImpl.java
@@ -65,7 +65,7 @@ public abstract class KeyElementImpl extends DBMemberElementImpl implements KeyE
      */
     public ColumnElement[] getColumns() {
         DBElement[] dbe = columns.getElements();
-        return (ColumnElement[]) Arrays.asList(dbe).toArray(new ColumnElement[dbe.length]);
+        return Arrays.asList(dbe).toArray(new ColumnElement[dbe.length]);
     }
   
     /** Find a column by name.

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -609,8 +609,8 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                                     else
                                         fkName = fkName.trim();
 //                                    schemas = ((rset.get(new Integer(6)) == rset.get(new Integer(2))) || rset.get(new Integer(6)).equals(rset.get(new Integer(2)))) ? true : false;                                    
-                                    local.add(fkName + "." + ((String) rset.get(new Integer(7))) + "." + ((String) rset.get(new Integer(8)))); //NOI18N
-                                    ref.add(fkName + "." + ((String) rset.get(new Integer(3))) + "." + ((String) rset.get(new Integer(4)))); //NOI18N
+                                    local.add(fkName + "." + rset.get(new Integer(7)) + "." + rset.get(new Integer(8))); //NOI18N
+                                    ref.add(fkName + "." + rset.get(new Integer(3)) + "." + rset.get(new Integer(4))); //NOI18N
                                     if (! fk.contains(fkName))
                                         fk.add(fkName);
                                     rset.clear();

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
@@ -135,7 +135,7 @@ public class TableElementImpl extends DBElementImpl implements TableElement.Impl
     @Override
     public ColumnElement[] getColumns() {
         DBElement[] dbe = columns.getElements();
-        return (ColumnElement[]) Arrays.asList(dbe).toArray(new ColumnElement[dbe.length]);
+        return Arrays.asList(dbe).toArray(new ColumnElement[dbe.length]);
     }
   
     /** Find a column by name.
@@ -176,23 +176,23 @@ public class TableElementImpl extends DBElementImpl implements TableElement.Impl
                             rset = bridge.getDriverSpecification().getRow();
                             Object type = rset.get(new Integer(5));
                             if (type != null) {
-                                sqlType = (new Integer((String) rset.get(new Integer(5)))).intValue();
+                                sqlType = (new Integer(rset.get(new Integer(5)))).intValue();
                             } else {
                                 sqlType = 0; //java.sql.Types.NULL
                             }
                             // #192609: IllegalArgumentException: aType == null
                             if ("PostgreSQL".equalsIgnoreCase(dmd.getDatabaseProductName())) { // NOI18N
                                 if (Types.DISTINCT == sqlType) {
-                                    sqlType = (new Integer((String) rset.get(new Integer(22)))).intValue();
+                                    sqlType = (new Integer(rset.get(new Integer(22)))).intValue();
                                 }
                             }
-                            sqlTypeName = (String) rset.get(new Integer(6));
-                            colName = (String) rset.get(new Integer(4));
-                            colNull = (String) rset.get(new Integer(11));
-                            colSize = (String) rset.get(new Integer(7));
-                            colDec = (String) rset.get(new Integer(9));
+                            sqlTypeName = rset.get(new Integer(6));
+                            colName = rset.get(new Integer(4));
+                            colNull = rset.get(new Integer(11));
+                            colSize = rset.get(new Integer(7));
+                            colDec = rset.get(new Integer(9));
                             
-                            strAutoIncrement = (String)rset.get(new Integer(23));
+                            strAutoIncrement = rset.get(new Integer(23));
                             rset.clear();
                         } else {
                             sqlType = rs.getInt("DATA_TYPE"); //NOI18N
@@ -268,7 +268,7 @@ public class TableElementImpl extends DBElementImpl implements TableElement.Impl
     @Override
     public IndexElement[] getIndexes() {
         DBElement[] dbe = indexes.getElements();        
-        return (IndexElement[]) Arrays.asList(dbe).toArray(new IndexElement[dbe.length]);
+        return Arrays.asList(dbe).toArray(new IndexElement[dbe.length]);
     }
   
     /** Find an index by name.
@@ -398,7 +398,7 @@ public class TableElementImpl extends DBElementImpl implements TableElement.Impl
     @Override
     public KeyElement[] getKeys() {
         DBElement[] dbe = keys.getElements();
-        return (KeyElement[]) Arrays.asList(dbe).toArray(new KeyElement[dbe.length]);
+        return Arrays.asList(dbe).toArray(new KeyElement[dbe.length]);
     }
   
     /** Find a key by name.
@@ -563,7 +563,7 @@ public class TableElementImpl extends DBElementImpl implements TableElement.Impl
                 while (rs.next()) {
                     if (bridge != null) {
                         rset = bridge.getDriverSpecification().getRow();
-                        keySeq = (Object) rset.get(new Integer(5));
+                        keySeq = rset.get(new Integer(5));
                         colName = (String) rset.get(new Integer(4));
                         rset.clear();
                     } else {
@@ -653,7 +653,7 @@ public class TableElementImpl extends DBElementImpl implements TableElement.Impl
     @Override
     public ColumnPairElement[] getColumnPairs() {
         DBElement[] dbe = columnPairs.getElements();
-        return (ColumnPairElement[]) Arrays.asList(dbe).toArray(new ColumnPairElement[dbe.length]);
+        return Arrays.asList(dbe).toArray(new ColumnPairElement[dbe.length]);
     }
     
     @Override

--- a/java/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupport.java
+++ b/java/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupport.java
@@ -216,7 +216,7 @@ public final class MethodModelSupport {
                     Iterator<Map.Entry<String, Object>> it = annotation.getArguments().entrySet().iterator();
                     while (it.hasNext()) {
                         Map.Entry<String, Object> pairs = it.next();
-                        annotationArgs.add(genUtils.createAnnotationArgument((String) pairs.getKey(),pairs.getValue()));
+                        annotationArgs.add(genUtils.createAnnotationArgument(pairs.getKey(), pairs.getValue()));
                     }
                     annotationTree = genUtils.createAnnotation(annotation.getType(), annotationArgs);
                 }

--- a/java/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/rename/RelationshipMappingRename.java
+++ b/java/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/rename/RelationshipMappingRename.java
@@ -320,7 +320,7 @@ public final class RelationshipMappingRename extends JavaRefactoringPlugin {
             try {
                 DataObject dobj = DataObject.find(getParentFile());
                 if (dobj != null) {
-                    EditorCookie.Observable obs = (EditorCookie.Observable)dobj.getLookup().lookup(EditorCookie.Observable.class);
+                    EditorCookie.Observable obs = dobj.getLookup().lookup(EditorCookie.Observable.class);
                     if (obs != null && obs instanceof CloneableEditorSupport) {
                         CloneableEditorSupport supp = (CloneableEditorSupport)obs;
 

--- a/java/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/whereused/RelationshipMappingWhereUsed.java
+++ b/java/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/whereused/RelationshipMappingWhereUsed.java
@@ -261,7 +261,7 @@ public final class RelationshipMappingWhereUsed extends JavaRefactoringPlugin {
             try {
                 DataObject dobj = DataObject.find(getParentFile());
                 if (dobj != null) {
-                    EditorCookie.Observable obs = (EditorCookie.Observable)dobj.getLookup().lookup(EditorCookie.Observable.class);
+                    EditorCookie.Observable obs = dobj.getLookup().lookup(EditorCookie.Observable.class);
                     if (obs != null && obs instanceof CloneableEditorSupport) {
                         CloneableEditorSupport supp = (CloneableEditorSupport)obs;
 

--- a/java/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationScanner.java
+++ b/java/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationScanner.java
@@ -216,10 +216,10 @@ public class AnnotationScanner {
             Set<ElementKind> kinds) throws InterruptedException
     {
         Set<TypeElement> result = new HashSet<TypeElement>();
-        result.add( (TypeElement) typeElement );
+        result.add(typeElement);
         
         Set<TypeElement> toProcess = new HashSet<TypeElement>();
-        toProcess.add((TypeElement) typeElement );
+        toProcess.add(typeElement);
         while ( toProcess.size() >0 ){
             TypeElement element = toProcess.iterator().next();
             toProcess.remove( element );

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/PersistenceMetadata.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/PersistenceMetadata.java
@@ -69,7 +69,7 @@ public final class PersistenceMetadata {
         }
         Persistence persistence = null;
         synchronized (ddMap) {
-            persistence = (Persistence) ddMap.get(fo);
+            persistence = ddMap.get(fo);
             if (persistence == null) {
                 InputStream is=fo.getInputStream();
                 String version=Persistence.VERSION_1_0;

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/PersistenceUtils.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/PersistenceUtils.java
@@ -129,7 +129,7 @@ public class PersistenceUtils {
             }
         }
         
-        return (PersistenceUnit[])result.toArray(new PersistenceUnit[result.size()]);
+        return result.toArray(new PersistenceUnit[result.size()]);
     }
     
     /**

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/CompletionContext.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/CompletionContext.java
@@ -305,7 +305,7 @@ public class CompletionContext {
     public List<String> getExistingAttributes() {
         if (existingAttributes == null) {
             try {
-                existingAttributes = (List<String>)support.runWithSequence(
+                existingAttributes = support.runWithSequence(
                         documentContext.getCurrentTokenOffset(),
                         this::getExistingAttributesLocked
                 );

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CCPaintComponent.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CCPaintComponent.java
@@ -225,7 +225,7 @@ public class CCPaintComponent extends JPanel {
     }
     
     protected int getWidth(String s) {
-        Integer i = (Integer)widths.get(s);
+        Integer i = widths.get(s);
         if (i != null) {
             return i.intValue();
         } else {

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/ETCompletionContextResolver.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/ETCompletionContextResolver.java
@@ -90,7 +90,7 @@ public class ETCompletionContextResolver implements CompletionContextResolver {
 
     private List<JPACompletionItem> completecreateNamedQueryparameters(JPACodeCompletionProvider.Context ctx, List<JPACompletionItem> results) {
         Project prj = FileOwnerQuery.getOwner(ctx.getFileObject());
-        EntityClassScopeProvider provider = (EntityClassScopeProvider) prj.getLookup().lookup(EntityClassScopeProvider.class);
+        EntityClassScopeProvider provider = prj.getLookup().lookup(EntityClassScopeProvider.class);
         EntityClassScope ecs = null;
         Entity[] entities = null;
         if (provider != null) {

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/JPACodeCompletionProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/JPACodeCompletionProvider.java
@@ -217,7 +217,7 @@ public class JPACodeCompletionProvider implements CompletionProvider {
                 }
                 results = new ArrayList<JPACompletionItem>();
                 while (resolversItr.hasNext()) {
-                    CompletionContextResolver resolver = (CompletionContextResolver) resolversItr.next();
+                    CompletionContextResolver resolver = resolversItr.next();
                     TaskUserAction task = new TaskUserAction(controller, resolver, startOffset);
                     try {
                         EntityClassScope scope = EntityClassScope.getEntityClassScope(URLMapper.findFileObject(controller.getCompilationUnit().getSourceFile().toUri().toURL()));

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/PUCompletor.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/PUCompletor.java
@@ -214,7 +214,7 @@ public abstract class PUCompletor {
                 public void run(CompilationController cc) throws Exception {
                     cc.toPhase(Phase.ELEMENTS_RESOLVED);
                     Project project = FileOwnerQuery.getOwner(fo);
-                    EntityClassScopeProvider provider = (EntityClassScopeProvider) project.getLookup().lookup(EntityClassScopeProvider.class);
+                    EntityClassScopeProvider provider = project.getLookup().lookup(EntityClassScopeProvider.class);
                     EntityClassScope ecs = null;
                     Entity[] entities = null;
                     if (provider != null) {

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/CMPMappingModel.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/CMPMappingModel.java
@@ -180,12 +180,12 @@ public class CMPMappingModel {
         
         Iterator<String> keyIt = cmrFieldMapping.keySet().iterator();
         while (keyIt.hasNext()) {
-            String key = (String) keyIt.next();
-            ColumnData[] value = (ColumnData[]) cmrFieldMapping.get(key);
+            String key = keyIt.next();
+            ColumnData[] value = cmrFieldMapping.get(key);
             List l = Arrays.asList(value);
             Object otherValue = other.cmrFieldMapping.get(key);
             if (otherValue == null || 
-                !l.equals(Arrays.asList((ColumnData[])other.cmrFieldMapping.get(key)))) {
+                !l.equals(Arrays.asList(other.cmrFieldMapping.get(key)))) {
                 return false;
             }
         }

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEjbGenerator.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEjbGenerator.java
@@ -195,16 +195,16 @@ public class DbSchemaEjbGenerator {
     }
     
     public EntityClass[] getBeans() {
-        return (EntityClass[])beans.values().toArray(new EntityClass[beans.size()]);
+        return beans.values().toArray(new EntityClass[beans.size()]);
     }
     
     public EntityRelation[] getRelations() {
-        return (EntityRelation[])relations.toArray(new EntityRelation[relations.size()]);
+        return relations.toArray(new EntityRelation[relations.size()]);
     }
     
     
     private EntityClass getBean(String tableName) {
-        return (EntityClass)beans.get(tableName);
+        return beans.get(tableName);
     }
     
     private EntityClass addBean(String tableName) {
@@ -585,11 +585,11 @@ public class DbSchemaEjbGenerator {
     private List getFieldNames(EntityClass bean) {
         List<String> result = new ArrayList<>();
         for (Iterator<EntityMember> i = bean.getFields().iterator(); i.hasNext();) {
-            EntityMember member = (EntityMember)i.next();
+            EntityMember member = i.next();
             result.add(member.getMemberName());
         }
         for (Iterator<RelationshipRole> i = bean.getRoles().iterator(); i.hasNext();) {
-            RelationshipRole role = (RelationshipRole)i.next();
+            RelationshipRole role = i.next();
             result.add(role.getFieldName());
         }
         return result;
@@ -640,7 +640,7 @@ public class DbSchemaEjbGenerator {
                 ret.put(fkc, key);
             }
         }
-        return (ForeignKeyElement[]) ret.values().toArray(new ForeignKeyElement[]{});
+        return ret.values().toArray(new ForeignKeyElement[]{});
     }
 
     /**

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/JavaPersistenceGenerator.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/JavaPersistenceGenerator.java
@@ -672,7 +672,7 @@ public class JavaPersistenceGenerator implements PersistenceGenerator {
                             " in " + FileUtil.getFileDisplayName(copy.getFileObject())); // NOI18N
                 }
                 moduleElement = copy.getElements().getModuleOf(typeElement);
-                originalClassTree = (ClassTree) copy.getTrees().getTree(typeElement);
+                originalClassTree = copy.getTrees().getTree(typeElement);
                 assert originalClassTree != null;
                 newClassTree = originalClassTree;
                 genUtils = GenerationUtils.newInstance(copy);
@@ -733,7 +733,7 @@ public class JavaPersistenceGenerator implements PersistenceGenerator {
                 String memberName = m.getMemberName();
                 String memberType = getMemberType(m);
 
-                String columnName = (String) dbMappings.getCMPFieldMapping().get(memberName);
+                String columnName = dbMappings.getCMPFieldMapping().get(memberName);
                 if(!useDefaults || !memberName.equalsIgnoreCase(columnName)){
                     columnAnnArguments.add(genUtils.createAnnotationArgument("name", columnName)); //NOI18N
                 }
@@ -1335,7 +1335,7 @@ public class JavaPersistenceGenerator implements PersistenceGenerator {
                     } else {
                         pkProperty = property = createProperty(m);
                     }
-                    String pkColumnName = (String) dbMappings.getCMPFieldMapping().get(memberName);
+                    String pkColumnName = dbMappings.getCMPFieldMapping().get(memberName);
                     pkColumnNames.add(pkColumnName);
                 } else {
                     //check type
@@ -1492,7 +1492,7 @@ public class JavaPersistenceGenerator implements PersistenceGenerator {
                 } else {  // Role A
                     if (role.isMany() && role.isToMany()) { // ManyToMany
                         List<ExpressionTree> joinTableAnnArguments = new ArrayList<ExpressionTree>();
-                        String jTN =  (String) dbMappings.getJoinTableMapping().get(role.getFieldName());
+                        String jTN =  dbMappings.getJoinTableMapping().get(role.getFieldName());
 
                         if(existingJoinTables.get(jTN) != null){
                             //update isn't supported yet, just return if same join table already exists
@@ -1533,9 +1533,9 @@ public class JavaPersistenceGenerator implements PersistenceGenerator {
 
                         annotations.add(genUtils.createAnnotation("javax.persistence.JoinTable", joinTableAnnArguments)); // NOI18N
                     } else { // ManyToOne, OneToMany, OneToOne
-                        ColumnData[] columns = (ColumnData[]) dbMappings.getCmrFieldMapping().get(role.getFieldName());
+                        ColumnData[] columns = dbMappings.getCmrFieldMapping().get(role.getFieldName());
                         CMPMappingModel relatedMappings = beanMap.get(role.getParent().getRoleB().getEntityName()).getCMPMapping();
-                        ColumnData[] invColumns = (ColumnData[]) relatedMappings.getCmrFieldMapping().get(role.getParent().getRoleB().getFieldName());
+                        ColumnData[] invColumns = relatedMappings.getCmrFieldMapping().get(role.getParent().getRoleB().getFieldName());
                         if (columns.length == 1) {
                             if (existingJoinColumns.get(columns[0].getColumnName()) != null) {
                                 return;

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceLocation.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceLocation.java
@@ -43,7 +43,7 @@ public final class PersistenceLocation {
      *         a persistence location or the location does not exist.
      */
     public static FileObject getLocation(Project project) {
-        PersistenceLocationProvider provider = (PersistenceLocationProvider)project.getLookup().lookup(PersistenceLocationProvider.class);
+        PersistenceLocationProvider provider = project.getLookup().lookup(PersistenceLocationProvider.class);
         if (provider != null) {
             return provider.getLocation();
         }
@@ -61,7 +61,7 @@ public final class PersistenceLocation {
      * @since 1.37
      */
     public static FileObject getLocation(Project project, FileObject fo) {
-        PersistenceLocationProvider provider = (PersistenceLocationProvider)project.getLookup().lookup(PersistenceLocationProvider.class);
+        PersistenceLocationProvider provider = project.getLookup().lookup(PersistenceLocationProvider.class);
         if (provider != null) {
             return provider.getLocation(fo);
         }
@@ -80,7 +80,7 @@ public final class PersistenceLocation {
      *         PersistenceLocationProvider in its lookup.
      */
     public static FileObject createLocation(Project project) throws IOException {
-        PersistenceLocationProvider provider = (PersistenceLocationProvider)project.getLookup().lookup(PersistenceLocationProvider.class);
+        PersistenceLocationProvider provider = project.getLookup().lookup(PersistenceLocationProvider.class);
         if (provider != null) {
             return provider.createLocation();
         }
@@ -101,7 +101,7 @@ public final class PersistenceLocation {
      * @since 1.37
      */
     public static FileObject createLocation(Project project, FileObject fo) throws IOException {
-        PersistenceLocationProvider provider = (PersistenceLocationProvider)project.getLookup().lookup(PersistenceLocationProvider.class);
+        PersistenceLocationProvider provider = project.getLookup().lookup(PersistenceLocationProvider.class);
         if (provider != null) {
             return provider.createLocation(fo);
         }

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceScopes.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistence/api/PersistenceScopes.java
@@ -59,7 +59,7 @@ public final class PersistenceScopes {
      */
     public static PersistenceScopes getPersistenceScopes(Project project) {
         Parameters.notNull("project", project); // NOI18N
-        PersistenceScopesProvider provider = (PersistenceScopesProvider)project.getLookup().lookup(PersistenceScopesProvider.class);
+        PersistenceScopesProvider provider = project.getLookup().lookup(PersistenceScopesProvider.class);
         if (provider != null) {
             return provider.getPersistenceScopes();
         }
@@ -77,7 +77,7 @@ public final class PersistenceScopes {
      */
     public static PersistenceScopes getPersistenceScopes(Project project, FileObject fo) {
         Parameters.notNull("project", project); // NOI18N
-        PersistenceScopesProvider provider = (PersistenceScopesProvider)project.getLookup().lookup(PersistenceScopesProvider.class);
+        PersistenceScopesProvider provider = project.getLookup().lookup(PersistenceScopesProvider.class);
         if (provider != null) {
             return provider.getPersistenceScopes(fo);
         }

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/ProjectEntityClassScopeProvider.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/ProjectEntityClassScopeProvider.java
@@ -35,7 +35,7 @@ public class ProjectEntityClassScopeProvider implements EntityClassScopeProvider
     public EntityClassScope findEntityClassScope(FileObject fo) {
         Project project = FileOwnerQuery.getOwner(fo);
         if (project != null) {
-            EntityClassScopeProvider provider = (EntityClassScopeProvider)project.getLookup().lookup(EntityClassScopeProvider.class);
+            EntityClassScopeProvider provider = project.getLookup().lookup(EntityClassScopeProvider.class);
             if (provider != null) {
                 return provider.findEntityClassScope(fo);
             }

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/ProjectPersistenceScopeProvider.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/ProjectPersistenceScopeProvider.java
@@ -35,7 +35,7 @@ public class ProjectPersistenceScopeProvider implements PersistenceScopeProvider
     public PersistenceScope findPersistenceScope(FileObject fo) {
         Project project = FileOwnerQuery.getOwner(fo);
         if (project != null) {
-            PersistenceScopeProvider provider = (PersistenceScopeProvider)project.getLookup().lookup(PersistenceScopeProvider.class);
+            PersistenceScopeProvider provider = project.getLookup().lookup(PersistenceScopeProvider.class);
             if (provider != null) {
                 return provider.findPersistenceScope(fo);
             }

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/SourceRootsUi.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/SourceRootsUi.java
@@ -440,7 +440,7 @@ out:        for( int i = 0; i < files.length; i++ ) {
             ListSelectionModel selectionModel = this.rootsList.getSelectionModel();
             selectionModel.clearSelection();
             for( int i = 0; i < si.length; i++ ) {
-                Vector item = (Vector) rootsModel.getDataVector().elementAt(si[i]);
+                Vector item = (Vector)rootsModel.getDataVector().elementAt(si[i]);
                 int newIndex = si[i]-1;
                 rootsModel.removeRow( si[i] );
                 rootsModel.insertRow( newIndex, item );
@@ -461,7 +461,7 @@ out:        for( int i = 0; i < files.length; i++ ) {
             ListSelectionModel selectionModel = this.rootsList.getSelectionModel();
             selectionModel.clearSelection();
             for( int i = si.length -1 ; i >= 0 ; i-- ) {
-                Vector item = (Vector) rootsModel.getDataVector().elementAt(si[i]);
+                Vector item = (Vector)rootsModel.getDataVector().elementAt(si[i]);
                 int newIndex = si[i] + 1;
                 rootsModel.removeRow( si[i] );
                 rootsModel.insertRow( newIndex, item );

--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/javadoc/JavadocImports.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/javadoc/JavadocImports.java
@@ -853,7 +853,7 @@ public final class JavadocImports {
                     // if position in token == 0 resolve CC according to previous token
                     jdctx.jdts.movePrevious();
                 }
-                jdctx.positions = (DocSourcePositions) trees.getSourcePositions();
+                jdctx.positions = trees.getSourcePositions();
                 if (jdctx.positions != null) {
                     //insideTag(result[0], jdctx, caretOffset, prevTagError ? Kind.SEE : JavadocCompletionUtils.normalizedKind(result[0].getLeaf()));
                     insideTag(result[0], jdctx, caretOffset);

--- a/java/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectGenerator.java
+++ b/java/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectGenerator.java
@@ -130,7 +130,7 @@ public class J2SESampleProjectGenerator {
             projectFolder = projectFolder.getParentFile();            
         }
         while (!nameStack.empty()) {
-            projLoc = projLoc.createFolder ((String)nameStack.pop());
+            projLoc = projLoc.createFolder(nameStack.pop());
             assert projLoc != null;
         }
         return projLoc;

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/SourceFoldersWizardPanel.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/SourceFoldersWizardPanel.java
@@ -112,7 +112,7 @@ public class SourceFoldersWizardPanel implements WizardDescriptor.Panel, ChangeL
             while (it.hasNext()) {
                 String path = it.next();
                 assert it.hasNext();
-                String label = (String)it.next();
+                String label = it.next();
                 // try to find if the model already contains this source folder
                 boolean found = false;
                 for (int i = 0; i < pm.getSourceFoldersCount(); i++) {

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
@@ -778,13 +778,13 @@ public class J2SEModularProjectProperties {
         final LinkedList<String> oldRootPathProps = new LinkedList<>(Arrays.asList (roots.getRootPathProperties()));
         boolean rootsAreSame = true;
         for (int i=0; i<data.size();i++) {
-            File f = (File) ((Vector)data.elementAt(i)).elementAt(0);
+            File f = (File)data.elementAt(i).elementAt(0);
             rootURLs[i] = Utilities.toURI(f).toURL();
             if (!rootURLs[i].toExternalForm().endsWith("/")) {  //NOI18N
                 rootURLs[i] = new URL(rootURLs[i]+"/");
             }
             validateURL(rootURLs[i],f);
-            rootPaths[i] = (String) ((Vector)data.elementAt(i)).elementAt(1);
+            rootPaths[i] = (String)data.elementAt(i).elementAt(1);
             rootsAreSame &= !oldRootURLs.isEmpty() &&
                             oldRootURLs.removeFirst().equals(rootURLs[i]) &&
                             roots.getRootPath(oldRootPathProps.removeFirst()).equals(rootPaths[i]);

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectProperties.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectProperties.java
@@ -780,13 +780,13 @@ public class J2SEProjectProperties {
         final LinkedList<String> oldRootProps = new LinkedList<String>(Arrays.asList (roots.getRootProperties()));
         boolean rootsAreSame = true;
         for (int i=0; i<data.size();i++) {
-            File f = (File) ((Vector)data.elementAt(i)).elementAt(0);
+            File f = (File)data.elementAt(i).elementAt(0);
             rootURLs[i] = Utilities.toURI(f).toURL();
             if (!rootURLs[i].toExternalForm().endsWith("/")) {  //NOI18N
                 rootURLs[i] = new URL(rootURLs[i]+"/");
             }
             validateURL(rootURLs[i],f);
-            rootLabels[i] = (String) ((Vector)data.elementAt(i)).elementAt(1);
+            rootLabels[i] = (String)data.elementAt(i).elementAt(1);
             rootsAreSame &= !oldRootURLs.isEmpty() &&
                             oldRootURLs.removeFirst().equals(rootURLs[i]) &&
                             roots.getRootDisplayName(oldRootLabels.removeFirst(), oldRootProps.removeFirst()).equals(rootLabels[i]);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/variables/NbVariablesRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/variables/NbVariablesRequestHandler.java
@@ -149,7 +149,7 @@ public final class NbVariablesRequestHandler {
             return future;
         }
 
-        Session session = ((NbDebugSession) context.getDebugSession()).getSession();
+        Session session = context.getDebugSession().getSession();
         Models.CompoundModel localsModel = localsModelProvider.getModel(session);
 
         int threadId;

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/JPDAStart.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/JPDAStart.java
@@ -237,7 +237,7 @@ public class JPDAStart implements Runnable {
                     );
             Iterator<JPDADebugger> it = debuggers.iterator();
             while (it.hasNext()) {
-                JPDADebugger d = (JPDADebugger) it.next();
+                JPDADebugger d = it.next();
                 d.removePropertyChangeListener(
                         JPDADebugger.PROP_STATE,
                         this

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/OpenProjectFastIndex.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/OpenProjectFastIndex.java
@@ -559,7 +559,7 @@ class OpenProjectFastIndex implements ClassIndexManagerListener {
             this.dirStartPositions = new int[size * 2];
             this.dirNames = new String[size];
             for (int i = size - 1; i >= 0; i--) {
-                Object[] data = (Object[])indices.get(i);
+                Object[] data = indices.get(i);
                 dirStartPositions[i] = (Integer)data[1];
                 dirStartPositions[i + size] = (Integer)data[2];
                 dirNames[i] = (String)data[0];

--- a/java/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenAssemblyGrammar.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenAssemblyGrammar.java
@@ -98,7 +98,7 @@ public class MavenAssemblyGrammar extends AbstractSchemaBasedGrammar {
                     it = project.getRuntimeDependencies().iterator();
                 }
                 while (it.hasNext()) {
-                    Dependency elem = (Dependency) it.next();
+                    Dependency elem = it.next();
                     String str = elem.getGroupId() + ":" + elem.getArtifactId(); //NOI18N
                     if (str.startsWith(virtualTextCtx.getCurrentPrefix())) {
                         toRet.add(new MyTextElement(str, virtualTextCtx.getCurrentPrefix()));

--- a/java/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenProjectGrammar.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenProjectGrammar.java
@@ -304,10 +304,12 @@ public class MavenProjectGrammar extends AbstractSchemaBasedGrammar {
                 return false;
             }
         });
+
         List<GrammarResult> toReturn = new ArrayList<GrammarResult>();
         Collection<String> params = new HashSet<String>();
+
         while (it.hasNext()) {
-            Element el = (Element)it.next();
+            Element el = it.next();
             String editable = el.getChildText("editable"); //NOI18N
             if ("true".equalsIgnoreCase(editable)) { //NOI18N
                 String name = el.getChildText("name"); //NOI18N

--- a/java/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/LocationAwareMavenXpp3Writer.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/LocationAwareMavenXpp3Writer.java
@@ -536,10 +536,10 @@ public class LocationAwareMavenXpp3Writer {
             writeValue(serializer, "uniqueVersion", String.valueOf(deploymentRepository.isUniqueVersion()), deploymentRepository);
         }
         if (deploymentRepository.getReleases() != null) {
-            writeRepositoryPolicy((RepositoryPolicy) deploymentRepository.getReleases(), "releases", serializer);
+            writeRepositoryPolicy(deploymentRepository.getReleases(), "releases", serializer);
         }
         if (deploymentRepository.getSnapshots() != null) {
-            writeRepositoryPolicy((RepositoryPolicy) deploymentRepository.getSnapshots(), "snapshots", serializer);
+            writeRepositoryPolicy(deploymentRepository.getSnapshots(), "snapshots", serializer);
         }
         if (deploymentRepository.getId() != null) {
             writeValue(serializer, "id", deploymentRepository.getId(), deploymentRepository);
@@ -623,19 +623,19 @@ public class LocationAwareMavenXpp3Writer {
         int start = b.length();
 
         if (distributionManagement.getRepository() != null) {
-            writeDeploymentRepository((DeploymentRepository) distributionManagement.getRepository(), "repository", serializer);
+            writeDeploymentRepository(distributionManagement.getRepository(), "repository", serializer);
         }
         if (distributionManagement.getSnapshotRepository() != null) {
-            writeDeploymentRepository((DeploymentRepository) distributionManagement.getSnapshotRepository(), "snapshotRepository", serializer);
+            writeDeploymentRepository(distributionManagement.getSnapshotRepository(), "snapshotRepository", serializer);
         }
         if (distributionManagement.getSite() != null) {
-            writeSite((Site) distributionManagement.getSite(), "site", serializer);
+            writeSite(distributionManagement.getSite(), "site", serializer);
         }
         if (distributionManagement.getDownloadUrl() != null) {
             writeValue(serializer, "downloadUrl", distributionManagement.getDownloadUrl(), distributionManagement);
         }
         if (distributionManagement.getRelocation() != null) {
-            writeRelocation((Relocation) distributionManagement.getRelocation(), "relocation", serializer);
+            writeRelocation(distributionManagement.getRelocation(), "relocation", serializer);
         }
         if (distributionManagement.getStatus() != null) {
             writeValue(serializer, "status", distributionManagement.getStatus(), distributionManagement);
@@ -767,7 +767,7 @@ public class LocationAwareMavenXpp3Writer {
             writeValue(serializer, "modelVersion", model.getModelVersion(), model);
         }
         if (model.getParent() != null) {
-            writeParent((Parent) model.getParent(), "parent", serializer);
+            writeParent(model.getParent(), "parent", serializer);
         }
         if (model.getGroupId() != null) {
             writeValue(serializer, "groupId", model.getGroupId(), model);
@@ -829,7 +829,7 @@ public class LocationAwareMavenXpp3Writer {
             serializer.endTag(NAMESPACE, "mailingLists");
         }
         if (model.getPrerequisites() != null) {
-            writePrerequisites((Prerequisites) model.getPrerequisites(), "prerequisites", serializer);
+            writePrerequisites(model.getPrerequisites(), "prerequisites", serializer);
         }
         if ((model.getModules() != null) && (model.getModules().size() > 0)) {
             serializer.startTag(NAMESPACE, "modules");
@@ -846,16 +846,16 @@ public class LocationAwareMavenXpp3Writer {
             logLocation(model, "modules", start2, b.length());
         }
         if (model.getScm() != null) {
-            writeScm((Scm) model.getScm(), "scm", serializer);
+            writeScm(model.getScm(), "scm", serializer);
         }
         if (model.getIssueManagement() != null) {
-            writeIssueManagement((IssueManagement) model.getIssueManagement(), "issueManagement", serializer);
+            writeIssueManagement(model.getIssueManagement(), "issueManagement", serializer);
         }
         if (model.getCiManagement() != null) {
-            writeCiManagement((CiManagement) model.getCiManagement(), "ciManagement", serializer);
+            writeCiManagement(model.getCiManagement(), "ciManagement", serializer);
         }
         if (model.getDistributionManagement() != null) {
-            writeDistributionManagement((DistributionManagement) model.getDistributionManagement(), "distributionManagement", serializer);
+            writeDistributionManagement(model.getDistributionManagement(), "distributionManagement", serializer);
         }
         if ((model.getProperties() != null) && (model.getProperties().size() > 0)) {
             serializer.startTag(NAMESPACE, "properties");
@@ -871,7 +871,7 @@ public class LocationAwareMavenXpp3Writer {
             logLocation(model, "properties", start2, b.length());
         }
         if (model.getDependencyManagement() != null) {
-            writeDependencyManagement((DependencyManagement) model.getDependencyManagement(), "dependencyManagement", serializer);
+            writeDependencyManagement(model.getDependencyManagement(), "dependencyManagement", serializer);
         }
         if ((model.getDependencies() != null) && (model.getDependencies().size() > 0)) {
             serializer.startTag(NAMESPACE, "dependencies");
@@ -898,13 +898,13 @@ public class LocationAwareMavenXpp3Writer {
             serializer.endTag(NAMESPACE, "pluginRepositories");
         }
         if (model.getBuild() != null) {
-            writeBuild((Build) model.getBuild(), "build", serializer);
+            writeBuild(model.getBuild(), "build", serializer);
         }
         if (model.getReports() != null) {
              writeXpp3DOM(serializer, (Xpp3Dom)model.getReports(), model);
         }
         if (model.getReporting() != null) {
-            writeReporting((Reporting) model.getReporting(), "reporting", serializer);
+            writeReporting(model.getReporting(), "reporting", serializer);
         }
         if ((model.getProfiles() != null) && (model.getProfiles().size() > 0)) {
             serializer.startTag(NAMESPACE, "profiles");
@@ -1021,7 +1021,7 @@ public class LocationAwareMavenXpp3Writer {
         if ((plugin.getDependencies() != null) && (plugin.getDependencies().size() > 0)) {
             serializer.startTag(NAMESPACE, "dependencies");
             for (Iterator<Dependency> iter = plugin.getDependencies().iterator(); iter.hasNext();) {
-                Dependency o = (Dependency) iter.next();
+                Dependency o = iter.next();
                 writeDependency(o, "dependency", serializer);
             }
             serializer.endTag(NAMESPACE, "dependencies");
@@ -1085,7 +1085,7 @@ public class LocationAwareMavenXpp3Writer {
         if ((pluginManagement.getPlugins() != null) && (pluginManagement.getPlugins().size() > 0)) {
             serializer.startTag(NAMESPACE, "plugins");
             for (Iterator<Plugin> iter = pluginManagement.getPlugins().iterator(); iter.hasNext();) {
-                Plugin o = (Plugin) iter.next();
+                Plugin o = iter.next();
                 writePlugin(o, "plugin", serializer);
             }
             serializer.endTag(NAMESPACE, "plugins");
@@ -1117,10 +1117,10 @@ public class LocationAwareMavenXpp3Writer {
             writeValue(serializer, "id", profile.getId(), profile);
         }
         if (profile.getActivation() != null) {
-            writeActivation((Activation) profile.getActivation(), "activation", serializer);
+            writeActivation(profile.getActivation(), "activation", serializer);
         }
         if (profile.getBuild() != null) {
-            writeBuildBase((BuildBase) profile.getBuild(), "build", serializer);
+            writeBuildBase(profile.getBuild(), "build", serializer);
         }
         if ((profile.getModules() != null) && (profile.getModules().size() > 0)) {
             serializer.startTag(NAMESPACE, "modules");
@@ -1129,7 +1129,7 @@ public class LocationAwareMavenXpp3Writer {
             int index = 0;
             InputLocation tracker = profile.getLocation("modules");
             for (Iterator<String> iter = profile.getModules().iterator(); iter.hasNext();) {
-                String module = (String) iter.next();
+                String module = iter.next();
                 writeValue(serializer, "module", module, tracker, index);
                 index = index + 1;
             }
@@ -1137,7 +1137,7 @@ public class LocationAwareMavenXpp3Writer {
             logLocation(profile, "modules", start2, b.length());
         }
         if (profile.getDistributionManagement() != null) {
-            writeDistributionManagement((DistributionManagement) profile.getDistributionManagement(), "distributionManagement", serializer);
+            writeDistributionManagement(profile.getDistributionManagement(), "distributionManagement", serializer);
         }
         if ((profile.getProperties() != null) && (profile.getProperties().size() > 0)) {
             serializer.startTag(NAMESPACE, "properties");
@@ -1153,7 +1153,7 @@ public class LocationAwareMavenXpp3Writer {
             logLocation(profile, "properties", start2, b.length());
         }
         if (profile.getDependencyManagement() != null) {
-            writeDependencyManagement((DependencyManagement) profile.getDependencyManagement(), "dependencyManagement", serializer);
+            writeDependencyManagement(profile.getDependencyManagement(), "dependencyManagement", serializer);
         }
         if ((profile.getDependencies() != null) && (profile.getDependencies().size() > 0)) {
             serializer.startTag(NAMESPACE, "dependencies");
@@ -1174,7 +1174,7 @@ public class LocationAwareMavenXpp3Writer {
         if ((profile.getPluginRepositories() != null) && (profile.getPluginRepositories().size() > 0)) {
             serializer.startTag(NAMESPACE, "pluginRepositories");
             for (Iterator<Repository> iter = profile.getPluginRepositories().iterator(); iter.hasNext();) {
-                Repository o = (Repository) iter.next();
+                Repository o = iter.next();
                 writeRepository(o, "pluginRepository", serializer);
             }
             serializer.endTag(NAMESPACE, "pluginRepositories");
@@ -1183,7 +1183,7 @@ public class LocationAwareMavenXpp3Writer {
             writeXpp3DOM(serializer, (Xpp3Dom)profile.getReports(), profile);
         }
         if (profile.getReporting() != null) {
-            writeReporting((Reporting) profile.getReporting(), "reporting", serializer);
+            writeReporting(profile.getReporting(), "reporting", serializer);
         }
         serializer.endTag(NAMESPACE, tagName).flush();
         logLocation(profile, "", start, b.length());
@@ -1229,7 +1229,7 @@ public class LocationAwareMavenXpp3Writer {
         if ((reportPlugin.getReportSets() != null) && (reportPlugin.getReportSets().size() > 0)) {
             serializer.startTag(NAMESPACE, "reportSets");
             for (Iterator<ReportSet> iter = reportPlugin.getReportSets().iterator(); iter.hasNext();) {
-                ReportSet o = (ReportSet) iter.next();
+                ReportSet o = iter.next();
                 writeReportSet(o, "reportSet", serializer);
             }
             serializer.endTag(NAMESPACE, "reportSets");
@@ -1260,7 +1260,7 @@ public class LocationAwareMavenXpp3Writer {
             InputLocation tracker = reportSet.getLocation("reports");
             int index = 0;
             for (Iterator<String> iter = reportSet.getReports().iterator(); iter.hasNext();) {
-                String report = (String) iter.next();
+                String report = iter.next();
                 writeValue(serializer, "report", report, tracker, index);
                 index = index + 1;
             }
@@ -1292,7 +1292,7 @@ public class LocationAwareMavenXpp3Writer {
         if ((reporting.getPlugins() != null) && (reporting.getPlugins().size() > 0)) {
             serializer.startTag(NAMESPACE, "plugins");
             for (Iterator<ReportPlugin> iter = reporting.getPlugins().iterator(); iter.hasNext();) {
-                ReportPlugin o = (ReportPlugin) iter.next();
+                ReportPlugin o = iter.next();
                 writeReportPlugin(o, "plugin", serializer);
             }
             serializer.endTag(NAMESPACE, "plugins");
@@ -1308,10 +1308,10 @@ public class LocationAwareMavenXpp3Writer {
         StringBuffer b = b(serializer);
         int start = b.length();
         if (repository.getReleases() != null) {
-            writeRepositoryPolicy((RepositoryPolicy) repository.getReleases(), "releases", serializer);
+            writeRepositoryPolicy(repository.getReleases(), "releases", serializer);
         }
         if (repository.getSnapshots() != null) {
-            writeRepositoryPolicy((RepositoryPolicy) repository.getSnapshots(), "snapshots", serializer);
+            writeRepositoryPolicy(repository.getSnapshots(), "snapshots", serializer);
         }
         if (repository.getId() != null) {
             writeValue(serializer, "id", repository.getId(), repository);
@@ -1370,7 +1370,7 @@ public class LocationAwareMavenXpp3Writer {
             InputLocation inclTracker = resource.getLocation("includes");
             int index = 0;
             for (Iterator<String> iter = resource.getIncludes().iterator(); iter.hasNext();) {
-                String include = (String) iter.next();
+                String include = iter.next();
                 writeValue(serializer, "include", include, inclTracker, index);
                 index = index + 1;
             }
@@ -1384,7 +1384,7 @@ public class LocationAwareMavenXpp3Writer {
             InputLocation inclTracker = resource.getLocation("excludes");
             int index = 0;
             for (Iterator<String> iter = resource.getExcludes().iterator(); iter.hasNext();) {
-                String exclude = (String) iter.next();
+                String exclude = iter.next();
                 writeValue(serializer, "exclude", exclude, inclTracker, index);
                 index = index + 1;
             }

--- a/java/maven/src/org/netbeans/modules/maven/api/PluginPropertyUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/PluginPropertyUtils.java
@@ -344,7 +344,7 @@ public class PluginPropertyUtils {
             @Override
             public String[] build(Xpp3Dom conf, ExpressionEvaluator eval) {
                 if (conf != null) {
-                    Xpp3Dom dom = (Xpp3Dom) conf; // MNG-4862
+                    Xpp3Dom dom = conf; // MNG-4862
                     Xpp3Dom source = dom.getChild(multiProperty);
                     if (source != null) {
                         List<String> toRet = new ArrayList<String>();

--- a/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
+++ b/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
@@ -72,7 +72,7 @@ public class SourceGroupSupport {
                 result.add(sourceGroups[i]);
             }
         }
-        return (SourceGroup[]) result.toArray(new SourceGroup[result.size()]);
+        return result.toArray(new SourceGroup[result.size()]);
     }
 
     public static boolean isValidPackageName(String packageName) {
@@ -190,7 +190,7 @@ public class SourceGroupSupport {
         List<FileObject> sourceRoots = getFileObjects(rootURLs, true);
         for (int i = 0; i < sourceRoots.size(); i++) {
             FileObject sourceRoot = sourceRoots.get(i);
-            SourceGroup srcGroup = (SourceGroup) foldersToSourceGroupsMap.get(sourceRoot);
+            SourceGroup srcGroup = foldersToSourceGroupsMap.get(sourceRoot);
             if (srcGroup != null) {
                 result.add(srcGroup);
             }

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerateDOMScannerSupport.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerateDOMScannerSupport.java
@@ -253,7 +253,7 @@ public class GenerateDOMScannerSupport implements XMLGenerateCookie {
                         varTree = new ArrayList<VariableTree>();
                         varTree.add(var);
                         while (it.hasNext()) {
-                            TreeElementDecl next = (TreeElementDecl) it.next();
+                            TreeElementDecl next = it.next();
                             String tagName = next.getName();
                             String methodName = GenerateSupportUtils.getJavaName (METHOD_SCAN_ELEMENT + "_" + tagName);
                           
@@ -336,7 +336,7 @@ public class GenerateDOMScannerSupport implements XMLGenerateCookie {
         sb2.append ("org.w3c.dom.Element nodeElement = (org.w3c.dom.Element)node;\n"); // NOI18N
         it = dtd.getElementDeclarations().iterator();
         while (it.hasNext()) {
-            String tagName = ((TreeElementDecl)it.next()).getName();
+            String tagName = it.next().getName();
             if (elements.contains(tagName) == false) continue;
             sb2.append ("if (nodeElement.getTagName().equals (\"").append (tagName).append ("\")) {\n"); // NOI18N
             sb2.append (METHOD_SCAN_ELEMENT).append ("_").append (GenerateSupportUtils.getJavaName (tagName)).append (" (nodeElement);\n}\n"); // NOI18N

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsParser.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsParser.java
@@ -85,7 +85,7 @@ public class SAXBindingsParser extends org.xml.sax.helpers.DefaultHandler {
     private void dispatch(final boolean fireOnlyIfMixed) throws SAXException {
         if (fireOnlyIfMixed && buffer.length() == 0) return; //skip it
         
-        Object[] ctx = (Object[]) context.peek();
+        Object[] ctx = context.peek();
         String here = (String) ctx[0];
         Attributes attrs = (Attributes) ctx[1];
         buffer.delete(0, buffer.length());

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorSupport.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorSupport.java
@@ -400,7 +400,7 @@ public final class SAXGeneratorSupport implements XMLGenerateCookie {
         if (obj == null) return;
 
         try {
-            EditorCookie editor = (EditorCookie) obj.getCookie(EditorCookie.class);
+            EditorCookie editor = obj.getCookie(EditorCookie.class);
             Document doc = editor.openDocument();
 
             if (data == null) {
@@ -417,7 +417,7 @@ public final class SAXGeneratorSupport implements XMLGenerateCookie {
             // ignore, there will be missing file header
         }
 
-        SaveCookie cake = (SaveCookie) obj.getCookie(SaveCookie.class);
+        SaveCookie cake = obj.getCookie(SaveCookie.class);
         if (cake != null) cake.save();
     }
 

--- a/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/PropertyCompleter.java
+++ b/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/impl/PropertyCompleter.java
@@ -152,7 +152,7 @@ public class PropertyCompleter extends InstanceCompleter {
         if (namePrefix.startsWith("<")) {
             namePrefix = namePrefix.substring(1);
         }
-        for (PropertyValue pv : (Collection<PropertyValue>)instance.getProperties()) {
+        for (PropertyValue pv : instance.getProperties()) {
             existingPropNames.add(pv.getPropertyName());
         }
     }

--- a/platform/api.progress.nb/src/org/netbeans/modules/progress/spi/UIInternalHandle.java
+++ b/platform/api.progress.nb/src/org/netbeans/modules/progress/spi/UIInternalHandle.java
@@ -80,7 +80,7 @@ public final class UIInternalHandle extends InternalHandle {
             // no UI atm
             return false;
         }
-        viewAction = (Action)al;
+        viewAction = al;
         return true;
     }
 

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
@@ -813,14 +813,14 @@ public final class MultiViewPeer implements PropertyChangeListener {
         }
         if (badOnes.size() > 0) {
             CloseOperationState[] states = new CloseOperationState[badOnes.size()];
-            states = (CloseOperationState[])badOnes.toArray(states);
+            states = badOnes.toArray(states);
             boolean res = closeHandler.resolveCloseOperation(states);
             if( res && SpiAccessor.DEFAULT.shouldCheckCanCloseAgain(closeHandler) ) {
                 //#236369 - check if everything saved ok
                 col = model.getCreatedElements();
                 it = col.iterator();
                 while (it.hasNext()) {
-                   MultiViewElement el = (MultiViewElement)it.next();
+                   MultiViewElement el = it.next();
                    CloseOperationState state = el.canCloseElement();
                    if (!state.canClose()) {
                        res = false;

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewTopComponentLookup.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewTopComponentLookup.java
@@ -113,7 +113,7 @@ class MultiViewTopComponentLookup extends Lookup {
             Iterator<Lookup.Item> it = s.iterator();
             Set instances = new HashSet<>();
             while (it.hasNext()) {
-                Lookup.Item i = (Lookup.Item)it.next();
+                Lookup.Item i = it.next();
                 if (instances.contains(i.getInstance())) {
                     it.remove();
                 } else {
@@ -159,7 +159,7 @@ class MultiViewTopComponentLookup extends Lookup {
             LookupEvent ev2 = new LookupEvent(this);
             LookupListener[] ls;
             synchronized (listeners) {
-                ls = (LookupListener[])listeners.toArray(new LookupListener[listeners.size()]);
+                ls = listeners.toArray(new LookupListener[listeners.size()]);
             }
             for (int i = 0; i < ls.length; i++) {
                 ls[i].resultChanged(ev2);

--- a/platform/core.startup/src/org/netbeans/core/startup/layers/SessionManager.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/layers/SessionManager.java
@@ -126,7 +126,7 @@ public final class SessionManager {
         java.beans.PropertyChangeEvent event = new java.beans.PropertyChangeEvent(this, name, null, null);
         for (int i = 0; i < list.size(); i++) {
             try {
-                ((PropertyChangeListener) list.get(i)).propertyChange(event);
+                list.get(i).propertyChange(event);
             }
             catch (RuntimeException e) {
                 Exceptions.printStackTrace(e);

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
@@ -2247,7 +2247,7 @@ public class ETable extends JTable {
                 if (currentSelectionIndex >= sz) {
                     currentSelectionIndex = sz - 1;
                 }
-                int selRow = ((Integer)results.get(currentSelectionIndex)).intValue();
+                int selRow = results.get(currentSelectionIndex).intValue();
                 setRowSelectionInterval(selRow, selRow);
                 Rectangle rect = getCellRect(selRow, 0, true);
                 scrollRectToVisible(rect);

--- a/platform/openide.actions/src/org/openide/actions/WorkspaceSwitchAction.java
+++ b/platform/openide.actions/src/org/openide/actions/WorkspaceSwitchAction.java
@@ -84,7 +84,7 @@ public class WorkspaceSwitchAction extends CallableSystemAction {
         }
 
         // check on currently active workspace
-        JRadioButtonMenuItem curItem = (JRadioButtonMenuItem) workspace2Menu.get(currentDeskRef[0]);
+        JRadioButtonMenuItem curItem = workspace2Menu.get(currentDeskRef[0]);
 
         if (curItem != null) {
             curItem.setSelected(true);

--- a/platform/openide.explorer/src/org/netbeans/modules/openide/explorer/TabbedContainerBridgeImpl.java
+++ b/platform/openide.explorer/src/org/netbeans/modules/openide/explorer/TabbedContainerBridgeImpl.java
@@ -52,7 +52,7 @@ class TabbedContainerBridgeImpl extends TabbedContainerBridge {
         List<TabData> l = cont.getModel().getTabs();
         Object[] items = new Object[l.size()];
         for (int i=0; i < items.length; i++) {
-            items[i] = ((TabData) l.get(i)).getUserObject();
+            items[i] = l.get(i).getUserObject();
         }
         return items;
     }

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/RadioInplaceEditor.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/RadioInplaceEditor.java
@@ -397,14 +397,14 @@ class RadioInplaceEditor extends JPanel implements InplaceEditor, ActionListener
                 new Runnable() {
                     public void run() {
                         for (int i = 0; i < theList.size(); i++) {
-                            ((java.awt.event.ActionListener) theList.get(i)).actionPerformed(event);
+                            theList.get(i).actionPerformed(event);
                         }
                     }
                 }
             );
         } else {
             for (int i = 0; i < list.size(); i++) {
-                ((java.awt.event.ActionListener) theList.get(i)).actionPerformed(event);
+                theList.get(i).actionPerformed(event);
             }
         }
     }

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
@@ -199,18 +199,18 @@ final class XMLMapAttr implements Map {
         attrName = (String) keyValuePair[0];
 
         synchronized (this) {
-            attr = (Attr) map.get(attrName);
+            attr = map.get(attrName);
         }
 
         Object retVal = null;
         if (attr == null && origAttrName.startsWith("class:")) { // NOI18N
             synchronized (this) {
-                attr = (Attr) map.get(origAttrName.substring(6));
+                attr = map.get(origAttrName.substring(6));
             }
             retVal = attr != null ? attr.getType(params) : null;
         } else if (attr == null && origAttrName.startsWith("raw:")) { // NOI18N
             synchronized (this) {
-                attr = (Attr) map.get(origAttrName.substring(4));
+                attr = map.get(origAttrName.substring(4));
             }
             if (attr != null && attr.keyIndex == 9) {
                 return attr.methodValue(attr.value, params).getMethod();
@@ -343,7 +343,7 @@ final class XMLMapAttr implements Map {
 
         while (entryIter.hasNext()) {
             String attrName = (String) entryIter.next();
-            Attr attr = (Attr) map.get(attrName);
+            Attr attr = map.get(attrName);
 
             if (attr != null) {
                 attr.transformMe();

--- a/platform/openide.options/src/org/openide/options/SystemOption.java
+++ b/platform/openide.options/src/org/openide/options/SystemOption.java
@@ -344,7 +344,7 @@ WHILE:
 
                     if (useMethod) {
                         // set the value
-                        Method write = (Method) map.get(name);
+                        Method write = map.get(name);
 
                         if (write != null) {
                             // if you have where to set the value

--- a/platform/openide.util/src/org/netbeans/modules/openide/util/DefaultMutexImplementation.java
+++ b/platform/openide.util/src/org/netbeans/modules/openide/util/DefaultMutexImplementation.java
@@ -612,7 +612,7 @@ public class DefaultMutexImplementation implements MutexImplementation {
 
                 for (int i = 0; i < size; i++) {
                     try {
-                        Runnable r = (Runnable) runnables.get(i);
+                        Runnable r = runnables.get(i);
 
                         r.run();
                     }

--- a/profiler/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLCompletionProvider.java
+++ b/profiler/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLCompletionProvider.java
@@ -250,7 +250,7 @@ public class OQLCompletionProvider implements CompletionProvider {
 
                         clzs = e.getHeap().getJavaClassesByRegExp(prefix).iterator();
                         while(clzs.hasNext()) {
-                            String className = ((JavaClass)clzs.next()).getName();
+                            String className = clzs.next().getName();
 
                             String[] sig = splitClassName(className);
 
@@ -270,7 +270,7 @@ public class OQLCompletionProvider implements CompletionProvider {
                         if (camel != null) {
                             clzs = e.getHeap().getJavaClassesByRegExp(camel).iterator();
                             while(clzs.hasNext()) {
-                                String className = ((JavaClass)clzs.next()).getName();
+                                String className = clzs.next().getName();
                                 completions.add("02 " + className); // NOI18N
                             }
                         }

--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
@@ -69,7 +69,7 @@ public class Snapshot {
             int fldsCount = flds.size();
 
             for (int i = 0; i < fldsCount; i++) {
-                if ("referent".equals(((Field) flds.get(i)).getName())) { // NOI18N
+                if ("referent".equals(flds.get(i).getName())) { // NOI18N
                     referentFieldIndex = i;
                     break;
                 }
@@ -319,7 +319,7 @@ public class Snapshot {
 
     public GCRoot[] getRootsArray() {
         List<GCRoot> rootList = getRootsList();
-        return (GCRoot[]) rootList.toArray(new GCRoot[0]);
+        return rootList.toArray(new GCRoot[0]);
     }
    
     public ReferenceChain[] rootsetReferencesTo(Instance target, boolean includeWeak) {

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -3094,7 +3094,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
         JsDocumentationHolder holder = JsDocumentationSupport.getDocumentationHolder(parserResult);
         if (holder.getOccurencesMap().containsKey(jsObject.getName())) {
             for (OffsetRange offsetRange : holder.getOccurencesMap().get(jsObject.getName())) {
-                ((JsObjectImpl)jsObject).addOccurrence(offsetRange);
+                jsObject.addOccurrence(offsetRange);
             }
         }
     }

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/Inflector.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/Inflector.java
@@ -516,7 +516,7 @@ public class Inflector {
 
         // Scan our patterns for a match and return the correct replacement
         for (int i = 0; i < plurals.size(); i++) {
-            Replacer replacer = (Replacer) plurals.get(i);
+            Replacer replacer = plurals.get(i);
             if (replacer.matches(word)) {
                 return replacer.replacement();
             }
@@ -545,7 +545,7 @@ public class Inflector {
 
         // Scan our patterns for a match and return the correct replacement
         for (int i = 0; i < singulars.size(); i++) {
-            Replacer replacer = (Replacer) singulars.get(i);
+            Replacer replacer = singulars.get(i);
             if (replacer.matches(word)) {
                 return replacer.replacement();
             }


### PR DESCRIPTION
Warning messages like this will no longer happen.

   [repeat] /home/bwalker/src/netbeans/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/ReflectionHelper.java:700: warning: [cast] redundant cast to JavaParameter
   [repeat]                     JavaParameter actualParameter = (JavaParameter) parameterList.get(ii);
   [repeat]                                                     ^





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

