### PR TITLE
exile job for unreliable tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -357,7 +357,6 @@ matrix:
             - hide-logs.sh ant $OPTS -f java/debugger.jpda.js test
             - hide-logs.sh ant $OPTS -f java/debugger.jpda.projects test
             - hide-logs.sh ant $OPTS -f java/debugger.jpda.projectsui test
-            - hide-logs.sh ant $OPTS -f java/gradle.java test
             #- ant $OPTS -f java/debugger.jpda.truffle test
             #- ant $OPTS -f java/debugger.jpda.ui test
             - travis_wait hide-logs.sh ant $OPTS -f java/editor.htmlui test
@@ -369,7 +368,6 @@ matrix:
             #- ant $OPTS -f java/java.kit test
             #- ant $OPTS -f java/java.lexer test
             #- ant $OPTS -f java/java.lexer test
-            - ant $OPTS -f java/java.lsp.server test
             #- ant $OPTS -f java/java.metrics test
             - ant $OPTS -f java/java.module.graph test
             - ant $OPTS -f java/java.navigation test
@@ -722,6 +720,18 @@ matrix:
           script:
             - export JAVA_HOME=$TEST_JDK
             - hide-logs.sh ant $OPTS commit-validation
+
+#   exile: for tests which don't behave. Job should be kept short to be easily restartable
+        - name: Test unreliable tests on Java 8
+          jdk: openjdk8
+          env:
+            - OPTS="-Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json -quiet -Dcluster.config=java -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true"
+          before_script:
+            - nbbuild/travis/ant.sh $OPTS clean
+            - nbbuild/travis/ant.sh $OPTS build
+          script:
+            - travis_retry ant $OPTS -f java/java.lsp.server test
+            - travis_retry hide-logs.sh ant $OPTS -f java/gradle.java test
 
 after_failure:
   - nbbuild/travis/print-junit-report.sh


### PR DESCRIPTION
lets give this a try to make job 13 more reliable

1. identify unreliable tests
2. isolate them into their own job (easier restartable without having to run well behaving tests multiple times)
3. maybe use `travis_retry`


- - -
logs from a different PR where i had to restart job 13 four times in a row:
```
https://app.travis-ci.com/github/apache/netbeans/jobs/563140526
org.netbeans.modules.java.lsp.server.explorer.ProjectViewTest

      failed: testOnceExistedDeletedItemInfo

org.netbeans.modules.java.lsp.server.project.LspBrokenReferencesImplTest

      failed: testIgnoredErrorsTimeout

org.netbeans.modules.java.source.parsing.PartialReparseTest

      failed: testIntroduceParseError2
---
https://app.travis-ci.com/github/apache/netbeans/jobs/563138079
org.netbeans.modules.java.lsp.server.explorer.ProjectViewTest

      failed: testEmptyPackageRemains
---
https://app.travis-ci.com/github/apache/netbeans/jobs/563294404
org.netbeans.modules.java.lsp.server.project.LspBrokenReferencesImplTest

      failed: testIgnoredErrorsTimeout
---
https://app.travis-ci.com/github/apache/netbeans/jobs/563294404
org.netbeans.modules.java.lsp.server.explorer.ProjectViewTest

      failed: testProjectSourcePackages
```