### PR TITLE
Do not search unnecessarily deep.

### DIFF
--- a/.github/workflows/cv.yml
+++ b/.github/workflows/cv.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.hgexternalcache
-          key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
+          key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-
 
       - name: Clean

--- a/.github/workflows/ensure-jdk8.yml
+++ b/.github/workflows/ensure-jdk8.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.hgexternalcache
-          key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
+          key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-
 
       - name: Set up JDK 8

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.hgexternalcache
-          key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
+          key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-
 
       - name: Get maven coordinates

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.hgexternalcache
-          key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
+          key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-
 
       - name: Clean

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ jobs:
           path: |
             ~/.hgexternalcache
             ~/Library/Caches/Homebrew
-          key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
+          key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-
 
       - run: brew install ant

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.hgexternalcache
-          key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
+          key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-
 
       - name: Setup PHP

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.hgexternalcache
-          key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
+          key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-
 
       - name: Clean


### PR DESCRIPTION
The Windows Github workflow occasionaly fails on timeout, and as @JaroslavTulach  experiments indicated, the path expression `**/external/binaries-list` is too broad and it the filesystem search seems to take ages on Windows, Bill knows why.

The search can be narrowed as we do not have `binaries-list` on 3rd and lower levels (now). I made the change to all workflows, so the computed hash allows to share the binaries.

