### PR TITLE
Improve handling of recursive JS structures

### DIFF
--- a/webcommon/javascript2.editor/test/unit/data/testfiles/indexer/SelfreferencingFunction.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/indexer/SelfreferencingFunction.js
@@ -1,0 +1,25 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+function mod(actions) {
+    return actions.map((action) => {
+        action = { action };
+        return action;
+    });
+};

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/indexer/SelfreferencingFunction.js.indexed
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/indexer/SelfreferencingFunction.js.indexed
@@ -1,0 +1,74 @@
+
+
+Document 0
+Searchable Keys:
+  bn : SelfreferencingFunctionmod#=>#21
+  bni : selfreferencingfunctionmod#=>#21
+  fqn : mod.SelfreferencingFunctionmod#=>#21A
+  offset : 870
+
+Not Searchable Keys:
+  assign : 
+  flag : 4289
+  param : action:
+  return : 
+
+
+Document 1
+Searchable Keys:
+  bn : action
+  bni : action
+  fqn : mod.SelfreferencingFunctionmod#=>#21.actionP
+  offset : 871
+
+Not Searchable Keys:
+  assign : 
+  flag : 131138
+
+
+Document 2
+Searchable Keys:
+  bn : actions
+  bni : actions
+  fqn : mod.actionsP
+  offset : 836
+
+Not Searchable Keys:
+  assign : 
+  flag : 131138
+
+
+Document 3
+Searchable Keys:
+  bn : mod
+  bni : mod
+  fqn : modO
+  offset : 832
+
+Not Searchable Keys:
+  assign : 
+  flag : 8258
+  param : actions:
+  return : 0|,928,@pro;actions@call;map
+
+
+Document 4
+Searchable Keys:
+  bn : param
+  bni : param
+  fqn : mod.actions.map.paramP
+  offset : 0
+
+Not Searchable Keys:
+  assign : 
+  flag : 131138
+
+
+Document 5
+Searchable Keys:
+  usage : actions:map#F
+  usage : map
+  usage : mod
+  usage : param
+
+Not Searchable Keys:

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/indexer/SelfreferencingObject.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/indexer/SelfreferencingObject.js
@@ -1,0 +1,24 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+a = {
+    height: 1
+};
+
+a.a = {a};

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/indexer/SelfreferencingObject.js.indexed
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/indexer/SelfreferencingObject.js.indexed
@@ -1,0 +1,45 @@
+
+
+Document 0
+Searchable Keys:
+  bn : a
+  bni : a
+  fqn : a.aO
+  offset : 849
+
+Not Searchable Keys:
+  assign : 
+  flag : 2097218
+
+
+Document 1
+Searchable Keys:
+  bn : a
+  bni : a
+  fqn : aO
+  offset : 823
+
+Not Searchable Keys:
+  assign : 
+  flag : 2097218
+
+
+Document 2
+Searchable Keys:
+  bn : height
+  bni : height
+  fqn : a.heightO
+  offset : 833
+
+Not Searchable Keys:
+  assign : Number:-1:1|
+  flag : 578
+
+
+Document 3
+Searchable Keys:
+  usage : a:a#P
+  usage : a:height#P:a#P
+  usage : height
+
+Not Searchable Keys:

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsTestBase.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsTestBase.java
@@ -25,9 +25,11 @@ import java.util.Set;
 import org.netbeans.lib.lexer.test.TestLanguageProvider;
 import org.netbeans.modules.csl.api.test.CslTestBase;
 import org.netbeans.modules.csl.spi.DefaultLanguageConfig;
+import org.netbeans.modules.javascript2.editor.index.JsIndexer;
 import org.netbeans.modules.javascript2.lexer.api.JsTokenId;
 import org.netbeans.modules.parsing.impl.indexing.IndexingUtils;
 import org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater;
+import org.netbeans.modules.parsing.spi.indexing.EmbeddingIndexerFactory;
 
 /**
  * @author Tor Norbye
@@ -50,12 +52,17 @@ public abstract class JsTestBase extends CslTestBase {
     protected DefaultLanguageConfig getPreferredLanguage() {
         return new TestJsLanguage();
     }
-    
+
     @Override
     protected String getPreferredMimeType() {
         return JsTokenId.JAVASCRIPT_MIME_TYPE;
     }
-    
+
+    @Override
+    public EmbeddingIndexerFactory getIndexerFactory() {
+        return new JsIndexer.Factory();
+    }
+
     public static class TestJsLanguage extends JsLanguage {
 
         public TestJsLanguage() {

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/index/RecursiveStructuresTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/index/RecursiveStructuresTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.editor.index;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.netbeans.modules.javascript2.editor.JsTestBase;
+import org.netbeans.modules.javascript2.editor.navigation.OccurrencesSupport;
+import org.netbeans.modules.javascript2.model.api.Model;
+import org.netbeans.modules.javascript2.types.spi.ParserResult;
+import org.netbeans.modules.parsing.api.ParserManager;
+import org.netbeans.modules.parsing.api.ResultIterator;
+import org.netbeans.modules.parsing.api.Source;
+import org.netbeans.modules.parsing.api.UserTask;
+
+/**
+ * The JS support functions need to guard against self referential models. If
+ * there is no guard, unlimited recursion can occur, leading to a stack
+ * overflow.
+ */
+public class RecursiveStructuresTest extends JsTestBase {
+
+    public RecursiveStructuresTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // org.netbeans.modules.javascript2.model.api.Model has an assert
+        // detecting cycles. This must be deactivated for tests
+        Field f = Model.class.getDeclaredField("assertFired");
+        f.setAccessible(true);
+        ((AtomicBoolean) f.get(null)).set(true);
+    }
+
+    public void testIndexingSelfreferencingObject() throws Exception {
+        checkIndexer("/testfiles/indexer/SelfreferencingObject.js");
+    }
+
+    public void testIndexingSelfreferencingFunction() throws Exception {
+        checkIndexer("/testfiles/indexer/SelfreferencingFunction.js");
+    }
+
+    public void testOccurrencesSelfreferencingObject() throws Exception {
+        Model m = getModel("/testfiles/indexer/SelfreferencingObject.js");
+        OccurrencesSupport os = new OccurrencesSupport(m);
+        os.getOccurrence(0);
+    }
+
+    public void testOccurrencesSelfreferencingFunction() throws Exception {
+        Model m = getModel("/testfiles/indexer/SelfreferencingFunction.js");
+        OccurrencesSupport os = new OccurrencesSupport(m);
+        os.getOccurrence(0);
+    }
+
+    public Model getModel(String file) throws Exception {
+        final Model[] globals = new Model[1];
+        Source source = getTestSource(getTestFile(file));
+
+        ParserManager.parse(Collections.singleton(source), new UserTask() {
+            public @Override
+            void run(ResultIterator resultIterator) throws Exception {
+                ParserResult parameter = (ParserResult) resultIterator.getParserResult();
+                Model model = Model.getModel(parameter, false);
+                globals[0] = model;
+            }
+        });
+        return globals[0];
+    }
+}


### PR DESCRIPTION
JS structures, that reference themselves can cause unlimited recursion
in several places. In this changeset the JsIndexer and
OccurrencesSupport are modified, so that recursive structures can be
scanned without causing a StackOverflowError.

Closes: #3669