### PR TITLE
[NETBEANS-5599] PHP 8.1 Support: New in initializers (Part 4)

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/StaticStatement.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/StaticStatement.java
@@ -20,17 +20,22 @@ package org.netbeans.modules.php.editor.parser.astnodes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Represents the static statement
- * <pre>e.g.<pre> static $a
+ * Represents the static statement.
+ *
+ * e.g.
+ * <pre>
+ * static $a
  * static $a, $b=5;
+ * </pre>
  */
 public class StaticStatement extends Statement {
 
-    private ArrayList<Expression> expressions = new ArrayList<>();
+    private final ArrayList<Expression> expressions = new ArrayList<>();
 
     private StaticStatement(int start, int end, Expression[] expressions) {
         super(start, end);
@@ -65,7 +70,7 @@ public class StaticStatement extends Statement {
      * @return expression list of the static statement
      */
     public List<Expression> getExpressions() {
-        return this.expressions;
+        return Collections.unmodifiableList(this.expressions);
     }
 
     @Override

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/PHP81UnhandledError.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/PHP81UnhandledError.java
@@ -30,10 +30,16 @@ import org.netbeans.modules.php.editor.CodeUtils;
 import org.netbeans.modules.php.editor.lexer.PHPTokenId;
 import org.netbeans.modules.php.editor.parser.PHPParseResult;
 import org.netbeans.modules.php.editor.parser.astnodes.ASTNode;
+import org.netbeans.modules.php.editor.parser.astnodes.Assignment;
+import org.netbeans.modules.php.editor.parser.astnodes.AttributeDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.BodyDeclaration;
+import org.netbeans.modules.php.editor.parser.astnodes.ClassInstanceCreation;
 import org.netbeans.modules.php.editor.parser.astnodes.ConstantDeclaration;
+import org.netbeans.modules.php.editor.parser.astnodes.Expression;
+import org.netbeans.modules.php.editor.parser.astnodes.FormalParameter;
 import org.netbeans.modules.php.editor.parser.astnodes.Identifier;
 import org.netbeans.modules.php.editor.parser.astnodes.IntersectionType;
+import org.netbeans.modules.php.editor.parser.astnodes.StaticStatement;
 import org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultVisitor;
 import org.openide.filesystems.FileObject;
 import org.openide.util.NbBundle;
@@ -102,8 +108,60 @@ public final class PHP81UnhandledError extends UnhandledErrorRule {
 
         @Override
         public void visit(IntersectionType node) {
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
             createError(node);
             super.visit(node);
+        }
+
+        @Override
+        public void visit(StaticStatement node) {
+            // static $a = new A();
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            for (Expression expression : node.getExpressions()) {
+                if (CancelSupport.getDefault().isCancelled()) {
+                    return;
+                }
+                if (expression instanceof Assignment) {
+                    Assignment assignment = (Assignment) expression;
+                    if (assignment.getOperator() == Assignment.Type.EQUAL) {
+                        checkNewInInitializer(assignment.getRightHandSide());
+                    }
+                }
+            }
+            super.visit(node);
+        }
+
+        @Override
+        public void visit(FormalParameter node) {
+            // function func($param = new A()) {}
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            checkNewInInitializer(node.getDefaultValue());
+            super.visit(node);
+        }
+
+        @Override
+        public void visit(AttributeDeclaration attributeDeclaration) {
+            // #[AnAttribute(new A())]
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            List<Expression> parameters = attributeDeclaration.getParameters();
+            // #[MyAttribute] this case is null
+            if (parameters != null) {
+                for (Expression parameter : parameters) {
+                    if (CancelSupport.getDefault().isCancelled()) {
+                        return;
+                    }
+                    checkNewInInitializer(parameter);
+                }
+            }
+            super.visit(attributeDeclaration);
         }
 
         private void checkConstantDeclaration(ConstantDeclaration constantDeclaration) {
@@ -111,6 +169,22 @@ public final class PHP81UnhandledError extends UnhandledErrorRule {
                 for (Identifier name : constantDeclaration.getNames()) {
                     createError(name);
                 }
+            }
+            // New in initializer
+            // const CONSTANT = new Constant();
+            if (constantDeclaration.isGlobal()) {
+                for (Expression initializer : constantDeclaration.getInitializers()) {
+                    if (CancelSupport.getDefault().isCancelled()) {
+                        return;
+                    }
+                    checkNewInInitializer(initializer);
+                }
+            }
+        }
+
+        private void checkNewInInitializer(Expression node) {
+            if (node instanceof ClassInstanceCreation) {
+                createError(node);
             }
         }
 


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/NETBEANS-5599
- RFC:https://wiki.php.net/rfc/new_in_initializers
- Fix PHP81UnhandledError

#### Screenshots
PHP 8.1
![nb-php81-new-in-initializers](https://user-images.githubusercontent.com/738383/155078606-fa1bf8d8-9e7e-43eb-a580-adb4a41c07da.png)


PHP 8.0
![nb-php81-new-in-initializers-php80](https://user-images.githubusercontent.com/738383/155078629-cc68c417-033b-4bce-90cf-7b96e4439cd6.png)

