### PR TITLE
fix enterprise cluster build on JDK 17 + add upstream-JDK build job.

### DIFF
--- a/.github/workflows/linux-upstream-jdk.yml
+++ b/.github/workflows/linux-upstream-jdk.yml
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Apache Netbeans
+
+on:
+  push:
+  pull_request:
+
+# job is intended for early detection of build failures on new JDKs
+jobs:
+  linux:
+    name: Check Build on Linux/JDK17
+    runs-on: ubuntu-latest
+    env:
+      ANT_OPTS: -Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json
+
+    steps:
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+            distribution: 'zulu'
+            java-version: 17
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Caching dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.hgexternalcache
+          key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
+          restore-keys: ${{ runner.os }}-
+
+      - name: Clean
+        run: ant -Dcluster.config=full clean
+
+      - name: Build (cluster.config=full)
+        run: ant -Dcluster.config=full build
+
+# todo: figure out if anything is testable post JDK 15


### PR DESCRIPTION
it turns out that the enterprise cluster was the last cluster with build problems on JDK 17. Java cluster was fixed back in #3278 and gradle #3326. 

@matthiasblaesing must have fixed the javascript cluster without telling anyone :)

everything builds locally, lets see if CI agrees.

this fixes the following build error:
```
 [repeat] Note: generating beans in org.netbeans.modules.j2ee.deployment.impl.gen.nbd
   [repeat] Note: parsing: file:///mnt/ram/netbeans/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/plugins/api/netbeans-deployment.dtd
   [repeat] /mnt/ram/netbeans/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/gen/nbd/package-info.java:28: error: Failed to process
   [repeat] package org.netbeans.modules.j2ee.deployment.impl.gen.nbd;
   [repeat] ^
   [repeat] error: java.lang.reflect.InaccessibleObjectException: Unable to make field transient java.util.HashMap$Node[] java.util.HashMap.table accessible: module java.base does not "opens java.util" to unnamed module @392c130a
   [repeat]   	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
   [repeat]   	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
   [repeat]   	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
   [repeat]   	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
   [repeat]   	at org.netbeans.modules.schema2beansdev.gen.JavaUtil.getOptimialHashMapSize(JavaUtil.java:855)
   [repeat]   	at org.netbeans.modules.schema2beansdev.gen.JavaUtil.getOptimialHashMapSize(JavaUtil.java:839)
   [repeat]   	at org.netbeans.modules.schema2beansdev.JavaBeanClass.genExtendBaseBean(JavaBeanClass.java:4421)
   [repeat]   	at org.netbeans.modules.schema2beansdev.JavaBeanClass.genAllParts(JavaBeanClass.java:119)
   [repeat]   	at org.netbeans.modules.schema2beansdev.JavaBeanClass.generate(JavaBeanClass.java:54)
   [repeat]   	at org.netbeans.modules.schema2beansdev.BeanBuilder.doGeneration(BeanBuilder.java:906)
   [repeat]   	at org.netbeans.modules.schema2beansdev.BeanBuilder.process(BeanBuilder.java:556)
   [repeat]   	at org.netbeans.modules.schema2beansdev.GenBeans.doIt(GenBeans.java:841)
   [repeat]   	at org.netbeans.modules.schema2beansdev.Schema2BeansProcessor.handle(Schema2BeansProcessor.java:163)
   [repeat]   	at org.netbeans.modules.schema2beansdev.Schema2BeansProcessor.process(Schema2BeansProcessor.java:68)
   [repeat]   	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor(JavacProcessingEnvironment.java:1023)
...
```

