### PR TITLE
workaround due to old JDK bug (see JDK-4530952).

### DIFF
--- a/platform/api.search/src/org/netbeans/modules/search/BasicSearchForm.java
+++ b/platform/api.search/src/org/netbeans/modules/search/BasicSearchForm.java
@@ -1112,7 +1112,10 @@ final class BasicSearchForm extends JPanel implements ChangeListener,
 
         @Override
         public void setItem(Object item) {
-            area.setText(Objects.toString(item, ""));
+            String text = Objects.toString(item, "");
+            if (!text.equals(area.getText())) { // see BasicComboBoxEditor.setItem(item) or JDK-4530952
+                area.setText(text);
+            }
         }
 
         @Override


### PR DESCRIPTION
fixes #3752

This was difficult to find since the symptoms were fairly misleading.

For some reason the click event only disappeared when the find button was clicked, while cancel worked reliably with a single click. But there was nothing special about the find button beside it being the default action / already focused.

see https://bugs.openjdk.java.net/browse/JDK-4530952