### PR TITLE
#3748 Note for Advanced Proxy Options

### DIFF
--- a/platform/core.ui/src/org/netbeans/core/ui/options/general/AdvancedProxyPanel.form
+++ b/platform/core.ui/src/org/netbeans/core/ui/options/general/AdvancedProxyPanel.form
@@ -42,29 +42,12 @@
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace min="12" pref="12" max="12" attributes="0"/>
-              <Component id="cbUseProxyAuthentication" min="-2" max="-2" attributes="0"/>
-          </Group>
-          <Group type="102" alignment="1" attributes="0">
-              <Group type="103" groupAlignment="1" attributes="0">
-                  <Group type="102" alignment="1" attributes="0">
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="sSeparator" pref="512" max="32767" attributes="1"/>
-                  </Group>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="lblBasicAuthNote" pref="0" max="32767" attributes="0"/>
+                  <Component id="cbUseProxyAuthentication" alignment="1" max="32767" attributes="0"/>
+                  <Component id="sSeparator" alignment="1" max="32767" attributes="1"/>
                   <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="-2" max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="lUserName" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="lUserPassword" alignment="0" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <EmptySpace min="-2" max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="pfUserPassword" pref="423" max="32767" attributes="2"/>
-                          <Component id="tfUserName" alignment="0" pref="423" max="32767" attributes="2"/>
-                      </Group>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Component id="lHttpProxyHost" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="lHttpsProxyHost" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -73,13 +56,11 @@
                       </Group>
                       <EmptySpace min="-2" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="lNonProxyHostsDescription" alignment="0" min="-2" pref="349" max="-2" attributes="1"/>
-                          <Component id="cbSameProxySettings" alignment="0" min="-2" pref="325" max="-2" attributes="1"/>
                           <Group type="102" alignment="0" attributes="0">
                               <Group type="103" groupAlignment="1" attributes="0">
-                                  <Component id="tfHttpProxyHost" alignment="0" pref="281" max="32767" attributes="2"/>
-                                  <Component id="tfSocksHost" alignment="0" pref="281" max="32767" attributes="2"/>
-                                  <Component id="tfHttpsProxyHost" alignment="0" pref="281" max="32767" attributes="2"/>
+                                  <Component id="tfHttpProxyHost" alignment="0" max="32767" attributes="2"/>
+                                  <Component id="tfSocksHost" alignment="0" max="32767" attributes="2"/>
+                                  <Component id="tfHttpsProxyHost" alignment="0" max="32767" attributes="2"/>
                               </Group>
                               <EmptySpace min="-2" max="-2" attributes="0"/>
                               <Group type="103" groupAlignment="0" attributes="0">
@@ -94,11 +75,24 @@
                                   <Component id="tfHttpsProxyPort" alignment="0" max="32767" attributes="1"/>
                               </Group>
                           </Group>
-                          <Component id="tfNonProxyHosts" alignment="0" pref="388" max="32767" attributes="2"/>
+                          <Component id="tfNonProxyHosts" alignment="0" max="32767" attributes="2"/>
+                          <Component id="cbSameProxySettings" alignment="0" max="32767" attributes="1"/>
+                          <Component id="lNonProxyHostsDescription" alignment="0" max="32767" attributes="1"/>
+                      </Group>
+                  </Group>
+                  <Group type="102" alignment="1" attributes="0">
+                      <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                          <Component id="lUserName" max="32767" attributes="0"/>
+                          <Component id="lUserPassword" max="32767" attributes="0"/>
+                      </Group>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="tfUserName" max="32767" attributes="2"/>
+                          <Component id="pfUserPassword" max="32767" attributes="2"/>
                       </Group>
                   </Group>
               </Group>
-              <EmptySpace min="-2" pref="18" max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -149,7 +143,9 @@
                   <Component id="lUserPassword" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="pfUserPassword" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace pref="30" max="32767" attributes="0"/>
+              <EmptySpace pref="68" max="32767" attributes="0"/>
+              <Component id="lblBasicAuthNote" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -166,6 +162,9 @@
       </Properties>
     </Component>
     <Component class="javax.swing.JTextField" name="tfHttpProxyHost">
+      <Properties>
+        <Property name="columns" type="int" value="20"/>
+      </Properties>
       <AccessibilityProperties>
         <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/options/general/Bundle.properties" key="ACD_AdvancedProxyPanel_tfHttpProxyHost" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
@@ -203,6 +202,9 @@
       </Properties>
     </Component>
     <Component class="javax.swing.JTextField" name="tfHttpsProxyHost">
+      <Properties>
+        <Property name="columns" type="int" value="20"/>
+      </Properties>
       <AccessibilityProperties>
         <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/options/general/Bundle.properties" key="ACD_AdvancedProxyPanel_tfHttpsProxyHost" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
@@ -220,6 +222,9 @@
       </Properties>
     </Component>
     <Component class="javax.swing.JTextField" name="tfSocksHost">
+      <Properties>
+        <Property name="columns" type="int" value="20"/>
+      </Properties>
       <AccessibilityProperties>
         <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/options/general/Bundle.properties" key="ACD_AdvancedProxyPanel_tfSocksHost" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
@@ -368,6 +373,25 @@
           <ResourceString bundle="org/netbeans/modules/options/general/Bundle.properties" key="ACD_AdvancedProxyPanel_pfUserPassword" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </AccessibilityProperties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="lblBasicAuthNote">
+      <Properties>
+        <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
+          <FontInfo relative="true">
+            <Font component="lblBasicAuthNote" property="font" relativeSize="true" size="-2"/>
+          </FontInfo>
+        </Property>
+        <Property name="horizontalAlignment" type="int" value="0"/>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/core/ui/options/general/Bundle.properties" key="AdvancedProxyPanel.lblBasicAuthNote.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+        <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
+          <Color id="Cursor Por defecto"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="mouseClicked" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="lblBasicAuthNoteMouseClicked"/>
+      </Events>
     </Component>
   </SubComponents>
 </Form>

--- a/platform/core.ui/src/org/netbeans/core/ui/options/general/AdvancedProxyPanel.java
+++ b/platform/core.ui/src/org/netbeans/core/ui/options/general/AdvancedProxyPanel.java
@@ -18,12 +18,16 @@
  */
 package org.netbeans.core.ui.options.general;
 
+import java.awt.Desktop;
+import java.net.URI;
+import java.net.URISyntaxException;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import org.netbeans.api.options.OptionsDisplayer;
 import org.netbeans.spi.options.OptionsPanelController;
 import org.openide.DialogDescriptor;
 import org.openide.NotificationLineSupport;
+import org.openide.util.Exceptions;
 
 /**
  *
@@ -176,6 +180,7 @@ public class AdvancedProxyPanel extends javax.swing.JPanel {
         lUserName.setEnabled (use);
         pfUserPassword.setEnabled (use);
         lUserPassword.setEnabled (use);
+        lblBasicAuthNote.setEnabled(use);
     }
     
     private void followHttpHostIfDemand () {
@@ -272,9 +277,12 @@ public class AdvancedProxyPanel extends javax.swing.JPanel {
         lUserPassword = new javax.swing.JLabel();
         tfUserName = new javax.swing.JTextField();
         pfUserPassword = new javax.swing.JPasswordField();
+        lblBasicAuthNote = new javax.swing.JLabel();
 
         lHttpProxyHost.setLabelFor(tfHttpProxyHost);
         org.openide.awt.Mnemonics.setLocalizedText(lHttpProxyHost, org.openide.util.NbBundle.getMessage(AdvancedProxyPanel.class, "LBL_AdvancedProxyPanel_lHttpProxyHost")); // NOI18N
+
+        tfHttpProxyHost.setColumns(20);
 
         org.openide.awt.Mnemonics.setLocalizedText(cbSameProxySettings, org.openide.util.NbBundle.getMessage(AdvancedProxyPanel.class, "LBL_AdvancedProxyPanel_cbSameProxySettings")); // NOI18N
         cbSameProxySettings.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
@@ -287,8 +295,12 @@ public class AdvancedProxyPanel extends javax.swing.JPanel {
         lHttpsProxyHost.setLabelFor(tfHttpsProxyHost);
         org.openide.awt.Mnemonics.setLocalizedText(lHttpsProxyHost, org.openide.util.NbBundle.getMessage(AdvancedProxyPanel.class, "LBL_AdvancedProxyPanel_lHttpsProxyHots")); // NOI18N
 
+        tfHttpsProxyHost.setColumns(20);
+
         lSocksHost.setLabelFor(tfSocksHost);
         org.openide.awt.Mnemonics.setLocalizedText(lSocksHost, org.openide.util.NbBundle.getMessage(AdvancedProxyPanel.class, "LBL_AdvancedProxyPanel_lSocksHost")); // NOI18N
+
+        tfSocksHost.setColumns(20);
 
         lHttpProxyPort.setLabelFor(tfHttpProxyPort);
         org.openide.awt.Mnemonics.setLocalizedText(lHttpProxyPort, org.openide.util.NbBundle.getMessage(AdvancedProxyPanel.class, "LBL_AdvancedProxyPanel_lHttpProxyPort")); // NOI18N
@@ -324,29 +336,27 @@ public class AdvancedProxyPanel extends javax.swing.JPanel {
         lUserPassword.setLabelFor(pfUserPassword);
         org.openide.awt.Mnemonics.setLocalizedText(lUserPassword, org.openide.util.NbBundle.getMessage(AdvancedProxyPanel.class, "LBL_AdvancedProxyPanel_lUserPassword")); // NOI18N
 
+        lblBasicAuthNote.setFont(lblBasicAuthNote.getFont().deriveFont(lblBasicAuthNote.getFont().getSize()-2f));
+        lblBasicAuthNote.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
+        org.openide.awt.Mnemonics.setLocalizedText(lblBasicAuthNote, org.openide.util.NbBundle.getMessage(AdvancedProxyPanel.class, "AdvancedProxyPanel.lblBasicAuthNote.text")); // NOI18N
+        lblBasicAuthNote.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
+        lblBasicAuthNote.addMouseListener(new java.awt.event.MouseAdapter() {
+            public void mouseClicked(java.awt.event.MouseEvent evt) {
+                lblBasicAuthNoteMouseClicked(evt);
+            }
+        });
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addGap(12, 12, 12)
-                .addComponent(cbUseProxyAuthentication))
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                .addContainerGap()
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(lblBasicAuthNote, javax.swing.GroupLayout.DEFAULT_SIZE, 569, Short.MAX_VALUE)
+                    .addComponent(cbUseProxyAuthentication, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(sSeparator, javax.swing.GroupLayout.Alignment.TRAILING)
                     .addGroup(layout.createSequentialGroup()
-                        .addContainerGap()
-                        .addComponent(sSeparator, javax.swing.GroupLayout.DEFAULT_SIZE, 512, Short.MAX_VALUE))
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
-                        .addContainerGap()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(lUserName)
-                            .addComponent(lUserPassword))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(pfUserPassword, javax.swing.GroupLayout.DEFAULT_SIZE, 423, Short.MAX_VALUE)
-                            .addComponent(tfUserName, javax.swing.GroupLayout.DEFAULT_SIZE, 423, Short.MAX_VALUE)))
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
-                        .addGap(12, 12, 12)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(lHttpProxyHost)
                             .addComponent(lHttpsProxyHost)
@@ -354,13 +364,11 @@ public class AdvancedProxyPanel extends javax.swing.JPanel {
                             .addComponent(lNonProxyHosts))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(lNonProxyHostsDescription, javax.swing.GroupLayout.PREFERRED_SIZE, 349, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(cbSameProxySettings, javax.swing.GroupLayout.PREFERRED_SIZE, 325, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addGroup(layout.createSequentialGroup()
                                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                    .addComponent(tfHttpProxyHost, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, 281, Short.MAX_VALUE)
-                                    .addComponent(tfSocksHost, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, 281, Short.MAX_VALUE)
-                                    .addComponent(tfHttpsProxyHost, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, 281, Short.MAX_VALUE))
+                                    .addComponent(tfHttpProxyHost, javax.swing.GroupLayout.Alignment.LEADING)
+                                    .addComponent(tfSocksHost, javax.swing.GroupLayout.Alignment.LEADING)
+                                    .addComponent(tfHttpsProxyHost, javax.swing.GroupLayout.Alignment.LEADING))
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                                     .addComponent(lHttpProxyPort)
@@ -371,8 +379,18 @@ public class AdvancedProxyPanel extends javax.swing.JPanel {
                                     .addComponent(tfHttpProxyPort)
                                     .addComponent(tfSocksPort)
                                     .addComponent(tfHttpsProxyPort)))
-                            .addComponent(tfNonProxyHosts, javax.swing.GroupLayout.DEFAULT_SIZE, 388, Short.MAX_VALUE))))
-                .addGap(18, 18, 18))
+                            .addComponent(tfNonProxyHosts)
+                            .addComponent(cbSameProxySettings, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(lNonProxyHostsDescription, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                            .addComponent(lUserName, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(lUserPassword, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(tfUserName)
+                            .addComponent(pfUserPassword))))
+                .addContainerGap())
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -415,7 +433,9 @@ public class AdvancedProxyPanel extends javax.swing.JPanel {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(lUserPassword)
                     .addComponent(pfUserPassword, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(30, Short.MAX_VALUE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 68, Short.MAX_VALUE)
+                .addComponent(lblBasicAuthNote)
+                .addContainerGap())
         );
 
         tfHttpProxyHost.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(AdvancedProxyPanel.class, "ACD_AdvancedProxyPanel_tfHttpProxyHost")); // NOI18N
@@ -451,6 +471,19 @@ private void cbSameProxySettingsActionPerformed(java.awt.event.ActionEvent evt) 
     }
     followHttpProxyIfDemand ();
 }//GEN-LAST:event_cbSameProxySettingsActionPerformed
+
+    private void lblBasicAuthNoteMouseClicked(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_lblBasicAuthNoteMouseClicked
+        if (!lblBasicAuthNote.isEnabled()) {
+            return;
+        }
+        try {
+            // Issue https://github.com/apache/netbeans/issues/3748
+            URI uri = new URI("https://netbeans.apache.org/wiki/ProxyBasicAuth"); // NOI18N
+            Desktop.getDesktop().browse(uri);
+        } catch (Exception ex) {
+            Exceptions.printStackTrace(ex);
+        }
+    }//GEN-LAST:event_lblBasicAuthNoteMouseClicked
     
     
     // Variables declaration - do not modify//GEN-BEGIN:variables
@@ -466,6 +499,7 @@ private void cbSameProxySettingsActionPerformed(java.awt.event.ActionEvent evt) 
     private javax.swing.JLabel lSocksPort;
     private javax.swing.JLabel lUserName;
     private javax.swing.JLabel lUserPassword;
+    private javax.swing.JLabel lblBasicAuthNote;
     private javax.swing.JPasswordField pfUserPassword;
     private javax.swing.JSeparator sSeparator;
     private javax.swing.JTextField tfHttpProxyHost;

--- a/platform/core.ui/src/org/netbeans/core/ui/options/general/Bundle.properties
+++ b/platform/core.ui/src/org/netbeans/core/ui/options/general/Bundle.properties
@@ -248,3 +248,4 @@ GeneralOptionsPanel.lblTestResult.text=
 GeneralOptionsPanel.proxy.result.ok=Connection passed
 GeneralOptionsPanel.proxy.result.failed=Connection failed ({0})
 AdvancedProxyPanel.cbUseProxyAuthentication.actionCommand=Proxy Re&quires Explicit Authentication
+AdvancedProxyPanel.lblBasicAuthNote.text=NOTE: See https://netbeans.apache.org/wiki/ProxyBasicAuth  if your proxy uses Basic auth.


### PR DESCRIPTION
Adding a note in the Advanced Proxy Options to warn users of JDK >= 8u111, because Basic auth disables HTTPS tunneling from this on. See #3748 for details.

Users are redirected to https://netbeans.apache.org/wiki/ProxyBasicAuth for more information.

New dialog looks like this (design window):

![imagen](https://user-images.githubusercontent.com/564140/159081824-c9e2fa3d-ad68-469c-854d-c8636897630b.png)

Labels also fill horizontally (previous dialog didn't).
