### PR TITLE
HuntDiff: make public final

### DIFF
--- a/ide/diff/src/org/netbeans/modules/diff/builtin/provider/HuntDiff.java
+++ b/ide/diff/src/org/netbeans/modules/diff/builtin/provider/HuntDiff.java
@@ -29,12 +29,12 @@ import java.util.regex.Matcher;
 import org.netbeans.api.diff.Difference;
 
 /**
- * Internal Diff algorithm.
+ * Diff algorithm.
  * 
  * @author Maros Sandor
  * @author Martin Entlicher
  */
-class HuntDiff {
+public final class HuntDiff {
 
     private static final Pattern spaces = Pattern.compile("(\\s+)");
     


### PR DESCRIPTION
This class is useful for standalone applications that use netbeans-modules-diff (i.e. https://github.com/GeertjanWielenga/netbeans-visual-diff-standalone).
While it says 'Internal', I think it would be more useful to make it public.
I'd rather make it public than see it copy/pasted in client programs.
Since everything is private static, it makes sense to make it also final.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

