### PR TITLE
Fix getFile returning null

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
@@ -105,7 +105,7 @@ public final class GradleFiles implements Serializable {
         List<File> ret = new ArrayList<>(3);
         for (Kind kind:Kind.PROPERTIES){
             File f = getFile(kind);
-            if (f.exists()){
+            if (f != null && f.exists()){
                 ret.add(f);
             }
         }


### PR DESCRIPTION
Fix issue #3662 : Gradle Compile a file in buildSrc folder fails with a NullPointer

Situation:
Gradle project has a custom build logic project under it. ( Build Script - Custom Build Logic )
In Netbeans you can open the project
If you select a separate file - Right Click - Compile, you get the exception
If you try to build the project, you get the exception

java.lang.NullPointerException
	at org.netbeans.modules.gradle.spi.GradleFiles.searchPropertyFiles(GradleFiles.java:108)
	at org.netbeans.modules.gradle.spi.GradleFiles.getPropertyFiles(GradleFiles.java:179)
	at org.netbeans.modules.gradle.api.execute.GradleCommandLine.addGradleSettingJvmargs(GradleCommandLine.java:804)
	at org.netbeans.modules.gradle.api.execute.GradleCommandLine.configure(GradleCommandLine.java:838)
	at org.netbeans.modules.gradle.execute.GradleDaemonExecutor.run(GradleDaemonExecutor.java:207)
	at org.netbeans.core.execution.RunClassThread.doRun(RunClassThread.java:132)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
[catch] at org.netbeans.core.execution.RunClassThread.run(RunClassThread.java:81)
