### PR TITLE
project wide refactoring: avoid String.replaceAll() if possible.

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ProjectWhiteListQueryImplementation.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ProjectWhiteListQueryImplementation.java
@@ -194,7 +194,7 @@ public class ProjectWhiteListQueryImplementation implements WhiteListQueryImplem
 
                 publicPackagesStr = attrs.getValue("OpenIDE-Module-Public-Packages");
                 if(publicPackagesStr != null && !"".equals(publicPackagesStr)) {
-                    publicPackagesStr = publicPackagesStr.replaceAll(" ", "");
+                    publicPackagesStr = publicPackagesStr.replace(" ", "");
                 }
 
                 if (publicPackagesStr != null && !"-".equals(publicPackagesStr)) {

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/LibraryStartVisualPanel.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/LibraryStartVisualPanel.java
@@ -179,12 +179,12 @@ final class LibraryStartVisualPanel extends NewTemplateVisualPanel {
                     if (manifest != null) {
                         Attributes attributes = manifest.getMainAttributes();
                         if(attributes.getValue("Specification-Title") != null) {
-                            data.setProjectName(attributes.getValue("Specification-Title").replaceAll("[0-9._-]+$", "").replaceAll(" ", "-"));
+                            data.setProjectName(attributes.getValue("Specification-Title").replaceAll("[0-9._-]+$", "").replace(" ", "-"));
                         } else {
                             if (manifest.getEntries().size() == 1) {
                                 attributes = manifest.getEntries().values().iterator().next();
                                 if(attributes.getValue("Specification-Title") != null) {
-                                    data.setProjectName(attributes.getValue("Specification-Title").replaceAll("[0-9._-]+$", "").replaceAll(" ", "-"));
+                                    data.setProjectName(attributes.getValue("Specification-Title").replaceAll("[0-9._-]+$", "").replace(" ", "-"));
                                 }
                             }
                         }

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ModuleList.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ModuleList.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -614,9 +613,9 @@ public final class ModuleList {
                 } else {
                     // Wildcard. Convert to regexp and do a brute-force search.
                     // Not the most efficient option but should probably suffice.
-                    String regex = "\\Q" + pattern.replaceAll("\\*\\*", "__DBLASTERISK__"). // NOI18N
-                                                   replaceAll("\\*", "\\\\E[^/]*\\\\Q"). // NOI18N
-                                                   replaceAll("__DBLASTERISK__", "\\\\E.*\\\\Q") + "\\E"; // NOI18N
+                    String regex = "\\Q" + pattern.replace("**", "__DBLASTERISK__") // NOI18N
+                                                  .replace("*", "\\E[^/]*\\Q") // NOI18N
+                                                  .replace("__DBLASTERISK__", "\\E.*\\Q") + "\\E"; // NOI18N
                     Pattern regexp = Pattern.compile(regex);
                     for (String clusterFile : scanDirForFiles(cluster)) {
                         if (regexp.matcher(clusterFile).matches()) {

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingModel.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingModel.java
@@ -719,7 +719,7 @@ public abstract class BrandingModel {
         for (BundleKey bundleKey : internationalizedResourceBundleKeys) {
             String localizedBundlepath = bundlepath;
             if(!localizedBundlepath.endsWith("_" + this.locale.toString() + ".properties"))
-                localizedBundlepath = bundlepath.replaceAll(".properties", "_" + this.locale.toString() + ".properties");
+                localizedBundlepath = bundlepath.replace(".properties", "_" + this.locale.toString() + ".properties");
             if (key.equals(bundleKey.getKey()) &&
                 backslashesToSlashes(bundleKey.getBundleFilePath()).endsWith(localizedBundlepath) &&
                 codenamebase.equals(bundleKey.getModuleEntry().getCodeNameBase()))
@@ -736,7 +736,7 @@ public abstract class BrandingModel {
         Set<BrandingSupport.BundleKey> brandedBundleKeys = branding.getBrandedBundleKeys();
         String localizedBundlepath = key.getBundleFilePath();
         if(!localizedBundlepath.endsWith("_" + this.locale.toString() + ".properties"))
-                localizedBundlepath = localizedBundlepath.replaceAll(".properties", "_" + this.locale.toString() + ".properties");
+                localizedBundlepath = localizedBundlepath.replace(".properties", "_" + this.locale.toString() + ".properties");
         File bundleFile = new File(localizedBundlepath);
         if(!bundleFile.exists()) {
             for(BrandingSupport.BundleKey keyIter:brandedBundleKeys) {
@@ -795,7 +795,7 @@ public abstract class BrandingModel {
             String bundleFilePath = bundleKey.getBundleFilePath();
             String localizedBundlepath = bundlepath;
             if(bundleFilePath.endsWith("_" + this.locale.toString() + ".properties"))
-                localizedBundlepath = bundlepath.replaceAll(".properties", "_" + this.locale.toString() + ".properties");
+                localizedBundlepath = bundlepath.replace(".properties", "_" + this.locale.toString() + ".properties");
             if (key.equals(bundleKey.getKey()) &&
                 backslashesToSlashes(bundleFilePath).endsWith(localizedBundlepath) &&
                 codenamebase.equals(bundleKey.getModuleEntry().getCodeNameBase()))
@@ -822,7 +822,7 @@ public abstract class BrandingModel {
         for (BundleKey bundleKey : internationalizedResourceBundleKeys) {
             String localizedBundlepath = bundlepath;
             if(!localizedBundlepath.endsWith("_" + this.locale.toString() + ".properties"))
-                localizedBundlepath = bundlepath.replaceAll(".properties", "_" + this.locale.toString() + ".properties");
+                localizedBundlepath = bundlepath.replace(".properties", "_" + this.locale.toString() + ".properties");
             if (key.equals(bundleKey.getKey()) &&
                 backslashesToSlashes(bundleKey.getBundleFilePath()).endsWith(localizedBundlepath) &&
                 codenamebase.equals(bundleKey.getModuleEntry().getCodeNameBase()))
@@ -855,7 +855,7 @@ public abstract class BrandingModel {
             String bundleFilePath = bundleKey.getBundleFilePath();
             String localizedBundlepath = bundlepath;
             if(bundleFilePath.endsWith("_" + this.locale.toString() + ".properties"))
-                localizedBundlepath = bundlepath.replaceAll(".properties", "_" + this.locale.toString() + ".properties");
+                localizedBundlepath = bundlepath.replace(".properties", "_" + this.locale.toString() + ".properties");
             if (backslashesToSlashes(bundleFilePath).endsWith(localizedBundlepath) &&
                 codenamebase.equals(bundleKey.getModuleEntry().getCodeNameBase()))
                 return true;
@@ -880,7 +880,7 @@ public abstract class BrandingModel {
         for (BundleKey bundleKey : internationalizedResourceBundleKeys) {
             String localizedBundlepath = bundlepath;
             if(!localizedBundlepath.endsWith("_" + this.locale.toString() + ".properties"))
-                localizedBundlepath = bundlepath.replaceAll(".properties", "_" + this.locale.toString() + ".properties");
+                localizedBundlepath = bundlepath.replace(".properties", "_" + this.locale.toString() + ".properties");
             if (backslashesToSlashes(bundleKey.getBundleFilePath()).endsWith(localizedBundlepath) &&
                 codenamebase.equals(bundleKey.getModuleEntry().getCodeNameBase()))
                 return true;

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
@@ -607,7 +607,7 @@ public class InternationalizationResourceBundleBrandingPanel extends AbstractBra
         }
 
         private String escapeTagDefinitions (String text) {
-            return text.replaceAll("<", "&lt;").replaceAll(">", "&gt;"); // NOI18N
+            return text.replace("<", "&lt;").replace(">", "&gt;"); // NOI18N
         }
 
         public void refresh() {

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/ResourceBundleBrandingPanel.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/ResourceBundleBrandingPanel.java
@@ -572,7 +572,7 @@ public class ResourceBundleBrandingPanel extends AbstractBrandingPanel
         }
 
         private String escapeTagDefinitions (String text) {
-            return text.replaceAll("<", "&lt;").replaceAll(">", "&gt;"); // NOI18N
+            return text.replace("<", "&lt;").replace(">", "&gt;"); // NOI18N
         }
 
         public void refresh() {

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/options/NewOptionsIterator.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/options/NewOptionsIterator.java
@@ -553,7 +553,7 @@ public final class NewOptionsIterator extends BasicWizardIterator {
         String getClassNamePrefix() {
             if (classNamePrefix == null) {
                 classNamePrefix = isAdvanced() ? getSecondaryPanelTitle() : getCategoryName();
-                classNamePrefix = classNamePrefix.trim().replaceAll(" ", "");
+                classNamePrefix = classNamePrefix.trim().replace(" ", "");
                 if (!Utilities.isJavaIdentifier(classNamePrefix)) {
                     classNamePrefix = "";
                 }

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/quicksearch/NewQuickSearchIterator.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/quicksearch/NewQuickSearchIterator.java
@@ -88,7 +88,7 @@ public class NewQuickSearchIterator extends BasicWizardIterator {
         cmf.add(cmf.createFileWithSubstitutions(actionPath, template, replaceTokens));
 
         // add layer entry about the provider
-        String category = "QuickSearch/" + model.getCategoryName().replaceAll(" ", ""); // NOI18N
+        String category = "QuickSearch/" + model.getCategoryName().replace(" ", ""); // NOI18N
         String dashedPkgName = model.getPackageName().replace('.', '-');
         String dashedFqClassName = dashedPkgName + '-' + fileName;
         String instanceFullPath = category + "/" // NOI18N

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
@@ -211,7 +211,7 @@ public class MavenNbModuleImpl implements NbModuleProvider {
             MavenProject prj = project.getLookup().lookup(NbMavenProject.class).getMavenProject();
             //same fallback is in nbm-maven-plugin, keep it synchronized with codeNameBase parameter
             codename = prj.getGroupId() + "." + prj.getArtifactId(); //NOI18N
-            codename = codename.replaceAll( "-", "." ); //NOI18N
+            codename = codename.replace( "-", "." ); //NOI18N
         }
         return codename;
     }
@@ -295,7 +295,7 @@ public class MavenNbModuleImpl implements NbModuleProvider {
         for (NbModuleProvider.ModuleDependency mdep : dependencies) {
         String codeNameBase = mdep.getCodeNameBase();
         SpecificationVersion version = mdep.getVersion();
-        String artifactId = codeNameBase.replaceAll("\\.", "-"); //NOI18N
+        String artifactId = codeNameBase.replace(".", "-"); //NOI18N
         NbMavenProject watch = project.getLookup().lookup(NbMavenProject.class);
         if (hasDependency(codeNameBase)) {
             //TODO
@@ -379,7 +379,7 @@ public class MavenNbModuleImpl implements NbModuleProvider {
     }
 
     public @Override boolean hasDependency(String codeNameBase) throws IOException {
-        String artifactId = codeNameBase.replaceAll("\\.", "-"); //NOI18N
+        String artifactId = codeNameBase.replace(".", "-"); //NOI18N
         NbMavenProject watch = project.getLookup().lookup(NbMavenProject.class);
         Set<Artifact> set = watch.getMavenProject().getDependencyArtifacts();
         if (set != null) {
@@ -485,7 +485,7 @@ public class MavenNbModuleImpl implements NbModuleProvider {
      */ 
     @Override
     public SpecificationVersion getDependencyVersion(String codenamebase) throws IOException {
-        String artifactId = codenamebase.replaceAll("\\.", "-"); //NOI18N
+        String artifactId = codenamebase.replace(".", "-"); //NOI18N
         NbMavenProject watch = project.getLookup().lookup(NbMavenProject.class);
         for (Artifact art : watch.getMavenProject().getArtifacts()) {
             if (art.getGroupId().startsWith("org.netbeans") && art.getArtifactId().equals(artifactId)) { //NOI18N

--- a/contrib/cordova.platforms.ios/src/org/netbeans/modules/cordova/platforms/ios/IOSDebugTransport.java
+++ b/contrib/cordova.platforms.ios/src/org/netbeans/modules/cordova/platforms/ios/IOSDebugTransport.java
@@ -445,7 +445,7 @@ public abstract class IOSDebugTransport extends MobileDebugTransport implements 
             if (normUrl.endsWith("/")) { // NOI18N
                 normUrl = normUrl.substring(0, normUrl.length() - 1);
             }
-            return getConnectionURL().toString().equals(normUrl.replaceAll("file:///", "file:/"));
+            return getConnectionURL().toString().equals(normUrl.replace("file:///", "file:/"));
         }
 
         private String getTabForUrl() {

--- a/contrib/groovy.grailsproject/src/org/netbeans/modules/groovy/grailsproject/ui/wizards/GrailsArtifactWizardIterator.java
+++ b/contrib/groovy.grailsproject/src/org/netbeans/modules/groovy/grailsproject/ui/wizards/GrailsArtifactWizardIterator.java
@@ -335,7 +335,7 @@ public class GrailsArtifactWizardIterator implements WizardDescriptor.ProgressIn
             packageName = FileUtil.getRelativePath(groups.get(i).getRootFolder(), targetFolder);
         }
         if (packageName != null) {
-            packageName = packageName.replaceAll("/", "."); // NOI18N
+            packageName = packageName.replace("/", "."); // NOI18N
         }
         return packageName;
     }

--- a/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/WLPluginProperties.java
+++ b/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/WLPluginProperties.java
@@ -445,8 +445,8 @@ public final class WLPluginProperties {
             WLProductProperties prodProps = manager.getProductProperties();
             String mwHome = prodProps.getMiddlewareHome();
             if (mwHome != null) {
-                File serverModuleFile = FileUtil.normalizeFile(new File(new File(mwHome),
-                        serverModulesJar.replaceAll("/", Matcher.quoteReplacement(File.separator)))); // NOI18N
+                File serverModuleFile = FileUtil.normalizeFile(
+                        new File(new File(mwHome), serverModulesJar.replace("/", File.separator))); // NOI18N
                 return new File[] {weblogicJar, serverModuleFile};
             }
         }
@@ -515,8 +515,7 @@ public final class WLPluginProperties {
         }
 
         // init the input stream for the file and the w3c document object
-        File file = new File(serverRoot + File.separator
-                + DOMAIN_LIST.replaceAll("/", Matcher.quoteReplacement(File.separator)));
+        File file = new File(serverRoot + File.separator + DOMAIN_LIST.replace("/", File.separator));
         if (!file.exists() || !file.canRead()) {
             return Collections.emptyList();
         }

--- a/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/optional/NonProxyHostsHelper.java
+++ b/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/optional/NonProxyHostsHelper.java
@@ -67,8 +67,8 @@ public final class NonProxyHostsHelper {
     }
 
     private static String getModifiedNonProxyHosts (String systemPreset) {
-        String fromSystem = systemPreset.replaceAll (";", "|").replaceAll (",", "|"); //NOI18N
-        String fromUser = getPresetNonProxyHosts () == null ? "" : getPresetNonProxyHosts ().replaceAll (";", "|").replaceAll (",", "|"); //NOI18N
+        String fromSystem = systemPreset.replace (";", "|").replace (",", "|"); //NOI18N
+        String fromUser = getPresetNonProxyHosts () == null ? "" : getPresetNonProxyHosts ().replace (";", "|").replace (",", "|"); //NOI18N
         if (Utilities.isWindows ()) {
             fromSystem = addReguralToNonProxyHosts (fromSystem);
         }

--- a/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/ui/wizard/WLInstantiatingIterator.java
+++ b/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/ui/wizard/WLInstantiatingIterator.java
@@ -179,7 +179,7 @@ public class WLInstantiatingIterator  implements WizardDescriptor.InstantiatingI
         if (message.toUpperCase(Locale.ENGLISH).startsWith("<HTML>")) {
             return message;
         }
-        return "<html>" + message.replaceAll("<",  "&lt;").replaceAll(">",  "&gt;") + "</html>"; // NIO18N
+        return "<html>" + message.replace("<",  "&lt;").replace(">",  "&gt;") + "</html>"; // NIO18N
     }
     // the main and additional instance properties
     private String serverRoot;

--- a/contrib/websvc.wsitconf/test/unit/src/org/netbeans/modules/websvc/wsitconf/wsdlmodelext/ProfileTest.java
+++ b/contrib/websvc.wsitconf/test/unit/src/org/netbeans/modules/websvc/wsitconf/wsdlmodelext/ProfileTest.java
@@ -75,7 +75,7 @@ public class ProfileTest extends NbTestCase {
             }
             for (int i=1; i<profiles.size(); i++) {
                 String profile = profiles.get(i);
-                String profFileName = profile.replaceAll(" ", "");
+                String profFileName = profile.replace(" ", "");
 
                 //default profile set
                 ProfilesModelHelper.getInstance(cfgV).setSecurityProfile(b, profile, false);

--- a/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/Utils.java
+++ b/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/Utils.java
@@ -49,6 +49,6 @@ public class Utils {
     }
     
     private static String unquote(String s) {
-        return s.replaceAll("_s_", " ").replaceAll("_u_", "_");
+        return s.replace("_s_", " ").replace("_u_", "_");
     }
 }

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ProxySettings.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ProxySettings.java
@@ -157,8 +157,8 @@ class ProxySettings {
     }
 
     private static String getModifiedNonProxyHosts (String systemPreset) {
-        String fromSystem = systemPreset.replaceAll (";", "|").replaceAll (",", "|"); //NOI18N
-        String fromUser = getPresetNonProxyHosts () == null ? "" : getPresetNonProxyHosts ().replaceAll (";", "|").replaceAll (",", "|"); //NOI18N
+        String fromSystem = systemPreset.replace (";", "|").replace (",", "|"); //NOI18N
+        String fromUser = getPresetNonProxyHosts () == null ? "" : getPresetNonProxyHosts ().replace (";", "|").replace (",", "|"); //NOI18N
         if (Utilities.isWindows ()) {
             fromSystem = addReguralToNonProxyHosts (fromSystem);
         }

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/ide/Hk2TargetModuleID.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/ide/Hk2TargetModuleID.java
@@ -93,9 +93,9 @@ public class Hk2TargetModuleID implements TargetModuleID {
         // !PW FIXME path ought to be URL encoded by the time we get here.
         if (null != contextPath) {
             if(!contextPath.startsWith("/")) {
-                return target.getServerUri() + "/" + contextPath.replaceAll(" ", "%20");
+                return target.getServerUri() + "/" + contextPath.replace(" ", "%20");
             } else {
-                return target.getServerUri() + contextPath.replaceAll(" ", "%20");
+                return target.getServerUri() + contextPath.replace(" ", "%20");
             }
         }
         return null;

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/EjbGenerationUtil.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/EjbGenerationUtil.java
@@ -111,7 +111,7 @@ public class EjbGenerationUtil {
             packageName = FileUtil.getRelativePath(groups [i].getRootFolder(), targetFolder);
         }
         if (packageName != null) {
-            packageName = packageName.replaceAll("/", ".");
+            packageName = packageName.replace("/", ".");
         }
         return packageName+"";
     }

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/session/TimerOptions.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/session/TimerOptions.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.j2ee.ejbcore.ejb.wizard.session;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -97,7 +96,7 @@ public final class TimerOptions {
     }
 
     private static String omitNewLines(String string) {
-        return string.replaceAll("\n", ""); //NOI18N
+        return string.replace("\n", ""); //NOI18N
     }
 
     private static String[] splitScheduleSections(String scheduleValue) {
@@ -135,7 +134,7 @@ public final class TimerOptions {
             if (row.length != 2) {
                 return false;
             } else {
-                map.put(row[0].trim(), row[1].trim().replaceAll("\"", "")); //NOI18N
+                map.put(row[0].trim(), row[1].trim().replace("\"", "")); //NOI18N
             }
         }
         return true;

--- a/enterprise/j2ee.sun.appsrv/src/org/netbeans/modules/j2ee/sun/ide/editors/ProxySettings.java
+++ b/enterprise/j2ee.sun.appsrv/src/org/netbeans/modules/j2ee/sun/ide/editors/ProxySettings.java
@@ -291,8 +291,8 @@ public class ProxySettings {
     }
 
     private static String getModifiedNonProxyHosts (String systemPreset) {
-        String fromSystem = systemPreset.replaceAll (";", "|").replaceAll (",", "|"); //NOI18N
-        String fromUser = getPresetNonProxyHosts () == null ? "" : getPresetNonProxyHosts ().replaceAll (";", "|").replaceAll (",", "|"); //NOI18N
+        String fromSystem = systemPreset.replace (";", "|").replace (",", "|"); //NOI18N
+        String fromUser = getPresetNonProxyHosts () == null ? "" : getPresetNonProxyHosts ().replace (";", "|").replace (",", "|"); //NOI18N
         if (Utilities.isWindows ()) {
             fromSystem = addReguralToNonProxyHosts (fromSystem);
         }

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectLocationPanel.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectLocationPanel.java
@@ -512,7 +512,7 @@ private void sharableProjectActionPerformed(java.awt.event.ActionEvent evt) {//G
 
     public static String decorateMessage(String message) {
         if (message != null) {
-            return "<html>" + message.replaceAll("<",  "&lt;").replaceAll(">",  "&gt;") + "</html>"; // NIO18N
+            return "<html>" + message.replace("<",  "&lt;").replace(">",  "&gt;") + "</html>"; // NIO18N
         }
         return null;
     }

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyStartRunnable.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyStartRunnable.java
@@ -170,7 +170,7 @@ class WildflyStartRunnable implements Runnable {
                                 while ((line = br.readLine()) != null) {
                                     noNL.append(line);
                                 }
-                                value = noNL.toString().replaceAll("<", "").replace(">", "").replace(" ", "").replace("\"", "").replace('|', ',').trim();
+                                value = noNL.toString().replace("<", "").replace(">", "").replace(" ", "").replace("\"", "").replace('|', ',').trim();
                             } catch (IOException ioe) {
                                 Exceptions.attachLocalizedMessage(ioe, NbBundle.getMessage(WildflyStartRunnable.class, "ERR_NonProxyHostParsingError"));
                                 Logger.getLogger("global").log(Level.WARNING, null, ioe);

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/hyperlink/MicronautConfigHyperlinkProvider.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/hyperlink/MicronautConfigHyperlinkProvider.java
@@ -129,7 +129,7 @@ public class MicronautConfigHyperlinkProvider implements HyperlinkProviderExt {
                         }
                         TypeElement te = (TypeElement) handle[0].resolve(controller);
                         if (te != null) {
-                            String name = "set" + propertyName.replaceAll("-", "");
+                            String name = "set" + propertyName.replace("-", "");
                             for (ExecutableElement executableElement : ElementFilter.methodsIn(te.getEnclosedElements())) {
                                 if (name.equalsIgnoreCase(executableElement.getSimpleName().toString())) {
                                     handle[0] = ElementHandle.create(executableElement);

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/refactor/MicronautRefactoringFactory.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/refactor/MicronautRefactoringFactory.java
@@ -139,7 +139,7 @@ public class MicronautRefactoringFactory implements RefactoringPluginFactory {
                                             ConfigurationMetadataSource source = group.getSources().get(info.className);
                                             if (source != null) {
                                                 for (ConfigurationMetadataProperty property : source.getProperties().values()) {
-                                                    String name = "set" + property.getName().replaceAll("-", "");
+                                                    String name = "set" + property.getName().replace("-", "");
                                                     if (name.equalsIgnoreCase(info.methodName)) {
                                                         for (FileObject configFile : configFiles) {
                                                             MicronautConfigUtilities.collectUsages(configFile, property.getId(), usage -> {

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/ProxySettings.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/ProxySettings.java
@@ -156,8 +156,8 @@ class ProxySettings {
     }
 
     private static String getModifiedNonProxyHosts (String systemPreset) {
-        String fromSystem = systemPreset.replaceAll (";", "|").replaceAll (",", "|"); //NOI18N
-        String fromUser = getPresetNonProxyHosts () == null ? "" : getPresetNonProxyHosts ().replaceAll (";", "|").replaceAll (",", "|"); //NOI18N
+        String fromSystem = systemPreset.replace (";", "|").replace (",", "|"); //NOI18N
+        String fromUser = getPresetNonProxyHosts () == null ? "" : getPresetNonProxyHosts ().replace (";", "|").replace (",", "|"); //NOI18N
         if (Utilities.isWindows ()) {
             fromSystem = addReguralToNonProxyHosts (fromSystem);
         }

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/ide/Hk2TargetModuleID.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/ide/Hk2TargetModuleID.java
@@ -93,9 +93,9 @@ public class Hk2TargetModuleID implements TargetModuleID {
         // !PW FIXME path ought to be URL encoded by the time we get here.
         if (null != contextPath) {
             if(!contextPath.startsWith("/")) {
-                return target.getServerUri() + "/" + contextPath.replaceAll(" ", "%20");
+                return target.getServerUri() + "/" + contextPath.replace(" ", "%20");
             } else {
-                return target.getServerUri() + contextPath.replaceAll(" ", "%20");
+                return target.getServerUri() + contextPath.replace(" ", "%20");
             }
         }
         return null;

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManagerImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManagerImpl.java
@@ -497,7 +497,7 @@ public class TomcatManagerImpl implements ProgressObject, Runnable {
 
                 // Create a connection for this command
                 String uri = tm.getPlainUri ();
-                String withoutSpaces = (uri + command).replaceAll(" ", "%20");  //NOI18N
+                String withoutSpaces = (uri + command).replace(" ", "%20");  //NOI18N
                 urlToConnectTo = new URL(withoutSpaces);
                 
                 if (Boolean.getBoolean("org.netbeans.modules.tomcat5.LogManagerCommands")) { // NOI18N

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatModule.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatModule.java
@@ -76,7 +76,7 @@ public final class TomcatModule implements TargetModuleID {
     }
 
     public String getWebURL () {
-        return target.getServerUri () + path.replaceAll(" ", "%20");
+        return target.getServerUri () + path.replace(" ", "%20");
     }
     
     public String toString () {

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/InstallPanelVisual.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/InstallPanelVisual.java
@@ -422,7 +422,7 @@ class InstallPanelVisual extends javax.swing.JPanel {
         // prevent the message from being cut off - wizard descriptor issue work-around
         return errorMessage == null 
                 ? null
-                : "<html>" + errorMessage.replaceAll("<",  "&lt;").replaceAll(">",  "&gt;") + "</html>"; // NIO18N
+                : "<html>" + errorMessage.replace("<",  "&lt;").replace(">",  "&gt;") + "</html>"; // NIO18N
     }
     
     public boolean isInfoMessage() {

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/TagLibParseSupport.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/TagLibParseSupport.java
@@ -419,9 +419,7 @@ public class TagLibParseSupport implements org.openide.nodes.Node.Cookie, TagLib
         }
         
         private String translate (String text){
-            String value = text.replaceAll("&lt;", "<");
-            value = value.replaceAll("&gt;", ">");
-            return value;
+            return text.replace("&lt;", "<").replace("&gt;", ">");
         }
 
     }

--- a/enterprise/web.debug/src/org/netbeans/modules/web/debug/EngineContextProviderImpl.java
+++ b/enterprise/web.debug/src/org/netbeans/modules/web/debug/EngineContextProviderImpl.java
@@ -115,7 +115,7 @@ public class EngineContextProviderImpl extends SourcePathProvider {
             SourcePathProvider provider = getDefaultContext();
             if (provider != null) {
                 String path = relativePath.substring(11);
-                path = path.replaceAll("/_", "/"); // NOI8N
+                path = path.replace("/_", "/"); // NOI8N
                 if (path.startsWith("/")) {
                     path = path.substring(1);
                 }

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/refactoring/RefactoringUtil.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/refactoring/RefactoringUtil.java
@@ -59,7 +59,7 @@ public final class RefactoringUtil {
     }
     
     private static String encodeAngleBrackets(String str) {
-        return str.replaceAll("<", "&lt;").replaceAll(">", "&gt;"); //NOI18N
+        return str.replace("<", "&lt;").replace(">", "&gt;"); //NOI18N
     }
 
     private static String highlight(String text, OffsetRange offsetRange) {

--- a/enterprise/web.freeform/test/unit/src/org/netbeans/modules/web/freeform/WebProjectNatureTest.java
+++ b/enterprise/web.freeform/test/unit/src/org/netbeans/modules/web/freeform/WebProjectNatureTest.java
@@ -46,7 +46,7 @@ public class WebProjectNatureTest extends NbTestCase {
                       "    <foo bar=\"baz\" quux=\"whatever\">hello</foo>\n" +
                       "    <x>OK</x>\n" +
                       "</web-data>\n";
-        String xml2expected = xml1.replaceAll("/1", "/2");
+        String xml2expected = xml1.replace("/1", "/2");
         Document doc1 = XMLUtil.parse(new InputSource(new StringReader(xml1)), false, true, null, null);
         Element el1 = doc1.getDocumentElement();
         Element el2 = LookupProviderImpl.upgradeSchema(el1);

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFFrameworkProvider.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFFrameworkProvider.java
@@ -515,7 +515,7 @@ public class JSFFrameworkProvider extends WebFrameworkProvider {
                                     String content = readResource(getClass().getResourceAsStream(RESOURCE_FOLDER + FORWARD_JSF), "UTF-8"); //NOI18N
                                     content = content.replace("__FORWARD__", ConfigurationUtils.translateURI(facesMapping, WELCOME_JSF));
                                     Charset encoding = FileEncodingQuery.getDefaultEncoding();
-                                    content = content.replaceAll("__ENCODING__", encoding.name());
+                                    content = content.replace("__ENCODING__", encoding.name());
                                     FileObject target = FileUtil.createData(webModule.getDocumentBase(), FORWARD_JSF);//NOI18N
                                     createFile(target, content, encoding.name());  //NOI18N
                                     DataObject dob = DataObject.find(target);
@@ -706,7 +706,7 @@ public class JSFFrameworkProvider extends WebFrameworkProvider {
             if (!panel.isEnableFacelets() && createWelcome && canCreateNewFile(webModule.getDocumentBase(), WELCOME_JSF)) {
                 String content = readResource(getClass().getResourceAsStream(RESOURCE_FOLDER + WELCOME_JSF), "UTF-8"); //NOI18N
                 Charset encoding = FileEncodingQuery.getDefaultEncoding();
-                content = content.replaceAll("__ENCODING__", encoding.name());
+                content = content.replace("__ENCODING__", encoding.name());
                 FileObject target = FileUtil.createData(webModule.getDocumentBase(), WELCOME_JSF);
                 createFile(target, content, encoding.name());
                 DataObject dob = DataObject.find(target);

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/editor/JSFEditorUtilities.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/editor/JSFEditorUtilities.java
@@ -309,9 +309,7 @@ public class JSFEditorUtilities {
     private static String addNewLines(final BaseBean bean) throws IOException {
         StringWriter sWriter = new StringWriter();
         bean.writeNode(sWriter);
-        String sBean = sWriter.toString();
-        sBean = sBean.replaceAll("><", ">"+END_LINE+"<");               //NOI18N
-        return sBean;
+        return sWriter.toString().replace("><", ">"+END_LINE+"<");     //NOI18N
     }
     
     private static int writeString(BaseDocument doc, String text, int offset){

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/JsfForm.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/JsfForm.java
@@ -79,10 +79,10 @@ public final class JsfForm extends EntityClass implements ActiveEditorDrop, Pale
             stringBuffer.append("<").append(jsfLibrariesSupport.getLibraryPrefix(DefaultLibraryInfo.JSF_CORE)).append(":view>\n"); //NOI18N
         }
         stringBuffer.append(MessageFormat.format(
-                BEGIN[formType].replaceAll("__HTML__", jsfLibrariesSupport.getLibraryPrefix(DefaultLibraryInfo.HTML)), //NOI18N
+                BEGIN[formType].replace("__HTML__", jsfLibrariesSupport.getLibraryPrefix(DefaultLibraryInfo.HTML)), //NOI18N
                 new Object[] {variable}));
 
-        stringBuffer.append(END[formType].replaceAll("__HTML__", jsfLibrariesSupport.getLibraryPrefix(DefaultLibraryInfo.HTML))); //NOI18N
+        stringBuffer.append(END[formType].replace("__HTML__", jsfLibrariesSupport.getLibraryPrefix(DefaultLibraryInfo.HTML))); //NOI18N
         if (surroundWithFView) {
             stringBuffer.append("</").append(jsfLibrariesSupport.getLibraryPrefix(DefaultLibraryInfo.JSF_CORE)).append(":view>\n"); //NOI18N
         }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/JsfTable.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/JsfTable.java
@@ -74,10 +74,10 @@ public final class JsfTable extends EntityClass implements ActiveEditorDrop, Pal
             stringBuffer.append(PaletteUtils.createViewTag(jsfLibrariesSupport, target, false)).append("\n"); // NOI18N
         }
         stringBuffer.append(MessageFormat.format(
-                BEGIN[formType].replaceAll("__HTML__", jsfLibrariesSupport.getLibraryPrefix(DefaultLibraryInfo.HTML)), //NOI18N,
+                BEGIN[formType].replace("__HTML__", jsfLibrariesSupport.getLibraryPrefix(DefaultLibraryInfo.HTML)), //NOI18N
                 new Object [] {variable, "item"})); //NOI18N
         
-        stringBuffer.append(END[formType].replaceAll("__HTML__", jsfLibrariesSupport.getLibraryPrefix(DefaultLibraryInfo.HTML))); //NOI18N
+        stringBuffer.append(END[formType].replace("__HTML__", jsfLibrariesSupport.getLibraryPrefix(DefaultLibraryInfo.HTML))); //NOI18N
         if (surroundWithFView) {
             stringBuffer.append(PaletteUtils.createViewTag(jsfLibrariesSupport, target, true)).append("\n"); // NOI18N
         }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/PersistenceClientIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/PersistenceClientIterator.java
@@ -287,7 +287,7 @@ public class PersistenceClientIterator implements TemplateWizard.Iterator {
                 progressContributor.progress(progressMsg, progressIndex++);
                 progressPanel.setText(progressMsg);
                 String content = JpaControllerUtil.readResource(PersistenceClientIterator.class.getClassLoader().getResourceAsStream(JSFClientGenerator.RESOURCE_FOLDER + UTIL_CLASS_NAMES[i] + ".java.txt"), "UTF-8"); //NOI18N
-                content = content.replaceAll("__PACKAGE__", utilPackage);
+                content = content.replace("__PACKAGE__", utilPackage);
                 FileObject target = FileUtil.createData(utilFolder, UTIL_CLASS_NAMES[i] + "."+JAVA_EXT);//NOI18N
                 String projectEncoding = JpaControllerUtil.getProjectEncodingAsString(project, target);
                 JpaControllerUtil.createFile(target, content, projectEncoding);  //NOI18N

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/TemplateIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/TemplateIterator.java
@@ -341,7 +341,7 @@ public class TemplateIterator implements TemplateWizard.Iterator {
             is = templatePanel.getTemplate();
             String content = JSFFrameworkProvider.readResource(is, ENCODING);
             if (!jsfVersion.isAtLeast(JSFVersion.JSF_2_0)) {
-                content = content.replaceAll("h:head", "head").replaceAll("h:body", "body"); //NOI18N
+                content = content.replace("h:head", "head").replace("h:body", "body"); //NOI18N
             }
             String namespaceLocation = jsfVersion.isAtLeast(JSFVersion.JSF_2_2) ? NamespaceUtils.JCP_ORG_LOCATION : NamespaceUtils.SUN_COM_LOCATION;
 

--- a/enterprise/web.primefaces/src/org/netbeans/modules/web/primefaces/PrimefacesImplementation.java
+++ b/enterprise/web.primefaces/src/org/netbeans/modules/web/primefaces/PrimefacesImplementation.java
@@ -240,7 +240,7 @@ public class PrimefacesImplementation implements JsfComponentImplementation {
                     int indexOfVersion = propertiesText.indexOf(versionItem); //NOI18N
                     String version = propertiesText.substring(indexOfVersion + versionItem.length());
                     version = version.substring(0, version.indexOf("\n")); //NOI18N
-                    poms.add(new URI(baseUri.replaceAll("<VERSION>", version.trim()))); //NOI18N
+                    poms.add(new URI(baseUri.replace("<VERSION>", version.trim()))); //NOI18N
                 }
             } catch (URISyntaxException ex) {
                 LOGGER.log(Level.WARNING, "Primefaces version wasn't parsed", ex);

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsFrameworkProvider.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsFrameworkProvider.java
@@ -157,7 +157,7 @@ public class StrutsFrameworkProvider extends WebFrameworkProvider {
             if (resource != null){
                 String name = resource.getAttributeValue("parameter");
                 if (name != null) {
-                    name = name.replaceAll("/", ".");
+                    name = name.replace("/", ".");
                     panel.setAppResource(name);
                 }
             }
@@ -366,7 +366,7 @@ public class StrutsFrameworkProvider extends WebFrameworkProvider {
             //copy Welcome.jsp
             if (canCreateNewFile(wm.getDocumentBase(), "welcomeStruts.jsp")) { //NOI18N
                 content = readResource (this.getClass().getClassLoader().getResourceAsStream(RESOURCE_FOLDER + "welcome.jsp"), "UTF-8"); //NOI18N
-                content = content.replaceAll("__ENCODING__", FileEncodingQuery.getDefaultEncoding().name());
+                content = content.replace("__ENCODING__", FileEncodingQuery.getDefaultEncoding().name());
                 target = FileUtil.createData(wm.getDocumentBase(), "welcomeStruts.jsp");//NOI18N
                 createFile(target, content, "UTF-8"); //NOI18N
                 File indexJsp = new File(FileUtil.toFile(wm.getDocumentBase()), "index.jsp");  //NOI18N

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/editor/StrutsEditorUtilities.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/editor/StrutsEditorUtilities.java
@@ -344,9 +344,7 @@ public class StrutsEditorUtilities {
     private static String addNewLines(final BaseBean bean) throws IOException {
         StringWriter sWriter = new StringWriter();
         bean.writeNode(sWriter);
-        String sBean = sWriter.toString();
-        sBean = sBean.replaceAll("><", ">"+END_LINE+"<");               //NOI18N
-        return sBean;
+        return sWriter.toString().replace("><", ">"+END_LINE+"<");        //NOI18N
     }
     
     private static int writeString(BaseDocument doc, String text, int offset) throws BadLocationException {

--- a/enterprise/weblogic.common/src/org/netbeans/modules/weblogic/common/api/WebLogicLayout.java
+++ b/enterprise/weblogic.common/src/org/netbeans/modules/weblogic/common/api/WebLogicLayout.java
@@ -42,7 +42,6 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
@@ -196,8 +195,8 @@ public final class WebLogicLayout {
             // XXX cache values
             File mwHome = getMiddlewareHome(config.getServerHome());
             if (mwHome != null) {
-                File serverModuleFile = FileUtil.normalizeFile(new File(mwHome,
-                        serverModulesJar.replaceAll("/", Matcher.quoteReplacement(File.separator)))); // NOI18N
+                File serverModuleFile = FileUtil.normalizeFile(
+                        new File(mwHome, serverModulesJar.replace("/", File.separator))); // NOI18N
                 return new File[] {weblogicJar, serverModuleFile};
             }
         }

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/MethodExceptionDialog.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/MethodExceptionDialog.java
@@ -108,7 +108,7 @@ public class MethodExceptionDialog extends JPanel {
     }
 
     private String escape(String line) {
-        return line.replaceAll("<", "&lt;").replaceAll(">", "&gt;"); // NOI18N
+        return line.replace("<", "&lt;").replace(">", "&gt;"); // NOI18N
     }
 
     private final JButton okButton = new JButton(NbBundle.getMessage(this.getClass(), "OPTION_OK")); // NOI18N

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/codegen/model/WadlModeler.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/codegen/model/WadlModeler.java
@@ -165,9 +165,7 @@ public class WadlModeler extends ResourceModel {
     }
     
     private String findResourceNameFromPath(String path) {
-        String name = path.replaceAll("/", "");
-        name = name.replace("{", "");
-        name = name.replace("}", "");
+        String name = path.replace("/", "").replace("{", "").replace("}", "");
         return ClientStubModel.normalizeName(name);
     }
         

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/ContentPanel.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/ContentPanel.java
@@ -26,7 +26,6 @@ import javax.swing.JTable;
 import javax.swing.SwingUtilities;
 import javax.swing.table.TableCellRenderer;
 import org.netbeans.modules.ide.ergonomics.fod.FeatureManager;
-import org.openide.util.RequestProcessor;
 
 public final class ContentPanel extends JPanel {
     static String FINDING_MODULES = "finding-modules";
@@ -101,9 +100,7 @@ public final class ContentPanel extends JPanel {
     }
     
     private static String prepareToolTip (String original) {
-        String res = "";
-        res = "<html>" + original.replaceAll (",", "<br>")+ "</html>"; // NOI18N
-        return res;
+        return "<html>" + original.replace (",", "<br>")+ "</html>"; // NOI18N
     }
     
     /** This method is called from within the constructor to

--- a/extide/gradle/src/org/netbeans/modules/gradle/newproject/ProjectAttributesPanelVisual.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/newproject/ProjectAttributesPanelVisual.java
@@ -325,7 +325,7 @@ public final class ProjectAttributesPanelVisual extends JPanel implements Docume
             String part1 = tfGroup.getText().trim();
             part1 = !part1.isEmpty() ? part1 + "." : part1;
 
-            String part2 = tfProjectName.getText().trim().replaceAll(" ", "").replace('-', '.');
+            String part2 = tfProjectName.getText().trim().replace(" ", "").replace('-', '.');
             tfPackageBase.getDocument().removeDocumentListener(this);
             tfPackageBase.setText(part1 + part2);
             tfPackageBase.getDocument().addDocumentListener(this);

--- a/extide/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/NbInputHandler.java
+++ b/extide/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/NbInputHandler.java
@@ -87,10 +87,9 @@ final class NbInputHandler implements InputHandler {
         String promptText = request.getPrompt().trim();
         JLabel prompt = new JLabel();
         if (promptText.contains("\n")) { // #35712
-            prompt.setText("<html>" + promptText.
-                    replaceAll("&", "&amp;").
-                    replaceAll("<", "&lt;").
-                    replaceAll("\r?\n", "<br>"));
+            prompt.setText("<html>" + promptText.replace("&", "&amp;")
+                                                .replace("<", "&lt;")
+                                                .replaceAll("\r?\n", "<br>"));
         } else {
             prompt.setText(promptText);
         }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionHandler.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionHandler.java
@@ -185,7 +185,7 @@ public class CompletionHandler implements CodeCompletionHandler2 {
             }
 
             if (forURL) {
-                methodSignature = methodSignature.replaceAll(", ", ",%20");
+                methodSignature = methodSignature.replace(", ", ",%20");
             }
 
             return methodSignature;

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyCompletionCollector.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyCompletionCollector.java
@@ -382,10 +382,9 @@ public class GroovyCompletionCollector implements CompletionCollector {
         static String stripHtml( String htmlText ) {
             if( null == htmlText )
                 return null;
-            String res = htmlText.replaceAll( "<[^>]*>", "" ); // NOI18N // NOI18N
-            res = res.replaceAll( "&nbsp;", " " ); // NOI18N // NOI18N
-            res = res.trim();
-            return res;
+            return htmlText.replaceAll( "<[^>]*>", "" ) // NOI18N
+                           .replace( "&nbsp;", " " ) // NOI18N
+                           .trim();
         }
         
         @Override

--- a/groovy/groovy.editor/test/qa-functional/src/org/netbeans/test/groovy/GeneralGroovy.java
+++ b/groovy/groovy.editor/test/qa-functional/src/org/netbeans/test/groovy/GeneralGroovy.java
@@ -350,7 +350,7 @@ public class GeneralGroovy extends JellyTestCase {
         opNewProjectWizard.next();
 
         JDialogOperator jdNew = new JDialogOperator("New");
-        JTextComponentOperator jtName = new JTextComponentOperator(jdNew, sampleName.replaceAll(" ", "").replaceAll("-", ""));
+        JTextComponentOperator jtName = new JTextComponentOperator(jdNew, sampleName.replace(" ", "").replace("-", ""));
         jtName.setText(projectName);
         opNewProjectWizard.finish();
         waitScanFinished();

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/wizard/AbstractGroovyWizard.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/wizard/AbstractGroovyWizard.java
@@ -121,7 +121,7 @@ public abstract class AbstractGroovyWizard extends AbstractFileWizard {
             packageName = FileUtil.getRelativePath(groups.get(i).getRootFolder(), targetFolder);
         }
         if (packageName != null) {
-            packageName = packageName.replaceAll("/", "."); // NOI18N
+            packageName = packageName.replace("/", "."); // NOI18N
         }
         return packageName;
     }

--- a/harness/nbjunit/test/unit/src/org/netbeans/junit/diff/LineDiffTest.java
+++ b/harness/nbjunit/test/unit/src/org/netbeans/junit/diff/LineDiffTest.java
@@ -44,7 +44,7 @@ public class LineDiffTest extends NbTestCase {
     }
     
     private void doOutputToFile(File f, String content) throws IOException {
-        content = content.replaceAll("\n", System.getProperty("line.separator"));
+        content = content.replace("\n", System.getProperty("line.separator"));
         Writer w = new FileWriter(f);
         try {
             w.write(content);

--- a/ide/csl.api/src/org/netbeans/modules/csl/navigation/GsfStructureProvider.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/navigation/GsfStructureProvider.java
@@ -119,10 +119,9 @@ public class GsfStructureProvider implements StructureProvider {
         static String stripHtml( String htmlText ) {
             if( null == htmlText )
                 return null;
-            String res = htmlText.replaceAll( "<[^>]*>", "" ); // NOI18N // NOI18N
-            res = res.replaceAll( "&nbsp;", " " ); // NOI18N // NOI18N
-            res = res.trim();
-            return res;
+            return htmlText.replaceAll( "<[^>]*>", "" ) // NOI18N
+                           .replace( "&nbsp;", " " ) // NOI18N
+                           .trim();
         }
         
         @Override

--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -715,8 +715,8 @@ public abstract class CslTestBase extends NbTestCase {
         } else {
             // We want to ignore different line separators (like \r\n against \n) because they
             // might be causing failing tests on a different operation systems like Windows :]
-            String expectedUnified = expectedTrimmed.replaceAll("\r", "");
-            String actualUnified = actualTrimmed.replaceAll("\r", "");
+            String expectedUnified = expectedTrimmed.replace("\r", "");
+            String actualUnified = actualTrimmed.replace("\r", "");
             
             // if there is '**' in the actualUnified, it may stand for whatever word of the expected
             // content in that position.
@@ -926,8 +926,8 @@ public abstract class CslTestBase extends NbTestCase {
         } else {
             // We want to ignore different line separators (like \r\n against \n) because they
             // might be causing failing tests on a different operation systems like Windows :]
-            final String expectedUnified = expectedTrimmed.replaceAll("\r", "");
-            final String actualUnified = actualTrimmed.replaceAll("\r", "");
+            final String expectedUnified = expectedTrimmed.replace("\r", "");
+            final String actualUnified = actualTrimmed.replace("\r", "");
 
             if (expectedUnified.equals(actualUnified)) {
                 return; // Only difference is in line separation --> Test passed
@@ -988,8 +988,8 @@ public abstract class CslTestBase extends NbTestCase {
         } else {
             // We want to ignore different line separators (like \r\n against \n) because they
             // might be causing failing tests on a different operation systems like Windows :]
-            final String expectedUnified = expectedTrimmed.replaceAll("\r", "");
-            final String actualUnified = actualTrimmed.replaceAll("\r", "");
+            final String expectedUnified = expectedTrimmed.replace("\r", "");
+            final String actualUnified = actualTrimmed.replace("\r", "");
 
             if (expectedUnified.equals(actualUnified)) {
                 return; // Only difference is in line separation --> Test passed

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/CssHelpResolver.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/CssHelpResolver.java
@@ -154,8 +154,8 @@ public class CssHelpResolver {
         int firstLineEnd = anchor_part.indexOf("\n");  //NOI18N
         if (firstLineEnd > 0) {
             String firstLine = anchor_part.substring(0, firstLineEnd);
-            firstLine = firstLine.replaceAll("<strong>'", "<strong style=\"font-size: large\">");   //NOI18N
-            firstLine = firstLine.replaceAll("'</strong>", "</strong>"); //NOI18N
+            firstLine = firstLine.replace("<strong>'", "<strong style=\"font-size: large\">");   //NOI18N
+            firstLine = firstLine.replace("'</strong>", "</strong>"); //NOI18N
             anchor_part = firstLine + anchor_part.substring(firstLineEnd + 1);
         }
         return anchor_part;

--- a/ide/css.lib/src/org/netbeans/modules/css/lib/TokenNode.java
+++ b/ide/css.lib/src/org/netbeans/modules/css/lib/TokenNode.java
@@ -83,6 +83,6 @@ public class TokenNode extends AbstractParseTreeNode {
     }
     
     private CharSequence escapeNL(CharSequence text) {
-        return text.toString().replaceAll("\n", "\\\\n");
+        return text.toString().replace("\n", "\\n");
     }
 }

--- a/ide/diff/src/org/netbeans/modules/diff/EditorBufferSelectorPanel.java
+++ b/ide/diff/src/org/netbeans/modules/diff/EditorBufferSelectorPanel.java
@@ -113,10 +113,9 @@ class EditorBufferSelectorPanel extends JPanel implements ListSelectionListener,
                 if (null == htmlText) {
                     return null;
                 }
-                String res = htmlText.replaceAll("<[^>]*>", ""); // NOI18N // NOI18N
-                res = res.replaceAll("&nbsp;", " "); // NOI18N // NOI18N
-                res = res.trim();
-                return res;
+                return htmlText.replaceAll( "<[^>]*>", "" ) // NOI18N
+                               .replace( "&nbsp;", " " ) // NOI18N
+                               .trim();
             }
         });
 

--- a/ide/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergePanel.java
+++ b/ide/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergePanel.java
@@ -1597,7 +1597,7 @@ public class MergePanel extends javax.swing.JPanel implements java.awt.event.Act
     }
     
     private void writeText(Writer w, String text) throws IOException {
-        text = text.replaceAll("\n", System.getProperty("line.separator"));
+        text = text.replace("\n", System.getProperty("line.separator"));
         w.write(text);
     }
 

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/LocalNativeProcess.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/LocalNativeProcess.java
@@ -254,7 +254,7 @@ public final class LocalNativeProcess extends AbstractNativeProcess {
 
                         String errorMsg = loc("LocalNativeProcess.windowsProcessStartFailed.1073741515.text", cmd.toString()); // NOI18N
                         if (info.isPtyMode()) {
-                            errorMsg = errorMsg.replaceAll("\n", "\n\r"); // NOI18N
+                            errorMsg = errorMsg.replace("\n", "\n\r"); // NOI18N
                         }
 
                         try {

--- a/ide/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldOperationTest.java
+++ b/ide/editor.fold/test/unit/src/org/netbeans/modules/editor/fold/FoldOperationTest.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -35,11 +34,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.BadLocationException;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertSame;
-import static junit.framework.Assert.assertTrue;
 import org.netbeans.api.editor.fold.Fold;
 import org.netbeans.api.editor.fold.FoldHierarchy;
 import org.netbeans.api.editor.fold.FoldHierarchyEvent;
@@ -472,7 +466,7 @@ public class FoldOperationTest extends NbTestCase {
     
     private List<FoldInfo> readFoldData(String pathName) throws Exception {
         List<FoldInfo> result = new ArrayList<FoldInfo>();
-        File f = new File(getDataDir(), pathName.replaceAll("/", Matcher.quoteReplacement(File.separator)));
+        File f = new File(getDataDir(), pathName.replace("/", File.separator));
         if (!f.exists()) {
             throw new IllegalArgumentException("Data file not found: " + pathName);
         }

--- a/ide/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
+++ b/ide/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
@@ -176,14 +176,14 @@ public class SearchComboBoxEditor implements ComboBoxEditor {
                     @Override
                     public void insertString(DocumentFilter.FilterBypass fb, int offset, String string, AttributeSet attr) throws BadLocationException {
                         if (string != null) {
-                            fb.insertString(offset, string.replaceAll("\\t", "").replaceAll("\\n", ""), attr); //NOI18N
+                            fb.insertString(offset, string.replace("\t", "").replace("\n", ""), attr); //NOI18N
                         }
                     }
 
                     @Override
                     public void replace(DocumentFilter.FilterBypass fb, int offset, int length, String string, AttributeSet attr) throws BadLocationException {
                         if (string != null) {
-                            fb.replace(offset, length, string.replaceAll("\\t", "").replaceAll("\\n", ""), attr); //NOI18N
+                            fb.replace(offset, length, string.replace("\t", "").replace("\n", ""), attr); //NOI18N
                         }
                     }
                 });

--- a/ide/editor/src/org/netbeans/modules/editor/NbEditorKit.java
+++ b/ide/editor/src/org/netbeans/modules/editor/NbEditorKit.java
@@ -222,7 +222,7 @@ public class NbEditorKit extends ExtKit implements Callable {
     private void addSystemActionMapping(String editorActionName, String systemActionId) {
         Action a = getActionByName(editorActionName);
         if (a != null) {
-            a.putValue(SYSTEM_ACTION_CLASS_NAME_PROPERTY, systemActionId.replaceAll("\\.", "-"));
+            a.putValue(SYSTEM_ACTION_CLASS_NAME_PROPERTY, systemActionId.replace(".", "-"));
         }
     }
     

--- a/ide/git/src/org/netbeans/modules/git/ui/blame/AnnotationBar.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/blame/AnnotationBar.java
@@ -1166,7 +1166,7 @@ final class AnnotationBar extends JComponent implements Accessible, PropertyChan
                         LOG.log(Level.INFO, "HG.AB: can not HTML escape: ", message);  // NOI18N
                     }
                     if (escaped != null) {
-                        String lined = escaped.replaceAll("\n", "<br>");  // NOI18N
+                        String lined = escaped.replace("\n", "<br>");  // NOI18N
                         annotation.append("<p>").append(lined); // NOI18N
                     }
                 }

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/refactoring/ExtractInlinedStyleRefactoringPlugin.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/refactoring/ExtractInlinedStyleRefactoringPlugin.java
@@ -438,7 +438,7 @@ public class ExtractInlinedStyleRefactoringPlugin implements RefactoringPlugin {
                     //adds the new free element name into all of them
 
                     //replace the namespace postfix by something allowed in css selector name
-                    String tagName = si.getTag().replaceAll(":", "_"); //NOI18N
+                    String tagName = si.getTag().replace(":", "_"); //NOI18N
 
                     String generatedSelectorName = getFirstFreeSelectorName(
                             selectorType, tagName, editedFileElements, targetFileElements);

--- a/ide/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/models/ViewModelSupport.java
+++ b/ide/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/models/ViewModelSupport.java
@@ -97,9 +97,9 @@ public abstract class ViewModelSupport {
         sb.append ("<font color=");
         sb.append (Integer.toHexString ((color.getRGB () & 0xffffff)));
         sb.append (">");
-        text = text.replaceAll ("&", "&amp;");
-        text = text.replaceAll ("<", "&lt;");
-        text = text.replaceAll (">", "&gt;");
+        text = text.replace ("&", "&amp;");
+        text = text.replace ("<", "&lt;");
+        text = text.replace (">", "&gt;");
         sb.append (text);
         sb.append ("</font>");
         if (italics) sb.append ("</i>");

--- a/ide/jumpto/src/org/netbeans/modules/jumpto/quicksearch/GoToSymbolProvider.java
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/quicksearch/GoToSymbolProvider.java
@@ -26,7 +26,6 @@ import org.netbeans.spi.jumpto.symbol.SymbolDescriptor;
 import org.netbeans.spi.quicksearch.SearchProvider;
 import org.netbeans.spi.quicksearch.SearchRequest;
 import org.netbeans.spi.quicksearch.SearchResponse;
-import org.openide.filesystems.FileObject;
 import org.openide.util.NbBundle;
 
 /**
@@ -72,9 +71,7 @@ public class GoToSymbolProvider implements SearchProvider {
     }
      
     private static String escapeLtGt(String input) {
-        String temp = input.replaceAll("<", "&lt;"); // NOI18N
-        temp = temp.replaceAll(">", "&gt;"); // NOI18N
-        return temp;
+        return input.replace("<", "&lt;").replace(">", "&gt;"); // NOI18N
     }
      
     private static class GoToSymbolCommand implements Runnable {

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/keymap/EditorBridge.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/keymap/EditorBridge.java
@@ -584,7 +584,7 @@ public final class EditorBridge extends KeymapManager {
                     LOG.warning("The action " + action + " doesn't provide short description, using its name."); //NOI18N
                     name = getId();
                 }
-                name = name.replaceAll("&", "").trim(); //NOI18N
+                name = name.replace("&", "").trim(); //NOI18N
             }
             return name;
         }
@@ -601,7 +601,7 @@ public final class EditorBridge extends KeymapManager {
             if (delegaitngActionId == null) {
                 delegaitngActionId = (String) action.getValue(NbEditorKit.SYSTEM_ACTION_CLASS_NAME_PROPERTY);
                 if (delegaitngActionId != null) {
-                    delegaitngActionId = delegaitngActionId.replaceAll("\\.", "-");
+                    delegaitngActionId = delegaitngActionId.replace(".", "-");
                 }
             }
             return delegaitngActionId;

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/LogContext.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/LogContext.java
@@ -1001,10 +1001,10 @@ import org.openide.util.BaseUtilities;
         } else {
             sb.append("\nNOT executed");
         }
-        sb.append("\nScanned roots: ").append(scannedSourceRoots.values().toString().replaceAll(",", "\n\t")).
+        sb.append("\nScanned roots: ").append(scannedSourceRoots.values().toString().replace(",", "\n\t")).
                 append("\n, total time: ").append(totalScanningTime);
         
-        sb.append("\nCurrent root(s): ").append(frozenCurrentRoots.values().toString().replaceAll(",", "\n\t"));
+        sb.append("\nCurrent root(s): ").append(frozenCurrentRoots.values().toString().replace(",", "\n\t"));
         sb.append("\nCurrent indexer(s): ");
         for (RootInfo ri : frozenCurrentRoots.values()) {
             sb.append("\n\t").append(ri.url);

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskCache.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskCache.java
@@ -148,10 +148,9 @@ public class TaskCache {
 
                         String description = convertor.getMessage(err);
                         if (description != null && description.length() > 0) {
-                            description = description.replaceAll("\\\\", "\\\\\\\\"); //NOI18N
-                            description = description.replaceAll("\n", "\\\\n"); //NOI18N
-                            description = description.replaceAll(":", "\\\\d"); //NOI18N
-
+                            description = description.replace("\\", "\\\\") //NOI18N
+                                                     .replace("\n", "\\n") //NOI18N
+                                                     .replace(":", "\\d"); //NOI18N
                             pw.println(description);
                         }
                     }

--- a/ide/project.ant/src/org/netbeans/modules/project/ant/AntBasedProjectFactorySingleton.java
+++ b/ide/project.ant/src/org/netbeans/modules/project/ant/AntBasedProjectFactorySingleton.java
@@ -373,8 +373,7 @@ public final class AntBasedProjectFactorySingleton implements ProjectFactory2 {
             IOException ioe = new IOException(projectDiskFile + ": " + e, e);
             String msg = e.getMessage().
                     // org/apache/xerces/impl/msg/XMLSchemaMessages.properties validation (3.X.4)
-                    replaceFirst("^cvc-[^:]+: ", ""). // NOI18N
-                    replaceAll("http://www.netbeans.org/ns/", ".../"); // NOI18N
+                    replaceFirst("^cvc-[^:]+: ", "").replace("http://www.netbeans.org/ns/", ".../"); // NOI18N
             Exceptions.attachLocalizedMessage(ioe, NbBundle.getMessage(AntBasedProjectFactorySingleton.class,
                                                                         "AntBasedProjectFactorySingleton.parseError",
                                                                         projectDiskFile.getName(), msg));

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/XMLUtil.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/XMLUtil.java
@@ -146,20 +146,20 @@ public class XMLUtil {
     private static String convertChars(String msg, boolean attribute) {
         String result=msg;
         if (msg.indexOf("&")>=0) //NOI18N
-            result = result.replaceAll("&","&amp;"); //NOI18N
+            result = result.replace("&","&amp;"); //NOI18N
         if (msg.indexOf("<")>=0) //NOI18N
-            result = result.replaceAll("<","&lt;"); //NOI18N
+            result = result.replace("<","&lt;"); //NOI18N
         if (msg.indexOf(">")>=0) //NOI18N   
-            result = result.replaceAll(">","&gt;"); //NOI18N
+            result = result.replace(">","&gt;"); //NOI18N
         if (attribute) { //NOI18N
             if (msg.indexOf("\"")>=0) //NOI18N
-                result = result.replaceAll("\"","&quot;"); //NOI18N
+                result = result.replace("\"","&quot;"); //NOI18N
             if (msg.indexOf("'")>=0) //NOI18N
-                result = result.replaceAll("'","&apos;"); //NOI18N
+                result = result.replace("'","&apos;"); //NOI18N
             if (msg.indexOf("\n")>=0) //NOI18N
-                result = result.replaceAll("\n","&#xA"); //NOI18N
+                result = result.replace("\n","&#xA"); //NOI18N
             if (msg.indexOf("\t")>=0) //NOI18N
-                result = result.replaceAll("\t","&#x9"); //NOI18N
+                result = result.replace("\t","&#x9"); //NOI18N
         }
         return result;
     }

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/SwitcherTable.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/eval/SwitcherTable.java
@@ -159,7 +159,7 @@ public class SwitcherTable extends JTable {
         if( null == htmlText )
             return null;
         String res = htmlText.replaceAll( "<[^>]*>", "" ); // NOI18N // NOI18N
-        res = res.replaceAll( "&nbsp;", " " ); // NOI18N // NOI18N
+        res = res.replace( "&nbsp;", " " ); // NOI18N // NOI18N
         res = res.trim();
         return res;
     }

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/SwitcherTable.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/SwitcherTable.java
@@ -156,7 +156,7 @@ public class SwitcherTable extends JTable {
         if( null == htmlText )
             return null;
         String res = htmlText.replaceAll( "<[^>]*>", "" ); // NOI18N // NOI18N
-        res = res.replaceAll( "&nbsp;", " " ); // NOI18N // NOI18N
+        res = res.replace( "&nbsp;", " " ); // NOI18N // NOI18N
         res = res.trim();
         return res;
     }

--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/CodeEvaluator.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/CodeEvaluator.java
@@ -477,16 +477,12 @@ public final class CodeEvaluator {
                 this.type = type;
                 this.value = value;
                 this.toStringValue = toStringValue;
-                StringBuffer buf = new StringBuffer();
-                buf.append("<html>");
-                String text = expression.replaceAll ("&", "&amp;");
-                text = text.replaceAll ("<", "&lt;");
-                text = text.replaceAll (">", "&gt;");
-                text = text.replaceAll ("\n", "<br/>");
-                text = text.replaceAll ("\r", "");
-                buf.append(text);
-                buf.append("</html>");
-                this.tooltip = buf.toString();
+                String text = expression.replace("&", "&amp;")
+                                        .replace("<", "&lt;")
+                                        .replace(">", "&gt;")
+                                        .replace("\n", "<br/>")
+                                        .replace("\r", "");
+                this.tooltip = "<html>"+text+"</html>";
             }
 
             /**

--- a/ide/spi.viewmodel/src/org/netbeans/modules/viewmodel/TreeModelNode.java
+++ b/ide/spi.viewmodel/src/org/netbeans/modules/viewmodel/TreeModelNode.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.viewmodel;
 
-import java.awt.Component;
 import java.awt.Image;
 import java.awt.datatransfer.Transferable;
 import java.awt.event.ActionEvent;
@@ -37,8 +36,6 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,13 +47,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
-import javax.swing.JTable;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
-
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 import org.netbeans.spi.viewmodel.AsynchronousModelFilter;
@@ -81,7 +75,6 @@ import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.RequestProcessor.Task;
-import org.openide.util.actions.CallableSystemAction;
 import org.openide.util.datatransfer.PasteType;
 import org.openide.util.lookup.Lookups;
 
@@ -1042,30 +1035,29 @@ public class TreeModelNode extends AbstractNode {
         if (!(text.length() > 6 && text.substring(0, 6).equalsIgnoreCase(HTML_START_TAG))) {
             return text;
         }
-        text = text.replaceAll ("<i>", "");
-        text = text.replaceAll ("</i>", "");
-        text = text.replaceAll ("<b>", "");
-        text = text.replaceAll ("</b>", "");
-        text = text.replaceAll (HTML_START_TAG, "");
-        text = text.replaceAll (HTML_END_TAG, "");
-        text = text.replaceAll ("</font>", "");
+        text = text.replace ("<i>", "")
+                   .replace ("</i>", "")
+                   .replace ("<b>", "")
+                   .replace ("</b>", "")
+                   .replace (HTML_START_TAG, "")
+                   .replace (HTML_END_TAG, "")
+                   .replace ("</font>", "");
         int i = text.indexOf ("<font");
         while (i >= 0) {
             int j = text.indexOf (">", i);
             text = text.substring (0, i) + text.substring (j + 1);
             i = text.indexOf ("<font");
         }
-        text = text.replaceAll ("&lt;", "<");
-        text = text.replaceAll ("&gt;", ">");
-        text = text.replaceAll ("&amp;", "&");
-        return text;
+        return text.replace ("&lt;", "<")
+                   .replace ("&gt;", ">")
+                   .replace ("&amp;", "&");
     }
     
     /** Adjusts HTML text so that it's rendered correctly.
      * In particular, this assures that white characters are visible.
      */
     private static String adjustHTML(String text) {
-        text = text.replaceAll(java.util.regex.Matcher.quoteReplacement("\\"), "\\\\\\\\");
+        text = text.replace("\\", "\\\\");
         StringBuffer sb = null;
         int j = 0;
         for (int i = 0; i < text.length(); i++) {

--- a/ide/subversion/src/org/netbeans/modules/subversion/client/parser/WorkingCopyDetails.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/client/parser/WorkingCopyDetails.java
@@ -385,8 +385,8 @@ public class WorkingCopyDetails {
 
         List<String> keywordsList = new ArrayList<String>();
         
-        rawKeywords = rawKeywords.replaceAll("\n", " ");
-        rawKeywords = rawKeywords.replaceAll("\t", " ");        
+        rawKeywords = rawKeywords.replace("\n", " ");
+        rawKeywords = rawKeywords.replace("\t", " ");        
         keywordsList.addAll(normalizeKeywords(rawKeywords.split(" ")));             // NOI18N          
 
         String[] keywords = keywordsList.toArray(new String[keywordsList.size()]);

--- a/ide/subversion/src/org/netbeans/modules/subversion/options/SvnOptionsController.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/options/SvnOptionsController.java
@@ -372,7 +372,7 @@ public final class SvnOptionsController extends OptionsPanelController implement
     }
     
     private void onManageLabelsClick() {     
-        String labelFormat = panel.annotationTextField.getText().replaceAll(" ", "");        
+        String labelFormat = panel.annotationTextField.getText().replace(" ", "");        
         annotationSettings.show(labelFormat != null && labelFormat.indexOf("{folder}") > -1);                
     }
     

--- a/ide/subversion/src/org/netbeans/modules/subversion/util/SvnUtils.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/util/SvnUtils.java
@@ -900,7 +900,7 @@ public class SvnUtils {
      * @return
      */
     public static String fixLineEndings(String text) {
-        return text.replaceAll("\r\n", "\n").replace('\r', '\n');
+        return text.replace("\r\n", "\n").replace('\r', '\n');
     }
 
     public static boolean hasMetadata (File file) {

--- a/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/StatusTestHidden.java
+++ b/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/commands/StatusTestHidden.java
@@ -352,7 +352,7 @@ public class StatusTestHidden extends AbstractCommandTestCase {
                 throw e;
             }
         }
-        setProperty(externals, "svn:externals", "e1/e2\t" + repo2Url.appendPath("e1").appendPath("e2").toString().replaceAll(" ", "%20"));
+        setProperty(externals, "svn:externals", "e1/e2\t" + repo2Url.appendPath("e1").appendPath("e2").toString().replace(" ", "%20"));
         
         commit(externals);
         update(externals);        

--- a/ide/versioning.util/src/org/netbeans/modules/versioning/history/SummaryCellRenderer.java
+++ b/ide/versioning.util/src/org/netbeans/modules/versioning/history/SummaryCellRenderer.java
@@ -706,8 +706,7 @@ class SummaryCellRenderer implements ListCellRenderer {
         }
 
         private String prepareText (String text) {
-            text = text.replaceAll("\n", "<br>"); //NOI18N
-            return "<html><body>" + text + "</body></html>"; //NOI18N
+            return "<html><body>" + text.replace("\n", "<br>") + "</body></html>"; //NOI18N
         }
         
     }

--- a/ide/web.common/src/org/netbeans/modules/web/common/api/ServerURLMapping.java
+++ b/ide/web.common/src/org/netbeans/modules/web/common/api/ServerURLMapping.java
@@ -89,7 +89,7 @@ public final class ServerURLMapping {
         try {
             URL url = projectFile.toURL();
             String urlString = url.toURI().toString();
-            String urlString2 = urlString.replaceAll("file:/", "file:///"); //NOI18N
+            String urlString2 = urlString.replace("file:/", "file:///"); //NOI18N
             if (!urlString.equals(urlString2)) {
                 url = new URL(urlString2);
             }

--- a/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/CSS.java
+++ b/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/CSS.java
@@ -618,7 +618,7 @@ public class CSS {
     private String replaceHoverInStyleSheetText(String styleSheetText) {
         String clazz = getClassForHover();
         if (clazz != null) {
-            styleSheetText = styleSheetText.replaceAll(":hover", "." + clazz); // NOI18N
+            styleSheetText = styleSheetText.replace(":hover", "." + clazz); // NOI18N
         }
         return styleSheetText;
     }

--- a/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/CatalogEntityResolver.java
+++ b/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/CatalogEntityResolver.java
@@ -186,6 +186,6 @@ public class CatalogEntityResolver extends UserCatalog implements EntityResolver
      *  see : http://www.faqs.org/rfcs/rfc3151.html
      */
     private String URNtoPublic(String urn) {
-        return urn.replace('+',' ').replaceAll(":","//").replaceAll(";","::").replaceAll("%2B","+").replaceAll("%3A",":").replaceAll("%2F","/").replaceAll("%3B",";").replaceAll("%27","'").replaceAll("%3F","?").replaceAll("%23","#").replaceAll("%25","%");
+        return urn.replace('+',' ').replace(":","//").replace(";","::").replace("%2B","+").replace("%3A",":").replace("%2F","/").replace("%3B",";").replace("%27","'").replace("%3F","?").replace("%23","#").replace("%25","%");
     }
 }

--- a/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionUtil.java
+++ b/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionUtil.java
@@ -199,7 +199,7 @@ public class CompletionUtil {
      */
     public static void loadSchemaURIs(String schemaLocation, List<URI> uris, Map<String, String> schemaLocationMap) {
         StringTokenizer st = new StringTokenizer(
-                schemaLocation.replaceAll("\n", " "), " "); //NOI18N
+                schemaLocation.replace("\n", " "), " "); //NOI18N
         while(st.hasMoreTokens()) {
             URI uri = null;
             try {

--- a/ide/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/ReorderTest.java
+++ b/ide/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/ReorderTest.java
@@ -212,7 +212,7 @@ public class ReorderTest extends TestCase {
 			if(child instanceof Element)
 				System.out.print(((Element)child).getAttribute("name")+", ");
 			else if(child instanceof Text)
-				System.out.print("["+((Text)child).getTokens().get(0).getValue().replaceAll("\n", "~")+"]");
+				System.out.print("["+((Text)child).getTokens().get(0).getValue().replace("\n", "~")+"]");
 		}
 		System.out.println();
         }

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Attribute.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Attribute.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.xml.xdm.nodes;
 
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 import org.netbeans.modules.xml.xdm.visitor.XMLNodeVisitor;
 
 /**
@@ -246,31 +245,24 @@ public class Attribute extends NodeImpl implements Node, org.w3c.dom.Attr {
     
     private String insertEntityReference(String text) {
         // just make sure we replace & with &amp; and not &amp; with &&amp;amp; and so on
-        String result = removeEntityReference(text);
-        result = result.replaceAll("&","&amp;");   //replace &
-        result = result.replaceAll("<","&lt;");    //replace <
-//        result = result.replaceAll(">","&gt;");    //replace >
-        result = result.replaceAll("'","&apos;");  //replace '
-        result = result.replaceAll("\"","&quot;"); //replace "
-        return result;
+        return removeEntityReference(text)
+                    .replace("&", "&amp;")   //replace &
+                    .replace("<", "&lt;")    //replace <
+//                    .replace(">", "&gt;")    //replace >
+                    .replace("'", "&apos;")  //replace '
+                    .replace("\"", "&quot;"); //replace "
     }
 
     private String removeEntityReference(String text) {
-        String result = text;
-        result = AMPERSAND_PATTERN.matcher(result).replaceAll("&");   //replace with &
-        result = LESS_THAN_PATTERN.matcher(result).replaceAll("<");    //replace with <
-//        result = result.replaceAll("&gt;",">");    //replace with >
-        result = APOSTROPHE_PATTERN.matcher(result).replaceAll("'");  //replace with '
-        result = QUOTE_PATTERN.matcher(result).replaceAll("\""); //replace with "
-        return result;
+        return text.replace("&amp;", "&")   //replace with &
+                   .replace("&lt;", "<")    //replace with <
+//                   .replace("&gt;", ">")    //replace with >
+                   .replace("&apos;", "'")  //replace with '
+                   .replace("&quot;", "\""); //replace with "
     }
     
     private String name = null;
     private String value = null;
-    private static final Pattern AMPERSAND_PATTERN = Pattern.compile("&amp;"); //NOI18N
-    private static final Pattern LESS_THAN_PATTERN = Pattern.compile("&lt;"); //NOI18N
-    private static final Pattern APOSTROPHE_PATTERN = Pattern.compile("&apos;"); //NOI18N
-    private static final Pattern QUOTE_PATTERN = Pattern.compile("&quot;");//NOI18N
 }
 
 

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Text.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Text.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.xml.xdm.nodes;
 import java.util.List;
-import java.util.regex.Pattern;
 import org.netbeans.modules.xml.xdm.visitor.XMLNodeVisitor;
 
 /**
@@ -315,26 +314,20 @@ public class Text extends NodeImpl implements Node, org.w3c.dom.Text {
     
     private String insertEntityReference(String text) {
         // just make sure we replace & with &amp; and not &amp; with &&amp;amp; and so on
-        String result = removeEntityReference(text);
-        result = result.replaceAll("&","&amp;");   //replace &
-        result = result.replaceAll("<","&lt;");    //replace <
-        result = result.replaceAll(">","&gt;");    //replace >
-//        result = result.replaceAll("'","&apos;");  //replace '
-//        result = result.replaceAll("\"","&quot;"); //replace "
-        return result;
+        return removeEntityReference(text)
+                    .replace("&", "&amp;")   //replace &
+                    .replace("<", "&lt;")    //replace <
+                    .replace(">", "&gt;");    //replace >
+//                    .replace("'", "&apos;");  //replace '
+//                    .replace("\"", "&quot;"); //replace "
     }
 
     private String removeEntityReference(String text) {
-        String result = text;
-        result = AMPERSAND_PATTERN.matcher(result).replaceAll("&");   //replace with &
-        result = LESS_THAN_PATTERN.matcher(result).replaceAll("<");    //replace with <
-        result = GREATER_THAN_PATTERN.matcher(result).replaceAll(">");    //replace with >
-//        result = result.replaceAll("&apos;","'");  //replace with '
-//        result = result.replaceAll("&quot;","\""); //replace with "
-        return result;
+        return text.replace("&amp;", "&")   //replace with &
+                   .replace("&lt;", "<")    //replace with <
+                   .replace("&gt;", ">");    //replace with >
+//                   .replace("&apos;", "'");  //replace with '
+//                   .replace("&quot;", "\""); //replace with "
     }  
 
-    private static final Pattern AMPERSAND_PATTERN = Pattern.compile("&amp;"); //NOI18N
-    private static final Pattern LESS_THAN_PATTERN = Pattern.compile("&lt;"); //NOI18N
-    private static final Pattern GREATER_THAN_PATTERN = Pattern.compile("&gt;"); //NOI18N
 }

--- a/ide/xml/src/org/netbeans/modules/xml/wizard/impl/SchemaPanel.java
+++ b/ide/xml/src/org/netbeans/modules/xml/wizard/impl/SchemaPanel.java
@@ -262,7 +262,7 @@ private void removeButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-
                  uri = file.getName();
                  if (uri != null) {
                     // we need to escape spaces, URI does not like them
-                    uri = uri.replaceAll(" ", "%20"); // NOI18N
+                    uri = uri.replace(" ", "%20"); // NOI18N
                     try {
                         // escape the non-ASCII characters
                         uri = new URI(uri).toASCIIString();

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/Utils.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/Utils.java
@@ -51,9 +51,9 @@ public final class Utils {
         }
         sb.append(hexColor);
         sb.append ("\">");
-        text = text.replaceAll ("&", "&amp;");
-        text = text.replaceAll ("<", "&lt;");
-        text = text.replaceAll (">", "&gt;");
+        text = text.replace ("&", "&amp;");
+        text = text.replace ("<", "&lt;");
+        text = text.replace (">", "&gt;");
         sb.append (text);
         sb.append ("</font>");
         if (italics) sb.append ("</i>");

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/vars/models/TruffleVariablesTableModel.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/vars/models/TruffleVariablesTableModel.java
@@ -194,9 +194,9 @@ public class TruffleVariablesTableModel implements TableModelFilter, TableHTMLMo
         sb.append(id);
         sb.append("]</font> ");
         
-        text = text.replaceAll("&", "&amp;");
-        text = text.replaceAll("<", "&lt;");
-        text = text.replaceAll(">", "&gt;");
+        text = text.replace("&", "&amp;");
+        text = text.replace("<", "&lt;");
+        text = text.replace(">", "&gt;");
         sb.append(text);
         sb.append("</font>");
         sb.append("</html>");

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BoldVariablesTableModelFilter.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BoldVariablesTableModelFilter.java
@@ -220,9 +220,9 @@ Constants {
         }
         sb.append(hexColor);
         sb.append ("\">");
-        text = text.replaceAll ("&", "&amp;");
-        text = text.replaceAll ("<", "&lt;");
-        text = text.replaceAll (">", "&gt;");
+        text = text.replace ("&", "&amp;");
+        text = text.replace ("<", "&lt;");
+        text = text.replace (">", "&gt;");
         sb.append (text);
         sb.append ("</font>");
         if (italics) sb.append ("</i>");

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorNodeModelFilter.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/EvaluatorNodeModelFilter.java
@@ -166,16 +166,12 @@ public class EvaluatorNodeModelFilter implements ExtendedNodeModelFilter {
         if (node == result.getResult()) {
             String str = result.getExpression();
             if (str != null) {
-                StringBuffer buf = new StringBuffer();
-                buf.append("<html>");
-                str = str.replaceAll ("&", "&amp;");
-                str = str.replaceAll ("<", "&lt;");
-                str = str.replaceAll (">", "&gt;");
-                str = str.replaceAll ("\n", "<br/>");
-                str = str.replaceAll ("\r", "");
-                buf.append(str);
-                buf.append("</html>");
-                return buf.toString();
+                str = str.replace ("&", "&amp;")
+                         .replace ("<", "&lt;")
+                         .replace (">", "&gt;")
+                         .replace ("\n", "<br/>")
+                         .replace ("\r", "");
+                return "<html>"+str+"</html>";
             }
         }
         if (node instanceof DefaultHistoryItem) {

--- a/java/form/src/org/netbeans/modules/form/ComponentLayer.java
+++ b/java/form/src/org/netbeans/modules/form/ComponentLayer.java
@@ -170,7 +170,7 @@ class ComponentLayer extends JPanel
                 msg = "<html><b>" + msg + "</b><br><br>"; // NOI18N
                 StringWriter sw = new StringWriter();
                 ex.printStackTrace(new PrintWriter(sw));
-                msg += sw.toString().replaceAll("\n", "<br>"); // NOI18N
+                msg += sw.toString().replace("\n", "<br>"); // NOI18N
                 Insets insets = getInsets();
                 JLabel label = new JLabel(msg);
                 label.setBorder(BorderFactory.createEmptyBorder(insets.top, insets.left, insets.bottom, insets.right));

--- a/java/form/test/qa-functional/src/org/netbeans/qa/form/OpenTempl_defaultPackTest.java
+++ b/java/form/test/qa-functional/src/org/netbeans/qa/form/OpenTempl_defaultPackTest.java
@@ -368,7 +368,7 @@ public class OpenTempl_defaultPackTest extends ExtJellyTestCase {
     public void testJavaFile(String javafile) throws IOException {
 
         
-        assertFile(new File(getWorkDir() + File.separator + this.getName() + ".ref"), getGoldenFile(File.separatorChar+System.getProperty("os.name")+File.separatorChar+javafile + "JavaFile" + jdkVersion.replaceAll("jdk", "") + ".pass"), new File(getWorkDir(), javafile + "java.diff"));
+        assertFile(new File(getWorkDir() + File.separator + this.getName() + ".ref"), getGoldenFile(File.separatorChar+System.getProperty("os.name")+File.separatorChar+javafile + "JavaFile" + jdkVersion.replace("jdk", "") + ".pass"), new File(getWorkDir(), javafile + "java.diff"));
 
 
     }

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerIterator.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerIterator.java
@@ -197,7 +197,7 @@ public class JpaControllerIterator implements TemplateWizard.Iterator {
                         JpaControllerUtil.class.getClassLoader().
                         getResourceAsStream(RESOURCE_FOLDER + 
                                 EXCEPTION_CLASS_NAMES[i] + ".java.txt"), "UTF-8"); //NOI18N
-                content = content.replaceAll("__PACKAGE__", exceptionPackage);
+                content = content.replace("__PACKAGE__", exceptionPackage);
                 FileObject target = FileUtil.createData(exceptionFolder, 
                         EXCEPTION_CLASS_NAMES[i] + ".java");//NOI18N
                 String projectEncoding = JpaControllerUtil.

--- a/java/java.debug/src/org/netbeans/modules/java/debug/TreeNode.java
+++ b/java/java.debug/src/org/netbeans/modules/java/debug/TreeNode.java
@@ -181,7 +181,7 @@ public class TreeNode extends AbstractNode implements OffsetProvider {
     
     private String translate(String input) {
         for (int cntr = 0; cntr < c.length; cntr++) {
-            input = input.replaceAll(c[cntr], tags[cntr]);
+            input = input.replace(c[cntr], tags[cntr]);
         }
         
         return input;

--- a/java/java.editor/src/org/netbeans/modules/editor/java/GoToSupport.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/GoToSupport.java
@@ -1228,7 +1228,7 @@ public class GoToSupport {
     
     private static String translate(String input) {
         for (int cntr = 0; cntr < c.length; cntr++) {
-            input = input.replaceAll(c[cntr], tags[cntr]);
+            input = input.replace(c[cntr], tags[cntr]);
         }
         
         return input;

--- a/java/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ElementNode.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/ElementNode.java
@@ -136,7 +136,7 @@ public class ElementNode extends AbstractNode {
     
     private static String translateToHTML(String input) {
         for (int cntr = 0; cntr < c.length; cntr++) {
-            input = input.replaceAll(c[cntr], tags[cntr]);
+            input = input.replace(c[cntr], tags[cntr]);
         }
         
         return input;

--- a/java/java.editor/src/org/netbeans/modules/java/editor/fold/ResourceStringFoldProvider.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/fold/ResourceStringFoldProvider.java
@@ -235,7 +235,7 @@ public class ResourceStringFoldProvider extends ParsingFoldSupport{
                 message =  message.substring(0, newline);
                 
             }
-            message = message.replaceAll("\\.\\.\\.", "\u2026");
+            message = message.replace("...", "\u2026");
             
             FoldInfo info = FoldInfo.range(start, end, JavaFoldTypeProvider.BUNDLE_STRING).
                     withDescription(message).
@@ -365,7 +365,7 @@ public class ResourceStringFoldProvider extends ParsingFoldSupport{
                 if (pack.isUnnamed()) {
                     return null;
                 }
-                return pack.getQualifiedName().toString().replaceAll("\\.", "/") + "/" + bfn;
+                return pack.getQualifiedName().toString().replace(".", "/") + "/" + bfn;
             }
             return null;
         }

--- a/java/java.editor/src/org/netbeans/modules/java/editor/options/CodeCompletionPanel.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/options/CodeCompletionPanel.java
@@ -463,7 +463,7 @@ public class CodeCompletionPanel extends javax.swing.JPanel implements DocumentL
         String[] entries = text.split(","); // NOI18N
         for (String entry : entries) {
             // strip zero width spaces
-            entry = entry.replaceAll("\u200B", "");  // NOI18N
+            entry = entry.replace("\u200B", "");  // NOI18N
             entry = entry.trim();
             if (entry.length() != 0 && entry.matches(JAVA_FQN_REGEX)){
                 model.insertElementAt(entry, index);

--- a/java/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectIterator.java
+++ b/java/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectIterator.java
@@ -78,7 +78,7 @@ public class J2SESampleProjectIterator implements WizardDescriptor.AsynchronousI
         }
         String name = displayName;
         if (name != null) {
-            name = name.replaceAll(" ", ""); //NOI18N
+            name = name.replace(" ", ""); //NOI18N
         }
         templateWizard.putProperty (WizardProperties.NAME, name);        
         basicPanel = new PanelConfigureProject(displayName);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/LoggerStringConcat.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/LoggerStringConcat.java
@@ -178,10 +178,9 @@ public class LoggerStringConcat {
     }
     
     private static String literalToMessageFormat(String v) {
-        String fmtValue = v.replaceAll("'", "''");
-        fmtValue = fmtValue.replaceAll(Pattern.quote("{"), Matcher.quoteReplacement("'{'"));
-        fmtValue = fmtValue.replaceAll(Pattern.quote("}"), Matcher.quoteReplacement("'}'"));
-        return fmtValue;
+        return v.replace("'", "''")
+                .replace("{", "'{'")
+                .replace("}", "'}'");
     }
 
     private static void rewrite(WorkingCopy wc, ExpressionTree level, MethodInvocationTree invocation, TreePath message) {

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/ConvertAnonymousToInnerTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/ConvertAnonymousToInnerTest.java
@@ -651,7 +651,7 @@ public class ConvertAnonymousToInnerTest extends NbTestCase {
     }
     
     private static String removeWhitespaces(String text) {
-        return text.replaceAll(" ", "").replaceAll("\n", "");
+        return text.replace(" ", "").replace("\n", "");
     }
 
     public void test179766a() throws Exception {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
@@ -119,12 +119,10 @@ class NotifyDescriptorAdapter {
         if (!original.startsWith("<html>")) { // NOI18N
             return original;
         }
-        String res = 
-                original.replaceAll("<p/>|</p>|<br>", "\n"). // NOI18N
-                    replaceAll( "<[^>]*>", "" ). // NOI18N 
-                    replaceAll( "&nbsp;", " " ); // NOI18N 
-        res = res.trim();
-        return res;
+        return original.replaceAll("<p/>|</p>|<br>", "\n") // NOI18N
+                       .replaceAll("<[^>]*>", "")
+                       .replace("&nbsp;", " ") // NOI18N
+                       .trim();
     }
     
     public String getAccessibleDescription(Object o) {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
@@ -2738,7 +2738,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         
         str = Reformatter.reformat(str + " class A{}", cs, cs.getRightMargin() - col);
 
-        str = str.trim().replaceAll("\n", "\n" + whitespace(col));
+        str = str.trim().replace("\n", "\n" + whitespace(col));
 
         try {
             adjustSpans(annotations, str);

--- a/java/java.source.base/src/org/netbeans/modules/java/source/usages/ExecutableFilesIndex.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/usages/ExecutableFilesIndex.java
@@ -146,10 +146,8 @@ public class ExecutableFilesIndex {
         Set<String> result = new HashSet<String>();
 
         for (String file : executableFiles) {
-            file = file.replaceAll("\\\\d", ":"); //NOI18N
-            file = file.replaceAll("\\\\\\\\", "\\\\"); //NOI18N
-
-            result.add(file);
+            result.add(file.replace("\\d", ":") //NOI18N
+                           .replace("\\\\", "\\")); //NOI18N
         }
         
         return result;
@@ -159,15 +157,12 @@ public class ExecutableFilesIndex {
         StringBuilder attribute = new StringBuilder();
         boolean first = true;
 
-        for (String s : values) {
+        for (String value : values) {
             if (!first) {
                 attribute.append("::"); //NOI18N
             }
-            s = s.replaceAll("\\\\", "\\\\\\\\"); //NOI18N
-            s = s.replaceAll(":", "\\\\d"); //NOI18N
-
-            attribute.append(s);
-
+            attribute.append(value.replace("\\", "\\\\") //NOI18N
+                                  .replace(":", "\\d")); //NOI18N
             first = false;
         }
         

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RewriteInCommentTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RewriteInCommentTest.java
@@ -132,7 +132,7 @@ public class RewriteInCommentTest extends GeneratorTestBase {
             }
         });
 
-        assertEquals(code.replaceAll("test", "foo"), mr.getResultingSource(fo));
+        assertEquals(code.replace("test", "foo"), mr.getResultingSource(fo));
     }
     
     String getGoldenPckg() {

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/FastTypeProvider.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/FastTypeProvider.java
@@ -202,7 +202,7 @@ public final class FastTypeProvider implements TypeProvider {
 
             if (pkgName != null && !"".equals(pkgName)) {
                 StringBuilder sb = new StringBuilder();
-                s = sb.append(pkgName).append('.').append(simpleName).toString().replaceAll("\\.", "/"); // NOI18N
+                s = sb.append(pkgName).append('.').append(simpleName).toString().replace(".", "/"); // NOI18N
             }
             return root.getFileObject(s + JAVA_EXTENSION);
         }

--- a/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/UIJavaUtils.java
+++ b/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/UIJavaUtils.java
@@ -111,8 +111,8 @@ public final class UIJavaUtils {
 		    try {
 			TypeElement enclosingTypeElement = compilationController.getElementUtilities().enclosingTypeElement(method);
 			String originalPath = FileUtil.toFile(fo2open[0]).getAbsolutePath();
-			String elementFQP = element.toString().replaceAll("\\.", Matcher.quoteReplacement(File.separator)); //NOI18N
-			String newPath = originalPath.substring(0, originalPath.indexOf(elementFQP)) + enclosingTypeElement.getQualifiedName().toString().replaceAll("\\.", Matcher.quoteReplacement(File.separator)) + ".java"; //NOI18N
+			String elementFQP = element.toString().replace(".", File.separator); //NOI18N
+			String newPath = originalPath.substring(0, originalPath.indexOf(elementFQP)) + enclosingTypeElement.getQualifiedName().toString().replace(".", File.separator) + ".java"; //NOI18N
 			fo2open[0] = FileUtil.toFileObject(new File(newPath));
                         
                         if(fo2open[0] == null) {

--- a/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/hints/Utils.java
+++ b/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/hints/Utils.java
@@ -66,7 +66,7 @@ public class Utils {
 	    List<String> framework2Add = new ArrayList<String>();
 	    for (String framework : testingFrameworks) {
 		String preffiledName = Utils.getPreffiledName(info, framework);
-		preffiledName = preffiledName.replaceAll("\\.", "/").concat(".java"); //NOI18N
+		preffiledName = preffiledName.replace(".", "/").concat(".java"); //NOI18N
 		String path = targetFolderPath.concat("/").concat(preffiledName);
 		File f = new File(path);
 		FileObject fo = FileUtil.toFileObject(f);
@@ -77,7 +77,7 @@ public class Utils {
 		} else {
 		    try {
 			String testMethodName = getTestMethodName(methodName);
-			if (fo != null && !fo.asText().replaceAll("\n", "").trim().contains(testMethodName.concat("("))) { //NOI18N
+			if (fo != null && !fo.asText().replace("\n", "").trim().contains(testMethodName.concat("("))) { //NOI18N
 			    framework2Add.add(framework);
 			}
 		    } catch (IOException ex) {

--- a/java/jshell.support/src/org/netbeans/modules/jshell/tool/JShellTool.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/tool/JShellTool.java
@@ -451,7 +451,7 @@ public class JShellTool implements MessageHandler {
         String indentedNewLine = LINE_SEP + feedback.getPre()
                 + String.format("   %-" + (aLen + 4) + "s", "");
         for (Entry<String, String> e : a2b.entrySet()) {
-            hard(format, e.getKey(), e.getValue().replaceAll("\n", indentedNewLine));
+            hard(format, e.getKey(), e.getValue().replace("\n", indentedNewLine));
         }
     }
 

--- a/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitTestMethodNode.java
+++ b/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitTestMethodNode.java
@@ -78,7 +78,7 @@ public class AntJUnitTestMethodNode extends JUnitTestMethodNode {
             try {
                 String text = testFO.asText();
                 if (text != null) {
-                    text = text.replaceAll("\n", "").replaceAll(" ", "");
+                    text = text.replace("\n", "").replace(" ", "");
                     if ((text.contains("@RunWith") || text.contains("@org.junit.runner.RunWith")) //NOI18N
                             && text.contains("Parameterized.class)")) {  //NOI18N
                         parameterized = true;

--- a/java/junit.ant/src/org/netbeans/modules/junit/ant/XmlOutputParser.java
+++ b/java/junit.ant/src/org/netbeans/modules/junit/ant/XmlOutputParser.java
@@ -477,7 +477,7 @@ final class XmlOutputParser extends DefaultHandler {
             line = line.substring(0, logPos);
         }
 
-        Matcher matcher = regexp.getComparisonPattern().matcher(line.replaceAll("\n", "")); // NOI18N
+        Matcher matcher = regexp.getComparisonPattern().matcher(line.replace("\n", "")); // NOI18N
         if (matcher.matches()){
             String startExpected = "expected:<"; // NOI18N
             String startActual = "> but was:<"; // NOI18N

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestSingleMethodSupport.java
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestSingleMethodSupport.java
@@ -108,7 +108,7 @@ public class TestSingleMethodSupport {
 		if (pane != null) {
 		    String text = pane.getText();
                     if (text != null) {  //NOI18N
-                        text = text.replaceAll("\n", "").replaceAll(" ", "");
+                        text = text.replace("\n", "").replace(" ", "");
 			if ((text.contains("@RunWith") || text.contains("@org.junit.runner.RunWith")) //NOI18N
 			    && text.contains("Parameterized.class)")) {  //NOI18N
 			    return false;

--- a/java/junit/test/unit/src/org/netbeans/modules/junit/api/RegexpUtilsTest.java
+++ b/java/junit/test/unit/src/org/netbeans/modules/junit/api/RegexpUtilsTest.java
@@ -557,7 +557,7 @@ public class RegexpUtilsTest extends TestCase {
             assertFalse("should not match: " + string,
                         pattern.matcher(string).matches());
             assertTrue("should match: " + string,
-                        pattern.matcher(string.replaceAll("\n", "")).matches());
+                        pattern.matcher(string.replace("\n", "")).matches());
         }
     }
     

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
@@ -1553,7 +1553,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                                 }
                             }
                         } else if (ArtifactInfo.ARTIFACT_ID.equals(fieldName)) {
-                            String aid = one.replaceAll("-", "?").replaceAll("\\.", "?");
+                            String aid = one.replace("-", "?").replace(".", "?");
                             try {
                                 q = constructQuery(MAVEN.ARTIFACT_ID, aid);
                             } catch (IllegalArgumentException iae) {
@@ -1566,7 +1566,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                                 }
                             }
                         } else if (ArtifactInfo.GROUP_ID.equals(fieldName)) {
-                            String gid = one.replaceAll("-", "?").replaceAll("\\.", "?");
+                            String gid = one.replace("-", "?").replace(".", "?");
                             try {
                                 q = constructQuery(MAVEN.GROUP_ID, gid);
                             } catch (IllegalArgumentException iae) {

--- a/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
@@ -785,7 +785,7 @@ public class BasicPanelVisual extends JPanel implements DocumentListener, Window
         
         if (projectNameTextField.getDocument() == doc) {
             String projName = projectNameTextField.getText().trim();
-            txtArtifactId.setText(projName.replaceAll(" ", ""));
+            txtArtifactId.setText(projName.replace(" ", ""));
         }
         
         if (!changedPackage && (projectNameTextField.getDocument() == doc || txtGroupId.getDocument() == doc)) {

--- a/java/performance/src/org/netbeans/modules/performance/guitracker/ActionTracker.java
+++ b/java/performance/src/org/netbeans/modules/performance/guitracker/ActionTracker.java
@@ -758,12 +758,11 @@ public class ActionTracker {
     }
 
     private static String getShortenName(String name) {
-        name = name.replaceAll("javax.swing", "j");
-        name = name.replaceAll("org.netbeans.modules", "o.n.m");
-        name = name.replaceAll("org.netbeans", "o.n");
-        name = name.replaceAll("org.openide.awt", "o.o.a");
-        name = name.replaceAll("org.openide", "o.o");
-        return name;
+        return name.replace("javax.swing", "j")
+                   .replace("org.netbeans.modules", "o.n.m")
+                   .replace("org.netbeans", "o.n")
+                   .replace("org.openide.awt", "o.o.a")
+                   .replace("org.openide", "o.o");
     }
 
     /**

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveClassPanel.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveClassPanel.java
@@ -468,7 +468,7 @@ private void bypassRefactoringCheckBoxItemStateChanged(java.awt.event.ItemEvent 
                 SourceGroup g = (SourceGroup) rootComboBox.getSelectedItem();
                 String packageName = packageComboBox.getSelectedItem().toString();
                 if (packageComboBox.getSelectedIndex() > -1 && g != null && packageName != null) {
-                    String pathname = packageName.replaceAll("\\.", "/"); // NOI18N
+                    String pathname = packageName.replace(".", "/"); // NOI18N
                     FileObject fo = g.getRootFolder().getFileObject(pathname);
                     ClassPath bootCp = ClassPath.getClassPath(fo, ClassPath.BOOT);
                     if(bootCp == null) {

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveMembersPanel.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveMembersPanel.java
@@ -271,7 +271,7 @@ public class MoveMembersPanel extends javax.swing.JPanel implements CustomRefact
                 SourceGroup g = (SourceGroup) rootComboBox.getSelectedItem();
                 String packageName = packageComboBox.getSelectedItem().toString();
                 if (g != null && packageName != null) {
-                    String pathname = packageName.replaceAll("\\.", "/"); // NOI18N
+                    String pathname = packageName.replace(".", "/"); // NOI18N
                     FileObject fo = g.getRootFolder().getFileObject(pathname);
                     ClassPath bootCp = ClassPath.getClassPath(fo, ClassPath.BOOT);
                     ClassPath compileCp = ClassPath.getClassPath(fo, ClassPath.COMPILE);

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CustomScopePanel.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CustomScopePanel.java
@@ -693,7 +693,7 @@ public class CustomScopePanel extends javax.swing.JPanel implements ExplorerMana
                     ClassIndex index = cpInfo.getClassIndex();
                     Set<String> packageNames = index.getPackageNames("", false, EnumSet.of(ClassIndex.SearchScope.SOURCE)); // NOI18N
                     for (String packageName : packageNames) {
-                        String pathname = packageName.replaceAll("\\.", "/"); // NOI18N
+                        String pathname = packageName.replace(".", "/"); // NOI18N
                         final FileObject folder = sg.getRootFolder().getFileObject(pathname);
                         if(folder != null) {
                             PackageData data = new PackageData(sourceData, packageName, sourceData, folder, folders); // NOI18N

--- a/java/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/RefactoringTestCase.java
+++ b/java/refactoring.java/test/qa-functional/src/org/netbeans/modules/test/refactoring/RefactoringTestCase.java
@@ -205,7 +205,7 @@ public abstract class RefactoringTestCase extends JellyTestCase {
             Object invoke = method.invoke(parent);
             Label2Text parser = new Label2Text();
             String invoke_str = (String) invoke;
-            String ret = invoke_str.replaceAll("&nbsp;", " ");
+            String ret = invoke_str.replace("&nbsp;", " ");
             parser.parse(new StringReader(ret));
             ret = parser.result.toString();
             return ret;

--- a/java/testng.ui/src/org/netbeans/modules/testng/ui/wizards/NewTestSuiteWizardIterator.java
+++ b/java/testng.ui/src/org/netbeans/modules/testng/ui/wizards/NewTestSuiteWizardIterator.java
@@ -198,7 +198,7 @@ public final class NewTestSuiteWizardIterator implements WizardDescriptor.Instan
             packageName = FileUtil.getRelativePath(groups[i].getRootFolder(), targetFolder);
         }
         if (packageName != null) {
-            packageName = packageName.replaceAll("/", "."); // NOI18N
+            packageName = packageName.replace("/", "."); // NOI18N
         }
         return packageName;
     }

--- a/java/testng.ui/src/org/netbeans/modules/testng/ui/wizards/NewTestWizardIterator.java
+++ b/java/testng.ui/src/org/netbeans/modules/testng/ui/wizards/NewTestWizardIterator.java
@@ -252,7 +252,7 @@ public final class NewTestWizardIterator implements WizardDescriptor.Instantiati
             packageName = FileUtil.getRelativePath(groups[i].getRootFolder(), targetFolder);
         }
         if (packageName != null) {
-            packageName = packageName.replaceAll("/", "."); // NOI18N
+            packageName = packageName.replace("/", "."); // NOI18N
         }
         return packageName;
     }

--- a/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/ControllerFileMaker.java
+++ b/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/ControllerFileMaker.java
@@ -207,20 +207,20 @@ class ControllerFileMaker {
             fname = FMT_controllerClassName(capitalize(context.getName()));
             // folder name within the classpath. Make 
             String resName = cp.getResourceName(context.getPrimaryFile().getParent());
-            packageName = resName.replaceAll("/", ".");
+            packageName = resName.replace("/", ".");
             targetFolder = context.getFolder();
         } else {
             int dot = cn.lastIndexOf('.');
             if (dot == -1) {
                 fname = cn;
                 String resName = cp.getResourceName(context.getPrimaryFile().getParent());
-                packageName = resName.replaceAll("/", ".");
+                packageName = resName.replace("/", ".");
                 targetFolder = context.getFolder();
             } else {
                 // convert the prefix into package:
                 packageName = cn.substring(0, dot);
                 fname = cn.substring(dot + 1);
-                folderName = packageName.replaceAll("\\.", "/");
+                folderName = packageName.replace(".", "/");
                 FileObject folder;
                 
                 folder = root.getFileObject(folderName);

--- a/javafx/javafx2.samples/src/org/netbeans/modules/javafx2/samples/JavaFXSampleProjectIterator.java
+++ b/javafx/javafx2.samples/src/org/netbeans/modules/javafx2/samples/JavaFXSampleProjectIterator.java
@@ -85,7 +85,7 @@ public class JavaFXSampleProjectIterator implements TemplateWizard.Iterator {
         this.wiz = templateWizard;
         String name = templateWizard.getTemplate().getNodeDelegate().getDisplayName();
         if (name != null) {
-            name = name.replaceAll(" ", ""); //NOI18N
+            name = name.replace(" ", ""); //NOI18N
         }
         templateWizard.putProperty(WizardProperties.NAME, name);
         basicPanel = new PanelConfigureProject(templateWizard.getTemplate().getNodeDelegate().getDisplayName());

--- a/nb/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/ClusterUpdateProvider.java
+++ b/nb/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/ClusterUpdateProvider.java
@@ -90,7 +90,7 @@ public class ClusterUpdateProvider implements UpdateProvider {
     public Map<String, UpdateItem> getUpdateItems () throws IOException {
         Map<String, UpdateItem> res = new HashMap<String, UpdateItem> ();
         for (File cf: readModules (cluster)) {
-            String cnb = (cf.getName ().substring (0, cf.getName ().length () - ".xml".length ())).replaceAll ("-", "."); // NOI18N
+            String cnb = (cf.getName ().substring (0, cf.getName ().length () - ".xml".length ())).replace ("-", "."); // NOI18N
             Map<String, String> attr = new HashMap<String, String> (7);
             readConfigFile (cf, attr);
             String jarName = attr.get ("jar");

--- a/nb/welcome/src/org/netbeans/modules/welcome/content/RSSFeed.java
+++ b/nb/welcome/src/org/netbeans/modules/welcome/content/RSSFeed.java
@@ -494,9 +494,9 @@ public class RSSFeed extends JPanel implements Constants, PropertyChangeListener
     }
     
     private String stripHtml( String htmlSnippet ) {
-        String res = htmlSnippet.replaceAll( "<[^>]*>", "" ); // NOI18N // NOI18N
-        res = res.replaceAll( "&nbsp;", " " ); // NOI18N // NOI18N
-        return res.trim();
+        return htmlSnippet.replaceAll( "<[^>]*>", "" ) // NOI18N
+                          .replace( "&nbsp;", " " ) // NOI18N
+                          .trim();
     }
     
     protected int getMaxDecsriptionLength() {

--- a/php/languages.neon/src/org/netbeans/modules/languages/neon/lexer/NeonLexerUtils.java
+++ b/php/languages.neon/src/org/netbeans/modules/languages/neon/lexer/NeonLexerUtils.java
@@ -56,11 +56,9 @@ public final class NeonLexerUtils {
     }
 
     public static String replaceLinesAndTabs(String input) {
-        String escapedString = input;
-        escapedString = escapedString.replaceAll("\n", "\\\\n"); //NOI18N
-        escapedString = escapedString.replaceAll("\r", "\\\\r"); //NOI18N
-        escapedString = escapedString.replaceAll("\t", "\\\\t"); //NOI18N
-        return escapedString;
+        return input.replace("\n", "\\n") //NOI18N
+                    .replace("\r", "\\r") //NOI18N
+                    .replace("\t", "\\t"); //NOI18N
     }
 
 }

--- a/php/php.atoum/test/unit/src/org/netbeans/modules/php/atoum/coverage/CloverLogParserTest.java
+++ b/php/php.atoum/test/unit/src/org/netbeans/modules/php/atoum/coverage/CloverLogParserTest.java
@@ -103,9 +103,9 @@ public class CloverLogParserTest extends NbTestCase {
         Charset charset = StandardCharsets.UTF_8;
         String content = new String(Files.readAllBytes(path), charset);
         String workdirReplacement = Matcher.quoteReplacement(getDataDir().getAbsolutePath());
-        content = content.replaceAll("%WORKDIR%", workdirReplacement);
+        content = content.replace("%WORKDIR%", workdirReplacement);
         String separatorReplacement = Matcher.quoteReplacement(File.separator);
-        content = content.replaceAll("%SEP%", separatorReplacement);
+        content = content.replace("%SEP%", separatorReplacement);
         Files.write(path, content.getBytes(charset));
     }
 

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/lexer/PHPLexerUtils.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/lexer/PHPLexerUtils.java
@@ -138,20 +138,16 @@ public class PHPLexerUtils extends TestCase {
      * @return String the formatted string
      */
     public static String getXmlStringValue(String input) {
-        String escapedString = input;
-        escapedString = escapedString.replaceAll("&", "&amp;"); //$NON-NLS-1$ //$NON-NLS-2$
-        escapedString = escapedString.replaceAll(">", "&gt;"); //$NON-NLS-1$ //$NON-NLS-2$
-        escapedString = escapedString.replaceAll("<", "&lt;"); //$NON-NLS-1$ //$NON-NLS-2$
-        escapedString = escapedString.replaceAll("'", "&apos;"); //$NON-NLS-1$ //$NON-NLS-2$
-        escapedString = replaceLinesAndTabs(escapedString);
-        return escapedString;
+        String escapedString = input.replace("&", "&amp;") //$NON-NLS-1$ //$NON-NLS-2$
+                                    .replace(">", "&gt;") //$NON-NLS-1$ //$NON-NLS-2$
+                                    .replace("<", "&lt;") //$NON-NLS-1$ //$NON-NLS-2$
+                                    .replace("'", "&apos;"); //$NON-NLS-1$ //$NON-NLS-2$
+        return replaceLinesAndTabs(escapedString);
     }
     
     public static String replaceLinesAndTabs(String input) {
-        String escapedString = input;
-        escapedString = escapedString.replaceAll("\n","\\\\n");
-        escapedString = escapedString.replaceAll("\r","\\\\r");
-        escapedString = escapedString.replaceAll("\t","\\\\t");
-        return escapedString;
+        return input.replace("\n","\\n")
+                    .replace("\r","\\r")
+                    .replace("\t","\\t");
     }
 }

--- a/php/php.latte/test/unit/src/org/netbeans/modules/php/latte/utils/TestUtils.java
+++ b/php/php.latte/test/unit/src/org/netbeans/modules/php/latte/utils/TestUtils.java
@@ -53,9 +53,9 @@ public class TestUtils {
      */
     public static String replaceLinesAndTabs(String input) {
         String escapedString = input;
-        escapedString = escapedString.replaceAll("\n","\\\\n"); //NOI18N
-        escapedString = escapedString.replaceAll("\r","\\\\r"); //NOI18N
-        escapedString = escapedString.replaceAll("\t","\\\\t"); //NOI18N
+        escapedString = escapedString.replace("\n","\\n"); //NOI18N
+        escapedString = escapedString.replace("\r","\\r"); //NOI18N
+        escapedString = escapedString.replace("\t","\\t"); //NOI18N
         return escapedString;
     }
 

--- a/php/php.twig/test/unit/src/org/netbeans/modules/php/twig/editor/util/TestUtils.java
+++ b/php/php.twig/test/unit/src/org/netbeans/modules/php/twig/editor/util/TestUtils.java
@@ -58,9 +58,9 @@ public final class TestUtils {
      */
     public static String replaceLinesAndTabs(String input) {
         String escapedString = input;
-        escapedString = escapedString.replaceAll("\n","\\\\n"); //NOI18N
-        escapedString = escapedString.replaceAll("\r","\\\\r"); //NOI18N
-        escapedString = escapedString.replaceAll("\t","\\\\t"); //NOI18N
+        escapedString = escapedString.replace("\n","\\n"); //NOI18N
+        escapedString = escapedString.replace("\r","\\r"); //NOI18N
+        escapedString = escapedString.replace("\t","\\t"); //NOI18N
         return escapedString;
     }
 

--- a/platform/api.search/src/org/netbeans/modules/search/PatternSandbox.java
+++ b/platform/api.search/src/org/netbeans/modules/search/PatternSandbox.java
@@ -764,7 +764,7 @@ public abstract class PatternSandbox extends JPanel
         @Override
         protected void highlightIndividualMatches(Pattern p) {
 
-            String text = textPane.getText().replaceAll("\r\n", "\n");  //NOI18N
+            String text = textPane.getText().replace("\r\n", "\n");  //NOI18N
 
             Pattern sep = Pattern.compile("\n");                        //NOI18N
             Matcher m = sep.matcher(new TimeLimitedCharSequence(text));

--- a/platform/api.search/src/org/netbeans/modules/search/ui/ResultsOutlineSupport.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ui/ResultsOutlineSupport.java
@@ -23,7 +23,6 @@ import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.datatransfer.Transferable;
 import java.awt.event.HierarchyEvent;
-import java.awt.event.HierarchyListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -403,8 +402,7 @@ public class ResultsOutlineSupport {
                     : "<html>" + htmlName + "</html>";       // #214330 //NOI18N
             String stripped = (htmlName == null)
                     ? null
-                    : htmlName.replaceAll("<b>", "").replaceAll( //NOI18N
-                    "</b>", "");                                        //NOI18N
+                    : htmlName.replace("<b>", "").replace("</b>", "");  //NOI18N
             this.setDisplayName(stripped);
         }
 

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateUnitProviderImpl.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateUnitProviderImpl.java
@@ -324,7 +324,7 @@ public final class UpdateUnitProviderImpl {
         String codeName, String displayName, URL url, ProviderCategory c
     ) {
         if (codeName.contains ("/")) {
-            codeName = codeName.replaceAll ("/", "_");
+            codeName = codeName.replace ("/", "_");
         }
         Preferences providerPreferences = getPreferences ().node (codeName);
         assert providerPreferences != null : "Preferences node " + codeName + " found.";

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/PersistenceManager.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/PersistenceManager.java
@@ -1361,8 +1361,8 @@ public final class PersistenceManager implements PropertyChangeListener {
      */
     public static String escapeTcId4XmlContent (String tcName) {
         if (tcName.indexOf('&') != -1 || tcName.indexOf('\'') != -1) {
-            tcName = tcName.replaceAll("&", "&amp;");
-            tcName = tcName.replaceAll("'", "&apos;");
+            tcName = tcName.replace("&", "&amp;");
+            tcName = tcName.replace("'", "&apos;");
         }
         return tcName;
     }

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/Table.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/popupswitcher/Table.java
@@ -332,7 +332,7 @@ class Table extends JTable {
         if( null == htmlText )
             return null;
         String res = htmlText.replaceAll( "<[^>]*>", "" ); // NOI18N // NOI18N
-        res = res.replaceAll( "&nbsp;", " " ); // NOI18N // NOI18N
+        res = res.replace( "&nbsp;", " " ); // NOI18N // NOI18N
         res = res.trim();
         return res;
     }

--- a/platform/netbinox/src/org/netbeans/modules/netbinox/Netbinox.java
+++ b/platform/netbinox/src/org/netbeans/modules/netbinox/Netbinox.java
@@ -127,7 +127,7 @@ class Netbinox extends Equinox {
             final String pref = "reference:";
             if (url.startsWith(pref)) {
                 // workaround for problems with space in path
-                url = url.replaceAll("%20", " ");
+                url = url.replace("%20", " ");
                 String filePart = url.substring(pref.length());
                 if (installArea != null && filePart.startsWith(installArea)) {
                     String relPath = filePart.substring(installArea.length());

--- a/platform/o.n.bootstrap/src/org/netbeans/Stamps.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Stamps.java
@@ -914,7 +914,7 @@ public final class Stamps {
     }
 
     static String clusterLocalStamp(File cluster) {
-        return cluster.getName().replaceAll("\\.\\.", "__");
+        return cluster.getName().replace("..", "__");
     }
     
     static String readRelativePath(DataInput dis) throws IOException {

--- a/platform/o.n.core/src/org/netbeans/core/ProxySettings.java
+++ b/platform/o.n.core/src/org/netbeans/core/ProxySettings.java
@@ -253,8 +253,8 @@ public class ProxySettings {
     }
 
     private static String getModifiedNonProxyHosts (String systemPreset) {
-        String fromSystem = systemPreset.replaceAll (";", "|").replaceAll (",", "|"); //NOI18N
-        String fromUser = getPresetNonProxyHosts () == null ? "" : getPresetNonProxyHosts ().replaceAll (";", "|").replaceAll (",", "|"); //NOI18N
+        String fromSystem = systemPreset.replace (";", "|").replace (",", "|"); //NOI18N
+        String fromUser = getPresetNonProxyHosts () == null ? "" : getPresetNonProxyHosts ().replace (";", "|").replace (",", "|"); //NOI18N
         if (Utilities.isWindows ()) {
             fromSystem = addReguralToNonProxyHosts (fromSystem);
         }

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/outline/DefaultOutlineCellRenderer.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/outline/DefaultOutlineCellRenderer.java
@@ -273,9 +273,9 @@ public class DefaultOutlineCellRenderer extends DefaultTableCellRenderer {
                 if (displayName != null) {
                     if (rendata.isHtmlDisplayName(value) && !(displayName.startsWith("<html") || displayName.startsWith("<HTML"))) {
                         if (swingRendering) {
-                            setText("<html>" + displayName.replaceAll(" ", "&nbsp;") + "</html>"); // NOI18N
+                            setText("<html>" + displayName.replace(" ", "&nbsp;") + "</html>"); // NOI18N
                         } else {
-                            label.setText("<html>" + displayName.replaceAll(" ", "&nbsp;") + "</html>"); // NOI18N
+                            label.setText("<html>" + displayName.replace(" ", "&nbsp;") + "</html>"); // NOI18N
                         }
                     } else {
                         if (swingRendering) {

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/popupswitcher/SwitcherTable.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/popupswitcher/SwitcherTable.java
@@ -218,7 +218,7 @@ public class SwitcherTable extends JTable {
         if( null == htmlText )
             return null;
         String res = htmlText.replaceAll( "<[^>]*>", "" ); // NOI18N // NOI18N
-        res = res.replaceAll( "&nbsp;", " " ); // NOI18N // NOI18N
+        res = res.replace( "&nbsp;", " " ); // NOI18N // NOI18N
         res = res.trim();
         return res;
     }

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/TestUtilHid.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/TestUtilHid.java
@@ -335,7 +335,7 @@ public class TestUtilHid {
                 String urlVal = null;
 
                 if (fileContents != null) {
-                    urlVal = (path + getName()).replaceAll("/", "-");
+                    urlVal = (path + getName()).replace("/", "-");
                     File f = new File(baseFolder, urlVal);
                     FileWriter wr = new FileWriter(f);
                     wr.append(fileContents);

--- a/platform/openide.loaders/test/unit/src/org/openide/loaders/FolderOrderIllegalTest.java
+++ b/platform/openide.loaders/test/unit/src/org/openide/loaders/FolderOrderIllegalTest.java
@@ -93,7 +93,7 @@ public class FolderOrderIllegalTest extends NbTestCase {
         
         DataObject[] arr = f.getChildren();
         
-        String txt = Arrays.toString(arr).replaceAll(", ", "\n");
+        String txt = Arrays.toString(arr).replace(", ", "\n");
         assertEquals("All 10:\n" + txt, 10, arr.length);//fail("OK:\n" + txt);
     }
 }

--- a/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesLookupTest.java
+++ b/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesLookupTest.java
@@ -100,7 +100,7 @@ public class MetaInfServicesLookupTest extends NbTestCase {
         
         LOG.info("generating " + jar);
         
-        URL data = MetaInfServicesLookupTest.class.getResource(n.replaceAll("\\.jar", "\\.txt"));
+        URL data = MetaInfServicesLookupTest.class.getResource(n.replace(".jar", ".txt"));
         assertNotNull("Data found", data);
         StringBuffer sb = new StringBuffer();
         InputStreamReader r = new InputStreamReader(data.openStream());

--- a/platform/openide.util.ui/test/unit/src/org/openide/xml/XMLUtilTest.java
+++ b/platform/openide.util.ui/test/unit/src/org/openide/xml/XMLUtilTest.java
@@ -306,7 +306,7 @@ public class XMLUtilTest extends NbTestCase {
         doc.getDocumentElement().appendChild(doc.createElement("child"));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         XMLUtil.write(doc, baos, "UTF-8");
-        String data = baos.toString()/*#62680*/.replaceAll("\r\n", "\n");
+        String data = baos.toString()/*#62680*/.replace("\r\n", "\n");
         assertTrue("had reasonable indentation in\n" + data, data.indexOf("<root>\n    <child/>\n</root>\n") != -1);
     }
     
@@ -343,7 +343,7 @@ public class XMLUtilTest extends NbTestCase {
         c.appendChild(doc.importNode(d2, true));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         XMLUtil.write(doc, baos, "UTF-8");
-        String data2 = baos.toString().replaceAll("\r\n", "\n");
+        String data2 = baos.toString().replace("\r\n", "\n");
         //System.err.println("normalized data:\n" + ignoreSpaceChanges(data, doctype) + "\nnormalized data2:\n" + ignoreSpaceChanges(data2, doctype));
         assertEquals("identity replacement should not mess up indentation in \n" + data2, ignoreSpaceChanges(data, doctype), ignoreSpaceChanges(data2, doctype));
     }
@@ -369,7 +369,7 @@ public class XMLUtilTest extends NbTestCase {
         Document doc = XMLUtil.parse(new InputSource(new StringReader(data)), false, false, null, null);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         XMLUtil.write(doc, baos, "UTF-8");
-        String data2 = baos.toString().replaceAll("\r\n", "\n");
+        String data2 = baos.toString().replace("\r\n", "\n");
         assertEquals("identity replacement should not mess up significant whitespace", data, data2);
     }
     

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/LayersBridge.java
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/LayersBridge.java
@@ -959,7 +959,7 @@ public class LayersBridge extends KeymapManager implements KeymapManager.WithRev
                 if (name == null) {
                     name = ""; // #185619: not intended for presentation in this dialog
                 }
-                name = name.replaceAll ("&", "").trim (); // NOI18N
+                name = name.replace ("&", "").trim (); // NOI18N
             }
             return name;
         }

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/SpecialkeyPanel.java
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/SpecialkeyPanel.java
@@ -208,7 +208,7 @@ public class SpecialkeyPanel extends javax.swing.JPanel implements ActionListene
             } else if (source == wheelDownButton) {
                 text = "MOUSE_WHEEL_DOWN"; // NOI18N
             } else {
-                text = ((JButton) source).getText().toUpperCase().replaceAll(" ", "_"); // NOI18N
+                text = ((JButton) source).getText().toUpperCase().replace(" ", "_"); // NOI18N
             }
 
             //add the text to target textfield

--- a/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/recent/RecentSearches.java
+++ b/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/recent/RecentSearches.java
@@ -305,6 +305,6 @@ public class RecentSearches {
      * results.
      */
     private String translateHTMLEntities(String s) {
-        return s.replaceAll("\\&amp;", "&");                            //NOI18N
+        return s.replace("&amp;", "&");                            //NOI18N
     }
 }

--- a/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/Query.java
+++ b/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/Query.java
@@ -99,8 +99,8 @@ final class Query {
 
             public void run() {
                 String query = searchString;
-                query = query.replaceAll( " ", "+" ); //NOI18N //NOI18N
-                query = query.replaceAll( "#", "%23" ); //NOI18N //NOI18N
+                query = query.replace( " ", "+" ); //NOI18N //NOI18N
+                query = query.replace( "#", "%23" ); //NOI18N //NOI18N
                 query += "&num=" + MAX_NUM_OF_RESULTS; //NOI18N
                 query += "&hl=" + Locale.getDefault().getLanguage(); //NOI18N
                 if( null != SITE_SEARCH )

--- a/platform/uihandler/src/org/netbeans/modules/uihandler/SlownessReporter.java
+++ b/platform/uihandler/src/org/netbeans/modules/uihandler/SlownessReporter.java
@@ -98,7 +98,7 @@ class SlownessReporter {
                     latestActionClassName = getParam(rec, 4);
                 }
                 if (latestActionClassName != null) {
-                    latestActionClassName = latestActionClassName.replaceAll("&", ""); // NOI18N
+                    latestActionClassName = latestActionClassName.replace("&", ""); // NOI18N
                     Pattern p = Pattern.compile(DELEGATE_PATTERN);
                     Matcher m = p.matcher(latestActionClassName);
                     if (m.find()) {

--- a/webcommon/cordova.platforms/src/org/netbeans/modules/cordova/platforms/BrowserURLMapperImpl.java
+++ b/webcommon/cordova.platforms/src/org/netbeans/modules/cordova/platforms/BrowserURLMapperImpl.java
@@ -41,7 +41,7 @@ public class BrowserURLMapperImpl implements BrowserURLMapperImplementation {
             if (uri.getAuthority() != null && uri.getAuthority().contains("localhost")) { // NOI18N
                 String baseUrl = uri.getScheme() + "://" + uri.getAuthority();
                 return new BrowserURLMapperImplementation.BrowserURLMapper(baseUrl,
-                        baseUrl.replaceAll("localhost", WebUtils.getLocalhostInetAddress().getHostAddress())); // NOI18N
+                        baseUrl.replace("localhost", WebUtils.getLocalhostInetAddress().getHostAddress())); // NOI18N
             }
         } catch (URISyntaxException ex) {
             Exceptions.printStackTrace(ex);

--- a/webcommon/cordova.platforms/src/org/netbeans/modules/cordova/platforms/spi/MobileDebugTransport.java
+++ b/webcommon/cordova.platforms/src/org/netbeans/modules/cordova/platforms/spi/MobileDebugTransport.java
@@ -77,7 +77,7 @@ public abstract class MobileDebugTransport implements TransportImplementation {
      * @return 
      */
     protected final String translate(String toString) {
-        return toString.replaceAll("localhost", WebUtils.getLocalhostInetAddress().getHostAddress()); // NOI18N
+        return toString.replace("localhost", WebUtils.getLocalhostInetAddress().getHostAddress()); // NOI18N
     }
 
     public final void setBaseUrl(String documentURL) {
@@ -86,8 +86,8 @@ public abstract class MobileDebugTransport implements TransportImplementation {
             int idx = documentURL.lastIndexOf("/www/");
             assert idx > -1 : "document url does not contain 'www' in path: " + documentURL;
             documentURL = documentURL.substring(0, idx + "/www/".length());
-            documentURL = documentURL.replaceAll("file:///", "file:/");
-            documentURL = documentURL.replaceAll("file:/", "file:///");
+            documentURL = documentURL.replace("file:///", "file:/");
+            documentURL = documentURL.replace("file:/", "file:///");
             try { 
                 mapper.setBrowserURLRoot(WebUtils.urlToString(new URL(documentURL)));
             } catch (MalformedURLException ex) {

--- a/webcommon/cordova/src/org/netbeans/modules/cordova/CordovaPerformer.java
+++ b/webcommon/cordova/src/org/netbeans/modules/cordova/CordovaPerformer.java
@@ -458,7 +458,7 @@ public class CordovaPerformer implements BuildPerformer {
             FileObject config = project.getProjectDirectory().getFileObject(configPath);
             SourceConfig conf = new SourceConfig(FileUtil.toFile(config));
             if (fresh) {
-                final String appName = ProjectUtils.getInformation(project).getDisplayName().replaceAll(" ", "_").replaceAll("-", "_").replaceAll("\\.","_"); // NOI18N
+                final String appName = ProjectUtils.getInformation(project).getDisplayName().replace(" ", "_").replace("-", "_").replaceAll("\\.","_"); // NOI18N
                 conf.setId(DEFAULT_ID_PREFIX + "." + appName); // NOI18N
                 conf.setName(appName);
                 conf.setDescription(DEFAULT_DESCRIPTION);

--- a/webcommon/javascript.jstestdriver/src/org/netbeans/modules/javascript/jstestdriver/JSTestDriverSupport.java
+++ b/webcommon/javascript.jstestdriver/src/org/netbeans/modules/javascript/jstestdriver/JSTestDriverSupport.java
@@ -315,7 +315,7 @@ public class JSTestDriverSupport {
             String s = JSTestDriverCustomizerPanel.getServerURL();
             // #230400 - use IP address instead of localhost so that mobile browsers testing works:
             if (bd.getBrowserFamily().isMobile() && s.startsWith("http://localhost:")) {
-                s = s.replaceAll("localhost", WebUtils.getLocalhostInetAddress().getHostAddress());
+                s = s.replace("localhost", WebUtils.getLocalhostInetAddress().getHostAddress());
             }
             s = s+"/capture"; //NOI18N
             if (bd.hasNetBeansIntegration()) {

--- a/webcommon/javascript.v8debug.ui/src/org/netbeans/modules/javascript/v8debug/ui/eval/EvaluationResultsModel.java
+++ b/webcommon/javascript.v8debug.ui/src/org/netbeans/modules/javascript/v8debug/ui/eval/EvaluationResultsModel.java
@@ -174,16 +174,12 @@ public class EvaluationResultsModel extends VariablesModel {
         if (node == result.getResult()) {
             String str = result.getExpression();
             if (str != null) {
-                StringBuffer buf = new StringBuffer();
-                buf.append("<html>");
-                str = str.replaceAll ("&", "&amp;");
-                str = str.replaceAll ("<", "&lt;");
-                str = str.replaceAll (">", "&gt;");
-                str = str.replaceAll ("\n", "<br/>");
-                str = str.replaceAll ("\r", "");
-                buf.append(str);
-                buf.append("</html>");
-                return buf.toString();
+                str = str.replace ("&", "&amp;")
+                         .replace ("<", "&lt;")
+                         .replace (">", "&gt;")
+                         .replace ("\n", "<br/>")
+                         .replace ("\r", "");
+                return "<html>"+str+"</html>";
             }
         }
         if (node instanceof DefaultHistoryItem) {

--- a/webcommon/languages.apacheconf/src/org/netbeans/modules/languages/apacheconf/lexer/ApacheConfLexerUtils.java
+++ b/webcommon/languages.apacheconf/src/org/netbeans/modules/languages/apacheconf/lexer/ApacheConfLexerUtils.java
@@ -54,9 +54,9 @@ public class ApacheConfLexerUtils {
 
     public static String replaceLinesAndTabs(String input) {
         String escapedString = input;
-        escapedString = escapedString.replaceAll("\n","\\\\n"); //NOI18N
-        escapedString = escapedString.replaceAll("\r","\\\\r"); //NOI18N
-        escapedString = escapedString.replaceAll("\t","\\\\t"); //NOI18N
+        escapedString = escapedString.replace("\n", "\\n"); //NOI18N
+        escapedString = escapedString.replace("\r", "\\r"); //NOI18N
+        escapedString = escapedString.replace("\t", "\\t"); //NOI18N
         return escapedString;
     }
 

--- a/webcommon/languages.ini/test/unit/src/org/netbeans/modules/languages/ini/util/TestUtils.java
+++ b/webcommon/languages.ini/test/unit/src/org/netbeans/modules/languages/ini/util/TestUtils.java
@@ -56,9 +56,9 @@ public final class TestUtils {
      */
     public static String replaceLinesAndTabs(String input) {
         String escapedString = input;
-        escapedString = escapedString.replaceAll("\n","\\\\n"); //NOI18N
-        escapedString = escapedString.replaceAll("\r","\\\\r"); //NOI18N
-        escapedString = escapedString.replaceAll("\t","\\\\t"); //NOI18N
+        escapedString = escapedString.replace("\n", "\\n"); //NOI18N
+        escapedString = escapedString.replace("\r", "\\r"); //NOI18N
+        escapedString = escapedString.replace("\t", "\\t"); //NOI18N
         return escapedString;
     }
 

--- a/webcommon/selenium2.webclient/src/org/netbeans/modules/selenium2/webclient/api/TestRunnerReporter.java
+++ b/webcommon/selenium2.webclient/src/org/netbeans/modules/selenium2/webclient/api/TestRunnerReporter.java
@@ -229,7 +229,7 @@ public final class TestRunnerReporter {
     }
     
     static String removeEscapeCharachters(String line) {
-        return line.replace("[?25l", "").replace("[2K", "").replaceAll("\u001B", "").replaceAll("\\[[;\\d]*m", "").trim();
+        return line.replace("[?25l", "").replace("[2K", "").replace("\u001B", "").replaceAll("\\[[;\\d]*m", "").trim();
     }
 
     private Manager getManager() {

--- a/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/webkit/Utilities.java
+++ b/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/webkit/Utilities.java
@@ -142,7 +142,7 @@ public class Utilities {
                     int startLine = range.getStartLine();
                     if (start == -1 && startLine != -1) {
                         try {
-                            styleSheetText = styleSheetText.replaceAll("\r", ""); // NOI18N
+                            styleSheetText = styleSheetText.replace("\r", ""); // NOI18N
                             start = LexerUtils.getLineBeginningOffset(sourceModel.getModelSource(), startLine);
                             start += range.getStartColumn();
                             end = LexerUtils.getLineBeginningOffset(sourceModel.getModelSource(), range.getEndLine());

--- a/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/webkit/WebKitPageModel.java
+++ b/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/webkit/WebKitPageModel.java
@@ -773,7 +773,7 @@ public class WebKitPageModel extends PageModel {
     List<DOMNode> matchingNodes(String selector) {
         List<DOMNode> domNodes = Collections.EMPTY_LIST;
         if (selector != null) {
-            selector = selector.replaceAll(":hover", "." + CSSUtils.HOVER_CLASS); // NOI18N
+            selector = selector.replace(":hover", "." + CSSUtils.HOVER_CLASS); // NOI18N
             DOM dom = webKit.getDOM();
             Node documentElement = dom.getDocument();
             if (documentElement != null) {

--- a/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/eval/ui/EvaluationResultsModel.java
+++ b/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/eval/ui/EvaluationResultsModel.java
@@ -143,16 +143,12 @@ public class EvaluationResultsModel extends VariablesModel {
         if (node == result.getResult()) {
             String str = result.getExpression();
             if (str != null) {
-                StringBuffer buf = new StringBuffer();
-                buf.append("<html>");
-                str = str.replaceAll ("&", "&amp;");
-                str = str.replaceAll ("<", "&lt;");
-                str = str.replaceAll (">", "&gt;");
-                str = str.replaceAll ("\n", "<br/>");
-                str = str.replaceAll ("\r", "");
-                buf.append(str);
-                buf.append("</html>");
-                return buf.toString();
+                str = str.replace ("&", "&amp;")
+                         .replace ("<", "&lt;")
+                         .replace (">", "&gt;")
+                         .replace ("\n", "<br/>")
+                         .replace ("\r", "");
+                return "<html>"+str+"</html>";
             }
         }
         if (node instanceof DefaultHistoryItem) {


### PR DESCRIPTION
project wide micro optimization (low hanging fruits)

`String.replaceAll()` is expecting regexps as arguments, while `String.replace()` can be used for simple substitutions. Due to its sub-optimal name `replaceAll` is sometimes unintentionally used even without any regexps involved (as seen in this PR :)).

`String.replace()`
 - is cleaner / doesn't require additional character escaping
 - and safer / less error prone
 - is 10-20x faster /  produces less garbage
 
this might fix some bugs too, for example `localizedBundlepath.replaceAll(".properties", ...)` didn't escape the '.' which could potentially cause issues with certain filenames.

used [jackpot rules](https://github.com/mbien/jackpot-inspections/blob/0832be385a6512eceebeef7651423d71c5315b90/ProbableBugs.hint#L25-L30) for the simple cases and to find candidates, adjustments were made manually.

I looked through it at least twice by now + ran some manual tests with a dev build.

split into 6 commits to make review easier, planning to squash after approval.