### PR TITLE
increase git clone depth so that we can restart older jobs post merge.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ cache:
 
 git:
   quiet: true
-  depth: 3
+  depth: 50
 
 matrix:
     include:

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -38,6 +38,9 @@
 
   <target name="bootstrap" description="Bootstrap NetBeans-specific Ant extensions."
           depends="-jdk-init,-load-build-properties">
+    <echo message="ant version: ${ant.version}"/>
+    <echo message="Java version: ${java.version}"/>
+    <echo message="JAVA_HOME: ${java.home}"/>
     <fail message="You need to run on JDK 8+ to build NetBeans; java.home=${java.home}">
         <condition>
             <matches pattern="^1\.[01234567].*" string="${java.version}"/>


### PR DESCRIPTION
travis fails to restart old jobs of already integrated commits, for example:
```
fatal: reference is not a tree: 49e167edc46e335e1587ba22749650c5617f9954

The command "git checkout -qf 49e167edc46e335e1587ba22749650c5617f9954" failed and exited with 128 during .
```
setting `--depth` to 50 should improve the situation a bit (I hope) without having to clone the entire repo.

I also added some java version info printout to ant.