### PR TITLE
Cleanup warnings related to Enumeration rawtype

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ApisupportAntUtils.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ApisupportAntUtils.java
@@ -676,13 +676,13 @@ public class ApisupportAntUtils {
         if (dir == null) {
             return;
         }
-        for (Enumeration en1 = dir.getFolders(false); en1.hasMoreElements(); ) {
+        for (Enumeration<? extends FileObject> en1 = dir.getFolders(false); en1.hasMoreElements(); ) {
             FileObject subDir = (FileObject) en1.nextElement();
             if (VisibilityQuery.getDefault().isVisible(subDir)) {
                 scanForPackages(validPkgs, subDir, ext);
             }
         }
-        for (Enumeration en2 = dir.getData(false); en2.hasMoreElements(); ) {
+        for (Enumeration<? extends FileObject> en2 = dir.getData(false); en2.hasMoreElements(); ) {
             FileObject kid = (FileObject) en2.nextElement();
             if (kid.hasExt(ext) && Utilities.isJavaIdentifier(kid.getName())) {
                 // at least one class inside directory -> valid package

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractEntry.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractEntry.java
@@ -114,7 +114,7 @@ abstract class AbstractEntry implements ModuleEntry {
         }
         JarFile jf = new JarFile(jar);
         try {
-            Enumeration entries = jf.entries();
+            Enumeration<JarEntry> entries = jf.entries();
             ENTRY: while (entries.hasMoreElements()) {
                 JarEntry entry = (JarEntry) entries.nextElement();
                 String path = entry.getName();

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
@@ -611,7 +611,7 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
     @Override
     public Enumeration enabled(GrammarEnvironment ctx) {
         if (ctx.getFileObject() == null) return null;
-        Enumeration en = ctx.getDocumentChildren();
+        Enumeration<Node> en = ctx.getDocumentChildren();
         while (en.hasMoreElements()) {
             Node next = (Node) en.nextElement();
             if (next.getNodeType() == Node.DOCUMENT_TYPE_NODE) {

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/AppClientProvider.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/AppClientProvider.java
@@ -520,8 +520,7 @@ public final class AppClientProvider extends J2eeModuleProvider
     }
 
     private static class IT implements Iterator<J2eeModule.RootedEntry> {
-        
-        Enumeration ch;
+        Enumeration<? extends FileObject> ch;
         FileObject root;
         
         private IT(FileObject f) {

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/AppClientProjectProperties.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/AppClientProjectProperties.java
@@ -532,7 +532,7 @@ public final class AppClientProjectProperties {
         projectProperties.put(ProjectProperties.EXCLUDES, excludes);
         
         StringBuilder sb = new StringBuilder();
-        for (Enumeration elements = ANNOTATION_PROCESSORS_MODEL.elements(); elements.hasMoreElements();) {
+        for (Enumeration<String> elements = ANNOTATION_PROCESSORS_MODEL.elements(); elements.hasMoreElements();) {
             sb.append(elements.nextElement());
             if (elements.hasMoreElements())
                 sb.append(',');

--- a/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ClasspathUtil.java
+++ b/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ClasspathUtil.java
@@ -248,7 +248,7 @@ public class ClasspathUtil {
             if (file.isFile()) {
                 JarFile jf = new JarFile(file);
                 try {
-                    Enumeration entries = jf.entries();
+                    Enumeration<JarEntry> entries = jf.entries();
                     while (entries.hasMoreElements()) {
                         JarEntry entry = (JarEntry) entries.nextElement();
                         if (classFilePathFirst.equals(entry.getName())) {

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataObject.java
@@ -454,7 +454,7 @@ public class EarDataObject extends DD2beansDataObject
                         }
                     }
                     else if (options[1].equals (e.getSource ())) {
-                        Enumeration en = connectionPanel.listModel.elements ();
+                        Enumeration<DDChangeEvent> en = connectionPanel.listModel.elements ();
                         while (en.hasMoreElements ()) {
                             processDDChangeEvent ((DDChangeEvent)en.nextElement ());
                         }

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/client/ClientDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/client/ClientDataObject.java
@@ -343,7 +343,7 @@ public class ClientDataObject extends  DDMultiViewDataObject
                         processButton.setEnabled(false);
                     }
                 } else if (options[1].equals(e.getSource())) {
-                    Enumeration en = connectionPanel.listModel.elements();
+                    Enumeration<DDChangeEvent> en = connectionPanel.listModel.elements();
                     while (en.hasMoreElements()) {
                         processDDChangeEvent((DDChangeEvent)en.nextElement());
                     }

--- a/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/EarProjectGenerator.java
+++ b/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/EarProjectGenerator.java
@@ -244,14 +244,10 @@ public final class EarProjectGenerator {
                 FileObject fileBeingCopied = null;
                 if (null != appXml) {
                     // make a backup copy of the application.xml and its siblings
-                    Enumeration filesToBackup =
-                            appXml.getParent().getChildren(false);
-                    while (null != filesToBackup &&
-                            filesToBackup.hasMoreElements()) {
-                        fileBeingCopied =
-                                (FileObject) filesToBackup.nextElement();
-                        if (fileBeingCopied.isData() &&
-                                fileBeingCopied.canRead()) {
+                    Enumeration<? extends FileObject> filesToBackup = appXml.getParent().getChildren(false);
+                    while (null != filesToBackup && filesToBackup.hasMoreElements()) {
+                        fileBeingCopied = (FileObject) filesToBackup.nextElement();
+                        if (fileBeingCopied.isData() && fileBeingCopied.canRead()) {
                             try {
                                 FileUtil.copyFile(fileBeingCopied,
                                         appXml.getParent(),

--- a/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ProjectEar.java
+++ b/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ProjectEar.java
@@ -413,7 +413,7 @@ public final class ProjectEar extends J2eeApplicationProvider
             }
             
             ArrayList<FileObject> filteredContent = new ArrayList<FileObject>(5);
-            Enumeration ch = f.getChildren(true);
+            Enumeration<? extends FileObject> ch = f.getChildren(true);
             while (ch.hasMoreElements()) {
                 FileObject fo = (FileObject) ch.nextElement();
                 String fileName = fo.getNameExt();

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarProvider.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarProvider.java
@@ -25,6 +25,7 @@ import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -529,7 +530,7 @@ public final class EjbJarProvider extends J2eeModuleProvider
     }
 
     private static class IT implements Iterator<J2eeModule.RootedEntry> {
-        java.util.Enumeration ch;
+        Enumeration<? extends FileObject> ch;
         FileObject root;
         
         private IT(FileObject f) {

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/RunTimeDDCatalog.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/RunTimeDDCatalog.java
@@ -588,7 +588,7 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
     @Override
     public Enumeration enabled(GrammarEnvironment ctx) {
         if (ctx.getFileObject() == null) return null;
-        Enumeration en = ctx.getDocumentChildren();
+        Enumeration<Node> en = ctx.getDocumentChildren();
         while (en.hasMoreElements()) {
             Node next = (Node) en.nextElement();
             if (next.getNodeType() == Node.DOCUMENT_TYPE_NODE) {

--- a/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/DeployOnSaveManager.java
+++ b/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/DeployOnSaveManager.java
@@ -27,6 +27,7 @@ import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
 import static java.util.Collections.unmodifiableList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -518,7 +519,7 @@ public final class DeployOnSaveManager {
                 FileObject destRoot = FileUtil.createFolder(destDir);
 
                 // create target FOs map keyed by relative paths
-                java.util.Enumeration destFiles = destRoot.getChildren(true);
+                Enumeration<? extends FileObject> destFiles = destRoot.getChildren(true);
                 Map<String, FileObject> destMap = new HashMap<>();
                 int rootPathLen = destRoot.getPath().length();
                 for (; destFiles.hasMoreElements();) {

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/WebLocationsWizardPanel.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/WebLocationsWizardPanel.java
@@ -149,7 +149,7 @@ public class WebLocationsWizardPanel implements WizardDescriptor.Panel {
     }
 
     private String guessJavaRoot (FileObject dir) {
-        Enumeration ch = dir.getChildren (true);
+        Enumeration<? extends FileObject> ch = dir.getChildren (true);
         try {
             while (ch.hasMoreElements ()) {
                 FileObject f = (FileObject) ch.nextElement ();

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/Controller.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/Controller.java
@@ -871,7 +871,7 @@ class Controller  {
                 int oldValue = -1;
                 int i = 0;
                 
-                for(Enumeration e = directory.getData(false); e.hasMoreElements(); ++i) {
+                for(Enumeration<? extends FileObject> e = directory.getData(false); e.hasMoreElements(); ++i) {
                     FileObject fo = (FileObject) e.nextElement();
                     FileLock lock = null;
                     try {
@@ -926,7 +926,7 @@ class Controller  {
 	    return;
 	}
 
-	Enumeration e = null;
+	Enumeration<? extends FileObject> e = null;
 	Vector<TransactionNode> nodes = new Vector<>(); 
 	int numtns = 0;
 	TransactionNode[] tns = null;

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/Util.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/Util.java
@@ -109,7 +109,7 @@ public class Util  {
 	}
 	if(ht == null || ht.isEmpty()) return false;
 	
-	Enumeration e = ht.keys();
+	Enumeration<String> e = ht.keys();
 
 	while(e.hasMoreElements()) {
 	    String name = (String)e.nextElement();
@@ -139,7 +139,7 @@ public class Util  {
 	catch(Exception ex) { }
 			    
 	if(ht != null && ht.size() > 0) {
-	    Enumeration e = ht.keys();
+	    Enumeration<String> e = ht.keys();
 	    while(e.hasMoreElements()) {
 		String name = (String)e.nextElement();
 		String[] value = (String[])(ht.get(name));

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FindComponentModules.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FindComponentModules.java
@@ -200,8 +200,8 @@ public final class FindComponentModules extends Task {
         Preferences pref = FindComponentModules.getPreferences ();
         String value = pref.get (ENABLE_LATER, null);
         if (value != null && value.trim ().length () > 0) {
-            StringTokenizer st = new StringTokenizer (value, ","); // NOI18N
-            while (st.hasMoreElements ()) {
+            StringTokenizer st = new StringTokenizer(value, ","); // NOI18N
+            while (st.hasMoreElements()) {
                 String codeName = st.nextToken().trim();
                 UpdateElement el = findUpdateElement(codeName, true);
                 if (el != null) {

--- a/groovy/groovy.antproject/src/org/netbeans/modules/groovy/antproject/base/AbstractGroovyActionProvider.java
+++ b/groovy/groovy.antproject/src/org/netbeans/modules/groovy/antproject/base/AbstractGroovyActionProvider.java
@@ -406,7 +406,7 @@ public abstract class AbstractGroovyActionProvider implements ActionProvider {
             ErrorManager.getDefault().notify(ErrorManager.INFORMATIONAL, ex);
             return targets;
         }
-        Enumeration propNames = props.propertyNames();
+        Enumeration<?> propNames = props.propertyNames();
         while (propNames.hasMoreElements()) {
             String propName = (String) propNames.nextElement();
             if (propName.startsWith("$target.")) {

--- a/groovy/groovy.antproject/src/org/netbeans/modules/groovy/antproject/base/AbstractGroovyExtender.java
+++ b/groovy/groovy.antproject/src/org/netbeans/modules/groovy/antproject/base/AbstractGroovyExtender.java
@@ -206,7 +206,7 @@ public abstract class AbstractGroovyExtender implements GroovyExtenderImplementa
             if (file.isFile()) {
                 JarFile jf = new JarFile(file);
                 try {
-                    Enumeration entries = jf.entries();
+                    Enumeration<JarEntry> entries = jf.entries();
                     while (entries.hasMoreElements()) {
                         JarEntry entry = (JarEntry) entries.nextElement();
                         if (classFilePath.equals(entry.getName())) {

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
@@ -574,7 +574,7 @@ public final class AddDriverDialog extends javax.swing.JPanel {
                         String file  = dlm.get(i);
                         JarFile jf = new JarFile(file);
                         try {
-                            Enumeration entries = jf.entries();
+                            Enumeration<JarEntry> entries = jf.entries();
                             while (entries.hasMoreElements()) {
                                 JarEntry entry = (JarEntry)entries.nextElement();
                                 String className = entry.getName();

--- a/ide/image/src/org/netbeans/modules/image/ImageOpenSupport.java
+++ b/ide/image/src/org/netbeans/modules/image/ImageOpenSupport.java
@@ -133,7 +133,7 @@ public class ImageOpenSupport extends OpenSupport implements OpenCookie, CloseCo
             final ImageDataObject imageObj = (ImageDataObject)entry.getDataObject();
             final CloneableTopComponent.Ref editors = allEditors;
 
-            Enumeration e = editors.getComponents();
+            Enumeration<CloneableTopComponent> e = editors.getComponents();
             while(e.hasMoreElements()) {
                 final Object pane = e.nextElement();
                 SwingUtilities.invokeLater(new Runnable() {

--- a/ide/xml.core/src/org/netbeans/modules/xml/core/lib/XSLT10PseudoDTDGrammarQueryProvider.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/core/lib/XSLT10PseudoDTDGrammarQueryProvider.java
@@ -39,7 +39,7 @@ public class XSLT10PseudoDTDGrammarQueryProvider extends GrammarQueryManager {
 
     @Override
     public Enumeration enabled(GrammarEnvironment ctx) {
-        Enumeration en = ctx.getDocumentChildren();
+        Enumeration<Node> en = ctx.getDocumentChildren();
         while (en.hasMoreElements()) {
             Node next = (Node) en.nextElement();
             if (next.getNodeType() == Node.ELEMENT_NODE) {

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/ContentModel.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/ContentModel.java
@@ -554,7 +554,7 @@ abstract class ContentModel {
         private final List<String> list = new LinkedList<>();
         
         // source of lazy stack initilization
-        private final Enumeration en;
+        private final Enumeration<String> en;
         
         // current stack position
         private int current;

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
@@ -192,7 +192,7 @@ class DTDGrammar implements ExtendedGrammarQuery {
                 contentModels.put(el.getTagName(), model);
             }
             if (model instanceof ContentModel) {
-                Enumeration en = ((ContentModel)model).whatCanFollow(new PreviousEnumeration(el, ctx));
+                Enumeration<String> en = ((ContentModel)model).whatCanFollow(new PreviousEnumeration(el, ctx));
                 if (en == null) return org.openide.util.Enumerations.empty();
                 String prefix = ctx.getCurrentPrefix();
                 elements = new TreeSet<>();

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataObject.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataObject.java
@@ -202,7 +202,7 @@ public abstract class XmlMultiViewDataObject extends MultiDataObject implements 
     public boolean canClose() {
         final CloneableTopComponent topComponent = ((CloneableTopComponent) getEditorSupport().getMVTC());
         if (topComponent != null){
-            Enumeration enumeration = topComponent.getReference().getComponents();
+            Enumeration<CloneableTopComponent> enumeration = topComponent.getReference().getComponents();
             if (enumeration.hasMoreElements()) {
                 enumeration.nextElement();
                 if (enumeration.hasMoreElements()) {

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewEditorSupport.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewEditorSupport.java
@@ -797,7 +797,7 @@ public class XmlMultiViewEditorSupport extends DataEditorSupport implements Seri
                         Object o = iterator.next();
                         if (o instanceof CloneableTopComponent) {
                             final CloneableTopComponent topComponent = (CloneableTopComponent) o;
-                            Enumeration en = topComponent.getReference().getComponents();
+                            Enumeration<CloneableTopComponent> en = topComponent.getReference().getComponents();
                             if (mvtc == topComponent) {
                                 if (en.hasMoreElements()) {
                                     // Remember next cloned top component

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionView.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionView.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.xml.multiview.ui;
 
 import javax.swing.JPanel;
 import java.awt.*;
+import java.util.Enumeration;
 import java.util.Hashtable;
 
 import org.openide.nodes.Node;
@@ -279,7 +280,7 @@ public class SectionView extends PanelView implements SectionFocusCookie, Contai
      * if no matching panel was found.
      */
     public SectionPanel findSectionPanel(Object key) {
-        java.util.Enumeration en = map.keys();
+        Enumeration<Node> en = map.keys();
         while (en.hasMoreElements()) {
             NodeSectionPanel pan = map.get(en.nextElement());
             if (pan instanceof SectionPanel) {

--- a/ide/xml/src/org/netbeans/modules/xml/text/TextEditorSupport.java
+++ b/ide/xml/src/org/netbeans/modules/xml/text/TextEditorSupport.java
@@ -559,7 +559,7 @@ public class TextEditorSupport extends DataEditorSupport implements EditorCookie
                 StatusDisplayer.getDefault().setStatusText(msg);
             }
 
-            Enumeration en = allEditors.getComponents();
+            Enumeration<CloneableTopComponent> en = allEditors.getComponents();
             while ( en.hasMoreElements() ) {
                 CloneableTopComponent editor = (CloneableTopComponent)en.nextElement();
                 if ( editor instanceof CloneableEditor ) {

--- a/java/ant.grammar/src/org/netbeans/modules/ant/grammar/AntGrammarQueryProvider.java
+++ b/java/ant.grammar/src/org/netbeans/modules/ant/grammar/AntGrammarQueryProvider.java
@@ -43,7 +43,7 @@ public final class AntGrammarQueryProvider extends GrammarQueryManager {
         if (f != null && !f.getMIMEType().equals("text/x-ant+xml")) {
             return null;
         }
-        Enumeration en = ctx.getDocumentChildren();
+        Enumeration<Node> en = ctx.getDocumentChildren();
         while (en.hasMoreElements()) {
             Node next = (Node) en.nextElement();
             if (next.getNodeType() == Node.ELEMENT_NODE) {

--- a/java/beans/src/org/netbeans/modules/beans/beaninfo/BIEditorSupport.java
+++ b/java/beans/src/org/netbeans/modules/beans/beaninfo/BIEditorSupport.java
@@ -312,7 +312,7 @@ public final class BIEditorSupport extends DataEditorSupport
             return false;
         
         boolean oneOrLess = true;
-        Enumeration en = ((CloneableTopComponent)tc).getReference().getComponents();
+        Enumeration<CloneableTopComponent> en = ((CloneableTopComponent)tc).getReference().getComponents();
         if (en.hasMoreElements()) {
             en.nextElement();
             if (en.hasMoreElements())
@@ -666,7 +666,7 @@ public final class BIEditorSupport extends DataEditorSupport
                 for (TopComponent o : closed) {
                     if (o instanceof CloneableTopComponent) {
                         final CloneableTopComponent topComponent = (CloneableTopComponent) o;
-                        Enumeration en = topComponent.getReference().getComponents();
+                        Enumeration<CloneableTopComponent> en = topComponent.getReference().getComponents();
                         if (multiviewTC == topComponent) {
                             if (en.hasMoreElements()) {
                                 // Remember next cloned top component

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DBSchemaFileList.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DBSchemaFileList.java
@@ -63,7 +63,7 @@ public class DBSchemaFileList {
     }
 
     private void searchRoot(FileObject root, String rootDisplayName) {
-        Enumeration ch = root.getChildren(true);
+        Enumeration<? extends FileObject> ch = root.getChildren(true);
         while (ch.hasMoreElements()) {
             FileObject f = (FileObject) ch.nextElement();
             if (f.getExt().equals(DBSchemaManager.DBSCHEMA_EXT) && !f.isFolder()) {

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectionComboModel.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectionComboModel.java
@@ -31,6 +31,7 @@ import javax.swing.AbstractListModel;
 import javax.swing.ComboBoxModel;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeNode;
 import org.netbeans.modules.java.hints.providers.spi.HintMetadata;
 import org.netbeans.modules.java.hints.providers.spi.HintMetadata.Options;
 import org.netbeans.modules.java.hints.spiimpl.options.HintsPanelLogic.HintCategory;
@@ -45,7 +46,7 @@ public final class InspectionComboModel extends AbstractListModel implements Com
 
     public InspectionComboModel(Collection<? extends HintMetadata> hints) {
         DefaultMutableTreeNode root = (DefaultMutableTreeNode) constructTM(hints, false).getRoot();
-        Enumeration enumeration = root.preorderEnumeration();
+        Enumeration<TreeNode> enumeration = root.preorderEnumeration();
         
         hintsList = new ArrayList<Object>();
         while (enumeration.hasMoreElements()) {

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
@@ -655,7 +655,7 @@ public class J2SEModularProjectProperties {
         projectProperties.put(ProjectProperties.EXCLUDES, excludes);
 
         StringBuilder sb = new StringBuilder();
-        for (Enumeration elements = ANNOTATION_PROCESSORS_MODEL.elements(); elements.hasMoreElements();) {
+        for (Enumeration<String> elements = ANNOTATION_PROCESSORS_MODEL.elements(); elements.hasMoreElements();) {
             sb.append(elements.nextElement());
             if (elements.hasMoreElements())
                 sb.append(',');

--- a/java/java.platform.ui/src/org/netbeans/modules/java/platform/wizard/SelectorPanel.form
+++ b/java/java.platform.ui/src/org/netbeans/modules/java/platform/wizard/SelectorPanel.form
@@ -21,12 +21,17 @@
 
 -->
 
-<Form version="1.0" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+<Form version="1.2" maxVersion="1.2" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <AuxValues>
+    <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+    <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,44,0,0,1,-112"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>

--- a/java/java.platform.ui/src/org/netbeans/modules/java/platform/wizard/SelectorPanel.java
+++ b/java/java.platform.ui/src/org/netbeans/modules/java/platform/wizard/SelectorPanel.java
@@ -23,10 +23,12 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ItemListener;
+import java.util.Enumeration;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import javax.swing.AbstractButton;
 import javax.swing.ButtonGroup;
 import javax.swing.ButtonModel;
 import javax.swing.JLabel;
@@ -114,7 +116,7 @@ class SelectorPanel extends javax.swing.JPanel implements ItemListener {
     
     private void readSettings () {
         if (this.group.getSelection()==null) {
-            java.util.Enumeration buttonEnum = this.group.getElements();
+            Enumeration<AbstractButton> buttonEnum = this.group.getElements();
             assert buttonEnum.hasMoreElements();
             ((JRadioButton)buttonEnum.nextElement()).setSelected(true);
         }

--- a/java/maven.grammar/src/org/netbeans/modules/maven/codegen/NewPluginPanel.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/codegen/NewPluginPanel.java
@@ -124,7 +124,7 @@ public class NewPluginPanel extends javax.swing.JPanel implements ChangeListener
 
     public List<String> getGoals () {
         List<String> goals = new ArrayList<String>();
-        Enumeration e  = listModel.elements();
+        Enumeration<GoalEntry> e  = listModel.elements();
         GoalEntry ge;
         while (e.hasMoreElements()) {
             ge = (GoalEntry) e.nextElement();

--- a/java/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenQueryProvider.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenQueryProvider.java
@@ -54,7 +54,7 @@ public final class MavenQueryProvider extends GrammarQueryManager {
     public Enumeration enabled(GrammarEnvironment ctx) {
         // check if is supported environment..
         if (getGrammar(ctx) != null) {
-            Enumeration en = ctx.getDocumentChildren();
+            Enumeration<Node> en = ctx.getDocumentChildren();
             while (en.hasMoreElements()) {
                 Node next = (Node)en.nextElement();
                 if (next.getNodeType() == Node.ELEMENT_NODE) {

--- a/php/php.samples/src/org/netbeans/modules/php/samples/PHPSamplesWizardIterator.java
+++ b/php/php.samples/src/org/netbeans/modules/php/samples/PHPSamplesWizardIterator.java
@@ -91,7 +91,7 @@ public class PHPSamplesWizardIterator implements WizardDescriptor./*Progress*/In
         // Always open top dir as a project:
         resultSet.add(dir);
         // Look for nested projects to open as well:
-        Enumeration e = dir.getFolders(true);
+        Enumeration<? extends FileObject> e = dir.getFolders(true);
         while (e.hasMoreElements()) {
             FileObject subfolder = (FileObject) e.nextElement();
             if (ProjectManager.getDefault().isProject(subfolder)) {

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/wizard/SiteTemplateWizard.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/wizard/SiteTemplateWizard.java
@@ -440,7 +440,7 @@ public class SiteTemplateWizard extends JPanel {
         RP.post(new Runnable() {
             @Override
             public void run() {
-                Enumeration templates = onlineTemplatesListModel.elements();
+                Enumeration<SiteTemplateImplementation> templates = onlineTemplatesListModel.elements();
                 while (templates.hasMoreElements()) {
                     SiteTemplateImplementation template = (SiteTemplateImplementation) templates.nextElement();
                     try {


### PR DESCRIPTION
Cleanup a bunch of warnings that look like this..

   [repeat] /home/bwalker/src/netbeans/ide/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java:153: warning: [rawtypes] found raw type: Enumeration
   [repeat]                 Enumeration en = ctx.getDocumentChildren();
   [repeat]                 ^
   [repeat]   missing type arguments for generic class Enumeration<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in interface Enumeration





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

