### PR TITLE
Support for Call Hierarchy for LSP

### DIFF
--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -51,6 +51,21 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="CallHierarchyProvider">
+        <api name="LSP_API"/>
+        <summary>Added CallHierarchyProvider and relevant elements</summary>
+        <version major="1" minor="9"/>
+        <date day="9" month="3" year="2022"/>
+        <author login="sdedic"/>
+        <compatibility binary="compatible" source="compatible" addition="yes" deletion="no"/>
+        <description>
+            <a href="@TOP@/org/netbeans/spi/lsp/CallHiearchyProvider.html">CallHierarchyProvider</a> SPI allows to trace incoming and
+            outgoing calls. <a href="@TOP@/org/netbeans/api/lsp/CallHierarchyEntry.html">CallHierarchyEntry</a> describes a specific call site 
+            or target.
+        </description>
+        <class package="org.netbeans.api.lsp" name="CallHierarchyEntry"/>
+        <class package="org.netbeans.spi.lsp" name="CallHierarchyProvider"/>
+    </change>
     <change id="StructureProvider">
         <api name="LSP_API"/>
         <summary>Adding StructeProvider and StructureElement</summary>

--- a/ide/api.lsp/manifest.mf
+++ b/ide/api.lsp/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.lsp/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/lsp/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.8
+OpenIDE-Module-Specification-Version: 1.9
 AutoUpdate-Show-In-Client: false
 

--- a/ide/api.lsp/src/org/netbeans/api/lsp/CallHierarchyEntry.java
+++ b/ide/api.lsp/src/org/netbeans/api/lsp/CallHierarchyEntry.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.lsp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.spi.lsp.CallHierarchyProvider;
+
+/**
+ * Represents an entry in a call hierarchy chain. The entry identifies an element in a source which is the origin or target
+ * of an invocation/call. 
+ * 
+ * @since 1.9
+ * @author sdedic
+ */
+public final class CallHierarchyEntry {
+    /**
+     * The call origin or target element.
+     */
+    private StructureElement    element;
+    
+    /**
+     * Opaque implementation-specific data.
+     */
+    private String  customData;
+
+    /**
+     * Returns description of the call hierarchy element. See {@link StructureElemen} for structure details,
+     * @return description of the structural languagein call hierarchy
+     */
+    @NonNull
+    public StructureElement getElement() {
+        return element;
+    }
+    
+    /**
+     * Returns an opaque, mime type specific data which shall be interpreted by the {@link CallHierarchyProvider}
+     * in subsequent calls. For example, method signature can be put here.
+     * @return provider-specific data
+     */
+    @CheckForNull
+    public String getCustomData() {
+        return customData;
+    }
+
+    /**
+     * Constructs a new entry object.
+     * @param element represents call target or call origin, depending on usage
+     * @param customData implementation-specific data
+     */
+    public CallHierarchyEntry(StructureElement element, String customData) {
+        this.element = element;
+        this.customData = customData;
+    }
+    
+    
+    /**
+     * This structure is used for two purposes. For <b>outgoing calls</b> the {@link #getItem}
+     * returns the call target, and {@link #getRanges} returns locations in the origin
+     * {@link CallHierarchyElement} where the target is invoked from. For <b>incoming calls</b>
+     * the {@link #getItem} identifies the element that makes the call, while {@link #getRanges}
+     * locations where the call was made from from that element.
+     * 
+     */
+    public static final class Call {
+        private final CallHierarchyEntry item;
+        private final List<Range> ranges;
+
+        public Call(@NonNull CallHierarchyEntry item, List<Range> ranges) {
+            this.item = item;
+            this.ranges = ranges.size() > 1 ? 
+                        Collections.unmodifiableList(new ArrayList<>(ranges))
+                    : ranges.isEmpty() ? 
+                        Collections.emptyList() : Collections.singletonList(ranges.get(0));
+        }
+        
+        /**
+         * @return Target or origin element of the call.
+         */
+        @NonNull
+        public CallHierarchyEntry getItem() {
+            return item;
+        }
+
+        /**
+         * @return text locations within the origin element where the target is invoked.
+         */
+        public List<Range> getRanges() {
+            return ranges;
+        }
+    }
+}

--- a/ide/api.lsp/src/org/netbeans/api/lsp/Range.java
+++ b/ide/api.lsp/src/org/netbeans/api/lsp/Range.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.lsp;
+
+/**
+ * Represents a textual range. Range covers text from `startOffset' to `endOffset' (exclusive).
+ * @since 1.9
+ */
+public final class Range {
+
+    private final int startOffset;
+    private final int endOffset;
+
+    /**
+     * Creates a range from startOffset, up to and excluding endOffset.
+     * @param startOffset start of the range
+     * @param endOffset end of the range, exclusive
+     */
+    public Range(int startOffset, int endOffset) {
+        this.startOffset = startOffset;
+        this.endOffset = endOffset;
+    }
+
+    /**
+     * @return start of the range.
+     */
+    public int getStartOffset() {
+        return startOffset;
+    }
+
+    /**
+     * @return end of the range.
+     */
+    public int getEndOffset() {
+        return endOffset;
+    }
+    
+}

--- a/ide/api.lsp/src/org/netbeans/modules/lsp/StructureElementAccessor.java
+++ b/ide/api.lsp/src/org/netbeans/modules/lsp/StructureElementAccessor.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.lsp.StructureElement;
+import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
 import org.openide.util.Parameters;
 
@@ -53,6 +54,6 @@ public abstract class StructureElementAccessor {
         DEFAULT = accessor;
     }
     
-    public abstract StructureElement createStructureElement(@NonNull String name, String detail, int selectionStartOffset, int selectionEndOffset, int expandedStartOffset, int expandedEndOffset, @NonNull StructureElement.Kind kind, Set<StructureElement.Tag> tags, List<StructureElement> children);
+    public abstract StructureElement createStructureElement(FileObject file, @NonNull String name, String detail, int selectionStartOffset, int selectionEndOffset, int expandedStartOffset, int expandedEndOffset, @NonNull StructureElement.Kind kind, Set<StructureElement.Tag> tags, List<StructureElement> children);
     
 }

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/CallHierarchyProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/CallHierarchyProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.spi.lsp;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.swing.text.Document;
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.lsp.CallHierarchyEntry;
+
+/**
+ * Provides call hierarchy for the given location in a document. May provide list of
+ * calls originating from an element (i.e. method, field initializer), or callers to
+ * the element at the passed document's offset.
+ * <p>
+ * First {@link #findCallOrigin} should be called, producing a {@link CallHierarchyEntry} 
+ * that describes the element at the given position. In subsequent calls, inbound or
+ * outbound calls may be inspected for the passed Entry using {@link #findIncomingCalls}
+ * or {@link #findOugoingCalls}. 
+ * <p>
+ * Note that the returned CompletableFutures may become completed cancelled if the implementation (for example)
+ * displays user-facing UI like progress, which allows the user to interrupt the operation. If the reported
+ * exception is a {@link java.util.concurrent.CompletionException}, its cause should be also checked.
+ * 
+ * @since 1.9
+ * @author sdedic
+ */
+public interface CallHierarchyProvider {
+    /**
+     * Returns a {@link CallHierarchyEntry} that corresponds to the given document's location. 
+     * If the location does not represent a valid starting point, the returned Future will complete
+     * with {@code null} result. Any errors, i.e. parsing or I/O will be reported through the
+     * returned Future.
+     * <p>
+     * 
+     * @param doc the document
+     * @param offset location in the document
+     * @return location entry, or {@code null}
+     */
+    @CheckForNull
+    public CompletableFuture<List<CallHierarchyEntry>> findCallOrigin(@NonNull Document doc, int offset);
+
+    /**
+     * Returns a list of locations that call into the passed call target. The method may return {@code null}, if the
+     * call target location is not supported or is invalid. The {@link CallHierarchyEntry.Call#getRanges() Call.getRanges()} 
+     * describes ranges int he caller {@link StructureElement} where the target is invoked.
+     * @param callTarget the call target location
+     * @return list of callers, or {@code null}
+     */
+    @CheckForNull
+    public CompletableFuture<List<CallHierarchyEntry.Call>> findIncomingCalls(@NonNull CallHierarchyEntry callTarget);
+
+    /**
+     * Returns a list of locations that are called from the passed source. The method may return {@code null}, if the
+     * call target location is not supported or is invalid. The {@link CallHierarchyEntry.Call#getRanges() Call.getRanges()} 
+     * describe ranges in the call source, where the specific {@link StructureElement} target is called from.
+     * @param callSource the location to inspect
+     * @return list of callees, or {@code null}
+     */
+    @CheckForNull
+    public CompletableFuture<List<CallHierarchyEntry.Call>> findOutgoingCalls(@NonNull CallHierarchyEntry callSource);
+}

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import javax.swing.text.Document;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.modules.lsp.StructureElementAccessor;
+import org.openide.filesystems.FileObject;
 
 /**
  * Interface for building structure of symbols at a given document.
@@ -99,6 +100,7 @@ public interface StructureProvider {
         private StructureElement.Kind kind;
         private Set<StructureElement.Tag> tags;
         private List<StructureElement> children;
+        private FileObject file;
 
         private Builder(@NonNull String name, @NonNull StructureElement.Kind kind) {
             this.name = name;
@@ -247,6 +249,18 @@ public interface StructureProvider {
         }
         
         /**
+         * Sets file which contains the structure element. {@code null} stands
+         * for either implicit or inaccessible.
+         * @param f file object
+         * @return this instance
+         * @since 1.9
+         */
+        public Builder file(FileObject f) {
+            this.file = f;
+            return this;
+        }
+        
+        /**
          * Builds structure element.
          *
          * @since 1.8
@@ -254,7 +268,7 @@ public interface StructureProvider {
         @NonNull
         public StructureElement build() {
             return StructureElementAccessor.getDefault()
-                    .createStructureElement(name, detail, selectionStartOffset, 
+                    .createStructureElement(file, name, detail, selectionStartOffset, 
                             selectionEndOffset, expandedStartOffset, expandedEndOffset, 
                             kind, tags, children);
         }

--- a/java/java.editor/nbproject/project.xml
+++ b/java/java.editor/nbproject/project.xml
@@ -58,7 +58,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.2</specification-version>
+                        <specification-version>1.9</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -257,7 +257,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.58</specification-version>
+                        <specification-version>1.63</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
@@ -18,37 +18,24 @@
  */
 package org.netbeans.modules.editor.java;
 
-import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
-import com.sun.source.tree.MethodTree;
-import com.sun.source.tree.NewClassTree;
-import com.sun.source.tree.Tree;
-import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
-import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.PackageElement;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.TypeParameterElement;
-import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.ArrayType;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.swing.text.Document;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
 import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.ElementUtilities;
 import org.netbeans.api.java.source.JavaSource;
-import org.netbeans.api.java.source.TreeUtilities;
+import org.netbeans.api.java.source.ui.ElementHeaders;
 import org.netbeans.api.lsp.StructureElement;
 import org.netbeans.spi.lsp.StructureProvider;
 
@@ -99,220 +86,14 @@ public class JavaStructureProvider implements StructureProvider {
         return Collections.EMPTY_LIST;
     }
 
+    private static final ElementUtilities.ElementAcceptor ALL_ACCEPTOR = new ElementUtilities.ElementAcceptor() {
+        @Override
+        public boolean accept(Element e, TypeMirror type) {
+            return true;
+        }
+    };
+    
     private static StructureElement element2StructureElement(CompilationInfo info, Element el) {
-        TreePath path = info.getTrees().getPath(el);
-        if (path == null) {
-            return null;
-        }
-        TreeUtilities tu = info.getTreeUtilities();
-        if (tu.isSynthetic(path)) {
-            return null;
-        }
-
-        Builder builder = StructureProvider.newBuilder(createName(info, el), convertKind(el.getKind()));
-        builder.detail(createDetail(info, el));
-        setOffsets(info, el, builder);
-        if (info.getElements().isDeprecated(el)) {
-            builder.addTag(StructureElement.Tag.Deprecated);
-        }
-        for (Element child : el.getEnclosedElements()) {
-            StructureElement jse = element2StructureElement(info, child);
-            if (jse != null) {
-                builder.children(jse);
-            }
-        }
-        if (path.getLeaf().getKind() == Tree.Kind.METHOD || path.getLeaf().getKind() == Tree.Kind.VARIABLE) {
-            getAnonymousInnerClasses(info, path, builder);
-        }
-        return builder.build();
-    }
-
-    private static String createName(CompilationInfo ci, Element original) {
-        switch (original.getKind()) {
-            case PACKAGE:
-                PackageElement pe = (PackageElement) original;
-                return pe.getSimpleName().toString();
-            case CLASS:
-            case INTERFACE:
-            case ENUM:
-            case ANNOTATION_TYPE:
-            case RECORD:
-                TypeElement te = (TypeElement) original;
-                StringBuilder sb = new StringBuilder();
-                sb.append(te.getSimpleName());
-                List<? extends TypeParameterElement> typeParams = te.getTypeParameters();
-                if (typeParams != null && !typeParams.isEmpty()) {
-                    sb.append("<"); // NOI18N
-                    for (Iterator<? extends TypeParameterElement> it = typeParams.iterator(); it.hasNext();) {
-                        TypeParameterElement tp = it.next();
-                        sb.append(tp.getSimpleName());
-                        List<? extends TypeMirror> bounds = tp.getBounds();
-                        if (!bounds.isEmpty()) {
-                            if (bounds.size() > 1 || !"java.lang.Object".equals(bounds.get(0).toString())) { // NOI18N
-                                sb.append(" extends "); // NOI18N
-                                for (Iterator<? extends TypeMirror> bIt = bounds.iterator(); bIt.hasNext();) {
-                                    sb.append(Utilities.getTypeName(ci, bIt.next(), false));
-                                    if (bIt.hasNext()) {
-                                        sb.append(" & "); // NOI18N
-                                    }
-                                }
-                            }
-                        }
-                        if (it.hasNext()) {
-                            sb.append(", "); // NOI18N
-                        }
-                    }
-                    sb.append(">"); // NOI18N
-                }
-                return sb.toString();
-            case FIELD:
-            case ENUM_CONSTANT:
-            case RECORD_COMPONENT:
-                return original.getSimpleName().toString();
-            case CONSTRUCTOR:
-            case METHOD:
-                ExecutableElement ee = (ExecutableElement) original;
-                sb = new StringBuilder();
-                if (ee.getKind() == ElementKind.CONSTRUCTOR) {
-                    sb.append(ee.getEnclosingElement().getSimpleName());
-                } else {
-                    sb.append(ee.getSimpleName());
-                }
-                sb.append("("); // NOI18N
-                for (Iterator<? extends VariableElement> it = ee.getParameters().iterator(); it.hasNext();) {
-                    VariableElement param = it.next();
-                    if (!it.hasNext() && ee.isVarArgs() && param.asType().getKind() == TypeKind.ARRAY) {
-                        sb.append(Utilities.getTypeName(ci, ((ArrayType) param.asType()).getComponentType(), false, false));
-                        sb.append("...");
-                    } else {
-                        sb.append(Utilities.getTypeName(ci, param.asType(), false, false));
-                    }
-                    sb.append(" "); // NOI18N
-                    sb.append(param.getSimpleName());
-                    if (it.hasNext()) {
-                        sb.append(", "); // NOI18N
-                    }
-                }
-                sb.append(")"); // NOI18N
-                return sb.toString();
-        }
-        return null;
-    }
-
-    private static StructureElement.Kind convertKind(ElementKind kind) {
-        switch (kind) {
-            case PACKAGE:
-                return StructureElement.Kind.Package;
-            case ENUM:
-                return StructureElement.Kind.Enum;
-            case CLASS:
-            case RECORD:
-                return StructureElement.Kind.Class;
-            case ANNOTATION_TYPE:
-                return StructureElement.Kind.Interface;
-            case INTERFACE:
-                return StructureElement.Kind.Interface;
-            case ENUM_CONSTANT:
-            case RECORD_COMPONENT:
-                return StructureElement.Kind.EnumMember;
-            case FIELD:
-                return StructureElement.Kind.Field; //TODO: constant
-            case PARAMETER:
-                return StructureElement.Kind.Variable;
-            case LOCAL_VARIABLE:
-                return StructureElement.Kind.Variable;
-            case EXCEPTION_PARAMETER:
-                return StructureElement.Kind.Variable;
-            case METHOD:
-                return StructureElement.Kind.Method;
-            case CONSTRUCTOR:
-                return StructureElement.Kind.Constructor;
-            case TYPE_PARAMETER:
-                return StructureElement.Kind.TypeParameter;
-            case RESOURCE_VARIABLE:
-                return StructureElement.Kind.Variable;
-            case MODULE:
-                return StructureElement.Kind.Module;
-            case STATIC_INIT:
-            case INSTANCE_INIT:
-            case OTHER:
-            default:
-                return StructureElement.Kind.File; //XXX: what here?
-            }
-    }
-    
-    private static String createDetail(CompilationInfo ci, Element original) {
-        ElementKind kind = original.getKind();
-        String detail = null;
-        if (kind == ElementKind.FIELD || kind == ElementKind.METHOD) {
-            StringBuilder sb = new StringBuilder();
-            if (kind == ElementKind.FIELD) {
-                sb.append(": ");
-                sb.append(Utilities.getTypeName(ci, original.asType(), false));
-                detail = sb.toString();
-            } else {
-                // METHOD   
-                TypeMirror rt = ((ExecutableElement) original).getReturnType();
-                if (rt.getKind() == TypeKind.VOID) {
-                    sb.append(": void");
-                } else {
-                    sb.append(": ");
-                    sb.append(Utilities.getTypeName(ci, rt, false));
-                }
-            }
-            detail = sb.toString();
-        }
-        return detail;
-    }
-    
-    private static void setOffsets(CompilationInfo ci, Element original, Builder builder) {
-        TreePath path = ci.getTrees().getPath(original);
-        Tree tree = path.getLeaf();
-        long start = ci.getTrees().getSourcePositions().getStartPosition(ci.getCompilationUnit(), tree);
-        int expandedStart = (int) start;
-        long end = ci.getTrees().getSourcePositions().getEndPosition(ci.getCompilationUnit(), tree);
-        if (end == -1) {
-            end = start;
-        }
-        int expandedEnd = (int) end;
-        builder.expandedStartOffset(expandedStart).expandedEndOffset(expandedEnd);
-        int[] span = null;
-        switch (tree.getKind()) {
-            case CLASS:
-                span = ci.getTreeUtilities().findNameSpan((ClassTree) tree);
-                break;
-            case METHOD:
-                span = ci.getTreeUtilities().findNameSpan((MethodTree) tree);
-                break;
-            case VARIABLE:
-                span = ci.getTreeUtilities().findNameSpan((VariableTree) tree);
-                break;
-        }
-        if (span == null) {
-            builder.selectionStartOffset(expandedStart).selectionEndOffset(expandedEnd);
-        } else {
-            builder.selectionStartOffset(span[0]).selectionEndOffset(span[1]);
-        }
-    }
-    
-    private static void getAnonymousInnerClasses(CompilationInfo info, TreePath path, Builder builder) {
-        new TreePathScanner<Void, Void>() {
-            @Override
-            public Void visitNewClass(NewClassTree node, Void p) {
-                if (node.getClassBody() != null) {
-                    Element e = info.getTrees().getElement(new TreePath(getCurrentPath(), node.getClassBody()));
-                    if (e != null) {
-                        Element te = info.getTrees().getElement(new TreePath(getCurrentPath(), node.getIdentifier()));
-                        if (te != null) {
-                            StructureElement jse = element2StructureElement(info, te);
-                            if (jse != null) {
-                                builder.children(jse);
-                            }
-                        }
-                    }
-                }
-                return null;
-            }
-        }.scan(path, null);
+        return ElementHeaders.toStructureElement(info, el, ALL_ACCEPTOR);
     }
 }

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -128,7 +128,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.4</specification-version>
+                        <specification-version>1.9</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -46,6 +46,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import com.google.gson.InstanceCreator;
 import com.google.gson.JsonObject;
+import org.eclipse.lsp4j.CallHierarchyRegistrationOptions;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeLensOptions;
@@ -709,6 +710,10 @@ public final class Server {
                 capabilities.setImplementationProvider(true);
                 capabilities.setDocumentHighlightProvider(true);
                 capabilities.setReferencesProvider(true);
+                
+                CallHierarchyRegistrationOptions chOpts = new CallHierarchyRegistrationOptions();
+                chOpts.setWorkDoneProgress(true);
+                capabilities.setCallHierarchyProvider(chOpts);
                 List<String> commands = new ArrayList<>(Arrays.asList(GRAALVM_PAUSE_SCRIPT,
                         JAVA_BUILD_WORKSPACE,
                         JAVA_CLEAN_WORKSPACE,

--- a/java/java.sourceui/apichanges.xml
+++ b/java/java.sourceui/apichanges.xml
@@ -84,6 +84,20 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="StructureElement">
+            <api name="general"/>
+            <summary>Added conversion from javac Elements to LSP structures.</summary>
+            <version major="1" minor="63"/>
+            <date day="9" month="3" year="2022"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes"/>
+            <description>
+                Utility methods for conversion of javac-specific <code>Elements</code> to abstracted 
+                <a href="@org-netbeans-api-lsp@/org/netbeans/api/lsp/StructureElement.html">StructureElements</a> defined by
+                the LSP protocol.
+            </description>
+            <class package="org.netbeans.api.java.source.ui" name="ElementHeaders"/>
+        </change>
         <change id="ElementOpenGetLocation">
             <api name="general"/>
             <summary>Adding ElementOpen.getLocation(ClasspathInfo, ElementHandle, String)</summary>

--- a/java/java.sourceui/nbproject/project.properties
+++ b/java/java.sourceui/nbproject/project.properties
@@ -18,7 +18,7 @@ javadoc.apichanges=${basedir}/apichanges.xml
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
-spec.version.base=1.62.0
+spec.version.base=1.63.0
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/java/java.sourceui/nbproject/project.xml
+++ b/java/java.sourceui/nbproject/project.xml
@@ -53,6 +53,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.api.lsp</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.8</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -356,6 +365,14 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.java.j2seplatform</code-name-base>
+                        <recursive/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.java.platform.ui</code-name-base>
+                        <recursive/>
                     </test-dependency>
                 </test-type>
             </test-dependencies>

--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementHeaders.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementHeaders.java
@@ -24,11 +24,19 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
+import java.util.concurrent.CompletableFuture;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Name;
+import javax.lang.model.type.TypeMirror;
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.java.queries.SourceJavadocAttacher;
 import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.ElementUtilities;
 import org.netbeans.api.java.source.TreeUtilities;
+import org.netbeans.api.lsp.StructureElement;
 import org.netbeans.modules.java.source.pretty.VeryPretty;
+import org.netbeans.modules.java.source.ui.LspElementUtils;
 import org.netbeans.modules.java.ui.ElementHeaderFormater;
 
 /**
@@ -190,6 +198,91 @@ public final class ElementHeaders {
 
    }
     
-    
+   /**
+    * Converts an javac {@link Element} into LSP {@link StructureElement}. This method does not
+    * work for binary elements, just for elements from the parsed source. To work with
+    * non-local elements, use {@link #resolveStructureElement}. If {@code childAcceptor}
+    * is not {@code null}, children are fetched recursively and filed into {@link StructureElement#getChildren()}; 
+    * the acceptor is applied to all levels. The method returns {@code null} if the passed CompilationInfo
+    * does not contain source information for the Element.
+    * 
+    * @param info compilation info
+    * @param el element to convert
+    * @param childAcceptor {@code null} to ignore children, non-null to filter.
+    * @return created item or {@code null}
+    * @since 1.63
+    */
+    @CheckForNull
+    public static StructureElement toStructureElement(CompilationInfo info, Element el, ElementUtilities.ElementAcceptor childAcceptor) {
+        return LspElementUtils.element2StructureElement(info, el, childAcceptor);
+    }
 
+    /**
+     * Converts a javac {@link Element} into LSP {@link StructureElement}. This method supports also elements that are not part of
+     * the "{@code info}" compilation. If `{@code resolveSources}' is true, it will try to acquire their relevant source, possibly using
+     * {@link SourceJavadocAttacher} API.
+     * As this process may take some time, the call may complete asynchronously when the element's source is acquired. {@code null}
+     * is returned for Elements outside that have no source associated when {@code resolveSources} is false.
+     * <p>
+     * Calling {@link CompletableFuture#cancel} on the returned value performs cancel on the possible long-running task(s) in a best-effort way: it is
+     * not guaranteed that the already started processes interrupt.
+     * @param info compilation
+     * @param el the element to convert
+     * @param resolveSources 
+     * @return completion handle for the StructureElement
+    * @since 1.63
+     */
+    public static CompletableFuture<StructureElement> resolveStructureElement(CompilationInfo info, Element el, boolean resolveSources) {
+        return LspElementUtils.createStructureElement(info, el, resolveSources);
+    }
+
+    /**
+     * Converts Javac {@link ElementKind} to a suitable LSP structure kind. Note
+     * that not all kinds are supported - such ElementKinds are converted to
+     *
+     * @param kind
+     * @return LSP kind suitable for DocumentSymbol - like structures.
+     */
+    public static StructureElement.Kind javaKind2Structure(Element el) {
+        ElementKind kind = el.getKind();
+        switch (kind) {
+            case PACKAGE:
+                return StructureElement.Kind.Package;
+            case ENUM:
+                return StructureElement.Kind.Enum;
+            case CLASS:
+            case RECORD:
+                return StructureElement.Kind.Class;
+            case ANNOTATION_TYPE:
+                return StructureElement.Kind.Interface;
+            case INTERFACE:
+                return StructureElement.Kind.Interface;
+            case ENUM_CONSTANT:
+            case RECORD_COMPONENT:
+                return StructureElement.Kind.EnumMember;
+            case FIELD:
+                return StructureElement.Kind.Field; //TODO: constant
+            case PARAMETER:
+                return StructureElement.Kind.Variable;
+            case LOCAL_VARIABLE:
+                return StructureElement.Kind.Variable;
+            case EXCEPTION_PARAMETER:
+                return StructureElement.Kind.Variable;
+            case METHOD:
+                return StructureElement.Kind.Method;
+            case CONSTRUCTOR:
+                return StructureElement.Kind.Constructor;
+            case TYPE_PARAMETER:
+                return StructureElement.Kind.TypeParameter;
+            case RESOURCE_VARIABLE:
+                return StructureElement.Kind.Variable;
+            case MODULE:
+                return StructureElement.Kind.Module;
+            case STATIC_INIT:
+            case INSTANCE_INIT:
+            case OTHER:
+            default:
+                return StructureElement.Kind.File; //XXX: what here?
+        }
+    }
 }

--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
@@ -291,7 +291,7 @@ public final class ElementOpen {
      * @since 1.58
      */
     public static CompletableFuture<Location> getLocation(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> el, String resourceName) {
-        final CompletableFuture<Object[]> future = getFutureOpenInfo(cpInfo, el, resourceName, new AtomicBoolean());
+        final CompletableFuture<Object[]> future = getFutureOpenInfo(cpInfo, el, resourceName, new AtomicBoolean(), true);
         return future.thenApply(openInfo -> {
             if (openInfo != null && openInfo[0] != null && (int) openInfo[1] != (-1) && (int) openInfo[2] != (-1)) {
                 FileObject file = (FileObject) openInfo[0];
@@ -357,13 +357,13 @@ public final class ElementOpen {
         return FileObjects.CLASS.equals(file.getExt()) || ClassParser.MIME_TYPE.equals(file.getMIMEType(ClassParser.MIME_TYPE));
     }
 
-    private static CompletableFuture<Object[]> getFutureOpenInfo(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> el, String resourceName, AtomicBoolean cancel) {
+    static CompletableFuture<Object[]> getFutureOpenInfo(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> el, String resourceName, AtomicBoolean cancel, boolean acquire) {
         Object[] openInfo = getOpenInfo(cpInfo, el, cancel);
         if (openInfo != null) {
             return CompletableFuture.completedFuture(openInfo);
         }
         // try to attach sources
-        if (resourceName != null) {
+        if (resourceName != null && acquire) {
             final ClassPath cp = ClassPathSupport.createProxyClassPath(
                 cpInfo.getClassPath(ClasspathInfo.PathKind.BOOT),
                 cpInfo.getClassPath(ClasspathInfo.PathKind.COMPILE),
@@ -411,7 +411,7 @@ public final class ElementOpen {
         return CompletableFuture.completedFuture(generated != null ? getOpenInfo(generated, el, cancel) : null);
     }
 
-    private static Object[] getOpenInfo(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> el, AtomicBoolean cancel) {
+    static Object[] getOpenInfo(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> el, AtomicBoolean cancel) {
         FileObject fo = SourceUtils.getFile(el, cpInfo);
         if (fo != null && fo.isFolder()) {
             fo = fo.getFileObject("package-info.java"); // NOI18N
@@ -423,7 +423,7 @@ public final class ElementOpen {
         assert fo != null;
 
         try {
-            Object[] result = new Object[6];
+            Object[] result = new Object[7];
             result[0] = fo;
             getOffset(fo, handle, result, cancel);
             return result;
@@ -521,7 +521,7 @@ public final class ElementOpen {
 
                     v.scan(cu, null);
                     Tree elTree = v.declTree;
-
+                    result[6] = TreePathHandle.create(el, info);
                     if (elTree != null) {
                         result[1] = (int)info.getTrees().getSourcePositions().getStartPosition(cu, elTree);
                         result[2] = (int)info.getTrees().getSourcePositions().getEndPosition(cu, elTree);
@@ -608,6 +608,11 @@ public final class ElementOpen {
             @Override
             public Object[] getOpenInfo(ClasspathInfo cpInfo, ElementHandle<? extends Element> el, AtomicBoolean cancel) {
                 return ElementOpen.getOpenInfo(cpInfo, el, cancel);
+            }
+
+            @Override
+            public CompletableFuture<Object[]> getOpenInfoFuture(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> el, String nameOpt, AtomicBoolean cancel, boolean acquire) {
+                return ElementOpen.getFutureOpenInfo(cpInfo, el, nameOpt, cancel, acquire);
             }
         });
     }

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/ElementOpenAccessor.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/ElementOpenAccessor.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.java.source.ui;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.lang.model.element.Element;
 import org.netbeans.api.java.source.ClasspathInfo;
@@ -41,6 +42,8 @@ public abstract class ElementOpenAccessor {
     }
     
     public abstract Object[] getOpenInfo(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> el, AtomicBoolean cancel);
+    
+    public abstract CompletableFuture<Object[]> getOpenInfoFuture(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> el, String nameOpt, AtomicBoolean cancel, boolean acquire);
 
     static {
         try {

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/LspElementUtils.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/LspElementUtils.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.source.ui;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.ElementHandle;
+import org.netbeans.api.java.source.ElementUtilities.ElementAcceptor;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.TreePathHandle;
+import org.netbeans.api.java.source.TreeUtilities;
+import org.netbeans.api.java.source.TypeUtilities;
+import org.netbeans.api.java.source.ui.ElementHeaders;
+import org.netbeans.api.lsp.StructureElement;
+import org.netbeans.spi.lsp.StructureProvider;
+import org.openide.filesystems.FileObject;
+
+/**
+ *
+ * @author sdedic
+ */
+public class LspElementUtils {
+    
+    public  static StructureElement element2StructureElement(CompilationInfo info, Element el, ElementAcceptor childAcceptor) {
+        TreePath path = info.getTrees().getPath(el);
+        if (path == null) {
+            return null;
+        }
+        TreeUtilities tu = info.getTreeUtilities();
+        if (tu.isSynthetic(path)) {
+            return null;
+        }
+
+        StructureProvider.Builder builder = StructureProvider.newBuilder(createName(info, el), ElementHeaders.javaKind2Structure(el));
+        builder.detail(createDetail(info, el));
+        setOffsets(info, el, builder);
+        if (info.getElements().isDeprecated(el)) {
+            builder.addTag(StructureElement.Tag.Deprecated);
+        }
+
+        if (childAcceptor != null) {
+            for (Element child : el.getEnclosedElements()) {
+                TreePath p = info.getTrees().getPath(child);
+                if (p == null) {
+                    continue;
+                }
+                TypeMirror m = info.getTrees().getTypeMirror(p);
+                if (childAcceptor.accept(child, m)) {
+                    StructureElement jse = element2StructureElement(info, child, childAcceptor);
+                    if (jse != null) {
+                        builder.children(jse);
+                    }
+                }
+            }
+            if (path.getLeaf().getKind() == Tree.Kind.METHOD || path.getLeaf().getKind() == Tree.Kind.VARIABLE) {
+                getAnonymousInnerClasses(info, path, builder, childAcceptor);
+            }
+            // ensure children is always filled, if the caller requested traversal, force creation of the list.
+            builder.children();
+        }
+        return builder.build();
+    }
+    
+    public static CompletableFuture<StructureElement> createStructureElement(CompilationInfo info, Element el, boolean resolveSources) {
+        TreePath path = info.getTrees().getPath(el);
+        AtomicBoolean cancel = new AtomicBoolean();
+        CompletableFuture<StructureProvider.Builder> f1 = createStructureElement0(path, info, el, cancel, resolveSources);
+        CompletableFuture<StructureElement> ret = f1.thenApply(b -> b == null ? null : b.build());
+        ret.exceptionally(t -> {
+            if (t instanceof CompletionException) {
+                t = t.getCause();
+            }
+            if (t instanceof CancellationException) {
+                // set the cancel flag on
+                cancel.set(true);
+                // attempt to cancel the 'main' future to interrupt the potential opening process. Will have no effect,
+                // if the main future was cancelled for some reason.
+                f1.cancel(true);
+            }
+            return null;
+        });
+        return ret;
+    }
+    
+    private static CompletableFuture<StructureProvider.Builder> createStructureElement0(TreePath path, CompilationInfo info, Element el, AtomicBoolean cancel, boolean acquire) {
+        StructureProvider.Builder builder = StructureProvider.newBuilder(createName(info, el), ElementHeaders.javaKind2Structure(el));
+        builder.detail(createDetail(info, el));
+        if (info.getElements().isDeprecated(el)) {
+            builder.addTag(StructureElement.Tag.Deprecated);
+        }
+        return setFutureOffsets(info, el, builder, cancel, acquire);
+    }
+    
+    private static String createName(CompilationInfo ci, Element original) {
+        switch (original.getKind()) {
+            case PACKAGE:
+                PackageElement pe = (PackageElement) original;
+                return pe.getSimpleName().toString();
+            case CLASS:
+            case INTERFACE:
+            case ENUM:
+            case ANNOTATION_TYPE:
+            case RECORD:
+                TypeElement te = (TypeElement) original;
+                StringBuilder sb = new StringBuilder();
+                sb.append(te.getSimpleName());
+                List<? extends TypeParameterElement> typeParams = te.getTypeParameters();
+                if (typeParams != null && !typeParams.isEmpty()) {
+                    sb.append("<"); // NOI18N
+                    for (Iterator<? extends TypeParameterElement> it = typeParams.iterator(); it.hasNext();) {
+                        TypeParameterElement tp = it.next();
+                        sb.append(tp.getSimpleName());
+                        List<? extends TypeMirror> bounds = tp.getBounds();
+                        if (!bounds.isEmpty()) {
+                            if (bounds.size() > 1 || !"java.lang.Object".equals(bounds.get(0).toString())) { // NOI18N
+                                sb.append(" extends "); // NOI18N
+                                for (Iterator<? extends TypeMirror> bIt = bounds.iterator(); bIt.hasNext();) {
+                                    sb.append(getTypeName(ci, bIt.next(), false));
+                                    if (bIt.hasNext()) {
+                                        sb.append(" & "); // NOI18N
+                                    }
+                                }
+                            }
+                        }
+                        if (it.hasNext()) {
+                            sb.append(", "); // NOI18N
+                        }
+                    }
+                    sb.append(">"); // NOI18N
+                }
+                return sb.toString();
+            case FIELD:
+            case ENUM_CONSTANT:
+            case RECORD_COMPONENT:
+                return original.getSimpleName().toString();
+            case CONSTRUCTOR:
+            case METHOD:
+                ExecutableElement ee = (ExecutableElement) original;
+                sb = new StringBuilder();
+                if (ee.getKind() == ElementKind.CONSTRUCTOR) {
+                    sb.append(ee.getEnclosingElement().getSimpleName());
+                } else {
+                    sb.append(ee.getSimpleName());
+                }
+                sb.append("("); // NOI18N
+                for (Iterator<? extends VariableElement> it = ee.getParameters().iterator(); it.hasNext();) {
+                    VariableElement param = it.next();
+                    if (!it.hasNext() && ee.isVarArgs() && param.asType().getKind() == TypeKind.ARRAY) {
+                        sb.append(getTypeName(ci, ((ArrayType) param.asType()).getComponentType(), false, false));
+                        sb.append("...");
+                    } else {
+                        sb.append(getTypeName(ci, param.asType(), false, false));
+                    }
+                    sb.append(" "); // NOI18N
+                    sb.append(param.getSimpleName());
+                    if (it.hasNext()) {
+                        sb.append(", "); // NOI18N
+                    }
+                }
+                sb.append(")"); // NOI18N
+                return sb.toString();
+        }
+        return null;
+    }
+
+    private static String createDetail(CompilationInfo ci, Element original) {
+        ElementKind kind = original.getKind();
+        String detail = null;
+        if (kind == ElementKind.FIELD || kind == ElementKind.METHOD) {
+            StringBuilder sb = new StringBuilder();
+            if (kind == ElementKind.FIELD) {
+                sb.append(": ");
+                sb.append(getTypeName(ci, original.asType(), false));
+                detail = sb.toString();
+            } else {
+                // METHOD   
+                TypeMirror rt = ((ExecutableElement) original).getReturnType();
+                if (rt.getKind() == TypeKind.VOID) {
+                    sb.append(": void");
+                } else {
+                    sb.append(": ");
+                    sb.append(getTypeName(ci, rt, false));
+                }
+            }
+            detail = sb.toString();
+        }
+        return detail;
+    }
+    
+    private static StructureProvider.Builder processOffsetInfo(Object[] info, StructureProvider.Builder builder) {
+        int selStart = (int)info[3];
+        if (selStart < 0) {
+            selStart = (int)info[1];
+        }
+        int selEnd = (int)info[4];
+        if (selEnd < 0) {
+            selEnd = (int)info[2];
+        }
+        TreePathHandle pathHandle = (TreePathHandle)info[6];
+        FileObject f = (FileObject)info[0];
+        boolean[] synthetic = new boolean[1];
+        if (f != null) {
+            builder.file(f);
+            try {
+                JavaSource js = JavaSource.forFileObject(f);
+                if (js == null) {
+                    return null;
+                }
+                js.runUserActionTask((cc) -> {
+                    TreePath path = pathHandle.resolve(cc);
+                    synthetic[0] = cc.getTreeUtilities().isSynthetic(path);
+                }, true);
+            } catch (IOException ex) {
+                // ignore
+            }
+        }
+        if (synthetic[0]) {
+            return null;
+        }
+        builder.expandedStartOffset((int)info[1]).expandedEndOffset((int)info[2]);
+        builder.selectionStartOffset(selStart).selectionEndOffset(selEnd);
+       return builder; 
+    }
+    
+    private static CompletableFuture<StructureProvider.Builder> setFutureOffsets(CompilationInfo ci, Element original, 
+            StructureProvider.Builder builder, AtomicBoolean cancel, boolean acquire) {
+        ElementHandle<Element> h = ElementHandle.create(original);
+        String name;
+        if (original.getKind().isClass() || original.getKind().isInterface()) {
+            name = h.getBinaryName().replace(".", "/") + ".class";
+        } else {
+            TypeElement e = ci.getElementUtilities().enclosingTypeElement(original);
+            if (e != null) {
+                name = e.getQualifiedName().toString();
+            } else {
+                name = h.getBinaryName();
+            }
+        }
+        
+        return ElementOpenAccessor.getInstance().getOpenInfoFuture(ci.getClasspathInfo(), h, name, cancel, acquire).thenApply(
+            info -> processOffsetInfo(info, builder));
+    }
+    
+    private static void setOffsets(CompilationInfo ci, Element original, StructureProvider.Builder builder) {
+        ElementHandle<Element> h = ElementHandle.create(original);
+        processOffsetInfo(ElementOpenAccessor.getInstance().getOpenInfo(ci.getClasspathInfo(), h, new AtomicBoolean()), builder);
+    }
+    
+    private static void getAnonymousInnerClasses(CompilationInfo info, TreePath path, StructureProvider.Builder builder, ElementAcceptor childAcceptor) {
+        new TreePathScanner<Void, Void>() {
+            @Override
+            public Void visitNewClass(NewClassTree node, Void p) {
+                if (node.getClassBody() != null) {
+                    Element e = info.getTrees().getElement(new TreePath(getCurrentPath(), node.getClassBody()));
+                    if (e != null) {
+                        TreePath path = new TreePath(getCurrentPath(), node.getIdentifier());
+                        TypeMirror m = info.getTrees().getTypeMirror(path);
+                        Element te = info.getTrees().getElement(path);
+                        if (te != null & childAcceptor.accept(te, m)) {
+                            StructureElement jse = element2StructureElement(info, te, childAcceptor);
+                            if (jse != null) {
+                                builder.children(jse);
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public Void visitClass(ClassTree node, Void p) {
+                Element e = info.getTrees().getElement(getCurrentPath());
+                TypeMirror m = info.getTrees().getTypeMirror(getCurrentPath());
+                if (e != null & childAcceptor.accept(e, m)) {
+                    StructureElement jse = element2StructureElement(info, e, childAcceptor);
+                    if (jse != null) {
+                        builder.children(jse);
+                    }
+                }
+                return super.visitClass(node, p);
+            }
+            
+        }.scan(path, null);
+    }
+
+    public static CharSequence getTypeName(CompilationInfo info, TypeMirror type, boolean fqn) {
+        return getTypeName(info, type, fqn, false);
+    }
+
+    public static CharSequence getTypeName(CompilationInfo info, TypeMirror type, boolean fqn, boolean varArg) {
+        Set<TypeUtilities.TypeNameOptions> options = EnumSet.noneOf(TypeUtilities.TypeNameOptions.class);
+        if (fqn) {
+            options.add(TypeUtilities.TypeNameOptions.PRINT_FQN);
+        }
+        if (varArg) {
+            options.add(TypeUtilities.TypeNameOptions.PRINT_AS_VARARG);
+        }
+        return info.getTypeUtilities().getTypeName(type, options.toArray(new TypeUtilities.TypeNameOptions[0]));
+    }
+}

--- a/java/java.sourceui/test/unit/data/structureElement/Test.java
+++ b/java/java.sourceui/test/unit/data/structureElement/Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package test;
+
+/**
+ *
+ * @author sdedic
+ */
+public class Test {
+    public String a;
+    
+    public void m(int param) {
+        class Anon1 {
+            
+        } // end Anon1 
+    } // end m
+    
+    static class Inner {
+        public void innerMethod(String p) {
+            
+        } // end innerMethod 
+    } // end Inner 
+    
+    Inner innerField;
+    
+    org.openide.util.Cancellable cancel;
+} // end Test

--- a/java/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/ElementHeadersTest.java
+++ b/java/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/ElementHeadersTest.java
@@ -21,23 +21,53 @@ package org.netbeans.api.java.source.ui;
 import com.sun.source.util.TreePath;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.type.TypeMirror;
 
 import javax.swing.text.Document;
+import org.netbeans.api.java.classpath.ClassPath;
 
 import org.netbeans.api.java.lexer.JavaTokenId;
+import org.netbeans.api.java.queries.SourceForBinaryQuery;
+import org.netbeans.api.java.queries.SourceJavadocAttacher;
+import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.ElementUtilities.ElementAcceptor;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.api.java.source.JavaSource.Phase;
 import org.netbeans.api.java.source.SourceUtilsTestUtil;
 import org.netbeans.api.java.source.SourceUtilsTestUtil2;
 import org.netbeans.api.java.source.TestUtilities;
 import org.netbeans.api.lexer.Language;
+import org.netbeans.api.lsp.StructureElement;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.JavaDataLoader;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.netbeans.spi.java.queries.SourceJavadocAttacherImplementation;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
 import org.openide.loaders.DataObject;
+import org.openide.util.RequestProcessor;
 
 /**
  *
@@ -52,10 +82,24 @@ public class ElementHeadersTest extends NbTestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        SourceUtilsTestUtil.prepareTest(new String[0], new Object[] {JavaDataLoader.class});
     }
     
+    Callable<Void> prepareEnvCallback = null;
+    FileObject[] classPathElements = new FileObject[0];
+    List<Object> extraServicesInLookup = new ArrayList<>();
+    
     private void prepareTest(String fileName, String code) throws Exception {
+        List<Object> extras = new ArrayList<>();
+        extras.add(JavaDataLoader.class);
+        extras.addAll(extraServicesInLookup);
+        SourceUtilsTestUtil.prepareTest(
+                new String[] { 
+                    "org/netbeans/modules/java/platform/resources/layer.xml",
+                    "org/netbeans/modules/java/j2seplatform/resources/layer.xml" 
+                }, 
+                extras.toArray(new Object[extras.size()])
+        );
+
         clearWorkDir();
         
         FileUtil.refreshAll();
@@ -76,7 +120,11 @@ public class ElementHeadersTest extends NbTestCase {
         
         TestUtilities.copyStringToFile(dataFile, code);
         
-        SourceUtilsTestUtil.prepareTest(sourceRoot, buildRoot, cache);
+        if (prepareEnvCallback != null) {
+            prepareEnvCallback.call();
+        }
+        
+        SourceUtilsTestUtil.prepareTest(sourceRoot, buildRoot, cache, classPathElements);
         
         DataObject od = DataObject.find(data);
         EditorCookie ec = od.getCookie(EditorCookie.class);
@@ -123,5 +171,292 @@ public class ElementHeadersTest extends NbTestCase {
     public void test134664() throws Exception {
         SourceUtilsTestUtil2.disableConfinementTest();
         performTest("test/Test.java", "package test; public class Test { public Tfst {} }", 43, ElementHeaders.NAME, "Tfst");
+    }
+    
+    private String fileContent;
+    
+    private TreePath pathInSource(String fragment) throws Exception {
+        Path f = getDataDir().toPath().resolve("structureElement/Test.java");
+        String content = String.join("\n", Files.readAllLines(f));
+        int x = fragment.indexOf('^');
+        if (x == -1) {
+            x = 0;
+        } else {
+            fragment = fragment.substring(0, x) + fragment.substring(x + 1);
+        }
+        int pos = content.indexOf(fragment);
+        assertTrue(pos >= 0);
+        
+        pos += x;
+        
+        prepareTest("test/Test.java", content);
+        fileContent = content;
+        TreePath path = info.getTreeUtilities().pathFor(pos);
+        return path;
+    }
+
+    /**
+     * Loads structureElement/Test.java and parses. Creates StructureElement from the position marked by ^ in the passed search fragment.
+     * @param fragment piece of text to search for. ^ marks the caret position
+     * @param acc element accessor to pass to the API
+     * @return StructureElement instance
+     * @throws Exception 
+     */
+    private StructureElement processTestSource(String fragment, ElementAcceptor acc) throws Exception {
+        TreePath path = pathInSource(fragment);
+        assertNotNull(path);
+        Element el = info.getTrees().getElement(path);
+        
+        return ElementHeaders.toStructureElement(info, el, acc);
+    }
+    
+    private Pattern compileWithSymbols(String pattern) {
+        return Pattern.compile(pattern.replace("#", "(?<s>(?=.?))").replace("@", "(?<e>(?=.?))").
+                replace("{", Pattern.quote("{")), Pattern.DOTALL | Pattern.MULTILINE);
+    }
+    /**
+     * Checks that the StructureElement has proper ranges. The beginPattern is a regexp that contains # for selection start and @ for 
+     * expanded start. Since the end is usually in completely different
+     * @param beginPattern
+     * @param endSelPattern
+     * @param endPattern
+     * @param se 
+     */
+    private void assertRanges(String beginPattern, String endSelPattern, String endPattern, StructureElement se) {
+        assertNotNull(se);
+        // the zero-width lookahead ".?" will match the position of the marker character. Without lookahead, the preceding character (and its position)
+        // could be recorded, i.e. @public void would yield position of the space before `public`, not position of the 'p'.
+        Matcher m = compileWithSymbols(beginPattern).matcher(fileContent);
+        assertTrue(m.find());
+        assertEquals(2, m.groupCount());
+        
+        int selS = m.start("s");
+        int expS = m.start("e");
+        
+        assertEquals(selS, se.getSelectionStartOffset());
+        assertEquals(expS, se.getExpandedStartOffset());
+
+        m = compileWithSymbols(endSelPattern).matcher(fileContent);
+        assertTrue(m.find());
+        int selE = m.start("s");
+        assertEquals(selE, se.getSelectionEndOffset());
+        
+        m = compileWithSymbols(endPattern).matcher(fileContent);
+        assertTrue(m.find());
+        int expE = m.start("e");
+        assertEquals(expE, se.getExpandedEndOffset());
+    }
+    
+    private void assertTestClass(StructureElement se) {
+        assertEquals("Test", se.getName());
+        assertRanges("@public class #Test", "class Test#", "}@ // end Test", se);
+        assertNotNull(se.getFile());
+    }
+    
+    /**
+     * Checks that just class element is returned, checks bounds.
+     */
+    public void testToStructureClassShallow() throws Exception {
+        StructureElement se = processTestSource("class Te^st", null);
+        assertNull(se.getChildren());
+        assertTestClass(se);
+    }
+
+    private void assertTestMethod(StructureElement se) {
+        assertEquals("m(int param)", se.getName());
+        assertEquals(StructureElement.Kind.Method, se.getKind());
+        assertNotNull(se.getFile());
+        
+        assertRanges("@public void #m", "public void m#", "}@ // end m", se);
+    }
+    
+    /**
+     * Checks that just method element is returned, checks bounds.
+     */
+    public void testToStructureMethodShallow() throws Exception {
+        StructureElement se = processTestSource("public void m^", null);
+        assertTestMethod(se);
+        assertNull(se.getChildren());
+    }
+    
+    private void assertTestField(StructureElement se) {
+        assertEquals("a", se.getName());
+        assertEquals(StructureElement.Kind.Field, se.getKind());
+        assertNotNull(se.getFile());
+        
+        assertRanges("@public String #a", "public String a#", "public String a;@", se);
+    }
+    
+    /**
+     * Checks that field element is returned with proper bounds.
+     */
+    public void testToStructureField() throws Exception {
+        StructureElement se = processTestSource("String ^a", null);
+        assertTestField(se);
+    }
+    
+    private ElementAcceptor ALL = new ElementAcceptor() {
+            @Override
+            public boolean accept(Element e, TypeMirror type) {
+                // do not accept inner class
+                return e.getKind() != ElementKind.CLASS;
+            }
+    };
+    
+    private List<StructureElement> sortChildren(StructureElement parent) {
+        List<StructureElement> ch = new ArrayList<>(parent.getChildren());
+        Collections.sort(ch, new Comparator<StructureElement>() {
+            @Override
+            public int compare(StructureElement o1, StructureElement o2) {
+                return o1.getSelectionStartOffset() - o2.getSelectionStartOffset();
+            }
+        });
+        return ch;
+    }
+    
+    public void testSelectedChildren() throws Exception {
+        StructureElement se = processTestSource("class Test^", ALL);
+        assertTestClass(se);
+        assertNotNull(se.getChildren());
+        assertEquals(4, se.getChildren().size());
+        
+        List<StructureElement> sorted = sortChildren(se);
+        
+        assertTestField(sorted.get(0));
+        assertTestMethod(sorted.get(1));
+    }
+    
+    public void testAllChildrenStructure() throws Exception {
+        StructureElement se = processTestSource("class Test^", new ElementAcceptor() {
+            @Override
+            public boolean accept(Element e, TypeMirror type) {
+                return true;
+            }
+        });
+        assertTestClass(se);
+        assertNotNull(se.getChildren());
+        assertEquals(5, se.getChildren().size());
+
+        List<StructureElement> sorted = sortChildren(se);
+        
+        assertTestField(sorted.get(0));
+        assertTestMethod(sorted.get(1));
+        
+        StructureElement ce = sorted.get(2);
+        assertEquals(StructureElement.Kind.Class, ce.getKind());
+        assertEquals("Inner", ce.getName());
+        assertNotNull(ce.getChildren());
+        assertEquals(1, ce.getChildren().size());
+        
+        assertRanges("@static class #Inner {", "class Inner# {", "}@ // end Inner", ce);
+    }
+    
+    public void testStructureNonLocalReference() throws Exception {
+        TreePath path = pathInSource("public String ^a;");
+        TypeMirror aType = info.getTrees().getTypeMirror(path);
+        
+        Element stringEl = info.getTypes().asElement(aType);
+        StructureElement e = ElementHeaders.toStructureElement(info, stringEl, ALL);
+        assertNull(e);
+    }
+
+    public void testResolveNonLocalReference() throws Exception {
+        TreePath path = pathInSource("public String ^a;");
+        TypeMirror aType = info.getTrees().getTypeMirror(path);
+        Element stringEl = info.getTypes().asElement(aType);
+        ClasspathInfo cpInfo = info.getClasspathInfo();
+        final ClassPath cp = ClassPathSupport.createProxyClassPath(
+            cpInfo.getClassPath(ClasspathInfo.PathKind.BOOT),
+            cpInfo.getClassPath(ClasspathInfo.PathKind.COMPILE),
+            cpInfo.getClassPath(ClasspathInfo.PathKind.SOURCE));
+        final FileObject resource = cp.findResource("java/lang/String.class");
+        assertNotNull(resource);
+        SourceForBinaryQuery.Result r = SourceForBinaryQuery.findSourceRoots(URLMapper.findURL(cp.findOwnerRoot(resource), URLMapper.INTERNAL));
+        if (r == null || r.getRoots().length == 0) {
+            // skip the test, no sources for JDK.
+            return;
+        }
+        CompletableFuture<StructureElement> f = ElementHeaders.resolveStructureElement(info, stringEl, true);
+        StructureElement se = f.get();
+        assertNotNull(se);
+    }
+    
+    FileObject openideBin;
+    
+    /**
+     * Checks that a long-running call that involves SourceJavadocAttacher can be cancelled by the client.
+     * @throws Exception 
+     */
+    public void testUseSourceAttacher() throws Exception {
+        SJAImpl sja = new SJAImpl();
+        
+        extraServicesInLookup.add(sja);
+        
+        URL cancURL = getClass().getClassLoader().getResource("org/openide/util/Cancellable.class");
+        assertNotNull(cancURL);
+        
+        prepareEnvCallback = () -> {
+            openideBin = sourceRoot.getParent().createFolder("openide-bin");
+            FileObject utilDir = FileUtil.createFolder(openideBin, "org/openide/util");
+            FileObject cf = utilDir.createData("Cancellable", "class");
+            try (InputStream is = cancURL.openStream(); OutputStream os = cf.getOutputStream()) {
+                FileUtil.copy(is, os);
+            }
+            classPathElements = new FileObject[] { openideBin };
+            return null;
+        };
+
+        TreePath path = pathInSource("Cancellable ^cancel;");
+        TypeMirror aType = info.getTrees().getTypeMirror(path);
+        Element cancelEl = info.getTypes().asElement(aType);
+        assertEquals(ElementKind.INTERFACE, cancelEl.getKind());
+        
+        sja.reset();
+        CompletableFuture<StructureElement> f = ElementHeaders.resolveStructureElement(info, cancelEl, true);
+        assertFalse(f.isDone());
+        StructureElement se;
+        
+        try {
+            se = f.get(500, TimeUnit.MILLISECONDS);
+            fail("Should time out");
+        } catch (TimeoutException ex) {
+            // expected
+        }
+        sja.sourceLatch.countDown();
+        se = f.get();
+        assertNotNull(se);
+    }
+    
+    static RequestProcessor RP = new RequestProcessor(ElementHeadersTest.class);
+    
+    static class SJAImpl implements SourceJavadocAttacherImplementation {
+        volatile CountDownLatch sourceLatch;
+        
+        void reset() {
+            sourceLatch = new CountDownLatch(1);
+        }
+        
+        @Override
+        public boolean attachSources(URL root, SourceJavadocAttacher.AttachmentListener listener) throws IOException {
+            RP.post(() -> {
+                if (sourceLatch != null) {
+                    try {
+                        sourceLatch.await();
+                        listener.attachmentSucceeded();
+                    } catch (InterruptedException ex) {
+                        listener.attachmentFailed();
+                    }
+                } else {
+                    listener.attachmentFailed();
+                }
+            });
+            return true;
+        }
+
+        @Override
+        public boolean attachJavadoc(URL root, SourceJavadocAttacher.AttachmentListener listener) throws IOException {
+            return false;
+        }
+        
     }
 }

--- a/java/refactoring.java/nbproject/project.xml
+++ b/java/refactoring.java/nbproject/project.xml
@@ -53,6 +53,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.api.lsp</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.9</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTasks.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTasks.java
@@ -177,7 +177,7 @@ final class CallHierarchyTasks {
         });
     }
     
-    private static final class RootResolver implements Task<CompilationController> {
+    static final class RootResolver implements Task<CompilationController> {
         
         private int offset = -1;
         private TreePathHandle tHandle;

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallOccurrence.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallOccurrence.java
@@ -67,6 +67,10 @@ final class CallOccurrence implements CallDescriptor {
         }
     }
 
+    public PositionBounds getSelectionBounds() {
+        return selectionBounds;
+    }
+
     public static CallOccurrence createOccurrence(
             CompilationInfo javac, TreePath selection, Call parent) {
         WhereUsedElement wue = WhereUsedElement.create(javac, selection, false);

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/LspCallHierarchyProvider.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/LspCallHierarchyProvider.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.refactoring.java.callhierarchy;
+
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.lang.model.element.Element;
+import javax.swing.text.Document;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.java.source.CompilationController;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.ElementHandle;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.ScanUtils;
+import org.netbeans.api.java.source.SourceUtils;
+import org.netbeans.api.java.source.Task;
+import org.netbeans.api.java.source.TreePathHandle;
+import org.netbeans.api.java.source.ui.ElementHeaders;
+import org.netbeans.api.lsp.CallHierarchyEntry;
+import org.netbeans.api.lsp.Range;
+import org.netbeans.api.lsp.StructureElement;
+import org.netbeans.modules.parsing.api.Embedding;
+import org.netbeans.modules.parsing.api.ParserManager;
+import org.netbeans.modules.parsing.api.ResultIterator;
+import org.netbeans.modules.parsing.api.Source;
+import org.netbeans.modules.parsing.api.UserTask;
+import org.netbeans.modules.parsing.spi.ParseException;
+import org.netbeans.modules.parsing.spi.Parser;
+import org.netbeans.spi.lsp.CallHierarchyProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.text.PositionBounds;
+import org.openide.util.Cancellable;
+import org.openide.util.RequestProcessor;
+
+/**
+ * Implementation of LSP call hierarchy for the java Mime type.
+ * @author sdedic
+ */
+@MimeRegistration(mimeType = "text/x-java", service = CallHierarchyProvider.class)
+public class LspCallHierarchyProvider implements CallHierarchyProvider {
+    private static final RequestProcessor HIERARCHY_RP = new RequestProcessor();
+    
+    private static final Element findEclosingExecutable(CompilationInfo ci, TreePath tp) {
+        while (tp != null && tp.getLeaf().getKind() != Tree.Kind.COMPILATION_UNIT) {
+            switch (tp.getLeaf().getKind()) {
+                case METHOD:
+                case CLASS:
+                case ENUM:
+                case INTERFACE:
+                    return ci.getTrees().getElement(tp);
+            }
+            tp = tp.getParentPath();
+        }
+        return null;
+    }
+    
+    @Override
+    public CompletableFuture<List<CallHierarchyEntry>> findCallOrigin(Document doc, int offset) {
+        class OriginT extends UserTask {
+            private final CompletableFuture<List<CallHierarchyEntry>> control;
+
+            public OriginT(CompletableFuture<List<CallHierarchyEntry>> control) {
+                this.control = control;
+            }
+            
+            @Override
+            public void run(ResultIterator resultIterator) throws Exception {
+                Parser.Result r = resultIterator.getParserResult(offset);
+                if ("text/x-java".equals(r.getSnapshot().getMimeType())) {
+                    CompilationInfo ci = CompilationInfo.get(r);
+                    if (ci == null || r.getSnapshot().getSource().getFileObject() == null) {
+                        control.complete(null);
+                        return;
+                    }
+                    TreePath tp = ci.getTreeUtilities().pathFor(offset);
+                    if (tp == null) {
+                        control.complete(null);
+                        return;
+                    }
+                    
+                    Element e = findEclosingExecutable(ci, tp);
+                    if (e == null) {
+                        return;
+                    }
+                    
+                    StructureElement se = ElementHeaders.toStructureElement(ci, e, null);
+                    CallHierarchyEntry item = new CallHierarchyEntry(se, signature(e));
+                    control.complete(Collections.singletonList(item));
+                    return;
+                }
+                for (Embedding e : resultIterator.getEmbeddings()) {
+                    // interrupt embedding search, results are already reported or the future cancelled.
+                    if (control.isDone()) {
+                        return;
+                    }
+                    run(resultIterator.getResultIterator(e));
+                }
+            }
+        }
+        
+        CompletableFuture<List<CallHierarchyEntry>> res = new CompletableFuture<List<CallHierarchyEntry>>();
+        HIERARCHY_RP.post(() -> {
+            try {
+                ParserManager.parse(Collections.singletonList(Source.create(doc)), new OriginT(res));
+            } catch (ParseException ex) {
+                res.completeExceptionally(ex);
+            }
+        });
+        return res;
+    }
+    
+    /**
+     * Special implementation of Future that relays {@code cancel()} to a {@link Cancellable}.
+     * @param <T> 
+     */
+    private static class CancellableF<T> extends CompletableFuture<T> {
+        private volatile Cancellable c;
+
+        public CancellableF() {
+        }
+
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            Cancellable c2 = this.c;
+            if (mayInterruptIfRunning && c2 != null) {
+                return c2.cancel();
+            } else {
+                return false;
+            }
+        }
+    }
+    
+    private static String signature(Element e) {
+        ElementHandle h = ElementHandle.create(e);
+        String extra = h.getKind().name() + "/" + String.join("/", SourceUtils.getJVMSignature(h));
+        return extra;
+    }
+    
+    static abstract class CallTask implements Task<CompilationController>, Cancellable {
+        final CallHierarchyModel.HierarchyType type;
+        final CancellableF<List<CallHierarchyEntry.Call>> res = new CancellableF<>();
+        final CallHierarchyEntry callTarget;
+        final AtomicBoolean cancelled = new AtomicBoolean();
+        final FileObject fo;
+        protected volatile CompletableFuture toCancel;
+
+        public CallTask(CallHierarchyEntry callTarget, CallHierarchyModel.HierarchyType type) {
+            this.callTarget = callTarget;
+            this.type = type;
+            this.fo = callTarget.getElement().getFile();
+
+            res.c = this;
+        }
+
+        @Override
+        public boolean cancel() {
+            CompletableFuture tc = toCancel;
+            return cancelled.getAndSet(true) && (tc == null || tc.cancel(true));
+        }
+        
+        public void run(CompilationController parameter) throws Exception {
+            List<CallHierarchyEntry.Call> calls = new ArrayList<>();
+            int s = callTarget.getElement().getSelectionStartOffset();
+            TreePath p = parameter.getTreeUtilities().pathFor(s);
+            Element e = null;
+
+            if (p != null) {
+                Element candidate = parameter.getTrees().getElement(p);
+                if (candidate != null) {
+                    // just do a sanity check
+                    if (callTarget.getCustomData() == null ||
+                        callTarget.getCustomData().equals(signature(candidate))) {
+                        e = candidate;
+                    }
+                }
+            }
+
+            if (e == null) {
+                res.complete(null);
+                return;
+            }
+            TreePathHandle tph = TreePathHandle.create(e, parameter);
+
+            CallHierarchyTasks.RootResolver rr = new CallHierarchyTasks.RootResolver(tph, true, true);
+            rr.run(parameter);
+
+            CallHierarchyModel m = CallHierarchyModel.create(tph, 
+                    EnumSet.of(CallHierarchyModel.Scope.ALL, CallHierarchyModel.Scope.BASE), type);
+            m.replaceRoot(rr.getRoot());
+
+            Call rootCall = m.getRoot();
+            m.computeCalls(m.getRoot(), () -> processComputedCall(parameter, rootCall));
+        }
+        
+        protected abstract CallHierarchyEntry.Call createCall(StructureElement se, Call c, String signature);
+        
+        protected CompletableFuture<List<CallHierarchyEntry.Call>> processAsync(CompilationInfo info, List<Call> refs, List<CallHierarchyEntry.Call> calls) {
+            List<CompletableFuture<StructureElement>> delayed = new ArrayList<>();
+            List<String> signatures = new ArrayList<>();
+            List<Call> delayedRefs = new ArrayList<>();
+
+            for (Call c : refs) {
+                TreePathHandle targetH = c.selection;
+                TreePath h = targetH.resolve(info);
+                Element target = info.getTrees().getElement(h);
+
+                CompletableFuture<StructureElement> elementFuture = ElementHeaders.resolveStructureElement(info, target, true);
+                if (elementFuture.isDone()) {
+                    try {
+                        calls.add(createCall(elementFuture.get(), c, signature(target)));
+                    } catch (ExecutionException ex) {
+                        Throwable cause = ex.getCause();
+                        if (cause instanceof CancellationException) {
+                            throw (CancellationException)cause;
+                        }
+                        throw new IllegalStateException(ex);
+                    } catch (InterruptedException ex) {
+                        CancellationException t = new CancellationException();
+                        t.initCause(ex);
+                        throw t;
+                    }
+                } else {
+                    signatures.add(signature(target));
+                    delayedRefs.add(c);
+                    delayed.add(elementFuture);
+                }
+            }
+            if (delayed.isEmpty()) {
+                return CompletableFuture.completedFuture(calls); 
+            }
+
+            return CompletableFuture.allOf(delayed.stream().filter(Objects::nonNull).toArray((i) -> new CompletableFuture[i])).
+                thenApply(x -> {
+                    int index = 0; 
+                    for (CompletableFuture<StructureElement> f : delayed) {
+                        if (f != null) {
+                            StructureElement se = f.getNow(null);
+                            if (se != null) {
+                                calls.add(createCall(se, refs.get(index), signatures.get(index)));
+                            }
+                        }
+                        index++;
+                    }
+                    return calls;
+                });
+        }
+
+        public CompletableFuture<List<CallHierarchyEntry.Call>> process() {
+            JavaSource js = JavaSource.forFileObject(fo);
+            if (js == null) {
+                return null;
+            }
+            HIERARCHY_RP.post(() -> {
+                try {
+                    ScanUtils.waitUserActionTask(js, this);
+                } catch (IOException | RuntimeException ex) {
+                    res.completeExceptionally(ex);
+                }
+            });
+            return toCancel != null ? toCancel : res;
+        }
+
+        protected void processComputedCall(CompilationInfo info, Call rootCall) {
+            List<CallHierarchyEntry.Call> calls = new ArrayList<>();
+            List<Call> refs = rootCall.getReferences();
+
+            if (cancelled.get()) {
+                return;
+            }
+            toCancel = processAsync(info, refs, calls);
+            toCancel.handle((r, ex) -> {
+                if (ex != null) { 
+                    res.completeExceptionally((Throwable)ex);
+                } else {
+                    res.complete(calls);
+                }
+                return null;
+            });
+        }
+    }
+    
+    @Override
+    public CompletableFuture<List<CallHierarchyEntry.Call>> findIncomingCalls(CallHierarchyEntry callTarget) {
+        
+        class T extends CallTask {
+
+            public T(CallHierarchyEntry callTarget) {
+                super(callTarget, CallHierarchyModel.HierarchyType.CALLER);
+            }
+
+            @Override
+            protected CallHierarchyEntry.Call createCall(StructureElement se, Call c, String signature) {
+                throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+            }
+            
+            
+
+            @Override
+            protected void processComputedCall(CompilationInfo info, Call rootCall) {
+                List<CallHierarchyEntry.Call> calls = new ArrayList<>();
+                List<Call> refs = rootCall.getReferences();
+                for (Call c : refs) {
+                    TreePathHandle targetH = c.selection;
+                    TreePath h = targetH.resolve(info);
+                    Element target = info.getTrees().getElement(h);
+                    StructureElement se = ElementHeaders.toStructureElement(info, target, null);
+                    CallHierarchyEntry i = new CallHierarchyEntry(se, signature(target));
+
+                    List<Range> ranges = new ArrayList<>();
+                    for (CallOccurrence oc : c.getOccurrences()) {
+                        PositionBounds pb = oc.getSelectionBounds();
+                        ranges.add(new Range(pb.getBegin().getOffset(), pb.getEnd().getOffset()));
+                    }
+                    CallHierarchyEntry.Call call = new CallHierarchyEntry.Call(i, ranges);
+
+                    calls.add(call);
+                }
+
+                res.complete(calls);
+            }
+            
+        }
+        return new T(callTarget).process();
+    }
+
+    @Override
+    public CompletableFuture<List<CallHierarchyEntry.Call>> findOutgoingCalls(CallHierarchyEntry callSource) {
+        class T extends CallTask {
+            
+            public T(CallHierarchyEntry callTarget) {
+                super(callTarget, CallHierarchyModel.HierarchyType.CALLEE);
+            }
+            
+            protected CallHierarchyEntry.Call createCall(StructureElement se, Call c, String signature) {
+                CallHierarchyEntry i = new CallHierarchyEntry(se, signature);
+
+                List<Range> ranges = new ArrayList<>();
+                for (CallOccurrence oc : c.getOccurrences()) {
+                    PositionBounds pb = oc.getSelectionBounds();
+                    ranges.add(new Range(pb.getBegin().getOffset(), pb.getEnd().getOffset()));
+                }
+                return new CallHierarchyEntry.Call(i, ranges);
+            }
+            
+            @Override
+            protected void processComputedCall(CompilationInfo info, Call rootCall) {
+                List<CallHierarchyEntry.Call> calls = new ArrayList<>();
+                List<Call> refs = rootCall.getReferences();
+                
+                if (cancelled.get()) {
+                    return;
+                }
+                toCancel = processAsync(info, refs, calls);
+                toCancel.handle((r, ex) -> {
+                    if (ex != null) { 
+                        res.completeExceptionally((Throwable)ex);
+                    } else {
+                        res.complete(calls);
+                    }
+                    return null;
+                });
+            }
+            
+        }
+        return new T(callSource).process();
+    } 
+}

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/LspCallHierarchyProvider.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/LspCallHierarchyProvider.java
@@ -186,6 +186,7 @@ public class LspCallHierarchyProvider implements CallHierarchyProvider {
         public void run(CompilationController parameter) throws Exception {
             List<CallHierarchyEntry.Call> calls = new ArrayList<>();
             int s = callTarget.getElement().getSelectionStartOffset();
+            parameter.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
             TreePath p = parameter.getTreeUtilities().pathFor(s);
             Element e = null;
 
@@ -223,11 +224,10 @@ public class LspCallHierarchyProvider implements CallHierarchyProvider {
             List<CompletableFuture<StructureElement>> delayed = new ArrayList<>();
             List<String> signatures = new ArrayList<>();
             List<Call> delayedRefs = new ArrayList<>();
-
+            
             for (Call c : refs) {
                 TreePathHandle targetH = c.selection;
-                TreePath h = targetH.resolve(info);
-                Element target = info.getTrees().getElement(h);
+                Element target = targetH.getElementHandle().resolve(info);
 
                 CompletableFuture<StructureElement> elementFuture = ElementHeaders.resolveStructureElement(info, target, true);
                 if (elementFuture.isDone()) {
@@ -315,35 +315,15 @@ public class LspCallHierarchyProvider implements CallHierarchyProvider {
 
             @Override
             protected CallHierarchyEntry.Call createCall(StructureElement se, Call c, String signature) {
-                throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-            }
-            
-            
+                CallHierarchyEntry i = new CallHierarchyEntry(se, signature);
 
-            @Override
-            protected void processComputedCall(CompilationInfo info, Call rootCall) {
-                List<CallHierarchyEntry.Call> calls = new ArrayList<>();
-                List<Call> refs = rootCall.getReferences();
-                for (Call c : refs) {
-                    TreePathHandle targetH = c.selection;
-                    TreePath h = targetH.resolve(info);
-                    Element target = info.getTrees().getElement(h);
-                    StructureElement se = ElementHeaders.toStructureElement(info, target, null);
-                    CallHierarchyEntry i = new CallHierarchyEntry(se, signature(target));
-
-                    List<Range> ranges = new ArrayList<>();
-                    for (CallOccurrence oc : c.getOccurrences()) {
-                        PositionBounds pb = oc.getSelectionBounds();
-                        ranges.add(new Range(pb.getBegin().getOffset(), pb.getEnd().getOffset()));
-                    }
-                    CallHierarchyEntry.Call call = new CallHierarchyEntry.Call(i, ranges);
-
-                    calls.add(call);
+                List<Range> ranges = new ArrayList<>();
+                for (CallOccurrence oc : c.getOccurrences()) {
+                    PositionBounds pb = oc.getSelectionBounds();
+                    ranges.add(new Range(pb.getBegin().getOffset(), pb.getEnd().getOffset()));
                 }
-
-                res.complete(calls);
+                return new CallHierarchyEntry.Call(i, ranges);
             }
-            
         }
         return new T(callTarget).process();
     }
@@ -367,6 +347,7 @@ public class LspCallHierarchyProvider implements CallHierarchyProvider {
                 return new CallHierarchyEntry.Call(i, ranges);
             }
             
+            /*
             @Override
             protected void processComputedCall(CompilationInfo info, Call rootCall) {
                 List<CallHierarchyEntry.Call> calls = new ArrayList<>();
@@ -385,7 +366,7 @@ public class LspCallHierarchyProvider implements CallHierarchyProvider {
                     return null;
                 });
             }
-            
+            */
         }
         return new T(callSource).process();
     } 


### PR DESCRIPTION
This PR adds support for `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls` and `callHierarchy/outgoingCalls` messages (see [LSP Protocol Spec 3.16](https://microsoft.github.io/language-server-protocol/specification#textDocument_prepareCallHierarchy) ).

I decided to **reuse** `StructureElement` invented as a part of Outline support: elements reported by the Call Hierarchy have exactly the same meaning, plus the `uri`, which is implicit in the Outline. I have added `file` property to `StructureElement` and relevant `StructureProvider.Builder` method.

In order to share code between Java Editor module (that implements Outline) and Java Refactoring module (which implements the Call Hierarchy, but does not export it through any API), I've introduced helper methods for LSP into `java.sourceui` module: `lsp.api` module represents an abstract UI, after all, so adapting Java-specific structures to abstract ones seemed reasonable. This API allows to move Java Element -> StructureElement conversion to `java.sourceui`, and can be called from both `java.editor` and `java.refactoring`.

The other reason to choose `java.sourceui` for introducing the API is that the `ElementOpen` implementation is here, and can be adjusted to support StructureElement creation without exposing additional APIs.

