### PR TITLE
[3731] Fixing unused import handling for module-infos.

### DIFF
--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/imports/UnusedImports.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/imports/UnusedImports.java
@@ -166,6 +166,7 @@ public class UnusedImports {
 	    scan(tree.getImports(), d);
 	    scan(tree.getPackageAnnotations(), d);
 	    scan(tree.getTypeDecls(), d);
+	    scan(tree.getModule(), d);
 	    return null;
         }
 


### PR DESCRIPTION
Fixes #3731 
Import usage is not detected, as the UnusedImports visitor does not descend into the module declaration (IIRC there was a change at some point, before it was included in getTypeDecls, I think).