### PR TITLE
Fix the wrong use of Enumeration interface

### DIFF
--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FindComponentModules.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FindComponentModules.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -201,10 +200,10 @@ public final class FindComponentModules extends Task {
         Preferences pref = FindComponentModules.getPreferences ();
         String value = pref.get (ENABLE_LATER, null);
         if (value != null && value.trim ().length () > 0) {
-            Enumeration en = new StringTokenizer (value, ","); // NOI18N
-            while (en.hasMoreElements ()) {
-                String codeName = ((String) en.nextElement ()).trim ();
-                UpdateElement el = findUpdateElement (codeName, true);
+            StringTokenizer st = new StringTokenizer (value, ","); // NOI18N
+            while (st.hasMoreElements ()) {
+                String codeName = st.nextToken().trim();
+                UpdateElement el = findUpdateElement(codeName, true);
                 if (el != null) {
                     res.add (el);
                 }


### PR DESCRIPTION
This is the wrong use of the Enumeration interface..

   [repeat] /home/bwalker/src/netbeans/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FindComponentModules.java:204: warning: [rawtypes] found raw type: Enumeration
   [repeat]             Enumeration en = new StringTokenizer (value, ","); // NOI18N
   [repeat]             ^
   [repeat]   missing type arguments for generic class Enumeration<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in interface Enumeration





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

