### PR TITLE
Create JavaParser dumpfile on FINE log level only.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -800,7 +800,9 @@ public class JavacParser extends Parser {
                     invalidate(false);
                 } else {
                     parserError = currentPhase;
-                    dumpSource(currentInfo, ex);
+                    if (LOGGER.isLoggable(Level.FINE)) {
+                        dumpSource(currentInfo, ex);
+                    }
                     throw ex;
                 }
             }
@@ -1348,7 +1350,7 @@ public class JavacParser extends Parser {
                 Exceptions.printStackTrace(exc);
             }
         } else {
-            LOGGER.log(Level.WARNING,
+            LOGGER.log(Level.FINE,
                     "Dump could not be written. Either dump file could not " + // NOI18N
                     "be created or all dump files were already used. Please " + // NOI18N
                     "check that you have write permission to '" + (f != null ? f.getParent() : "var/log") + "' and " + // NOI18N

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/VanillaPartialReparser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/VanillaPartialReparser.java
@@ -330,7 +330,7 @@ public class VanillaPartialReparser implements PartialReparser {
             }
             boolean a = false;
             assert a = true;
-            if (a) {
+            if (a && LOGGER.isLoggable(Level.FINE)) {
                 JavacParser.dumpSource(ci, t);
             }
             t.printStackTrace();


### PR DESCRIPTION

This is a trivial PR addressing the issue on #3728. Which puts the dumpfile creation under FINE loglevel.
