### PR TITLE
cleanup Byte & Short object constructors

### DIFF
--- a/ide/api.debugger/src/org/netbeans/api/debugger/Properties.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/Properties.java
@@ -1468,11 +1468,11 @@ public abstract class Properties {
                 if (classNames[0].equals(className)) {
                     return Boolean.valueOf(properties.getBoolean(propertyName, false));
                 } else if (classNames[1].equals(className)) {
-                    return new Byte(properties.getByte(propertyName, (byte) 0));
+                    return properties.getByte(propertyName, (byte)0);
                 } else if (classNames[2].equals(className)) {
                     return new Character(properties.getChar(propertyName, (char) 0));
                 } else if (classNames[3].equals(className)) {
-                    return new Short(properties.getShort(propertyName, (short) 0));
+                    return properties.getShort(propertyName, (short)0);
                 } else if (classNames[4].equals(className)) {
                     return Integer.valueOf(properties.getInt(propertyName, 0));
                 } else if (classNames[5].equals(className)) {

--- a/ide/html.lexer/src/org/netbeans/lib/html/lexer/HtmlLexer.java
+++ b/ide/html.lexer/src/org/netbeans/lib/html/lexer/HtmlLexer.java
@@ -606,7 +606,7 @@ public final class HtmlLexer implements Lexer<HTMLTokenId> {
                         if(input.readLength() > closeDelimiter.length()) {
                             input.backup(closeDelimiter.length());
                             //save the provider's index in the token's property so we can set the corresponding embdding in HTMLTokenId.language()
-                            return token(HTMLTokenId.EL_CONTENT, new HtmlTokenPropertyProvider(EL_CONTENT_PROVIDER_INDEX, new Byte((byte)(customELIndex - 1))));
+                            return token(HTMLTokenId.EL_CONTENT, new HtmlTokenPropertyProvider(EL_CONTENT_PROVIDER_INDEX, (byte)(customELIndex - 1)));
                         } else {
                             //return the open symbol token and switch to "in el" state
                             lexerState = INIT;
@@ -1088,7 +1088,7 @@ public final class HtmlLexer implements Lexer<HTMLTokenId> {
                         if(input.readLength() > closeDelimiter.length()) {
                             input.backup(closeDelimiter.length());
                             //save the provider's index in the token's property so we can set the corresponding embdding in HTMLTokenId.language()
-                            return token(HTMLTokenId.EL_CONTENT, new HtmlTokenPropertyProvider(EL_CONTENT_PROVIDER_INDEX, new Byte((byte)(customELIndex - 1))));
+                            return token(HTMLTokenId.EL_CONTENT, new HtmlTokenPropertyProvider(EL_CONTENT_PROVIDER_INDEX, (byte)(customELIndex - 1)));
                         } else {
                             //return the close symbol token and switch to "in value" state
                             lexerState = ISI_VAL_QUOT;
@@ -1416,7 +1416,7 @@ public final class HtmlLexer implements Lexer<HTMLTokenId> {
 
             case ISI_EL:
             case ISI_VAL_QUOT_EL:
-                return token(HTMLTokenId.EL_CONTENT, new HtmlTokenPropertyProvider(EL_CONTENT_PROVIDER_INDEX, new Byte((byte)(customELIndex - 1))));
+                return token(HTMLTokenId.EL_CONTENT, new HtmlTokenPropertyProvider(EL_CONTENT_PROVIDER_INDEX, (byte)(customELIndex - 1)));
 
 
         }

--- a/ide/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceURLMapper.java
+++ b/ide/javascript2.debug/src/org/netbeans/modules/javascript2/debug/sources/SourceURLMapper.java
@@ -183,7 +183,7 @@ public final class SourceURLMapper extends URLMapper {
             List<Byte> bytes = new ArrayList<>();
             while (text.length() > (i + 2) && text.charAt(i) == '%') {
                 int v = Integer.parseInt(text.substring(i+1, i+3), 16);
-                bytes.add(new Byte((byte) (v & 0xFF)));
+                bytes.add((byte)(v & 0xFF));
                 i += 3;
             }
             byte[] byteArray = new byte[bytes.size()];

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/Common.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/Common.java
@@ -367,33 +367,33 @@ public class Common {
     }
     
     public static Object defaultScalarValue(int type) {
-        switch(type & Common.MASK_TYPE) {
-	    case Common.TYPE_STRING:
-            return "";	// NOI18N
-        case Common.TYPE_COMMENT:
-            return "";	// NOI18N
-	    case Common.TYPE_BOOLEAN:
-            return Boolean.FALSE;
-	    case Common.TYPE_BYTE:
-            return new Byte((byte)0);
-	    case Common.TYPE_CHAR:
-            return new Character('\0');
-	    case Common.TYPE_SHORT:
-            return new Short((short)0);
-	    case Common.TYPE_INT:
-            return Integer.valueOf(0);
-	    case Common.TYPE_LONG:
-            return new Long(0);
-	    case Common.TYPE_FLOAT:
-            return new Float(0.0);
-	    case Common.TYPE_DOUBLE:
-            return new Double(0.0);
-	    default:
-            throw new IllegalArgumentException(Common.getMessage(
-                                                                 "UnknownType_msg", Integer.valueOf(type)));
+        switch (type & Common.MASK_TYPE) {
+            case Common.TYPE_STRING:
+                return "";	// NOI18N
+            case Common.TYPE_COMMENT:
+                return "";	// NOI18N
+            case Common.TYPE_BOOLEAN:
+                return Boolean.FALSE;
+            case Common.TYPE_BYTE:
+                return (byte)0;
+            case Common.TYPE_CHAR:
+                return new Character('\0');
+            case Common.TYPE_SHORT:
+                return (short)0;
+            case Common.TYPE_INT:
+                return Integer.valueOf(0);
+            case Common.TYPE_LONG:
+                return new Long(0);
+            case Common.TYPE_FLOAT:
+                return new Float(0.0);
+            case Common.TYPE_DOUBLE:
+                return new Double(0.0);
+            default:
+                throw new IllegalArgumentException(Common.getMessage(
+                        "UnknownType_msg", Integer.valueOf(type)));
         }
     }
-    
+
     
     /*
      *	Bundle utility methods. The following methods return a formated message

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/GraphManager.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/GraphManager.java
@@ -888,11 +888,11 @@ public class GraphManager extends Object {
 	    case Common.TYPE_BOOLEAN:
 		return Boolean.FALSE;
 	    case Common.TYPE_BYTE:
-		return new Byte((byte)0);
+		return (byte)0;
 	    case Common.TYPE_CHAR:
 		return new Character('\0');
 	    case Common.TYPE_SHORT:
-		return new Short((short)0);
+		return (short)0;
 	    case Common.TYPE_INT:
 		return Integer.valueOf(0);
 	    case Common.TYPE_LONG:
@@ -902,7 +902,7 @@ public class GraphManager extends Object {
 	    case Common.TYPE_DOUBLE:
 		return new Double(0.0);
 	    default:
-            throw new IllegalArgumentException(Common.getMessage("UnknownType", type));
+                throw new IllegalArgumentException(Common.getMessage("UnknownType", type));
 	}
     }
 }

--- a/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/EvaluatorApp.java
+++ b/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/EvaluatorApp.java
@@ -42,6 +42,9 @@ import java.util.Vector;
  * both after the invocation of the expression and invocation of the method.
  * 
  * @author Martin Entlicher
+ *
+ * WARNING: Do not change any of the primitive auto-boxing. It could potentially
+ * break the tests. We expressly want it done as part of testing.
  */
 public class EvaluatorApp extends BaseClass {
 

--- a/java/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/JDBCStubUtil.java
+++ b/java/j2ee.persistence/test/unit/src/org/netbeans/modules/db/test/jdbcstub/JDBCStubUtil.java
@@ -209,7 +209,7 @@ public final class JDBCStubUtil {
     
     private static void addAllAsReferenceType(List list, short[] values) {
         for (int i = 0; i < values.length; i++) {
-            list.add(new Short(values[i]));
+            list.add(values[i]);
         }
     }
     

--- a/java/j2ee.persistence/test/unit/src/org/netbeans/test/stub/api/Stub.java
+++ b/java/j2ee.persistence/test/unit/src/org/netbeans/test/stub/api/Stub.java
@@ -143,9 +143,9 @@ public final class Stub {
             
             if (retClass.isPrimitive()) {
                 if (retClass == Byte.TYPE) {
-                    return new Byte((byte)0);
+                    return (byte)0;
                 } else if (retClass == Short.TYPE) {
-                    return new Short((short)0);
+                    return (short)0;
                 } else if (retClass == Integer.TYPE) {
                     return new Integer(0);
                 } else if (retClass == Long.TYPE) {

--- a/nb/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SerParser.java
+++ b/nb/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SerParser.java
@@ -493,9 +493,9 @@ public final class SerParser implements ObjectStreamConstants {
         aw.values = new ArrayList<Object>(size);
         for (int i = 0; i < size; i++) {
             if (aw.classdesc.name.equals("[B")) { // NOI18N
-                aw.values.add(new Byte(readByte()));
+                aw.values.add(readByte());
             } else if (aw.classdesc.name.equals("[S")) { // NOI18N
-                aw.values.add(new Short(readShort()));
+                aw.values.add(readShort());
             } else if (aw.classdesc.name.equals("[I")) { // NOI18N
                 aw.values.add(new Integer(readInt()));
             } else if (aw.classdesc.name.equals("[J")) { // NOI18N
@@ -553,13 +553,13 @@ public final class SerParser implements ObjectStreamConstants {
     
     private List<NameValue> readNoWrClass(ClassDesc cd) throws IOException {
         List<FieldDesc> fields = cd.fields;
-        List<NameValue> values = new ArrayList<NameValue>(fields.size());
+        List<NameValue> values = new ArrayList<>(fields.size());
         for (int i = 0; i < fields.size(); i++) {
             FieldDesc fd = (FieldDesc)fields.get(i);
             if (fd.type.equals("B")) { // NOI18N
-                values.add(new NameValue(fd, new Byte(readByte())));
+                values.add(new NameValue(fd, readByte()));
             } else if (fd.type.equals("S")) { // NOI18N
-                values.add(new NameValue(fd, new Short(readShort())));
+                values.add(new NameValue(fd, readShort()));
             } else if (fd.type.equals("I")) { // NOI18N
                 values.add(new NameValue(fd, new Integer(readInt())));
             } else if (fd.type.equals("J")) { // NOI18N
@@ -579,5 +579,4 @@ public final class SerParser implements ObjectStreamConstants {
         if (DEBUG) System.err.println("readNoWrClass: " + values); // NOI18N
         return values;
     }
-
 }

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/IndexedPropertyEditor.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/IndexedPropertyEditor.java
@@ -352,7 +352,7 @@ class IndexedPropertyEditor extends Object implements ExPropertyEditor {
             }
 
             if (getConvertedType().equals(Byte.class)) {
-                value = new Byte((byte) 0);
+                value = (byte)0;
             }
 
             if (getConvertedType().equals(Character.class)) {
@@ -372,7 +372,7 @@ class IndexedPropertyEditor extends Object implements ExPropertyEditor {
             }
 
             if (getConvertedType().equals(Short.class)) {
-                value = new Short((short) 0);
+                value = (short)0;
             }
         } else {
             try {

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
@@ -918,9 +918,9 @@ final class XMLMapAttr implements Map {
                 try {
                     switch (index) {
                     case 0:
-                        return new Byte(value);
+                        return Byte.valueOf(value);
                     case 1:
-                        return new Short(value);
+                        return Short.valueOf(value);
                     case 2:
                         return new Integer(value); //(objI);
                     case 3:

--- a/platform/openide.windows/src/org/openide/windows/TopComponent.java
+++ b/platform/openide.windows/src/org/openide/windows/TopComponent.java
@@ -1164,7 +1164,7 @@ public class TopComponent extends JComponent implements Externalizable, Accessib
     * @param out the stream to serialize to
     */
     public void writeExternal(ObjectOutput out) throws IOException {
-        out.writeObject(new Short(serialVersion));
+        out.writeObject(serialVersion);
         out.writeInt(closeOperation);
         out.writeObject(getName());
         out.writeObject(getToolTipText());

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/ParameterInfo.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/ParameterInfo.java
@@ -179,7 +179,7 @@ public class ParameterInfo {
         if (type == Integer.class || type == Integer.TYPE) {
             return new Integer(0);
         } else if (type == Short.class || type == Short.TYPE) {
-            return new Short((short) 0);
+            return (short)0;
         } else if (type == Long.class || type == Long.TYPE) {
             return new Long(0);
         } else if (type == Float.class || type == Float.TYPE) {


### PR DESCRIPTION
It is more efficient to allow the VM to manage the auto-boxing of certain primitives than it is to invoke the
object constructor.

This change cleans up Byte & Short for this.

Tests have been left untouched because we expressly want to handle the boxing in each particular test.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

