### PR TITLE
Tame Gradle Project Loading

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
@@ -322,9 +322,10 @@ public class ActionProviderImpl implements ActionProvider {
                 final ActionProgress g = ActionProgress.start(context);
                 GradleLoadOptions opts = GradleLoadOptions
                         .loadForQuality(maxQualily)
+                        .force()
                         .withMessage(loadReason)
                         .withArgs(RunUtils.evaluateActionArgs(project, mapping.getName(), mapping.getReloadArgs(), ctx));
-                RequestProcessor.Task reloadTask = prj.forceReloadProject(opts);
+                RequestProcessor.Task reloadTask = prj.reloadProject(opts);
                 reloadTask.addTaskListener((t) -> {
                     g.finished(true);
                 });
@@ -341,9 +342,10 @@ public class ActionProviderImpl implements ActionProvider {
                         if (needReload && canReload) {
                             GradleLoadOptions opts = GradleLoadOptions
                                     .loadForQuality(maxQualily)
+                                    .force()
                                     .interactive()
                                     .withArgs(RunUtils.evaluateActionArgs(project, mapping.getName(), mapping.getReloadArgs(), outerCtx));
-                            RequestProcessor.Task reloadTask = prj.forceReloadProject(opts);
+                            RequestProcessor.Task reloadTask = prj.reloadProject(opts);
                             reloadTask.waitFinished();
                         }
                         project.getLookup().lookup(AfterBuildActionHook.class).afterAction(action, outerCtx, task.result(), out1);

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProject.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
@@ -37,7 +38,9 @@ import org.openide.util.lookup.InstanceContent;
  */
 public final class GradleProject implements Lookup.Provider {
 
-    final int sequence;
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    final int sequence = SEQ.getAndIncrement();
     final Set<String> problems;
     final Quality quality;
     final long evaluationTime = System.currentTimeMillis();
@@ -45,8 +48,7 @@ public final class GradleProject implements Lookup.Provider {
     final GradleBaseProject baseProject;
 
     @SuppressWarnings("rawtypes")
-    public GradleProject(int sequence, Quality quality, Set<String> problems, Collection infos) {
-        this.sequence = sequence;
+    public GradleProject(Quality quality, Set<String> problems, Collection infos) {
         this.quality = quality;
         Set<String> probs = new LinkedHashSet<>();
         for (String prob : problems) {
@@ -63,7 +65,6 @@ public final class GradleProject implements Lookup.Provider {
     }
 
     private GradleProject(Quality quality, Set<String> problems, GradleProject origin) {
-        this.sequence = origin.sequence;
         this.quality = quality;
         Set<String> probs = new LinkedHashSet<>();
         for (String prob : problems) {
@@ -99,7 +100,7 @@ public final class GradleProject implements Lookup.Provider {
     public boolean isOlderThan(GradleProject gp) {
         return gp != null ? sequence < gp.sequence : false;
     }
-    
+
     @NonNull
     public GradleBaseProject getBaseProject() {
         return baseProject;
@@ -107,7 +108,7 @@ public final class GradleProject implements Lookup.Provider {
 
     @Override
     public String toString() {
-        return "GradleProject{" + "quality=" + quality + ", baseProject=" + baseProject + '}';
+        return "GradleProject{" + "sequence=" + sequence + ", quality=" + quality + ", baseProject=" + baseProject + '}';
     }
 
     public final GradleProject invalidate(String... reasons) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -449,11 +449,7 @@ public final class NbGradleProjectImpl implements Project {
      * @param args optional argument for reload
      * @return Task representing the reloading process
      */
-    RequestProcessor.Task forceReloadProject(GradleLoadOptions opts) {
-        return reloadProject(opts.force());
-    }
-
-    private RequestProcessor.Task reloadProject(GradleLoadOptions opts) {
+    RequestProcessor.Task reloadProject(GradleLoadOptions opts) {
         return RELOAD_RP.post(() -> loadOwnProject(opts));
     }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
@@ -36,6 +36,7 @@ import org.netbeans.modules.gradle.api.GradleProjects;
 
 import static org.netbeans.modules.gradle.Bundle.*;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FULL_ONLINE;
+import org.netbeans.modules.gradle.loaders.GradleLoadOptions;
 
 /**
  *
@@ -77,7 +78,10 @@ public class ReloadAction  extends AbstractAction implements ContextAwareAction 
         for (Project project : reload) {
             if (project instanceof NbGradleProjectImpl) {
                 NbGradleProjectImpl impl = (NbGradleProjectImpl) project;
-                impl.forceReloadProject(ACT_ReloadingProject(), true, FULL_ONLINE);
+                GradleLoadOptions opts = GradleLoadOptions.AIM_FULL_ONLINE
+                        .interactive()
+                        .withMessage(ACT_ReloadingProject());
+                impl.forceReloadProject(opts);
             }
         }
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
@@ -35,7 +35,6 @@ import org.openide.util.NbBundle;
 import org.netbeans.modules.gradle.api.GradleProjects;
 
 import static org.netbeans.modules.gradle.Bundle.*;
-import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FULL_ONLINE;
 import org.netbeans.modules.gradle.loaders.GradleLoadOptions;
 
 /**
@@ -79,9 +78,10 @@ public class ReloadAction  extends AbstractAction implements ContextAwareAction 
             if (project instanceof NbGradleProjectImpl) {
                 NbGradleProjectImpl impl = (NbGradleProjectImpl) project;
                 GradleLoadOptions opts = GradleLoadOptions.AIM_FULL_ONLINE
+                        .force()
                         .interactive()
                         .withMessage(ACT_ReloadingProject());
-                impl.forceReloadProject(opts);
+                impl.reloadProject(opts);
             }
         }
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/ReloadProjectDependenciesDecorator.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ReloadProjectDependenciesDecorator.java
@@ -25,6 +25,7 @@ import org.netbeans.modules.gradle.spi.actions.AfterBuildActionHook;
 import java.io.PrintWriter;
 import java.util.Map;
 import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.loaders.GradleLoadOptions;
 import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.util.Lookup;
 
@@ -47,7 +48,7 @@ public class ReloadProjectDependenciesDecorator implements AfterBuildActionHook 
         for (Project dep : dependencies.values()) {
             NbGradleProjectImpl impl = dep.getLookup().lookup(NbGradleProjectImpl.class);
             if ((impl != null) && impl.getAimedQuality().betterThan(impl.getGradleProject().getQuality())) {
-                impl.forceReloadProject(null, false, impl.getAimedQuality());
+                impl.forceReloadProject(GradleLoadOptions.loadForQuality(impl.getAimedQuality()));
             }
         }
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/ReloadProjectDependenciesDecorator.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ReloadProjectDependenciesDecorator.java
@@ -48,7 +48,7 @@ public class ReloadProjectDependenciesDecorator implements AfterBuildActionHook 
         for (Project dep : dependencies.values()) {
             NbGradleProjectImpl impl = dep.getLookup().lookup(NbGradleProjectImpl.class);
             if ((impl != null) && impl.getAimedQuality().betterThan(impl.getGradleProject().getQuality())) {
-                impl.forceReloadProject(GradleLoadOptions.loadForQuality(impl.getAimedQuality()));
+                impl.reloadProject(GradleLoadOptions.loadForQuality(impl.getAimedQuality()).force());
             }
         }
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
@@ -52,13 +52,13 @@ public abstract class AbstractProjectLoader {
     }
 
     abstract GradleProject load();
- 
+
     abstract boolean isEnabled();
 
     boolean needsTrust() {
         return true;
     }
-    
+
     static final class ReloadContext {
 
         final NbGradleProjectImpl project;
@@ -69,7 +69,7 @@ public abstract class AbstractProjectLoader {
 
         public ReloadContext(NbGradleProjectImpl project, NbGradleProject.Quality aim, GradleCommandLine cmd, String description) {
             this.project = project;
-            this.previous = project.isGradleProjectLoaded() ? project.projectWithQuality(null, FALLBACK, false, false) : FallbackProjectLoader.createFallbackProject(project.getGradleFiles());
+            this.previous = project.isGradleProjectLoaded() ? project.projectWithQuality(GradleLoadOptions.AIM_FALLBACK) : FallbackProjectLoader.createFallbackProject(project.getGradleFiles());
             this.aim = aim;
             this.cmd = cmd;
             this.description = description;
@@ -109,7 +109,7 @@ public abstract class AbstractProjectLoader {
             }
 
         }
-        return new GradleProject(info.getQuality(), problems, results.values());
+        return new GradleProject(0, info.getQuality(), problems, results.values());
 
     }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
@@ -109,7 +109,7 @@ public abstract class AbstractProjectLoader {
             }
 
         }
-        return new GradleProject(0, info.getQuality(), problems, results.values());
+        return new GradleProject(info.getQuality(), problems, results.values());
 
     }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
@@ -62,7 +62,7 @@ public class FallbackProjectLoader extends AbstractProjectLoader {
             }
 
         }
-        return new GradleProject(0, NbGradleProject.Quality.FALLBACK, problems, infos.values());
+        return new GradleProject(NbGradleProject.Quality.FALLBACK, problems, infos.values());
     }
 
     @Override

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
@@ -62,9 +62,9 @@ public class FallbackProjectLoader extends AbstractProjectLoader {
             }
 
         }
-        return new GradleProject(NbGradleProject.Quality.FALLBACK, problems, infos.values());        
+        return new GradleProject(0, NbGradleProject.Quality.FALLBACK, problems, infos.values());
     }
-    
+
     @Override
     boolean isEnabled() {
         return true;

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleLoadContext.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleLoadContext.java
@@ -16,15 +16,34 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.modules.gradle;
+package org.netbeans.modules.gradle.loaders;
 
-import org.netbeans.modules.gradle.loaders.GradleLoadOptions;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.GradleProject;
 
 /**
  *
- * @author lkishalmi
+ * @author Laszlo Kishalmi
  */
-public interface GradleProjectLoader {
+public final class GradleLoadContext {
+    private static final AtomicInteger SEQ = new AtomicInteger();
+    private final int sequence;
 
-    GradleProject loadProject(GradleLoadOptions opts);
+    public final Project project;
+
+    public final GradleLoadOptions options;
+
+    public GradleLoadContext(Project project, GradleLoadOptions options) {
+        sequence = SEQ.getAndIncrement();
+        this.project = project;
+        this.options = options;
+    }
+
+
+    CompletableFuture<GradleProject> loadProjectFuture() {
+        return null;
+    }
+
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleLoadOptions.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleLoadOptions.java
@@ -83,4 +83,24 @@ public final class GradleLoadOptions {
     public static GradleLoadOptions loadForQuality(Quality aim) {
         return new GradleLoadOptions("", false, false, false, false, aim, new String[0]);
     }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("GradleLoadOptions: {");
+        sb.append("aim: ").append(aim).append(", ");
+        if (ignoreCache) {
+            sb.append("no-cache, ");
+        }
+        if (interactive) {
+            sb.append(" interactive, ");
+        }
+        if (sync) {
+            sb.append("sync, ");
+        }
+        if (force) {
+            sb.append("forced, ");
+        }
+        sb.append("args: ").append(args).append("}");
+        return sb.toString();
+    }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleLoadOptions.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleLoadOptions.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
+
+/**
+ *
+ * @author Laszlo Kishalmi
+ */
+public final class GradleLoadOptions {
+
+    public static final GradleLoadOptions AIM_FALLBACK    = loadForQuality(Quality.FALLBACK);
+    public static final GradleLoadOptions AIM_EVALUATED   = loadForQuality(Quality.EVALUATED);
+    public static final GradleLoadOptions AIM_FULL        = loadForQuality(Quality.FULL);
+    public static final GradleLoadOptions AIM_FULL_ONLINE = loadForQuality(Quality.FULL_ONLINE);
+
+    public final String message;
+    public final boolean ignoreCache;
+    public final boolean interactive;
+    public final boolean sync;
+    public final boolean force;
+    public final Quality aim;
+    public final String[] args;
+
+    private GradleLoadOptions(
+            String message,
+            boolean ignoreCache,
+            boolean interactive,
+            boolean sync,
+            boolean force,
+            Quality aim,
+            String[] args) {
+        this.message = message;
+        this.ignoreCache = ignoreCache;
+        this.interactive = interactive;
+        this.sync = sync;
+        this.force = force;
+        this.aim = aim;
+        this.args = args;
+    }
+
+    public GradleLoadOptions withMessage(String msg) {
+        return new GradleLoadOptions( msg, ignoreCache, interactive, sync, force, aim, args);
+    }
+
+    public GradleLoadOptions ignoreCache() {
+        return new GradleLoadOptions(message, true, interactive, sync, force, aim, args);
+    }
+
+    public GradleLoadOptions interactive() {
+        return new GradleLoadOptions(message, ignoreCache, true, sync, force, aim, args);
+    }
+
+    public GradleLoadOptions sync() {
+        return new GradleLoadOptions(message, ignoreCache, interactive, true, force, aim, args);
+    }
+
+    public GradleLoadOptions force() {
+        return new GradleLoadOptions(message, ignoreCache, interactive, sync, true, aim, args);
+    }
+
+    public GradleLoadOptions withArgs(String... args) {
+        return new GradleLoadOptions(message, ignoreCache, interactive, sync, force, aim, args);
+    }
+
+    public static GradleLoadOptions loadForQuality(Quality aim) {
+        return new GradleLoadOptions("", false, false, false, false, aim, new String[0]);
+    }
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
@@ -26,7 +26,6 @@ import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.GradleProject;
 import org.netbeans.modules.gradle.GradleProjectLoader;
 import org.netbeans.modules.gradle.NbGradleProjectImpl;
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
 import org.netbeans.modules.gradle.api.execute.RunUtils;
 import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
@@ -49,15 +48,15 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
     @NbBundle.Messages({
         "ERR_ProjectNotTrusted=Gradle execution is not trusted on this project."
     })
-    public GradleProject loadProject(NbGradleProject.Quality aim, String descriptionOpt, boolean ignoreCache, boolean interactive, String... args) {
-        LOGGER.info("Load aiming " +aim + " for "+ project);
-        GradleCommandLine cmd = new GradleCommandLine(args);
-        AbstractProjectLoader.ReloadContext ctx = new AbstractProjectLoader.ReloadContext((NbGradleProjectImpl) project, aim, cmd, descriptionOpt);
-        LOGGER.log(Level.FINER, "Load context: project = {0}, prev = {1}, aim = {2}, args = {3}", new Object[] { 
-            project, ctx.previous, aim, cmd});
+    public GradleProject loadProject(GradleLoadOptions opts) {
+        LOGGER.info("Load aiming " + opts.aim + " for "+ project);
+        GradleCommandLine cmd = new GradleCommandLine(opts.args);
+        AbstractProjectLoader.ReloadContext ctx = new AbstractProjectLoader.ReloadContext((NbGradleProjectImpl) project, opts.aim, cmd, opts.message);
+        LOGGER.log(Level.FINER, "Load context: project = {0}, prev = {1}, aim = {2}, args = {3}", new Object[] {
+            project, ctx.previous, opts.aim, cmd});
         List<AbstractProjectLoader> loaders = new LinkedList<>();
 
-        if (!ignoreCache) loaders.add(new DiskCacheProjectLoader(ctx));
+        if (!opts.ignoreCache) loaders.add(new DiskCacheProjectLoader(ctx));
         if (GradleExperimentalSettings.getDefault().isBundledLoading()) {
             loaders.add(new BundleProjectLoader(ctx));
             loaders.add(new DiskCacheProjectLoader(ctx));
@@ -72,7 +71,7 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
             if (loader.isEnabled()) {
                 if (loader.needsTrust()) {
                     if (trust == null) {
-                        trust = RunUtils.isProjectTrusted(ctx.project, interactive);
+                        trust = RunUtils.isProjectTrusted(ctx.project, opts.interactive);
                     }
                     if (trust) {
                         ret = loader.load();

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
@@ -58,6 +58,7 @@ import org.netbeans.modules.gradle.GradleProjectLoader;
 import org.netbeans.modules.gradle.ProjectTrust;
 import org.netbeans.modules.gradle.api.GradleProjects;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
+import org.netbeans.modules.gradle.loaders.GradleLoadOptions;
 import org.openide.loaders.DataFolder;
 import org.openide.loaders.DataObject;
 import org.openide.util.NbBundle;
@@ -68,7 +69,7 @@ import org.openide.util.NbBundle;
  */
 public final class TemplateOperation implements Runnable {
     private static final Logger LOG = Logger.getLogger(TemplateOperation.class.getName());
-    
+
     public interface ProjectConfigurator {
         void configure(Project project);
     }
@@ -154,13 +155,13 @@ public final class TemplateOperation implements Runnable {
         steps.add(new InitGradleWrapper(target));
     }
 
-    /** *  Begin creation of new project using Gradle's 
+    /** *  Begin creation of new project using Gradle's
      * <a target="_blank" href="https://docs.gradle.org/current/userguide/build_init_plugin.html">gradle init</a>
-     * functionality. Use the returned {@link InitOperation} object to specify 
-     * additional properties and then call  
+     * functionality. Use the returned {@link InitOperation} object to specify
+     * additional properties and then call
      * {@link InitOperation#add()} to finish the request.
-     * 
-     * 
+     *
+     *
      * @param target the directory to place the project at
      * @param type either {@code java-application}, {@code java-library}, etc.
      * @return the {@link InitOperation} builder to finish the request
@@ -171,9 +172,9 @@ public final class TemplateOperation implements Runnable {
     }
 
     /** Builder to specify additional parameters for the {@link #createGradleInit(java.io.File, java.lang.String)}
-     * operation. At the end call {@link #add()} to finish the operation and 
+     * operation. At the end call {@link #add()} to finish the operation and
      * add it to the list of {@link OperationStep}s to perform.
-     * 
+     *
      * @since 2.20
      */
     public abstract class InitOperation {
@@ -328,7 +329,7 @@ public final class TemplateOperation implements Runnable {
             return "Step: " + getMessage();
         }
     }
-    
+
     private static final class CreateDirStep extends BaseOperationStep {
 
         final String message;
@@ -353,7 +354,7 @@ public final class TemplateOperation implements Runnable {
             }
             return null;
         }
-        
+
     }
 
     private static final class ConfigureProjectStep extends BaseOperationStep {
@@ -380,7 +381,7 @@ public final class TemplateOperation implements Runnable {
                     ProjectTrust.getDefault().trustProject(project);
                     NbGradleProjectImpl impl = project != null ? project.getLookup().lookup(NbGradleProjectImpl.class): null;
                     if (impl != null) {
-                        impl.projectWithQuality(null, Quality.FULL, false, false);
+                        impl.projectWithQuality(GradleLoadOptions.AIM_FULL);
                         configurator.configure(project);
                     }
 
@@ -428,7 +429,7 @@ public final class TemplateOperation implements Runnable {
                             //Just load the project into the cache.
                             GradleProjectLoader loader = nbProject.getLookup().lookup(GradleProjectLoader.class);
                             if (loader != null) {
-                                loader.loadProject(Quality.FULL_ONLINE, null, true, false);
+                                loader.loadProject(GradleLoadOptions.AIM_FULL_ONLINE.ignoreCache());
                             }
                         }
                         return Collections.singleton(projectDir);

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
@@ -26,7 +26,7 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.junit.NbTestCase;
-import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FULL_ONLINE;
+import org.netbeans.modules.gradle.loaders.GradleLoadOptions;
 import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
 import org.netbeans.modules.project.uiapi.ProjectOpenedTrampoline;
 import org.netbeans.spi.project.ui.ProjectOpenedHook;
@@ -83,15 +83,15 @@ public class AbstractGradleProjectTestCase extends NbTestCase {
         NbGradleProjectImpl.RELOAD_RP.submit(() -> {
             // A bit low level calls, just to allow UI interaction to
             // Trust the project.
-            impl.loadOwnProject(null, true, true, FULL_ONLINE);
+            impl.loadOwnProject(GradleLoadOptions.AIM_FULL_ONLINE.ignoreCache().interactive());
         }).get();
     }
-    
+
     protected void dumpProject(Project project){
         NbGradleProjectImpl impl = (NbGradleProjectImpl) project;
         impl.dumpProject();
     }
-    
+
     protected FileObject createGradleProject(String path, String buildScript, String settingsScript) throws IOException {
         FileObject ret = FileUtil.toFileObject(getWorkDir());
         if (path != null) {

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
@@ -215,7 +215,7 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
                 .ignoreCache()
                 .interactive()
                 .sync();
-        CompletableFuture<GradleProject> f = prjImpl.loadOwnProject0(opts);
+        CompletableFuture<GradleProject> f = prjImpl.loadOwnProject(opts);
         assertFalse(f.isDone());
         projL.processing.acquire();
         // still not done, since blocked inside the listener

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
@@ -37,6 +37,7 @@ import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.junit.AssertionFailedErrorException;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
+import org.netbeans.modules.gradle.loaders.GradleLoadOptions;
 import org.openide.filesystems.FileLock;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -46,21 +47,21 @@ import org.openide.filesystems.FileUtil;
  * @author sdedic
  */
 public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
-    
+
     public NbGradleProjectImplTest(String name) {
         super(name);
     }
-    
+
     private FileObject projectDir;
     private Project prj;
-    
+
     @Before
     @Override
     public void setUp() throws Exception {
         super.setUp();
         prj = createProject();
     }
-    
+
     @After
     @Override
     public void tearDown() throws Exception {
@@ -72,7 +73,7 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         prj = null;
         super.tearDown();
     }
-    
+
     private Project createProject() throws Exception {
         int rnd = new Random().nextInt(1000000);
         FileObject a = createGradleProject("projectA-" + rnd,
@@ -80,7 +81,7 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         projectDir = a;
         return ProjectManager.getDefault().findProject(a);
     }
-    
+
     private void assertHasNoConnection(Project p) throws Exception {
         ProjectConnection pconn = p.getLookup().lookup(ProjectConnection.class);
         if (pconn instanceof GradleProjectConnection) {
@@ -88,34 +89,34 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
             assertFalse(gpconn.hasConnection());
         }
     }
-    
+
     /**
      * Checks that untrusted unopened project will present itself as a fallback.
-     * @throws Exception 
+     * @throws Exception
      */
     public void testUntrustedProjectFallback() throws Exception {
         NbGradleProject ngp = NbGradleProject.get(prj);
-        
+
         assertTrue(ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
     }
-    
+
     /**
      * Checks that untrusted unopened project will present itself as a fallback.
-     * @throws Exception 
+     * @throws Exception
      */
     public void testInitialLoadDoesNotFireChange() throws Exception {
         NbGradleProject ngp = NbGradleProject.get(prj);
         assertTrue(ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
         assertHasNoConnection(prj);
     }
-    
+
     /**
      * Checks that an attempt to reload project with escalated quality will fail
      * for an untrusted project.
-     * @throws Exception 
+     * @throws Exception
      */
     public void testUntrustedProjectCannotGoUp() throws Exception {
-        
+
         NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
         assertTrue(prjImpl.getGradleProject().getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
         // attempt to load everything
@@ -124,17 +125,17 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         assertTrue(prjImpl.getGradleProject().getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
         assertHasNoConnection(prj);
     }
-    
+
     /**
      * Check that a trusted project can be loaded as 'evaluated' quality, at least.
-     * @throws Exception 
+     * @throws Exception
      */
     public void testTrustedProjectLoadsToEvaluated() throws Exception {
-        
+
         NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
         assertTrue(prjImpl.getGradleProject().getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
         ProjectTrust.getDefault().trustProject(prj);
-        
+
         // attempt to load everything
         prjImpl.setAimedQuality(NbGradleProject.Quality.FULL);
         // ... it loaded, but did not escalate the quality bcs not trusted
@@ -146,7 +147,7 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         volatile Semaphore block = new Semaphore(20);
         Queue<PropertyChangeEvent> all = new ArrayBlockingQueue<>(20);
         Semaphore processing = new Semaphore(0);
-        
+
         @Override
         public void propertyChange(PropertyChangeEvent evt) {
             processing.release();
@@ -159,22 +160,22 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
             all.add(evt);
         }
     }
-    
+
     L projL = new L();
-    
+
     /**
      * Checks that initial load with 'fallback' quality does not fire 'project reloaded'
      * event.
      */
     public void testInitialLoadReloadNotFired() throws Exception {
         NbGradleProject ngp = NbGradleProject.get(prj);
-        
+
         ngp.addPropertyChangeListener(projL);
-        
+
         Quality q = ngp.getQuality();
         assertNull(projL.e);
     }
-    
+
     /**
      * After the project changes (increases) the quality after initial load, check
      * that the ProjectInfo property change is fired.
@@ -184,17 +185,17 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         ProjectTrust.getDefault().trustProject(prj);
         // initializes the project
         assertTrue(ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
-        
+
         // force project reload
         ngp.addPropertyChangeListener(projL);
         NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
         prjImpl.setAimedQuality(NbGradleProject.Quality.FULL);
         assertTrue(prjImpl.getGradleProject().getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
-        
+
         assertNotNull(projL.e);
         assertEquals(NbGradleProject.PROP_PROJECT_INFO, projL.e.getPropertyName());
     }
-    
+
     /**
      * Checks that ProjectInfo events are processed before completion of the load future
      */
@@ -203,13 +204,18 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         ProjectTrust.getDefault().trustProject(prj);
         // initializes the project
         assertTrue(ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
-        
+
         ngp.addPropertyChangeListener(projL);
         NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
-        
+
         // block the dispatch
         projL.block.drainPermits();
-        CompletableFuture<GradleProject> f = prjImpl.loadOwnProject0("Test reload", true, true, Quality.FULL, false, true);
+        GradleLoadOptions opts = GradleLoadOptions.AIM_FULL
+                .withMessage("Test reload")
+                .ignoreCache()
+                .interactive()
+                .sync();
+        CompletableFuture<GradleProject> f = prjImpl.loadOwnProject0(opts);
         assertFalse(f.isDone());
         projL.processing.acquire();
         // still not done, since blocked inside the listener
@@ -219,7 +225,7 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         GradleProject p = f.get();
         assertTrue(p.getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
     }
-    
+
     /**
      * Checks that request to increase the quality changes the project. This case checks the project
      * going from state {@link Quality#FALLBACK} (never built, trusted) to at least {@link Quality#EVALUATED}
@@ -230,16 +236,16 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         ProjectTrust.getDefault().trustProject(prj);
         // initializes the project
         assertTrue(ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
-        
+
         NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
         GradleProject curProject = prjImpl.getGradleProject();
         prjImpl.setAimedQuality(Quality.FULL);
         GradleProject newProject = prjImpl.getGradleProject();
         assertTrue(newProject.getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
         assertNotSame(newProject, curProject);
-        
+
     }
-    
+
     /**
      * Aiming for EVALUATED quality does not force execution of the Gradle project, if
      * the evaluated state does not exist.
@@ -258,7 +264,7 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         assertSame(newProject, curProject);
         assertHasNoConnection(prj);
     }
-    
+
     /**
      * Trusts and closes the project. To avoid project caches, creates a copy in another
      * folder & swaps (FileObject will be different, name the same).
@@ -270,13 +276,13 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         ProjectTrust.getDefault().trustProject(prj);
 
         FileObject s = projectDir.getParent().createFolder("second");
-        
+
         // open and close the project.
         OpenProjects.getDefault().open(new Project[] { prj }, false);
         OpenProjects.getDefault().openProjects().get();
         OpenProjects.getDefault().close(new Project[] { prj });
         OpenProjects.getDefault().openProjects().get();
-        
+
         assertTrue(ngp.getQuality().atLeast(Quality.EVALUATED));
 
         copy(projectDir, s);
@@ -289,7 +295,7 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         try (FileLock fl = s.lock()) {
             s.rename(fl, origName, null);
         }
-        
+
         Project prj2 = FileOwnerQuery.getOwner(s);
         NbGradleProject ngp2 = NbGradleProject.get(prj2);
         // initializes the project, since it is trusted (reopened), should come
@@ -310,24 +316,24 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
             }
         }
     }
-    
+
     public void testSufficientAimedQualityNoop() throws Exception {
         checkProjectDoesNotChange(Quality.FULL);
     }
-    
+
     public void testDecreaseAimedQualityNoop() throws Exception {
         checkProjectDoesNotChange(Quality.EVALUATED);
     }
-    
+
     private void checkProjectDoesNotChange(Quality aimed) throws Exception {
         NbGradleProject ngp = NbGradleProject.get(prj);
         ProjectTrust.getDefault().trustProject(prj);
         NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
         prjImpl.setAimedQuality(Quality.FULL);
         assertTrue(ngp.getQuality().atLeast(Quality.FULL));
-        
+
         GradleProject curProject = prjImpl.getGradleProject();
-        
+
         prjImpl.setAimedQuality(aimed);
         GradleProject newProject = prjImpl.getGradleProject();
         assertTrue(newProject.getQuality().atLeast(Quality.FULL));


### PR DESCRIPTION
@sdedic this is an attempt to tame the Gradle project loading methods and calls. My motivation was, that I started to get lost in the calls when a Gradle project, loaded re-loaded.

What I'm trying here is to move the options of the different kind of re-loads into a separate class as [GradleLoadOptions](extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleLoadOptions.java) so the code can be more descriptive, and the usage of certain load flags could be more easily tracked. I could be completely wrong with this PR and my approach could be wrong as well. Your feedback is essential.

I've tried not to break things, though made a few not compatible changes. loadedProjectSerial and currentSerial in NBGradleProjectImpl were moved to a new sequence field to GradleProject, so dumpProject() cannot set the loadedProjectSerial to zero.

Tests seems to be fine, save NbGradleProjectImpl.testEventsProcessedBeforeCompletion() which hangs in infinite wait. Unfortunately I could not crack what that test really does, so I need some help there. 

There are some unused code mentioning GradleLoadContext that shall be ignored.

I have purposefully not changed the javadoc on the load methods yet, so the former parameters can be looked up while replacing the calls with GradleLoadOptions arguments.