### PR TITLE
Cleanup deprecated constructor use

### DIFF
--- a/java/junit/src/org/netbeans/modules/junit/AbstractTestGenerator.java
+++ b/java/junit/src/org/netbeans/modules/junit/AbstractTestGenerator.java
@@ -180,7 +180,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
 
     private final boolean isNewTestClass;
 
-    private List<String>processedClassNames;
+    private List<String> processedClassNames;
 
     /**
      * cached value of <code>JUnitSettings.getGenerateMainMethodBody()</code>
@@ -467,26 +467,30 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
         }
 
         List<MethodTree> members;
-        if (membersCount == 0) {
-            members = Collections.emptyList();
-        } else if (membersCount == 1) {
-            if (constructor != null) {
-                members = Collections.singletonList(constructor);
-            } else {
-                members = Collections.singletonList(
-                        generateAbstractMethodImpl(abstractMethods.get(0),
-                                                   workingCopy));
-            }
-        } else {
-            members = new ArrayList(membersCount);
-            if (constructor != null) {
-                members.add(constructor);
-            }
-            for (ExecutableElement abstractMethod : abstractMethods) {
-                members.add(generateAbstractMethodImpl(abstractMethod,
-                                                       workingCopy));
-            }
+        switch (membersCount) {
+            case 0:
+                members = Collections.emptyList();
+                break;
 
+            case 1:
+                if (constructor != null) {
+                    members = Collections.singletonList(constructor);
+                } else {
+                    members = Collections.singletonList(
+                            generateAbstractMethodImpl(abstractMethods.get(0),
+                                    workingCopy));
+                }
+                break;
+                
+            default:
+                members = new ArrayList(membersCount);
+                if (constructor != null) {
+                    members.add(constructor);
+                }   for (ExecutableElement abstractMethod : abstractMethods) {
+                    members.add(generateAbstractMethodImpl(abstractMethod,
+                            workingCopy));
+                }
+                break;
         }
 
         final TreeMaker maker = workingCopy.getTreeMaker();
@@ -494,8 +498,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
         switch(srcClass.getKind()) {
             case INTERFACE:
             case ANNOTATION_TYPE:
-                List<ExpressionTree> implemetnts =
-                    new ArrayList<ExpressionTree>();
+                List<ExpressionTree> implemetnts = new ArrayList<>();
                 implemetnts.add(maker.QualIdent(srcClass));
                 return maker.Class(
                     maker.Modifiers(Collections.singleton(PUBLIC)),
@@ -921,7 +924,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
                                             trees);
 
         List<? extends Tree> tstMembersOrig = tstClass.getMembers();
-        List<Tree> tstMembers = new ArrayList<Tree>(tstMembersOrig.size() + 4);
+        List<Tree> tstMembers = new ArrayList<>(tstMembersOrig.size() + 4);
         tstMembers.addAll(tstMembersOrig);
 
         if (generateMissingInitMembers) {
@@ -1044,7 +1047,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
         Iterator<ExecutableElement> srcMethodsIt = srcMethods.iterator();
         Iterator<String> tstMethodNamesIt = testMethodNames.iterator();
 
-        List<MethodTree> testMethods = new ArrayList<MethodTree>(srcMethods.size());
+        List<MethodTree> testMethods = new ArrayList<>(srcMethods.size());
         while (srcMethodsIt.hasNext()) {
             assert tstMethodNamesIt.hasNext();
 
@@ -1458,7 +1461,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
                             retTypeTree,
                             methodCall);
 
-                    List<ExpressionTree> comparisonArgs = new ArrayList<ExpressionTree>(2);
+                    List<ExpressionTree> comparisonArgs = new ArrayList<>(2);
                     comparisonArgs.add(maker.Identifier(expectedValue.getName().toString()));
                     comparisonArgs.add(maker.Identifier(actualValue.getName().toString()));
                     if ((retTypeKind == TypeKind.DOUBLE) || (retTypeKind == TypeKind.FLOAT)){
@@ -1593,8 +1596,9 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
         }
 
         Set<Modifier> noModifiers = Collections.<Modifier>emptySet();
-        List<VariableTree> paramVariables = new ArrayList<VariableTree>(params.size());
+        List<VariableTree> paramVariables = new ArrayList<>(params.size());
         int index = 0;
+        
         for (TypeMirror param : params) {
             if (param.getKind() == TypeKind.TYPEVAR){
                 param = getSuperType(workingCopy, param);
@@ -1750,29 +1754,29 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
                     defValue = maker.Literal(Boolean.FALSE);
                     break;
                 case CHAR:
-                    defValue = maker.Literal(new Character(' '));
+                    defValue = maker.Literal(' ');
                     break;
                 case BYTE:
-                    defValue = maker.Literal(new Byte((byte) 0));
+                    defValue = maker.Literal((byte) 0);
                     break;
                 case SHORT:
-                    defValue = maker.Literal(new Short((short) 0));
+                    defValue = maker.Literal((short) 0);
                     break;
                 case INT:
-                    defValue = maker.Literal(new Integer(0));
+                    defValue = maker.Literal(0);
                     break;
                 case FLOAT:
-                    defValue = maker.Literal(new Float(0.0F));
+                    defValue = maker.Literal(0.0F);
                     break;
                 case LONG:
-                    defValue = maker.Literal(new Long(0L));
+                    defValue = maker.Literal(0L);
                     break;
                 case DOUBLE:
-                    defValue = maker.Literal(new Double(0.0));
+                    defValue = maker.Literal(0.0D);
                     break;
                 default:
                     assert false : "unknown primitive type";            //NOI18N
-                    defValue = maker.Literal(new Integer(0));
+                    defValue = maker.Literal(0);
                     break;
             }
         } else if ((typeKind == TypeKind.DECLARED)
@@ -2009,7 +2013,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
             return Collections.<T>emptyList();
         }
 
-        List<T> elements = new ArrayList<T>(handles.size());
+        List<T> elements = new ArrayList<>(handles.size());
         for (ElementHandle<T> handle : handles) {
             T element = handle.resolve(compInfo);
             if (element != null) {
@@ -2226,7 +2230,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
 
     private List<VariableTree> generateEJBLookupCode(TreeMaker maker, TypeElement srcClass, ExecutableElement srcMethod) {
         final String ejbContainerPackage = "javax.ejb.embeddable.EJBContainer"; // NOI18N
-        List<VariableTree> trees = new ArrayList<VariableTree>();
+        List<VariableTree> trees = new ArrayList<>();
 
         // TODO: there are probably better ways how to generate code below:
         IdentifierTree container = maker.Identifier(ejbContainerPackage); 

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDumpSegment.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDumpSegment.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-
 /**
  *
  * @author Tomas Hurka
@@ -59,9 +58,9 @@ class ClassDumpSegment extends TagBounds {
     final int superClassIDOffset;
     ClassDump java_lang_Class;
     boolean newSize;
-    Map<JavaClass,List<Field>> fieldsCache;
-    private List<JavaClass> classes;
-    private Map /*<Byte,JavaClass>*/ primitiveArrayMap;
+    Map<JavaClass, List<Field>> fieldsCache;
+    private List<ClassDump> classes;
+    private Map<Integer, ClassDump> primitiveArrayMap;
 
     //~ Constructors -------------------------------------------------------------------------------------------------------------
 
@@ -165,13 +164,13 @@ class ClassDumpSegment extends TagBounds {
 
     Map getClassIdToClassMap() {
         Collection allClasses = createClassCollection();
-        Map map = new HashMap(allClasses.size()*4/3);
-        Iterator classIt = allClasses.iterator();
+        Map<Long, ClassDump> map = new HashMap<>(allClasses.size()*4/3);
+        Iterator<ClassDump> classIt = allClasses.iterator();
         
         while(classIt.hasNext()) {
-            ClassDump cls = (ClassDump) classIt.next();
+            ClassDump cls = (ClassDump)classIt.next();
             
-            map.put(new Long(cls.getJavaClassId()),cls);
+            map.put(cls.getJavaClassId(), cls);
         }
         return map;
     }
@@ -202,20 +201,19 @@ class ClassDumpSegment extends TagBounds {
         }
     }
 
-    synchronized List<JavaClass> createClassCollection() {
+    synchronized List<ClassDump> createClassCollection() {
         if (classes != null) {
             return classes;
         }
 
-        List<JavaClass> cls = new ArrayList<>(1000);
+        List<ClassDump> cls = new ArrayList<>(1000);
 
         long[] offset = new long[] { startOffset };
 
         while (offset[0] < endOffset) {
             long start = offset[0];
-            int tag = hprofHeap.readDumpTag(offset);
 
-            if (tag == HprofHeap.CLASS_DUMP) {
+            if (hprofHeap.readDumpTag(offset) == HprofHeap.CLASS_DUMP) {
                 ClassDump classDump = new ClassDump(this, start);
                 long classId = classDump.getJavaClassId();
                 LongMap.Entry classEntry = hprofHeap.idToOffsetMap.put(classId, start);
@@ -235,55 +233,118 @@ class ClassDumpSegment extends TagBounds {
 
     void extractSpecialClasses() {
         ClassDump java_lang_Object = null;
-        primitiveArrayMap = new HashMap();
+        primitiveArrayMap = new HashMap<>();
 
-        Iterator classIt = classes.iterator();
+        Iterator<ClassDump> classIt = classes.iterator();
 
         while (classIt.hasNext()) {
             ClassDump jcls = (ClassDump) classIt.next();
             String vmName = jcls.getLoadClass().getVMName();
             Integer typeObj = null;
 
-            if (vmName.equals("[Z")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.BOOLEAN);
-            } else if (vmName.equals("[C")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.CHAR);
-            } else if (vmName.equals("[F")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.FLOAT);
-            } else if (vmName.equals("[D")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.DOUBLE);
-            } else if (vmName.equals("[B")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.BYTE);
-            } else if (vmName.equals("[S")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.SHORT);
-            } else if (vmName.equals("[I")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.INT);
-            } else if (vmName.equals("[J")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.LONG);
-            } else if (vmName.equals("java/lang/Class")) { // NOI18N
-                java_lang_Class = jcls;
-            } else if (vmName.equals("java/lang/Object")) { // NOI18N
-                java_lang_Object = jcls;
-            } else if (vmName.equals("boolean[]")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.BOOLEAN);
-            } else if (vmName.equals("char[]")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.CHAR);
-            } else if (vmName.equals("float[]")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.FLOAT);
-            } else if (vmName.equals("double[]")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.DOUBLE);
-            } else if (vmName.equals("byte[]")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.BYTE);
-            } else if (vmName.equals("short[]")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.SHORT);
-            } else if (vmName.equals("int[]")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.INT);
-            } else if (vmName.equals("long[]")) { // NOI18N
-                typeObj = Integer.valueOf(HprofHeap.LONG);
-            } else if (vmName.equals("java.lang.Class")) { // NOI18N
-                java_lang_Class = jcls;
-            } else if (vmName.equals("java.lang.Object")) { // NOI18N
-                java_lang_Object = jcls;
+            switch (vmName) {
+                case "[Z":
+                    // NOI18N
+                    typeObj = HprofHeap.BOOLEAN;
+                    break;
+                    
+                case "[C":
+                    // NOI18N
+                    typeObj = HprofHeap.CHAR;
+                    break;
+                    
+                case "[F":
+                    // NOI18N
+                    typeObj = HprofHeap.FLOAT;
+                    break;
+                    
+                case "[D":
+                    // NOI18N
+                    typeObj = HprofHeap.DOUBLE;
+                    break;
+                    
+                case "[B":
+                    // NOI18N
+                    typeObj = HprofHeap.BYTE;
+                    break;
+                    
+                case "[S":
+                    // NOI18N
+                    typeObj = HprofHeap.SHORT;
+                    break;
+                    
+                case "[I":
+                    // NOI18N
+                    typeObj = HprofHeap.INT;
+                    break;
+                    
+                case "[J":
+                    // NOI18N
+                    typeObj = HprofHeap.LONG;
+                    break;
+                    
+                case "java/lang/Class":
+                    // NOI18N
+                    java_lang_Class = jcls;
+                    break;
+                    
+                case "java/lang/Object":
+                    // NOI18N
+                    java_lang_Object = jcls;
+                    break;
+                    
+                case "boolean[]":
+                    // NOI18N
+                    typeObj = HprofHeap.BOOLEAN;
+                    break;
+                    
+                case "char[]":
+                    // NOI18N
+                    typeObj = HprofHeap.CHAR;
+                    break;
+                    
+                case "float[]":
+                    // NOI18N
+                    typeObj = HprofHeap.FLOAT;
+                    break;
+                    
+                case "double[]":
+                    // NOI18N
+                    typeObj = HprofHeap.DOUBLE;
+                    break;
+                    
+                case "byte[]":
+                    // NOI18N
+                    typeObj = HprofHeap.BYTE;
+                    break;
+                    
+                case "short[]":
+                    // NOI18N
+                    typeObj = HprofHeap.SHORT;
+                    break;
+                    
+                case "int[]":
+                    // NOI18N
+                    typeObj = HprofHeap.INT;
+                    break;
+                    
+                case "long[]":
+                    // NOI18N
+                    typeObj = HprofHeap.LONG;
+                    break;
+                    
+                case "java.lang.Class":
+                    // NOI18N
+                    java_lang_Class = jcls;
+                    break;
+                    
+                case "java.lang.Object":
+                    // NOI18N
+                    java_lang_Object = jcls;
+                    break;
+                    
+                default:
+                    break;
             }
 
             if (typeObj != null) {
@@ -296,20 +357,21 @@ class ClassDumpSegment extends TagBounds {
     }
 
     //---- Serialization support
+    @Override
     void writeToStream(DataOutputStream out) throws IOException {
         super.writeToStream(out);
         if (classes == null) {
             out.writeInt(0);
         } else {
             out.writeInt(classes.size());
-            for (int i=0; i<classes.size(); i++) {
-                ClassDump classDump = (ClassDump) classes.get(i);
+            for (int i=0; i < classes.size(); i++) {
+                ClassDump classDump = (ClassDump)classes.get(i);
 
                 classDump.writeToStream(out);
-                Long size = (Long) arrayMap.get(classDump);
+                Long size = (Long)arrayMap.get(classDump);
                 out.writeBoolean(size != null);
                 if (size != null) {
-                    out.writeLong(size.longValue());
+                    out.writeLong(size);
                 }
             }
         }
@@ -319,14 +381,14 @@ class ClassDumpSegment extends TagBounds {
         this(heap, start, end);
         int classesSize = dis.readInt();
         if (classesSize != 0) {
-            List<JavaClass> cls = new ArrayList<>(classesSize);
-            arrayMap = new HashMap(classesSize / 15);
+            List<ClassDump> cls = new ArrayList<>(classesSize);
+            arrayMap = new HashMap<>(classesSize / 15);
             
-            for (int i=0; i<classesSize; i++) {
+            for (int i=0; i < classesSize; i++) {
                 ClassDump c = new ClassDump(this, dis.readLong(), dis);
                 cls.add(c);
                 if (dis.readBoolean()) {
-                    Long size = Long.valueOf(dis.readLong());
+                    Long size = dis.readLong();
                     arrayMap.put(c, size);
                 }
             }
@@ -341,11 +403,9 @@ class ClassDumpSegment extends TagBounds {
             super(SIZE,0.75f,true);
         }
 
+        @Override
         protected boolean removeEldestEntry(Map.Entry eldest) {
-            if (size() > SIZE) {
-                return true;
-            }
-            return false;
+            return size() > SIZE;
         }
     }
 }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeCPU.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeCPU.java
@@ -338,14 +338,29 @@ public class ProfilerRuntimeCPU extends ProfilerRuntime {
         byte methodId = -1;
         int sessionHash = -1;
 
-        if ("GET".equals(method)) { // NOI18N
-            methodId = 1;
-        } else if ("POST".equals(method)) { // NOI18N
-            methodId = 2;
-        } else if ("PUT".equals(method)) { // NOI18N
-            methodId = 3;
-        } else if ("DELETE".equals(method)) { // NOI18N
-            methodId = 4;
+        if (null != method) switch (method) {
+            case "GET":
+                // NOI18N
+                methodId = 1;
+                break;
+                
+            case "POST":
+                // NOI18N
+                methodId = 2;
+                break;
+                
+            case "PUT":
+                // NOI18N
+                methodId = 3;
+                break;
+                
+            case "DELETE":
+                // NOI18N
+                methodId = 4;
+                break;
+                
+            default:
+                break;
         }
 
         if (sessionId != null) {
@@ -532,11 +547,11 @@ public class ProfilerRuntimeCPU extends ProfilerRuntime {
             return;
         }
         ti.inProfilingRuntimeMethod++;
-        ti.addParameter(Boolean.valueOf(b));
+        ti.addParameter(b);
         ti.inProfilingRuntimeMethod--; 
     }
 
-    public static void addParameter(char b) {
+    public static void addParameter(char c) {
         if (recursiveInstrumentationDisabled) {
             return;
         }
@@ -548,7 +563,7 @@ public class ProfilerRuntimeCPU extends ProfilerRuntime {
         }
 
         ti.inProfilingRuntimeMethod++;
-        ti.addParameter(new Character(b));
+        ti.addParameter(c);
         ti.inProfilingRuntimeMethod--; 
     }
 
@@ -564,11 +579,11 @@ public class ProfilerRuntimeCPU extends ProfilerRuntime {
         }
 
         ti.inProfilingRuntimeMethod++;
-        ti.addParameter(new Byte(b));
+        ti.addParameter(b);
         ti.inProfilingRuntimeMethod--; 
     }
 
-    public static void addParameter(short b) {
+    public static void addParameter(short s) {
         if (recursiveInstrumentationDisabled) {
             return;
         }
@@ -580,11 +595,11 @@ public class ProfilerRuntimeCPU extends ProfilerRuntime {
         }
 
         ti.inProfilingRuntimeMethod++;
-        ti.addParameter(new Short(b));
+        ti.addParameter(s);
         ti.inProfilingRuntimeMethod--; 
     }
 
-    public static void addParameter(int b) {
+    public static void addParameter(int i) {
         if (recursiveInstrumentationDisabled) {
             return;
         }
@@ -596,11 +611,11 @@ public class ProfilerRuntimeCPU extends ProfilerRuntime {
         }
 
         ti.inProfilingRuntimeMethod++;
-        ti.addParameter(new Integer(b));
+        ti.addParameter(i);
         ti.inProfilingRuntimeMethod--; 
     }
 
-    public static void addParameter(long b) {
+    public static void addParameter(long l) {
         if (recursiveInstrumentationDisabled) {
             return;
         }
@@ -612,11 +627,11 @@ public class ProfilerRuntimeCPU extends ProfilerRuntime {
         }
 
         ti.inProfilingRuntimeMethod++;
-        ti.addParameter(new Long(b));
+        ti.addParameter(l);
         ti.inProfilingRuntimeMethod--; 
     }
 
-    public static void addParameter(float b) {
+    public static void addParameter(float f) {
         if (recursiveInstrumentationDisabled) {
             return;
         }
@@ -628,11 +643,11 @@ public class ProfilerRuntimeCPU extends ProfilerRuntime {
         }
 
         ti.inProfilingRuntimeMethod++;
-        ti.addParameter(new Float(b));
+        ti.addParameter(f);
         ti.inProfilingRuntimeMethod--; 
     }
 
-    public static void addParameter(double b) {
+    public static void addParameter(double d) {
         if (recursiveInstrumentationDisabled) {
             return;
         }
@@ -644,7 +659,7 @@ public class ProfilerRuntimeCPU extends ProfilerRuntime {
         }
 
         ti.inProfilingRuntimeMethod++;
-        ti.addParameter(new Double(b));
+        ti.addParameter(d);
         ti.inProfilingRuntimeMethod--; 
     }
 
@@ -690,32 +705,32 @@ public class ProfilerRuntimeCPU extends ProfilerRuntime {
     private static int writeParameter(byte[] evBuf, int curPos, Object p) {
         Class type = p.getClass();
         if (type == Integer.class) {
-            int vp = ((Integer)p).intValue();
+            int vp = ((Integer)p);
             evBuf[curPos++] = ProfilerInterface.INT;
             evBuf[curPos++] = (byte) ((vp >> 24) & 0xFF);
             evBuf[curPos++] = (byte) ((vp >> 16) & 0xFF);
             evBuf[curPos++] = (byte) ((vp >> 8) & 0xFF);
             evBuf[curPos++] = (byte) ((vp) & 0xFF);
         } else if (type == Boolean.class) {
-            boolean vp = ((Boolean)p).booleanValue();
+            boolean vp = ((Boolean)p);
             evBuf[curPos++] = ProfilerInterface.BOOLEAN;
             evBuf[curPos++] = (byte) (vp ? 1 : 0);
         } else if (type == Byte.class) {
-            byte vp = ((Byte)p).byteValue();
+            byte vp = ((Byte)p);
             evBuf[curPos++] = ProfilerInterface.BYTE;
             evBuf[curPos++] = vp;
         } else if (type == Character.class) {
-            char vp = ((Character)p).charValue();
+            char vp = ((Character)p);
             evBuf[curPos++] = ProfilerInterface.CHAR;
             evBuf[curPos++] = (byte) ((vp >> 8) & 0xFF);
             evBuf[curPos++] = (byte) ((vp) & 0xFF);
         } else if (type == Short.class) {
-            short vp = ((Short) p).shortValue();
+            short vp = ((Short) p);
             evBuf[curPos++] = ProfilerInterface.SHORT;
             evBuf[curPos++] = (byte) ((vp >> 8) & 0xFF);
             evBuf[curPos++] = (byte) ((vp) & 0xFF);
         } else if (type == Long.class) {
-            long vp = ((Long)p).longValue();
+            long vp = ((Long)p);
             evBuf[curPos++] = ProfilerInterface.LONG;
             evBuf[curPos++] = (byte) ((vp >> 56) & 0xFF);
             evBuf[curPos++] = (byte) ((vp >> 48) & 0xFF);
@@ -726,14 +741,14 @@ public class ProfilerRuntimeCPU extends ProfilerRuntime {
             evBuf[curPos++] = (byte) ((vp >> 8) & 0xFF);
             evBuf[curPos++] = (byte) ((vp) & 0xFF); 
         } else if (type == Float.class) {
-            int vp = Float.floatToIntBits(((Float)p).floatValue());
+            int vp = Float.floatToIntBits((Float)p);
             evBuf[curPos++] = ProfilerInterface.FLOAT;
             evBuf[curPos++] = (byte) ((vp >> 24) & 0xFF);
             evBuf[curPos++] = (byte) ((vp >> 16) & 0xFF);
             evBuf[curPos++] = (byte) ((vp >> 8) & 0xFF);
             evBuf[curPos++] = (byte) ((vp) & 0xFF);
         } else if (type == Double.class) {
-            long vp = Double.doubleToLongBits(((Double)p).doubleValue());
+            long vp = Double.doubleToLongBits(((Double)p));
             evBuf[curPos++] = ProfilerInterface.DOUBLE;
             evBuf[curPos++] = (byte) ((vp >> 56) & 0xFF);
             evBuf[curPos++] = (byte) ((vp >> 48) & 0xFF);


### PR DESCRIPTION
Cleaning some old code to make it more current..

- removed use of old deprecated constructor use
- use autobox/unbox for encapsulation
- change chain-of-if statement to switch w/ string
- some code cleanup





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

