### PR TITLE
about window update

### DIFF
--- a/platform/o.n.core/nbproject/project.properties
+++ b/platform/o.n.core/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javac.target=1.8
 
 javadoc.arch=${basedir}/arch.xml

--- a/platform/o.n.core/src/org/netbeans/core/actions/AboutAction.java
+++ b/platform/o.n.core/src/org/netbeans/core/actions/AboutAction.java
@@ -20,15 +20,11 @@
 package org.netbeans.core.actions;
 
 import java.awt.Dialog;
-import java.awt.Dimension;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
-import java.security.KeyStore;
 import javax.swing.*;
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.actions.CallableSystemAction;
-import org.openide.util.actions.Presenter;
 
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
@@ -44,6 +40,7 @@ public class AboutAction extends CallableSystemAction {
         putValue("noIconInMenu", Boolean.TRUE); // NOI18N
     }
 
+    @Override
     public void performAction () {
         DialogDescriptor descriptor = new DialogDescriptor(
             new org.netbeans.core.ui.ProductInformationPanel (),
@@ -73,14 +70,17 @@ public class AboutAction extends CallableSystemAction {
         }
     }
     
+    @Override
     protected boolean asynchronous() {
         return false;
     }
     
+    @Override
     public HelpCtx getHelpCtx() {
         return new HelpCtx(AboutAction.class);
     }
 
+    @Override
     public String getName() {
         return NbBundle.getMessage(AboutAction.class, "About");
     }

--- a/platform/o.n.core/src/org/netbeans/core/ui/ProductInformationPanel.form
+++ b/platform/o.n.core/src/org/netbeans/core/ui/ProductInformationPanel.form
@@ -41,9 +41,9 @@
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="1" attributes="0">
                   <Component id="imagePanel" alignment="0" pref="190" max="32767" attributes="0"/>
-                  <Component id="jScrollPane2" alignment="0" pref="190" max="32767" attributes="0"/>
-                  <Component id="jScrollPane3" alignment="1" pref="190" max="32767" attributes="0"/>
-                  <Component id="jPanel1" alignment="0" pref="190" max="32767" attributes="1"/>
+                  <Component id="descriptionScrollPane" alignment="0" pref="190" max="32767" attributes="0"/>
+                  <Component id="copyrightScrollPane" alignment="1" pref="190" max="32767" attributes="0"/>
+                  <Component id="buttonPanel" alignment="0" pref="190" max="32767" attributes="1"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
@@ -53,24 +53,28 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" attributes="0">
               <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Component id="imagePanel" pref="27" max="32767" attributes="0"/>
+              <Component id="imagePanel" pref="79" max="32767" attributes="0"/>
               <EmptySpace min="-2" pref="14" max="-2" attributes="0"/>
-              <Component id="jScrollPane3" pref="151" max="32767" attributes="2"/>
+              <Component id="copyrightScrollPane" pref="70" max="32767" attributes="2"/>
               <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
-              <Component id="jScrollPane2" pref="129" max="32767" attributes="0"/>
+              <Component id="descriptionScrollPane" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
-              <Component id="jPanel1" min="-2" max="-2" attributes="0"/>
+              <Component id="buttonPanel" min="-2" max="-2" attributes="0"/>
               <EmptySpace min="-2" max="-2" attributes="1"/>
           </Group>
       </Group>
     </DimensionLayout>
   </Layout>
   <SubComponents>
-    <Container class="javax.swing.JPanel" name="jPanel1">
+    <Container class="javax.swing.JPanel" name="buttonPanel">
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+      </AuxValues>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
       <SubComponents>
-        <Component class="javax.swing.JButton" name="jButton2">
+        <Component class="javax.swing.JButton" name="closeButton">
           <Properties>
             <Property name="mnemonic" type="int" editor="org.netbeans.modules.i18n.form.FormI18nMnemonicEditor">
               <ResourceString bundle="org/netbeans/core/ui/Bundle.properties" key="MNE_Close" replaceFormat="NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
@@ -80,8 +84,12 @@
             </Property>
           </Properties>
           <Events>
-            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButton2ActionPerformed"/>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="closeButtonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
               <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="1.0"/>
@@ -90,13 +98,15 @@
         </Component>
       </SubComponents>
     </Container>
-    <Container class="javax.swing.JScrollPane" name="jScrollPane3">
+    <Container class="javax.swing.JScrollPane" name="copyrightScrollPane">
       <Properties>
         <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
           <Border info="null"/>
         </Property>
       </Properties>
       <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
         <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
       </AuxValues>
 
@@ -112,6 +122,9 @@
             <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
               <Connection code="getCopyrightText()" type="code"/>
             </Property>
+            <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[50, 0]"/>
+            </Property>
           </Properties>
           <Events>
             <EventHandler event="mouseClicked" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="copyrightMouseClicked"/>
@@ -122,8 +135,14 @@
         </Component>
       </SubComponents>
     </Container>
-    <Container class="javax.swing.JScrollPane" name="jScrollPane2">
+    <Container class="javax.swing.JScrollPane" name="descriptionScrollPane">
+      <Properties>
+        <Property name="horizontalScrollBarPolicy" type="int" value="32"/>
+        <Property name="verticalScrollBarPolicy" type="int" value="21"/>
+      </Properties>
       <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
         <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
       </AuxValues>
 
@@ -131,14 +150,18 @@
       <SubComponents>
         <Component class="javax.swing.JTextPane" name="description">
           <Properties>
-            <Property name="contentType" type="java.lang.String" value="text/html" noResource="true"/>
             <Property name="editable" type="boolean" value="false"/>
+            <Property name="contentType" type="java.lang.String" value="text/html" noResource="true"/>
             <Property name="text" type="java.lang.String" value="&lt;div style=&quot;font-size: 12pt; font-family: Verdana, &apos;Verdana CE&apos;,  Arial, &apos;Arial CE&apos;, &apos;Lucida Grande CE&apos;, lucida, &apos;Helvetica CE&apos;, sans-serif;&quot;&gt;&#xa;    &lt;b&gt;Product Version:&lt;/b&gt; {0}&lt;br&gt; &lt;b&gt;Java:&lt;/b&gt; {1}; {2}&lt;br&gt; &lt;b&gt;System:&lt;/b&gt; {3}; {4}; {5}&lt;br&gt;&lt;b&gt;Userdir:&lt;/b&gt; {6}&lt;/div&gt;"/>
           </Properties>
         </Component>
       </SubComponents>
     </Container>
     <Container class="javax.swing.JPanel" name="imagePanel">
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+      </AuxValues>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
       <SubComponents>


### PR DESCRIPTION
before:
![About](https://user-images.githubusercontent.com/114367/155246244-2d3dbce9-7025-4f2b-9c49-23112d16b0c6.png)

after:
![About2](https://user-images.githubusercontent.com/114367/155246282-735aa3df-0da2-4f70-bbbf-8d0a5e755d50.png)


 - layout tweaks
 - some code cleanup / language level upgrade

context:
inspired by a discussion on NB slack.

The two text panels are in scroll areas which makes it a bit difficult to compute their size for the window. (the point of a scroll area is to not care about the dimensions of its content).

The lower panel has predictable content, so I disabled the vertical scrollbar and set the horizontal scrollbar to show-always so that it is part of the layout computation. Height is now set to default, since it can size itself now.

The upper panel had fixed size, it still has, it just lost around 50px in height. Btw should we add a github link there?

Rest are minor cleanups in the involved areas.