### PR TITLE
Add Apache NetBeans Snap Package as an option to GitHub Bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
@@ -95,6 +95,7 @@ body:
       options:
         - "Apache NetBeans provided installer"
         - "Apache NetBeans binary zip"
+        - "Apache NetBeans Snap Package"
         - "Third-party package"
         - "Own source build"
         - "Apache VSNetBeans for VSCode"


### PR DESCRIPTION
Just a small addition.
