### PR TITLE
Fix maven daemon detection on windows platform

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/cmd/ShellConstructor.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/cmd/ShellConstructor.java
@@ -44,7 +44,9 @@ public class ShellConstructor implements Constructor {
     public List<String> construct() {
 
         // use mvnd if its the home of a daemon
-        String ex = Files.exists(Paths.get(mavenHome.getPath(), "bin", "mvnd")) ? "mvnd" : "mvn"; //NOI18N
+        String mavenDaemonSuffixDetection = Utilities.isWindows() ? ".exe" : "";
+        String ex = Files.exists(Paths.get(mavenHome.getPath(), "bin", "mvnd" + mavenDaemonSuffixDetection)) ? "mvnd" : "mvn"; //NOI18N
+
         List<String> command = new ArrayList<>();
 
         if (Utilities.isWindows()) {


### PR DESCRIPTION
In the "bin" folder of "mvnd-0.7.1-windows-amd64" (latest current release), the list of files is as follows:
```
├── mvnd-bash-completion.bash
├── mvnd-sync.exe
├── mvnd.cmd
├── mvnd.exe
└── mvnd.sh
```
I take the liberty of adding the suffix ".cmd" when detecting under windows only