### PR TITLE
Ignore dependencies for BOM-like projects.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.codehaus.groovy.runtime.InvokerHelper;
+import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
@@ -53,6 +54,8 @@ import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.initialization.IncludedBuild;
+import org.gradle.api.plugins.JavaPlatformPlugin;
+import org.gradle.api.plugins.UnknownPluginException;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -554,7 +557,13 @@ class NbProjectInfoBuilder {
         model.getExt().put("resolved_sources_artifacts", resolvedSourcesArtifacts);
         model.getExt().put("resolved_javadoc_artifacts", resolvedJavadocArtifacts);
         model.getInfo().put("project_dependencies", projects);
-        model.getInfo().put("unresolved_problems", unresolvedProblems);
+        // NETBEANS-5846: if this project uses javaPlatform plugin with dependencies enabled, 
+        // do not report unresolved problems
+        if (!(project.getPlugins().hasPlugin(JavaPlatformPlugin.class) && 
+            Boolean.TRUE.equals(getProperty(project, "javaPlatform", "allowDependencies")))) {
+            
+            model.getInfo().put("unresolved_problems", unresolvedProblems);
+        }
         model.registerPerf("dependencies", System.currentTimeMillis() - time);
     }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -403,7 +403,7 @@ public final class NbGradleProjectImpl implements Project {
             loadedProjectSerial = s;
             this.attemptedQuality = aim;
             
-            boolean replace = project == null;
+            boolean replace = project == null || force;
             if (project != null) {
                 if (prj.getQuality().betterThan(project.getQuality())) {
                     replace = true;

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
@@ -39,7 +39,7 @@ import org.netbeans.modules.gradle.spi.GradleFiles;
 public final class ProjectInfoDiskCache extends AbstractDiskCache<GradleFiles, QualifiedProjectInfo> {
 
     // Increase this number if new info is gathered from the projects.
-    private static final int COMPATIBLE_CACHE_VERSION = 19;
+    private static final int COMPATIBLE_CACHE_VERSION = 20;
     private static final String INFO_CACHE_FILE_NAME = "project-info.ser"; //NOI18N
     private static final Map<GradleFiles, ProjectInfoDiskCache> DISK_CACHES = Collections.synchronizedMap(new WeakHashMap<>());
 


### PR DESCRIPTION

Following suggestion in [NETBEANS-5846](https://issues.apache.org/jira/browse/NETBEANS-5846). The ProjectInfoBuilder in `gradle-tooling` was changed so it does not produce `unresolved_problems` if the project uses `javaPlatform` plugin w/ dependencies enabled. 

The 2nd commit is a bugfix - during testing, I used `Reload Project` action and the project did not degrade to the new (broken) state after change in buildscript + reload. My fault, the `force` parameter to loadProject was not used at all.
