### PR TITLE
Clean up the use of deprecated numeric constructors

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewNbModuleWizardIterator.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewNbModuleWizardIterator.java
@@ -259,7 +259,7 @@ public class NewNbModuleWizardIterator implements WizardDescriptor.AsynchronousI
             if (c instanceof JComponent) { // assume Swing components
                 JComponent jc = (JComponent) c;
                 // step number
-                jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, new Integer(i)); // NOI18N
+                jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, i); // NOI18N
                 // names of currently used steps
                 jc.putClientProperty(WizardDescriptor.PROP_CONTENT_DATA, steps); // NOI18N
                 

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/BasicWizardIterator.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/BasicWizardIterator.java
@@ -396,7 +396,7 @@ public abstract class BasicWizardIterator implements WizardDescriptor.Asynchrono
             panel.addPropertyChangeListener(this);
             panel.setName(panel.getPanelName()); // NOI18N
             this.panel = panel;
-            panel.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, new Integer(stepIndex)); // NOI18N
+            panel.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, stepIndex); // NOI18N
             // names of currently used steps
             panel.putClientProperty(WizardDescriptor.PROP_CONTENT_DATA, allSteps); // NOI18N
         }

--- a/enterprise/profiler.j2ee/src/org/netbeans/modules/profiler/j2ee/J2EEProfilerSPI.java
+++ b/enterprise/profiler.j2ee/src/org/netbeans/modules/profiler/j2ee/J2EEProfilerSPI.java
@@ -155,7 +155,7 @@ public class J2EEProfilerSPI implements org.netbeans.modules.j2ee.deployment.pro
         if ((startingStateTimeout != null) && !"".equals(startingStateTimeout)) { // NOI18N
 
             try {
-                int timeout = new Integer(startingStateTimeout);
+                int timeout = Integer.parseInt(startingStateTimeout);
                 STARTING_STATE_TIMEOUT = timeout;
                 ProfilerLogger.log(">>> Profiler agent startup timeout redefined to " + STARTING_STATE_TIMEOUT + " ms"); // NOI18N
             } catch (Exception ex) {

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/palette/items/ChooseCustomizer.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/palette/items/ChooseCustomizer.java
@@ -112,7 +112,7 @@ public class ChooseCustomizer extends javax.swing.JPanel {
 
         jSpinner1.setModel(new SpinnerNumberModel(Choose.DEFAULT_WHENS, 1, Integer.MAX_VALUE, 1));
         jSpinner1.setEditor(new JSpinner.NumberEditor(jSpinner1, "#"));
-        jSpinner1.setValue(new Integer(Choose.DEFAULT_WHENS));
+        jSpinner1.setValue(Choose.DEFAULT_WHENS);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/ServletData.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/ServletData.java
@@ -122,10 +122,10 @@ class ServletData extends DeployData {
 
     private List<String> getUrlPatterns() {
         if (webApp == null) {
-            return new ArrayList<String>();
+            return new ArrayList<>();
         }
         ServletMapping[] maps = webApp.getServletMapping();
-        List<String> l = new ArrayList<String>();
+        List<String> l = new ArrayList<>();
         for (int i = 0; i < maps.length; i++) {
             l.addAll(Arrays.asList(((ServletMapping25)maps[i]).getUrlPatterns()));
         }
@@ -137,7 +137,7 @@ class ServletData extends DeployData {
             return filterMappings;
         }
         if (webApp == null) {
-            return new ArrayList<FilterMappingData>();
+            return new ArrayList<>();
         }
 
         LOG.finer("Creating the filter mapping list"); //NOI18N
@@ -146,7 +146,7 @@ class ServletData extends DeployData {
         for (int i = 0; i < fm.length; ++i) {
             LOG.finer("Servlet name: " + fm[i].getFilterName()); //NOI18N
         }
-        filterMappings = new ArrayList<FilterMappingData>();
+        filterMappings = new ArrayList<>();
         filterMappings.add(new FilterMappingData(getName()));
 
         String string;
@@ -276,7 +276,7 @@ class ServletData extends DeployData {
         char ch = id.charAt(id.length() - 1);
         if (Character.isDigit(ch)) {
             String lastDigit = id.substring(id.length() - 1);
-            int num = new Integer(lastDigit) + 1;
+            int num = Integer.parseInt(lastDigit) + 1;
             return id.substring(0, id.length() - 1) + num;
         } else {
             return id + "_1"; //NOI18N
@@ -302,7 +302,7 @@ class ServletData extends DeployData {
     void parseUrlMappingString(String raw) {
         urlMappings = null;
         StringTokenizer st = new StringTokenizer(raw, ",");
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
 
         while (st.hasMoreTokens()) {
             String mapping = st.nextToken().trim();

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/JsfVariableContext.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/JsfVariableContext.java
@@ -103,13 +103,12 @@ public class JsfVariableContext implements Comparable {
     public int compareTo(Object o) {
         final JsfVariableContext c = (JsfVariableContext)o;
 
-        int comp = new Integer(getFrom()).compareTo(c.getFrom());
-        if(comp != 0) {
+        int comp = Integer.valueOf(getFrom()).compareTo(c.getFrom());
+        if (comp != 0) {
             return comp;
         } else {
-            return new Integer(getTo()).compareTo(c.getTo());
+            return Integer.valueOf(getTo()).compareTo(c.getTo());
         }
-
     }
 
     @Override

--- a/ide/xml.tax/lib/src/org/netbeans/tax/TreeEntityDecl.java
+++ b/ide/xml.tax/lib/src/org/netbeans/tax/TreeEntityDecl.java
@@ -343,7 +343,7 @@ public class TreeEntityDecl extends TreeNodeDecl implements DTD.Child, Parameter
         this.systemId     = null;
         this.notationName = null;
         
-        firePropertyChange (PROP_TYPE,          new Short (oldType), new Short (this.type));
+        firePropertyChange (PROP_TYPE, oldType, this.type);
         firePropertyChange (PROP_INTERNAL_TEXT, oldInternalText,     newInternalText);
         firePropertyChange (PROP_PUBLIC_ID,     oldPublicId,         this.publicId);
         firePropertyChange (PROP_SYSTEM_ID,     oldSystemId,         this.systemId);
@@ -485,7 +485,7 @@ public class TreeEntityDecl extends TreeNodeDecl implements DTD.Child, Parameter
         this.systemId     = newSystemId;
         this.notationName = null;
         
-        firePropertyChange (PROP_TYPE,          new Short (oldType), new Short (this.type));
+        firePropertyChange (PROP_TYPE, oldType, this.type);
         firePropertyChange (PROP_INTERNAL_TEXT, oldInternalText,     this.internalText);
         firePropertyChange (PROP_PUBLIC_ID,     oldPublicId,         newPublicId);
         firePropertyChange (PROP_SYSTEM_ID,     oldSystemId,         newSystemId);
@@ -543,7 +543,7 @@ public class TreeEntityDecl extends TreeNodeDecl implements DTD.Child, Parameter
         }
         this.notationName = newNotationName;
         
-        firePropertyChange (PROP_TYPE,          new Short (oldType), new Short (this.type));
+        firePropertyChange (PROP_TYPE, oldType, this.type);
         firePropertyChange (PROP_NOTATION_NAME, oldNotationName,     newNotationName);
     }
     
@@ -594,7 +594,7 @@ public class TreeEntityDecl extends TreeNodeDecl implements DTD.Child, Parameter
         this.systemId     = newSystemId;
         this.notationName = newNotationName;
         
-        firePropertyChange (PROP_TYPE,          new Short (oldType), new Short (this.type));
+        firePropertyChange (PROP_TYPE, oldType, this.type);
         firePropertyChange (PROP_INTERNAL_TEXT, oldInternalText,     this.internalText);
         firePropertyChange (PROP_PUBLIC_ID,     oldPublicId,         newPublicId);
         firePropertyChange (PROP_SYSTEM_ID,     oldSystemId,         newSystemId);

--- a/ide/xml.tax/lib/src/org/netbeans/tax/TreeUtilities.java
+++ b/ide/xml.tax/lib/src/org/netbeans/tax/TreeUtilities.java
@@ -1581,7 +1581,7 @@ public final class TreeUtilities {
             ( type != TreeAttlistDeclAttributeDef.TYPE_NMTOKENS ) &&
             ( type != TreeAttlistDeclAttributeDef.TYPE_ENUMERATED ) &&
             ( type != TreeAttlistDeclAttributeDef.TYPE_NOTATION ) ) {
-                throw new InvalidArgumentException (new Short (type), Util.THIS.getString ("PROP_invalid_attribute_list_declaration_type"));
+                throw new InvalidArgumentException (type, Util.THIS.getString ("PROP_invalid_attribute_list_declaration_type"));
             }
         }
         
@@ -1603,7 +1603,7 @@ public final class TreeUtilities {
             ( defaultType != TreeAttlistDeclAttributeDef.DEFAULT_TYPE_REQUIRED ) &&
             ( defaultType != TreeAttlistDeclAttributeDef.DEFAULT_TYPE_IMPLIED ) &&
             ( defaultType != TreeAttlistDeclAttributeDef.DEFAULT_TYPE_FIXED ) ) {
-                throw new InvalidArgumentException (new Short (defaultType), Util.THIS.getString ("PROP_invalid_attribute_list_declaration_default_type"));
+                throw new InvalidArgumentException (defaultType, Util.THIS.getString ("PROP_invalid_attribute_list_declaration_default_type"));
             }
         }
         

--- a/ide/xml.tax/lib/src/org/netbeans/tax/io/TreeStreamResult.java
+++ b/ide/xml.tax/lib/src/org/netbeans/tax/io/TreeStreamResult.java
@@ -722,9 +722,9 @@ public class TreeStreamResult implements TreeOutputResult {
          * Autodetect quoting char giving highets priority to '"'.
          */
         private String createQuoteString (String value) {
-            Character quote = new Character (QUOTE);
+            Character quote = QUOTE;
             if ( value.indexOf (QUOTE) != -1 ) {
-                quote = new Character (APOSTROPHE);
+                quote = APOSTROPHE;
             }
             return createQuoteString (value, quote);
         }

--- a/java/beans/src/org/netbeans/modules/beans/ModePropertyEditor.java
+++ b/java/beans/src/org/netbeans/modules/beans/ModePropertyEditor.java
@@ -63,10 +63,10 @@ public class ModePropertyEditor extends PropertyEditorSupport {
     public void setAsText (String text) {
         for (int i = 0; i < getTags().length ; i++)
             if (getTags()[i] == text) {
-                setValue(new Integer(values[i]));
+                setValue(values[i]);
                 return;
             }
 
-        setValue( new Integer(0) );
+        setValue(0);
     }
 }

--- a/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/EditorContextSupport.java
+++ b/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/EditorContextSupport.java
@@ -418,7 +418,7 @@ public final class EditorContextSupport {
                                             }
                                         }
                                     }
-                                    result.add(new Integer((int) lineMap.getLineNumber(pos)));
+                                    result.add((int)lineMap.getLineNumber(pos));
                                 }
                             }
                         }
@@ -602,7 +602,7 @@ public final class EditorContextSupport {
                         }
                     }
                     LineMap lineMap = ci.getCompilationUnit().getLineMap();
-                    result[0] = new Integer((int) lineMap.getLineNumber(pos));
+                    result[0] = (int)lineMap.getLineNumber(pos);
                 }
             });
             if (!f.isDone()) {

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/SourceURLMapper.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/SourceURLMapper.java
@@ -177,7 +177,7 @@ public final class SourceURLMapper extends URLMapper {
             List<Byte> bytes = new ArrayList<>();
             while (text.length() > (i + 2) && text.charAt(i) == '%') {
                 int v = Integer.parseInt(text.substring(i+1, i+3), 16);
-                bytes.add(new Byte((byte) (v & 0xFF)));
+                bytes.add((byte)(v & 0xFF));
                 i += 3;
             }
             byte[] byteArray = new byte[bytes.size()];

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/SourcePosition.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/SourcePosition.java
@@ -92,7 +92,7 @@ final class SourcePosition {
     private static synchronized long getId(Source s) {
         Long id = sourceId.get(s);
         if (id == null) {
-            id = new Long(nextId++);
+            id = nextId++;
             sourceId.put(s, id);
         }
         return id;

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsTreeModelFilter.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsTreeModelFilter.java
@@ -108,7 +108,7 @@ public class BreakpointsTreeModelFilter implements TreeModelFilter {
                 if (mI != null) {
                     line = Math.max(line, mI.intValue());
                 }
-                mI = new Integer(line);
+                mI = line;
                 maxLines.put(fn, mI);
             }
             if (--n == 0) break;

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDADebuggerImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDADebuggerImpl.java
@@ -2217,7 +2217,7 @@ public class JPDADebuggerImpl extends JPDADebugger {
             "org.openide.awt.SwingBrowserImpl.do-not-block-awt",
             String.valueOf (state != STATE_DISCONNECTED)
         );
-        return new PropertyChangeEvent(this, PROP_STATE, new Integer (o), new Integer (state));
+        return new PropertyChangeEvent(this, PROP_STATE, o, state);
     }
 
     private void setState (int state) {

--- a/java/i18n/src/org/netbeans/modules/i18n/regexp/Parser.java
+++ b/java/i18n/src/org/netbeans/modules/i18n/regexp/Parser.java
@@ -358,8 +358,7 @@ public class Parser {
             case '.':
                 result = new TreeNode(TreeNode.METACHAR,
                                       start,
-                                      start + 1,
-                                      new Character(ch));
+                                      start + 1, ch);
                 break;
 
             case '[':
@@ -384,8 +383,7 @@ public class Parser {
                     case 'B':
                         result = new TreeNode(TreeNode.METACHAR,
                                               start,
-                                              start + 2,
-                                              new Character(ch2));
+                                              start + 2, ch2);
                         break;
 
                     case 'u':
@@ -426,8 +424,7 @@ public class Parser {
                         }
                         result = new TreeNode(TreeNode.CHAR,
                                               start,
-                                              start + 2,
-                                              new Character(parsedChar));
+                                              start + 2, parsedChar);
                         break;
                 }
                 break;
@@ -449,8 +446,7 @@ public class Parser {
                 }
                 result = new TreeNode(TreeNode.CHAR,
                                       start,
-                                      start + 1,
-                                      new Character(ch));
+                                      start + 1, ch);
                 break;
         }
         return result;
@@ -472,8 +468,7 @@ public class Parser {
             case '?':
                 result = new TreeNode(TreeNode.QUANTIFIER,
                                       start,
-                                      start + 1,
-                                      new Character(ch));
+                                      start + 1, ch);
                 return result;
             case '{':
                 break;
@@ -604,7 +599,7 @@ public class Parser {
         TreeNode result = new TreeNode(TreeNode.NUMBER,
                                        start,
                                        start + endIndex,
-                                       new Integer(number));
+                                       number);
         return result;
     }
 
@@ -900,14 +895,12 @@ public class Parser {
                 }
                 result = new TreeNode(TreeNode.CHAR,
                                       start,
-                                      start + 2,
-                                      new Character(parsedChar));
+                                      start + 2, parsedChar);
                 break;
             default:
                 result = new TreeNode(TreeNode.CHAR,
                                       start,
-                                      start + 1,
-                                      new Character(ch));
+                                      start + 1, ch);
                 break;
         }
         return result;

--- a/java/java.editor/src/org/netbeans/modules/java/editor/imports/ClipboardHandler.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/imports/ClipboardHandler.java
@@ -399,7 +399,7 @@ public class ClipboardHandler {
                     "exportDone",  // NOI18N
                     new Class[] {javax.swing.JComponent.class, Transferable.class, int.class});
                 method.setAccessible(true);
-                method.invoke(delegate, new Object[] {source, data, new Integer(action)});
+                method.invoke(delegate, new Object[] {source, data, action});
             } catch (NoSuchMethodException ex) {
                 Exceptions.printStackTrace(ex);
             } catch (IllegalAccessException ex) {

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
@@ -103,9 +103,9 @@ public class J2SEModularProjectProperties {
     
     //Hotfix of the issue #70058
     //Should be removed when the StoreGroup SPI will be extended to allow false default value in ToggleButtonModel
-    private static final Integer BOOLEAN_KIND_TF = new Integer( 0 );
-    private static final Integer BOOLEAN_KIND_YN = new Integer( 1 );
-    private static final Integer BOOLEAN_KIND_ED = new Integer( 2 );
+    private static final Integer BOOLEAN_KIND_TF = 0;
+    private static final Integer BOOLEAN_KIND_YN = 1;
+    private static final Integer BOOLEAN_KIND_ED = 2;
     private static final String COS_MARK = ".netbeans_automatic_build";     //NOI18N
     private static final Logger LOG = Logger.getLogger(J2SEModularProjectProperties.class.getName());
     private Integer javacDebugBooleanKind;
@@ -478,6 +478,7 @@ public class J2SEModularProjectProperties {
             }
             // Store properties
             ProjectManager.mutex().writeAccess(new Mutex.ExceptionAction<Void>() {
+                @Override
                 public Void run() throws IOException {
                     storeProperties();
                     //Delete COS mark
@@ -706,7 +707,7 @@ public class J2SEModularProjectProperties {
     private void resolveProjectDependencies() {
             
         // Create a set of old and new artifacts.
-        Set<ClassPathSupport.Item> oldArtifacts = new HashSet<ClassPathSupport.Item>();
+        Set<ClassPathSupport.Item> oldArtifacts = new HashSet<>();
         EditableProperties projectProperties = updateHelper.getProperties( AntProjectHelper.PROJECT_PROPERTIES_PATH );        
         oldArtifacts.addAll( cs.itemsList( projectProperties.get( ProjectProperties.JAVAC_MODULEPATH ) ) );
         oldArtifacts.addAll( cs.itemsList( projectProperties.get( ProjectProperties.JAVAC_CLASSPATH ) ) );
@@ -720,7 +721,7 @@ public class J2SEModularProjectProperties {
         oldArtifacts.addAll( cs.itemsList( projectProperties.get( ProjectProperties.RUN_TEST_CLASSPATH ) ) );
         oldArtifacts.addAll( cs.itemsList( projectProperties.get( ProjectProperties.ENDORSED_CLASSPATH ) ) );
                    
-        Set<ClassPathSupport.Item> newArtifacts = new HashSet<ClassPathSupport.Item>();
+        Set<ClassPathSupport.Item> newArtifacts = new HashSet<>();
         newArtifacts.addAll( ClassPathUiSupport.getList( JAVAC_MODULEPATH_MODEL ) );
         newArtifacts.addAll( ClassPathUiSupport.getList( JAVAC_CLASSPATH_MODEL ) );
         newArtifacts.addAll( ClassPathUiSupport.getList( JAVAC_PROCESSORMODULEPATH_MODEL ) );
@@ -734,9 +735,9 @@ public class J2SEModularProjectProperties {
         newArtifacts.addAll( ClassPathUiSupport.getList( ENDORSED_CLASSPATH_MODEL ) );
                 
         // Create set of removed artifacts and remove them
-        Set<ClassPathSupport.Item> removed = new HashSet<ClassPathSupport.Item>(oldArtifacts);
+        Set<ClassPathSupport.Item> removed = new HashSet<>(oldArtifacts);
         removed.removeAll( newArtifacts );
-        Set<ClassPathSupport.Item> added = new HashSet<ClassPathSupport.Item>(newArtifacts);
+        Set<ClassPathSupport.Item> added = new HashSet<>(newArtifacts);
         added.removeAll(oldArtifacts);
         
         
@@ -878,7 +879,7 @@ public class J2SEModularProjectProperties {
                 return s1 != null ? (s2 != null ? s1.compareTo(s2) : 1) : (s2 != null ? -1 : 0);
             }
         });
-        Map<String,String> def = new TreeMap<String,String>();
+        Map<String,String> def = new TreeMap<>();
         for (String prop : CONFIG_AWARE_PROPERTIES) {
             String v = updateHelper.getProperties(AntProjectHelper.PRIVATE_PROPERTIES_PATH).getProperty(prop);
             if (v == null) {
@@ -897,7 +898,7 @@ public class J2SEModularProjectProperties {
                 }
                 final String relPath = FileUtil.getRelativePath(project.getProjectDirectory(), kid);
                 if (relPath != null) {
-                    m.put(kid.getName(), new TreeMap<String,String>(updateHelper.getProperties(relPath)));
+                    m.put(kid.getName(), new TreeMap<>(updateHelper.getProperties(relPath)));
                 }
             }
         }
@@ -913,7 +914,7 @@ public class J2SEModularProjectProperties {
                 }
                 final String relPath = FileUtil.getRelativePath(project.getProjectDirectory(), kid);
                 if (relPath != null) {
-                    c.putAll(new HashMap<String,String>(updateHelper.getProperties(relPath)));
+                    c.putAll(new HashMap<>(updateHelper.getProperties(relPath)));
                 }
             }
         }
@@ -993,7 +994,7 @@ public class J2SEModularProjectProperties {
     }
     
     void loadIncludesExcludes(IncludeExcludeVisualizer v) {
-        Set<File> roots = new HashSet<File>();
+        Set<File> roots = new HashSet<>();
         for (DefaultTableModel model : new DefaultTableModel[] {MODULE_ROOTS_MODEL, TEST_MODULE_ROOTS_MODEL}) {
             for (Object row : model.getDataVector()) {
                 File d = (File) ((Vector) row).elementAt(0);
@@ -1013,8 +1014,8 @@ public class J2SEModularProjectProperties {
     }
 
     boolean makeSharable() {
-        List<String> libs = new ArrayList<String>();
-        List<String> jars = new ArrayList<String>();
+        List<String> libs = new ArrayList<>();
+        List<String> jars = new ArrayList<>();
         collectLibs(JAVAC_CLASSPATH_MODEL, libs, jars);
         collectLibs(JAVAC_PROCESSORPATH_MODEL, libs, jars);
         collectLibs(JAVAC_TEST_CLASSPATH_MODEL, libs, jars);

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectProperties.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectProperties.java
@@ -103,9 +103,9 @@ public class J2SEProjectProperties {
     
     //Hotfix of the issue #70058
     //Should be removed when the StoreGroup SPI will be extended to allow false default value in ToggleButtonModel
-    private static final Integer BOOLEAN_KIND_TF = new Integer( 0 );
-    private static final Integer BOOLEAN_KIND_YN = new Integer( 1 );
-    private static final Integer BOOLEAN_KIND_ED = new Integer( 2 );
+    private static final Integer BOOLEAN_KIND_TF = 0;
+    private static final Integer BOOLEAN_KIND_YN = 1;
+    private static final Integer BOOLEAN_KIND_ED = 2;
     private static final String COS_MARK = ".netbeans_automatic_build";     //NOI18N
     private static final Logger LOG = Logger.getLogger(J2SEProjectProperties.class.getName());
     private Integer javacDebugBooleanKind;

--- a/java/java.project.ui/src/org/netbeans/modules/java/project/ui/NewJavaFileWizardIterator.java
+++ b/java/java.project.ui/src/org/netbeans/modules/java/project/ui/NewJavaFileWizardIterator.java
@@ -450,7 +450,7 @@ public class NewJavaFileWizardIterator implements WizardDescriptor.AsynchronousI
             if (c instanceof JComponent) { // assume Swing components
                 JComponent jc = (JComponent)c;
                 // Step #.
-                jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, new Integer(i));
+                jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, i);
                 // Step name (actually the whole list for reference).
                 jc.putClientProperty(WizardDescriptor.PROP_CONTENT_DATA, steps);
             }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/ComputeDiff.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/ComputeDiff.java
@@ -48,7 +48,7 @@ class ComputeDiff<E> {
     /**
      * The list of differences, as <code>Difference</code> instances.
      */
-    private List<Difference> diffs = new ArrayList<Difference>();
+    private List<Difference> diffs = new ArrayList<>();
     
     /**
      * The pending, uncommitted difference.
@@ -275,22 +275,22 @@ class ComputeDiff<E> {
         int aPrevStart = 0;
         int bPrevStart = 0;
         
-        TreeMap<Integer, Integer> matches = new TreeMap<Integer, Integer>();
+        TreeMap<Integer, Integer> matches = new TreeMap<>();
         int bEndOrig;
         do {
             Map<E, List<Integer>> bMatches = null;
             if (comparator == null) {
                 if (a.length > 0 && a[0] instanceof Comparable) {
                     // this uses the Comparable interface
-                    bMatches = new TreeMap<E, List<Integer>>();
+                    bMatches = new TreeMap<>();
                 } else {
                     // this just uses hashCode()
-                    bMatches = new HashMap<E, List<Integer>>();
+                    bMatches = new HashMap<>();
                 }
             } else {
                 // we don't really want them sorted, but this is the only Map
                 // implementation (as of JDK 1.4) that takes a comparator.
-                bMatches = new TreeMap<E, List<Integer>>(comparator);
+                bMatches = new TreeMap<>(comparator);
             }
             aStart = aPrevStart;
             bStart = bPrevStart;
@@ -304,11 +304,11 @@ class ComputeDiff<E> {
             bEndOrig = bEnd;
 
             while (aStart <= aEnd && bStart <= bEnd && equals(a[aStart], b[bStart])) {
-                matches.put(new Integer(aStart++), new Integer(bStart++));
+                matches.put(aStart++, bStart++);
             }
 
             while (aStart <= aEnd && bStart <= bEnd && equals(a[aEnd], b[bEnd])) {
-                matches.put(new Integer(aEnd--), new Integer(bEnd--));
+                matches.put(aEnd--, bEnd--);
             }
         
 
@@ -317,21 +317,21 @@ class ComputeDiff<E> {
                 E key = element;
                 List<Integer> positions = bMatches.get(key);
                 if (positions == null) {
-                    positions = new ArrayList<Integer>();
+                    positions = new ArrayList<>();
                     bMatches.put(key, positions);
                 }
-                positions.add(new Integer(bi));
+                positions.add(bi);
             }
 
-            thresh = new TreeMap<Integer, Integer>();
-            Map<Integer, Object[]> links = new HashMap<Integer, Object[]>();
+            thresh = new TreeMap<>();
+            Map<Integer, Object[]> links = new HashMap<>();
 
             for (int i = aStart; i <= aEnd; ++i) {
                 E aElement = a[i]; // keygen here.
                 List<Integer> positions = bMatches.get(aElement);
 
                 if (positions != null) {
-                    Integer  k   = new Integer(0);
+                    Integer  k   = 0;
                     ListIterator<Integer> pit = positions.listIterator(positions.size());
                     while (pit.hasPrevious()) {
                         Integer j = pit.previous();
@@ -341,8 +341,8 @@ class ComputeDiff<E> {
                         if (k == null) {
                             // nothing
                         } else {
-                            Object value = k.intValue() > 0 ? links.get(new Integer(k.intValue() - 1)) : null;
-                            links.put(k, new Object[] { value, new Integer(i), j });
+                            Object value = k > 0 ? links.get(k - 1) : null;
+                            links.put(k, new Object[] { value, i, j });
                         }
                     }
                 }
@@ -368,14 +368,14 @@ class ComputeDiff<E> {
      * Converts the map (indexed by java.lang.Integers) into an array.
      */
     protected static Integer[] toArray(TreeMap map) {
-        int       size = map.size() == 0 ? 0 : 1 + ((Integer)map.lastKey()).intValue();
+        int       size = map.isEmpty() ? 0 : 1 + ((Integer)map.lastKey());
         Integer[] ary  = new Integer[size];
         Iterator  it   = map.keySet().iterator();
         
         while (it.hasNext()) {
             Integer idx = (Integer)it.next();
             Integer val = (Integer)map.get(idx);
-            ary[idx.intValue()] = val;
+            ary[idx] = val;
         }
         return ary;
     }
@@ -384,7 +384,7 @@ class ComputeDiff<E> {
      * Returns whether the integer is not zero (including if it is not null).
      */
     protected static boolean isNonzero(Integer i) {
-        return i != null && i.intValue() != 0;
+        return i != null && i != 0;
     }
     
     /**
@@ -418,11 +418,11 @@ class ComputeDiff<E> {
      */
     protected void append(Integer value) {
         Integer addIdx = null;
-        if (thresh.size() == 0) {
-            addIdx = new Integer(0);
+        if (thresh.isEmpty()) {
+            addIdx = 0;
         } else {
             Integer lastKey = thresh.lastKey();
-            addIdx = new Integer(lastKey.intValue() + 1);
+            addIdx = lastKey + 1;
         }
         thresh.put(addIdx, value);
     }
@@ -431,28 +431,28 @@ class ComputeDiff<E> {
      * Inserts the given values into the threshold map.
      */
     protected Integer insert(Integer j, Integer k) {
-        if (isNonzero(k) && isGreaterThan(k, j) && isLessThan(new Integer(k.intValue() - 1), j)) {
+        if (isNonzero(k) && isGreaterThan(k, j) && isLessThan(k - 1, j)) {
             thresh.put(k, j);
         } else {
             int hi = -1;
             
             if (isNonzero(k)) {
-                hi = k.intValue();
+                hi = k;
             } else if (thresh.size() > 0) {
-                hi = (thresh.lastKey()).intValue();
+                hi = (thresh.lastKey());
             }
             
             // off the end?
             if (hi == -1 || j.compareTo(getLastValue()) > 0) {
                 append(j);
-                k = new Integer(hi + 1);
+                k = hi + 1;
             } else {
                 // binary search for insertion point:
                 int lo = 0;
                 
                 while (lo <= hi) {
                     int     index = (hi + lo) / 2;
-                    Integer val   = thresh.get(new Integer(index));
+                    Integer val   = thresh.get(index);
                     int     cmp   = j.compareTo(val);
                     
                     if (cmp == 0) {
@@ -464,11 +464,10 @@ class ComputeDiff<E> {
                     }
                 }
                 
-                thresh.put(new Integer(lo), j);
-                k = new Integer(lo);
+                thresh.put(lo, j);
+                k = lo;
             }
         }
         return k;
     }
-    
 }

--- a/java/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/TemplateWizardIterator.java
+++ b/java/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/TemplateWizardIterator.java
@@ -266,7 +266,7 @@ class TemplateWizardIterator implements WizardDescriptor.AsynchronousInstantiati
         SuperclassPanel() {
             ResourceBundle bundle = NbBundle.getBundle(TemplateWizardIterator.class);
             setName(bundle.getString("CTL_SuperclassTitle")); // NOI18N
-            putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, new Integer(1)); //NOI18N
+            putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, 1); //NOI18N
             getAccessibleContext()
                 .setAccessibleDescription(bundle.getString("ACSD_SuperclassPanel")); // NOI18N
 

--- a/java/junit/src/org/netbeans/modules/junit/AbstractTestGenerator.java
+++ b/java/junit/src/org/netbeans/modules/junit/AbstractTestGenerator.java
@@ -1465,7 +1465,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
                     comparisonArgs.add(maker.Identifier(expectedValue.getName().toString()));
                     comparisonArgs.add(maker.Identifier(actualValue.getName().toString()));
                     if ((retTypeKind == TypeKind.DOUBLE) || (retTypeKind == TypeKind.FLOAT)){
-                        comparisonArgs.add(maker.Identifier(new Double(0).toString()));
+                        comparisonArgs.add(maker.Identifier(Integer.toString(0)));
                     }
 
                     MethodInvocationTree comparison = maker.MethodInvocation(

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/ui/JavaRefactoringGlobalAction.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/ui/JavaRefactoringGlobalAction.java
@@ -76,7 +76,7 @@ final class JavaRefactoringGlobalAction extends NodeAction {
     }
 
     protected void setMnemonic(char m) {
-        putValue(Action.MNEMONIC_KEY, new Integer(m));
+        putValue(Action.MNEMONIC_KEY, m);
     }
 
     @Override

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ChangeParametersPanel.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ChangeParametersPanel.java
@@ -616,7 +616,7 @@ public class ChangeParametersPanel extends JPanel implements CustomRefactoringPa
     private void addButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_addButtonActionPerformed
         acceptEditedValue(); 
         int rowCount = model.getRowCount();
-        model.addRow(new Object[] { "Object", paramname + rowCount, "null", new Integer(-1), Boolean.TRUE }); // NOI18N
+        model.addRow(new Object[] { "Object", paramname + rowCount, "null", -1, Boolean.TRUE }); // NOI18N
         paramTable.scrollRectToVisible(paramTable.getCellRect(rowCount, 0, false));
         paramTable.changeSelection(rowCount, 0, false, false);
         autoEdit(paramTable);
@@ -776,7 +776,7 @@ public class ChangeParametersPanel extends JPanel implements CustomRefactoringPa
             Boolean removable = !scan.hasRefernces();
             // Used to check if var was user in overridden/overriding methods
 //            if (model.getRowCount()<=originalIndex) {
-            newModel.add(new Object[]{typeRepresentation, par.toString(), "", new Integer(originalIndex), removable});
+            newModel.add(new Object[]{typeRepresentation, par.toString(), "", originalIndex, removable});
 //            } else {
 //                removable = Boolean.valueOf(model.isRemovable(originalIndex) && removable.booleanValue());
 //                ((Vector) model.getDataVector().get(originalIndex)).set(4, removable);

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringGlobalAction.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringGlobalAction.java
@@ -65,7 +65,7 @@ public abstract class JavaRefactoringGlobalAction extends NodeAction {
     }
     
     protected void setMnemonic(char m) {
-        putValue(Action.MNEMONIC_KEY, new Integer(m));
+        putValue(Action.MNEMONIC_KEY, m);
     }
     
     private static String trim(String arg) {

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveMembersPanel.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveMembersPanel.java
@@ -454,7 +454,7 @@ public class MoveMembersPanel extends javax.swing.JPanel implements CustomRefact
                     @Override
                     public void componentHidden(ComponentEvent e) {}
                 });
-                layeredPaneAbove.add(label, new Integer(JLayeredPane.POPUP_LAYER - 1));
+                layeredPaneAbove.add(label, (JLayeredPane.POPUP_LAYER - 1));
             }
         } else {
             JLayeredPane layeredPaneAbove = JLayeredPane.getLayeredPaneAbove(outlineView1);

--- a/java/testng/src/org/netbeans/modules/testng/AbstractTestGenerator.java
+++ b/java/testng/src/org/netbeans/modules/testng/AbstractTestGenerator.java
@@ -432,7 +432,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
         } else if (testMethods.isEmpty()) {
             members = Collections.singletonList(abstractClassImpl);
         } else {
-            members = new ArrayList<Tree>(testMethods.size() + 1);
+            members = new ArrayList<>(testMethods.size() + 1);
             ((List<Tree>) members).addAll(testMethods);
             ((List<Tree>) members).add(abstractClassImpl);
         }
@@ -918,7 +918,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
                                             trees);
 
         List<? extends Tree> tstMembersOrig = tstClass.getMembers();
-        List<Tree> tstMembers = new ArrayList<Tree>(tstMembersOrig.size() + 4);
+        List<Tree> tstMembers = new ArrayList<>(tstMembersOrig.size() + 4);
         tstMembers.addAll(tstMembersOrig);
 
         if (generateMissingInitMembers) {
@@ -1041,7 +1041,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
         Iterator<ExecutableElement> srcMethodsIt = srcMethods.iterator();
         Iterator<String> tstMethodNamesIt = testMethodNames.iterator();
 
-        List<MethodTree> testMethods = new ArrayList<MethodTree>(srcMethods.size());
+        List<MethodTree> testMethods = new ArrayList<>(srcMethods.size());
         while (srcMethodsIt.hasNext()) {
             assert tstMethodNamesIt.hasNext();
 
@@ -1465,7 +1465,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
                     comparisonArgs.add(maker.Identifier(actualValue.getName().toString()));
                     comparisonArgs.add(maker.Identifier(expectedValue.getName().toString()));
                     if ((retTypeKind == TypeKind.DOUBLE) || (retTypeKind == TypeKind.FLOAT)){
-                        comparisonArgs.add(maker.Identifier(new Double(0).toString()));
+                        comparisonArgs.add(maker.Identifier(Double.toString(0)));
                     }
 
                     MethodInvocationTree comparison = maker.MethodInvocation(
@@ -1551,7 +1551,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
         }
 
         Set<Modifier> noModifiers = Collections.<Modifier>emptySet();
-        List<VariableTree> paramVariables = new ArrayList<VariableTree>(params.size());
+        List<VariableTree> paramVariables = new ArrayList<>(params.size());
         int index = 0;
         for (TypeMirror param : params) {
             if (param.getKind() == TypeKind.TYPEVAR){
@@ -1685,29 +1685,29 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
                     defValue = maker.Literal(Boolean.FALSE);
                     break;
                 case CHAR:
-                    defValue = maker.Literal(new Character(' '));
+                    defValue = maker.Literal(' ');
                     break;
                 case BYTE:
-                    defValue = maker.Literal(new Byte((byte) 0));
+                    defValue = maker.Literal((byte) 0);
                     break;
                 case SHORT:
-                    defValue = maker.Literal(new Short((short) 0));
+                    defValue = maker.Literal((short) 0);
                     break;
                 case INT:
-                    defValue = maker.Literal(new Integer(0));
+                    defValue = maker.Literal(0);
                     break;
                 case FLOAT:
-                    defValue = maker.Literal(new Float(0.0F));
+                    defValue = maker.Literal(0.0F);
                     break;
                 case LONG:
-                    defValue = maker.Literal(new Long(0L));
+                    defValue = maker.Literal(0L);
                     break;
                 case DOUBLE:
-                    defValue = maker.Literal(new Double(0.0));
+                    defValue = maker.Literal(0.0D);
                     break;
                 default:
                     assert false : "unknown primitive type";            //NOI18N
-                    defValue = maker.Literal(new Integer(0));
+                    defValue = maker.Literal(0);
                     break;
             }
         } else if ((typeKind == TypeKind.DECLARED)
@@ -2156,7 +2156,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
 
     private List<VariableTree> generateEJBLookupCode(TreeMaker maker, TypeElement srcClass, ExecutableElement srcMethod) {
         final String ejbContainerPackage = "javax.ejb.embeddable.EJBContainer"; // NOI18N
-        List<VariableTree> trees = new ArrayList<VariableTree>();
+        List<VariableTree> trees = new ArrayList<>();
 
         // TODO: there are probably better ways how to generate code below:
         IdentifierTree container = maker.Identifier(ejbContainerPackage); 

--- a/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBWizardIterator.java
+++ b/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/ui/JAXBWizardIterator.java
@@ -120,8 +120,7 @@ public class JAXBWizardIterator implements TemplateWizard.Iterator  {
             if (c instanceof JComponent) { // assume Swing components
                 JComponent jc = (JComponent) c;
                 // Step #.
-                jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, //NOI18N
-                                                    new Integer(i)); 
+                jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, i); //NOI18N
                 // Step name (actually the whole list for reference).
                 jc.putClientProperty(WizardDescriptor.PROP_CONTENT_DATA, steps); //NOI18N
             }
@@ -207,8 +206,7 @@ public class JAXBWizardIterator implements TemplateWizard.Iterator  {
             if (c instanceof JComponent) { // assume Swing components
                 JComponent jc = (JComponent) c;
                 // Step #.
-                jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, //NOI18N
-                        new Integer(i)); 
+                jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, i); //NOI18N
                 // Step name (actually the whole list for reference).
                 jc.putClientProperty(WizardDescriptor.PROP_CONTENT_DATA, steps); //NOI18N
             }

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorAbstractPanel.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorAbstractPanel.java
@@ -104,7 +104,7 @@ public abstract class SAXGeneratorAbstractPanel extends JPanel implements Custom
         }
         
         void setIndex(int index) {
-            this.index = new Integer(index);
+            this.index = index;
         }
         
         public void readSettings(java.lang.Object p1) {

--- a/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelProjectLocationExtSrc.form
+++ b/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelProjectLocationExtSrc.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 

--- a/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelProjectLocationExtSrc.java
+++ b/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelProjectLocationExtSrc.java
@@ -158,10 +158,10 @@ public class PanelProjectLocationExtSrc extends SettingsPanel {
             File file;
             do {
                 index++;
-                projectName = MessageFormat.format(formater, new Object[]{new Integer(index)});
+                projectName = MessageFormat.format(formater, new Object[]{index});
                 file = new File(projectLocation, projectName);
             } while (file.exists());
-            settings.putProperty(JavaFXProjectWizardIterator.PROP_NAME_INDEX, new Integer(index));
+            settings.putProperty(JavaFXProjectWizardIterator.PROP_NAME_INDEX, index);
             this.projectLocation.setText(projectLocation.getAbsolutePath());
             this.setCalculateProjectFolder(true);
         } else {

--- a/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelProjectLocationVisual.java
+++ b/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/PanelProjectLocationVisual.java
@@ -291,7 +291,7 @@ public class PanelProjectLocationVisual extends SettingsPanel implements Documen
                     while ((projectName = validFreeProjectName(projectLocation, formatter, baseCount)) == null) {
                         baseCount++;
                     }
-                    settings.putProperty(JavaFXProjectWizardIterator.PROP_NAME_INDEX, new Integer(baseCount));
+                    settings.putProperty(JavaFXProjectWizardIterator.PROP_NAME_INDEX, baseCount);
                     break;
                 case PRELOADER:
                     baseCount = WizardSettings.getNewPreloaderCount() + 1;
@@ -299,7 +299,7 @@ public class PanelProjectLocationVisual extends SettingsPanel implements Documen
                     while ((projectName = validFreeProjectName(projectLocation, formatter, baseCount)) == null) {
                         baseCount++;
                     }
-                    settings.putProperty(JavaFXProjectWizardIterator.PROP_NAME_INDEX, new Integer(baseCount));
+                    settings.putProperty(JavaFXProjectWizardIterator.PROP_NAME_INDEX, baseCount);
                     break;
                 case SWING:
                     baseCount = WizardSettings.getNewFxSwingCount() + 1;
@@ -307,7 +307,7 @@ public class PanelProjectLocationVisual extends SettingsPanel implements Documen
                     while ((projectName = validFreeProjectName(projectLocation, formatter, baseCount)) == null) {
                         baseCount++;
                     }
-                    settings.putProperty(JavaFXProjectWizardIterator.PROP_NAME_INDEX, new Integer(baseCount));
+                    settings.putProperty(JavaFXProjectWizardIterator.PROP_NAME_INDEX, baseCount);
                     break;
                 default:
                     baseCount = WizardSettings.getNewLibraryCount() + 1;
@@ -315,7 +315,7 @@ public class PanelProjectLocationVisual extends SettingsPanel implements Documen
                     while ((projectName = validFreeProjectName(projectLocation, formatter, baseCount)) == null) {
                         baseCount++;
                     }
-                    settings.putProperty(JavaFXProjectWizardIterator.PROP_NAME_INDEX, new Integer(baseCount));
+                    settings.putProperty(JavaFXProjectWizardIterator.PROP_NAME_INDEX, baseCount);
             }
         }
         this.projectNameTextField.setText(projectName);
@@ -339,7 +339,7 @@ public class PanelProjectLocationVisual extends SettingsPanel implements Documen
 
     // Private methods ---------------------------------------------------------
     private String validFreeProjectName(final File parentFolder, final String formater, final int index) {
-        String name = MessageFormat.format(formater, new Object[]{new Integer(index)});
+        String name = MessageFormat.format(formater, new Object[]{index});
         File file = new File(parentFolder, name);
         return file.exists() ? null : name;
     }

--- a/nbi/engine/nbproject/project.properties
+++ b/nbi/engine/nbproject/project.properties
@@ -36,8 +36,12 @@ build.test.classes.dir=${build.dir}/test/classes
 build.test.results.dir=${build.dir}/test/results
 debug.classpath=\
     ${run.classpath}
+debug.modulepath=\
+    ${run.modulepath}
 debug.test.classpath=\
     ${run.test.classpath}
+debug.test.modulepath=\
+    ${run.test.modulepath}
 # This directory is removed when the project is cleaned:
 dist.dir=dist
 dist.jar=${dist.dir}/nbi-engine.jar
@@ -56,6 +60,8 @@ javac.classpath=
 # Space-separated list of extra javac options
 javac.compilerargs=-Xlint:unchecked
 javac.deprecation=true
+javac.modulepath=
+javac.processormodulepath=
 javac.processorpath=\
     ${javac.classpath}
 javac.source=1.8
@@ -67,6 +73,8 @@ javac.test.classpath=\
     ${file.reference.jetty-util-6.0.2.jar}:\
     ${file.reference.servlet-api-2.5-6.0.2.jar}:\
     ${file.reference.junit-4.13.2.jar}
+javac.test.modulepath=\
+    ${javac.modulepath}
 javadoc.additionalparam=-header "NBI Engine API"
 javadoc.author=true
 javadoc.encoding=
@@ -98,8 +106,12 @@ platform.active=default_platform
 run.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}
+run.modulepath=\
+    ${javac.modulepath}
 run.test.classpath=\
     ${javac.test.classpath}:\
     ${build.test.classes.dir}
+run.test.modulepath=\
+    ${javac.test.modulepath}
 src.dir=src
 test.tests.dir=tests

--- a/nbi/engine/src/org/netbeans/installer/utils/LogManager.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/LogManager.java
@@ -95,7 +95,7 @@ public final class LogManager {
     private static void initializeConsoleLogging () {
         // check whether we should log to console as well
         if (System.getProperty(LOG_TO_CONSOLE_PROPERTY) != null) {
-            logToConsole = new Boolean(System.getProperty(LOG_TO_CONSOLE_PROPERTY));
+            logToConsole = Boolean.parseBoolean(System.getProperty(LOG_TO_CONSOLE_PROPERTY));
         } else {
             logToConsole = DEFAULT_LOG_TO_CONSOLE;
         }

--- a/nbi/engine/src/org/netbeans/installer/utils/helper/Version.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/helper/Version.java
@@ -43,24 +43,23 @@ public class Version {
     private long update;
     private long build;
     
-    private Version(
-            final String string) {
+    private Version(final String string) {
         String[] split = string.split("[\\._\\-]+"); //NOI18N
 
         if (split.length > 0) {
-            major = new Long(split[0]);
+            major = Long.parseLong(split[0]);
         }
         if (split.length > 1) {
-            minor = new Long(split[1]);
+            minor = Long.parseLong(split[1]);
         }
         if (split.length > 2) {
-            micro = new Long(split[2]);
+            micro = Long.parseLong(split[2]);
         }
         if (split.length > 3) {
-            update = new Long(split[3]);
+            update = Long.parseLong(split[3]);
         }
         if (split.length > 4) {
-            build = new Long(split[4]);
+            build = Long.parseLong(split[4]);
         }
     }
     

--- a/nbi/engine/src/org/netbeans/installer/utils/system/UnixNativeUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/UnixNativeUtils.java
@@ -939,12 +939,12 @@ public class UnixNativeUtils extends NativeUtils {
                         throw new IOException();
                     }
 
-                    final long limit = new Long(numbers[2]).longValue();
-                    final long usage = new Long(numbers[0]).longValue();
+                    final long limit = Long.parseLong(numbers[2]);
+                    final long usage = Long.parseLong(numbers[0]);
                     final long freespace = (limit - usage) * 1024;
 
                     if (limit > 0 && freespace >= 0) {
-                        pathSpace.add(new Pair<String, Long>(quotedPath, freespace));
+                        pathSpace.add(new Pair<>(quotedPath, freespace));
                     }
                 }
             }
@@ -958,7 +958,7 @@ public class UnixNativeUtils extends NativeUtils {
                 final String s = p.getFirst();
                 if (s.length() > longestPath.length() && path.startsWith(s)) {
                     longestPath = s;
-                    freespace = p.getSecond().longValue();
+                    freespace = p.getSecond();
                 }
             }
             return freespace;
@@ -1144,7 +1144,6 @@ public class UnixNativeUtils extends NativeUtils {
         try {
             setEnvironmentVariable(
                     "LANG", "C", EnvironmentScope.PROCESS, false);
-
             setEnvironmentVariable(
                     "LC_COLLATE", "C", EnvironmentScope.PROCESS, false);
             setEnvironmentVariable(
@@ -1164,7 +1163,7 @@ public class UnixNativeUtils extends NativeUtils {
             // a quick and dirty solution - we assume that % is present only once in
             // each line - in the part where the percentage is reported, hence we
             // look for the percentage sign and then for the first slash
-            final List<File> roots = new LinkedList<File>();
+            final List<File> roots = new LinkedList<>();
             for (int i = 1; i < lines.length; i++) {
                 int index = lines[i].indexOf("%");
                 if (index != -1) {
@@ -1207,7 +1206,6 @@ public class UnixNativeUtils extends NativeUtils {
         try {
             setEnvironmentVariable(
                     "LANG", "C", EnvironmentScope.PROCESS, false);
-
             setEnvironmentVariable(
                     "LC_COLLATE", "C", EnvironmentScope.PROCESS, false);
             setEnvironmentVariable(
@@ -1236,13 +1234,11 @@ public class UnixNativeUtils extends NativeUtils {
                 if (index != -1) {                    
                     String parts[] = lines[i].substring(0, index).split("[ ]+");
                     if (parts.length > 1) {
-                        return new Long(parts[parts.length - 2]).longValue() * 1024L;
+                        return Long.parseLong(parts[parts.length - 2]) * 1024L;
                     }
                 }
             }
-        } catch (IOException e) {
-            LogManager.log(e);
-        } catch (NumberFormatException e) {
+        } catch (IOException | NumberFormatException e) {
             LogManager.log(e);
         }
         return 0L;
@@ -1263,17 +1259,17 @@ public class UnixNativeUtils extends NativeUtils {
                 Integer [] wModes = new Integer [] {FileAccessMode.WU, FileAccessMode.WG, FileAccessMode.WO };
                 Integer [] xModes = new Integer [] {FileAccessMode.EU, FileAccessMode.EG, FileAccessMode.EO };
                 
-                List <Pair <List <Integer>, String >> modes = new ArrayList <Pair <List <Integer> , String >>();
+                List <Pair <List <Integer>, String >> modes = new ArrayList<>();
                 
-                modes.add(new Pair <List <Integer>, String > (new ArrayList <Integer> (Arrays.asList(rModes)), "r"));
-                modes.add(new Pair <List <Integer>, String > (new ArrayList <Integer> (Arrays.asList(wModes)), "w"));
-                modes.add(new Pair <List <Integer>, String > (new ArrayList <Integer> (Arrays.asList(xModes)), "x"));
+                modes.add(new Pair< >(new ArrayList<>(Arrays.asList(rModes)), "r"));
+                modes.add(new Pair< >(new ArrayList<>(Arrays.asList(wModes)), "w"));
+                modes.add(new Pair< >(new ArrayList<>(Arrays.asList(xModes)), "x"));
                 
                 for (int i = 0; i < modes.size(); i++) {
                     String m = StringUtils.EMPTY_STRING;
                     List<Integer> list = modes.get(i).getFirst();
                     for (int j = 0; j < list.size(); j++) {
-                        if ((mode & list.get(j).intValue()) != 0) {
+                        if ((mode & list.get(j)) != 0) {
                             m += (j == 0 ? "u" : (j == 1 ? "g" : "o"));
                         }
                     }                    
@@ -1331,9 +1327,7 @@ public class UnixNativeUtils extends NativeUtils {
             }
 
             return permissions;
-        } catch (IOException e) {
-            return -1;
-        } catch (IndexOutOfBoundsException e) {
+        } catch (IOException | IndexOutOfBoundsException e) {
             return -1;
         }
     }
@@ -1348,7 +1342,6 @@ public class UnixNativeUtils extends NativeUtils {
             try {
                 setEnvironmentVariable(
                         "LANG", "C", EnvironmentScope.PROCESS, false);
-
                 setEnvironmentVariable(
                         "LC_COLLATE", "C", EnvironmentScope.PROCESS, false);
                 setEnvironmentVariable(
@@ -1372,9 +1365,7 @@ public class UnixNativeUtils extends NativeUtils {
             if (matcher.find()) {
                 adm = Integer.parseInt(matcher.group(1)) == 0;
             }
-        } catch (IOException e) {
-            LogManager.log(e);
-        } catch (NumberFormatException e) {
+        } catch (IOException | NumberFormatException e) {
             LogManager.log(e);
         }
         return adm;
@@ -1397,7 +1388,7 @@ public class UnixNativeUtils extends NativeUtils {
         protected void writeCleaningFileList(File listFile, List<String> files) throws IOException {
             // be sure that the list file contains end-of-line
             // otherwise the installer will run into Issue 104079
-            List<String> newList = new LinkedList<String> (files);
+            List<String> newList = new LinkedList<> (files);
             newList.add(SystemUtils.getLineSeparator());
             FileUtils.writeStringList(listFile, newList);
         }

--- a/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/ExeLauncher.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/ExeLauncher.java
@@ -134,7 +134,7 @@ public class ExeLauncher extends CommonLauncher {
                     testJVMClass);
             
             // add java compatibility properties number
-            addNumber(fos, new Long("" + compatibleJava.size()).longValue());
+            addNumber(fos, Long.parseLong("" + compatibleJava.size()));
             addJavaCompatibleProperties(fos);
             
             //add overall bundled number and size

--- a/nbi/engine/src/org/netbeans/installer/utils/system/windows/WindowsRegistry.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/windows/WindowsRegistry.java
@@ -645,7 +645,7 @@ public class WindowsRegistry {
             } else if (value instanceof Integer) {
                 LogManager.log("Type is integer. Set REG_DWORD value");
                 
-                set32BitValue(section, key, name, ((Integer) value).intValue());
+                set32BitValue(section, key, name, (Integer) value);
             } else if (value instanceof Long) {
                 LogManager.log("Type is long. Set REG_DWORD value");
                 
@@ -786,9 +786,9 @@ public class WindowsRegistry {
     }
     public boolean IsWow64Process() {
         if(wow64process == null) {
-            wow64process = new Boolean(IsWow64Process0());
+            wow64process = IsWow64Process0();
         }
-        return wow64process.booleanValue();
+        return wow64process;
     }
     
     // private //////////////////////////////////////////////////////////////////////
@@ -796,9 +796,9 @@ public class WindowsRegistry {
         if(im==MODE_DEFAULT) {
             return null;
         } else if(im==MODE_32BIT) {
-            return new Boolean(System.getProperty("os.arch").equals("amd64"));
+            return System.getProperty("os.arch").equals("amd64");
         } else if(im==MODE_64BIT) {
-            return new Boolean(IsWow64Process());
+            return IsWow64Process();
         } else {
             return null;
         }
@@ -809,11 +809,11 @@ public class WindowsRegistry {
         }
         //running 32-bit application in Windows x64
         if(IsWow64Process()) {
-            return bm.booleanValue() ? MODE_64BIT : MODE_32BIT;
+            return bm ? MODE_64BIT : MODE_32BIT;
         }
         //running 64-bit application in Windows x64
         if(System.getProperty("os.arch").equals("amd64")) {
-            return !bm.booleanValue() ? MODE_64BIT : MODE_32BIT;
+            return !bm ? MODE_64BIT : MODE_32BIT;
         }
         return MODE_DEFAULT;
     }

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/actions/SearchForJavaAction.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/actions/SearchForJavaAction.java
@@ -50,8 +50,8 @@ import org.netbeans.installer.wizard.components.panels.JdkLocationPanel;
 public class SearchForJavaAction extends WizardAction {
     /////////////////////////////////////////////////////////////////////////////////
     // Instance
-    private static List<File> javaLocations = new LinkedList<File>();
-    private static List<String> javaLabels = new LinkedList<String>();
+    private static List<File> javaLocations = new LinkedList<>();
+    private static List<String> javaLabels  = new LinkedList<>();
     
     public SearchForJavaAction() {
         setProperty(TITLE_PROPERTY, DEFAULT_TITLE);
@@ -66,7 +66,7 @@ public class SearchForJavaAction extends WizardAction {
     public void execute(Progress progress) {
         LogManager.logEntry("search for all java locations");
         getWizardUi().setProgress(progress);
-        final List<File> locations = new LinkedList<File>();
+        final List<File> locations = new LinkedList<>();
         progress.setTitle(SEARCH_INSTALLED_JAVAS);
         progress.setDetail(StringUtils.EMPTY_STRING);
         progress.setPercentage(Progress.START);
@@ -366,12 +366,12 @@ public class SearchForJavaAction extends WizardAction {
                 nativeUtils.getWindowsRegistry();
         
         final int currentMode = registry.getMode();
-        List <Boolean> modes = new ArrayList <Boolean> ();
+        List <Boolean> modes = new ArrayList <> ();
         modes.add(null); //default mode
         
         if(registry.isAlternativeModeSupported()) {
             LogManager.log("... alternative registry view is also supported");
-            modes.add(new Boolean(true));//alternative mode
+            modes.add(true);//alternative mode
         }        
         try {
           for (Boolean mode : modes) {

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/PreInstallSummaryPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/PreInstallSummaryPanel.java
@@ -273,7 +273,7 @@ public class PreInstallSummaryPanel extends ErrorMessagePanel {
                         downloadSize+=product.getDownloadSize();
                     }
                     // the critical check point - we download all the data
-                    spaceMap.put(downloadDataDirRoot, new Long(downloadSize));                
+                    spaceMap.put(downloadDataDirRoot, downloadSize);                
                     long lastDataSize = 0;
                     
                     for (Product product: toInstall) {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/global/TransactionalSupport.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/global/TransactionalSupport.java
@@ -106,10 +106,10 @@ public class TransactionalSupport {
                     System.out.println("DEBUG: [" + Thread.currentThread().getName() + "] Releasing ownership for a shared lock"); // NOI18N
                 }
 
-                int counter = roCounter.intValue();
+                int counter = roCounter;
 
                 if (counter > 1) {
-                    lockRead.set(new Integer(counter - 1));
+                    lockRead.set(counter - 1);
                 } else {
                     lockRead.set(null);
                     unlockShared();
@@ -128,10 +128,10 @@ public class TransactionalSupport {
                                        + "] Releasing ownership for an exclusive lock"); // NOI18N
                 }
 
-                int counter = rwCounter.intValue();
+                int counter = rwCounter;
 
                 if (counter > 1) {
-                    lockWrite.set(new Integer(counter - 1));
+                    lockWrite.set(counter - 1);
                 } else {
                     lockWrite.set(null);
 
@@ -162,7 +162,7 @@ public class TransactionalSupport {
             }
 
             lockedExclusively = true;
-            lockWrite.set(new Integer(1));
+            lockWrite.set(1);
 
             return true;
         }
@@ -183,10 +183,10 @@ public class TransactionalSupport {
             Integer counter = (Integer) lockRead.get();
 
             if (counter == null) {
-                lockRead.set(new Integer(1));
+                lockRead.set(1);
                 sharedLockCount++; // turn the lock counter only if the current thread doesn't own the sahred lock already
             } else {
-                lockRead.set(new Integer(counter.intValue() + 1));
+                lockRead.set(counter + 1);
             }
 
             result = true;
@@ -216,7 +216,7 @@ public class TransactionalSupport {
             lockedShared = false;
             sharedLockCount = 0;
             lockedExclusively = true;
-            lockWrite.set(new Integer(counter.intValue() + 1));
+            lockWrite.set(counter + 1);
             lockRead.set(null);
             result = true;
         } else {
@@ -241,7 +241,7 @@ public class TransactionalSupport {
                                    + "] Relocking a previously owned exclusive lock"); // NOI18N
             }
 
-            lockWrite.set(new Integer(counter.intValue() + 1));
+            lockWrite.set(counter + 1);
             result = true;
         } else {
             if (DEBUG) {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/DominatorTree.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/DominatorTree.java
@@ -89,7 +89,7 @@ class DominatorTree {
     private boolean computeOneLevel(boolean ignoreDirty) throws IOException {
         boolean changed = false;
         LongSet newDirtySet = new LongSet(map.size()/10);
-        List<Long> additionalIds = new ArrayList();
+        List<Long> additionalIds = new ArrayList<>();
         int additionalIndex = 0;
         // debug 
 //        long processedId = 0;
@@ -176,7 +176,7 @@ class DominatorTree {
                     Instance val = ((ObjectFieldValue)v).getInstance();
                     if (val != null) {
                         long idp = val.getInstanceId();
-                        Long idO = new Long(idp);
+                        Long idO = idp;
                         long idomO = map.get(idp);
                         if (idomO > 0) {
                             additionalIds.add(idO);

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
@@ -527,7 +527,7 @@ class HprofHeap implements Heap {
 
             if (classIdOffset != 0) {
                 long classId = dumpBuffer.getID(start + 1 + classIdOffset);
-                classDump = (ClassDump) classIdToClassMap.get(new Long(classId));
+                classDump = (ClassDump) classIdToClassMap.get(classId);
             }
 
             if (classDump != null) {
@@ -624,7 +624,7 @@ class HprofHeap implements Heap {
 
             if (tag == INSTANCE_DUMP) {
                 long classId = dumpBuffer.getID(start+1+idSize+4);
-                ClassDump classDump = (ClassDump) classIdToClassMap.get(new Long(classId));
+                ClassDump classDump = (ClassDump) classIdToClassMap.get(classId);
                 long instanceId = dumpBuffer.getID(start+1);
                 long inOff = start+1+idSize+4+idSize+4;
                 List fields = classDump.getAllInstanceFields();
@@ -726,7 +726,7 @@ class HprofHeap implements Heap {
             boolean isTreeObj = instanceEntry.isTreeObj();
             long instSize = 0;
             
-            if (!isTreeObj && (instanceEntry.getNearestGCRootPointer() != 0 || gcRoots.getGCRoot(new Long(instanceId)) != null)) {
+            if (!isTreeObj && (instanceEntry.getNearestGCRootPointer() != 0 || gcRoots.getGCRoot(instanceId) != null)) {
                 long origSize = instanceEntry.getRetainedSize();
                 if (origSize < 0) origSize = 0;
                 Instance instance = getInstanceByID(instanceId);

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofProxy.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofProxy.java
@@ -94,7 +94,7 @@ class HprofProxy {
                     offset = Integer.valueOf(0);
                 }
                 if (len == null) {
-                    len = new Integer(chars.getLength());
+                    len = chars.getLength();
                 }
                 char[] charArr = getChars(chars, coder, offset.intValue(), len.intValue());
 

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NumberList.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NumberList.java
@@ -174,7 +174,7 @@ class NumberList {
                 if (el == 0L) {     // end of the block, move to next one
                     break;
                 }
-                numbers.add(new Long(el));
+                numbers.add(el);
             }
             long nextBlock = getOffsetToNextBlock(block);
             if (nextBlock == 0L) {
@@ -254,7 +254,7 @@ class NumberList {
                 buf.put(el);
             }            
         } else {
-            Long offsetObj = new Long(blockOffset);
+            Long offsetObj = blockOffset;
             int offset = slot*numberSize;
             for (int i=numberSize-1;i>=0;i--) {
                 byte el = (byte)(element >> (i*8));
@@ -275,7 +275,7 @@ class NumberList {
             buf.get(block);
             return block;
         } else {
-            Long offsetObj = new Long(offset);
+            Long offsetObj = offset;
 
             block = (byte[]) blockCache.get(offsetObj);
             if (block == null) {
@@ -290,7 +290,7 @@ class NumberList {
 
     private long addBlock() throws IOException {
         long offset=blocks*blockSize;
-        blockCache.put(new Long(offset),new byte[blockSize]);
+        blockCache.put(offset, new byte[blockSize]);
         blocks++;
         return offset;
     }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StackFrameSegment.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StackFrameSegment.java
@@ -69,11 +69,11 @@ class StackFrameSegment extends TagBounds {
         long[] offset;
         
         initIdToFrame();
-        initialOffset = (Long) idToFrame.get(new Long(stackFrameID/FRAME_DIV));
+        initialOffset = (Long) idToFrame.get(stackFrameID/FRAME_DIV);
         if (initialOffset == null) {
-            initialOffset = new Long(startOffset);
+            initialOffset = startOffset;
         }
-        offset = new long[] { initialOffset.longValue() };
+        offset = new long[] {initialOffset};
         while (offset[0] < endOffset) {
             long start = offset[0];
             long frameID = readStackFrameTag(offset);
@@ -107,11 +107,11 @@ class StackFrameSegment extends TagBounds {
             while (offset[0] < endOffset) {
                 long start = offset[0];
                 long frameID = readStackFrameTag(offset);
-                Long frameIDMask = new Long(frameID/FRAME_DIV);
+                Long frameIDMask = frameID / FRAME_DIV;
                 Long minOffset = (Long) idToFrame.get(frameIDMask);
                 
                 if (minOffset == null || minOffset > start) {
-                    idToFrame.put(frameIDMask, new Long(start));
+                    idToFrame.put(frameIDMask, start);
                 }
             }
 //            Systems.debug("idToFrame size:"+idToFrame.size());

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StackTraceSegment.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StackTraceSegment.java
@@ -61,11 +61,11 @@ class StackTraceSegment extends TagBounds {
         long[] offset;
         
         initSerialNumToFrame();
-        initialOffset = (Long) serialNumToStackTrace.get(new Long(stackTraceSerialNumber/SERIALNUM_DIV));
+        initialOffset = (Long) serialNumToStackTrace.get(stackTraceSerialNumber / SERIALNUM_DIV);
         if (initialOffset == null) {
             initialOffset = new Long(startOffset);
         }
-        offset = new long[] { initialOffset.longValue() };
+        offset = new long[] {initialOffset};
         while (offset[0] < endOffset) {
             long start = offset[0];
             long serialNumber = readStackTraceTag(offset);
@@ -96,15 +96,15 @@ class StackTraceSegment extends TagBounds {
         if (serialNumToStackTrace == null) {
             long[] offset = new long[] { startOffset };
 
-            serialNumToStackTrace = new HashMap();
+            serialNumToStackTrace = new HashMap<>();
             while (offset[0] < endOffset) {
                 long start = offset[0];
                 long serialNumber = readStackTraceTag(offset);
-                Long serialNumberMask = new Long(serialNumber/SERIALNUM_DIV);
+                Long serialNumberMask = serialNumber/SERIALNUM_DIV;
                 Long minOffset = (Long) serialNumToStackTrace.get(serialNumberMask);
                 
                 if (minOffset == null || minOffset > start) {
-                    serialNumToStackTrace.put(serialNumberMask, new Long(start));
+                    serialNumToStackTrace.put(serialNumberMask, start);
                 }
             }
 //            Systems.debug("serialNumToStackTrace size:"+serialNumToStackTrace.size());

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StringSegment.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StringSegment.java
@@ -55,7 +55,7 @@ class StringSegment extends TagBounds {
     //~ Methods ------------------------------------------------------------------------------------------------------------------
 
     String getStringByID(long stringID) {
-        Long stringIDObj = new Long(stringID);
+        Long stringIDObj = stringID;
         String string = (String) stringCache.get(stringIDObj);
         if (string == null) {
             string = createStringByID(stringID);

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/SyntheticClassObjectValue.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/SyntheticClassObjectValue.java
@@ -34,7 +34,7 @@ class SyntheticClassObjectValue extends HprofInstanceObjectValue {
     //~ Methods ------------------------------------------------------------------------------------------------------------------
 
     Object getTypeValue() {
-        return new Long(getInstanceId());
+        return getInstanceId();
     }
 
     public Instance getInstance() {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUCCTContainer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/CPUCCTContainer.java
@@ -386,7 +386,7 @@ public class CPUCCTContainer {
 
     protected void addFlatProfTimeForNode(int dataOfs) {
         int methodId = getMethodIdForNodeOfs(dataOfs);
-        Integer methodIdInt = new Integer(methodId);
+        Integer methodIdInt = methodId;
         boolean isRecursiveCall = methodsOnStack.contains(methodIdInt);
         
         if (methodId >= invPerMethodId.length) {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockGraphBuilder.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/locks/LockGraphBuilder.java
@@ -266,7 +266,7 @@ public class LockGraphBuilder extends BaseCallGraphBuilder implements LockProfil
     }
 
     private MonitorInfo getMonitorInfo(int monitorId) {
-        Integer mid = new Integer(monitorId);
+        Integer mid = monitorId;
         MonitorInfo mi = monitorInfos.get(mid);
         if (mi == null) {
             mi = new MonitorInfo(monitorId);
@@ -276,7 +276,7 @@ public class LockGraphBuilder extends BaseCallGraphBuilder implements LockProfil
     }
 
     private void registerNewMonitor(int monitorId, String className) {
-        Integer mid = new Integer(monitorId);
+        Integer mid = monitorId;
         MonitorInfo mi = monitorInfos.get(mid);
         if (mi == null) {
             mi = new MonitorInfo(monitorId,className);

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/HeapHistogramManager.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/HeapHistogramManager.java
@@ -199,7 +199,7 @@ class HeapHistogramManager {
             String name = ci.getName();
             Integer cindex = (Integer) classesIdMap.get(name);
             if (cindex == null) {
-                cindex = new Integer(classesIdMap.size());
+                cindex = classesIdMap.size();
                 classesIdMap.put(name, cindex);
                 newClassNames.put(name, cindex);
             }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerInterface.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerInterface.java
@@ -1494,7 +1494,7 @@ public class ProfilerInterface implements CommonConstants {
             int index = classIndex.size();
             classesArray[index] = clazz;
             loaders[index] = loadedClassesLoaders[i];
-            classIndex.put(clazz, new Integer(index));
+            classIndex.put(clazz, index);
         }
         for (int i = 0; i < classIndex.size(); i++) {
             Class<?> clazz = classesArray[i];

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntime.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntime.java
@@ -717,7 +717,7 @@ public class ProfilerRuntime implements CommonConstants {
         if (id == null || !lockContentionMonitoringEnabled) return -1;
         initThreadInfo(ti);
         int hash = System.identityHashCode(id);
-        Integer hashInt = new Integer(hash);
+        Integer hashInt = hash;
         if (knownMonitors.add(hashInt)) {
             int curPos = ti.evBufPos; // It's important to use a local copy for evBufPos, so that evBufPos is at event boundary at any moment
 

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeMemory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeMemory.java
@@ -176,7 +176,7 @@ public class ProfilerRuntimeMemory extends ProfilerRuntime {
         if (classIdInt == null) {
             int newClassId = externalActionsHandler.handleFirstTimeVMObjectAlloc(className, definingClassLoaderId);
 
-            classIdInt = new Integer(newClassId);
+            classIdInt = newClassId;
             synchronized (classIdMapLock) {
                 classIdMap.put(classNameId, classIdInt);
             }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeSampler.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ProfilerRuntimeSampler.java
@@ -90,7 +90,7 @@ class ProfilerRuntimeSampler extends ProfilerRuntime {
                             } else if (status != CommonConstants.THREAD_STATUS_ZOMBIE && mids.length>0) { 
                                 // new thread with a stacktrace
                                 ThreadInfo ti = ThreadInfo.getThreadInfo(t);
-                                tid = new Integer(ti.getThreadId());
+                                tid = ti.getThreadId();
                                 if (!ti.isInitialized()) {
                                     ti.initialize();
                                     ProfilerRuntime.writeThreadCreationEvent(t,tid.intValue());
@@ -99,7 +99,7 @@ class ProfilerRuntimeSampler extends ProfilerRuntime {
                             } else { // new thread which is not started yet or it did not ever have stacktrace 
                                 continue; 
                             }
-                            newArrayOffsetMap.put(ltid, new Integer(i));
+                            newArrayOffsetMap.put(ltid, i);
                             newThreadIdMap.put(ltid,tid);
                         }
                     }


### PR DESCRIPTION
This change cleans up the use of old deprecated numeric constructors..

Warnings like this will no longer happen:

```
[repeat] /home/bwalker/src/netbeans/java/testng/src/org/netbeans/modules/testng/AbstractTestGenerator.java:1700: warning: [deprecation] Float(float) in Float has been deprecated
[repeat]                     defValue = maker.Literal(new Float(0.0F));
[repeat]    
```
The newer implementation favor factory methods like `valueOf`() or `parseFloat`() since they are likely to
yield significantly better space and time performance by caching frequently requested values.

Also, the compiler/VM can do a better job of accessing the actual numeric values using autobox/unbox.

Most of these changes are in the enterprise/ide/java/profiler modules.

There are also some places that were changed to use the diamond operator.

---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

