### PR TITLE
Fix console encoding on JDK 18 (Maven + general execution)

### DIFF
--- a/ide/extexecution.base/src/org/netbeans/api/extexecution/base/BaseExecutionService.java
+++ b/ide/extexecution.base/src/org/netbeans/api/extexecution/base/BaseExecutionService.java
@@ -210,7 +210,27 @@ public final class BaseExecutionService {
 
                     Charset charset = descriptor.getCharset();
                     if (charset == null) {
-                        charset = Charset.defaultCharset();
+                        // If charset is not set for the descriptor, the
+                        // BaseExecutionService used the default charset to convert
+                        // output from command line invocations to strings. That encoding is
+                        // derived from the system file.encoding. From JDK 18 onwards its
+                        // default value changed to UTF-8.
+                        // JDK 18+ exposes the native encoding as the new system property
+                        // native.encoding, prior versions don't have that property and will
+                        // report NULL for it.
+                        // The algorithm is simple: If native.encoding is set, it will be used
+                        // else the old default will be queried via Charset#defaultCharset.
+                        String nativeEncoding = System.getProperty("native.encoding");
+                        if (nativeEncoding != null) {
+                            try {
+                                charset = Charset.forName(nativeEncoding);
+                            } catch (Exception ex) {
+                                LOGGER.log(java.util.logging.Level.WARNING, "Failed to get charset for native.encoding value : '" + nativeEncoding + "'", ex);
+                            }
+                        }
+                        if (charset == null) {
+                            charset = Charset.defaultCharset();
+                        }
                     }
 
                     tasks.add(InputReaderTask.newDrainingTask(

--- a/java/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
@@ -28,6 +28,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -201,7 +202,7 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
         private boolean skipLF = false;
 
         public Output(InputStream instream) {
-            str = new BufferedReader(new InputStreamReader(instream));
+            str = new BufferedReader(new InputStreamReader(instream, getNativeCharset()));
         }
 
         private String readLine() throws IOException {
@@ -700,7 +701,7 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
 
         public @Override void run() {
             Reader in = inputOutput.getIn();
-            try (Writer out = new OutputStreamWriter(str)) {
+            try (Writer out = new OutputStreamWriter(str, getNativeCharset())) {
                 while (true) {
                     int read = in.read();
                     if (read != -1) {
@@ -827,6 +828,30 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
         
     }    
 
+    private static Charset getNativeCharset() {
+        // The CommandLineOutputHandler used the default charset to convert
+        // output from command line invocations to strings. That encoding is
+        // derived from the system file.encoding. From JDK 18 onwards its
+        // default value changed to UTF-8.
+        // JDK 18+ exposes the native encoding as the new system property
+        // native.encoding, prior versions don't have that property and will
+        // report NULL for it.
+        // The algorithm is simple: If native.encoding is set, it will be used
+        // else the old default will be queried via Charset#defaultCharset.
+        String nativeEncoding = System.getProperty("native.encoding");
+        Charset nativeCharset = null;
+        if (nativeEncoding != null) {
+            try {
+                nativeCharset = Charset.forName(nativeEncoding);
+            } catch (Exception ex) {
+                LOG.log(java.util.logging.Level.WARNING, "Failed to get charset for native.encoding value : '" + nativeEncoding + "'", ex);
+            }
+        }
+        if (nativeCharset == null) {
+            nativeCharset = Charset.defaultCharset();
+        }
+        return nativeCharset;
+    }
 }
 
 


### PR DESCRIPTION
With JDK 18 the default charset for java was changed. Before this
change, the default charset (exposed as the system property
file.encoding) was platform specific. After the change the default
charset was unified to UTF-8 on all platforms.

Code that interacts with native APIs can use the system property
native.encoding to query the platform encoding and use that. And related
to this the same is true for applications interacting with the system
console.

The primarly affected platform is windows, as both mac OS and Linux
already default to UTF-8 as file encoding.

In this PR two areas are covered:

- General execution (using "External Execution API"): The module already
  allows users to specify the encoding to use. It used the default
  enconding as a fallback, if none was specified. This fallback was
  enhanced to query the native.encoding system property first. If it is
  present, it will be used as default encoding (JDK 18+), if it is
  missing, the original behavior using the default file encoding is
  activated.

- Maven target execution: maven target execution is basicly an external
  execution, so the same considerations apply. In contrast to the
  general execution API, the encoding for maven execution can't be
  overriden, so both code path (input + output) are configured to use
  the native.enconfig property if present or fallback to the default
  file encoding.