### PR TITLE
ide/lsp.client + MultiMimeLanguageServerProvider

### DIFF
--- a/ide/lsp.client/apichanges.xml
+++ b/ide/lsp.client/apichanges.xml
@@ -25,6 +25,18 @@
     <apidef name="lsp_client">LSP Client API</apidef>
 </apidefs>
 <changes>
+    <change id="MultiMimeLanguageServerProvider">
+        <api name="lsp_client" />
+        <summary>Adding MultiMimeLanguageServerProvider</summary>
+        <version major="0" minor="1.9" />
+        <date day="22" month="2" year="2022" />
+        <author login="vieiro" />
+        <compatibility addition="yes" binary="compatible" source="compatible" />
+        <description>
+               org.netbeans.modules.lsp.client.spi.MultiMimeLanguageServerProvider
+        </description>
+        <class name="MultiMimeLanguageServerProvider" package="org.netbeans.modules.lsp.client.spi"/>
+    </change>
     <change id="ServerRestarter">
         <api name="lsp_client" />
         <summary>Adding ServerRestarter</summary>

--- a/ide/lsp.client/nbproject/project.properties
+++ b/ide/lsp.client/nbproject/project.properties
@@ -24,4 +24,4 @@ release.external/org.eclipse.lsp4j.jsonrpc-0.12.0.jar=modules/ext/org.eclipse.ls
 release.external/org.eclipse.xtend.lib-2.19.0.jar=modules/ext/org.eclipse.xtend.lib-2.19.0.jar
 release.external/org.eclipse.xtend.lib.macro-2.19.0.jar=modules/ext/org.eclipse.xtend.lib.macro-2.19.0.jar
 release.external/org.eclipse.xtext.xbase.lib-2.19.0.jar=modules/ext/org.eclipse.xtext.xbase.lib-2.19.0.jar
-spec.version.base=1.15.0
+spec.version.base=1.16.0

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
@@ -255,8 +255,10 @@ public class LSPBindings {
             synchronized (LSPBindings.class) {
                 ServerDescription description = project2MimeType2Server.getOrDefault(baseUri, Collections.emptyMap()).remove(mt);
                 // Remove any other mimetypes as well.
-                for(String anotherMT: description.mimeTypes) {
-                    project2MimeType2Server.get(baseUri).remove(anotherMT);
+                if (description != null) {
+                    for(String anotherMT: description.mimeTypes) {
+                        project2MimeType2Server.get(baseUri).remove(anotherMT);
+                    }
                 }
                 Reference<LSPBindings> bRef = description != null ? description.bindings : null;
                 LSPBindings b = bRef != null ? bRef.get() : null;

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
@@ -284,7 +284,7 @@ public class LSPBindings {
             // If this is a MultiMimeLanguageServerProvider, then retrieve all 
             // mime types handled by this server.
             if (provider instanceof MultiMimeLanguageServerProvider) {
-                inDescription.mimeTypes = ((MultiMimeLanguageServerProvider)provider).getMimeTypes();
+                inDescription.mimeTypes = new HashSet<>(((MultiMimeLanguageServerProvider)provider).getMimeTypes());
             }
             LanguageServerDescription desc = provider.startServer(lkp);
 

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/spi/MultiMimeLanguageServerProvider.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/spi/MultiMimeLanguageServerProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.lsp.client.spi;
+
+import java.util.Set;
+
+/**
+ * Possibly start a language server. Should be installed in the Mime Lookup for
+ * all the given mime types that are handled by the given server.
+ * @author antonio
+ */
+public interface MultiMimeLanguageServerProvider extends LanguageServerProvider {
+
+    /**
+     * Returns the set of mime types handled by this server.
+     * @return The set of mime types handled by this server.
+     */
+    Set<String> getMimeTypes();
+
+}


### PR DESCRIPTION
Some LSP servers can handle files with different mime-types within the same project. 

For instance, "clangd", "ccls" and "apple/source-kit" are able to handle "text/x-c", "text/x-cpp" and others. C++ projects may include simple C files within the same project. 

This adds a new SPI interface "MultiMimeLanguageServerProvider" that returns a set of mime-types handled by the LSP server. 

The commit registers/deregisters all these mime-types at once. Otherwise the same LSP server may be started (restarted?)  several times for different mime types ( [in this loop](https://github.com/apache/netbeans/blob/76be2da4de40da05cd9f6c978d1e29bc16f99c1f/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java#L270)) possibly losing some previous state or causing multiple `initialize` requests to be sent (as reported in #3559).


