### PR TITLE
Fix Windows profiler.lib workflow by using Windows10SDK.20348

### DIFF
--- a/.github/workflows/native-binary-build-lib.profiler.yml
+++ b/.github/workflows/native-binary-build-lib.profiler.yml
@@ -176,6 +176,10 @@ jobs:
     # Step 3
     #   Build the native binary from C source code
     #
+    #   Use Windows 10 SDK 10.0.20348.0 since build fails with Windows 11 SDK 10.0.22000.0
+    #   https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170#vcvarsall-syntax
+    #   https://bugs.python.org/issue45220
+    #
     - name: Build native lib (64-bit)
       run: |
          echo on
@@ -184,7 +188,7 @@ jobs:
          set OUTPUTDIR=../../release/lib/deployed/jdk16/windows-amd64
          del /q /s "%OUTPUTDIR%"
          rem  set up a Visual Studio command prompt for 64-bit development
-         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" 10.0.20348.0
          rem
          rem
          call buildnative-windows64-16.bat
@@ -202,7 +206,7 @@ jobs:
          set OUTPUTDIR=../../release/lib/deployed/jdk16/windows
          del /q /s "%OUTPUTDIR%"
          rem   set up a Visual Studio command prompt for 32-bit development
-         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
+         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat" 10.0.20348.0
          rem
          rem
          call buildnative-windows-16.bat


### PR DESCRIPTION

About 4 months ago GitHub updated the windows-latest image to include the Windows 11 SDK which broke the "Profiler native binary build" workflow.

GitHub has also changed windows-latest to use the windows-2022 image.

The MR changes the build to use VS 2022 with the Windows 10 SDK.

Other potential fix could be to modify the rc file. see https://bugs.python.org/issue45220

---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

