### PR TITLE
Better finding missing class in ImportHelper

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/imports/ImportHelper.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/imports/ImportHelper.java
@@ -247,12 +247,28 @@ public final class ImportHelper {
      * @return missing class name
      */
     public static String getMissingClassName(String errorMessage) {
-        String errorPrefix = "unable to resolve class "; // NOI18N
-        if (!errorMessage.startsWith(errorPrefix)) {
+        String errorText = "unable to resolve class "; // NOI18N
+        String missingClass = null;
+        if (errorMessage.startsWith(errorText)) {
+            missingClass = errorMessage.substring(errorText.length());
+        } else {
+            // I really don't like how the missing class is founded, but so far .....
+            errorText = "doesn't refer to a local variable, static field or class"; //NOI18N
+            if (errorMessage.contains(errorText)) {
+                int startIndex = errorMessage.indexOf('\'');
+                if (startIndex > -1) {
+                    startIndex++;
+                    int endIndex = errorMessage.indexOf('\'', startIndex);
+                    if (endIndex > -1) {
+                        missingClass = errorMessage.substring(startIndex, endIndex);
+                    }
+                }
+            }
+        }
+            
+        if (missingClass == null) {
             return null;
         }
-
-        String missingClass = errorMessage.substring(errorPrefix.length());
         int idx = missingClass.indexOf(" ");
         if (idx != -1) {
             missingClass = missingClass.substring(0, idx);


### PR DESCRIPTION

This is a fix for creating Import hint fro a missing class. 

The current implementation is looking throught the error messages from parser and was looking for the message "unable to resolve class " only. I have added also message "doesn't refer to a local variable, static filed or class" than can create the import hint. 