### PR TITLE
[NETBEANS-6468] Fix Windows LAF on Windows 11 and Java 17

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/CloseButtonTabbedPane.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/CloseButtonTabbedPane.java
@@ -339,6 +339,11 @@ final class CloseButtonTabbedPane extends JTabbedPane implements PropertyChangeL
             || (osName.equals( "Windows NT (unknown)" ) && "10.0".equals( System.getProperty("os.version") ));
     }
 
+    private static boolean isWindows11() {
+        String osName = System.getProperty ("os.name");
+        return osName.indexOf("Windows 11") >= 0;
+    }
+
     private boolean isWindowsVistaLaF() {
         String osName = System.getProperty ("os.name");
         return osName.indexOf("Vista") >= 0 
@@ -551,7 +556,7 @@ final class CloseButtonTabbedPane extends JTabbedPane implements PropertyChangeL
                 @Override
                 public void setText(String text) {
                     super.setText(text);
-                    if (isWindowsLaF() && isWindows10()) {
+                    if (isWindowsLaF() && (isWindows10() || isWindows11())) {
                         int r = text.endsWith(" ") || text.endsWith("&nbsp;</html>") ? 0 : 3; // NOI18N
                         setBorder(BorderFactory.createEmptyBorder(0, 0, 0, r));
                     }

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/Startup.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/Startup.java
@@ -436,7 +436,7 @@ public final class Startup {
             buf.append("Nb."); //NOI18N
             buf.append(UIManager.getLookAndFeel().getID());
             if (UIUtils.isXPLF()) {
-                if (isWindows8() || isWindows10()) {
+                if (isWindows8() || isWindows10() || isWindows11()) {
                     buf.append("Windows8LFCustoms"); //NOI18N
                 } else if (isWindowsVista() || isWindows7()) {
                     buf.append("VistaLFCustoms"); //NOI18N
@@ -461,7 +461,7 @@ public final class Startup {
             switch (Arrays.asList(knownLFs).indexOf(UIManager.getLookAndFeel().getID())) {
                 case 1 :
                     if (UIUtils.isXPLF()) {
-                        if( isWindows8() || isWindows10() ) {
+                        if( isWindows8() || isWindows10() || isWindows11() ) {
                             result = new Windows8LFCustoms();
                         } else if (isWindowsVista() || isWindows7()) {
                             result = new VistaLFCustoms();
@@ -487,7 +487,7 @@ public final class Startup {
                 default :
                     // #79401 check if it's XP style LnF, for example jGoodies
                     if (UIUtils.isXPLF()) {
-                        if (isWindows8() || isWindows10()) {
+                        if (isWindows8() || isWindows10() || isWindows11()) {
                             result = new Windows8LFCustoms();
                         } else if (isWindowsVista() || isWindows7()) {
                             result = new VistaLFCustoms();
@@ -574,6 +574,11 @@ public final class Startup {
         String osName = System.getProperty ("os.name");
         return osName.indexOf("Windows 10") >= 0
             || (osName.equals( "Windows NT (unknown)" ) && "10.0".equals( System.getProperty("os.version") ));
+    }
+
+    private static boolean isWindows11() {
+        String osName = System.getProperty ("os.name");
+        return osName.indexOf("Windows 11") >= 0;
     }
 
     private static boolean isMac() {

--- a/platform/openide.awt/src/org/openide/awt/CloseButtonFactory.java
+++ b/platform/openide.awt/src/org/openide/awt/CloseButtonFactory.java
@@ -89,12 +89,8 @@ public final class CloseButtonFactory{
         return isWindowsLaF() && (isWindowsVista() || isWindows7()) && isWindowsXPLaF();
     }
 
-    private static boolean isWindows8LaF() {
-        return isWindowsLaF() && isWindows8() && isWindowsXPLaF();
-    }
-
-    private static boolean isWindows10LaF() {
-        return isWindowsLaF() && isWindows10() && isWindowsXPLaF();
+    private static boolean isWindows8OrAboveLaF() {
+        return isWindowsLaF() && (isWindows8() || isWindows10() || isWindows11()) && isWindowsXPLaF();
     }
 
     private static boolean isWindowsVista() {
@@ -107,6 +103,11 @@ public final class CloseButtonFactory{
         String osName = System.getProperty ("os.name");
         return osName.indexOf("Windows 10") >= 0
             || (osName.equals( "Windows NT (unknown)" ) && "10.0".equals( System.getProperty("os.version") ));
+    }
+
+    private static boolean isWindows11() {
+        String osName = System.getProperty ("os.name");
+        return osName.indexOf("Windows 11") >= 0;
     }
 
     private static boolean isWindows8() {
@@ -151,7 +152,7 @@ public final class CloseButtonFactory{
             }
         }
         if( null == closeTabImage ) {
-            if( isWindows8LaF() || isWindows10LaF() ) {
+            if( isWindows8OrAboveLaF() ) {
                 closeTabImage = Windows8VectorCloseButton.DEFAULT;
             } else if( isWindowsVistaLaF() ) {
                 closeTabImage = ImageUtilities.loadImageIcon("org/openide/awt/resources/vista_close_enabled.png", true); // NOI18N
@@ -181,7 +182,7 @@ public final class CloseButtonFactory{
             }
         }
         if( null == closeTabPressedImage ) {
-            if( isWindows8LaF() || isWindows10LaF() ) {
+            if( isWindows8OrAboveLaF() ) {
                 closeTabPressedImage = Windows8VectorCloseButton.PRESSED;
             } else if( isWindowsVistaLaF() ) {
                 closeTabPressedImage = ImageUtilities.loadImageIcon("org/openide/awt/resources/vista_close_pressed.png", true); // NOI18N
@@ -211,7 +212,7 @@ public final class CloseButtonFactory{
             }
         }
         if( null == closeTabMouseOverImage ) {
-            if( isWindows8LaF() || isWindows10LaF() ) {
+            if( isWindows8OrAboveLaF() ) {
                 closeTabMouseOverImage = Windows8VectorCloseButton.PRESSED;
             } else if( isWindowsVistaLaF() ) {
                 closeTabMouseOverImage = ImageUtilities.loadImageIcon("org/openide/awt/resources/vista_close_rollover.png", true); // NOI18N
@@ -242,7 +243,7 @@ public final class CloseButtonFactory{
             }
         }
         if( null == bigCloseTabImage ) {
-            if( isWindows8LaF() || isWindows10LaF() ) {
+            if( isWindows8OrAboveLaF() ) {
                 bigCloseTabImage = Windows8VectorCloseButton.DEFAULT;
             } else if( isWindowsVistaLaF() ) {
                 bigCloseTabImage = ImageUtilities.loadImageIcon("org/openide/awt/resources/vista_bigclose_enabled.png", true); // NOI18N
@@ -272,7 +273,7 @@ public final class CloseButtonFactory{
             }
         }
         if( null == bigCloseTabPressedImage ) {
-            if( isWindows8LaF() || isWindows10LaF() ) {
+            if( isWindows8OrAboveLaF() ) {
                 bigCloseTabPressedImage = Windows8VectorCloseButton.PRESSED;
             } else if( isWindowsVistaLaF() ) {
                 bigCloseTabPressedImage = ImageUtilities.loadImageIcon("org/openide/awt/resources/vista_bigclose_pressed.png", true); // NOI18N
@@ -302,7 +303,7 @@ public final class CloseButtonFactory{
             }
         }
         if( null == bigCloseTabMouseOverImage ) {
-            if( isWindows8LaF() || isWindows10LaF() ) {
+            if( isWindows8OrAboveLaF() ) {
                 bigCloseTabMouseOverImage = Windows8VectorCloseButton.PRESSED;
             } else if( isWindowsVistaLaF() ) {
                 bigCloseTabMouseOverImage = ImageUtilities.loadImageIcon("org/openide/awt/resources/vista_bigclose_rollover.png", true); // NOI18N

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/UIUtils.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/UIUtils.java
@@ -383,7 +383,7 @@ public final class UIUtils {
     public static boolean isWindowsModernLookAndFeel() {
         if (!isWindowsXPLookAndFeel()) return false;
         String osName = System.getProperty("os.name"); // NOI18N
-        return osName != null && (osName.contains("Windows 8") || osName.contains("Windows 10")); // NOI18N
+        return osName != null && (osName.contains("Windows 8") || osName.contains("Windows 10") || osName.contains("Windows 11")); // NOI18N
     }
     
     public static boolean isOracleLookAndFeel() {


### PR DESCRIPTION
When running NetBeans with the Windows LAF on Windows 11 and Java 17, parts of the LAF revert to an older look. See screenshot below.

This is due to the "os.name" system property being checked for the value "Windows 10" in various places. With Java 17 and Windows 11, this property can now have the value "Windows 11". This PR goes through each occurrence of "Windows 10" and also permits "Windows 11" in these cases.

![220219 Windows LAF problem on Windows 11](https://user-images.githubusercontent.com/886243/154819559-027b0162-1262-4a29-8889-360b375b0edd.png)

