### PR TITLE
Invoke arbitrary action from vscode

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/items/OCIItem.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/items/OCIItem.java
@@ -44,6 +44,10 @@ public class OCIItem {
         changeSupport = new ChangeSupport(this);
     }
 
+    public OCIItem() {
+        this(null, null);
+    }
+    
     /**
      * OCID of the item.
      * 

--- a/java/java.lsp.server/test/unit/src/META-INF/generated-layer.xml
+++ b/java/java.lsp.server/test/unit/src/META-INF/generated-layer.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
+<filesystem>
+    <folder name="Actions">
+        <folder name="Tools">
+            <file name="testAction1.instance">
+                <attr stringvalue="Test Action" name="displayName"/>
+                <attr methodvalue="org.openide.awt.Actions.context" name="instanceCreate"/>
+                <attr name="type" stringvalue="org.netbeans.modules.java.lsp.server.explorer.TestInfo"/>
+                <attr name="injectable" stringvalue="org.netbeans.modules.java.lsp.server.explorer.NodeActionsProviderTest$TestAction"/>
+                <attr name="delegate" methodvalue="org.openide.awt.Actions.inject"/>
+                <attr name="selectionType" stringvalue="EXACTLY_ONE"/>
+                <attr boolvalue="false" name="noIconInMenu"/>
+                <attr boolvalue="false" name="asynchronous"/>
+            </file>
+        </folder>
+    </folder>
+</filesystem>

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/NodeActionsProviderTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/NodeActionsProviderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.explorer;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.SwingUtilities;
+import static junit.framework.TestCase.assertEquals;
+import org.eclipse.lsp4j.LogTraceParams;
+import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.SetTraceParams;
+import org.eclipse.lsp4j.ShowDocumentParams;
+import org.eclipse.lsp4j.ShowDocumentResult;
+import org.eclipse.lsp4j.UnregistrationParams;
+import org.eclipse.lsp4j.WorkspaceFolder;
+import org.junit.Test;
+import org.netbeans.modules.java.lsp.server.TestCodeLanguageClient;
+import org.netbeans.modules.java.lsp.server.ui.AbstractGlobalActionContext;
+import org.openide.util.test.MockLookup;
+
+/**
+ *
+ * @author Jan Horvath
+ */
+public class NodeActionsProviderTest {
+
+    static CountDownLatch latch;
+
+    /**
+     * Test of processCommand method, of class NodeActionsProvider.
+     */
+    @Test
+    public void testProcessCommand() throws InterruptedException, InvocationTargetException {
+        latch = new CountDownLatch(1);
+        MockLookup.setLayersAndInstances(
+                new AbstractGlobalActionContext());
+        try {
+            NodeActionsProvider p = new NodeActionsProvider(Collections.EMPTY_SET);
+            Map<String, String> m = new HashMap<String, String>();
+            m.put("name", "test");
+            m.put("id", "test1");
+
+            SwingUtilities.invokeAndWait(() -> {
+                p.invokeAction(new TestCodeLanguageClient() {
+                    @Override
+                    public boolean isRequestDispatcherThread() {
+                        return super.isRequestDispatcherThread();
+                    }
+
+                    @Override
+                    public CompletableFuture<Void> registerCapability(RegistrationParams params) {
+                        return super.registerCapability(params);
+                    }
+
+                    @Override
+                    public CompletableFuture<Void> unregisterCapability(UnregistrationParams params) {
+                        return super.unregisterCapability(params);
+                    }
+
+                    @Override
+                    public CompletableFuture<ShowDocumentResult> showDocument(ShowDocumentParams params) {
+                        return super.showDocument(params);
+                    }
+
+                    @Override
+                    public CompletableFuture<List<WorkspaceFolder>> workspaceFolders() {
+                        return super.workspaceFolders();
+                    }
+
+                    @Override
+                    public void logTrace(LogTraceParams params) {
+                        super.logTrace(params);
+                    }
+
+                    @Override
+                    public void setTrace(SetTraceParams params) {
+                        super.setTrace(params);
+                    }
+
+                    @Override
+                    public CompletableFuture<Void> refreshSemanticTokens() {
+                        return super.refreshSemanticTokens();
+                    }
+
+                    @Override
+                    public CompletableFuture<Void> refreshCodeLenses() {
+                        return super.refreshCodeLenses();
+                    }
+                }, "Tools", "testAction1", Collections.singletonList(m));
+            });
+        } finally {
+            MockLookup.setInstances();
+        }
+        latch.await(2, TimeUnit.SECONDS);
+        assertEquals(0, latch.getCount());
+    }
+
+    public static class TestAction implements ActionListener {
+
+        private final TestInfo context;
+
+        public TestAction(TestInfo context) {
+            this.context = context;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            assertEquals("test1", context.id);
+            latch.countDown();
+        }
+    }
+
+}

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/TestInfo.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/TestInfo.java
@@ -16,34 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.modules.cloud.oracle.items;
+package org.netbeans.modules.java.lsp.server.explorer;
 
 /**
  *
- * @author Jan Horvath
  */
-public class DatabaseItem extends OCIItem {
-    private final String serviceUrl;
-    private final String connectionName;
+public class TestInfo {
+    String name;
+        String id;
 
-    public DatabaseItem(String id, String name, String serviceUrl, String connectionName) {
-        super(id, name);
-        this.serviceUrl = serviceUrl;
-        this.connectionName = connectionName;
-    }
+        public TestInfo() {
+            name = "1";
+            id = "2";
+        }
+        
+        public String getName() {
+            return name;
+        }
 
-    public DatabaseItem() {
-        super();
-        serviceUrl = null;
-        connectionName = null;
-    }
-    
-    public String getServiceUrl() {
-        return serviceUrl;
-    }
+        public void setName(String name) {
+            this.name = name;
+        }
 
-    public String getConnectionName() {
-        return connectionName;
-    }
-    
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
 }


### PR DESCRIPTION
Adding possibility to invoke arbitrary action from vscode. Any action registered in `java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml` can be called as a vscode command:
`vscode.commands.executeCommand('nbls:<Category>:<actionId>', <context>);`. Context will be converted to Action type defined in layer. 
