### PR TITLE
project wide oprimization: improved map traversal

### DIFF
--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
@@ -365,8 +365,7 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
     public void removeCatalogListener(CatalogListener l) {
         if (null == l)
             return;
-        if (catalogListeners.contains(l))
-            catalogListeners.remove(l);
+        catalogListeners.remove(l);
     }
     
     public  void fireCatalogListeners() {

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/db/DriverMaps.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/db/DriverMaps.java
@@ -88,8 +88,9 @@ public class DriverMaps {
     }
     
     private static final String getPrefix(Map<String, String> classMap, String inClass) {
-        for(String urlPrefix: classMap.keySet()) {
-            String dsClass = classMap.get(urlPrefix);
+        for(Map.Entry<String, String> entry: classMap.entrySet()) {
+            String urlPrefix = entry.getKey();
+            String dsClass = entry.getValue();
             if(dsClass.equalsIgnoreCase(inClass)) {
                 return urlPrefix;           
             }    

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/ServerSelectionHelper.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/ServerSelectionHelper.java
@@ -179,12 +179,8 @@ public class ServerSelectionHelper {
             }
 
             // We don't support J2EE 1.3 and J2EE 1.4 anymore
-            if (profiles.contains(Profile.J2EE_13)) {
-                profiles.remove(Profile.J2EE_13);
-            }
-            if (profiles.contains(Profile.J2EE_14)) {
-                profiles.remove(Profile.J2EE_14);
-            }
+            profiles.remove(Profile.J2EE_13);
+            profiles.remove(Profile.J2EE_14);
 
             // We want to have Java EE 6 Full profile for all project types except Web project
             if (J2eeModule.Type.WAR.equals(projectType)) {

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/MavenJaxWsSupportProvider.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/MavenJaxWsSupportProvider.java
@@ -392,8 +392,9 @@ public class MavenJaxWsSupportProvider extends ProjectOpenedHook
                 jaxWsSupport.removeService(oldServices.get(key));
             }
             // add new services
-            for (String key : newServices.keySet()) {
-                ServiceInfo serviceInfo = newServices.get(key);
+            for (Map.Entry<String, ServiceInfo> entry : newServices.entrySet()) {
+                String key = entry.getKey();
+                ServiceInfo serviceInfo = entry.getValue();
                 String wsdlLocation = serviceInfo.getWsdlLocation();
                 JaxWsService service = new JaxWsService(serviceInfo.getServiceName(), key);
                 if (wsdlLocation != null && wsdlLocation.length() > 0) {

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/RunTimeDDCatalog.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/RunTimeDDCatalog.java
@@ -357,8 +357,7 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
     public void removeCatalogListener(CatalogListener l) {
         if (null == l)
             return;
-        if (catalogListeners.contains(l))
-            catalogListeners.remove(l);
+        catalogListeners.remove(l);
     }
     
     public  void fireCatalogListeners() {

--- a/enterprise/performance.scripting/test/qa-functional/src/org/netbeans/performance/languages/actions/CountingSecurityManager.java
+++ b/enterprise/performance.scripting/test/qa-functional/src/org/netbeans/performance/languages/actions/CountingSecurityManager.java
@@ -240,13 +240,13 @@ public final class CountingSecurityManager extends SecurityManager {
             }
             int absoluteStacks = 0;
             synchronized (stacks) {
-                for (String s : stacks.keySet()) {
-                    int value = stacks.get(s);
+                for (int value : stacks.values()) {
                     absoluteStacks += value;
                 }
                 int min = absoluteStacks / 50;
-                for (String s : stacks.keySet()) {
-                    int value = stacks.get(s);
+                for (Map.Entry<String, int> entry : stacks.entrySet()) {
+                    String s = entry.getKey();
+                    int value = entry.getValue();
                     if (value > min) {
                         out.printf("count %5d; Stack:\n", value);
                         for (String line : s.split("\n")) {

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/InjectCompositeComponent.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/InjectCompositeComponent.java
@@ -233,8 +233,9 @@ public class InjectCompositeComponent {
                 @Override
                 public void run(ResultIterator resultIterator) throws Exception {
                     final Map<Library, String> importsMap = new LinkedHashMap<>();
-                    for (String uri : context.getDeclarations().keySet()) {
-                        String prefix = context.getDeclarations().get(uri);
+                    for (Map.Entry<String, String> entry : context.getDeclarations().entrySet()) {
+                        String uri = entry.getKey();
+                        String prefix = entry.getValue();
                         Library lib = jsfs.getLibrary(uri);
                         if (lib != null) {
                             importsMap.put(lib, prefix);

--- a/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/SceneSerializer.java
+++ b/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/SceneSerializer.java
@@ -166,8 +166,9 @@ public class SceneSerializer {
             sceneScopeElement = document.createElement(SCENE_SCOPE_ELEMENT);
             setAttribute(document, sceneScopeElement, SCENE_SCOPE_ATTR, scopeXml.toString());
 
-            for( String key : facesConfigScopeMap.keySet()){
-                PageFlowSceneData.PageData data = facesConfigScopeMap.get(key);
+            for( Map.Entry<String, PageFlowSceneData.PageData> entry : facesConfigScopeMap.entrySet()){
+                String key = entry.getKey();
+                PageFlowSceneData.PageData data = entry.getValue();
                 if ( data != null ) {
                     Element nodeElement = document.createElement(NODE_ELEMENT);
                     setAttribute(document, nodeElement, NODE_ID_ATTR, key);

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/client/ClientGenerationStrategy.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/client/ClientGenerationStrategy.java
@@ -518,8 +518,9 @@ abstract class ClientGenerationStrategy {
                 queryP.append(".header(\""+headerParam+"\","+javaIdentifier+")"); //NOI18N
             }
             Map<String, String> fixedHeaderParams = httpParams.getFixedHeaderParams();
-            for (String paramName : fixedHeaderParams.keySet()) {
-                String paramValue = fixedHeaderParams.get(paramName);
+            for (Entry<String, String> entry : fixedHeaderParams.entrySet()) {
+                String paramName = entry.getKey();
+                String paramValue = entry.getValue();
                 queryP.append(".header(\""+paramName+"\",\""+paramValue+"\")"); //NOI18N
             }
         }

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/ConfigurableActionsProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/ConfigurableActionsProviderImpl.java
@@ -463,13 +463,11 @@ public class ConfigurableActionsProviderImpl implements ProjectActionMappingProv
             this.actionIDs = r.actionIDs;
             
             if (oldCache != null) {
-                for (String id : oldCache.keySet()) {
-                    ActionData ad = oldCache.get(id);
+                for (ActionData ad : oldCache.values()) {
                     ad.detach();
                 }
             }
-            for (String id : newCache.keySet()) {
-                ActionData ad = newCache.get(id);
+            for (ActionData ad : newCache.values()) {
                 ad.attach(projectDirectory, null, fcl);
             }
             if (newCache.keySet().equals(oldConfigs)) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/CustomActionRegistrationSupport.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/CustomActionRegistrationSupport.java
@@ -203,8 +203,9 @@ public class CustomActionRegistrationSupport {
         ProjectManager.mutex().writeAccess(() -> {
             try {
                 project.getProjectDirectory().getFileSystem().runAtomicAction(() -> {
-                    for (String s : configHolders.keySet()) {
-                        ActionsHolder h = configHolders.get(s);
+                    for (Map.Entry<String, ActionsHolder> entry : configHolders.entrySet()) {
+                        String s = entry.getKey();
+                        ActionsHolder h = entry.getValue();
                         List<ActionMapping> actions = new ArrayList<>(h.customActions.values());
                         Collections.sort(actions, ActionMapping::compareTo);
                         try {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/StructureAnalyzer.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/StructureAnalyzer.java
@@ -121,8 +121,9 @@ public class StructureAnalyzer implements StructureScanner {
         // Process fields
         Map<String, FieldNode> names = new HashMap<>();
 
-        for (ASTClass clz : fields.keySet()) {
-            Set<FieldNode> assignments = fields.get(clz);
+        for (Map.Entry<ASTClass, Set<FieldNode>> entry : fields.entrySet()) {
+            ASTClass clz = entry.getKey();
+            Set<FieldNode> assignments = entry.getValue();
 
             // Find unique variables
             if (assignments != null) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/FieldCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/FieldCompletion.java
@@ -93,9 +93,7 @@ public class FieldCompletion extends BaseCompletion {
         Map<FieldSignature, CompletionItem> result = new CompleteElementHandler(context).getFields();
         
         FieldSignature prefixFieldSignature = new FieldSignature(context.getPrefix());
-        if (result.containsKey(prefixFieldSignature)) {
-            result.remove(prefixFieldSignature);
-        }
+        result.remove(prefixFieldSignature);
         for (Map.Entry<FieldSignature, CompletionItem> e :result.entrySet()) {
             proposals.putIfAbsent(e.getKey(), e.getValue());
         }

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/Actions.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/Actions.java
@@ -977,8 +977,9 @@ public class Actions {
                 map.put(treeListNode.getClass().getName(), list);
             }
 
-            for (String key : map.keySet()) {
-                List<TreeListNode> value = map.get(key);
+            for (Map.Entry<String, List<TreeListNode>> entry : map.entrySet()) {
+                String key = entry.getKey();
+                List<TreeListNode> value = entry.getValue();
                 Action action = null;
                 if (key.equals(RepositoryNode.class.getName()) || key.equals(ClosedRepositoryNode.class.getName())) {
                     action = new Actions.RemoveRepositoryAction(value.toArray(new RepositoryNode[value.size()]));

--- a/ide/code.analysis/src/org/netbeans/modules/analysis/ui/Nodes.java
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/ui/Nodes.java
@@ -391,8 +391,9 @@ public class Nodes {
     private static Map<Node, Map<AnalyzerFactory, List<ErrorDescription>>> resolveFileNodes(LogicalViewProvider lvp, LogicalViewCache lvc, final Node view, Map<FileObject, Map<AnalyzerFactory, List<ErrorDescription>>> errors) {
         Map<Node, Map<AnalyzerFactory, List<ErrorDescription>>> fileNodes = new HashMap<Node, Map<AnalyzerFactory, List<ErrorDescription>>>();
 
-        for (FileObject file : errors.keySet()) {
-            Map<AnalyzerFactory, List<ErrorDescription>> eds = errors.get(file);
+        for (Entry<FileObject, Map<AnalyzerFactory, List<ErrorDescription>>> entry : errors.entrySet()) {
+            FileObject file = entry.getKey();
+            Map<AnalyzerFactory, List<ErrorDescription>> eds = entry.getValue();
             Node foundChild = lvc.file2FileNode.get(file);
             
             if (foundChild == null) {

--- a/ide/csl.api/src/org/netbeans/modules/csl/core/GsfTaskProvider.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/core/GsfTaskProvider.java
@@ -313,8 +313,9 @@ public final class GsfTaskProvider extends PushTaskScanner  {
                 l.add(task);
             }
 
-            for (FileObject f : tasks.keySet()) {
-                List<Task> l = tasks.get(f);
+            for (Map.Entry<FileObject, List<Task>> entry : tasks.entrySet()) {
+                FileObject f = entry.getKey();
+                List<Task> l = entry.getValue();
                 LOG.log(Level.FINE, "Refreshing TL for {0} with {1}", new Object [] { f, l }); //NOI18N
                 callback.setTasks(f, l);
             }

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/SemanticHighlighter.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/SemanticHighlighter.java
@@ -291,9 +291,10 @@ public final class SemanticHighlighter extends IndexingAwareParserResultTask<Par
 
         Map<OffsetRange,Set<ColoringAttributes>> highlights = task.getHighlights();
         if (highlights != null) {
-            for (OffsetRange range : highlights.keySet()) {
+            for (Map.Entry<OffsetRange, Set<ColoringAttributes>> entry : highlights.entrySet()) {
 
-                Set<ColoringAttributes> colors = highlights.get(range);
+                OffsetRange range = entry.getKey();
+                Set<ColoringAttributes> colors = entry.getValue();
                 if (colors == null) {
                     continue;
                 }

--- a/ide/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsPanelLogic.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsPanelLogic.java
@@ -143,8 +143,9 @@ class HintsPanelLogic implements MouseListener, KeyListener, TreeSelectionListen
     }
     
     synchronized void applyChanges() {
-        for (UserConfigurableRule hint : changes.keySet()) {
-            ModifiedPreferences mn = changes.get(hint);
+        for (Map.Entry<UserConfigurableRule, ModifiedPreferences> entry : changes.entrySet()) {
+            UserConfigurableRule hint = entry.getKey();
+            ModifiedPreferences mn = entry.getValue();
             mn.store(HintsSettings.getPreferences(manager, hint, HintsSettings.getCurrentProfileId()));            
         }
         
@@ -181,8 +182,9 @@ class HintsPanelLogic implements MouseListener, KeyListener, TreeSelectionListen
      */
     boolean isChanged() {
         boolean isChanged = false;
-        for (UserConfigurableRule hint : changes.keySet()) {
-            ModifiedPreferences mn = changes.get(hint);
+        for (Map.Entry<UserConfigurableRule, ModifiedPreferences> entry : changes.entrySet()) {
+            UserConfigurableRule hint = entry.getKey();
+            ModifiedPreferences mn = entry.getValue();
 
             Boolean currentEnabled = mn.getBoolean(HintsSettings.ENABLED_KEY, hint.getDefaultEnabled());
             Boolean savedEnabled = HintsSettings.isEnabled(manager, hint);

--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -261,8 +261,9 @@ public abstract class CslTestBase extends NbTestCase {
             logger.addHandler(w);
 
             // initialize classpaths indexing
-            for(String cpId : classPathsForTest.keySet()) {
-                ClassPath cp = classPathsForTest.get(cpId);
+            for(Map.Entry<String, ClassPath> entry : classPathsForTest.entrySet()) {
+                String cpId = entry.getKey();
+                ClassPath cp = entry.getValue();
                 GlobalPathRegistry.getDefault().register(cpId, new ClassPath [] { cp });
             }
 
@@ -288,8 +289,9 @@ public abstract class CslTestBase extends NbTestCase {
             Waiter w = new Waiter(classPathContainsBinaries());
             logger.addHandler(w);
 
-            for(String cpId : classPathsForTest.keySet()) {
-                ClassPath cp = classPathsForTest.get(cpId);
+            for(Map.Entry<String, ClassPath> entry : classPathsForTest.entrySet()) {
+                String cpId = entry.getKey();
+                ClassPath cp = entry.getValue();
                 GlobalPathRegistry.getDefault().unregister(cpId, new ClassPath [] { cp });
             }
 

--- a/ide/css.editor/src/org/netbeans/modules/css/indexing/api/CssIndex.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/indexing/api/CssIndex.java
@@ -484,8 +484,9 @@ public class CssIndex {
         if(LOGGER.isLoggable(Level.FINE)) {
             StringBuilder deps = new StringBuilder();
             deps.append("dest2source:\n");
-            for(FileObject dest : allDepsCache.dest2source.keySet()) {
-                Collection<FileReference> source = allDepsCache.dest2source.get(dest);
+            for(Map.Entry<FileObject, Collection<FileReference>> entry : allDepsCache.dest2source.entrySet()) {
+                FileObject dest = entry.getKey();
+                Collection<FileReference> source = entry.getValue();
                 deps.append(dest.getNameExt());
                 deps.append("->");
                 for(FileReference fref : source) {
@@ -495,8 +496,9 @@ public class CssIndex {
                 deps.append('\n');
             }
             deps.append("source2dest:\n");
-            for(FileObject source : allDepsCache.source2dest.keySet()) {
-                Collection<FileReference> dest = allDepsCache.source2dest.get(source);
+            for(Map.Entry<FileObject, Collection<FileReference>> entry : allDepsCache.source2dest.entrySet()) {
+                FileObject source = entry.getKey();
+                Collection<FileReference> dest = entry.getValue();
                 deps.append(source.getNameExt());
                 deps.append("->");
                 for(FileReference fref : dest) {

--- a/ide/css.editor/src/org/netbeans/modules/css/refactoring/CssRenameRefactoringPlugin.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/refactoring/CssRenameRefactoringPlugin.java
@@ -325,9 +325,10 @@ public class CssRenameRefactoringPlugin implements RefactoringPlugin {
             Map<FileObject, CssFileModel> modelsCache = new WeakHashMap<>();
             Set<Entry> refactoredReferenceEntries = new HashSet<>();
             //now I need to find out what links go through the given folder
-            for (FileObject source : source2dest.keySet()) {
+            for (Map.Entry<FileObject, Collection<FileReference>> source2destEntry : source2dest.entrySet()) {
                 List<Difference> diffs = new ArrayList<>();
-                Collection<FileReference> destinations = source2dest.get(source);
+                FileObject source = source2destEntry.getKey();
+                Collection<FileReference> destinations = source2destEntry.getValue();
                 for (FileReference dest : destinations) {
                     FileReferenceModification modification = dest.createModification();
                     if (modification.rename(renamedFolder, newName)) {

--- a/ide/css.lib/src/org/netbeans/modules/css/lib/properties/GrammarParseTreeBuilder.java
+++ b/ide/css.lib/src/org/netbeans/modules/css/lib/properties/GrammarParseTreeBuilder.java
@@ -142,8 +142,9 @@ public class GrammarParseTreeBuilder implements GrammarResolverListener {
         peek.choosenBranches.add(element);
         
         //remove all children except the choosen one
-        for (GrammarElement key : peek.childrenMap.keySet()) {
-            Node.AbstractNode node = peek.childrenMap.get(key);
+        for (Map.Entry<GrammarElement, Node.AbstractNode> entry : peek.childrenMap.entrySet()) {
+            GrammarElement key = entry.getKey();
+            Node.AbstractNode node = entry.getValue();
             if(!peek.choosenBranches.contains(key)) {
                 group.removeChild(node);
             }

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/EditRulesPanel.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/EditRulesPanel.java
@@ -373,16 +373,18 @@ public class EditRulesPanel extends javax.swing.JPanel {
 
             CssIndex index = CssIndex.create(project);
             findAllClassDeclarations = index.findAllClassDeclarations();
-            for (FileObject file : findAllClassDeclarations.keySet()) {
-                Collection<String> classes = findAllClassDeclarations.get(file);
+            for (Map.Entry<FileObject, Collection<String>> entry : findAllClassDeclarations.entrySet()) {
+                FileObject file = entry.getKey();
+                Collection<String> classes = entry.getValue();
                 for (String clz : classes) {
                     SELECTORS_MODEL.addElement(SelectorItem.createClass(clz, file));
                 }
             }
 
             findAllIdDeclarations = index.findAllIdDeclarations();
-            for (FileObject file : findAllIdDeclarations.keySet()) {
-                Collection<String> ids = findAllIdDeclarations.get(file);
+            for (Map.Entry<FileObject, Collection<String>> entry : findAllIdDeclarations.entrySet()) {
+                FileObject file = entry.getKey();
+                Collection<String> ids = entry.getValue();
                 for (String id : ids) {
                     SELECTORS_MODEL.addElement(SelectorItem.createId(id, file));
                 }

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/PropertyValuesEditor.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/PropertyValuesEditor.java
@@ -187,8 +187,7 @@ public class PropertyValuesEditor extends PropertyEditorSupport implements ExPro
                                 Collection<String> hashColorCodes = new TreeSet<>();
                                 CssIndex index = CssIndex.create(project);
                                 Map<FileObject, Collection<String>> result = index.findAll(RefactoringElementType.COLOR);
-                                for (FileObject f : result.keySet()) {
-                                    Collection<String> colors = result.get(f);
+                                for (Collection<String> colors : result.values()) {
 //                                boolean usedInCurrentFile = f.equals(file);
                                     for (String color : colors) {
                                         hashColorCodes.add(color);

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/RuleEditorNode.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/RuleEditorNode.java
@@ -214,8 +214,9 @@ public class RuleEditorNode extends AbstractNode {
                                 break update; //canot merge - the collections differ
                             }
 
-                            for (String declarationName : oName2DeclarationMap.keySet()) {
-                                PropertyDeclaration oldD = oName2DeclarationMap.get(declarationName);
+                            for (Entry<String, PropertyDeclaration> entry : oName2DeclarationMap.entrySet()) {
+                                String declarationName = entry.getKey();
+                                PropertyDeclaration oldD = entry.getValue();
                                 PropertyDeclaration newD = nName2DeclarationMap.get(declarationName);
 
                                 //update the existing DeclarationProperty with the fresh

--- a/ide/db.dataview/src/org/netbeans/modules/db/dataview/output/UpdatedRowContext.java
+++ b/ide/db.dataview/src/org/netbeans/modules/db/dataview/output/UpdatedRowContext.java
@@ -49,9 +49,7 @@ class UpdatedRowContext {
     }
 
     public void removeUpdateForSelectedRow(int row) {
-        if(changedData.containsKey(Integer.valueOf(row))){
-            changedData.remove(Integer.valueOf(row));
-        }
+        changedData.remove(Integer.valueOf(row));
     }
 
     public Set<Integer> getUpdateKeys() {

--- a/ide/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/GotoLineOrBookmarkPanel.java
+++ b/ide/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/GotoLineOrBookmarkPanel.java
@@ -343,9 +343,7 @@ public class GotoLineOrBookmarkPanel extends JPanel implements ActionListener, F
 
     private void updateHistory() {
         String value = getValue();
-        if (history.contains(value)) {
-            history.remove(value); // move item to top
-        }
+        history.remove(value); // move item to top
         history.add(0, value);
         // assure it won't hold more than MAX_ITEMS
         if (history.size() > MAX_HISTORY_ITEMS) {

--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
@@ -92,8 +92,9 @@ final class CodeTemplatesModel {
             
             // Load the table
             List<Vector<String>> table = new ArrayList<Vector<String>>();
-            for(String abbreviation : abbreviationsMap.keySet()) {
-                CodeTemplateDescription ctd = abbreviationsMap.get(abbreviation);
+            for(Map.Entry<String, CodeTemplateDescription> entry : abbreviationsMap.entrySet()) {
+                String abbreviation = entry.getKey();
+                CodeTemplateDescription ctd = entry.getValue();
                 Vector<String> line =  new Vector<String>(3);
                 line.add(abbreviation);
                 if (LOG.isLoggable(Level.FINER)) {
@@ -133,8 +134,9 @@ final class CodeTemplatesModel {
     }
     
     String findLanguage(String mimeType) {
-        for(String lang : languageToMimeType.keySet()) {
-            String mt = languageToMimeType.get(lang);
+        for(Map.Entry<String, String> entry : languageToMimeType.entrySet()) {
+            String lang = entry.getKey();
+            String mt = entry.getValue();
             if (mt.equals(mimeType)) {
                 return lang;
             }
@@ -152,8 +154,9 @@ final class CodeTemplatesModel {
     
     void saveChanges () {
         // Save modified code templates
-        for(String language : languageToModel.keySet()) {
-            TM tableModel = languageToModel.get(language);
+        for(Map.Entry<String, TM> entry : languageToModel.entrySet()) {
+            String language = entry.getKey();
+            TM tableModel = entry.getValue();
             
             if (!tableModel.isModified()) {
                 continue;
@@ -201,8 +204,7 @@ final class CodeTemplatesModel {
             return true;
         }
 
-        for(String l : languageToModel.keySet()) {
-            TM tableModel = languageToModel.get(l);
+        for(TM tableModel : languageToModel.values()) {
             if (tableModel.isModified()) {
                 return true;
             }

--- a/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldOptionsController.java
+++ b/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldOptionsController.java
@@ -151,8 +151,9 @@ public class FoldOptionsController extends OptionsPanelController implements Pre
             changed = false;
             copy = new HashMap<>(preferences);
         }
-        for (String s : copy.keySet()) {
-            MemoryPreferences p = copy.get(s);
+        for (Map.Entry<String, MemoryPreferences> entry : copy.entrySet()) {
+            String s = entry.getKey();
+            MemoryPreferences p = entry.getValue();
             try {
                 if (PREF_LOG.isLoggable(Level.FINE)) {
                     if ((p.getPreferences() instanceof OverridePreferences) &&

--- a/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldOptionsPanel.java
+++ b/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldOptionsPanel.java
@@ -206,8 +206,7 @@ final class FoldOptionsPanel extends javax.swing.JPanel implements ActionListene
     
     boolean isChanged() {
         boolean isChanged= false;
-        for(String mime : panels.keySet()) {
-            JComponent panel = panels.get(mime);
+        for(JComponent panel : panels.values()) {
             if(panel instanceof DefaultFoldingOptions) {
                 isChanged |= ((DefaultFoldingOptions)panel).isChanged();
             }

--- a/ide/editor.macros/src/org/netbeans/modules/editor/macros/MacroShortcutsInjector.java
+++ b/ide/editor.macros/src/org/netbeans/modules/editor/macros/MacroShortcutsInjector.java
@@ -110,8 +110,9 @@ public final class MacroShortcutsInjector extends StorageFilter<Collection<KeySt
     public void beforeSave(Map<Collection<KeyStroke>, MultiKeyBinding> map, MimePath mimePath, String profile, boolean defaults) {
         Set<Collection<KeyStroke>> keysToFilterOut = new HashSet<Collection<KeyStroke>>();
         
-        for(Collection<KeyStroke> keys : map.keySet()) {
-            MultiKeyBinding shortcut = map.get(keys);
+        for(Map.Entry<Collection<KeyStroke>,MultiKeyBinding> entry : map.entrySet()) {
+            Collection<KeyStroke> keys = entry.getKey();
+            MultiKeyBinding shortcut = entry.getValue();
             if (shortcut.getActionName().equals(MacroDialogSupport.RunMacroAction.runMacroAction)) {
                 keysToFilterOut.add(keys);
                 if (LOG.isLoggable(Level.FINE)) {

--- a/ide/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosModel.java
+++ b/ide/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosModel.java
@@ -48,7 +48,6 @@ import org.netbeans.modules.editor.macros.storage.MacroDescription;
 import org.netbeans.modules.editor.macros.storage.MacrosStorage;
 import org.netbeans.modules.editor.settings.storage.api.EditorSettings;
 import org.netbeans.modules.editor.settings.storage.api.EditorSettingsStorage;
-import org.netbeans.modules.editor.settings.storage.spi.support.StorageSupport;
 import org.netbeans.spi.options.OptionsPanelController;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
@@ -101,8 +100,9 @@ public final class MacrosModel {
                 mimeType2Macros.put(mimeType, map);
             }
             
-            for(String macroName : macros.keySet()) {
-                MacroDescription md = macros.get(macroName);
+            for(Map.Entry<String, MacroDescription> entry : macros.entrySet()) {
+                String macroName = entry.getKey();
+                MacroDescription md = entry.getValue();
                 Macro macro = new Macro(this, mimeType, md);
                 
                 map.put(macroName, macro);
@@ -120,12 +120,14 @@ public final class MacrosModel {
     public void save() {
         EditorSettingsStorage<String, MacroDescription> ess = EditorSettingsStorage.<String, MacroDescription>get(MacrosStorage.ID);
         
-        for(MimePath mimeType : mimeType2Macros.keySet()) {
-            Map<String, Macro> map = mimeType2Macros.get(mimeType);
+        for(Map.Entry<MimePath, Map<String, Macro>> mimeType2MacrosEntry : mimeType2Macros.entrySet()) {
+            MimePath mimeType = mimeType2MacrosEntry.getKey();
+            Map<String, Macro> map = mimeType2MacrosEntry.getValue();
 
             Map<String, MacroDescription> macros = new HashMap<String, MacroDescription>(map.size());
-            for(String macroName : map.keySet()) {
-                Macro macro = map.get(macroName);
+            for(Map.Entry<String, Macro> macroEntry : map.entrySet()) {
+                String macroName = macroEntry.getKey();
+                Macro macro = macroEntry.getValue();
                 macros.put(macroName, macro.getMacroDescription());
             }
             
@@ -428,8 +430,9 @@ public final class MacrosModel {
     private void fireChanged() {
         EditorSettingsStorage<String, MacroDescription> ess = EditorSettingsStorage.<String, MacroDescription>get(MacrosStorage.ID);
 
-        for (MimePath mimeType : mimeType2Macros.keySet()) {
-            Map<String, Macro> map = mimeType2Macros.get(mimeType);
+        for (Map.Entry<MimePath, Map<String, Macro>> entry : mimeType2Macros.entrySet()) {
+            MimePath mimeType = entry.getKey();
+            Map<String, Macro> map = entry.getValue();
             Map<String, MacroDescription> current = new HashMap<>(map.size());
             for (String macroName : map.keySet()) {
                 current.put(macroName, map.get(macroName).getMacroDescription());

--- a/ide/editor.search/src/org/netbeans/modules/editor/search/SearchPropertiesSupport.java
+++ b/ide/editor.search/src/org/netbeans/modules/editor/search/SearchPropertiesSupport.java
@@ -89,8 +89,9 @@ public final class SearchPropertiesSupport {
         }
         
         public synchronized void saveToPrefs() {
-            for (String editorFindSupportProperty : props.keySet()) {
-                Object value = props.get(editorFindSupportProperty);
+            for (Map.Entry<String, Object> entry : props.entrySet()) {
+                String editorFindSupportProperty = entry.getKey();
+                Object value = entry.getValue();
                 if (value != null) {
                     getInstance().getPrefs().put(id + editorFindSupportProperty, value.toString());
                 } else {

--- a/ide/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/StorageImpl.java
+++ b/ide/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/StorageImpl.java
@@ -272,8 +272,9 @@ public final class StorageImpl <K extends Object, V extends Object> {
                         }
 
                         // Then add all new entries
-                        for (K key : added.keySet()) {
-                            V value = added.get(key);
+                        for (Map.Entry<? extends K, ? extends V> entry : added.entrySet()) {
+                            K key = entry.getKey();
+                            V value = entry.getValue();
                             V origValue = map.put(key, value);
                             if (LOG.isLoggable(Level.FINEST) && origValue != null && !origValue.equals(value)) {
                                 LOG.finest("--- Replacing old entry for '" + key + "', orig value = '" + origValue + "', new value = '" + value + "'"); //NOI18N

--- a/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/NbUtils.java
+++ b/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/NbUtils.java
@@ -56,8 +56,9 @@ public class NbUtils {
     public static Map<String, AttributeSet> immutize(Map<String, ? extends AttributeSet> map, Object... filterOutKeys) {
         Map<String, AttributeSet> immutizedMap = new HashMap<>();
         
-        for(String name : map.keySet()) {
-            AttributeSet attribs = map.get(name);
+        for(Map.Entry<String, ? extends AttributeSet> entry : map.entrySet()) {
+            String name = entry.getKey();
+            AttributeSet attribs = entry.getValue();
             
             if (filterOutKeys.length == 0) {
                 immutizedMap.put(name, AttributesUtilities.createImmutable(attribs));

--- a/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/ProfilesTracker.java
+++ b/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/ProfilesTracker.java
@@ -230,8 +230,9 @@ public final class ProfilesTracker {
 
             HashMap<String, ProfileDescription> newProfiles = new HashMap<>();
             HashMap<String, ProfileDescription> newProfilesByDisplayName = new HashMap<>();
-            for(String id : scan.keySet()) {
-                List<Object []> profileInfos = scan.get(id);
+            for(Map.Entry<String, List<Object []>> entry : scan.entrySet()) {
+                String id = entry.getKey();
+                List<Object []> profileInfos = entry.getValue();
 
                 // Determine profile's display name and if it can roll back user changes
                 String displayName  = null;

--- a/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/fontscolors/CompositeFCS.java
+++ b/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/fontscolors/CompositeFCS.java
@@ -258,8 +258,9 @@ public final class CompositeFCS extends FontColorSettings {
         if (LOG.isLoggable(Level.FINE)) {
             LOG.fine("System provided desktop hints:"); //NOI18N
             if (desktopHints != null) {
-                for (Object key : desktopHints.keySet()) {
-                    Object value = desktopHints.get(key);
+                for (Map.Entry<?, ?> entry : desktopHints.entrySet()) {
+                    Object key = entry.getKey();
+                    Object value = entry.getValue();
                     String humanReadableKey = translateRenderingHintsConstant(key);
                     String humanReadableValue = translateRenderingHintsConstant(value);
                     LOG.fine("  " + humanReadableKey + " = " + humanReadableValue); //NOI18N
@@ -349,8 +350,9 @@ public final class CompositeFCS extends FontColorSettings {
 
         if (LOG.isLoggable(Level.FINE)) {
             LOG.fine("Editor Rendering hints:"); //NOI18N
-            for (Object key : hints.keySet()) {
-                Object value = hints.get(key);
+            for (Map.Entry<Object, Object> entry : hints.entrySet()) {
+                Object key = entry.getKey();
+                Object value = entry.getValue();
                 String humanReadableKey = translateRenderingHintsConstant(key);
                 String humanReadableValue = translateRenderingHintsConstant(value);
                 LOG.fine("  " + humanReadableKey + " = " + humanReadableValue); //NOI18N

--- a/ide/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/keybindings/KeybindingStorageTest.java
+++ b/ide/editor.settings.storage/test/unit/src/org/netbeans/modules/editor/settings/storage/keybindings/KeybindingStorageTest.java
@@ -142,8 +142,9 @@ public class KeybindingStorageTest extends NbTestCase {
     }
 
     private void checkMapConsistency(Map<Collection<KeyStroke>, MultiKeyBinding> keybindings) {
-        for(Collection<KeyStroke> keyStrokes : keybindings.keySet()) {
-            MultiKeyBinding mkb = keybindings.get(keyStrokes);
+        for(Map.Entry<Collection<KeyStroke>,MultiKeyBinding> entry : keybindings.entrySet()) {
+            Collection<KeyStroke> keyStrokes = entry.getKey();
+            MultiKeyBinding mkb = entry.getValue();
             assertEquals("Inconsistent keystrokes", keyStrokes, mkb.getKeyStrokeList());
         }
     }

--- a/ide/editor/src/org/netbeans/modules/editor/impl/CustomizableSideBar.java
+++ b/ide/editor/src/org/netbeans/modules/editor/impl/CustomizableSideBar.java
@@ -156,8 +156,9 @@ public final class CustomizableSideBar {
             if (panelsMap != null) {
                 Map<SideBarPosition, JComponent> map = new HashMap<SideBarPosition, JComponent>();
                 
-                for(SideBarPosition pos : panelsMap.keySet()) {
-                    Reference<JPanel> ref = panelsMap.get(pos);
+                for(Map.Entry<SideBarPosition, Reference<JPanel>> entry : panelsMap.entrySet()) {
+                    SideBarPosition pos = entry.getKey();
+                    Reference<JPanel> ref = entry.getValue();
                     if (ref != null) {
                         JPanel panel = ref.get();
                         if (panel != null) {
@@ -182,8 +183,9 @@ public final class CustomizableSideBar {
             Map<SideBarPosition, Reference<JPanel>> panelsMap = new HashMap<SideBarPosition, Reference<JPanel>>();
             Map<SideBarPosition, JComponent> map = new HashMap<SideBarPosition, JComponent>();
             
-            for(SideBarPosition pos : sideBarsMap.keySet()) {
-                List<JComponent> sideBars = sideBarsMap.get(pos);
+            for(Map.Entry<SideBarPosition, List<JComponent>> entry : sideBarsMap.entrySet()) {
+                SideBarPosition pos = entry.getKey();
+                List<JComponent> sideBars = entry.getValue();
                 
                 JPanel panel = pos.getPosition() == SideBarPosition.WEST ?
                         new WestSidebarHolder(target) :

--- a/ide/editor/src/org/netbeans/modules/editor/impl/KitsTrackerImpl.java
+++ b/ide/editor/src/org/netbeans/modules/editor/impl/KitsTrackerImpl.java
@@ -478,8 +478,9 @@ public final class KitsTrackerImpl extends KitsTracker {
                             clazz = clazz.getSuperclass()
                         ) {
                             boolean kitClassFinal = (clazz.getModifiers() & Modifier.FINAL) != 0;
-                            for(String mimeType : mimeType2kitClass.keySet()) {
-                                FileObject f = mimeType2kitClass.get(mimeType);
+                            for(Map.Entry<String, FileObject> entry : mimeType2kitClass.entrySet()) {
+                                String mimeType = entry.getKey();
+                                FileObject f = entry.getValue();
                                 if (isInstanceOf(f, clazz, !kitClassFinal)) {
                                     list.add(mimeType);
                                 }

--- a/ide/editor/src/org/netbeans/modules/editor/impl/highlighting/ComposedTextHighlighting.java
+++ b/ide/editor/src/org/netbeans/modules/editor/impl/highlighting/ComposedTextHighlighting.java
@@ -26,6 +26,7 @@ import java.awt.im.InputMethodHighlight;
 import java.text.AttributedCharacterIterator;
 import java.text.AttributedString;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.event.DocumentEvent;
@@ -127,8 +128,9 @@ public final class ComposedTextHighlighting extends AbstractHighlightsContainer 
                 for(char c = aci.first(); c != AttributedCharacterIterator.DONE; c = aci.next()) {
                     sb.append("'").append(c).append("' = {"); //NOI18N
                     Map<AttributedCharacterIterator.Attribute, ?> attributes = aci.getAttributes();
-                    for(AttributedCharacterIterator.Attribute key : attributes.keySet()) {
-                        Object value = attributes.get(key);
+                    for(Map.Entry<AttributedCharacterIterator.Attribute, ?> attributeEntry : attributes.entrySet()) {
+                        AttributedCharacterIterator.Attribute key = attributeEntry.getKey();
+                        Object value = attributeEntry.getValue();
                         if (value instanceof InputMethodHighlight) {
                             sb.append("'").append(key).append("' = {"); //NOI18N
                             Map<TextAttribute, ?> style = ((InputMethodHighlight) value).getStyle();
@@ -136,8 +138,9 @@ public final class ComposedTextHighlighting extends AbstractHighlightsContainer 
                                 style = Toolkit.getDefaultToolkit().mapInputMethodHighlight((InputMethodHighlight) value);
                             }
                             if (style != null) {
-                                for(TextAttribute ta : style.keySet()) {
-                                    Object tav = style.get(ta);
+                                for(Map.Entry<TextAttribute, ?> styleEntry : style.entrySet()) {
+                                    TextAttribute ta = styleEntry.getKey();
+                                    Object tav = styleEntry.getValue();
                                     sb.append("'").append(ta).append("' = '").append(tav).append("', "); //NOI18N
                                 }
                             } else {
@@ -201,8 +204,7 @@ public final class ComposedTextHighlighting extends AbstractHighlightsContainer 
     }
 
     private AttributeSet translateAttributes(Map<AttributedCharacterIterator.Attribute, ?> source) {
-        for(AttributedCharacterIterator.Attribute sourceKey : source.keySet()) {
-            Object sourceValue = source.get(sourceKey);
+        for(Object sourceValue : source.values()) {
             
             // Ignore any non-input method related highlights
             if (!(sourceValue instanceof InputMethodHighlight)) {

--- a/ide/editor/test/unit/src/org/netbeans/modules/editor/impl/SideBarFactoriesProviderTest.java
+++ b/ide/editor/test/unit/src/org/netbeans/modules/editor/impl/SideBarFactoriesProviderTest.java
@@ -64,8 +64,9 @@ public class SideBarFactoriesProviderTest extends NbTestCase {
         Map<SideBarPosition, List> c = p.getFactories();
         
         assertEquals(3, c.size());
-        for (SideBarPosition pos : c.keySet()) {
-            List ll = c.get(pos);
+        for (Map.Entry<SideBarPosition, List> entry : c.entrySet()) {
+            SideBarPosition pos = entry.getKey();
+            List ll = entry.getValue();
             if (SideBarPosition.WEST_NAME.equals(pos.getPositionName())) {
                 Object o = ll.get(0);
                 assertTrue(o instanceof SBF2);

--- a/ide/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzerResult.java
+++ b/ide/html.editor.lib/src/org/netbeans/modules/html/editor/lib/api/SyntaxAnalyzerResult.java
@@ -563,8 +563,9 @@ public class SyntaxAnalyzerResult {
     public Map<String, String> getDeclaredNamespaces() {
         Map<String, Collection<String>> all = new HashMap<>(getAllDeclaredNamespaces());
         Map<String, String> firstPrefixOnly = new HashMap<>();
-        for (String namespace : all.keySet()) {
-            Collection<String> prefixes = all.get(namespace);
+        for (Map.Entry<String, Collection<String>> entry : all.entrySet()) {
+            String namespace = entry.getKey();
+            Collection<String> prefixes = entry.getValue();
             if (prefixes != null && prefixes.size() > 0) {
                 firstPrefixOnly.put(namespace, prefixes.iterator().next());
             }

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlDeclarationFinder.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlDeclarationFinder.java
@@ -333,8 +333,9 @@ public class HtmlDeclarationFinder implements DeclarationFinder {
             }
 
             DeclarationLocation dl = null;
-            for (FileObject f : occurances.keySet()) {
-                Collection<EntryHandle> entries = occurances.get(f);
+            for (Map.Entry<FileObject, Collection<EntryHandle>> entry : occurances.entrySet()) {
+                FileObject f = entry.getKey();
+                Collection<EntryHandle> entries = entry.getValue();
                 for (EntryHandle entryHandle : entries) {
                     //grrr, the main declarationlocation must be also added to the alternatives
                     //if there are more than one

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlRenameRefactoringPlugin.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/refactoring/HtmlRenameRefactoringPlugin.java
@@ -140,9 +140,10 @@ public class HtmlRenameRefactoringPlugin implements RefactoringPlugin {
             Map<FileObject, HtmlFileModel> modelsCache = new WeakHashMap<>();
             Set<Entry> refactoredReferenceEntries = new HashSet<>();
             //now I need to find out what links go through the given folder
-            for (FileObject source : source2dest.keySet()) {
+            for (Map.Entry<FileObject, Collection<FileReference>> source2destEntry : source2dest.entrySet()) {
                 List<Difference> diffs = new ArrayList<>();
-                Collection<FileReference> destinations = source2dest.get(source);
+                FileObject source = source2destEntry.getKey();
+                Collection<FileReference> destinations = source2destEntry.getValue();
                 for (FileReference dest : destinations) {
                     FileReferenceModification modification = dest.createModification();
                     if (modification.rename(renamedFolder, newName)) {

--- a/ide/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitAction.java
+++ b/ide/mercurial/src/org/netbeans/modules/mercurial/ui/commit/CommitAction.java
@@ -446,9 +446,10 @@ public class CommitAction extends ContextAction {
 
         boolean enabled = commit.isEnabled();
 
-        for (HgFileNode fileNode : files.keySet()) {
+        for (Entry<HgFileNode, CommitOptions> entry : files.entrySet()) {
 
-            CommitOptions options = files.get(fileNode);
+            HgFileNode fileNode = entry.getKey();
+            CommitOptions options = entry.getValue();
             if (options == CommitOptions.EXCLUDE) {
                 continue;
             }

--- a/ide/options.editor/src/org/netbeans/modules/options/colors/SyntaxColoringPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/colors/SyntaxColoringPanel.java
@@ -503,8 +503,9 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     @Override
     public void applyChanges() {
         if (colorModel == null) return;
-        for(String profile : toBeSaved.keySet()) {
-            Set<String> toBeSavedLanguages = toBeSaved.get(profile);
+        for(Map.Entry<String, Set<String>> entry : toBeSaved.entrySet()) {
+            String profile = entry.getKey();
+            Set<String> toBeSavedLanguages = entry.getValue();
             Map<String, List<AttributeSet>> schemeMap = profiles.get(profile);
             for(String languageName : toBeSavedLanguages) {
                 colorModel.setCategories(
@@ -832,8 +833,9 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     
     private void fireChanged() {
         boolean isChanged = false;
-        for(String profile : toBeSaved.keySet()) {
-            Set<String> toBeSavedLanguages = toBeSaved.get(profile);
+        for(Map.Entry<String, Set<String>> entry : toBeSaved.entrySet()) {
+            String profile = entry.getKey();
+            Set<String> toBeSavedLanguages = entry.getValue();
             Map<String, List<AttributeSet>> schemeMap = profiles.get(profile);
             for(String languageName : toBeSavedLanguages) {
                 String[] mimePath = getMimePath(languageName);

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsPanelController.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsPanelController.java
@@ -254,8 +254,9 @@ public final class CodeCompletionOptionsPanelController extends OptionsPanelCont
         }
 
         public void applyChanges() {
-            for(String mimeType : mimeTypePreferences.keySet()) {
-                ProxyPreferences pp = mimeTypePreferences.get(mimeType);
+            for(Map.Entry<String, ProxyPreferences> entry : mimeTypePreferences.entrySet()) {
+                String mimeType = entry.getKey();
+                ProxyPreferences pp = entry.getValue();
                 pp.silence();
                 try {
                     LOG.fine("    flushing pp for '" + mimeType + "'"); //NOI18N
@@ -268,8 +269,9 @@ public final class CodeCompletionOptionsPanelController extends OptionsPanelCont
 
         public void destroy() {
             // destroy all proxy preferences
-            for(String mimeType : mimeTypePreferences.keySet()) {
-                ProxyPreferences pp = mimeTypePreferences.get(mimeType);
+            for(Map.Entry<String, ProxyPreferences> entry : mimeTypePreferences.entrySet()) {
+                String mimeType = entry.getKey();
+                ProxyPreferences pp = entry.getValue();
                 pp.removeNodeChangeListener(weakNodeL);
                 pp.removePreferenceChangeListener(weakPrefL);
                 pp.destroy();

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/keymap/EditorBridge.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/keymap/EditorBridge.java
@@ -190,8 +190,9 @@ public final class EditorBridge extends KeymapManager {
         // convert actionToShortcuts: Map (ShortcutAction > Set (String (shortcut AS-M)))
         // to mimeTypeToKeyBinding: Map (String (mimetype) > List (MultiKeyBinding)).
         Map<String, List<MultiKeyBinding>> mimeTypeToKeyBinding = new HashMap<String, List<MultiKeyBinding>>(); // editor shortcuts
-        for(ShortcutAction action : actionToShortcuts.keySet()) {
-            Set<String> shortcuts = actionToShortcuts.get(action);
+        for(Map.Entry<ShortcutAction, Set<String>> entry : actionToShortcuts.entrySet()) {
+            ShortcutAction action = entry.getKey();
+            Set<String> shortcuts = entry.getValue();
 
             action = action.getKeymapManagerInstance(EDITOR_BRIDGE);
             if (!(action instanceof EditorAction)) {
@@ -270,8 +271,9 @@ public final class EditorBridge extends KeymapManager {
         }
 
         // 2) save all shortcuts
-        for (String mimeType : keyBindingSettings.keySet()) {
-            KeyBindingSettingsFactory kbs = keyBindingSettings.get(mimeType);
+        for (Map.Entry<String, KeyBindingSettingsFactory> entry : keyBindingSettings.entrySet()) {
+            String mimeType = entry.getKey();
+            KeyBindingSettingsFactory kbs = entry.getValue();
             kbs.setKeyBindings(profile, mimeTypeToKeyBinding.get(mimeType));
         }
     }
@@ -457,8 +459,9 @@ public final class EditorBridge extends KeymapManager {
         Map<String, Set<String>> actionNameToShortcuts = convertKeymap(keyBindings);
 
         // 3) create Map (EditorAction > Set (String (shortcut)))
-        for (String actionName : actionNameToShortcuts.keySet()) {
-            Set<String> keyStrokes = actionNameToShortcuts.get(actionName);
+        for (Map.Entry<String, Set<String>> entry : actionNameToShortcuts.entrySet()) {
+            String actionName = entry.getKey();
+            Set<String> keyStrokes = entry.getValue();
             ShortcutAction action = (ShortcutAction) getEditorActionsMap ().get (actionName);
             if (action == null) {
                 if (LOG.isLoggable(Level.FINE)) {

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveTabPanelController.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveTabPanelController.java
@@ -260,8 +260,9 @@ public final class OnSaveTabPanelController extends OptionsPanelController {
         }
 
         public void applyChanges() {
-            for(String mimeType : mimeTypePreferences.keySet()) {
-                ProxyPreferences pp = mimeTypePreferences.get(mimeType);
+            for(Map.Entry<String, ProxyPreferences> entry : mimeTypePreferences.entrySet()) {
+                String mimeType = entry.getKey();
+                ProxyPreferences pp = entry.getValue();
                 pp.silence();
                 try {
                     LOG.fine("    flushing pp for '" + mimeType + "'"); //NOI18N
@@ -274,8 +275,9 @@ public final class OnSaveTabPanelController extends OptionsPanelController {
 
         public void destroy() {
             // destroy all proxy preferences
-            for(String mimeType : mimeTypePreferences.keySet()) {
-                ProxyPreferences pp = mimeTypePreferences.get(mimeType);
+            for(Map.Entry<String, ProxyPreferences> entry : mimeTypePreferences.entrySet()) {
+                String mimeType = entry.getKey();
+                ProxyPreferences pp = entry.getValue();
                 pp.removeNodeChangeListener(weakNodeL);
                 pp.removePreferenceChangeListener(weakPrefL);
                 pp.destroy();

--- a/ide/options.editor/src/org/netbeans/modules/options/indentation/FormattingPanelController.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/indentation/FormattingPanelController.java
@@ -351,8 +351,9 @@ public final class FormattingPanelController extends OptionsPanelController {
         }
 
         public void applyChanges() {
-            for(String mimeType : mimeTypePreferences.keySet()) {
-                ProxyPreferences pp = mimeTypePreferences.get(mimeType);
+            for(Map.Entry<String, ProxyPreferences> entry : mimeTypePreferences.entrySet()) {
+                String mimeType = entry.getKey();
+                ProxyPreferences pp = entry.getValue();
 
                 pp.silence();
 
@@ -382,8 +383,9 @@ public final class FormattingPanelController extends OptionsPanelController {
 
         public void destroy() {
             // destroy all proxy preferences
-            for(String mimeType : mimeTypePreferences.keySet()) {
-                ProxyPreferences pp = mimeTypePreferences.get(mimeType);
+            for(Map.Entry<String, ProxyPreferences> entry : mimeTypePreferences.entrySet()) {
+                String mimeType = entry.getKey();
+                ProxyPreferences pp = entry.getValue();
                 pp.removeNodeChangeListener(weakNodeL);
                 pp.removePreferenceChangeListener(weakPrefL);
                 pp.destroy();

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileObjectCrawler.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileObjectCrawler.java
@@ -169,8 +169,9 @@ NEXT_FILE:      for(FileObject f : files) {
                     }
                     cluster.add(f);
                 }
-                for(FileObject parent : clusters.keySet()) {
-                    Set<FileObject> cluster = clusters.get(parent);
+                for(Map.Entry<FileObject, Set<FileObject>> clusterEntry : clusters.entrySet()) {
+                    FileObject parent = clusterEntry.getKey();
+                    Set<FileObject> cluster = clusterEntry.getValue();
                     StringBuilder relativePath = relPaths.get(parent);
                     if (relativePath != null) {
                         finished = collect(
@@ -454,8 +455,9 @@ NEXT_FILE:      for(FileObject f : files) {
         }
         public static void logHistogram(Level level, Map<String, Integer> data) {
             Map<Integer, Set<String>> sortedMap = new TreeMap<>(REVERSE);
-            for(String item : data.keySet()) {
-                Integer freq = data.get(item);
+            for(Map.Entry<String, Integer> entry : data.entrySet()) {
+                String item = entry.getKey();
+                Integer freq = entry.getValue();
                 Set<String> items = sortedMap.get(freq);
                 if (items == null) {
                     items = new TreeSet<>();

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerCache.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerCache.java
@@ -432,8 +432,9 @@ public abstract class IndexerCache <T extends SourceIndexerFactory> {
                 Map<String, Set<IndexerInfo<T>>> _infosByName = new HashMap<String, Set<IndexerInfo<T>>>();
                 Map<String, Collection<IndexerInfo<T>>> _infosByMimeType = new HashMap<String, Collection<IndexerInfo<T>>>();
                 List<IndexerInfo<T>> _orderedInfos = new ArrayList<IndexerInfo<T>>();
-                for (T factory : factories.keySet()) {
-                    Set<String> mimeTypes = factories.get(factory);
+                for (Map.Entry<T, Set<String>> entry : factories.entrySet()) {
+                    T factory = entry.getKey();
+                    Set<String> mimeTypes = entry.getValue();
                     String factoryName = getIndexerName(factory);
                     IndexerInfo<T> info = new IndexerInfo<T>(factory, factoryName, getIndexerVersion(factory), mimeTypes);
 
@@ -625,8 +626,9 @@ public abstract class IndexerCache <T extends SourceIndexerFactory> {
 
     private void writeLastKnownIndexers(Map<String, Set<IndexerInfo<T>>> lki) {
         Properties props = new Properties();
-        for(String indexerName : lki.keySet()) {
-            Set<IndexerInfo<T>> iinfos = lki.get(indexerName);
+        for(Map.Entry<String, Set<IndexerInfo<T>>> entry : lki.entrySet()) {
+            String indexerName = entry.getKey();
+            Set<IndexerInfo<T>> iinfos = entry.getValue();
             int indexerVersion = -1;
             Set<String> mimeTypes = new HashSet<String>();
             for(IndexerInfo<T> iinfo : iinfos) {

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/LogContext.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/LogContext.java
@@ -635,8 +635,9 @@ import org.openide.util.BaseUtilities;
             if (ri.allResCount > -1) {
                 this.allResCount = ri.allResCount;
             }
-            for (String id : ri.rootIndexerTime.keySet()) {
-                Long spent = ri.rootIndexerTime.get(id);
+            for (Map.Entry<String, Long> entry : ri.rootIndexerTime.entrySet()) {
+                String id = entry.getKey();
+                Long spent = entry.getValue();
                 Long my = rootIndexerTime.get(id);
                 if (my == null) {
                     my = spent;

--- a/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ConstrainedBinaryIndexerTest.java
+++ b/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ConstrainedBinaryIndexerTest.java
@@ -85,8 +85,9 @@ public class ConstrainedBinaryIndexerTest extends IndexingTestBase {
 
     @Override
     protected void tearDown() throws Exception {
-        for(String id : registeredClasspaths.keySet()) {
-            Set<ClassPath> classpaths = registeredClasspaths.get(id);
+        for(Map.Entry<String, Set<ClassPath>> entry : registeredClasspaths.entrySet()) {
+            String id = entry.getKey();
+            Set<ClassPath> classpaths = entry.getValue();
             GlobalPathRegistry.getDefault().unregister(id, classpaths.toArray(new ClassPath[classpaths.size()]));
         }
 

--- a/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IndexerVersionsTest.java
+++ b/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/IndexerVersionsTest.java
@@ -112,8 +112,9 @@ public class IndexerVersionsTest extends IndexingTestBase {
 
     @Override
     protected void tearDown() throws Exception {
-        for(String id : registeredClasspaths.keySet()) {
-            Set<ClassPath> classpaths = registeredClasspaths.get(id);
+        for(Map.Entry<String, Set<ClassPath>> entry : registeredClasspaths.entrySet()) {
+            String id = entry.getKey();
+            Set<ClassPath> classpaths = entry.getValue();
             GlobalPathRegistry.getDefault().unregister(id, classpaths.toArray(new ClassPath[classpaths.size()]));
         }
 

--- a/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater2Test.java
+++ b/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater2Test.java
@@ -127,8 +127,9 @@ public class RepositoryUpdater2Test extends IndexingTestBase {
 
     @Override
     protected void tearDown() throws Exception {
-        for(String id : registeredClasspaths.keySet()) {
-            Set<ClassPath> classpaths = registeredClasspaths.get(id);
+        for(Map.Entry<String, Set<ClassPath>> entry : registeredClasspaths.entrySet()) {
+            String id = entry.getKey();
+            Set<ClassPath> classpaths = entry.getValue();
             GlobalPathRegistry.getDefault().unregister(id, classpaths.toArray(new ClassPath[classpaths.size()]));
         }
 

--- a/ide/project.libraries/src/org/netbeans/modules/project/libraries/LibrariesStorage.java
+++ b/ide/project.libraries/src/org/netbeans/modules/project/libraries/LibrariesStorage.java
@@ -602,8 +602,9 @@ implements WritableLibraryProvider<LibraryImplementation>, ChangeListener {
         }
 
         synchronized String findPath(final LibraryImplementation library) {
-            for (String key : librariesByPath.keySet()) {
-                LibraryImplementation lib = librariesByPath.get(key);
+            for (Map.Entry<String, LibraryImplementation> entry : librariesByPath.entrySet()) {
+                String key = entry.getKey();
+                LibraryImplementation lib = entry.getValue();
                 if (library.equals (lib)) {
                     return key;
                 }

--- a/ide/projectapi/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementation.java
+++ b/ide/projectapi/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementation.java
@@ -314,8 +314,9 @@ public class SimpleFileOwnerQueryImplementation implements FileOwnerQueryImpleme
     static void serialize() {
         try {
             Preferences p = NbPreferences.forModule(SimpleFileOwnerQueryImplementation.class).node("externalOwners");
-            for (URI uri : externalOwners.keySet()) {
-                URI ownerURI = externalOwners.get(uri);
+            for (Map.Entry<URI, URI> entry : externalOwners.entrySet()) {
+                URI uri = entry.getKey();
+                URI ownerURI = entry.getValue();
                 if (ownerURI != UNOWNED_URI) {
                 p.put(uri.toString(), ownerURI.toString());
             }

--- a/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
@@ -1214,9 +1214,7 @@ public final class OpenProjectList {
         
         String templateName = template.getPath();
         
-        if ( getRecentTemplates().contains( templateName ) ) {
-            getRecentTemplates().remove( templateName );
-        }
+        getRecentTemplates().remove(templateName);
         getRecentTemplates().add( 0, templateName );
         
         if ( getRecentTemplates().size() > 100 ) {

--- a/ide/projectui/src/org/netbeans/modules/project/ui/actions/BuildExecutionSupportImpl.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/actions/BuildExecutionSupportImpl.java
@@ -106,9 +106,7 @@ public class BuildExecutionSupportImpl implements BuildExecutionSupportImplement
                         list = new ArrayList<BuildExecutionSupport.ActionItem>();
                         historyItems.put(action, list);
                     }
-                    if (list.contains(ai)) {
-                        list.remove(ai);
-                    }
+                    list.remove(ai);
                     list.add(ai);
                     if (list.size() > HISTORY_MAX) {
                         list.remove(0);

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beansdev/SchemaRep.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beansdev/SchemaRep.java
@@ -3228,8 +3228,7 @@ public class SchemaRep implements PrefixGuesser {
                 t = null;
             String oldType = type;
             type = t;
-            if (schemaTypeDefs.containsKey(oldType))  // FIXME
-                schemaTypeDefs.remove(oldType);
+            schemaTypeDefs.remove(oldType); // FIXME
             if (t == null)
                 return;
             putSchemaTypeDef(type, this);

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
@@ -489,8 +489,9 @@ public class DebuggerManagerListener extends DebuggerManagerAdapter {
                                     windowsToClose.remove(ci);
                                 }
                             }
-                            for (EngineComponentsProvider ecp : openedWindowsByProvider.keySet()) {
-                                List<? extends ComponentInfo> cis = openedWindowsByProvider.get(ecp);
+                            for (Map.Entry<EngineComponentsProvider, List<? extends ComponentInfo>> entry : openedWindowsByProvider.entrySet()) {
+                                EngineComponentsProvider ecp = entry.getKey();
+                                List<? extends ComponentInfo> cis = entry.getValue();
                                 List<ComponentInfo> closing = new ArrayList<ComponentInfo>(cis);
                                 closing.retainAll(windowsToClose);
                                 ecp.willCloseNotify(closing);

--- a/ide/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitAction.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/ui/commit/CommitAction.java
@@ -566,8 +566,9 @@ public class CommitAction extends ContextAction {
         boolean enabled = commit.isEnabled();
         commit.setEnabled(false);
 
-        for (SvnFileNode fileNode : files.keySet()) {
-            CommitOptions options = files.get(fileNode);
+        for (Map.Entry<SvnFileNode, CommitOptions> entry : files.entrySet()) {
+            SvnFileNode fileNode = entry.getKey();
+            CommitOptions options = entry.getValue();
             if (options == CommitOptions.EXCLUDE) {
                 continue;
             }

--- a/ide/subversion/src/org/netbeans/modules/subversion/ui/ignore/IgnoreAction.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/ui/ignore/IgnoreAction.java
@@ -147,8 +147,9 @@ public class IgnoreAction extends ContextAction {
                         return;
                     }
                 }
-                for (File parent : names.keySet()) {
-                    Set<String> patterns = names.get(parent);
+                for (Map.Entry<File, Set<String>> entry : names.entrySet()) {
+                    File parent = entry.getKey();
+                    Set<String> patterns = entry.getValue();
                     if(isCanceled()) {
                         return;
                     }

--- a/ide/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/ToDoCustomizer.java
+++ b/ide/tasklist.todo/src/org/netbeans/modules/tasklist/todo/settings/ToDoCustomizer.java
@@ -152,8 +152,9 @@ class ToDoCustomizer extends javax.swing.JPanel implements DocumentListener{
             Settings.getDefault().setScanCommentsOnly(checkScanCommentsOnly.isSelected());            
             
             // make sure modified identifiers are saved
-            for (String id : id2comments.keySet()) {
-                CommentTags comments = id2comments.get(id);
+            for (Map.Entry<String, CommentTags> entry : id2comments.entrySet()) {
+                String id = entry.getKey();
+                CommentTags comments = entry.getValue();
                 for (int i = 0; i < extensionIdentifiers.size(); i++) {
                     ExtensionIdentifier identifier = extensionIdentifiers.get(i);
                     if (identifier.getId().equals(id)) {

--- a/ide/tasklist.ui/src/org/netbeans/modules/tasklist/ui/FoldingTaskListModel.java
+++ b/ide/tasklist.ui/src/org/netbeans/modules/tasklist/ui/FoldingTaskListModel.java
@@ -149,8 +149,9 @@ class FoldingTaskListModel extends TaskListModel {
         if( tasks.isEmpty() )
             return;
         Map<FoldingGroup,List<Task>> grouppedTasksMap = divideByGroup( tasks );
-        for( FoldingGroup fg : grouppedTasksMap.keySet() ) {
-            List<Task> tasksInGroup = grouppedTasksMap.get( fg );
+        for( Map.Entry<FoldingGroup, List<Task>> entry : grouppedTasksMap.entrySet() ) {
+            FoldingGroup fg = entry.getKey( );
+            List<Task> tasksInGroup = entry.getValue();
             fg.add( tasksInGroup );
         }
         sortTaskList();
@@ -161,8 +162,9 @@ class FoldingTaskListModel extends TaskListModel {
         if( tasks.isEmpty() )
             return;
         Map<FoldingGroup,List<Task>> grouppedTasksMap = divideByGroup( tasks );
-        for( FoldingGroup fg : grouppedTasksMap.keySet() ) {
-            List<Task> tasksInGroup = grouppedTasksMap.get( fg );
+        for( Map.Entry<FoldingGroup, List<Task>> entry : grouppedTasksMap.entrySet() ) {
+            FoldingGroup fg = entry.getKey( );
+            List<Task> tasksInGroup = entry.getValue();
             fg.remove( tasksInGroup );
         }
     }

--- a/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/options/GeneralOptionsPanel.java
+++ b/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/options/GeneralOptionsPanel.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
@@ -222,8 +223,9 @@ final class GeneralOptionsPanel extends javax.swing.JPanel implements ActionList
     }
     
     void cancel() {
-        for(VersioningSystem vs : savedDisconnectedFolders.keySet()) {
-            List<String> saved = savedDisconnectedFolders.get(vs);
+        for(Map.Entry<VersioningSystem, List<String>> entry : savedDisconnectedFolders.entrySet()) {
+            VersioningSystem vs = entry.getKey();
+            List<String> saved = entry.getValue();
             List<String> current = Arrays.asList(Utils.getDisconnectedRoots(vs));
             for (String folder : saved) {
                 if (!current.contains(folder)) {

--- a/ide/web.common/src/org/netbeans/modules/web/common/api/FileReferenceModification.java
+++ b/ide/web.common/src/org/netbeans/modules/web/common/api/FileReferenceModification.java
@@ -54,8 +54,7 @@ public class FileReferenceModification {
         if(absolutePathLink) {
             b.append('/'); //initial slash
         }
-        for(FileObject file : items.keySet()) {
-            String item = items.get(file);
+        for(String item : items.values()) {
             b.append(item);
             b.append('/'); //NOI18N
         }

--- a/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionContextImpl.java
+++ b/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionContextImpl.java
@@ -983,8 +983,7 @@ public class CompletionContextImpl extends CompletionContext {
             return;
         
 //        specialCompletion = true;
-        for(String prefix : declaredNamespaces.keySet()) {
-            String temp = declaredNamespaces.get(prefix);
+        for(String temp : declaredNamespaces.values()) {
             try {
                 if (nsModelMap.containsKey(temp)) {
                     // ignore, was added from specific location
@@ -1023,15 +1022,17 @@ public class CompletionContextImpl extends CompletionContext {
 
         //if the tns is already present in declared namespaces,
         //return the prefix
-        for(String key : getDeclaredNamespaces().keySet()) {
-            String ns = getDeclaredNamespaces().get(key);
+        for(Map.Entry<String, String> entry : getDeclaredNamespaces().entrySet()) {
+            String key = entry.getKey();
+            String ns = entry.getValue();
             if(ns.equals(tns))
                 return key;
         }
 
         //then try to look that up in the suggested namespace
-        for(String key : suggestedNamespaces.keySet()) {
-            String ns = suggestedNamespaces.get(key);
+        for(Map.Entry<String, String> entry : suggestedNamespaces.entrySet()) {
+            String key = entry.getKey();
+            String ns = entry.getValue();
             if(ns.equals(tns))
                 return key;
         }

--- a/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionUtil.java
+++ b/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionUtil.java
@@ -182,8 +182,9 @@ public class CompletionUtil {
             CompletionContextImpl context, String namespace) {
         List<String> list = new ArrayList<String>();
         
-        for(String key : context.getDeclaredNamespaces().keySet()) {
-            String ns = context.getDeclaredNamespaces().get(key);
+        for(Map.Entry<String, String> entry : context.getDeclaredNamespaces().entrySet()) {
+            String key = entry.getKey();
+            String ns = entry.getValue();
             if(ns.equals(namespace))
                 list.add(getPrefixFromXMLNS(key));
         }

--- a/ide/xml/src/org/netbeans/modules/xml/wizard/impl/XMLWizardIterator.java
+++ b/ide/xml/src/org/netbeans/modules/xml/wizard/impl/XMLWizardIterator.java
@@ -533,8 +533,9 @@ public class XMLWizardIterator implements TemplateWizard.Iterator {
             return;
         }
         StringBuffer sb = new StringBuffer();
-        for (String ns : nsAttrs.keySet()) {
-            String nsPrefix = nsAttrs.get(ns);
+        for (Map.Entry<String, String> entry : nsAttrs.entrySet()) {
+            String ns = entry.getKey();
+            String nsPrefix = entry.getValue();
             if ((nsPrefix != null) && (nsPrefix.trim().length() > 0)) {
                 String xmlnsString = "xmlns:" + nsPrefix + "='" + ns + "'";
                 if (xmlBuffer.indexOf(xmlnsString) == -1) {

--- a/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/FixClassesSupport.java
+++ b/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/FixClassesSupport.java
@@ -53,8 +53,9 @@ public class FixClassesSupport {
     public static void reloadClasses(final JPDADebugger debugger,
                                      Map<String, FileObject> classes) {
         final Map<String, byte[]> map = new HashMap<String, byte[]>();
-        for (String className : classes.keySet()) {
-            FileObject fo = classes.get(className);
+        for (Map.Entry<String, FileObject> entry : classes.entrySet()) {
+            String className = entry.getKey();
+            FileObject fo = entry.getValue();
             InputStream is = null;
             try {
                 is = fo.getInputStream();

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/ConnectPanel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/ConnectPanel.java
@@ -525,8 +525,9 @@ public class ConnectPanel extends JPanel implements ActionListener, HelpCtx.Prov
     ) {
         Map<String, Argument> defaultValues = connector.defaultArguments ();
         Map<String, String> argsToSave = new HashMap<String, String>();
-        for(String argName : args.keySet ()) {
-            Argument value = args.get (argName);
+        for(Map.Entry<String, Argument> entry : args.entrySet ()) {
+            String argName = entry.getKey ();
+            Argument value = entry.getValue();
             Argument defaultValue = defaultValues.get (argName);
             if ( value != null &&
                  value != defaultValue &&

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/CurrentThreadAnnotationListener.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/CurrentThreadAnnotationListener.java
@@ -643,13 +643,14 @@ public class CurrentThreadAnnotationListener extends DebuggerManagerAdapter {
                 //System.err.print("TASK annot: "+this.threadAnnotations.keySet()+" -> ");
                 this.threadAnnotations.keySet().removeAll(removeFutures);
                 //this.futureAnnotations.keySet().removeAll(removeFutures);
-                for (JPDAThread t : threadFutureAnnotations.keySet()) {
-                    FutureAnnotation fa = threadFutureAnnotations.get(t);
+                for (Map.Entry<JPDAThread, FutureAnnotation> entry : threadFutureAnnotations.entrySet()) {
+                    JPDAThread t = entry.getKey();
+                    FutureAnnotation fa = entry.getValue();
                     if (!this.annotationsToRemove.contains(fa)) {
                         this.threadAnnotations.put(t, fa.getAnnotation());
                     }
                 }
-                
+
                 //System.err.println(this.threadAnnotations.keySet());
                 /*for (JPDAThread t : futureAnnotations.keySet()) {
                     futureAnnotations.get(t).setAnnotation(threadAnnotations.get(t));

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
@@ -306,8 +306,9 @@ public final class GradleJavaSourceSet implements Serializable {
      * @return the matching {@link SourceType} or {@code null}.
      */
     public SourceType getSourceType(File f) {
-        for (SourceType type : sources.keySet()) {
-            Set<File> dirs = sources.get(type);
+        for (Map.Entry<SourceType, Set<File>> entry : sources.entrySet()) {
+            SourceType type = entry.getKey();
+            Set<File> dirs = entry.getValue();
             for (File dir : dirs) {
                 if (parentOrSame(f, dir)) {
                     return type;
@@ -329,8 +330,9 @@ public final class GradleJavaSourceSet implements Serializable {
 
     public Set<SourceType> getSourceTypes(File f) {
         Set<SourceType> ret = EnumSet.noneOf(SourceType.class);
-        for (SourceType type : sources.keySet()) {
-            Set<File> dirs = sources.get(type);
+        for (Map.Entry<SourceType, Set<File>> entry : sources.entrySet()) {
+            SourceType type = entry.getKey();
+            Set<File> dirs = entry.getValue();
             for (File dir : dirs) {
                 if (parentOrSame(f, dir)) {
                     ret.add(type);

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/OpenGradleProjectForBinary.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/OpenGradleProjectForBinary.java
@@ -52,8 +52,8 @@ public class OpenGradleProjectForBinary implements SourceForBinaryQueryImplement
                 if ("file".equals(uri.getScheme())) {
                     File jar = new File(uri);
                     Map<String, Project> projectArchives = projectArchives();
-                    if (projectArchives.containsKey(jar.getName())) {
-                        Project p = projectArchives.get(jar.getName());
+                    Project p = projectArchives.get(jar.getName());
+                    if (p != null) {
                         GradleJavaProject gjp = GradleJavaProject.get(p);
                         File archive = gjp.getArchive(GradleJavaProject.CLASSIFIER_NONE);
                         URL root = FileUtil.urlForArchiveOrDir(archive);

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/ui/PlatformUiSupport.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/ui/PlatformUiSupport.java
@@ -370,7 +370,7 @@ public final class PlatformUiSupport {
             if(!javacProfile.equals(props.getProperty(javacProfileKey))) {
                 props.setProperty(javacProfileKey, javacProfile);
             }
-        } else if (props.containsKey(javacProfileKey)) {
+        } else {
             props.remove(javacProfileKey);
         }
 

--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MethodExitDetector.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MethodExitDetector.java
@@ -189,8 +189,9 @@ public class MethodExitDetector extends CancellableTreePathScanner<Boolean, Stac
             return ;
         }
         
-        for (TypeMirror key : top.keySet()) {
-            List<Tree> topKey    = top.get(key);
+        for (Map.Entry<TypeMirror, List<Tree>> entry : top.entrySet()) {
+            TypeMirror key    = entry.getKey();
+            List<Tree> topKey = entry.getValue();
             List<Tree> resultKey = result.get(key);
             
             if (topKey == null)

--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/SemanticHighlighterBase.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/SemanticHighlighterBase.java
@@ -185,11 +185,12 @@ public abstract class SemanticHighlighterBase extends JavaParserResultTask {
         Map<Element, List<UnusedDescription>> element2Unused = UnusedDetector.findUnused(info) //XXX: unnecessarily ugly
                                                                              .stream()
                                                                              .collect(Collectors.groupingBy(ud -> ud.unusedElement));
-        for (Element decl : v.type2Uses.keySet()) {
+        for (Map.Entry<Element, List<Use>> entry : v.type2Uses.entrySet()) {
             if (cancel.get())
                 return true;
             
-            List<Use> uses = v.type2Uses.get(decl);
+            Element decl = entry.getKey();
+            List<Use> uses = entry.getValue();
             
             for (Use u : uses) {
                 if (u.spec == null)

--- a/java/java.editor/src/org/netbeans/modules/java/editor/imports/ComputeImports.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/imports/ComputeImports.java
@@ -323,8 +323,9 @@ public final class ComputeImports {
         
         // post processing: if some method hint was involved for a SN, we must retain ONLY
         // such Elements, which correspond to at least 1 method reference in the text. 
-        for (String sn : possibleMethodFQNs.keySet()) {
-            Set<String> fqns = possibleMethodFQNs.get(sn);
+        for (Map.Entry<String, Set<String>> entry : possibleMethodFQNs.entrySet()) {
+            String sn = entry.getKey();
+            Set<String> fqns = entry.getValue();
             
             List<Element> cands = candidates.get(sn);
             List<Element> rawCands = notFilteredCandidates.get(sn);
@@ -426,8 +427,9 @@ public final class ComputeImports {
         
         Set<TypeElement> validRights = new HashSet<TypeElement>();
         
-        for (TypeElement l : validPairs.keySet()) {
-            List<TypeElement> valid = validPairs.get(l);
+        for (Map.Entry<TypeElement, List<TypeElement>> entry : validPairs.entrySet()) {
+            TypeElement l = entry.getKey();
+            List<TypeElement> valid = entry.getValue();
             
             if (valid.isEmpty() && !leftReadOnly) {
                 //invalid left:

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/ProjectModel.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/ProjectModel.java
@@ -639,9 +639,7 @@ public class ProjectModel  {
         Iterator<JavaProjectGenerator.JavaCompilationUnit> it = javaCompilationUnitsList.iterator();
         while (it.hasNext()) {
             JavaProjectGenerator.JavaCompilationUnit cu = it.next();
-            if (cu.packageRoots.contains(location)) {
-                cu.packageRoots.remove(location);
-            }
+            cu.packageRoots.remove(location);
             if (cu.packageRoots.size() == 0) {
                 it.remove();
             }

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanelLogic.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanelLogic.java
@@ -758,8 +758,9 @@ public class HintsPanelLogic implements MouseListener, KeyListener, TreeSelectio
         
         public boolean isModified() {
             boolean isChanged = false;
-            for (HintMetadata hint : changes.keySet()) {
-                ModifiedHint e = changes.get(hint);
+            for (Entry<HintMetadata, ModifiedHint> entry : changes.entrySet()) {
+                HintMetadata hint = entry.getKey();
+                ModifiedHint e = entry.getValue();
                 if (e.enabledOverride != null) {
                     Boolean currentEnabled = e.enabledOverride;
                     Boolean savedEnabled = delegate.isEnabled(hint);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/Nodes.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/Nodes.java
@@ -120,8 +120,9 @@ public class Nodes {
         
         Map<Node, List<ErrorDescription>> fileNodes = new HashMap<Node, List<ErrorDescription>>();
         
-        for (FileObject file : errors.keySet()) {
-            List<ErrorDescription> eds = errors.get(file);
+        for (Map.Entry<FileObject, List<ErrorDescription>> entry : errors.entrySet()) {
+            FileObject file = entry.getKey();
+            List<ErrorDescription> eds = entry.getValue();
             Node foundChild = locateChild(view, lvp, file);
 
             if (foundChild == null) {

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/IndexerTransactionTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/IndexerTransactionTest.java
@@ -193,8 +193,9 @@ public class IndexerTransactionTest extends NbTestCase {
         logHandler.beforeFinishCallback = null;
         parserBlocker.release(1000);
 
-        for(String id : registeredClasspaths.keySet()) {
-            Set<ClassPath> classpaths = registeredClasspaths.get(id);
+        for(Map.Entry<String, Set<ClassPath>> entry : registeredClasspaths.entrySet()) {
+            String id = entry.getKey();
+            Set<ClassPath> classpaths = entry.getValue();
             GlobalPathRegistry.getDefault().unregister(id, classpaths.toArray(new ClassPath[classpaths.size()]));
         }
         registeredClasspaths.clear();

--- a/java/jshell.support/src/org/netbeans/modules/jshell/maven/MavenRunOptions.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/maven/MavenRunOptions.java
@@ -165,8 +165,9 @@ public class MavenRunOptions extends javax.swing.JPanel implements HelpCtx.Provi
             return;
         }
         Map<String, String> opts = nestedOptions.getChangedOptions();
-        for (String k : opts.keySet()) {
-            String v = opts.get(k);
+        for (Map.Entry<String, String> entry : opts.entrySet()) {
+            String k = entry.getKey();
+            String v = entry.getValue();
             if (v != null) {
                 am.addProperty(k, v);
             } else {

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsPanelLogic.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsPanelLogic.java
@@ -130,8 +130,9 @@ class HintsPanelLogic implements MouseListener, KeyListener, TreeSelectionListen
     }
     
     synchronized void applyChanges() {
-        for (POMErrorFixBase hint : changes.keySet()) {
-            ModifiedPreferences mn = changes.get(hint);
+        for (Map.Entry<POMErrorFixBase, ModifiedPreferences> entry : changes.entrySet()) {
+            POMErrorFixBase hint = entry.getKey();
+            ModifiedPreferences mn = entry.getValue();
             mn.store(hint.getConfiguration().getPreferences());
         }
     }
@@ -140,8 +141,9 @@ class HintsPanelLogic implements MouseListener, KeyListener, TreeSelectionListen
      */
     boolean isChanged() {
         boolean isChanged = false;
-        for (POMErrorFixBase hint : changes.keySet()) {
-            Preferences prefs = changes.get(hint);
+        for (Map.Entry<POMErrorFixBase, ModifiedPreferences> entry : changes.entrySet()) {
+            POMErrorFixBase hint = entry.getKey();
+            Preferences prefs = entry.getValue();
             try {
                 for (String key : prefs.keys()) {
                     String current = prefs.get(key, null);

--- a/java/maven/src/org/netbeans/modules/maven/dependencies/ExcludeDependencyPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/dependencies/ExcludeDependencyPanel.java
@@ -155,8 +155,9 @@ public class ExcludeDependencyPanel extends javax.swing.JPanel {
 
     public Map<Artifact, List<DependencyNode>> getDependencyExcludes() {
         Map<Artifact, List<DependencyNode>> toRet = new HashMap<Artifact, List<DependencyNode>>();
-        for (ChangeListener list : change2Trans.keySet()) {
-            CheckNode trans = change2Trans.get(list);
+        for (Map.Entry<ChangeListener, CheckNode> entry : change2Trans.entrySet()) {
+            ChangeListener list = entry.getKey();
+            CheckNode trans = entry.getValue();
             List<CheckNode> refs = change2Refs.get(list);
             List<DependencyNode> nds = new ArrayList<DependencyNode>();
             for (CheckNode ref : refs) {

--- a/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
@@ -660,8 +660,9 @@ public class BasicPanelVisual extends JPanel implements DocumentListener, Window
             File fil = art.getFile();
             if (fil.exists()) {
                 Map<String, String> props = arch.loadRequiredProperties();
-                for (String key : props.keySet()) {
-                    String defVal = props.get(key);
+                for (Map.Entry<String, String> entry : props.entrySet()) {
+                    String key = entry.getKey();
+                    String defVal = entry.getValue();
                     if ("groupId".equals(key) || "artifactId".equals(key) || "version".equals(key)) {
                         continue; //don't show the basic props as additionals..
                     }

--- a/java/maven/src/org/netbeans/modules/maven/newproject/idenative/IDENativeTemplateHandler.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/idenative/IDENativeTemplateHandler.java
@@ -166,8 +166,9 @@ public class IDENativeTemplateHandler extends CreateFromTemplateHandler {
         for (FileObject c : projectContents.getChildren()) {
             result.addAll(new FileBuilder(c, target).defaultMode(FileBuilder.Mode.COPY).withParameters(params).build());
         }
-        for (String k : params.keySet()) {
-            Object v = params.get(k);
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
+            String k = entry.getKey();
+            Object v = entry.getValue();
             if (v != null) {
                 p.put(k, v);
             }

--- a/java/maven/src/org/netbeans/modules/maven/spi/grammar/DialogFactory.java
+++ b/java/maven/src/org/netbeans/modules/maven/spi/grammar/DialogFactory.java
@@ -70,8 +70,9 @@ public final class DialogFactory {
         if (ret == DialogDescriptor.OK_OPTION) {
             Map<Artifact, List<DependencyNode>> dependencyExcludes = pnl.getDependencyExcludes();
             Map<Artifact, List<Artifact>> toRet = new HashMap<Artifact, List<Artifact>>();
-            for (Artifact exclude : dependencyExcludes.keySet()) {
-                List<DependencyNode> directs = dependencyExcludes.get(exclude);
+            for (Map.Entry<Artifact, List<DependencyNode>> entry : dependencyExcludes.entrySet()) {
+                Artifact exclude = entry.getKey();
+                List<DependencyNode> directs = entry.getValue();
                 List<Artifact> dirArts = new ArrayList<Artifact>();
                 for (DependencyNode nd : directs) {
                     dirArts.add(nd.getArtifact());

--- a/java/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CountingSecurityManager.java
+++ b/java/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CountingSecurityManager.java
@@ -239,13 +239,13 @@ public final class CountingSecurityManager extends SecurityManager {
             }
             int absoluteStacks = 0;
             synchronized (stacks) {
-                for (String s : stacks.keySet()) {
-                    int value = stacks.get(s);
+                for (int value : stacks.values()) {
                     absoluteStacks += value;
                 }
                 int min = absoluteStacks / 50;
-                for (String s : stacks.keySet()) {
-                    int value = stacks.get(s);
+                for (Map.Entry<String, int> entry : stacks.entrySet()) {
+                    String s = entry.getKey();
+                    int value = entry.getValue();
                     if (value > min) {
                         out.printf("count %5d; Stack:\n", value);
                         for (String line : s.split("\n")) {

--- a/java/performance/test/unit/src/org/netbeans/performance/scalability/CountingSecurityManager.java
+++ b/java/performance/test/unit/src/org/netbeans/performance/scalability/CountingSecurityManager.java
@@ -240,13 +240,13 @@ public final class CountingSecurityManager extends SecurityManager {
             }
             int absoluteStacks = 0;
             synchronized (stacks) {
-                for (String s : stacks.keySet()) {
-                    int value = stacks.get(s);
+                for (int value : stacks.values()) {
                     absoluteStacks += value;
                 }
                 int min = absoluteStacks / 50;
-                for (String s : stacks.keySet()) {
-                    int value = stacks.get(s);
+                for (Map.Entry<String, int> entry : stacks.entrySet()) {
+                    String s = entry.getKey();
+                    int value = entry.getValue();
                     if (value > min) {
                         out.printf("count %5d; Stack:\n", value);
                         for (String line : s.split("\n")) {

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InlineMethodTransformer.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InlineMethodTransformer.java
@@ -783,11 +783,9 @@ public class InlineMethodTransformer extends RefactoringVisitor {
             switch (grandparent.getKind()) {
                 case FOR_LOOP: {
                     ForLoopTree forLoopTree = (ForLoopTree) grandparent;
-                    if(translateMap.containsKey(grandparent)) {
-                        Tree newTree = translateMap.get(grandparent);
-                        if(newTree.getKind() == FOR_LOOP) {
-                            forLoopTree = (ForLoopTree) newTree;
-                        }
+                    Tree newTree = translateMap.get(grandparent);
+                    if (newTree != null && newTree.getKind() == FOR_LOOP) {
+                        forLoopTree = (ForLoopTree) newTree;
                     }
                     
                     StatementTree statement = forLoopTree.getStatement();

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaWhereUsedQueryPlugin.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaWhereUsedQueryPlugin.java
@@ -370,8 +370,9 @@ public class JavaWhereUsedQueryPlugin extends JavaRefactoringPlugin implements F
                 }
                 packages.add(nonRecursiveFolder);
             }
-            for (FileObject sourceRoot1 : folders.keySet()) {
-                Set<NonRecursiveFolder> packages1 = folders.get(sourceRoot1);
+            for (Map.Entry<FileObject, Set<NonRecursiveFolder>> entry : folders.entrySet()) {
+                FileObject sourceRoot1 = entry.getKey();
+                Set<NonRecursiveFolder> packages1 = entry.getValue();
                 if (packages1 != null && !packages1.isEmpty()) {
                     ClasspathInfo cpath;
                     if (isSearchFromBaseClass() && fo != null) {

--- a/java/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/matching/CopyFinderTest.java
+++ b/java/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/matching/CopyFinderTest.java
@@ -1504,8 +1504,9 @@ public class CopyFinderTest extends NbTestCase {
             }
             if (!actual.isEmpty()) {
                 Map<String, String> print = new HashMap<String, String>(actual.size());
-                for (String s : actual.keySet()) {
-                    int[] arr = actual.get(s);
+                for (Entry<String, int[]> entry : actual.entrySet()) {
+                    String s = entry.getKey();
+                    int[] arr = entry.getValue();
                     print.put(s, Arrays.toString(arr));
                 }
                 assertTrue("Extra duplicates found: " + print, actual.isEmpty());
@@ -1537,8 +1538,9 @@ public class CopyFinderTest extends NbTestCase {
             }
             if (!actualMulti.isEmpty()) {
                 Map<String, String> print = new HashMap<String, String>(actualMulti.size());
-                for (String s : actualMulti.keySet()) {
-                    int[] arr = actualMulti.get(s);
+                for (Entry<String, int[]> entry : actualMulti.entrySet()) {
+                    String s = entry.getKey();
+                    int[] arr = entry.getValue();
                     print.put(s, Arrays.toString(arr));
                 }
                 assertTrue("Extra multi duplicates found: " + print, actualMulti.isEmpty());

--- a/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectUtils.java
+++ b/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectUtils.java
@@ -1650,8 +1650,9 @@ public final class JFXProjectUtils {
     public static Map<String,String> copyMap(Map<String,String> map2Copy) {
         Map<String,String> newMap = new HashMap<String,String>();
         if(map2Copy != null) {
-            for(String key : map2Copy.keySet()) {
-                String value = map2Copy.get(key);
+            for(Map.Entry<String, String> entry : map2Copy.entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
                 newMap.put(key, value);
             }
         }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterQATest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterQATest.java
@@ -544,8 +544,9 @@ public class PHPFormatterQATest extends PHPFormatterTestBase {
         setupDocumentIndentation(doc, preferences);
 
         Preferences prefs = CodeStylePreferences.get(doc).getPreferences();
-        for (String option : options.keySet()) {
-            Object value = options.get(option);
+        for (Map.Entry<String, Object> entry : options.entrySet()) {
+            String option = entry.getKey();
+            Object value = entry.getValue();
             if (value instanceof Integer) {
                 prefs.putInt(option, ((Integer)value).intValue());
             }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTestBase.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTestBase.java
@@ -92,8 +92,9 @@ public abstract class PHPFormatterTestBase extends PHPTestBase {
         }
         options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
         Preferences prefs = CodeStylePreferences.get(doc).getPreferences();
-        for (String option : options.keySet()) {
-            Object value = options.get(option);
+        for (Map.Entry<String, Object> entry : options.entrySet()) {
+            String option = entry.getKey();
+            Object value = entry.getValue();
             if (value instanceof Integer) {
                 prefs.putInt(option, ((Integer) value).intValue());
             } else if (value instanceof String) {
@@ -175,8 +176,9 @@ public abstract class PHPFormatterTestBase extends PHPTestBase {
         setupDocumentIndentation(doc, indentPrefs);
 
         Preferences prefs = CodeStylePreferences.get(doc).getPreferences();
-        for (String option : options.keySet()) {
-            Object value = options.get(option);
+        for (Map.Entry<String, Object> entry : options.entrySet()) {
+            String option = entry.getKey();
+            Object value = entry.getValue();
             if (value instanceof Integer) {
                 prefs.putInt(option, ((Integer) value).intValue());
             } else if (value instanceof String) {

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPNewLineIndenterQATest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPNewLineIndenterQATest.java
@@ -243,8 +243,9 @@ public class PHPNewLineIndenterQATest extends PHPTestBase {
             options.put(FmtOptions.INDENT_SIZE, indentPrefs.getIndentation());
         }
         Preferences prefs = CodeStylePreferences.get(doc).getPreferences();
-        for (String option : options.keySet()) {
-            Object value = options.get(option);
+        for (Map.Entry<String, Object> entry : options.entrySet()) {
+            String option = entry.getKey();
+            Object value = entry.getValue();
             if (value instanceof Integer) {
                 prefs.putInt(option, ((Integer) value).intValue());
             } else if (value instanceof String) {

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPNewLineIndenterTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPNewLineIndenterTest.java
@@ -1246,8 +1246,9 @@ public class PHPNewLineIndenterTest extends PHPTestBase {
             options.put(FmtOptions.INDENT_SIZE, indentPrefs.getIndentation());
         }
         Preferences prefs = CodeStylePreferences.get(doc).getPreferences();
-        for (String option : options.keySet()) {
-            Object value = options.get(option);
+        for (Map.Entry<String, Object> entry : options.entrySet()) {
+            String option = entry.getKey();
+            Object value = entry.getValue();
             if (value instanceof Integer) {
                 prefs.putInt(option, ((Integer) value).intValue());
             } else if (value instanceof String) {

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpTypinghooksTestBase.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpTypinghooksTestBase.java
@@ -66,8 +66,9 @@ public abstract  class PhpTypinghooksTestBase extends PHPTestBase {
 
     protected void setOptionsForDocument(Document doc, Map<String, Object> options) throws Exception {
         Preferences prefs = CodeStylePreferences.get(doc).getPreferences();
-        for (String option : options.keySet()) {
-            Object value = options.get(option);
+        for (Map.Entry<String, Object> entry : options.entrySet()) {
+            String option = entry.getKey();
+            Object value = entry.getValue();
             if (value instanceof Integer) {
                 prefs.putInt(option, ((Integer)value).intValue());
             }

--- a/platform/api.visual/src/org/netbeans/modules/visual/graph/layout/HierarchicalLayout.java
+++ b/platform/api.visual/src/org/netbeans/modules/visual/graph/layout/HierarchicalLayout.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.SortedSet;
@@ -1092,14 +1093,11 @@ public class HierarchicalLayout<N, E> extends GraphLayout<N, E> {
 
             int minX = Integer.MAX_VALUE;
             int minY = Integer.MAX_VALUE;
-            for (N v : vertexPositions.keySet()) {
-                Point p = vertexPositions.get(v);
+            for (Point p : vertexPositions.values()) {
                 minX = Math.min(minX, p.x);
                 minY = Math.min(minY, p.y);
             }
-
-            for (E l : linkPositions.keySet()) {
-                List<Point> points = linkPositions.get(l);
+            for (List<Point> points : linkPositions.values()) {
                 for (Point p : points) {
                     if (p != null) {
                         minX = Math.min(minX, p.x);
@@ -1109,8 +1107,9 @@ public class HierarchicalLayout<N, E> extends GraphLayout<N, E> {
 
             }
 
-            for (N v : vertexPositions.keySet()) {
-                Point p = vertexPositions.get(v);
+            for (Map.Entry<N, Point> entry : vertexPositions.entrySet()) {
+                N v = entry.getKey();
+                Point p = entry.getValue();
                 p.x -= minX;
                 p.y -= minY;
                 Widget w = graph.getScene().findWidget(v);
@@ -1121,8 +1120,9 @@ public class HierarchicalLayout<N, E> extends GraphLayout<N, E> {
                 }
             }
 
-            for (E l : linkPositions.keySet()) {
-                List<Point> points = linkPositions.get(l);
+            for (Map.Entry<E, List<Point>> entry : linkPositions.entrySet()) {
+                E l = entry.getKey();
+                List<Point> points = entry.getValue();
 
                 for (Point p : points) {
                     if (p != null) {

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
@@ -444,8 +444,9 @@ public class Utilities {
         }
         
         boolean isEmpty = true;
-        for (UpdateElementImpl elementImpl : updates.keySet ()) {
-            File c = updates.get(elementImpl);
+        for (Map.Entry<UpdateElementImpl, File> entry : updates.entrySet ()) {
+            UpdateElementImpl elementImpl = entry.getKey();
+            File c = entry.getValue();
             // pass this module to given cluster ?
             if (cluster.equals (c)) {
                 Element module = document.createElement(UpdateTracking.ELEMENT_MODULE);
@@ -1284,8 +1285,9 @@ public class Utilities {
         Element root = document.getDocumentElement ();
         boolean isEmpty = true;
         
-        for (UpdateElementImpl impl : updates.keySet ()) {
-            File c = updates.get (impl);
+        for (Map.Entry<UpdateElementImpl, File> entry : updates.entrySet ()) {
+            UpdateElementImpl impl = entry.getKey ();
+            File c = entry.getValue();
             // pass this module to given cluster ?
             if (cluster.equals (c)) {
                 Element module = document.createElement (UpdateTracking.ELEMENT_ADDITIONAL_MODULE);

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/FeatureIncompleteTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/FeatureIncompleteTest.java
@@ -119,9 +119,8 @@ public class FeatureIncompleteTest extends NbTestCase {
             Map<String, UpdateItem> res = new HashMap<String, UpdateItem> (); //InstalledModuleProvider.getDefault().getUpdateItems();
 
             Set<String> deps = new HashSet<String>(items.size());
-            for (String id : items.keySet()) {
+            for (UpdateItem item : items.values()) {
                 String dep;
-                UpdateItem item = items.get(id);
                 assertNotNull("Impl of " + item + " available", Trampoline.SPI.impl(item));
                 UpdateItemImpl itemImpl = Trampoline.SPI.impl(item);
                 assertTrue("Impl of " + item + "is ModuleItem", itemImpl instanceof ModuleItem);

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateUnitFactoryTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateUnitFactoryTest.java
@@ -148,8 +148,9 @@ public class UpdateUnitFactoryTest extends NbTestCase {
         Map<String, UpdateUnit> updatedImpls = UpdateUnitFactory.getDefault ().appendUpdateItems (
                 installedImpls, p);
         boolean isInstalledAndHasUpdates = false;
-        for (String id : updatedImpls.keySet ()) {
-            UpdateUnit impl = updatedImpls.get (id);
+        for (Map.Entry<String, UpdateUnit> entry : updatedImpls.entrySet ()) {
+            String id = entry.getKey ();
+            UpdateUnit impl = entry.getValue();
             UpdateElement installed = impl.getInstalled ();
             List<UpdateElement> updates = impl.getAvailableUpdates ();
             isInstalledAndHasUpdates = isInstalledAndHasUpdates || installed != null && updates != null && ! updates.isEmpty ();

--- a/platform/core.windows/src/org/netbeans/core/windows/documentgroup/GroupsManager.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/documentgroup/GroupsManager.java
@@ -250,8 +250,9 @@ public class GroupsManager {
             }
 
             Map<String, String> oldId2newId = new HashMap<>(id2tc.size());
-            for( String oldId : id2tc.keySet() ) {
-                TopComponent tc = id2tc.get(oldId);
+            for( Map.Entry<String, TopComponent> entry : id2tc.entrySet() ) {
+                String oldId = entry.getKey();
+                TopComponent tc = entry.getValue();
                 ModeImpl mode = tcid2mode.get(oldId);
                 if( null != mode ) {
                     mode.dockInto(tc);

--- a/platform/core.windows/src/org/netbeans/core/windows/model/DefaultTopComponentGroupModel.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/model/DefaultTopComponentGroupModel.java
@@ -202,12 +202,8 @@ final class DefaultTopComponentGroupModel implements TopComponentGroupModel {
     
     public boolean removeUnloadedTopComponent(String tcID) {
         synchronized(LOCK_TOPCOMPONENTS) {
-            if(openingTopComponents.contains(tcID)) {
-                openingTopComponents.remove(tcID);
-            }
-            if(closingTopComponents.contains(tcID)) {
-                closingTopComponents.remove(tcID);
-            }
+            openingTopComponents.remove(tcID);
+            closingTopComponents.remove(tcID);
             return topComponents.remove(tcID);
         }
     }

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/GroupParser.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/GroupParser.java
@@ -255,8 +255,7 @@ class GroupParser {
             tcGroupConfigMap.put(sc.tcGroupConfigs[i].tc_id, sc.tcGroupConfigs[i]);
         }
         List<String> toDelete = new ArrayList<String>(10);
-        for (String s: tcGroupParserMap.keySet()) {
-            TCGroupParser tcGroupParser = tcGroupParserMap.get(s);
+        for (TCGroupParser tcGroupParser: tcGroupParserMap.values()) {
             if (!tcGroupConfigMap.containsKey(tcGroupParser.getName())) {
                 toDelete.add(tcGroupParser.getName());
             }

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/ModeParser.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/ModeParser.java
@@ -302,14 +302,12 @@ class ModeParser {
                 }
             }
             //Append remaining instances if any
-            for (String s: localMap.keySet()) {
-                TCRefParser tcRefParser = localMap.get(s);
+            for (TCRefParser tcRefParser: localMap.values()) {
                 localList.add(tcRefParser);
             }
         } else {
             //if (DEBUG) Debug.log(ModeParser.class, "-- -- NO ORDER, USING PARTIAL ORDERING");
-            for (String s: localMap.keySet()) {
-                TCRefParser tcRefParser = localMap.get(s);
+            for (TCRefParser tcRefParser: localMap.values()) {
                 localList.add(tcRefParser);
             }
             

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/PersistenceManager.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/PersistenceManager.java
@@ -1003,8 +1003,9 @@ public final class PersistenceManager implements PropertyChangeListener {
             return;
         }
 
-        for (Exception e : failedCompsMap.keySet()) {
-            String name = failedCompsMap.get(e);
+        for (Map.Entry<Exception, String> entry : failedCompsMap.entrySet()) {
+            Exception e = entry.getKey();
+            String name = entry.getValue();
             // create message
             String message = NbBundle.getMessage(PersistenceManager.class, 
                     (reading ? "FMT_TCReadError" : "FMT_TCWriteError"),

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/WindowManagerParser.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/WindowManagerParser.java
@@ -728,8 +728,7 @@ public class WindowManagerParser {
             modeConfigMap.put(wmc.modes[i].name, wmc.modes[i]);
         }
         List<String> toDelete = new ArrayList<String>(10);
-        for (String s: modeParserMap.keySet()) {
-            ModeParser modeParser = modeParserMap.get(s);
+        for (ModeParser modeParser: modeParserMap.values()) {
             if (!modeConfigMap.containsKey(modeParser.getName())) {
                 toDelete.add(modeParser.getName());
             }
@@ -762,8 +761,7 @@ public class WindowManagerParser {
             groupConfigMap.put(wmc.groups[i].name, wmc.groups[i]);
         }
         List<String> toDelete = new ArrayList<String>(10);
-        for (String s: groupParserMap.keySet()) {
-            GroupParser groupParser = groupParserMap.get(s);
+        for (GroupParser groupParser: groupParserMap.values()) {
             if (!groupConfigMap.containsKey(groupParser.getName())) {
                 toDelete.add(groupParser.getName());
             }

--- a/platform/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverImpl.java
+++ b/platform/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverImpl.java
@@ -219,8 +219,9 @@ public final class MIMEResolverImpl {
             @Override
             public void run() {
                 Document document = XMLUtil.createDocument("MIME-resolver", null, "-//NetBeans//DTD MIME Resolver 1.1//EN", "http://www.netbeans.org/dtds/mime-resolver-1_1.dtd");  //NOI18N
-                for (String mimeType : mimeToExtensions.keySet()) {
-                    Set<String> extensions = mimeToExtensions.get(mimeType);
+                for (Map.Entry<String, Set<String>> entry : mimeToExtensions.entrySet()) {
+                    String mimeType = entry.getKey();
+                    Set<String> extensions = entry.getValue();
                     if (!extensions.isEmpty()) {
                         Element fileElement = document.createElement("file");  //NOI18N
                         for (String extension : mimeToExtensions.get(mimeType)) {

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/ExportShortcutsAction.java
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/ExportShortcutsAction.java
@@ -308,8 +308,7 @@ public class ExportShortcutsAction {
             sb.append (actionName);
             XMLStorage.generateFolderEnd (sb, "td", "        ");
             
-            for (String profile: keymaps.keySet ()) {
-                Map<ShortcutAction, Set<String>> keymap = keymaps.get (profile);
+            for (Map<ShortcutAction, Set<String>> keymap: keymaps.values ()) {
                 Set<String> shortcuts = keymap.get (action);
 
                 XMLStorage.generateFolderStart (sb, "td", attribs, "        ");
@@ -417,8 +416,9 @@ public class ExportShortcutsAction {
                     actionToShortcuts.get (action)
                 );
             }
-            for (String actionName: sortedMap.keySet ()) {
-                Set<String> shortcuts = sortedMap.get (actionName);
+            for (Map.Entry<String, Set<String>> entry: sortedMap.entrySet ()) {
+                String actionName = entry.getKey ();
+                Set<String> shortcuts = entry.getValue();
                 for (String shortcut: shortcuts) {
                     attribs = new Attribs (true);
                     attribs.add ("actionName", actionName);

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/KeymapModel.java
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/KeymapModel.java
@@ -688,8 +688,9 @@ public class KeymapModel {
         Map<ShortcutAction,Set<String>> adding,
         Map<ShortcutAction, CompoundAction> sharedActions) {
 
-        for (ShortcutAction action : adding.keySet()) {
-            Set<String> shortcuts = adding.get(action);
+        for (Map.Entry<ShortcutAction, Set<String>> entry : adding.entrySet()) {
+            ShortcutAction action = entry.getKey();
+            Set<String> shortcuts = entry.getValue();
             if (shortcuts.isEmpty()) {
                 continue;
             }

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/MutableShortcutsModel.java
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/MutableShortcutsModel.java
@@ -547,8 +547,9 @@ class MutableShortcutsModel extends ShortcutsFinderImpl implements ShortcutsFind
                         Exceptions.printStackTrace(ex);
                     }
                 }
-                for (String profile: modifiedProfiles.keySet()) {
-                    Map<ShortcutAction, Set<String>> actionToShortcuts = modifiedProfiles.get (profile);
+                for (Map.Entry<String, Map<ShortcutAction, Set<String>>> entry: modifiedProfiles.entrySet()) {
+                    String profile = entry.getKey ();
+                    Map<ShortcutAction, Set<String>> actionToShortcuts = entry.getValue();
                     actionToShortcuts = convertToEmacs (actionToShortcuts);
                     model.changeKeymap (
                         profile, 

--- a/platform/spi.actions/src/org/netbeans/spi/actions/MergeAction.java
+++ b/platform/spi.actions/src/org/netbeans/spi/actions/MergeAction.java
@@ -152,8 +152,9 @@ final class MergeAction extends NbAction implements PropertyChangeListener {
 
     private void sievePropertyChanges() {
         Map<String, Object> nue = new HashMap<String, Object>();
-        for (String key : knownValues.keySet()) {
-            Object expected = knownValues.get(key);
+        for (Map.Entry<String, Object> entry : knownValues.entrySet()) {
+            String key = entry.getKey();
+            Object expected = entry.getValue();
             Object found = getValue(key);//del.getValue(key);
             if (found != expected) {
                 nue.put(key, found);

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerRowSorter.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerRowSorter.java
@@ -188,7 +188,7 @@ class ProfilerRowSorter extends TableRowSorter {
     
     void addRowFilter(RowFilter filter) {
         if (filters == null) filters = new HashSet();
-        if (filters.contains(filter)) filters.remove(filter);
+        filters.remove(filter);
         filters.add(filter);
         refreshRowFilter();
     }

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/editor/AngularJsDeclarationFinder.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/editor/AngularJsDeclarationFinder.java
@@ -184,8 +184,9 @@ public class AngularJsDeclarationFinder implements DeclarationFinder {
         
         if (!files.isEmpty()) {
             DeclarationLocation dl = null;
-            for (String shortPathName : files.keySet()) {
-                FileObject fileObject = files.get(shortPathName);
+            for (Map.Entry<String, FileObject> entry : files.entrySet()) {
+                String shortPathName = entry.getKey();
+                FileObject fileObject = entry.getValue();
                 DeclarationLocation dloc = new DeclarationLocation(fileObject, 0);
                 if (dl == null) {
                     dl = dloc;

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/index/AngularJsIndexer.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/index/AngularJsIndexer.java
@@ -323,16 +323,17 @@ public class AngularJsIndexer extends EmbeddingIndexer{
                     return;
                 }
                 if (templates != null && !templates.isEmpty()) {
-                    for (Map.Entry<URI, Map<String, AngularJsController.ModuleConfigRegistration>> entry : templates.entrySet()) {
-                        URI uri = entry.getKey();
-                        Map<String, AngularJsController.ModuleConfigRegistration> map = entry.getValue();
+                    for (Map.Entry<URI, Map<String, AngularJsController.ModuleConfigRegistration>> templateEntry : templates.entrySet()) {
+                        URI uri = templateEntry.getKey();
+                        Map<String, AngularJsController.ModuleConfigRegistration> map = templateEntry.getValue();
                         File file = Utilities.toFile(uri);
                         FileObject fo = FileUtil.toFileObject(file);
 
                         if (fo != null) {
                             IndexDocument elementDocument = support.createDocument(fo);
-                            for (String template : map.keySet()) {
-                                AngularJsController.ModuleConfigRegistration controller = map.get(template);
+                            for (Map.Entry<String, AngularJsController.ModuleConfigRegistration> entry : map.entrySet()) {
+                                String template = entry.getKey();
+                                AngularJsController.ModuleConfigRegistration controller = entry.getValue();
                                 StringBuilder sb = new StringBuilder();
                                 sb.append(template).append(":").append(controller.getControllerName()); //NOI18N
                                 if (controller.getControllerAsName() != null) {

--- a/webcommon/javascript.v8debug.ui/src/org/netbeans/modules/javascript/v8debug/ui/vars/models/VariablesModel.java
+++ b/webcommon/javascript.v8debug.ui/src/org/netbeans/modules/javascript/v8debug/ui/vars/models/VariablesModel.java
@@ -142,8 +142,9 @@ public class VariablesModel extends ViewModelSupport implements TreeModel,
                 }
                 ch[i++] = new Variable(Variable.Kind.ARGUMENT, name, ref, v, incompleteValue);
             }
-            for (String name : localRefs.keySet()) {
-                ReferencedValue rv = localRefs.get(name);
+            for (Map.Entry<String, ReferencedValue> entry : localRefs.entrySet()) {
+                String name = entry.getKey();
+                ReferencedValue rv = entry.getValue();
                 long ref = rv.getReference();
                 V8Value v = rvals.getReferencedValue(ref);
                 boolean incompleteValue = false;
@@ -232,8 +233,9 @@ public class VariablesModel extends ViewModelSupport implements TreeModel,
             childrenRet = null;
         }
         int chi = 0;
-        for (String name : properties.keySet()) {
-            V8Object.Property property = properties.get(name);
+        for (Map.Entry<String, V8Object.Property> entry : properties.entrySet()) {
+            String name = entry.getKey();
+            V8Object.Property property = entry.getValue();
             Variable var = new Variable(Variable.Kind.PROPERTY, name, property.getReference(), null, true, scope);
             if (children != null) {
                 children.add(var);

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
@@ -786,8 +786,7 @@ public class JsObjectImpl extends JsElementImpl implements JsObject {
     }
     
     protected void correctTypes(String fromType, String toType) {
-        for (Integer offset: assignments.keySet()) {
-            Collection<TypeUsage> types = assignments.get(offset);
+        for (Collection<TypeUsage> types: assignments.values()) {
             List<TypeUsage> copy = new ArrayList<>(types);
             String typeR = null;
             for (TypeUsage type : copy) {

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/OccurrenceBuilder.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/OccurrenceBuilder.java
@@ -79,8 +79,9 @@ public class OccurrenceBuilder {
     }
     
     public void processOccurrences(JsObject global) {
-        for (String name : holder.keySet()) {
-            Map<OffsetRange, Item> items = holder.get(name);
+        for (Map.Entry<String, Map<OffsetRange, Item>> entry : holder.entrySet()) {
+            String name = entry.getKey();
+            Map<OffsetRange, Item> items = entry.getValue();
             for (Item item : items.values()) {
                 processOccurrence(global, name, item);
             }

--- a/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/JSONWriter.java
+++ b/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/JSONWriter.java
@@ -1056,8 +1056,9 @@ public class JSONWriter {
     private static JSONArray storeProperties(Map<String, V8Object.Property> properties, V8Object.Array array) {
         JSONArray arrObj = new JSONArray();
         if (properties != null) {
-            for (String propName : properties.keySet()) {
-                V8Object.Property prop = properties.get(propName);
+            for (Map.Entry<String, V8Object.Property> entry : properties.entrySet()) {
+                String propName = entry.getKey();
+                V8Object.Property prop = entry.getValue();
                 JSONObject propObj = newJSONObject();
                 propObj.put(NAME, propName);
                 if (prop.getAttributes() != 0) {

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/UniqueVariableNameFinder.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/UniqueVariableNameFinder.java
@@ -40,8 +40,7 @@ public class UniqueVariableNameFinder {
     }
 
     public void addPattern(String pattern, int count) {
-        if(varDeclMap.containsKey(pattern))
-            varDeclMap.remove(pattern);
+        varDeclMap.remove(pattern);
         varDeclMap.put(pattern, new Integer(count));
     }
 


### PR DESCRIPTION
some project wide, map/collection related optimizations (low hanging fruits).

 Now that `referencedIn` is fixed in NB 13, we might as well use the opportunity to improve the codebase a bit with the help of jackpot :)

I picked some rules from [this](https://github.com/mbien/jackpot-inspections/) hint collection.

first commit:
If the right iterator view is used (keySet/entrySet/values), the loop body does not have to call map.get(key) on every iteration.
```java
// avoid inefficient map traversal
for ($K $k : $map.keySet()) {
    $preamble$;
    $V $v = $map.get($k);
    $body$;
} :: $map instanceof java.util.Map && !referencedIn($k, $preamble$)
=>
for ($V $v : $map.values()) {
    $preamble$;
    $body$;
}
:: !referencedIn($k, $body$)
=>
for (java.util.Map.Entry<$K, $V> entry : $map.entrySet()) {
    $preamble$;
    $K $k = entry.getKey();
    $V $v = entry.getValue();
    $body$;
}
:: otherwise
;;
```

second commit - no need to use contains() before remove()
```java
// contains + remove in succession
if ($col.contains($v)) {
    $col.remove($v);
} :: $col instanceof java.util.Collection
=>
$col.remove($v);
;;

if ($map.containsKey($k)) {
    $map.remove($k);
} :: $map instanceof java.util.Map
=>
$map.remove($k);
;;
```

third commit (not project wide, only two selected places to make review easier)
This one is risky, so I only applied it selectively.
```java
// contains + get in succession (dangerous! values can be null)
if ($map.containsKey($key)) {
    $preamble$;
    $V $v = $map.get($key);
    $body$;
} :: $map instanceof java.util.Map && !referencedIn($key, $preamble$)
=>
$V $v = $map.get($key);
if ($v != null) {
    $preamble$;
    $body$;
}
;;
```
