### PR TITLE
Cleanup deprecated constructor use

### DIFF
--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofInstanceValue.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofInstanceValue.java
@@ -40,14 +40,17 @@ class HprofInstanceValue extends HprofObject implements FieldValue {
 
     //~ Methods ------------------------------------------------------------------------------------------------------------------
 
+    @Override
     public Instance getDefiningInstance() {
         return field.classDump.getHprof().getInstanceByOffset(new long[] {instanceOffset});
     }
 
+    @Override
     public Field getField() {
         return field;
     }
 
+    @Override
     public String getValue() {
         return getTypeValue().toString();
     }
@@ -62,50 +65,41 @@ class HprofInstanceValue extends HprofObject implements FieldValue {
     static Object getTypeValue(final HprofByteBuffer dumpBuffer, final long position, final byte type) {
         switch (type) {
             case HprofHeap.OBJECT:
-
                 long obj = dumpBuffer.getID(position);
-
-                return new Long(obj);
+                return obj;
+                
             case HprofHeap.BOOLEAN:
-
                 byte b = dumpBuffer.get(position);
-
-                return Boolean.valueOf(b != 0);
+                return b != 0;
+                
             case HprofHeap.CHAR:
-
                 char ch = dumpBuffer.getChar(position);
-
-                return Character.valueOf(ch);
+                return ch;
+                
             case HprofHeap.FLOAT:
-
                 float f = dumpBuffer.getFloat(position);
-
-                return new Float(f);
+                return f;
+                
             case HprofHeap.DOUBLE:
-
                 double d = dumpBuffer.getDouble(position);
-
-                return new Double(d);
+                return d;
+                
             case HprofHeap.BYTE:
-
                 byte bt = dumpBuffer.get(position);
-
-                return new Byte(bt);
+                return bt;
+                
             case HprofHeap.SHORT:
-
                 short sh = dumpBuffer.getShort(position);
-
-                return new Short(sh);
+                return sh;
+                
             case HprofHeap.INT:
-
                 int i = dumpBuffer.getInt(position);
-
-                return Integer.valueOf(i);
+                return i;
+                
             case HprofHeap.LONG:
-
                 long lg = dumpBuffer.getLong(position);
-
-                return new Long(lg);
+                return lg;
+                
             default:
                 return "Invalid type " + type; // NOI18N
         }


### PR DESCRIPTION
Cleaned up the deprecated use of old constructors. The compiler/VM will now autobox this into a proper
class. So this change removes warnings like this:

[repeat] /home/bwalker/src/netbeans/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofInstanceValue.java:93: warning: [deprecation] Byte(byte) in Byte has been deprecated
[repeat]                 return new Byte(bt);
[repeat]                        ^

Also, added a couple of override annotations since I was here..





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

