### PR TITLE
Fix Gradle --warning-mode all action to work with any Gradle release

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/output/GradleProcessorFactory.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/output/GradleProcessorFactory.java
@@ -189,7 +189,7 @@ public class GradleProcessorFactory implements OutputProcessorFactory {
 
     static class WarningModeAllProcessor implements OutputProcessor {
 
-        private static Pattern WARNING_MODE_ALL = Pattern.compile("(You can use ')(\\-\\-warning\\-mode all)('.+)");
+        private static Pattern WARNING_MODE_ALL = Pattern.compile("(.+ ')(\\-\\-warning\\-mode all)('.+)");
         final RunConfig cfg;
 
         public WarningModeAllProcessor(RunConfig cfg) {


### PR DESCRIPTION
Well it seems earlier releases use: ```Use '--warning-mode all'``` while current ones use: ```You can use '--warning-mode all'``` term.