### PR TITLE
[NETBEANS-4826] Fixing java indexing in Groovy

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/GroovyIndexer.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/GroovyIndexer.java
@@ -45,6 +45,7 @@ import org.netbeans.modules.csl.api.Modifier;
 import org.netbeans.modules.groovy.editor.api.lexer.LexUtilities;
 import org.netbeans.modules.groovy.editor.api.elements.ast.ASTField;
 import org.netbeans.modules.groovy.editor.api.elements.ast.ASTMethod;
+import org.netbeans.modules.groovy.editor.api.elements.common.MethodElement;
 import org.netbeans.modules.groovy.editor.compiler.ClassNodeCache;
 import org.netbeans.modules.groovy.editor.compiler.PerfData;
 import org.netbeans.modules.groovy.editor.utils.GroovyUtils;
@@ -352,10 +353,10 @@ public class GroovyIndexer extends EmbeddingIndexer {
             sb.append(constructor.getName());
             sb.append(';');
 
-            List<String> params = constructor.getParameterTypes();
-            if (!params.isEmpty()) {
-                for (String paramName : params) {
-                    sb.append(paramName);
+            List<MethodElement.MethodParameter> params = constructor.getParameters();
+            if (params != null && !params.isEmpty()) {
+                for (MethodElement.MethodParameter param : params) {
+                    sb.append(param.getFqnType());
                     sb.append(",");
                 }
 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CaretLocation.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CaretLocation.java
@@ -36,6 +36,7 @@ public enum CaretLocation {
     INSIDE_PARAMETERS("INSIDE_PARAMETERS"), // inside a parameter-list definition (signature) of a method.
     INSIDE_COMMENT("INSIDE_COMMENT"),       // inside a line or block comment
     INSIDE_STRING("INSIDE_STRING"),         // inside string literal
+    INSIDE_IMPORT("INSIDE_IMPORT"),         // inside import statement
     UNDEFINED("UNDEFINED");
     
     private String id;

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionItem.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionItem.java
@@ -800,6 +800,12 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
         @Override
         public ElementKind getKind() {
             // TODO: kind could be class or interface, depending on ek - NETBEANS-5788
+            if (this.ek == javax.lang.model.element.ElementKind.FIELD) {
+                return ElementKind.FIELD;
+            }
+            if (this.ek == javax.lang.model.element.ElementKind.METHOD) {
+                return ElementKind.METHOD;
+            }
             return ElementKind.CLASS;
         }
 
@@ -810,7 +816,10 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
 
         @Override
         public Set<Modifier> getModifiers() {
-            return Collections.emptySet();
+            if (this.ek.isClass() || this.ek.isInterface()) {
+                return Collections.emptySet();
+            }
+            return Collections.singleton(Modifier.STATIC);
         }
         
         void assignHandle(ElementHandle h) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/CompletionContext.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/CompletionContext.java
@@ -298,19 +298,28 @@ public final class CompletionContext {
         boolean openBraceBeforePosition = false;
         // is there package statement?
         boolean afterPackagePosition = false;
-
+        boolean canBeImport = true;
+        
         ts.move(position);
 
         while (ts.isValid() && ts.movePrevious() && ts.offset() >= 0) {
             Token<GroovyTokenId> t = ts.token();
             if (t.id() == GroovyTokenId.LBRACE) {
                 openBraceBeforePosition = true;
+                canBeImport = false;
             } else if (t.id() == GroovyTokenId.LITERAL_class || t.id() == GroovyTokenId.LITERAL_interface || t.id() == GroovyTokenId.LITERAL_trait) {
                 classDefBeforePosition = true;
                 break;
             } else if (t.id() == GroovyTokenId.LITERAL_package) {
                 afterPackagePosition = true;
                 break;
+            } else if (canBeImport && t.id() == GroovyTokenId.LITERAL_import) {
+                return CaretLocation.INSIDE_IMPORT;
+            }
+            
+            if (canBeImport && !(t.id() == GroovyTokenId.DOT || t.id() == GroovyTokenId.IDENTIFIER
+                    || t.id() == GroovyTokenId.WHITESPACE || t.id() == GroovyTokenId.LITERAL_static)) {
+                canBeImport = false;
             }
         }
 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/TypesCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/TypesCompletion.java
@@ -321,10 +321,7 @@ public class TypesCompletion extends BaseCompletion {
             return;
         }
 
-        String ownerFQN = GroovyUtils.stripClassName(fqnTypeName);
-        if (!ownerFQN.isEmpty() && ownerFQN.endsWith("."))  {
-            ownerFQN = ownerFQN.substring(0, ownerFQN.length() - 1);
-        }
+        String ownerFQN = GroovyUtils.getPackageName(fqnTypeName);
         
         // We are dealing with prefix for some class type
         JavaElementHandle jh = null;

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/TypesCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/TypesCompletion.java
@@ -40,6 +40,7 @@ import org.netbeans.api.java.source.Task;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.modules.csl.api.CompletionProposal;
 import org.netbeans.modules.groovy.editor.api.GroovyIndex;
+import org.netbeans.modules.groovy.editor.api.completion.CaretLocation;
 import org.netbeans.modules.groovy.editor.api.completion.CompletionItem;
 import org.netbeans.modules.groovy.editor.completion.util.CamelCaseUtil;
 import org.netbeans.modules.groovy.editor.api.completion.util.ContextHelper;
@@ -303,7 +304,7 @@ public class TypesCompletion extends BaseCompletion {
         if ((onlyInterfaces && (type.getKind() != ElementKind.INTERFACE)) || alreadyPresent.contains(type)) {
             return;
         }
-
+        
         String fqnTypeName = type.getName();
         String typeName = GroovyUtils.stripPackage(fqnTypeName);
 
@@ -313,12 +314,24 @@ public class TypesCompletion extends BaseCompletion {
         if (constructorCompletion && typeName.toUpperCase().equals(request.getPrefix().toUpperCase())) {
             return;
         }
+        
+        if (type.getHandle() != null
+                &&!(type.getHandle().getKind().isClass() || type.getHandle().getKind().isInterface())
+                && request.location != CaretLocation.INSIDE_IMPORT) {
+            return;
+        }
 
+        String ownerFQN = GroovyUtils.stripClassName(fqnTypeName);
+        if (!ownerFQN.isEmpty() && ownerFQN.endsWith("."))  {
+            ownerFQN = ownerFQN.substring(0, ownerFQN.length() - 1);
+        }
+        
         // We are dealing with prefix for some class type
         JavaElementHandle jh = null;
         if (type.getHandle() != null) {
-            jh = new JavaElementHandle(fqnTypeName, typeName, type.getHandle(), Collections.emptyList(), Collections.emptySet());
+            jh = new JavaElementHandle(typeName, ownerFQN, type.getHandle(), Collections.emptyList(), Collections.emptySet());
         }
+        
         if (isPrefixed(request, typeName)) {
             alreadyPresent.add(type);
             proposals.putIfAbsent(fqnTypeName, CompletionAccessor.instance().createType(jh, fqnTypeName, typeName, anchor, type.getKind()));
@@ -327,7 +340,6 @@ public class TypesCompletion extends BaseCompletion {
         // We are dealing with CamelCase completion for some class type
         if (CamelCaseUtil.compareCamelCase(typeName, request.getPrefix())) {
             CompletionItem.TypeItem camelCaseProposal = CompletionAccessor.instance().createType(jh, fqnTypeName, typeName, anchor, ElementKind.CLASS);
-            
             proposals.putIfAbsent(fqnTypeName, camelCaseProposal);
         }
     }
@@ -360,7 +372,7 @@ public class TypesCompletion extends BaseCompletion {
                                 if (modifiers.contains(Modifier.PUBLIC)
                                     || samePackage && (modifiers.contains(Modifier.PROTECTED)
                                     || (!modifiers.contains(Modifier.PUBLIC) && !modifiers.contains(Modifier.PRIVATE)))) {
-
+                                    
                                     result.add(new TypeHolder(element.toString(), org.netbeans.api.java.source.ElementHandle.create(element)));
                                 }
                             }
@@ -377,8 +389,8 @@ public class TypesCompletion extends BaseCompletion {
                                 if (modifiers.contains(Modifier.PUBLIC)
                                     || samePackage && (modifiers.contains(Modifier.PROTECTED)
                                     || (!modifiers.contains(Modifier.PUBLIC) && !modifiers.contains(Modifier.PRIVATE)))) {
-
-                                    result.add(new TypeHolder(element.toString(), org.netbeans.api.java.source.ElementHandle.create(element)));
+                                    
+                                        result.add(new TypeHolder(pkg + "." + element.getSimpleName().toString(), org.netbeans.api.java.source.ElementHandle.create(element)));
                                 }
                             }
                         }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/resources/layer.xml
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/resources/layer.xml
@@ -126,13 +126,11 @@
                     </folder>
                 </folder>
 
-                <!-- Commented out because Groovy completiont tests are failing with JavaIndexer properly in place.
-                     Groovy maintainers must address this issue appropriately, see NETBEANS-4826
                 <file name="JavaIndexer.shadow">
-                    <!- - Ugly hack to make commit-validation work. Must change when NETBEANS-4795 is implemented - ->
+                    <!-- Ugly hack to make commit-validation work. Must change when NETBEANS-4795 is implemented -->
                     <attr name="originalFile" stringvalue="Editors/text/x-java/org-netbeans-modules-java-source-indexing-JavaCustomIndexer$Factory-register.instance"/>
                 </file>
-                          -->
+
 
             </folder>
             <folder name="x-gradle+x-groovy">

--- a/groovy/groovy.editor/test/unit/data/testfiles/Hello.groovy.indexed
+++ b/groovy/groovy.editor/test/unit/data/testfiles/Hello.groovy.indexed
@@ -52,8 +52,8 @@ Document 3
 Searchable Keys:
   class : SecondTestClass
   class-ig : secondtestclass
-  ctor : SecondTestClass;String;01
   ctor : SecondTestClass;int;01
+  ctor : SecondTestClass;java.lang.String;01
   fqn : foo.SecondTestClass
   method : getMetaClass;groovy.lang.MetaClass;01
   method : setMetaClass(groovy.lang.MetaClass);void;01
@@ -65,8 +65,8 @@ Document 4
 Searchable Keys:
   class : ThirdTestClass
   class-ig : thirdtestclass
-  ctor : ThirdTestClass;String;01
   ctor : ThirdTestClass;int;01
+  ctor : ThirdTestClass;java.lang.String;01
   fqn : foo.ThirdTestClass
   method : getMetaClass;groovy.lang.MetaClass;01
   method : setMetaClass(groovy.lang.MetaClass);void;01

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/import/staticImportCompletion/StaticImportCompletion.groovy.testStaticImportCompletion.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/import/staticImportCompletion/StaticImportCompletion.groovy.testStaticImportCompletion.completion
@@ -2,5 +2,5 @@ Code completion result for source line:
 import static java.lang.Math.P|I
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
-CLASS      PI                                         null
-CLASS      pow(double,double)                         null
+METHOD     pow                             [STATIC]   null
+FIELD      PI                              [STATIC]   null

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.completion
@@ -173,7 +173,7 @@ FIELD      enumConstants                   [PUBLIC]   Object[]
 FIELD      fields                          [PUBLIC]   Field[]
 FIELD      genericInterfaces               [PUBLIC]   Type[]
 FIELD      genericSuperclass               [PUBLIC]   Type
-FIELD      instance                        [STATIC]   Singleton3
+FIELD      instance                        [STATIC,   Singleton3
 FIELD      interface                       [PUBLIC]   boolean
 FIELD      interfaces                      [PUBLIC]   Class[]
 FIELD      localClass                      [PUBLIC]   boolean

--- a/java/java.source.base/src/org/netbeans/modules/java/source/JavaSourceUtilImpl.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/JavaSourceUtilImpl.java
@@ -26,6 +26,7 @@ import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import org.netbeans.api.java.source.support.ErrorAwareTreeScanner;
 import com.sun.source.util.Trees;
+import com.sun.tools.javac.api.ClientCodeWrapper;
 import com.sun.tools.javac.code.ClassFinder;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
@@ -487,6 +488,7 @@ public final class JavaSourceUtilImpl extends org.netbeans.modules.java.preproce
             throw new IllegalStateException(String.valueOf(l));
         }
         
+        @ClientCodeWrapper.Trusted
         private static final class MemOutFileObject extends FileObjects.Base {            
             private final ByteArrayOutputStream out;
             private long modified;

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ForwardingInferableJavaFileObject.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ForwardingInferableJavaFileObject.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.java.source.parsing;
 
+import com.sun.tools.javac.api.ClientCodeWrapper;
 import javax.tools.ForwardingJavaFileObject;
 import org.netbeans.api.annotations.common.NonNull;
 
@@ -26,6 +27,7 @@ import org.netbeans.api.annotations.common.NonNull;
  *
  * @author Tomas Zezula
  */
+@ClientCodeWrapper.Trusted
 public class ForwardingInferableJavaFileObject extends ForwardingJavaFileObject<InferableJavaFileObject> implements InferableJavaFileObject {
 
     public ForwardingInferableJavaFileObject(@NonNull final InferableJavaFileObject delegate) {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ForwardingPrefetchableJavaFileObject.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ForwardingPrefetchableJavaFileObject.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.java.source.parsing;
 
+import com.sun.tools.javac.api.ClientCodeWrapper;
 import java.io.IOException;
 import javax.tools.ForwardingJavaFileObject;
 import org.netbeans.api.annotations.common.NonNull;
@@ -26,6 +27,7 @@ import org.netbeans.api.annotations.common.NonNull;
  *
  * @author Dusan Balek
  */
+@ClientCodeWrapper.Trusted
 public class ForwardingPrefetchableJavaFileObject extends ForwardingJavaFileObject<PrefetchableJavaFileObject> implements PrefetchableJavaFileObject {
 
     public ForwardingPrefetchableJavaFileObject(@NonNull final PrefetchableJavaFileObject delegate) {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/MultiReleaseJarFileObject.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/MultiReleaseJarFileObject.java
@@ -18,12 +18,14 @@
  */
 package org.netbeans.modules.java.source.parsing;
 
+import com.sun.tools.javac.api.ClientCodeWrapper;
 import org.netbeans.api.annotations.common.NonNull;
 
 /**
  *
  * @author Tomas Zezula
  */
+@ClientCodeWrapper.Trusted
 final class MultiReleaseJarFileObject extends ForwardingInferableJavaFileObject {
     private final int start;
     MultiReleaseJarFileObject(

--- a/java/java.source.base/src/org/netbeans/modules/java/source/usages/VirtualSourceProviderQuery.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/usages/VirtualSourceProviderQuery.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.java.source.usages;
 
+import com.sun.tools.javac.api.ClientCodeWrapper;
 import java.net.URISyntaxException;
 import org.netbeans.modules.java.preprocessorbridge.spi.VirtualSourceProvider;
 import java.io.File;
@@ -34,6 +35,7 @@ import javax.tools.JavaFileObject;
 import org.netbeans.modules.java.source.indexing.JavaCustomIndexer.CompileTuple;
 import org.netbeans.modules.java.source.parsing.FileObjects;
 import org.netbeans.modules.java.source.parsing.ForwardingPrefetchableJavaFileObject;
+import org.netbeans.modules.java.source.parsing.PrefetchableJavaFileObject;
 import org.netbeans.modules.parsing.spi.indexing.Indexable;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
@@ -198,19 +200,27 @@ public final class VirtualSourceProviderQuery {
                     folder += '/';
                 }
                 res.add(new CompileTuple(
-                        new ForwardingPrefetchableJavaFileObject(
+                        new ForwardingPrefetchableJavaFileObjectImpl(
                         FileObjects.memoryFileObject(packageName,
                             baseName,new URI(rootURL + folder + baseName),
-                            System.currentTimeMillis(), content)) {
-                                @Override
-                                public JavaFileObject.Kind getKind() {
-                                    return JavaFileObject.Kind.SOURCE;
-                                }
-                            },
+                            System.currentTimeMillis(), content)),
                         indexable,true, this.currentProvider.index()));
             } catch (URISyntaxException ex) {
                 Exceptions.printStackTrace(ex);
             }
         }                
+
+        @ClientCodeWrapper.Trusted
+        static class ForwardingPrefetchableJavaFileObjectImpl extends ForwardingPrefetchableJavaFileObject {
+
+            public ForwardingPrefetchableJavaFileObjectImpl(PrefetchableJavaFileObject pjfo) {
+                super(pjfo);
+            }
+
+            @Override
+            public JavaFileObject.Kind getKind() {
+                return JavaFileObject.Kind.SOURCE;
+            }
+        }
     }
 }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FileObjectsTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FileObjectsTest.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.java.source.parsing;
 
+import com.sun.tools.javac.api.ClientCodeWrapper;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -229,6 +230,7 @@ public class FileObjectsTest extends NbTestCase {
         
     }
     
+    @ClientCodeWrapper.Trusted
     private static class TestZipFileObject extends FileObjects.ZipFileBase {
         
         private final String archiveURI;


### PR DESCRIPTION
This will turn back on indexing of Groovy files in Java. This means that Groovy classes can now be offered in java source files.  The Groovy file is used to create virtual Java source code that is indexed and stored in the java index. This will not only enable indexing, but features like code completion, hyperlinks, goto navigation should also work. 

More fixes were needed to get this working again. There are also a few fixes that improve the current staff, such as:

- static fields and methods are offered as fields and methods in import statements code completion - they were previously offered as classes in code completion. 
- correcting types of constructors that are strored in Groovy Index
- JavaElementHandles now are created with the fully qualifed names, there were created only with simple names. 
- adding @Trusted annotation for ForwardingJavaFileObject implementations

