### PR TITLE
Use constants defined in StandardCharsets instead of Charset name lookup.

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/FileEncodingQueryImpl.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/FileEncodingQueryImpl.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.apisupport.project.queries;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.spi.queries.FileEncodingQueryImplementation;
 import org.openide.filesystems.FileObject;
 
@@ -37,7 +38,7 @@ public class FileEncodingQueryImpl extends FileEncodingQueryImplementation {
     public FileEncodingQueryImpl() {}
 
     public Charset getEncoding(FileObject file) {
-        return Charset.forName("UTF-8");
+        return StandardCharsets.UTF_8;
     }
 
 }

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ModuleList.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/ModuleList.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,7 +55,6 @@ import org.netbeans.modules.apisupport.project.api.ManifestManager;
 import org.netbeans.modules.apisupport.project.api.Util;
 import org.netbeans.modules.apisupport.project.ui.customizer.ClusterInfo;
 import org.netbeans.modules.apisupport.project.ui.customizer.SuiteUtils;
-import static org.netbeans.modules.apisupport.project.universe.Bundle.*;
 import org.netbeans.spi.project.support.ant.PropertyEvaluator;
 import org.netbeans.spi.project.support.ant.PropertyProvider;
 import org.netbeans.spi.project.support.ant.PropertyUtils;
@@ -72,6 +72,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+
+import static org.netbeans.modules.apisupport.project.universe.Bundle.*;
 
 /**
  * Represents list of known modules.
@@ -867,7 +869,7 @@ public final class ModuleList {
         @Messages("junit_placeholder=JUnit from Maven")
         @Override protected LocalizedBundleInfo getBundleInfo() {
             try {
-                return LocalizedBundleInfo.load(new InputStream[] {new ByteArrayInputStream((LocalizedBundleInfo.NAME + '=' + junit_placeholder()).getBytes("ISO-8859-1"))});
+                return LocalizedBundleInfo.load(new InputStream[] {new ByteArrayInputStream((LocalizedBundleInfo.NAME + '=' + junit_placeholder()).getBytes(StandardCharsets.ISO_8859_1))});
             } catch (IOException x) {
                 assert false : x;
                 return LocalizedBundleInfo.EMPTY;

--- a/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/common/CreatedModifiedFilesTest.java
+++ b/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/common/CreatedModifiedFilesTest.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -222,7 +223,7 @@ public class CreatedModifiedFilesTest extends LayerTestBase {
         assertNotNull(registry);
         InputStream is = registry.getInputStream();
         try {
-            BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+            BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             assertEquals("org.example.module1.ProvideMeImpl1", r.readLine());
             assertEquals("org.example.module1.ProvideMeImpl2", r.readLine());
             assertEquals(null, r.readLine());
@@ -233,7 +234,7 @@ public class CreatedModifiedFilesTest extends LayerTestBase {
         assertNotNull(registry);
         is = registry.getInputStream();
         try {
-            BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+            BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             assertEquals("org.example.module1.ProvideMeImpl1", r.readLine());
             assertEquals(null, r.readLine());
         } finally {

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/api/EditableManifest.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/api/EditableManifest.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -76,7 +77,7 @@ public final class EditableManifest {
      * @throws IOException if reading the stream failed, or the contents were syntactically malformed
      */
     public EditableManifest(InputStream is) throws IOException {
-        BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8")); // NOI18N
+        BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
         sections = new LinkedList<Section>();
         String text;
         int blankLines = 0;
@@ -129,7 +130,7 @@ public final class EditableManifest {
      * @throws IOException if writing to the stream failed
      */
     public void write(OutputStream os) throws IOException {
-        Writer w = new OutputStreamWriter(os, "UTF-8"); // NOI18N
+        Writer w = new OutputStreamWriter(os, StandardCharsets.UTF_8);
         mainSection.write(w, !sections.isEmpty());
         Iterator<Section> it = sections.iterator();
         while (it.hasNext()) {

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/WritableXMLFileSystem.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/WritableXMLFileSystem.java
@@ -29,13 +29,13 @@ import java.io.InputStream;
 import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -72,7 +72,6 @@ import org.openide.filesystems.FileRenameEvent;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.Enumerations;
-import org.openide.util.Exceptions;
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
 
@@ -305,12 +304,8 @@ public final class WritableXMLFileSystem extends AbstractFileSystem
                     buf.append(((TreeText) o).getData().trim());
                 }
             }
-            try {
-                // This encoding is intentional...
-                return buf.toString().getBytes("UTF-8"); // NOI18N
-            } catch (UnsupportedEncodingException uee) {
-                throw new FileNotFoundException(uee.getMessage());
-            }
+            // This encoding is intentional...
+            return buf.toString().getBytes(StandardCharsets.UTF_8);
         }
     }
     

--- a/apisupport/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/TestUtil.java
+++ b/apisupport/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/TestUtil.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -96,7 +97,7 @@ public class TestUtil {
             JarOutputStream jos = manifest != null ? new JarOutputStream(os, manifest) : new JarOutputStream(os);
             for (Map.Entry<String,String> entry : contents.entrySet()) {
                 String path = entry.getKey();
-                byte[] data = entry.getValue().getBytes("UTF-8");
+                byte[] data = entry.getValue().getBytes(StandardCharsets.UTF_8);
                 JarEntry je = new JarEntry(path);
                 je.setSize(data.length);
                 CRC32 crc = new CRC32();
@@ -128,7 +129,7 @@ public class TestUtil {
     public static void dump(FileObject f, String contents) throws IOException {
         OutputStream os = f.getOutputStream();
         try {
-            Writer w = new OutputStreamWriter(os, "UTF-8");
+            Writer w = new OutputStreamWriter(os, StandardCharsets.UTF_8);
             w.write(contents);
             w.flush();
         } finally {

--- a/apisupport/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/api/EditableManifestTest.java
+++ b/apisupport/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/api/EditableManifestTest.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.apisupport.project.api;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -288,7 +289,7 @@ public class EditableManifestTest extends NbTestCase {
     }
     
     private static EditableManifest string2Manifest(String text) throws Exception {
-        return new EditableManifest(new ByteArrayInputStream(text.getBytes("UTF-8")));
+        return new EditableManifest(new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)));
     }
     
     private static String manifest2String(EditableManifest em) throws Exception {

--- a/apisupport/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/AbstractRefactoringPlugin.java
+++ b/apisupport/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/AbstractRefactoringPlugin.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
@@ -99,7 +100,7 @@ public abstract class AbstractRefactoringPlugin implements RefactoringPlugin {
     protected final int checkContentOfFile(FileObject fo, String classToLookFor) {
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(fo.getInputStream(), "UTF-8")); // NOI18N
+            reader = new BufferedReader(new InputStreamReader(fo.getInputStream(), StandardCharsets.UTF_8));
             String line = reader.readLine();
             int counter = 0;
             while (line != null) {

--- a/apisupport/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/Utility.java
+++ b/apisupport/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/Utility.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.modules.refactoring.api.Problem;
 import org.openide.ErrorManager;
 import org.openide.filesystems.FileObject;
@@ -82,7 +83,7 @@ public class Utility {
         try {
             OutputStream os = fileObject.getOutputStream();
             try {
-                PrintWriter writer = new PrintWriter(new OutputStreamWriter(os, "UTF-8")); // NOI18N
+                PrintWriter writer = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
                 writer.print(content);
                 writer.flush();
             } finally {
@@ -98,7 +99,7 @@ public class Utility {
         String content = null;
         try {
             StringWriter writer =new StringWriter();
-            reader = new BufferedReader(new InputStreamReader(fileObject.getInputStream(), "UTF-8")); // NOI18N
+            reader = new BufferedReader(new InputStreamReader(fileObject.getInputStream(), StandardCharsets.UTF_8));
             int chr = reader.read();
             while (chr != -1) {
                 writer.write(chr);

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/CreatedModifiedFiles.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/CreatedModifiedFiles.java
@@ -34,6 +34,7 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -638,7 +639,7 @@ public final class CreatedModifiedFiles {
             List<String> lines = new ArrayList<String>();
             InputStream serviceIS = service.getInputStream();
             try {
-                BufferedReader br = new BufferedReader(new InputStreamReader(serviceIS, "UTF-8")); // NOI18N
+                BufferedReader br = new BufferedReader(new InputStreamReader(serviceIS, StandardCharsets.UTF_8));
                 String line;
                 while ((line = br.readLine()) != null) {
                     lines.add(line);
@@ -649,7 +650,7 @@ public final class CreatedModifiedFiles {
 
             OutputStream os = service.getOutputStream();
             try {
-                PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, "UTF-8")); // NOI18N
+                PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
                 Iterator<String> it = lines.iterator();
                 while (it.hasNext()) {
                     String line = it.next();

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/DesignSupport.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/DesignSupport.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.MissingResourceException;
 import java.util.Set;
 import java.util.TreeSet;
@@ -197,7 +198,7 @@ public final class DesignSupport implements TaskListener, Runnable {
                         final String name = "Windows2/Modes/" + m.getNameExt(); // NOI18N
                         FileObject mode = FileUtil.createData(layer.getRoot(), name); // NOI18N
                         os = mode.getOutputStream();
-                        os.write(DesignSupport.readMode(m).getBytes("UTF-8")); // NOI18N
+                        os.write(DesignSupport.readMode(m).getBytes(StandardCharsets.UTF_8));
                         os.close();
                         sb.append(name).append("\n");
                     }

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/LayoutIterator.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/LayoutIterator.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.apisupport.project.ui.wizard.winsys;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -270,7 +271,7 @@ public final class LayoutIterator extends BasicWizardIterator {
                         FileObject wsmode = fo.createData(entry.getKey() + ".wsmode");
                         OutputStream os = wsmode.getOutputStream();
                         try {
-                            os.write(entry.getValue().getBytes("UTF-8"));
+                            os.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
                         } finally {
                             os.close();
                         }

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/NewTCIterator.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/NewTCIterator.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.apisupport.project.ui.wizard.winsys;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -422,7 +423,7 @@ public final class NewTCIterator extends BasicWizardIterator {
                         FileObject wsmode = FileUtil.createData(fo, entry.getKey() + ".wsmode");
                         OutputStream os = wsmode.getOutputStream();
                         try {
-                            os.write(entry.getValue().getBytes("UTF-8"));
+                            os.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
                         } finally {
                             os.close();
                         }

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
@@ -25,9 +25,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -162,14 +162,14 @@ public class MavenNbModuleImpl implements NbModuleProvider {
         return FileUtil.normalizeFile(rel);
     }
     
-    private Xpp3Dom getModuleDom() throws UnsupportedEncodingException, IOException, XmlPullParserException {
+    private Xpp3Dom getModuleDom() throws IOException, XmlPullParserException {
         //TODO convert to FileOBject and have the IO stream from there..
         File file = getModuleXmlLocation();
         if (!file.exists()) {
             return null;
         }
         FileInputStream is = new FileInputStream(file);
-        Reader reader = new InputStreamReader(is, "UTF-8"); //NOI18N
+        Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8);
         try {
             return Xpp3DomBuilder.build(reader);
         } finally {

--- a/apisupport/maven.apisupport/test/unit/src/org/netbeans/modules/maven/apisupport/NBMNativeMWITest.java
+++ b/apisupport/maven.apisupport/test/unit/src/org/netbeans/modules/maven/apisupport/NBMNativeMWITest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.maven.apisupport;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
@@ -142,7 +143,7 @@ public class NBMNativeMWITest extends NbTestCase {
         FileObject createDatap = wd.createFolder("testp");
         FileObject parentpomFile = createDatap.createData("pom", "xml");
         try (OutputStream os = parentpomFile.getOutputStream()) {
-            os.write(POMCOMPILER.getBytes("UTF-8"));
+            os.write(POMCOMPILER.getBytes(StandardCharsets.UTF_8));
         }
         MavenXpp3Reader reader = new MavenXpp3Reader();
         Model model = reader.read(new FileReader(FileUtil.toFile(parentpomFile)));
@@ -170,7 +171,7 @@ public class NBMNativeMWITest extends NbTestCase {
         FileObject createDatap = wd.createFolder("testp");
         FileObject parentpomFile = createDatap.createData("pom", "xml");
         try (OutputStream os = parentpomFile.getOutputStream()) {
-            os.write(POMJAR.getBytes("UTF-8"));
+            os.write(POMJAR.getBytes(StandardCharsets.UTF_8));
         }
         MavenXpp3Reader reader = new MavenXpp3Reader();
         Model model = reader.read(new FileReader(FileUtil.toFile(parentpomFile)));

--- a/contrib/cordova.platforms.ios/src/org/netbeans/modules/cordova/platforms/ios/IOSDebugTransport.java
+++ b/contrib/cordova.platforms.ios/src/org/netbeans/modules/cordova/platforms/ios/IOSDebugTransport.java
@@ -28,9 +28,8 @@ import com.dd.plist.XMLPropertyListParser;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.SocketException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -191,7 +190,7 @@ public abstract class IOSDebugTransport extends MobileDebugTransport implements 
             return "\"" + ((NSString) o).toString() + "\"";             //NOI18N
         } else if (o instanceof NSData) {
             NSData data = (NSData) o;
-            String asStr = new String(data.bytes(), Charset.forName("UTF-8"));
+            String asStr = new String(data.bytes(), StandardCharsets.UTF_8);
             return "Data: " + asStr;
         } else if (o != null) {
             return o.toString();
@@ -284,13 +283,8 @@ public abstract class IOSDebugTransport extends MobileDebugTransport implements 
     }
 
     protected static InputStream fromString(String str) {
-        try {
-            byte[] bytes = str.getBytes("UTF-8"); // NOI18N
-            return new ByteArrayInputStream(bytes);
-        } catch (UnsupportedEncodingException ex) {
-            Exceptions.printStackTrace(ex);
-            return null;
-        }
+        byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+        return new ByteArrayInputStream(bytes);
     }
 
     protected void stop() {

--- a/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/WLPluginProperties.java
+++ b/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/WLPluginProperties.java
@@ -26,6 +26,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -293,7 +294,7 @@ public final class WLPluginProperties {
                 javaHomeVendors.put("", getDefaultPlatformHome());
                 return properties;
             }
-            BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
             try {
                 String line;
                 String vendorName = null;
@@ -526,7 +527,7 @@ public final class WLPluginProperties {
         // read the list file line by line fetching out the domain paths
         try {
             // create a new reader for the FileInputStream
-            lnr = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8")); // NOI18N
+            lnr = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
 
             // read the lines
             String line;

--- a/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/WLTrustHandler.java
+++ b/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/WLTrustHandler.java
@@ -28,6 +28,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.math.BigInteger;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -167,7 +168,7 @@ public class WLTrustHandler implements WebLogicTrustHandler {
                         // we just trigger the trust manager here
                         socket.connect(new InetSocketAddress(config.getHost(), config.getPort()), CHECK_TIMEOUT); // NOI18N
                         socket.setSoTimeout(CHECK_TIMEOUT);
-                        PrintWriter out = new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), "UTF-8"), true); // NOI18N
+                        PrintWriter out = new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8), true);
                         try {
                             out.println("GET / HTTP/1.1\nHost:\n"); // NOI18N
                             return true;

--- a/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/j2ee/JaxWsPoliciesSupportImpl.java
+++ b/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/j2ee/JaxWsPoliciesSupportImpl.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -243,8 +244,7 @@ class JaxWsPoliciesSupportImpl implements JaxWsPoliciesSupportImplementation {
             BufferedReader reader = null;
             try {
                 InputStream stream = fileObject.getInputStream();
-                reader = new BufferedReader(  
-                        new InputStreamReader(stream, "UTF-8")); // NOI18N
+                reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
                 String line;
                 while( (line = reader.readLine()) != null ){
                     builder.append( line );

--- a/contrib/j2ee.weblogic9/test/unit/src/org/netbeans/modules/j2ee/weblogic9/WLPluginPropertiesTest.java
+++ b/contrib/j2ee.weblogic9/test/unit/src/org/netbeans/modules/j2ee/weblogic9/WLPluginPropertiesTest.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
@@ -116,7 +117,7 @@ public class WLPluginPropertiesTest extends NbTestCase {
             stringBuilder.append(line).append("\n");
         }
 
-        InputStream is = new ByteArrayInputStream(stringBuilder.toString().getBytes("UTF-8"));
+        InputStream is = new ByteArrayInputStream(stringBuilder.toString().getBytes(StandardCharsets.UTF_8));
         try {
             new JarOutputStream(new FileOutputStream(file), new Manifest(is)).close();
         } finally {

--- a/contrib/j2ee.weblogic9/test/unit/src/org/netbeans/modules/j2ee/weblogic9/j2ee/WLJ2eePlatformFactoryTest.java
+++ b/contrib/j2ee.weblogic9/test/unit/src/org/netbeans/modules/j2ee/weblogic9/j2ee/WLJ2eePlatformFactoryTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -129,7 +130,7 @@ public class WLJ2eePlatformFactoryTest extends NbTestCase {
             stringBuilder.append(line).append("\n");
         }
         
-        InputStream is = new ByteArrayInputStream(stringBuilder.toString().getBytes("UTF-8"));
+        InputStream is = new ByteArrayInputStream(stringBuilder.toString().getBytes(StandardCharsets.UTF_8));
         try {
             new JarOutputStream(new FileOutputStream(file), new Manifest(is)).close();
         } finally {

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/HttpMonitorHelper.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/HttpMonitorHelper.java
@@ -32,6 +32,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -150,8 +151,8 @@ public class HttpMonitorHelper {
         BufferedWriter fw= null;
         boolean deleteNew = true;
         try {
-            fr = new BufferedReader(new InputStreamReader(new FileInputStream(webXML),"ISO-8859-1"));
-            fw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(newWebXML),"ISO-8859-1"));
+            fr = new BufferedReader(new InputStreamReader(new FileInputStream(webXML), StandardCharsets.ISO_8859_1));
+            fw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(newWebXML), StandardCharsets.ISO_8859_1));
             while (true) {
                 String line = fr.readLine();
                 if (line == null)

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/PasswordFile.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/PasswordFile.java
@@ -23,6 +23,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -36,6 +37,7 @@ import java.util.logging.Level;
 import org.netbeans.modules.glassfish.tooling.data.GlassFishServer;
 import org.netbeans.modules.glassfish.tooling.logging.Logger;
 import org.netbeans.modules.glassfish.tooling.utils.OsUtils;
+
 import static org.netbeans.modules.glassfish.tooling.utils.ServerUtils.GF_DOMAIN_CONFIG_DIR_NAME;
 
 /**
@@ -352,7 +354,7 @@ public class PasswordFile {
         Writer out = null;
         createFilePosix();
         try {
-            out = new OutputStreamWriter(new FileOutputStream(file.toFile()), "UTF-8");
+            out = new OutputStreamWriter(new FileOutputStream(file.toFile()), StandardCharsets.UTF_8);
             out.write(dataToWrite());
         } catch (IOException ioe) {
             success = false;

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/utils/JavaUtils.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/utils/JavaUtils.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -66,7 +67,7 @@ public class JavaUtils {
     public static final String JAVA_HOME_ENV = "JAVA_HOME";
 
     /** UTF-8 {@link Charset}. */
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    public static final Charset UTF_8 = StandardCharsets.UTF_8;
     /**
      * Java VM version output regular expression pattern.
      * <p/>

--- a/enterprise/j2ee.ddloaders/test/unit/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataNodeTest.java
+++ b/enterprise/j2ee.ddloaders/test/unit/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataNodeTest.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import javax.swing.Action;
 import junit.framework.Assert;
@@ -107,7 +108,7 @@ public class EarDataNodeTest extends NbTestCase {
         f.getParentFile().mkdirs();
         OutputStream os = new FileOutputStream(f);
         try {
-            Writer w = new OutputStreamWriter(os, "UTF-8");
+            Writer w = new OutputStreamWriter(os, StandardCharsets.UTF_8);
             w.write(contents);
             w.flush();
         } finally {

--- a/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/test/TestUtilities.java
+++ b/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/test/TestUtilities.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
@@ -38,7 +39,7 @@ public class TestUtilities {
     public static final FileObject copyStringToFileObject(FileObject fo, String content) throws IOException {
         OutputStream os = fo.getOutputStream();
         try {
-            InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
             FileUtil.copy(is, os);
             return fo;
         } finally {

--- a/enterprise/j2ee.ejbverification/test/unit/src/org/netbeans/modules/j2ee/ejbverification/HintTestBase.java
+++ b/enterprise/j2ee.ejbverification/test/unit/src/org/netbeans/modules/j2ee/ejbverification/HintTestBase.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -53,12 +54,6 @@ import java.util.regex.Pattern;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.Document;
 import javax.tools.Diagnostic;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNotSame;
-import static junit.framework.Assert.assertTrue;
-
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.lexer.JavaTokenId;
@@ -116,6 +111,12 @@ import org.openide.loaders.DataObject;
 import org.openide.loaders.DataObjectNotFoundException;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Copy/pasted and refactored HintTestBase written by Honza Lahoda.
@@ -1309,7 +1310,7 @@ public class HintTestBase {
 
     private static FileObject copyStringToFile (FileObject f, String content) throws Exception {
         OutputStream os = f.getOutputStream();
-        os.write(content.getBytes("UTF-8"));
+        os.write(content.getBytes(StandardCharsets.UTF_8));
         os.close ();
 
         return f;

--- a/enterprise/j2ee.ejbverification/test/unit/src/org/netbeans/modules/j2ee/ejbverification/TestBase.java
+++ b/enterprise/j2ee.ejbverification/test/unit/src/org/netbeans/modules/j2ee/ejbverification/TestBase.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -335,7 +336,7 @@ public class TestBase extends NbTestCase {
     public static final FileObject copyStringToFileObject(FileObject fo, String content) throws IOException {
         OutputStream os = fo.getOutputStream();
         try {
-            InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
             try {
                 FileUtil.copy(is, os);
                 return fo;

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/devmodules/api/AntDeploymentHelper.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/devmodules/api/AntDeploymentHelper.java
@@ -26,8 +26,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.modules.j2ee.deployment.impl.ServerInstance;
 import org.netbeans.modules.j2ee.deployment.impl.ServerRegistry;
 import org.netbeans.modules.j2ee.deployment.plugins.spi.AntDeploymentProvider;
@@ -146,7 +148,7 @@ public final class AntDeploymentHelper {
                     try
                     {
                         OutputStream fileOS = fo.getOutputStream(lock);
-                        writer = new OutputStreamWriter(fileOS, "UTF-8"); // NOI18N
+                        writer = new OutputStreamWriter(fileOS, StandardCharsets.UTF_8);
                         String outString = os.toString("UTF-8"); // NOI18N
                         writer.write(outString, 0, outString.length());
                     }
@@ -194,8 +196,8 @@ public final class AntDeploymentHelper {
             throws IOException {
         boolean retVal = false;
 
-        BufferedReader reader1 = new BufferedReader(new java.io.InputStreamReader(stream1, "UTF-8")); // NOI18N
-        BufferedReader reader2 = new BufferedReader(new java.io.InputStreamReader(stream2, "UTF-8")); // NOI18N
+        BufferedReader reader1 = new BufferedReader(new InputStreamReader(stream1, StandardCharsets.UTF_8));
+        BufferedReader reader2 = new BufferedReader(new InputStreamReader(stream2, StandardCharsets.UTF_8));
 
         for (;;) {
             String line1 = reader1.readLine();

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/InitialServerFileDistributor.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/InitialServerFileDistributor.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Locale;
@@ -317,7 +318,7 @@ public class InitialServerFileDistributor extends ServerProgress {
             try {
                 jos.putNextEntry(new ZipEntry("META-INF/MANIFEST.MF")); // NOI18N
                 // UTF-8 guaranteed on any platform
-                jos.write("Manifest-Version: 1.0\n".getBytes("UTF-8")); // NOI18N
+                jos.write("Manifest-Version: 1.0\n".getBytes(StandardCharsets.UTF_8)); // NOI18N
             } finally {
                 jos.close();
             }

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ServerStringConverter.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ServerStringConverter.java
@@ -23,6 +23,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.NodeList;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -51,7 +52,7 @@ public class ServerStringConverter extends org.netbeans.spi.settings.DOMConverto
             FileObject dir = FileUtil.getConfigFile(destDir);
             FileObject fo = FileUtil.createData(dir, destFile);
             lock = fo.lock();
-            writer = new OutputStreamWriter(fo.getOutputStream(lock), "UTF-8"); // NOI18N
+            writer = new OutputStreamWriter(fo.getOutputStream(lock), StandardCharsets.UTF_8);
             create().write(writer, instance);
             return true;
             
@@ -80,7 +81,7 @@ public class ServerStringConverter extends org.netbeans.spi.settings.DOMConverto
             if (fo == null)
                 return null;
             
-            reader = new InputStreamReader(fo.getInputStream(), "UTF-8"); // NOI18N
+            reader = new InputStreamReader(fo.getInputStream(), StandardCharsets.UTF_8);
             return (ServerString) create().read(reader);
         } catch(Exception ioe) {
             Logger.getLogger("global").log(Level.WARNING, null, ioe);

--- a/enterprise/j2eeserver/test/unit/src/org/netbeans/modules/j2ee/deployment/plugins/api/InstancePropertiesTest.java
+++ b/enterprise/j2eeserver/test/unit/src/org/netbeans/modules/j2ee/deployment/plugins/api/InstancePropertiesTest.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.netbeans.api.keyring.Keyring;
@@ -144,7 +145,7 @@ public class InstancePropertiesTest extends ServerRegistryTestBase {
                     FileObject fo = folder.createData("Descriptor");
                     InputStream is = new ByteArrayInputStream(
                             ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                            + "<netbeans-deployment></netbeans-deployment>").getBytes("UTF-8"));
+                            + "<netbeans-deployment></netbeans-deployment>").getBytes(StandardCharsets.UTF_8));
                     try {
                         OutputStream os = fo.getOutputStream();
                         try {

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ArtifactCopyOnSaveSupport.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ArtifactCopyOnSaveSupport.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -411,7 +412,7 @@ public abstract class ArtifactCopyOnSaveSupport implements FileChangeListener,
             try {
                 jos.putNextEntry(new ZipEntry("META-INF/MANIFEST.MF")); // NOI18N
                 // UTF-8 guaranteed on any platform
-                jos.write("Manifest-Version: 1.0\n".getBytes("UTF-8")); // NOI18N
+                jos.write("Manifest-Version: 1.0\n".getBytes(StandardCharsets.UTF_8));
             } finally {
                 jos.close();
             }

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/MavenProjectRestSupport.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/MavenProjectRestSupport.java
@@ -26,7 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -36,9 +36,6 @@ import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectInformation;
 import org.netbeans.api.project.ProjectUtils;
-import org.netbeans.modules.j2ee.dd.api.web.ServletMapping;
-import org.netbeans.modules.j2ee.dd.api.web.ServletMapping25;
-import org.netbeans.modules.j2ee.dd.api.web.WebApp;
 import org.netbeans.modules.maven.api.NbMavenProject;
 import org.netbeans.modules.maven.api.execute.RunConfig;
 import org.netbeans.modules.maven.api.execute.RunUtils;
@@ -51,7 +48,6 @@ import org.openide.execution.ExecutorTask;
 import org.openide.filesystems.FileLock;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
-import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 
 /**
@@ -208,11 +204,9 @@ public class MavenProjectRestSupport extends RestSupport {
         try {
             lock = fo.lock();
             OutputStream os = fo.getOutputStream(lock);
-            writer = new BufferedWriter(new OutputStreamWriter(os, 
-                    Charset.forName("UTF-8")));         // NOI18N
+            writer = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
             InputStream is = RestSupport.class.getResourceAsStream("resources/"+name);
-            reader = new BufferedReader(new InputStreamReader(is, 
-                    Charset.forName("UTF-8")));         // NOI18N
+            reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             String line;
             String lineSep = "\n";//Unix
             if(File.separatorChar == '\\')//Windows

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/WSUtils.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/WSUtils.java
@@ -28,7 +28,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URI;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -143,7 +143,7 @@ public class WSUtils {
                 OutputStreamWriter osw = null;
                 try {
                     os = sunJaxwsFo.getOutputStream(lock);
-                    osw = new OutputStreamWriter(os, Charset.forName("UTF-8"));     // NOI18N
+                    osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
                     bw = new BufferedWriter(osw);
                     bw.write(sunJaxwsContent);
                 } finally {
@@ -168,8 +168,7 @@ public class WSUtils {
         // read the config from resource first
         StringBuffer sb = new StringBuffer();
         String lineSep = System.getProperty("line.separator");//NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(is, 
-                Charset.forName("UTF-8")));
+        BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
         String line = br.readLine();
         while (line != null) {
             sb.append(line);

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/ClientHandlerButtonListener.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/ClientHandlerButtonListener.java
@@ -38,6 +38,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -164,7 +165,7 @@ public class ClientHandlerButtonListener implements ActionListener {
                         FileLock lock = bindingHandlerFO.lock();
                         try {
                             os = bindingHandlerFO.getOutputStream(lock);
-                            osw = new OutputStreamWriter(os, Charset.forName("UTF-8")); //  NOI18N
+                            osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
                             bw = new BufferedWriter(osw);
                             bw.write(bindingsContent);
                         } finally {
@@ -392,7 +393,7 @@ public class ClientHandlerButtonListener implements ActionListener {
         StringBuilder sb = new StringBuilder();
         try {
             String lineSep = System.getProperty("line.separator");//NOI18N
-            isr = new InputStreamReader(is, Charset.forName("UTF-8"));
+            isr = new InputStreamReader(is, StandardCharsets.UTF_8);
             br = new BufferedReader(isr);
 
             String line = br.readLine();

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/HandlerButtonListener.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/HandlerButtonListener.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
@@ -269,8 +269,7 @@ public class HandlerButtonListener implements ActionListener{
         // read the config from resource first
         StringBuffer sb = new StringBuffer();
         String lineSep = System.getProperty("line.separator");//NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(is, 
-                Charset.forName("UTF-8")));         // NOI18N
+        BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
         String line = br.readLine();
         while (line != null) {
             sb.append(line);

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/HttpMonitorHelper.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/HttpMonitorHelper.java
@@ -32,6 +32,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -150,8 +151,8 @@ public class HttpMonitorHelper {
         BufferedWriter fw= null;
         boolean deleteNew = true;
         try {
-            fr = new BufferedReader(new InputStreamReader(new FileInputStream(webXML),"ISO-8859-1"));
-            fw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(newWebXML),"ISO-8859-1"));
+            fr = new BufferedReader(new InputStreamReader(new FileInputStream(webXML), StandardCharsets.ISO_8859_1));
+            fw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(newWebXML), StandardCharsets.ISO_8859_1));
             while (true) {
                 String line = fr.readLine();
                 if (line == null)

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/PasswordFile.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/PasswordFile.java
@@ -22,6 +22,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -34,8 +35,9 @@ import java.util.Set;
 import java.util.logging.Level;
 import org.netbeans.modules.payara.tooling.logging.Logger;
 import org.netbeans.modules.payara.tooling.utils.OsUtils;
-import static org.netbeans.modules.payara.tooling.utils.ServerUtils.PF_DOMAIN_CONFIG_DIR_NAME;
 import org.netbeans.modules.payara.tooling.data.PayaraServer;
+
+import static org.netbeans.modules.payara.tooling.utils.ServerUtils.PF_DOMAIN_CONFIG_DIR_NAME;
 
 /**
  * Support for <code>asadmin</code> <code>--passwordfile</code> file format.
@@ -351,7 +353,7 @@ public class PasswordFile {
         Writer out = null;
         createFilePosix();
         try {
-            out = new OutputStreamWriter(new FileOutputStream(file.toFile()), "UTF-8");
+            out = new OutputStreamWriter(new FileOutputStream(file.toFile()), StandardCharsets.UTF_8);
             out.write(dataToWrite());
         } catch (IOException ioe) {
             success = false;

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/utils/JavaUtils.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/utils/JavaUtils.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -66,7 +67,7 @@ public class JavaUtils {
     public static final String JAVA_HOME_ENV = "JAVA_HOME";
 
     /** UTF-8 {@link Charset}. */
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    public static final Charset UTF_8 = StandardCharsets.UTF_8;
     /**
      * Java VM version output regular expression pattern.
      * <p/>

--- a/enterprise/profiler.j2ee/test/unit/src/org/netbeans/modules/profiler/categories/j2ee/TestUtilities.java
+++ b/enterprise/profiler.j2ee/test/unit/src/org/netbeans/modules/profiler/categories/j2ee/TestUtilities.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import junit.framework.Assert;
 
@@ -79,7 +80,7 @@ public class TestUtilities extends ProxyLookup {
      {
         OutputStream os = fo.getOutputStream();
         try {
-            InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
             FileUtil.copy(is, os);
             return fo;
         } finally {

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManagerImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManagerImpl.java
@@ -46,6 +46,7 @@ import org.openide.util.RequestProcessor;
 import org.openide.util.NbBundle;
 import java.io.*;
 import java.net.Proxy;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -570,7 +571,7 @@ public class TomcatManagerImpl implements ProgressObject, Runnable {
                 }
 
                 // Process the response message
-                reader = new InputStreamReader(hconn.getInputStream(),"UTF-8"); //NOI18N
+                reader = new InputStreamReader(hconn.getInputStream(), StandardCharsets.UTF_8);
                 retries = -1;
                 StringBuffer buff = new StringBuffer();
                 String error = null;

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/BaseJspEditorSupport.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/BaseJspEditorSupport.java
@@ -28,6 +28,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -408,7 +409,7 @@ class BaseJspEditorSupport extends DataEditorSupport implements EditCookie, Edit
 
         String foundEncoding = (String) doc.getProperty(DOCUMENT_SAVE_ENCODING);
         String encoding = foundEncoding != null ? foundEncoding : defaulEncoding;
-        Charset charset = Charset.forName("UTF-8"); //NOI18N
+        Charset charset = StandardCharsets.UTF_8;
         try {
             charset = Charset.forName(encoding);
         } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {

--- a/enterprise/web.jsf.editor/test/unit/src/org/netbeans/modules/web/jsf/editor/JsfHtmlExtensionTest.java
+++ b/enterprise/web.jsf.editor/test/unit/src/org/netbeans/modules/web/jsf/editor/JsfHtmlExtensionTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
@@ -138,7 +139,7 @@ public class JsfHtmlExtensionTest extends TestBaseForTestProject {
     }
 
     public static void copyStringToFile(String string, File path) throws IOException {
-        try (InputStream inputStream = new ByteArrayInputStream(string.getBytes("UTF-8"))) {
+        try (InputStream inputStream = new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8))) {
             copyStreamToFile(inputStream, path);
         }
     }

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/api/WebProjectUtilities.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/api/WebProjectUtilities.java
@@ -54,6 +54,7 @@ import org.w3c.dom.Element;
 
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -893,7 +894,7 @@ public class WebProjectUtilities {
         // read the config from resource first
         StringBuilder sb = new StringBuilder();
         String lineSep = System.getProperty("line.separator"); // NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));
+        BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
         try {
             String line = br.readLine();
             while (line != null) {

--- a/enterprise/web.refactoring/src/org/netbeans/modules/web/refactoring/PositionBoundsResolver.java
+++ b/enterprise/web.refactoring/src/org/netbeans/modules/web/refactoring/PositionBoundsResolver.java
@@ -23,8 +23,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import javax.swing.JEditorPane;
 import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
@@ -171,15 +171,13 @@ public class PositionBoundsResolver {
         String lineSep = System.getProperty("line.separator");//NO18N
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(stream, "UTF-8"));//NO18N
+            reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
             String line = reader.readLine();
             while (line != null) {
                 result.append(line);
                 result.append(lineSep);
                 line = reader.readLine();
             }
-        } catch (UnsupportedEncodingException ex) {
-            Exceptions.printStackTrace(ex);
         } catch (IOException ex) {
             Exceptions.printStackTrace(ex);
         } finally {

--- a/enterprise/weblogic.common/src/org/netbeans/modules/weblogic/common/api/WebLogicRuntime.java
+++ b/enterprise/weblogic.common/src/org/netbeans/modules/weblogic/common/api/WebLogicRuntime.java
@@ -31,6 +31,7 @@ import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedAction;
@@ -599,8 +600,8 @@ public final class WebLogicRuntime {
             try {
                 socket.connect(new InetSocketAddress(host, port), timeout); // NOI18N
                 socket.setSoTimeout(timeout);
-                try (PrintWriter out = new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), "UTF-8"), true); // NOI18N
-                        BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream(), "UTF-8"))) { // NOI18N
+                try (PrintWriter out = new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8), true);
+                        BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8))) {
                     out.println("GET " + path + " HTTP/1.1\nHost:\n"); // NOI18N
                     String line = in.readLine();
                     return "HTTP/1.1 200 OK".equals(line) // NOI18N
@@ -667,11 +668,11 @@ public final class WebLogicRuntime {
         public InputReaders.FileInput getFileInput() {
             File fresh = config.getLogFile();
             if (currentInput == null) {
-                currentInput = new InputReaders.FileInput(fresh, Charset.forName("UTF-8")); // NOI18N
+                currentInput = new InputReaders.FileInput(fresh, StandardCharsets.UTF_8);
             } else {
                 File current = currentInput.getFile();
                 if (!current.equals(fresh) && fresh.lastModified() > current.lastModified()) {
-                    currentInput = new InputReaders.FileInput(fresh, Charset.forName("UTF-8")); // NOI18N
+                    currentInput = new InputReaders.FileInput(fresh, StandardCharsets.UTF_8);
                 }
             }
             return currentInput;

--- a/enterprise/weblogic.common/test/unit/src/org/netbeans/modules/weblogic/common/WebLogicLayoutTest.java
+++ b/enterprise/weblogic.common/test/unit/src/org/netbeans/modules/weblogic/common/WebLogicLayoutTest.java
@@ -29,6 +29,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import org.netbeans.junit.NbTestCase;
@@ -100,7 +101,7 @@ public class WebLogicLayoutTest extends NbTestCase {
             stringBuilder.append(line).append("\n");
         }
 
-        InputStream is = new ByteArrayInputStream(stringBuilder.toString().getBytes("UTF-8"));
+        InputStream is = new ByteArrayInputStream(stringBuilder.toString().getBytes(StandardCharsets.UTF_8));
         try {
             new JarOutputStream(new FileOutputStream(file), new Manifest(is)).close();
         } finally {

--- a/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/client/WebServicesClientSupport.java
+++ b/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/client/WebServicesClientSupport.java
@@ -21,10 +21,9 @@ package org.netbeans.modules.websvc.api.client;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
 
@@ -273,9 +272,8 @@ public final class WebServicesClientSupport {
         if (projectXml != null) {
             BufferedReader br = null;
             try {
-                br = new BufferedReader( new InputStreamReader( 
-                        new FileInputStream( FileUtil.toFile(projectXml)), 
-                            Charset.forName("UTF-8")));                 // NOI18N
+                br = new BufferedReader(new InputStreamReader( 
+                        new FileInputStream( FileUtil.toFile(projectXml)), StandardCharsets.UTF_8));
                 String line = null;
                 while ((line = br.readLine()) != null) {
                     if (line.contains("<web-service-client>")) {        //NOI18N

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/client/wizard/ClientInfo.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/client/wizard/ClientInfo.java
@@ -38,6 +38,7 @@ import java.net.ProxySelector;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JList;
@@ -1240,8 +1241,7 @@ private void saasBrowse(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_saasB
             LineNumberReader lnReader = null;
             boolean foundWsdlNamespace = false;
             try {
-                fr = new InputStreamReader( new FileInputStream(f), 
-                        Charset.forName( "UTF-8"));                         // NOI18N
+                fr = new InputStreamReader( new FileInputStream(f), StandardCharsets.UTF_8);
                 lnReader = new LineNumberReader(fr);
                 if (lnReader != null) {
                     String line = null;

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/ClientHandlerButtonListener.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/ClientHandlerButtonListener.java
@@ -38,6 +38,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
@@ -168,7 +169,7 @@ public class ClientHandlerButtonListener implements ActionListener {
                         FileLock lock = bindingHandlerFO.lock();
                         try {
                             os = bindingHandlerFO.getOutputStream(lock);
-                            osw = new OutputStreamWriter(os, Charset.forName("UTF-8"));// NOI18N
+                            osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
                             bw = new BufferedWriter(osw);
                             bw.write(bindingsContent);
                         } finally {
@@ -441,7 +442,7 @@ public class ClientHandlerButtonListener implements ActionListener {
         StringBuilder sb = new StringBuilder();
         try {
             String lineSep = System.getProperty("line.separator");      //NOI18N
-            isr = new InputStreamReader(is, Charset.forName("UTF-8"));  //NOI18N
+            isr = new InputStreamReader(is, StandardCharsets.UTF_8);
             br = new BufferedReader(isr);
 
             String line = br.readLine();

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/HandlerButtonListener.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/HandlerButtonListener.java
@@ -24,17 +24,12 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.TypeElement;
-import javax.swing.ListModel;
 import javax.swing.table.TableModel;
 import org.netbeans.api.java.source.CancellableTask;
 import org.netbeans.api.java.source.JavaSource;
@@ -257,51 +252,4 @@ public class HandlerButtonListener implements ActionListener{
         }
     }
     
-    private boolean isInModel(String className, ListModel model) {
-        for(int i = 0; i < model.getSize(); i++){
-            String cls = (String)model.getElementAt(i);
-            if(className.equals(cls)){
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    private boolean isNewHandler(String className, HandlerChain handlerChain){
-        if(handlerChain != null){
-            Handler[] handlers = handlerChain.getHandlers();
-            for(int i = 0; i < handlers.length; i++){
-                if(handlers[i].getHandlerClass().equals(className)){
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-    
-    private static String readResource(InputStream is) throws IOException {
-        // read the config from resource first
-        StringBuffer sb = new StringBuffer();
-        String lineSep = System.getProperty("line.separator");//NOI18N
-        BufferedReader br = null;
-        try {
-            new BufferedReader(new InputStreamReader(is,
-                Charset.forName("UTF-8")));
-        String line = br.readLine();
-            while (line != null) {
-                sb.append(line);
-                sb.append(lineSep);
-                line = br.readLine();
-            }
-        }
-        finally {
-            if ( br!= null ){
-                br.close();
-            }
-            else {
-                is.close();
-            }
-        }
-        return sb.toString();
-    }
 }

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/projects/J2SEJAXWSVersionProvider.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/projects/J2SEJAXWSVersionProvider.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.java.classpath.ClassPath;
@@ -70,8 +71,7 @@ public class J2SEJAXWSVersionProvider implements JAXWSVersionProvider{
             if (fo != null) {
                 try {
                     InputStream is = fo.getInputStream();
-                    BufferedReader r = new BufferedReader(new InputStreamReader(is, 
-                            Charset.forName("UTF-8")));
+                    BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
                     String ln = null;
                     String ver = null;
                     while ((ln=r.readLine()) != null) {

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/project/WSUtils.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/project/WSUtils.java
@@ -29,9 +29,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -77,7 +76,6 @@ import org.openide.modules.InstalledFileLocator;
 import org.openide.util.Mutex;
 import org.openide.util.MutexException;
 import org.openide.util.NbBundle;
-import org.openide.util.Utilities;
 import org.xml.sax.SAXException;
 
 
@@ -157,7 +155,7 @@ public class WSUtils {
                 BufferedWriter bw = null;
                 try {
                     bw = new BufferedWriter(new OutputStreamWriter(
-                            jaxWsFo.getOutputStream(lock), Charset.forName("UTF-8")));  // NOI18N
+                            jaxWsFo.getOutputStream(lock), StandardCharsets.UTF_8));
                     bw.write(jaxWsContent);
                 } finally {
                     lock.releaseLock();
@@ -181,8 +179,7 @@ public class WSUtils {
                 OutputStream os = null;
                 try {
                     os = handlerFo.getOutputStream(lock);
-                    bw = new BufferedWriter(new OutputStreamWriter(os, 
-                            Charset.forName("UTF-8")));             // NOI18N
+                    bw = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
                     bw.write(handlerContent);
                     bw.close();
                 } finally {
@@ -224,7 +221,7 @@ public class WSUtils {
                 OutputStreamWriter osw = null;
                 try {
                     os = sunJaxwsFo.getOutputStream(lock);
-                    osw = new OutputStreamWriter(os, Charset.forName("UTF-8"));     // NOI18N
+                    osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
                     bw = new BufferedWriter(osw);
                     bw.write(sunJaxwsContent);
                 } finally {
@@ -597,7 +594,7 @@ public class WSUtils {
                 BufferedWriter bw =null;
                 try {
                     bw = new BufferedWriter(new OutputStreamWriter(
-                            jaxWsCatalog.getOutputStream(lock), Charset.forName("UTF-8"))); // NOI18N
+                            jaxWsCatalog.getOutputStream(lock), StandardCharsets.UTF_8));
                     bw.write(jaxWsContent);
                 } finally {
                     lock.releaseLock();
@@ -616,8 +613,7 @@ public class WSUtils {
         boolean found = false;
         try {
             br = new BufferedReader(new InputStreamReader( 
-                    new FileInputStream( FileUtil.toFile(jaxWsFo)), 
-                        Charset.forName("UTF-8")));                 // NOI18N
+                    new FileInputStream(FileUtil.toFile(jaxWsFo)), StandardCharsets.UTF_8));
             String line = null;
             while ((line = br.readLine()) != null) {
                 if (line.contains("<client ")) { //NOI18N
@@ -638,8 +634,7 @@ public class WSUtils {
         boolean found = false;
         try {
             br = new BufferedReader(new InputStreamReader( 
-                    new FileInputStream( FileUtil.toFile(jaxWsFo)), 
-                        Charset.forName("UTF-8")));                 // NOI18N
+                    new FileInputStream(FileUtil.toFile(jaxWsFo)), StandardCharsets.UTF_8));
             String line = null;
             while ((line = br.readLine()) != null) {
                 if (line.contains("<client ") || line.contains("<service ")) { //NOI18N

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxwsmodel/project/AppClientJaxWsOpenHook.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxwsmodel/project/AppClientJaxWsOpenHook.java
@@ -21,10 +21,9 @@ package org.netbeans.modules.websvc.jaxwsmodel.project;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
@@ -101,8 +100,7 @@ public class AppClientJaxWsOpenHook extends ProjectOpenedHook {
                         final AntBuildExtender ext) throws IOException {
 
         BufferedReader br = new BufferedReader( new InputStreamReader( 
-                new FileInputStream(FileUtil.toFile(project_xml)), 
-                    Charset.forName("UTF-8")));                         // NOI18N
+                new FileInputStream(FileUtil.toFile(project_xml)), StandardCharsets.UTF_8));
         String line = null;
         boolean isOldVersion = false;
         while ((line = br.readLine()) != null) {

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxwsmodel/project/EjbJaxWsOpenHook.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxwsmodel/project/EjbJaxWsOpenHook.java
@@ -20,12 +20,11 @@ package org.netbeans.modules.websvc.jaxwsmodel.project;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.project.Project;
@@ -174,8 +173,7 @@ public class EjbJaxWsOpenHook extends ProjectOpenedHook {
                         final AntBuildExtender ext) throws IOException {
 
         BufferedReader br = new BufferedReader(new InputStreamReader( 
-                new FileInputStream(FileUtil.toFile(project_xml)),
-                    Charset.forName("UTF-8")));                         // NOI18N
+                new FileInputStream(FileUtil.toFile(project_xml)), StandardCharsets.UTF_8));
         String line = null;
         boolean isOldVersion = false;
         while ((line = br.readLine()) != null) {

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxwsmodel/project/J2seJaxWsOpenHook.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxwsmodel/project/J2seJaxWsOpenHook.java
@@ -21,11 +21,9 @@ package org.netbeans.modules.websvc.jaxwsmodel.project;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
-
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.java.project.JavaProjectConstants;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
@@ -106,8 +104,7 @@ public class J2seJaxWsOpenHook extends ProjectOpenedHook {
                         final AntBuildExtender ext) throws IOException {
 
         BufferedReader br = new BufferedReader(new InputStreamReader( 
-                new FileInputStream(FileUtil.toFile(project_xml)),
-                    Charset.forName("UTF-8")));                         // NOI18N
+                new FileInputStream(FileUtil.toFile(project_xml)), StandardCharsets.UTF_8));
         String line = null;
         boolean isOldVersion = false;
         while ((line = br.readLine()) != null) {

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxwsmodel/project/WebJaxWsOpenHook.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxwsmodel/project/WebJaxWsOpenHook.java
@@ -21,12 +21,11 @@ package org.netbeans.modules.websvc.jaxwsmodel.project;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.project.Project;
@@ -174,8 +173,7 @@ public class WebJaxWsOpenHook extends ProjectOpenedHook {
                         final AntBuildExtender ext) throws IOException {
 
         BufferedReader br = new BufferedReader(new InputStreamReader( 
-                new FileInputStream(FileUtil.toFile(project_xml)),
-                    Charset.forName("UTF-8")));                         // NOI18N
+                new FileInputStream(FileUtil.toFile(project_xml)), StandardCharsets.UTF_8));
         String line = null;
         boolean isOldVersion = false;
         while ((line = br.readLine()) != null) {

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/codegen/Wsdl2Java.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/codegen/Wsdl2Java.java
@@ -42,7 +42,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.InetSocketAddress;
 import java.net.ProxySelector;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.modules.websvc.manager.util.ManagerUtil;
@@ -310,8 +310,7 @@ public class Wsdl2Java {
             final String wsdlConfigEntry = "\t<wsdl location=\"" + wsdlFileName +
                     "\" packageName=\"" + packageName + "\"/>"; // NOI81N
             
-            PrintWriter configWriter = new PrintWriter( new OutputStreamWriter(
-                    out, Charset.forName("UTF-8")));            // NOI18N
+            PrintWriter configWriter = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
             
             try {
                 configWriter.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"); // NOI18N

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/client/Wadl2JavaHelper.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/client/Wadl2JavaHelper.java
@@ -29,7 +29,7 @@ import com.sun.source.tree.TypeParameterTree;
 import com.sun.source.tree.VariableTree;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -445,8 +445,7 @@ class Wadl2JavaHelper {
                 InputStreamReader is = null;
                 StringWriter writer = null;
                 try {
-                    is = new InputStreamReader(templateFo.getInputStream(), 
-                            Charset.forName("UTF-8"));          // NOI18N
+                    is = new InputStreamReader(templateFo.getInputStream(), StandardCharsets.UTF_8);
                     writer = new StringWriter();
                     char[] buffer = new char[1024];
                     int b;

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/codegen/TokenReplacer.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/codegen/TokenReplacer.java
@@ -20,11 +20,10 @@ package org.netbeans.modules.websvc.rest.codegen;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,9 +60,8 @@ public class TokenReplacer {
         FileLock lock = fo.lock();
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader( new InputStreamReader( 
-                    new FileInputStream((FileUtil.toFile(fo))), 
-                    Charset.forName("UTF-8")));         // NOI18N
+            reader = new BufferedReader(new InputStreamReader( 
+                    new FileInputStream((FileUtil.toFile(fo))), StandardCharsets.UTF_8));
             String line;
             StringBuffer sb = new StringBuffer();
             while ((line = reader.readLine()) != null) {

--- a/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/spi/MiscUtilities.java
+++ b/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/spi/MiscUtilities.java
@@ -37,7 +37,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -68,9 +68,7 @@ import org.netbeans.modules.j2ee.deployment.devmodules.spi.J2eeModuleProvider;
 import org.netbeans.modules.web.api.webmodule.WebModule;
 import org.netbeans.modules.websvc.rest.MiscPrivateUtilities;
 import org.netbeans.modules.websvc.rest.WebXmlUpdater;
-import static org.netbeans.modules.websvc.rest.WebXmlUpdater.getRestServletAdaptorByName;
 import org.netbeans.modules.websvc.rest.model.api.RestConstants;
-import static org.netbeans.modules.websvc.rest.spi.RestSupport.REST_SERVLET_ADAPTOR;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.filesystems.FileLock;
@@ -78,6 +76,9 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
+
+import static org.netbeans.modules.websvc.rest.WebXmlUpdater.getRestServletAdaptorByName;
+import static org.netbeans.modules.websvc.rest.spi.RestSupport.REST_SERVLET_ADAPTOR;
 
 /**
  * The purpose of this class is to trim down RestSupport and WebRestSupport down and
@@ -142,9 +143,9 @@ public class MiscUtilities {
         try {
             lock = fo.lock();
             OutputStream os = fo.getOutputStream(lock);
-            writer = new BufferedWriter(new OutputStreamWriter(os, Charset.forName("UTF-8")));
+            writer = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
             InputStream is = RestSupport.class.getResourceAsStream("resources/" + name);
-            reader = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));
+            reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             String line;
             String lineSep = "\n";
             if (File.separatorChar == '\\') {
@@ -185,7 +186,7 @@ public class MiscUtilities {
         try {
             writer = new BufferedWriter(content);
             InputStream is = fo.getInputStream();
-            reader = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));
+            reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             String line;
             String lineSep = "\n";
             if (File.separatorChar == '\\') {
@@ -209,7 +210,7 @@ public class MiscUtilities {
             FileLock lock = fo.lock();
             try {
                 OutputStream outputStream = fo.getOutputStream(lock);
-                writer = new BufferedWriter(new OutputStreamWriter(outputStream, Charset.forName("UTF-8")));
+                writer = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
                 writer.write(buffer.toString());
             } finally {
                 if (lock != null) {

--- a/enterprise/websvc.utilities/test/unit/src/org/netbeans/modules/websvc/api/support/java/TestUtilities.java
+++ b/enterprise/websvc.utilities/test/unit/src/org/netbeans/modules/websvc/api/support/java/TestUtilities.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.modules.java.source.usages.IndexUtil;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -43,7 +44,7 @@ public class TestUtilities {
     public static final FileObject copyStringToFileObject(FileObject fo, String content) throws IOException {
         OutputStream os = fo.getOutputStream();
         try {
-            InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
             FileUtil.copy(is, os);
             return fo;
         } finally {

--- a/ergonomics/ide.ergonomics/src-ant/org/netbeans/modules/ide/ergonomics/ant/ExtractLayer.java
+++ b/ergonomics/ide.ergonomics/src-ant/org/netbeans/modules/ide/ergonomics/ant/ExtractLayer.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.ide.ergonomics.ant;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -170,8 +171,8 @@ implements FileNameMapper, URIResolver, EntityResolver {
         String sep = "\n    ";
         ByteArrayOutputStream uberLayer = new ByteArrayOutputStream();
         try {
-            uberLayer.write("<?xml version='1.0' encoding='UTF-8'?>\n".getBytes("UTF-8"));
-            uberLayer.write("<filesystem>\n".getBytes("UTF-8"));
+            uberLayer.write("<?xml version='1.0' encoding='UTF-8'?>\n".getBytes(StandardCharsets.UTF_8));
+            uberLayer.write("<filesystem>\n".getBytes(StandardCharsets.UTF_8));
         } catch (IOException iOException) {
             throw new BuildException(iOException);
         }
@@ -237,7 +238,7 @@ implements FileNameMapper, URIResolver, EntityResolver {
         byte[] uberArr = null;
         DuplKeys duplKeys = null;
         try {
-            uberLayer.write("</filesystem>\n".getBytes("UTF-8"));
+            uberLayer.write("</filesystem>\n".getBytes(StandardCharsets.UTF_8));
             uberText = uberLayer.toString("UTF-8");
             uberArr = uberLayer.toByteArray();
             log("uberLayer for " + clusterName + "\n" + uberText, Project.MSG_VERBOSE);
@@ -337,12 +338,8 @@ implements FileNameMapper, URIResolver, EntityResolver {
             te.setProject(getProject());
             te.addText("\n\n\ncnbs=\\" + modules + "\n\n");
             te.setFiltering(false);
-            try {
-                final String antProjects = new String(bundleHeader.toByteArray(), "UTF-8");
-                te.addText(antProjects + "\n\n");
-            } catch (UnsupportedEncodingException ex) {
-                throw new BuildException(ex);
-            }
+            String antProjects = new String(bundleHeader.toByteArray(), StandardCharsets.UTF_8);
+            te.addText(antProjects + "\n\n");
             concat.addFooter(te);
             concat.execute();
         }

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureProjectFactory.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureProjectFactory.java
@@ -25,6 +25,7 @@ import java.beans.PropertyChangeSupport;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -204,7 +205,7 @@ implements ProjectFactory, PropertyChangeListener, Runnable {
                 is = prj.getInputStream();
                 len = is.read(arr);
                 if (len >= 0) {
-                    content = new String(arr, 0, len, "UTF-8");
+                    content = new String(arr, 0, len, StandardCharsets.UTF_8);
                 }
             } catch (IOException ex) {
                 LOG.log(Level.FINEST, "exception while reading " + prj, ex); // NOI18N

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FoDURLStreamHandler.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FoDURLStreamHandler.java
@@ -26,6 +26,7 @@ import java.io.SequenceInputStream;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
 import org.openide.util.NbBundle;
 import org.openide.util.URLStreamHandlerRegistration;
 
@@ -50,9 +51,9 @@ public class FoDURLStreamHandler extends URLStreamHandler {
             if (len == -1) {
                 throw new IOException();
             }
-            String head = new String(arr, 0, len, "UTF-8"); // NOI18N
+            String head = new String(arr, 0, len, StandardCharsets.UTF_8);
             String newHead = head.replaceFirst("<[bB][oO][dD][yY]>", NbBundle.getMessage(FoDURLStreamHandler.class, "MSG_NotEnabled")); // NOI18N
-            ByteArrayInputStream headIS = new ByteArrayInputStream(newHead.getBytes("UTF-8")); // NOI18N
+            ByteArrayInputStream headIS = new ByteArrayInputStream(newHead.getBytes(StandardCharsets.UTF_8));
 
             final SequenceInputStream seq = new SequenceInputStream(headIS, is);
 

--- a/ergonomics/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/LayersCheck.java
+++ b/ergonomics/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/LayersCheck.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.ide.ergonomics;
 
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.logging.Level;
@@ -55,7 +56,7 @@ public class LayersCheck extends NbTestCase {
             if (r == arr.length) {
                 fail("Too big layer " + u);
             }
-            String s = new String(arr, 0, r, "UTF-8");
+            String s = new String(arr, 0, r, StandardCharsets.UTF_8);
             if (s.contains("path=\"")) {
                 fail("There shall be no path attribute in " + u + ":\n" + s);
             }

--- a/ergonomics/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/FoDURLStreamHandlerFactoryTest.java
+++ b/ergonomics/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/FoDURLStreamHandlerFactoryTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.ide.ergonomics.fod;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import junit.framework.Test;
 import org.netbeans.junit.NbModuleSuite;
@@ -48,7 +49,7 @@ public class FoDURLStreamHandlerFactoryTest extends NbTestCase {
 
         byte[] arr = new byte[1024];
         int len = is.read(arr);
-        String s = new String(arr, 0, len, "UTF-8");
+        String s = new String(arr, 0, len, StandardCharsets.UTF_8);
         assertTrue("contains body: " + s, s.contains("<body>"));
         assertTrue("contains msg: " + s, s.contains("This feature is not yet enabled"));
     }
@@ -60,7 +61,7 @@ public class FoDURLStreamHandlerFactoryTest extends NbTestCase {
 
         byte[] arr = new byte[1024];
         int len = is.read(arr);
-        String s = new String(arr, 0, len, "UTF-8");
+        String s = new String(arr, 0, len, StandardCharsets.UTF_8);
         assertTrue("contains body: " + s, s.contains("<body>"));
         assertFalse("does not contain msg: " + s, s.contains("This feature is not yet enabled"));
     }

--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/AntBridge.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/bridge/AntBridge.java
@@ -37,6 +37,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.security.AllPermission;
 import java.security.CodeSource;
 import java.security.PermissionCollection;
@@ -790,7 +791,7 @@ public final class AntBridge {
                 META_INF_PLATFORM_PROVIDER_FS = FileUtil.createMemoryFileSystem();
                 FileObject file = FileUtil.createData(META_INF_PLATFORM_PROVIDER_FS.getRoot(), META_INF_PLATFORM_PROVIDER_REGISTRATION_NAME);
                 try (OutputStream out = file.getOutputStream()) {
-                    out.write("com.sun.tools.javac.platform.JDKPlatformProvider\n".getBytes("UTF-8"));
+                    out.write("com.sun.tools.javac.platform.JDKPlatformProvider\n".getBytes(StandardCharsets.UTF_8));
                 }
                 META_INF_PLATFORM_PROVIDER_REGISTRATION = file.toURL();
             } catch (Throwable t) {

--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/AdvancedActionPanel.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/AdvancedActionPanel.java
@@ -22,6 +22,7 @@ package org.apache.tools.ant.module.run;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.Collator;
 import java.util.Collections;
 import java.util.HashSet;
@@ -438,7 +439,7 @@ final class AdvancedActionPanel extends javax.swing.JPanel {
     @NonNull
     private static Properties parseProperties(@NonNull final String text) throws IOException {
         final Properties props = new Properties();
-        final ByteArrayInputStream bais = new ByteArrayInputStream(text.getBytes("ISO-8859-1"));  //NOI18N
+        final ByteArrayInputStream bais = new ByteArrayInputStream(text.getBytes(StandardCharsets.ISO_8859_1));
         props.load(bais);
         return props;
     }

--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutWizard.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutWizard.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -253,7 +254,7 @@ public final class ShortcutWizard extends WizardDescriptor {
                 FileObject shortcut = actionsBuild.createData(fname); // NOI18N
                 OutputStream os = shortcut.getOutputStream();
                 try {
-                    os.write(getContents().getBytes("UTF-8")); // NOI18N
+                    os.write(getContents().getBytes(StandardCharsets.UTF_8));
                 } finally {
                     os.close();
                 }

--- a/extide/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/xml/AntProjectSupportTest.java
+++ b/extide/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/xml/AntProjectSupportTest.java
@@ -22,6 +22,7 @@ package org.apache.tools.ant.module.xml;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import org.apache.tools.ant.module.api.AntProjectCookie;
 import org.apache.tools.ant.module.loader.AntProjectDataObject;
@@ -76,7 +77,7 @@ public class AntProjectSupportTest extends NbTestCase {
             public void run() throws IOException {
                 OutputStream os = fo.getOutputStream();
                 try {
-                    os.write("<project default='x'><target name='x'/></project>".getBytes("UTF-8"));
+                    os.write("<project default='x'><target name='x'/></project>".getBytes(StandardCharsets.UTF_8));
                 } finally {
                     os.close();
                 }

--- a/groovy/groovy.antproject/src/org/netbeans/modules/groovy/antproject/common/BuildScriptHelper.java
+++ b/groovy/groovy.antproject/src/org/netbeans/modules/groovy/antproject/common/BuildScriptHelper.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.groovy.support.api.GroovyExtender;
@@ -80,7 +81,7 @@ public class BuildScriptHelper {
         URL xml65 = BuildScriptHelper.class.getClassLoader().getResource(resource);
         URLConnection connection = xml65.openConnection();
         connection.setUseCaches(false);
-        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), "UTF-8")); // NOI18N
+        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
         try {
             List<String> lines65 = fo.asLines("UTF-8"); // NOI18N
             for (String line65 : lines65) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/NbGroovyErrorCollector.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/NbGroovyErrorCollector.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -310,7 +311,7 @@ class NbGroovyErrorCollector extends ErrorCollector {
         }
         StringBuilder sb = new StringBuilder();
         try (InputStream is = NbGroovyErrorCollector.class.getResourceAsStream(RESOURCE_FILTERED_ERRORS);
-             BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"))) {
+             BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
             String line;
             
             while ((line = r.readLine()) != null) {

--- a/harness/nbjunit/src/org/netbeans/junit/MockServices.java
+++ b/harness/nbjunit/src/org/netbeans/junit/MockServices.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -209,7 +210,7 @@ public class MockServices {
                     }
                     if (!impls.isEmpty()) {
                         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                        PrintWriter pw = new PrintWriter(new OutputStreamWriter(baos, "UTF-8"));
+                        PrintWriter pw = new PrintWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8));
                         for (String impl : impls) {
                             pw.println(impl);
                             pw.println("#position=100");

--- a/harness/nbjunit/src/org/netbeans/junit/NbModuleSuite.java
+++ b/harness/nbjunit/src/org/netbeans/junit/NbModuleSuite.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1282,7 +1283,7 @@ public class NbModuleSuite {
             byte[] bytes = new byte[4096];
             try {
                 for (int i; (i = is.read(bytes)) != -1;) {
-                    builder.append(new String(bytes, 0, i, "UTF-8"));
+                    builder.append(new String(bytes, 0, i, StandardCharsets.UTF_8));
                 }
             } finally {
                 if (close) {
@@ -1558,7 +1559,7 @@ public class NbModuleSuite {
                 }
             }
             FileOutputStream os = new FileOutputStream(file);
-            os.write(xml.getBytes("UTF-8"));
+            os.write(xml.getBytes(StandardCharsets.UTF_8));
             os.close();
         }
 

--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -115,7 +115,6 @@ import javax.swing.event.DocumentListener;
 import javax.swing.text.DefaultEditorKit;
 import javax.swing.text.Document;
 import javax.swing.text.Element;
-import junit.framework.Assert;
 import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.editor.mimelookup.MimePath;
@@ -227,7 +226,7 @@ public abstract class CslTestBase extends NbTestCase {
                 layers.add(en.nextElement());
             }
 
-            Assert.assertTrue(additionalLayers[cntr], found);
+            assertTrue(additionalLayers[cntr], found);
         }
 
         XMLFileSystem xmlFS = new XMLFileSystem();
@@ -342,7 +341,7 @@ public abstract class CslTestBase extends NbTestCase {
     public static final FileObject copyStringToFileObject(FileObject fo, String content) throws IOException {
         OutputStream os = fo.getOutputStream();
         try {
-            InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
             try {
                 FileUtil.copy(is, os);
                 return fo;

--- a/ide/css.lib/test/unit/src/org/netbeans/modules/css/lib/TestUtil.java
+++ b/ide/css.lib/test/unit/src/org/netbeans/modules/css/lib/TestUtil.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.css.lib;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
@@ -85,7 +86,7 @@ public class TestUtil {
 
     public static CssParserResult parse(FileObject file) throws ParseException, BadLocationException, IOException {
         //no loader here so we need to create the swing document
-        BufferedReader reader = new BufferedReader(new InputStreamReader(file.getInputStream(), "UTF-8"));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8));
         StringBuilder builder = new StringBuilder();
 
         char[] buffer = new char[8096];

--- a/ide/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLEditorProviderImpl.java
+++ b/ide/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLEditorProviderImpl.java
@@ -23,6 +23,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -81,7 +82,7 @@ public class SQLEditorProviderImpl implements SQLEditorProvider {
             try {
                 OutputStream stream = sqlFo.getOutputStream(lock);
                 try {
-                    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(stream, "UTF-8")); // NOI18N
+                    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(stream, StandardCharsets.UTF_8));
                     try {
                         writer.write(sql);
                     } finally {

--- a/ide/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLFileEncodingQueryImpl.java
+++ b/ide/db.sql.editor/src/org/netbeans/modules/db/sql/editor/SQLFileEncodingQueryImpl.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.db.sql.editor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.spi.queries.FileEncodingQueryImplementation;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -57,7 +58,7 @@ public class SQLFileEncodingQueryImpl extends FileEncodingQueryImplementation {
                 }
             }
             if (bytesRead == 4 && isUTF16(buff)) {
-                return Charset.forName("UTF-16");  //NOI18N
+                return StandardCharsets.UTF_16;
             }
         }
         return null;

--- a/ide/db/src/org/netbeans/modules/db/explorer/DatabaseConnectionConvertor.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/DatabaseConnectionConvertor.java
@@ -33,6 +33,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.LinkedList;
@@ -298,7 +299,7 @@ public class DatabaseConnectionConvertor implements Environment.Provider, Instan
     }
 
     static String decodePassword(byte[] bytes) throws CharacterCodingException {
-        CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder(); // NOI18N
+        CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
         ByteBuffer input = ByteBuffer.wrap(bytes);
         int outputLength = (int)(bytes.length * (double)decoder.maxCharsPerByte());
         if (outputLength == 0) {

--- a/ide/db/test/unit/src/org/netbeans/modules/db/explorer/DatabaseConnectionConvertorTest.java
+++ b/ide/db/test/unit/src/org/netbeans/modules/db/explorer/DatabaseConnectionConvertorTest.java
@@ -189,7 +189,7 @@ public class DatabaseConnectionConvertorTest extends TestBase {
     public void testDecodePassword() throws Exception {
         assertNotNull(DatabaseConnectionConvertor.decodePassword(new byte[0]));
         assertTrue(DatabaseConnectionConvertor.decodePassword(new byte[0]).isEmpty());
-        assertEquals("password", DatabaseConnectionConvertor.decodePassword("password".getBytes("UTF-8")));
+        assertEquals("password", DatabaseConnectionConvertor.decodePassword("password".getBytes(StandardCharsets.UTF_8)));
         try {
             DatabaseConnectionConvertor.decodePassword(new byte[] { (byte)0xff, (byte)0xff, (byte)0xff });
             fail();
@@ -210,7 +210,7 @@ public class DatabaseConnectionConvertorTest extends TestBase {
         FileObject fo = folder.createData(name);
         FileLock lock = fo.lock();
         try {
-            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), "UTF-8");
+            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), StandardCharsets.UTF_8);
             try {
                 writer.write("<?xml version='1.0' encoding='UTF-8'?>");
                 writer.write("<!DOCTYPE connection PUBLIC '-//NetBeans//DTD Database Connection 1.0//EN' 'http://www.netbeans.org/dtds/connection-1_0.dtd'>");

--- a/ide/db/test/unit/src/org/netbeans/modules/db/explorer/driver/JDBCDriverConvertorTest.java
+++ b/ide/db/test/unit/src/org/netbeans/modules/db/explorer/driver/JDBCDriverConvertorTest.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.db.explorer.driver;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import org.netbeans.api.db.explorer.JDBCDriver;
 import org.netbeans.modules.db.test.DOMCompare;
@@ -155,7 +156,7 @@ public class JDBCDriverConvertorTest extends TestBase {
         FileObject fo = folder.createData(fileName);
         FileLock lock = fo.lock();
         try {
-            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), "UTF-8");
+            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), StandardCharsets.UTF_8);
             try {
                 writer.write("<?xml version='1.0' encoding='UTF-8'?>");
                 writer.write("<!DOCTYPE driver PUBLIC '-//NetBeans//DTD JDBC Driver " + publicIdVer + "//EN' 'http://www.netbeans.org/dtds/jdbc-driver-" + systemIdVer + ".dtd'>");

--- a/ide/diff/src/org/netbeans/modules/diff/DiffFileEncodingQueryImplementation.java
+++ b/ide/diff/src/org/netbeans/modules/diff/DiffFileEncodingQueryImplementation.java
@@ -25,6 +25,7 @@ import org.openide.filesystems.FileObject;
 import java.nio.charset.Charset;
 import java.io.InputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
@@ -38,7 +39,7 @@ public class DiffFileEncodingQueryImplementation extends FileEncodingQueryImplem
 
     public Charset getEncoding(FileObject file) {
         if (!"text/x-diff".equals(file.getMIMEType())) return null;
-        return generatedByIDE(file) ? Charset.forName("UTF-8") : null;
+        return generatedByIDE(file) ? StandardCharsets.UTF_8 : null;
     }
 
     private boolean generatedByIDE(FileObject file) {
@@ -48,7 +49,7 @@ public class DiffFileEncodingQueryImplementation extends FileEncodingQueryImplem
         try {
             is = file.getInputStream();
             int n = is.read(buffer);
-            return n > 0 && ContextualPatch.MAGIC.startsWith(new String(buffer, 0, n, "US-ASCII"));
+            return n > 0 && ContextualPatch.MAGIC.startsWith(new String(buffer, 0, n, StandardCharsets.US_ASCII));
         } catch (IOException e) {
             Logger.getLogger(DiffFileEncodingQueryImplementation.class.getName()).log(Level.INFO, "FEQ failed", e);
         } finally {

--- a/ide/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/SSHKeyFileFilter.java
+++ b/ide/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/SSHKeyFileFilter.java
@@ -23,6 +23,7 @@ import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.netbeans.modules.nativeexecution.api.util.Authentication;
@@ -35,7 +36,7 @@ import org.openide.util.Exceptions;
 public class SSHKeyFileFilter implements FileFilter {
 
     private static final Pattern p = Pattern.compile("-+ *BEGIN.*PRIVATE.*KEY *-+.*"); // NOI18N
-    private static final Charset cs = Charset.forName("US-ASCII"); // NOI18N
+    private static final Charset cs = StandardCharsets.US_ASCII;
     private static final SSHKeyFileFilter instance = new SSHKeyFileFilter();
 
     private SSHKeyFileFilter() {

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/LocalNativeProcess.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/LocalNativeProcess.java
@@ -29,7 +29,7 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.SequenceInputStream;
 import java.lang.reflect.Field;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.logging.Level;
@@ -258,10 +258,7 @@ public final class LocalNativeProcess extends AbstractNativeProcess {
                         }
 
                         try {
-                            Charset charset = Charset.isSupported("UTF-8") // NOI18N
-                                    ? Charset.forName("UTF-8") // NOI18N
-                                    : Charset.defaultCharset();
-                            errorPipedOutputStream.write(errorMsg.getBytes(charset));
+                            errorPipedOutputStream.write(errorMsg.getBytes(StandardCharsets.UTF_8));
                             errorPipedOutputStream.flush();
                         } catch (IOException ex) {
                             Exceptions.printStackTrace(ex);

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/WindowsSupport.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/WindowsSupport.java
@@ -19,8 +19,8 @@
 package org.netbeans.modules.nativeexecution.api.util;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
@@ -371,7 +371,7 @@ public final class WindowsSupport {
             }
 
             if (cygwinVersion.startsWith("1.7")) { // NOI18N
-                charset = Charset.forName("UTF-8"); // NOI18N
+                charset = StandardCharsets.UTF_8;
             }
         } catch (Exception ex) {
         }

--- a/ide/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/StreamsHangup.java
+++ b/ide/dlight.nativeexecution/test/unit/src/org/netbeans/modules/nativeexecution/api/util/StreamsHangup.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -235,7 +236,7 @@ public class StreamsHangup {
     private static File writeFile(File f, String body) throws IOException {
         f.getParentFile().mkdirs();
         OutputStream os = new FileOutputStream(f);
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, "UTF-8"));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
         pw.print(body);
         pw.flush();
         os.close();

--- a/ide/docker.api/src/org/netbeans/modules/docker/ChunkedOutputStream.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/ChunkedOutputStream.java
@@ -22,6 +22,8 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
 /**
  *
  * @author Petr Hejl
@@ -34,19 +36,19 @@ public class ChunkedOutputStream extends FilterOutputStream {
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
-        out.write((Integer.toHexString(len) + "\r\n").getBytes("ISO-8859-1")); // NOI18N
+        out.write((Integer.toHexString(len) + "\r\n").getBytes(ISO_8859_1));
         out.write(b, off, len);
-        out.write("\r\n".getBytes("ISO-8859-1")); // NOI18N
+        out.write("\r\n".getBytes(ISO_8859_1));
     }
 
     @Override
     public void write(int b) throws IOException {
-        out.write("1\r\n".getBytes("ISO-8859-1")); // NOI18N
+        out.write("1\r\n".getBytes(ISO_8859_1));
         out.write(b);
-        out.write("\r\n".getBytes("ISO-8859-1")); // NOI18N
+        out.write("\r\n".getBytes(ISO_8859_1));
     }
 
     public void finish() throws IOException {
-        out.write("0\r\n\r\n".getBytes("ISO-8859-1")); // NOI18N
+        out.write("0\r\n\r\n".getBytes(ISO_8859_1));
     }
 }

--- a/ide/docker.api/src/org/netbeans/modules/docker/DockerConfig.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/DockerConfig.java
@@ -31,7 +31,7 @@ import java.nio.CharBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -138,7 +138,7 @@ public final class DockerConfig {
         StringBuilder sb = new StringBuilder(credentials.getUsername());
         sb.append(':');
         sb.append(credentials.getPassword());
-        String auth = Base64.getEncoder().encodeToString(sb.toString().getBytes("UTF-8")); // NOI18N
+        String auth = Base64.getEncoder().encodeToString(sb.toString().getBytes(StandardCharsets.UTF_8));
 
         JSONObject value = new JSONObject();
         value.put("auth", auth); // NOI18N
@@ -272,7 +272,7 @@ public final class DockerConfig {
             if (fileDesc.first().isFile()) {
                 try (FileInputStream is = new FileInputStream(fileDesc.first())) {
                     try (FileLock lock = is.getChannel().lock(0, Long.MAX_VALUE, true)) {
-                        Reader r = new InputStreamReader(new BufferedInputStream(is), "UTF-8");
+                        Reader r = new InputStreamReader(new BufferedInputStream(is), StandardCharsets.UTF_8);
                         JSONObject current = null;
                         if (fileDesc.first().length() > 0) {
                             current = (JSONObject) new JSONParser().parse(r);
@@ -296,7 +296,7 @@ public final class DockerConfig {
         }
 
         byte[] auth = Base64.getDecoder().decode((String) value.get("auth")); // NOI18N
-        CharBuffer chars = Charset.forName("UTF-8").newDecoder().decode(ByteBuffer.wrap(auth)); // NOI18N
+        CharBuffer chars = StandardCharsets.UTF_8.newDecoder().decode(ByteBuffer.wrap(auth));
         int index = -1;
         for (int i = 0; i < chars.length(); i++) {
             if (chars.get(i) == ':') {

--- a/ide/docker.api/src/org/netbeans/modules/docker/HttpUtils.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/HttpUtils.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Base64;
 import java.util.HashMap;
@@ -148,15 +149,15 @@ public final class HttpUtils {
         return URLEncoder.encode(value, "UTF-8");
     }
 
-    public static String encodeBase64(String value) throws UnsupportedEncodingException {
-        return Base64.getEncoder().encodeToString(value.getBytes("UTF-8"));
+    public static String encodeBase64(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }
 
     public static void configureHeaders(OutputStream os, Map<String, String> defaultHeaders,
             Pair<String, String>... headers) throws IOException {
         StringBuilder sb = new StringBuilder();
         configureHeaders(sb, defaultHeaders, headers);
-        os.write(sb.toString().getBytes("ISO-8859-1")); // NOI18N
+        os.write(sb.toString().getBytes(StandardCharsets.ISO_8859_1));
     }
 
     public static void configureHeaders(StringBuilder sb, Map<String, String> defaultHeaders,
@@ -220,7 +221,7 @@ public final class HttpUtils {
 
     private static Charset getCharset(String contentType) {
         // FIXME the spec default is ISO-8859-1
-        Charset encoding = Charset.forName("UTF-8"); // NOI18N
+        Charset encoding = StandardCharsets.UTF_8;
         if (contentType != null) {
             String[] parts = contentType.trim().split(";"); // NOI18N
             for (String p : parts) {

--- a/ide/docker.api/src/org/netbeans/modules/docker/IgnoreFileFilter.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/IgnoreFileFilter.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.openide.filesystems.FileObject;
@@ -85,7 +86,7 @@ public class IgnoreFileFilter implements FileFilter {
 
     private List<IgnorePattern> load(FileObject dockerignore, char separator) throws IOException {
         List<IgnorePattern> ret = new ArrayList<>();
-        try (BufferedReader r = new BufferedReader(new InputStreamReader(dockerignore.getInputStream(), "UTF-8"))) {
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(dockerignore.getInputStream(), StandardCharsets.UTF_8))) {
             String line;
             while ((line = r.readLine()) != null) {
                 String trimmed = line.trim();

--- a/ide/docker.api/src/org/netbeans/modules/docker/api/DockerAction.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/api/DockerAction.java
@@ -78,7 +78,6 @@ import org.netbeans.modules.docker.DockerConfig;
 import org.netbeans.modules.docker.DockerUtils;
 import org.netbeans.modules.docker.Endpoint;
 import org.netbeans.modules.docker.StreamResult;
-import static org.netbeans.modules.docker.api.DockerEntityType.Container;
 import org.newsclub.net.unix.AFUNIXSocket;
 import org.newsclub.net.unix.AFUNIXSocketAddress;
 import org.openide.filesystems.FileObject;
@@ -86,6 +85,10 @@ import org.openide.util.Pair;
 import org.openide.util.Parameters;
 import org.openide.util.io.NullInputStream;
 import org.openide.util.io.NullOutputStream;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.netbeans.modules.docker.api.DockerEntityType.Container;
 
 /**
  *
@@ -491,12 +494,12 @@ public class DockerAction {
             os.write(("POST /containers/" + container.getId()
                     + "/attach?logs=" + (logs ? 1 : 0)
                     + "&stream=1&stdout=1&stdin=" + (stdin ? 1 : 0)
-                    + "&stderr=1 HTTP/1.1\r\n").getBytes("ISO-8859-1"));
+                    + "&stderr=1 HTTP/1.1\r\n").getBytes(ISO_8859_1));
             HttpUtils.configureHeaders(os, DockerConfig.getDefault().getHttpHeaders(),
                     getHostHeader(),
                     Pair.of("Connection", "Upgrade"),
                     Pair.of("Upgrade", "tcp"));
-            os.write("\r\n".getBytes("ISO-8859-1"));
+            os.write("\r\n".getBytes(ISO_8859_1));
             os.flush();
 
             InputStream is = s.getInputStream();
@@ -548,13 +551,13 @@ public class DockerAction {
             try {
                 OutputStream os = s.getOutputStream();
                 os.write(("POST /images/create?fromImage="
-                        + HttpUtils.encodeParameter(imageName) + " HTTP/1.1\r\n").getBytes("ISO-8859-1"));
+                        + HttpUtils.encodeParameter(imageName) + " HTTP/1.1\r\n").getBytes(ISO_8859_1));
                 Pair<String, String> authHeader = null;
                 JSONObject auth = createAuthObject(CredentialsManager.getDefault().getCredentials(parsed.getRegistry()));
                 authHeader = Pair.of("X-Registry-Auth", HttpUtils.encodeBase64(auth.toJSONString()));
                 HttpUtils.configureHeaders(os, DockerConfig.getDefault().getHttpHeaders(),
                         getHostHeader(), ACCEPT_JSON_HEADER, authHeader);
-                os.write(("\r\n").getBytes("ISO-8859-1"));
+                os.write(("\r\n").getBytes(ISO_8859_1));
                 os.flush();
 
                 InputStream is = s.getInputStream();
@@ -624,13 +627,13 @@ public class DockerAction {
             Endpoint s = createEndpoint();
             try {
                 OutputStream os = s.getOutputStream();
-                os.write(("POST " + action.toString() + " HTTP/1.1\r\n").getBytes("ISO-8859-1"));
+                os.write(("POST " + action.toString() + " HTTP/1.1\r\n").getBytes(ISO_8859_1));
                 Pair<String, String> authHeader = null;
                 JSONObject auth = createAuthObject(CredentialsManager.getDefault().getCredentials(parsed.getRegistry()));
                 authHeader = Pair.of("X-Registry-Auth", HttpUtils.encodeBase64(auth.toJSONString()));
                 HttpUtils.configureHeaders(os, DockerConfig.getDefault().getHttpHeaders(),
                         getHostHeader(), ACCEPT_JSON_HEADER, authHeader);
-                os.write(("\r\n").getBytes("ISO-8859-1"));
+                os.write(("\r\n").getBytes(ISO_8859_1));
                 os.flush();
 
                 InputStream is = s.getInputStream();
@@ -752,7 +755,7 @@ public class DockerAction {
                     request.append("\r\n");
 
                     OutputStream os = s.getOutputStream();
-                    os.write(request.toString().getBytes("ISO-8859-1"));
+                    os.write(request.toString().getBytes(ISO_8859_1));
                     os.flush();
 
                     buildListener.onEvent(new BuildEvent(instance, request.toString(), false, null, false));
@@ -886,9 +889,9 @@ public class DockerAction {
             s = createEndpoint();
 
             OutputStream os = s.getOutputStream();
-            os.write(("GET /containers/" + container.getId() + "/logs?stderr=1&stdout=1&timestamps=1&follow=1 HTTP/1.1\r\n").getBytes("ISO-8859-1"));
+            os.write(("GET /containers/" + container.getId() + "/logs?stderr=1&stdout=1&timestamps=1&follow=1 HTTP/1.1\r\n").getBytes(ISO_8859_1));
             HttpUtils.configureHeaders(os, DockerConfig.getDefault().getHttpHeaders(), getHostHeader());
-            os.write("\r\n".getBytes("ISO-8859-1"));
+            os.write("\r\n".getBytes(ISO_8859_1));
             os.flush();
 
             InputStream is = s.getInputStream();
@@ -938,16 +941,16 @@ public class DockerAction {
         try {
             s = createEndpoint();
 
-            byte[] data = configuration.toJSONString().getBytes("UTF-8");
+            byte[] data = configuration.toJSONString().getBytes(UTF_8);
             Map<String, String> defaultHeaders = DockerConfig.getDefault().getHttpHeaders();
 
             OutputStream os = s.getOutputStream();
-            os.write(("POST " + (name != null ? "/containers/create?name=" + HttpUtils.encodeParameter(name) : "/containers/create") + " HTTP/1.1\r\n").getBytes("ISO-8859-1"));
+            os.write(("POST " + (name != null ? "/containers/create?name=" + HttpUtils.encodeParameter(name) : "/containers/create") + " HTTP/1.1\r\n").getBytes(ISO_8859_1));
             HttpUtils.configureHeaders(os, defaultHeaders,
                     getHostHeader(),
                     Pair.of("Content-Type", "application/json"),
                     Pair.of("Content-Length", Integer.toString(data.length)));
-            os.write("\r\n".getBytes("ISO-8859-1"));
+            os.write("\r\n".getBytes(ISO_8859_1));
             os.write(data);
             os.flush();
 
@@ -979,9 +982,9 @@ public class DockerAction {
                     DockerContainer.Status.STOPPED);
             ActionStreamResult r = attach(container, true, true);
 
-            os.write(("POST /containers/" + id + "/start HTTP/1.1\r\n").getBytes("ISO-8859-1"));
+            os.write(("POST /containers/" + id + "/start HTTP/1.1\r\n").getBytes(ISO_8859_1));
             HttpUtils.configureHeaders(os, defaultHeaders, getHostHeader());
-            os.write("\r\n".getBytes("ISO-8859-1"));
+            os.write("\r\n".getBytes(ISO_8859_1));
             os.flush();
 
             response = HttpUtils.readResponse(is);
@@ -1011,7 +1014,7 @@ public class DockerAction {
             OutputStream os = s.getOutputStream();
             // FIXME should we use default headers ?
             os.write(("GET /_ping HTTP/1.1\r\n"
-                    + "Host: " + getHostHeader().second() + "\r\n\r\n").getBytes("ISO-8859-1"));
+                    + "Host: " + getHostHeader().second() + "\r\n\r\n").getBytes(ISO_8859_1));
             os.flush();
 
             InputStream is = s.getInputStream();
@@ -1043,7 +1046,7 @@ public class DockerAction {
                 OutputStream os = s.getOutputStream();
                 os.write(("GET " + (since != null ? "/events?since=" + since : "/events") + " HTTP/1.1\r\n"
                         + "Host: " + getHostHeader().second() + "\r\n"
-                        + "Accept: application/json\r\n\r\n").getBytes("ISO-8859-1"));
+                        + "Accept: application/json\r\n\r\n").getBytes(ISO_8859_1));
                 os.flush();
 
                 InputStream is = s.getInputStream();
@@ -1102,10 +1105,10 @@ public class DockerAction {
             Endpoint s = createEndpoint();
             try {
                 OutputStream os = s.getOutputStream();
-                os.write(("GET " + action + " HTTP/1.1\r\n").getBytes("ISO-8859-1"));
+                os.write(("GET " + action + " HTTP/1.1\r\n").getBytes(ISO_8859_1));
                 HttpUtils.configureHeaders(os, DockerConfig.getDefault().getHttpHeaders(),
                         getHostHeader(), ACCEPT_JSON_HEADER);
-                os.write(("\r\n").getBytes("ISO-8859-1"));
+                os.write(("\r\n").getBytes(ISO_8859_1));
                 os.flush();
 
                 InputStream is = s.getInputStream();
@@ -1144,10 +1147,10 @@ public class DockerAction {
             Endpoint s = createEndpoint();
             try {
                 OutputStream os = s.getOutputStream();
-                os.write(("POST " + action + " HTTP/1.1\r\n").getBytes("ISO-8859-1"));
+                os.write(("POST " + action + " HTTP/1.1\r\n").getBytes(ISO_8859_1));
                 HttpUtils.configureHeaders(os, DockerConfig.getDefault().getHttpHeaders(),
                         getHostHeader(), Pair.of("Content-Type", "application/json"));
-                os.write(("\r\n").getBytes("ISO-8859-1"));
+                os.write(("\r\n").getBytes(ISO_8859_1));
                 os.flush();
 
                 InputStream is = s.getInputStream();
@@ -1189,10 +1192,10 @@ public class DockerAction {
             Endpoint s = createEndpoint();
             try {
                 OutputStream os = s.getOutputStream();
-                os.write(("DELETE " + action + " HTTP/1.1\r\n").getBytes("ISO-8859-1"));
+                os.write(("DELETE " + action + " HTTP/1.1\r\n").getBytes(ISO_8859_1));
                 HttpUtils.configureHeaders(os, DockerConfig.getDefault().getHttpHeaders(),
                         getHostHeader(), ACCEPT_JSON_HEADER);
-                os.write(("\r\n").getBytes("ISO-8859-1"));
+                os.write(("\r\n").getBytes(ISO_8859_1));
                 os.flush();
 
                 InputStream is = s.getInputStream();
@@ -1454,7 +1457,7 @@ public class DockerAction {
 
         @Override
         public Charset getCharset() {
-            return Charset.forName("UTF-8");
+            return UTF_8;
         }
 
         @Override

--- a/ide/docker.api/test/unit/src/org/netbeans/modules/docker/ChunkedInputStreamTest.java
+++ b/ide/docker.api/test/unit/src/org/netbeans/modules/docker/ChunkedInputStreamTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.junit.NbTestCase;
 
 /**
@@ -37,12 +38,12 @@ public class ChunkedInputStreamTest extends NbTestCase {
     }
 
     public void testSimple() throws Exception {
-        Charset charset = Charset.forName("UTF-8");
+        Charset charset = StandardCharsets.UTF_8;
         String data = "{\"status\":\"start\",\"id\":\"7ec0c471084729a05270be99fd8450d3e515587d9755f97e15e74a227b4e12a6\",\"from\":\"ubuntu:latest\",\"time\":1447673048}";
 
         ByteArrayInputStream bis = new ByteArrayInputStream(createChunk(createChunk(null, data, charset), "", charset));
         ChunkedInputStream is = new ChunkedInputStream(bis);
-        InputStreamReader r = new InputStreamReader(is, "UTF-8");
+        InputStreamReader r = new InputStreamReader(is, StandardCharsets.UTF_8);
         StringBuilder sb = new StringBuilder();
         int ch = -1;
         while ((ch = r.read()) != -1) {
@@ -52,7 +53,7 @@ public class ChunkedInputStreamTest extends NbTestCase {
     }
 
     public void testComplex() throws Exception {
-        Charset charset = Charset.forName("UTF-8");
+        Charset charset = StandardCharsets.UTF_8;
         String data1 = "{\"status\":\"die\",\"id\":\"7ec0c471084729a05270be99fd8450d3e515587d9755f97e15e74a227b4e12a6\",\"from\":\"ubuntu:latest\",\"time\":1447666993}";
         String data2 = "{\"status\":\"stop\",\"id\":\"7ec0c471084729a05270be99fd8450d3e515587d9755f97e15e74a227b4e12a6\",\"from\":\"ubuntu:latest\",\"time\":1447666993}";
         String data3 = "{\"status\":\"start\",\"id\":\"7ec0c471084729a05270be99fd8450d3e515587d9755f97e15e74a227b4e12a6\",\"from\":\"ubuntu:latest\",\"time\":1447667011}";
@@ -65,7 +66,7 @@ public class ChunkedInputStreamTest extends NbTestCase {
                 createChunk(createChunk(createChunk(createChunk(createChunk(createChunk(createChunk(createChunk(
                         null, data1, charset), data2, charset), data3, charset), data4, charset), data5, charset), data6, charset), data7, charset), "", charset));
         ChunkedInputStream is = new ChunkedInputStream(bis);
-        InputStreamReader r = new InputStreamReader(is, "UTF-8");
+        InputStreamReader r = new InputStreamReader(is, StandardCharsets.UTF_8);
         StringBuilder sb = new StringBuilder();
         int ch = -1;
         while ((ch = r.read()) != -1) {
@@ -75,12 +76,12 @@ public class ChunkedInputStreamTest extends NbTestCase {
     }
 
     public void testUnfinished() throws Exception {
-        Charset charset = Charset.forName("UTF-8");
+        Charset charset = StandardCharsets.UTF_8;
         String data = "{\"status\":\"die\",\"id\":\"7ec0c471084729a05270be99fd8450d3e515587d9755f97e15e74a227b4e12a6\",\"from\":\"ubuntu:latest\",\"time\":1447666993}";
 
         ByteArrayInputStream bis = new ByteArrayInputStream(createChunk(null, data, charset));
         ChunkedInputStream is = new ChunkedInputStream(bis);
-        InputStreamReader r = new InputStreamReader(is, "UTF-8");
+        InputStreamReader r = new InputStreamReader(is, StandardCharsets.UTF_8);
         StringBuilder sb = new StringBuilder();
         int count = data.length();
         while (count > 0) {
@@ -91,7 +92,7 @@ public class ChunkedInputStreamTest extends NbTestCase {
     }
 
     public void testBlocking() throws Exception {
-        Charset charset = Charset.forName("UTF-8");
+        Charset charset = StandardCharsets.UTF_8;
         String data = "{\"status\":\"die\",\"id\":\"7ec0c471084729a05270be99fd8450d3e515587d9755f97e15e74a227b4e12a6\",\"from\":\"ubuntu:latest\",\"time\":1447666993}";
 
         ByteArrayInputStream bis = new ByteArrayInputStream(createChunk(null, data, charset));
@@ -123,7 +124,7 @@ public class ChunkedInputStreamTest extends NbTestCase {
             }
         };
         ChunkedInputStream is = new ChunkedInputStream(fis);
-        InputStreamReader r = new InputStreamReader(is, "UTF-8");
+        InputStreamReader r = new InputStreamReader(is, StandardCharsets.UTF_8);
         StringBuilder sb = new StringBuilder();
         int count = data.length();
         while (count > 0) {
@@ -136,7 +137,7 @@ public class ChunkedInputStreamTest extends NbTestCase {
     private byte[] createChunk(byte[] previous, String data, Charset charset) throws UnsupportedEncodingException {
         byte[] bytes = data.getBytes(charset);
         String size = Integer.toString(bytes.length, 16) + "\r\n";
-        byte[] sizeBytes = size.getBytes("ISO-8859-1");
+        byte[] sizeBytes = size.getBytes(StandardCharsets.ISO_8859_1);
         int arraySize = sizeBytes.length + bytes.length + 2;
         if (previous != null) {
             arraySize += previous.length;

--- a/ide/docker.editor/src/org/netbeans/modules/docker/editor/util/DocDownloader.java
+++ b/ide/docker.editor/src/org/netbeans/modules/docker/editor/util/DocDownloader.java
@@ -20,11 +20,9 @@ package org.netbeans.modules.docker.editor.util;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
-import java.util.Collection;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,10 +37,11 @@ import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.progress.ProgressHandle;
 import org.netbeans.modules.csl.api.Documentation;
 import org.netbeans.modules.docker.editor.parser.Command;
-import static org.netbeans.modules.docker.editor.parser.Command.forName;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
+
+import static org.netbeans.modules.docker.editor.parser.Command.forName;
 
 /**
  *
@@ -70,7 +69,7 @@ public class DocDownloader {
                 }
                 return cancel.call() ?
                         ""  //NOI18N
-                        : new String(out.toByteArray(),"UTF-8");  //NOI18N
+                        : new String(out.toByteArray(), StandardCharsets.UTF_8);
             } finally {
                 handle.finish();
             }

--- a/ide/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/SettingsType.java
+++ b/ide/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/SettingsType.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -468,7 +469,7 @@ public final class SettingsType {
                 }
             } else {
                 try {
-                    BufferedReader ois = new BufferedReader(new InputStreamReader(link.getInputStream(), "UTF-8")); // NOI18N
+                    BufferedReader ois = new BufferedReader(new InputStreamReader(link.getInputStream(), StandardCharsets.UTF_8));
                     try {
                         targetFilePath = ois.readLine();
                         targetFilesystem = ois.readLine();

--- a/ide/editor.tools.storage/test/unit/src/org/netbeans/modules/editor/tools/storage/api/ToolPreferencesTest.java
+++ b/ide/editor.tools.storage/test/unit/src/org/netbeans/modules/editor/tools/storage/api/ToolPreferencesTest.java
@@ -24,6 +24,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
 import java.util.prefs.Preferences;
 import org.netbeans.junit.NbTestCase;
 
@@ -76,7 +77,7 @@ public class ToolPreferencesTest extends NbTestCase {
         p.node("a/b/c/d").put("test", "test");
         prefs.save();
         StringBuilder content = new StringBuilder();
-        try (Reader r = new InputStreamReader(new FileInputStream(settingsFile), "UTF-8")) {
+        try (Reader r = new InputStreamReader(new FileInputStream(settingsFile), StandardCharsets.UTF_8)) {
             int read;
             
             while ((read = r.read()) != (-1)) {

--- a/ide/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/BaseExecutionServiceTest.java
+++ b/ide/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/BaseExecutionServiceTest.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
@@ -250,7 +251,7 @@ public class BaseExecutionServiceTest extends NbTestCase {
     }
 
     public void testCharset() throws InterruptedException, ExecutionException, TimeoutException {
-        Charset charset = Charset.forName("UTF-16LE");
+        Charset charset = StandardCharsets.UTF_16LE;
         final String[] lines = new String[] {"Process line \u1234", "Process line \u1235", "Process line \u1236"};
 
         TestInputStream is = new TestInputStream(TestInputUtils.prepareInputStream(lines, "\n", charset, true));

--- a/ide/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersFileTest.java
+++ b/ide/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersFileTest.java
@@ -22,6 +22,7 @@ package org.netbeans.api.extexecution.base.input;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.netbeans.api.extexecution.base.input.InputReaders.FileInput;
 import org.netbeans.junit.NbTestCase;
@@ -36,7 +37,7 @@ public class InputReadersFileTest extends NbTestCase {
 
     private static final char[] TEST_CHARS_ROTATE = "jihgfedcba".toCharArray();
 
-    private static final Charset TEST_CHARSET = Charset.forName("UTF-8");
+    private static final Charset TEST_CHARSET = StandardCharsets.UTF_8;
 
     private static final int MAX_RETRIES = TEST_CHARS.length * 2;
 

--- a/ide/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersReaderTest.java
+++ b/ide/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersReaderTest.java
@@ -24,6 +24,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.netbeans.junit.NbTestCase;
 
@@ -37,7 +38,7 @@ public class InputReadersReaderTest extends NbTestCase {
 
     private static final int MAX_RETRIES = TEST_CHARS.length * 2;
 
-    private static final Charset TEST_CHARSET = Charset.forName("UTF-8");
+    private static final Charset TEST_CHARSET = StandardCharsets.UTF_8;
 
     public InputReadersReaderTest(String name) {
         super(name);

--- a/ide/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersStreamTest.java
+++ b/ide/extexecution.base/test/unit/src/org/netbeans/api/extexecution/base/input/InputReadersStreamTest.java
@@ -21,6 +21,7 @@ package org.netbeans.api.extexecution.base.input;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.netbeans.junit.NbTestCase;
 
@@ -34,7 +35,7 @@ public class InputReadersStreamTest extends NbTestCase {
 
     private static final int MAX_RETRIES = TEST_CHARS.length * 2;
 
-    private static final Charset TEST_CHARSET = Charset.forName("UTF-8");
+    private static final Charset TEST_CHARSET = StandardCharsets.UTF_8;
 
     public InputReadersStreamTest(String name) {
         super(name);

--- a/ide/extexecution/test/unit/src/org/netbeans/api/extexecution/ExecutionServiceTest.java
+++ b/ide/extexecution/test/unit/src/org/netbeans/api/extexecution/ExecutionServiceTest.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
@@ -331,7 +332,7 @@ public class ExecutionServiceTest extends NbTestCase {
     }
 
     public void testCharset() throws InterruptedException, ExecutionException, TimeoutException {
-        Charset charset = Charset.forName("UTF-16LE");
+        Charset charset = StandardCharsets.UTF_16LE;
         final String[] lines = new String[] {"Process line \u1234", "Process line \u1235", "Process line \u1236"};
 
         TestInputStream is = new TestInputStream(TestInputUtils.prepareInputStream(lines, "\n", charset, true));

--- a/ide/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersFileTest.java
+++ b/ide/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersFileTest.java
@@ -23,6 +23,7 @@ import org.netbeans.api.extexecution.input.InputReader;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.api.extexecution.input.InputReaders.FileInput;
@@ -37,7 +38,7 @@ public class InputReadersFileTest extends NbTestCase {
 
     private static final char[] TEST_CHARS_ROTATE = "jihgfedcba".toCharArray();
 
-    private static final Charset TEST_CHARSET = Charset.forName("UTF-8");
+    private static final Charset TEST_CHARSET = StandardCharsets.UTF_8;
 
     private static final int MAX_RETRIES = TEST_CHARS.length * 2;
 

--- a/ide/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersReaderTest.java
+++ b/ide/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersReaderTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.netbeans.junit.NbTestCase;
 
@@ -38,7 +39,7 @@ public class InputReadersReaderTest extends NbTestCase {
 
     private static final int MAX_RETRIES = TEST_CHARS.length * 2;
 
-    private static final Charset TEST_CHARSET = Charset.forName("UTF-8");
+    private static final Charset TEST_CHARSET = StandardCharsets.UTF_8;
 
     public InputReadersReaderTest(String name) {
         super(name);

--- a/ide/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersStreamTest.java
+++ b/ide/extexecution/test/unit/src/org/netbeans/api/extexecution/input/InputReadersStreamTest.java
@@ -23,6 +23,7 @@ import org.netbeans.api.extexecution.input.InputReader;
 import org.netbeans.api.extexecution.input.InputReaders;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.netbeans.junit.NbTestCase;
 
@@ -36,7 +37,7 @@ public class InputReadersStreamTest extends NbTestCase {
 
     private static final int MAX_RETRIES = TEST_CHARS.length * 2;
 
-    private static final Charset TEST_CHARSET = Charset.forName("UTF-8");
+    private static final Charset TEST_CHARSET = StandardCharsets.UTF_8;
 
     public InputReadersStreamTest(String name) {
         super(name);

--- a/ide/git/src/org/netbeans/modules/git/ui/commit/CommitAction.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/commit/CommitAction.java
@@ -25,6 +25,7 @@ import org.netbeans.modules.versioning.util.common.VCSCommitOptions;
 import org.netbeans.modules.versioning.util.common.VCSCommitTable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -169,7 +170,7 @@ public class CommitAction extends SingleRepositoryAction {
                 GitRepositoryState.CHERRY_PICKING, GitRepositoryState.CHERRY_PICKING_RESOLVED).contains(state)) {
             File f = new File(GitUtils.getGitFolderForRoot(repository), "MERGE_MSG"); //NOI18N
             try {
-                message = new String(FileUtils.getFileContentsAsByteArray(f), "UTF-8"); //NOI18N
+                message = new String(FileUtils.getFileContentsAsByteArray(f), StandardCharsets.UTF_8);
             } catch (IOException ex) {
                 LOG.log(Level.FINE, null, ex);
             }

--- a/ide/git/test/unit/src/org/netbeans/modules/git/AbstractGitTestCase.java
+++ b/ide/git/test/unit/src/org/netbeans/modules/git/AbstractGitTestCase.java
@@ -26,6 +26,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -110,7 +111,7 @@ public abstract class AbstractGitTestCase extends NbTestCase {
         BufferedReader r = null;
         try {
             StringBuilder sb = new StringBuilder();
-            r = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+            r = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
             for (String line = r.readLine(); line != null; line = r.readLine()) {
                 if (sb.length() > 0) {
                     sb.append('\n');

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodFinderImpl.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodFinderImpl.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public final class TestMethodFinderImpl extends EmbeddingIndexer {
                 class2methods.computeIfAbsent(className, name -> new ArrayList<>()).add(method);
             }
             output.getParentFile().mkdirs();
-            try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(output), "UTF-8"))) {
+            try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(output), StandardCharsets.UTF_8))) {
                 pw.print("url: "); //NOI18N
                 pw.println(url.toString());
                 for (Map.Entry<String, List<TestMethodController.TestMethod>> entry : class2methods.entrySet()) {

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodFinder.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodFinder.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -75,7 +76,7 @@ public final class TestMethodFinder {
     }
 
     private static void loadTestMethods(FileObject input, Map<FileObject, Collection<TestMethodController.TestMethod>> file2TestMethods) {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(input.getInputStream(), "UTF-8"))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(input.getInputStream(), StandardCharsets.UTF_8))) {
             FileObject fo = null;
             String className = null;
             Position classPosition = null;

--- a/ide/html.validation/src/org/netbeans/modules/html/validation/NbValidationTransaction.java
+++ b/ide/html.validation/src/org/netbeans/modules/html/validation/NbValidationTransaction.java
@@ -24,6 +24,7 @@ import com.thaiopensource.validate.*;
 import com.thaiopensource.validate.prop.rng.RngProperty;
 import com.thaiopensource.xml.sax.XMLReaderCreator;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -158,7 +159,7 @@ public class NbValidationTransaction extends ValidationTransaction {
         try {
             LOGGER.fine("Starting initialization.");
 
-            BufferedReader r = new BufferedReader(new InputStreamReader(LocalCacheEntityResolver.getPresetsAsStream(), "UTF-8"));
+            BufferedReader r = new BufferedReader(new InputStreamReader(LocalCacheEntityResolver.getPresetsAsStream(), StandardCharsets.UTF_8));
             String line;
             List<String> doctypes = new LinkedList<String>();
             List<String> namespaces = new LinkedList<String>();

--- a/ide/hudson.mercurial/src/org/netbeans/modules/hudson/mercurial/MercurialHyperlink.java
+++ b/ide/hudson.mercurial/src/org/netbeans/modules/hudson/mercurial/MercurialHyperlink.java
@@ -28,6 +28,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -36,7 +37,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.netbeans.api.diff.StreamSource;
 import org.netbeans.modules.hudson.ui.api.HudsonSCMHelper;
-import static org.netbeans.modules.hudson.mercurial.Bundle.*;
 import org.netbeans.modules.hudson.spi.HudsonJobChangeItem.HudsonJobChangeFile;
 import org.netbeans.modules.hudson.spi.HudsonJobChangeItem.HudsonJobChangeFile.EditType;
 import org.openide.filesystems.FileUtil;
@@ -44,6 +44,8 @@ import org.openide.util.NbBundle.Messages;
 import org.openide.util.RequestProcessor;
 import org.openide.windows.OutputEvent;
 import org.openide.windows.OutputListener;
+
+import static org.netbeans.modules.hudson.mercurial.Bundle.*;
 
 /**
  * Creates a hyperlink to a Mercurial change.
@@ -119,7 +121,7 @@ class MercurialHyperlink implements OutputListener {
             try {
                 InputStream is = rawrev.openStream();
                 try {
-                    BufferedReader r = new BufferedReader(new InputStreamReader(is, "ISO-8859-1")); // NOI18N
+                    BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.ISO_8859_1));
                     String line;
                     while ((line = r.readLine()) != null) {
                         Matcher m = PARENT_COMMENT.matcher(line);

--- a/ide/hudson/src/org/netbeans/modules/hudson/impl/HudsonConnector.java
+++ b/ide/hudson/src/org/netbeans/modules/hudson/impl/HudsonConnector.java
@@ -24,11 +24,11 @@ import java.io.InputStream;
 import java.net.HttpRetryException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -47,7 +47,6 @@ import org.netbeans.modules.hudson.api.HudsonJobBuild.Result;
 import org.netbeans.modules.hudson.api.HudsonMavenModuleBuild;
 import org.netbeans.modules.hudson.api.HudsonVersion;
 import org.netbeans.modules.hudson.api.Utilities;
-import static org.netbeans.modules.hudson.constants.HudsonXmlApiConstants.*;
 import org.netbeans.modules.hudson.spi.BuilderConnector;
 import org.netbeans.modules.hudson.spi.HudsonJobChangeItem;
 import org.netbeans.modules.hudson.spi.HudsonSCM;
@@ -61,6 +60,8 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXParseException;
+
+import static org.netbeans.modules.hudson.constants.HudsonXmlApiConstants.*;
 
 /**
  * Hudson Server Connector
@@ -145,7 +146,7 @@ public class HudsonConnector extends BuilderConnector {
         try {
             new ConnectionBuilder().homeURL(instanceUrl).
                     url(job.getUrl() + "build"). //NOI18N
-                    postData("delay=0sec".getBytes("UTF-8")). //NOI18N
+                    postData("delay=0sec".getBytes(StandardCharsets.UTF_8)). //NOI18N
                     followRedirects(false).connection(); // NOI18N
         } catch (MalformedURLException mue) {
             LOG.log(Level.INFO, "Malformed URL " + instanceUrl, mue);

--- a/ide/hudson/src/org/netbeans/modules/hudson/impl/HudsonConsoleDataProvider.java
+++ b/ide/hudson/src/org/netbeans/modules/hudson/impl/HudsonConsoleDataProvider.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
@@ -103,7 +104,7 @@ public class HudsonConsoleDataProvider extends BuilderConnector.ConsoleDataProvi
                         isToUse = new GZIPInputStream(is);
                     }
                     // XXX safer to check content type on connection, but in fact Stapler sets it to UTF-8
-                    BufferedReader r = new BufferedReader(new InputStreamReader(isToUse, "UTF-8")); //NOI18N
+                    BufferedReader r = new BufferedReader(new InputStreamReader(isToUse, StandardCharsets.UTF_8));
                     String line;
                     while ((line = r.readLine()) != null) {
                         boolean success = displayer.writeLine(line);

--- a/ide/hudson/src/org/netbeans/modules/hudson/impl/HudsonRemoteFileSystem.java
+++ b/ide/hudson/src/org/netbeans/modules/hudson/impl/HudsonRemoteFileSystem.java
@@ -30,6 +30,7 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Enumeration;
@@ -150,7 +151,7 @@ final class HudsonRemoteFileSystem extends RemoteFileSystem implements
             java.util.List<String> kids = new ArrayList<String>();
             InputStream is = conn.getInputStream();
             try {
-                BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8")); // NOI18N
+                BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
                 String line;
                 while ((line = r.readLine()) != null) {
                     if (line.endsWith("/")) { // NOI18N

--- a/ide/hudson/src/org/netbeans/modules/hudson/impl/ServletConnectionAuthenticator.java
+++ b/ide/hudson/src/org/netbeans/modules/hudson/impl/ServletConnectionAuthenticator.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.modules.hudson.api.ConnectionBuilder;
@@ -58,7 +59,7 @@ public class ServletConnectionAuthenticator implements ConnectionAuthenticator {
                         }
                         new ConnectionBuilder().url(new URL(home, realmURI)).
                                 postData(("j_username=" + URLEncoder.encode(auth[0], "UTF-8") + "&j_password=" + // NOI18N
-                                URLEncoder.encode(auth[1], "UTF-8")).getBytes("UTF-8")). // NOI18N
+                                URLEncoder.encode(auth[1], "UTF-8")).getBytes(StandardCharsets.UTF_8)). // NOI18N
                                 homeURL(home).authentication(false).connection();
                         LOGGER.log(Level.FINER, "Posted authentication to {0} worked", realmURI);
                         return conn.getURL().openConnection();

--- a/ide/libs.freemarker/test/unit/src/org/netbeans/api/templates/ProcessorTest.java
+++ b/ide/libs.freemarker/test/unit/src/org/netbeans/api/templates/ProcessorTest.java
@@ -34,6 +34,7 @@ import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -82,15 +83,15 @@ public class ProcessorTest extends TestCase {
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         Writer w = new OutputStreamWriter(out);
-        ByteArrayInputStream in = new ByteArrayInputStream("Hi!".getBytes("UTF-8"));
+        ByteArrayInputStream in = new ByteArrayInputStream("Hi!".getBytes(StandardCharsets.UTF_8));
 
         eng.getContext().setWriter(w);
 
-        InputStreamReader r = new InputStreamReader(in, "UTF-8");
+        InputStreamReader r = new InputStreamReader(in, StandardCharsets.UTF_8);
         eng.eval(r);
 
 
-        assertTrue("Content shall be unchanged", Arrays.equals("Hi!".getBytes("UTF-8"), out.toByteArray()));
+        assertTrue("Content shall be unchanged", Arrays.equals("Hi!".getBytes(StandardCharsets.UTF_8), out.toByteArray()));
 
     }
 

--- a/ide/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/SCFTHandlerTest.java
+++ b/ide/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/SCFTHandlerTest.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -338,7 +339,7 @@ public class SCFTHandlerTest extends NbTestCase {
         Map<String,String> parameters = Collections.singletonMap("type", "empty");
         
         FEQI.fs = root2.getFileSystem();
-        FEQI.result = Charset.forName("UTF-8");
+        FEQI.result = StandardCharsets.UTF_8;
         
         DataObject n = obj.createFromTemplate(folder, "complex", parameters);
         Integer cnt = TwoPartLoader.queried.get(n.getPrimaryFile());
@@ -355,7 +356,7 @@ public class SCFTHandlerTest extends NbTestCase {
             fail("Too small file: " + length + " for " + snd);
         }
         InputStream is = snd.getInputStream();
-        InputStreamReader r = new InputStreamReader(is, "UTF-8");
+        InputStreamReader r = new InputStreamReader(is, StandardCharsets.UTF_8);
         char[] cbuf = new char[1024];
         int len = r.read(cbuf);
         if (len == -1) {

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/WriterOutputStream.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/WriterOutputStream.java
@@ -23,10 +23,10 @@ import java.io.OutputStream;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -45,7 +45,7 @@ class WriterOutputStream extends OutputStream {
 
     public WriterOutputStream(Writer out) {
         this.writer = out;
-        this.decoder = Charset.forName("UTF-8"). //NOI18N
+        this.decoder = StandardCharsets.UTF_8.
                 newDecoder().
                 onMalformedInput(CodingErrorAction.REPLACE).
                 onUnmappableCharacter(CodingErrorAction.REPLACE).

--- a/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/UtilsTest.java
+++ b/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/UtilsTest.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.lsp.client;
 
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -62,7 +63,7 @@ public class UtilsTest extends NbTestCase {
                        "0123456789\n" +
                        "0123456789\n" +
                        "0123456789\n" +
-                       "0123456789\n").getBytes("UTF-8"));
+                       "0123456789\n").getBytes(StandardCharsets.UTF_8));
         }
         FileObject sourceFile2 = wd.createData("Test2.txt");
         try (OutputStream out = sourceFile2.getOutputStream()) {
@@ -70,7 +71,7 @@ public class UtilsTest extends NbTestCase {
                        "0123456789\n" +
                        "0123456789\n" +
                        "0123456789\n" +
-                       "0123456789\n").getBytes("UTF-8"));
+                       "0123456789\n").getBytes(StandardCharsets.UTF_8));
         }
         Map<String, List<TextEdit>> changes = new HashMap<>();
         changes.put(Utils.toURI(sourceFile1), Arrays.asList(new TextEdit(new Range(new Position(2, 3), new Position(2, 6)), "a"),
@@ -103,7 +104,7 @@ public class UtilsTest extends NbTestCase {
                        "0123456789\n" +
                        "0123456789\n" +
                        "0123456789\n" +
-                       "0123456789\n").getBytes("UTF-8"));
+                       "0123456789\n").getBytes(StandardCharsets.UTF_8));
         }
         FileObject sourceFile2 = wd.createData("Test2.txt");
         try (OutputStream out = sourceFile2.getOutputStream()) {
@@ -111,7 +112,7 @@ public class UtilsTest extends NbTestCase {
                        "0123456789\n" +
                        "0123456789\n" +
                        "0123456789\n" +
-                       "0123456789\n").getBytes("UTF-8"));
+                       "0123456789\n").getBytes(StandardCharsets.UTF_8));
         }
         FileObject sourceFile3 = wd.createData("Test3.txt");
         WorkspaceEdit edit = new WorkspaceEdit(Arrays.asList(Either.forLeft(new TextDocumentEdit(new VersionedTextDocumentIdentifier(Utils.toURI(sourceFile1), -1), Arrays.asList(new TextEdit(new Range(new Position(2, 3), new Position(2, 6)), "a"),

--- a/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/options/LanguageStorageTest.java
+++ b/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/options/LanguageStorageTest.java
@@ -23,6 +23,7 @@ import java.beans.BeanInfo;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -85,7 +86,7 @@ public class LanguageStorageTest extends NbTestCase {
 
         FileObject grammar = FileUtil.createData(data, "any.json");
         try (OutputStream out = grammar.getOutputStream()) {
-            out.write("{ \"scopeName\" : \"test\" }".getBytes("UTF-8"));
+            out.write("{ \"scopeName\" : \"test\" }".getBytes(StandardCharsets.UTF_8));
         }
         FileObject testFO = FileUtil.createData(root, "test.txt");
         assertEquals("content/unknown", FileUtil.getMIMEType(testFO));

--- a/ide/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ApplyDiffPatchAction.java
+++ b/ide/mercurial/src/org/netbeans/modules/mercurial/ui/diff/ApplyDiffPatchAction.java
@@ -36,6 +36,7 @@ import java.awt.Dialog;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
@@ -132,7 +133,7 @@ public class ApplyDiffPatchAction extends ContextAction {
     }
 
     private static boolean isNetBeansPatch (File patchFile) {
-        try (BufferedReader reader = Files.newBufferedReader(patchFile.toPath(), Charset.forName("UTF-8"))) {
+        try (BufferedReader reader = Files.newBufferedReader(patchFile.toPath(), StandardCharsets.UTF_8)) {
             boolean netbeansPatch = false;
             boolean cont = true;
             for (String line = reader.readLine(); line != null && cont; line = reader.readLine()) {

--- a/ide/mercurial/test/unit/src/org/netbeans/modules/mercurial/AbstractHgTestCase.java
+++ b/ide/mercurial/test/unit/src/org/netbeans/modules/mercurial/AbstractHgTestCase.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -198,7 +199,7 @@ public abstract class AbstractHgTestCase extends NbTestCase {
         BufferedReader r = null;
         try {
             StringBuilder sb = new StringBuilder();
-            r = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+            r = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
             for (String line = r.readLine(); line != null; line = r.readLine()) {
                 if (sb.length() > 0) {
                     sb.append('\n');

--- a/ide/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SnapshotMemLeakTest.java
+++ b/ide/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SnapshotMemLeakTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.parsing.api;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -202,7 +203,7 @@ public class SnapshotMemLeakTest extends NbTestCase {
     private FileObject generateFile(final int rounds) throws IOException {
         final FileObject wd = FileUtil.toFileObject(FileUtil.normalizeFile(getWorkDir()));
         final FileObject file = FileUtil.createData(wd, "test.foo");    //NOI18N
-        try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(file.getOutputStream(),"UTF-8"))) { //NOI18N
+        try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(file.getOutputStream(), StandardCharsets.UTF_8))) {
             for (int i = 0; i< rounds; i++) {
                 out.write(CONTENT);
                 out.write(CONTENT);

--- a/ide/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SourceTest.java
+++ b/ide/parsing.api/test/unit/src/org/netbeans/modules/parsing/api/SourceTest.java
@@ -23,14 +23,13 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultStyledDocument;
 import javax.swing.text.Document;
 import javax.swing.text.StyledDocument;
-import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.parsing.impl.SourceAccessor;
 import org.netbeans.modules.parsing.impl.TaskProcessor;
 import org.openide.cookies.EditorCookie;
@@ -332,11 +331,10 @@ public class SourceTest extends ParsingTestBase {
     }
 
     private void writeToFileObject(FileObject f, String documentContent, String eol) throws IOException {
-        assertTrue("No UTF-8 available", Charset.isSupported("UTF-8"));
         OutputStream os = f.getOutputStream();
         try {
-            byte [] eolBytes = eol.getBytes("UTF-8");
-            byte [] bytes = documentContent.getBytes("UTF-8");
+            byte [] eolBytes = eol.getBytes(StandardCharsets.UTF_8);
+            byte [] bytes = documentContent.getBytes(StandardCharsets.UTF_8);
             for(byte b : bytes) {
                 if (b == '\n') {
                     os.write(eolBytes);

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/TimeStamps.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/TimeStamps.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.Collections;
@@ -224,8 +225,7 @@ public final class TimeStamps {
             final File f = new File(cacheDir, TIME_STAMPS_FILE);
             assert f != null;
             try {
-                try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(f), "UTF-8")) //NOI18N
-                ) {
+                try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(f), StandardCharsets.UTF_8))) {
                     if (unseen != null) {
                         timestamps.keySet().removeAll(unseen);
                     }
@@ -264,8 +264,7 @@ public final class TimeStamps {
                     try {
                         boolean readOldPropertiesFormat = false;
                         {
-                            try (BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(f), "UTF-8")) //NOI18N
-                            ) {
+                            try (BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8))) {
                                 String line = in.readLine();
                                 if (line != null && line.startsWith(VERSION_2)) {
                                     // it's the new format

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskCache.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskCache.java
@@ -34,6 +34,7 @@ import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -138,7 +139,7 @@ public class TaskCache {
             boolean existed = interestedInReturnValue && output.exists();
             output.getParentFile().mkdirs();
             try {
-                final PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(output), "UTF-8")); //NOI18N
+                final PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(output), StandardCharsets.UTF_8));
                 try {
                     for (T err : errors) {
                         pw.print(convertor.getKind(err).name());
@@ -256,7 +257,7 @@ public class TaskCache {
 
     private List<Task> loadErrors(File input, FileObject file) throws IOException {
         List<Task> result = new LinkedList<Task>();
-        BufferedReader pw = new BufferedReader(new InputStreamReader(new FileInputStream(input), "UTF-8")); //NOI18N
+        BufferedReader pw = new BufferedReader(new InputStreamReader(new FileInputStream(input), StandardCharsets.UTF_8));
         String line;
 
         while ((line = pw.readLine()) != null) {

--- a/ide/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/AntBasedTestUtil.java
+++ b/ide/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/AntBasedTestUtil.java
@@ -35,6 +35,7 @@ import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -320,7 +321,7 @@ public class AntBasedTestUtil {
         }
         InputStream is = new FileInputStream(f);
         try {
-            Reader r = new InputStreamReader(is, "UTF-8");
+            Reader r = new InputStreamReader(is, StandardCharsets.UTF_8);
             StringBuilder b = new StringBuilder();
             char[] buf = new char[4096];
             int read;
@@ -477,7 +478,7 @@ public class AntBasedTestUtil {
         StringBuilder b = new StringBuilder((int)f.length());
         InputStream is = new FileInputStream(f);
         try {
-            Reader r = new InputStreamReader(is, "UTF-8");
+            Reader r = new InputStreamReader(is, StandardCharsets.UTF_8);
             char[] buf = new char[4096];
             int i;
             while ((i = r.read(buf)) != -1) {
@@ -504,7 +505,7 @@ public class AntBasedTestUtil {
        assert s2.length() - s.length() == count * (to.length() - from.length());
        OutputStream os = new FileOutputStream(f);
        try {
-           Writer w = new OutputStreamWriter(os, "UTF-8");
+           Writer w = new OutputStreamWriter(os, StandardCharsets.UTF_8);
            w.write(s2);
            w.flush();
        } finally {

--- a/ide/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/EditablePropertiesTest.java
+++ b/ide/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/EditablePropertiesTest.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.junit.NbTestCase;
 import org.openide.util.Utilities;
 
@@ -187,8 +188,8 @@ public class EditablePropertiesTest extends NbTestCase {
         Reader r1 = null;
         Reader r2 = null;
         try {
-            r1 = new InputStreamReader(new FileInputStream(f1), "ISO-8859-1");
-            r2 = new InputStreamReader(new FileInputStream(f2), "ISO-8859-1");
+            r1 = new InputStreamReader(new FileInputStream(f1), StandardCharsets.ISO_8859_1);
+            r2 = new InputStreamReader(new FileInputStream(f2), StandardCharsets.ISO_8859_1);
             return AntBasedTestUtil.countTextDiffs(r1, r2);
         } finally {
             if (r1 != null) {

--- a/ide/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/GeneratedFilesHelperTest.java
+++ b/ide/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/GeneratedFilesHelperTest.java
@@ -23,6 +23,7 @@ import org.netbeans.spi.project.ant.AntBuildExtenderImplementation;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import org.netbeans.api.project.Project;
@@ -182,9 +183,9 @@ public class GeneratedFilesHelperTest extends NbTestCase {
         String testDataNl = "hi mom\nhow are you\n";
         String testDataCrNl = "hi mom\r\nhow are you\r\n";
         String testDataCr = "hi mom\rhow are you\r";
-        String crcNl = GeneratedFilesHelper.computeCrc32(new ByteArrayInputStream(testDataNl.getBytes("UTF-8")));
-        String crcCrNl = GeneratedFilesHelper.computeCrc32(new ByteArrayInputStream(testDataCrNl.getBytes("UTF-8")));
-        String crcCr = GeneratedFilesHelper.computeCrc32(new ByteArrayInputStream(testDataCr.getBytes("UTF-8")));
+        String crcNl = GeneratedFilesHelper.computeCrc32(new ByteArrayInputStream(testDataNl.getBytes(StandardCharsets.UTF_8)));
+        String crcCrNl = GeneratedFilesHelper.computeCrc32(new ByteArrayInputStream(testDataCrNl.getBytes(StandardCharsets.UTF_8)));
+        String crcCr = GeneratedFilesHelper.computeCrc32(new ByteArrayInputStream(testDataCr.getBytes(StandardCharsets.UTF_8)));
         assertEquals("CRNL normalized -> NL", crcNl, crcCrNl);
         assertEquals("CR normalized -> NL", crcNl, crcCr);
     }

--- a/ide/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SequentialPropertyEvaluatorTest.java
+++ b/ide/project.ant/test/unit/src/org/netbeans/spi/project/support/ant/SequentialPropertyEvaluatorTest.java
@@ -20,6 +20,7 @@
 package org.netbeans.spi.project.support.ant;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -197,7 +198,7 @@ public class SequentialPropertyEvaluatorTest extends NbTestCase {
         assertEquals("no substitution", "zval", all.get("z"));
         // Yuck. But it failed once, so check it now.
         Properties p = new Properties();
-        p.load(new ByteArrayInputStream("project.mylib=../mylib\njavac.classpath=${project.mylib}/build/mylib.jar\nrun.classpath=${javac.classpath}:build/classes".getBytes("US-ASCII")));
+        p.load(new ByteArrayInputStream("project.mylib=../mylib\njavac.classpath=${project.mylib}/build/mylib.jar\nrun.classpath=${javac.classpath}:build/classes".getBytes(StandardCharsets.US_ASCII)));
         all = evaluateAll(Collections.<String,String>emptyMap(), Collections.singletonList(NbCollections.checkedMapByFilter(p, String.class, String.class, true)));
         assertNotNull("no circularity error", all);
         assertEquals("javac.classpath correctly substituted", "../mylib/build/mylib.jar", all.get("javac.classpath"));

--- a/ide/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesTestUtil.java
+++ b/ide/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesTestUtil.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.project.libraries;
 
 import org.netbeans.spi.project.libraries.WritableLibraryProvider;
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.IOException;
@@ -28,6 +27,7 @@ import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,9 +42,6 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
@@ -65,6 +62,9 @@ import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
 import org.openide.util.Mutex;
 import org.openide.util.WeakSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Common support classes for unit tests in this module.
@@ -429,7 +429,7 @@ public class LibrariesTestUtil {
                 PrintWriter out = null;
                 try {
                     lock = defFile.lock();
-                    out = new PrintWriter(new OutputStreamWriter(defFile.getOutputStream (lock),"UTF-8"));
+                    out = new PrintWriter(new OutputStreamWriter(defFile.getOutputStream (lock), StandardCharsets.UTF_8));
                     out.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");      //NOI18N
                     out.println("<!DOCTYPE library PUBLIC \"-//NetBeans//DTD Library Declaration 1.0//EN\" \"http://www.netbeans.org/dtds/library-declaration-1_0.dtd\">");
                     out.println("<library version=\"1.0\">");

--- a/ide/projectui/src/org/netbeans/modules/project/ui/TemplatesPanelGUI.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/TemplatesPanelGUI.java
@@ -37,6 +37,7 @@ import java.beans.VetoableChangeListener;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
@@ -63,7 +64,6 @@ import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.html.StyleSheet;
 import javax.swing.tree.TreePath;
 import org.netbeans.api.annotations.common.StaticResource;
-import static org.netbeans.modules.project.ui.Bundle.*;
 import org.openide.ErrorManager;
 import org.openide.WizardDescriptor;
 import org.openide.awt.HtmlBrowser;
@@ -89,6 +89,8 @@ import org.openide.util.Exceptions;
 import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.RequestProcessor;
+
+import static org.netbeans.modules.project.ui.Bundle.*;
 
 /**
  *
@@ -825,7 +827,7 @@ public class TemplatesPanelGUI extends javax.swing.JPanel implements PropertyCha
         try {
             byte[] arr = new byte[4096];
             int len = stream.read (arr, 0, arr.length);
-            String txt = new String(arr, 0, (len >= 0 ) ? len : 0, "ISO-8859-1").toUpperCase(Locale.ENGLISH);
+            String txt = new String(arr, 0, (len >= 0 ) ? len : 0, StandardCharsets.ISO_8859_1).toUpperCase(Locale.ENGLISH);
             // encoding
             return findEncoding (txt);
         } catch (IOException x) {

--- a/ide/schema2beans/test/unit/src/tests/MainTest.java
+++ b/ide/schema2beans/test/unit/src/tests/MainTest.java
@@ -20,6 +20,7 @@ package tests;
 
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import junit.framework.*;
 import org.netbeans.junit.*;
 
@@ -419,7 +420,7 @@ public class MainTest extends NbTestCase {
     private int runCommand(String cmd) throws java.io.IOException, java.lang.InterruptedException {
         System.out.println(cmd);
         Process proc = Runtime.getRuntime().exec(cmd);
-        Writer out = new BufferedWriter(new OutputStreamWriter(getRef(), "UTF-8"));
+        Writer out = new BufferedWriter(new OutputStreamWriter(getRef(), StandardCharsets.UTF_8));
         Thread outThread = new Thread(new InputMonitor("out: ", proc.getInputStream(), out));
         outThread.start();
         Thread errThread = new Thread(new InputMonitor("err: ", proc.getErrorStream(), out));

--- a/ide/spellchecker/src/org/netbeans/modules/spellchecker/DefaultLocaleQueryImplementation.java
+++ b/ide/spellchecker/src/org/netbeans/modules/spellchecker/DefaultLocaleQueryImplementation.java
@@ -24,6 +24,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.StringTokenizer;
 import org.netbeans.modules.spellchecker.spi.LocaleQueryImplementation;
@@ -59,7 +60,7 @@ public class DefaultLocaleQueryImplementation implements LocaleQueryImplementati
         if (file == null)
             return Locale.getDefault ();
         
-        Charset UTF8 = Charset.forName("UTF-8");
+        Charset UTF8 = StandardCharsets.UTF_8;
         
         BufferedReader r = null;
         
@@ -103,7 +104,7 @@ public class DefaultLocaleQueryImplementation implements LocaleQueryImplementati
     
     public static void setDefaultLocale(Locale locale) {
         FileObject file = getDefaultLocaleFile();
-        Charset UTF8 = Charset.forName("UTF-8");
+        Charset UTF8 = StandardCharsets.UTF_8;
         FileLock lock = null;
         PrintWriter pw = null;
         

--- a/ide/spellchecker/src/org/netbeans/modules/spellchecker/DictionaryImpl.java
+++ b/ide/spellchecker/src/org/netbeans/modules/spellchecker/DictionaryImpl.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -95,7 +96,7 @@ public class DictionaryImpl implements Dictionary {
         BufferedReader reader = null;
 
         try {
-            reader = new BufferedReader(new InputStreamReader(new FileInputStream(source), "UTF-8"));
+            reader = new BufferedReader(new InputStreamReader(new FileInputStream(source), StandardCharsets.UTF_8));
 
             String line = null;
 
@@ -231,7 +232,7 @@ public class DictionaryImpl implements Dictionary {
         BufferedWriter writer = null;
 
         try {
-            writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(source), "UTF-8"));
+            writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(source), StandardCharsets.UTF_8));
 
             for (String s : dictionary) {
                 writer.append(s);

--- a/ide/spellchecker/src/org/netbeans/modules/spellchecker/DictionaryProviderImpl.java
+++ b/ide/spellchecker/src/org/netbeans/modules/spellchecker/DictionaryProviderImpl.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -162,7 +163,7 @@ public class DictionaryProviderImpl implements DictionaryProvider {
             file = InstalledFileLocator.getDefault().locate("modules/dict/dictionary" + currentSuffix + ".description", cnb, false);
 
             if (file != null && InstalledFileLocator.getDefault().locate("modules/dict/dictionary" + currentSuffix + ".description_hidden", null, false) == null) {
-                BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+                BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
 
                 try {
                     String line;

--- a/ide/spellchecker/src/org/netbeans/modules/spellchecker/TrieDictionary.java
+++ b/ide/spellchecker/src/org/netbeans/modules/spellchecker/TrieDictionary.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -311,7 +312,7 @@ public class TrieDictionary implements Dictionary {
         for (URL u : sources) {
             FileObject f = URLMapper.findFileObject(u);
             u = f != null ? URLMapper.findURL(f, URLMapper.EXTERNAL) : u;
-            BufferedReader in = new BufferedReader(new InputStreamReader(u.openStream(), "UTF-8"));
+            BufferedReader in = new BufferedReader(new InputStreamReader(u.openStream(), StandardCharsets.UTF_8));
             
             try {
                 String line;

--- a/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/DictionaryInstallerPanel.java
+++ b/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/DictionaryInstallerPanel.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Set;
@@ -296,7 +297,7 @@ public class DictionaryInstallerPanel extends javax.swing.JPanel {
 
             //TODO: if the dictionary already exists, provide user with a warning.
             input = new InputStreamReader (new FileInputStream (description.dictionaryFile), description.fileEncoding);
-            output = new OutputStreamWriter (new FileOutputStream (file), "UTF-8"); // NOI18N
+            output = new OutputStreamWriter (new FileOutputStream (file), StandardCharsets.UTF_8);
             char[] buffer = new char[BUFFER_LENGTH];
             int len = BUFFER_LENGTH;
             do {

--- a/ide/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/TrieDictionaryTest.java
+++ b/ide/spellchecker/test/unit/src/org/netbeans/modules/spellchecker/TrieDictionaryTest.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -120,7 +121,7 @@ public class TrieDictionaryTest extends NbTestCase {
         clearWorkDir();
 
         File sourceFile = new File(getWorkDir(), "source");
-        Writer w = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(sourceFile), "UTF-8"));
+        Writer w = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(sourceFile), StandardCharsets.UTF_8));
 
         for (String d : data) {
             w.write(d);

--- a/ide/spi.palette/src/org/netbeans/modules/palette/ui/TextImporter.java
+++ b/ide/spi.palette/src/org/netbeans/modules/palette/ui/TextImporter.java
@@ -24,7 +24,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JButton;
@@ -174,12 +174,7 @@ public class TextImporter implements Runnable {
     }
     
     private String toUTF8( String s ) {
-        try {
-            return new String( s.getBytes("UTF-8") ); //NOI18N
-        } catch( UnsupportedEncodingException e ) {
-            Logger.getLogger(TextImporter.class.getName()).log(Level.WARNING, null, e);
-            return s;
-        }
+        return new String( s.getBytes(StandardCharsets.UTF_8) );
     }
     
     private void reorder( String fileName, FileObject categoryFolder, int dropIndex ) throws IOException {

--- a/ide/spi.palette/test/unit/src/org/netbeans/spi/palette/PaletteItemTest.java
+++ b/ide/spi.palette/test/unit/src/org/netbeans/spi/palette/PaletteItemTest.java
@@ -24,6 +24,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.junit.MockServices;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.palette.Category;
@@ -172,7 +173,7 @@ public class PaletteItemTest extends NbTestCase {
         FileObject fo = itemsFolder.createData(ITEM_FILE);
         FileLock lock = fo.lock();
         try {
-            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), "UTF-8");
+            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), StandardCharsets.UTF_8);
             try {
                 writer.write("<?xml version='1.0' encoding='UTF-8'?>");
                 writer.write("<!DOCTYPE editor_palette_item PUBLIC '-//NetBeans//Editor Palette Item 1.0//EN' 'http://www.netbeans.org/dtds/editor-palette-item-1_0.dtd'>");
@@ -195,7 +196,7 @@ public class PaletteItemTest extends NbTestCase {
         FileObject fo = itemsFolder.createData(ITEM_FILE);
         FileLock lock = fo.lock();
         try {
-            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), "UTF-8");
+            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), StandardCharsets.UTF_8);
             try {
                 writer.write("<?xml version='1.0' encoding='UTF-8'?>");
                 writer.write("<!DOCTYPE editor_palette_item PUBLIC '-//NetBeans//Editor Palette Item 1.0//EN' 'http://www.netbeans.org/dtds/editor-palette-item-1_0.dtd'>");
@@ -218,7 +219,7 @@ public class PaletteItemTest extends NbTestCase {
         FileObject fo = itemsFolder.createData(ITEM_FILE);
         FileLock lock = fo.lock();
         try {
-            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), "UTF-8");
+            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), StandardCharsets.UTF_8);
             try {
                 writer.write("<?xml version='1.0' encoding='UTF-8'?>");
                 writer.write("<!DOCTYPE editor_palette_item PUBLIC '-//NetBeans//Editor Palette Item 1.1//EN' 'http://www.netbeans.org/dtds/editor-palette-item-1_1.dtd'>");

--- a/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/parser/ConflictDescriptionParserTest.java
+++ b/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/parser/ConflictDescriptionParserTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -54,7 +55,7 @@ public class ConflictDescriptionParserTest extends NbTestCase {
         File dataDir = getDataDir();
         File dataFile = new File(dataDir, "treeConflictsParser");
         assert dataFile.exists();
-        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(dataFile), "UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(dataFile), StandardCharsets.UTF_8));
         for (String line = br.readLine(); line != null; line = br.readLine()) {
             testConflicts(line);
         }
@@ -68,7 +69,7 @@ public class ConflictDescriptionParserTest extends NbTestCase {
         File dataDir = getDataDir();
         File dataFile = new File(dataDir, "treeConflictsParserCorrupted");
         assert dataFile.exists();
-        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(dataFile), "UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(dataFile), StandardCharsets.UTF_8));
         for (String line = br.readLine(); line != null; line = br.readLine()) {
             ParserLogHandler handler = new ParserLogHandler();
             attachHandler(handler);

--- a/ide/textmate.lexer/test/unit/src/org/netbeans/modules/textmate/lexer/CreateRegistrationProcessorTest.java
+++ b/ide/textmate.lexer/test/unit/src/org/netbeans/modules/textmate/lexer/CreateRegistrationProcessorTest.java
@@ -24,6 +24,7 @@ import java.io.FileWriter;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.textmate.lexer.api.GrammarInjectionRegistration;
 import org.netbeans.modules.textmate.lexer.api.GrammarRegistration;
@@ -65,7 +66,7 @@ public class CreateRegistrationProcessorTest extends NbTestCase {
             AnnotationProcessorTestUtils.runJavac(getWorkDir(), null, outDir, null, System.err)
             );
         
-        try (Reader r = new InputStreamReader(new FileInputStream(new File(new File(outDir, "META-INF"), "generated-layer.xml")), "UTF-8")) {
+        try (Reader r = new InputStreamReader(new FileInputStream(new File(new File(outDir, "META-INF"), "generated-layer.xml")), StandardCharsets.UTF_8)) {
             StringBuilder content = new StringBuilder();
             int read;
             
@@ -113,7 +114,7 @@ public class CreateRegistrationProcessorTest extends NbTestCase {
             AnnotationProcessorTestUtils.runJavac(getWorkDir(), null, outDir, null, System.err)
             );
 
-        try (Reader r = new InputStreamReader(new FileInputStream(new File(new File(outDir, "META-INF"), "generated-layer.xml")), "UTF-8")) {
+        try (Reader r = new InputStreamReader(new FileInputStream(new File(new File(outDir, "META-INF"), "generated-layer.xml")), StandardCharsets.UTF_8)) {
             StringBuilder content = new StringBuilder();
             int read;
 

--- a/ide/utilities/src/org/netbeans/modules/url/EncodingQueryImpl.java
+++ b/ide/utilities/src/org/netbeans/modules/url/EncodingQueryImpl.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.url;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.spi.queries.FileEncodingQueryImplementation;
 import org.openide.filesystems.FileObject;
 
@@ -34,7 +35,7 @@ final class EncodingQueryImpl extends FileEncodingQueryImplementation {
     private final Charset charsetUtf8;
 
     EncodingQueryImpl() {
-        charsetUtf8 = Charset.forName("UTF-8");                         //NOI18N
+        charsetUtf8 = StandardCharsets.UTF_8;
     }
 
     @Override

--- a/ide/versioning.util/src/org/netbeans/modules/proxy/ProxySocketFactory.java
+++ b/ide/versioning.util/src/org/netbeans/modules/proxy/ProxySocketFactory.java
@@ -24,6 +24,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 import java.io.*;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.keyring.Keyring;
 import org.openide.util.NetworkSettings;
 
@@ -331,7 +332,7 @@ public class ProxySocketFactory extends SocketFactory {
     }
 
     static String encodeCredentials(String credentials) throws UnsupportedEncodingException {
-        return Base64.getEncoder().encodeToString(credentials.getBytes("US-ASCII"));
+        return Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.US_ASCII));
     }
 
     /**

--- a/ide/xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/AbstractTestCase.java
+++ b/ide/xml.lexer/test/unit/src/org/netbeans/api/xml/lexer/AbstractTestCase.java
@@ -21,6 +21,7 @@ package org.netbeans.api.xml.lexer;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.text.AbstractDocument;
@@ -94,7 +95,7 @@ public class AbstractTestCase extends NbTestCase {
     protected static Document getResourceAsDocument(String path) throws Exception {
         InputStream in = XMLTokenIdTest.class.getResourceAsStream(path);
         Document sd = new BaseDocument(true, "text/xml"); //NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(in,"UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         StringBuffer sbuf = new StringBuffer();
         try {
             String line = null;

--- a/ide/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/Utilities.java
+++ b/ide/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/Utilities.java
@@ -27,13 +27,13 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,7 +54,6 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.api.project.SourceGroup;
 import org.netbeans.editor.BaseDocument;
-import org.netbeans.modules.xml.retriever.XMLCatalogProvider;
 import org.netbeans.modules.xml.retriever.catalog.impl.*;
 import org.netbeans.modules.xml.retriever.catalog.impl.XAMCatalogWriteModelImpl;
 import org.netbeans.modules.xml.retriever.impl.Util;
@@ -141,12 +140,7 @@ public class Utilities {
             return null;
         }
         
-        try {
-            bytes = uriref.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException uee) {
-            // this can't happen
-            return uriref;
-        }
+        bytes = uriref.getBytes(StandardCharsets.UTF_8);
         
         for (int count = 0; count < bytes.length; count++) {
             int ch = bytes[count] & 0xFF;

--- a/ide/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/Util.java
+++ b/ide/xml.schema.completion/test/unit/src/org/netbeans/modules/xml/schema/completion/Util.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.editor.BaseDocument;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -47,7 +48,7 @@ public class Util {
     public static BaseDocument getResourceAsDocument(String path) throws Exception {
         InputStream in = Util.class.getResourceAsStream(path);
         BaseDocument sd = new BaseDocument(true, "text/xml"); //NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(in,"UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         StringBuffer sbuf = new StringBuffer();
         try {
             String line = null;

--- a/ide/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/CopyPasteTest.java
+++ b/ide/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/impl/xdm/CopyPasteTest.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import javax.swing.text.Document;
 import junit.framework.*;
@@ -55,7 +56,7 @@ public class CopyPasteTest extends TestCase {
     
     private String readFile(String filename) throws IOException {
         URL url = getClass().getResource(filename);
-        BufferedReader br =  new BufferedReader(new InputStreamReader(url.openStream(),"UTF-8"));
+        BufferedReader br =  new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
         StringBuffer sbuf = new StringBuffer();
         try {
             int c = 0;

--- a/ide/xml.text.obsolete90/test/unit/src/org/netbeans/modules/xml/text/syntax/AbstractTestCase.java
+++ b/ide/xml.text.obsolete90/test/unit/src/org/netbeans/modules/xml/text/syntax/AbstractTestCase.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Scanner;
 import javax.swing.text.Document;
@@ -70,7 +71,7 @@ public class AbstractTestCase extends TestCase {
         }
         InputStream in = AbstractTestCase.class.getResourceAsStream(path);
         BaseDocument sd = new BaseDocument(true, "text/xml"); //NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(in,"UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         StringBuffer sbuf = new StringBuffer();
         try {
             String line = null;

--- a/ide/xml.text/test/unit/src/org/netbeans/modules/xml/text/AbstractTestCase.java
+++ b/ide/xml.text/test/unit/src/org/netbeans/modules/xml/text/AbstractTestCase.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Scanner;
 import javax.swing.text.Document;
@@ -68,7 +69,7 @@ public class AbstractTestCase extends NbTestCase {
     protected static BaseDocument getResourceAsDocument(String path) throws Exception {
         InputStream in = AbstractTestCase.class.getResourceAsStream(path);
         BaseDocument sd = new BaseDocument(true, "text/xml"); //NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(in,"UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         StringBuffer sbuf = new StringBuffer();
         try {
             String line = null;

--- a/ide/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/Util.java
+++ b/ide/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/Util.java
@@ -31,6 +31,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import javax.swing.text.Document;
 import org.netbeans.modules.xml.schema.model.GlobalSimpleType;
@@ -81,7 +82,7 @@ public class Util {
     
     public static String getResourceAsString(String path) throws Exception {
         InputStream in = Util.class.getResourceAsStream(path);
-        BufferedReader br = new BufferedReader(new InputStreamReader(in,"UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         StringBuffer sbuf = new StringBuffer();
         try {
             String line = null;

--- a/ide/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/Util.java
+++ b/ide/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/Util.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.text.Document;
@@ -60,7 +61,7 @@ public class Util {
     
     public static String getResourceAsString(String path) throws Exception {
         InputStream in = Util.class.getResourceAsStream(path);
-        BufferedReader br = new BufferedReader(new InputStreamReader(in,"UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         StringBuffer sbuf = new StringBuffer();
         try {
             String line = null;
@@ -81,7 +82,7 @@ public class Util {
     
     public static Document loadDocument(InputStream in) throws Exception {
         Document sd = new BaseDocument(true, "text/xml"); //NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(in,"UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         StringBuffer sbuf = new StringBuffer();
         try {
             String line = null;

--- a/ide/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/perf/XDMPerfNumberTest.java
+++ b/ide/xml.xdm/test/unit/src/org/netbeans/modules/xml/xdm/perf/XDMPerfNumberTest.java
@@ -25,6 +25,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.netbeans.editor.BaseDocument;
@@ -111,7 +112,7 @@ public class XDMPerfNumberTest extends TestCase {
         java.net.URL url = getClass().getResource(SCHEMA_FILE);            
         // prepare document
         BaseDocument basedoc = new BaseDocument(true, "text/xml"); //NOI18N
-        insertStringInDocument(new InputStreamReader(url.openStream(),"UTF-8"), basedoc);
+        insertStringInDocument(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8), basedoc);
         long start = System.currentTimeMillis();
         SyntaxSupport sup = basedoc.getSyntaxSupport();
         TokenItem ti = sup.getTokenChain(0);
@@ -128,7 +129,7 @@ public class XDMPerfNumberTest extends TestCase {
         javax.swing.text.Document sd = new BaseDocument(true, "text/xml"); //NOI18N
         XDMModel model = null;
 
-        InputStreamReader reader = new InputStreamReader(getClass().getResourceAsStream(SCHEMA_FILE),"UTF-8");
+        InputStreamReader reader = new InputStreamReader(getClass().getResourceAsStream(SCHEMA_FILE), StandardCharsets.UTF_8);
         insertStringInDocument(reader, sd);
 
         start = System.currentTimeMillis();

--- a/ide/xml/test/unit/src/org/netbeans/modules/xml/wizard/XMLGeneratorTest.java
+++ b/ide/xml/test/unit/src/org/netbeans/modules/xml/wizard/XMLGeneratorTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import junit.framework.TestCase;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.editor.BaseKit;
@@ -58,7 +59,7 @@ public class XMLGeneratorTest extends TestCase {
     protected static BaseDocument getResourceAsDocument(String path) throws Exception {
         InputStream in = XMLGeneratorTest.class.getResourceAsStream(path);
         BaseDocument sd = new BaseDocument(true, "text/xml"); //NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(in,"UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         StringBuffer sbuf = new StringBuffer();
         try {
             String line = null;

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AdvancedActionPanel.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AdvancedActionPanel.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.ant.debugger;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.Collator;
 import java.util.*;
 import javax.swing.DefaultComboBoxModel;
@@ -300,7 +301,7 @@ final class AdvancedActionPanel extends javax.swing.JPanel {
             }
         }
         Properties props = new Properties();
-        ByteArrayInputStream bais = new ByteArrayInputStream(propertiesPane.getText().getBytes("ISO-8859-1"));
+        ByteArrayInputStream bais = new ByteArrayInputStream(propertiesPane.getText().getBytes(StandardCharsets.ISO_8859_1));
         props.load(bais);
         int verbosity = 2;
         String verbosityString = (String) verbosityComboBox.getSelectedItem();

--- a/java/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformFileEncodingQueryImplTest.java
+++ b/java/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformFileEncodingQueryImplTest.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.ant.freeform;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.spi.project.support.ant.AntProjectHelper;
@@ -58,7 +59,7 @@ public class FreeformFileEncodingQueryImplTest extends TestBase {
                 appendChild(doc.createElementNS(Util.NAMESPACE, "source-folder"));
         sf.appendChild(doc.createElementNS(Util.NAMESPACE, "label")).appendChild(doc.createTextNode("Sources"));
         sf.appendChild(doc.createElementNS(Util.NAMESPACE, "location")).appendChild(doc.createTextNode("../ext"));
-        final Charset expectedCharset = Charset.forName("UTF-8");
+        final Charset expectedCharset = StandardCharsets.UTF_8;
         sf.appendChild(doc.createElementNS(Util.NAMESPACE,"encoding")).appendChild(doc.createTextNode(expectedCharset.name()));
         Util.putPrimaryConfigurationData(helper, data);
         ProjectManager.getDefault().saveProject(p);

--- a/java/dbschema/test/unit/src/org/netbeans/modules/dbschema/migration/archiver/serializer/XMLGraphSerializerTest.java
+++ b/java/dbschema/test/unit/src/org/netbeans/modules/dbschema/migration/archiver/serializer/XMLGraphSerializerTest.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.dbschema.migration.archiver.serializer;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.junit.NbTestCase;
 
 /**
@@ -36,7 +37,7 @@ public class XMLGraphSerializerTest extends NbTestCase {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         new XMLGraphSerializer(outputStream).writeObject(new FooList());
 
-        String string = new String(outputStream.toByteArray(), "UTF-8");
+        String string = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
         assertTrue(string.contains("XMLGraphSerializerTest$Foo42"));
         assertTrue(string.contains("XMLGraphSerializerTest$Foo42#1"));
     }

--- a/java/debugger.jpda.js/test/unit/src/org/netbeans/modules/debugger/jpda/js/source/SourceTest.java
+++ b/java/debugger.jpda.js/test/unit/src/org/netbeans/modules/debugger/jpda/js/source/SourceTest.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.debugger.jpda.js.source;
 
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.junit.NbTestCase;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -43,7 +44,7 @@ public class SourceTest extends NbTestCase {
         
         FileObject fo = FileUtil.createMemoryFileSystem().getRoot().createData("test.js");
         final OutputStream os = fo.getOutputStream();
-        os.write(js.getBytes("UTF-8"));
+        os.write(js.getBytes(StandardCharsets.UTF_8));
         os.close();
         
         String wrap = AVATAR_PREFIX + js + AVATAR_SUFFIX;
@@ -60,7 +61,7 @@ public class SourceTest extends NbTestCase {
         
         FileObject fo = FileUtil.createMemoryFileSystem().getRoot().createData("test.js");
         final OutputStream os = fo.getOutputStream();
-        os.write(js.getBytes("UTF-8"));
+        os.write(js.getBytes(StandardCharsets.UTF_8));
         os.close();
         
         String wrap = "// Written by Martin\n// Tested by Jarda\n" + js;

--- a/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JspLineBreakpointTest.java
+++ b/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JspLineBreakpointTest.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import junit.framework.AssertionFailedError;
 import junit.framework.Test;
 import org.netbeans.api.debugger.DebuggerManager;
@@ -459,7 +460,7 @@ public class JspLineBreakpointTest extends NbTestCase {
                         int len = readU2();
                         writeU2(len);
                         byte[] utf8 = readBytes(len);
-                        String str = new String(utf8, "UTF-8");
+                        String str = new String(utf8, StandardCharsets.UTF_8);
                         if (isDebugEnabled())
                             System.out.println(i + " read class attr -- '" + str + "'");
                         if (str.equals(nameSDE)) {

--- a/java/form.refactoring/src/org/netbeans/modules/form/refactoring/FormRefactoringUpdate.java
+++ b/java/form.refactoring/src/org/netbeans/modules/form/refactoring/FormRefactoringUpdate.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -738,7 +739,7 @@ public class FormRefactoringUpdate extends SimpleRefactoringElementImplementatio
             if (outString != null) {
                 saveForUndo(formFile);
                 os = formFile.getOutputStream(lock);
-                os.write(outString.getBytes("UTF-8")); // NOI18N
+                os.write(outString.getBytes(StandardCharsets.UTF_8));
             }
         } catch (IOException ex) {
             Exceptions.printStackTrace(ex);

--- a/java/form/src/org/netbeans/modules/form/RenameSupport.java
+++ b/java/form/src/org/netbeans/modules/form/RenameSupport.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.modules.form.codestructure.CodeVariable;
 import org.openide.filesystems.FileObject;
 import org.openide.nodes.Node;
@@ -202,7 +203,7 @@ public class RenameSupport {
         try {
             String outString;
             is = formFile.getInputStream();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(is, "UTF-8")); // NOI18N
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             if (!shortName) {
                 // With fully qualified name we can safely do plain textual
                 // search/replace over the file and get all changes covered

--- a/java/form/src/org/netbeans/modules/form/palette/PaletteItemDataObject.java
+++ b/java/form/src/org/netbeans/modules/form/palette/PaletteItemDataObject.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.form.palette;
 import java.util.*;
 import java.io.*;
 import java.beans.*;
+import java.nio.charset.StandardCharsets;
 
 import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
@@ -225,7 +226,7 @@ public class PaletteItemDataObject extends MultiDataObject implements CookieSet.
         FileLock lock = itemFile.lock();
         OutputStream os = itemFile.getOutputStream(lock);
         try {
-            os.write(buff.toString().getBytes("UTF-8")); // NOI18N
+            os.write(buff.toString().getBytes(StandardCharsets.UTF_8));
         }
         finally {
             os.close();

--- a/java/form/test/unit/src/org/netbeans/modules/form/layoutdesign/KeepInitialComments.java
+++ b/java/form/test/unit/src/org/netbeans/modules/form/layoutdesign/KeepInitialComments.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import junit.framework.TestCase;
@@ -78,7 +79,7 @@ public class KeepInitialComments extends TestCase {
                       "  </Layout>\n" +
                       "</Form>\n";
         try (OutputStream out = file.getOutputStream();
-             Writer w = new OutputStreamWriter(out, "UTF-8")) {
+            Writer w = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
             w.append(code);
         }
 

--- a/java/i18n/test/unit/src/org/netbeans/modules/i18n/java/JavaI18nFinderTest.java
+++ b/java/i18n/test/unit/src/org/netbeans/modules/i18n/java/JavaI18nFinderTest.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import javax.swing.text.StyledDocument;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -92,7 +93,7 @@ public class JavaI18nFinderTest extends NbTestCase {
     
     private void writeFile(String content, FileObject file) throws Exception {
         OutputStream os = file.getOutputStream();
-        os.write(content.getBytes("UTF-8"));
+        os.write(content.getBytes(StandardCharsets.UTF_8));
         os.close();
     }
     

--- a/java/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/TestUtilities.java
+++ b/java/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/TestUtilities.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.modules.java.source.usages.IndexUtil;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -43,7 +44,7 @@ public class TestUtilities {
     public static final FileObject copyStringToFileObject(FileObject fo, String content) throws IOException {
         OutputStream os = fo.getOutputStream();
         try {
-            InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
             FileUtil.copy(is, os);
             return fo;
         } finally {

--- a/java/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/util/PositionBoundsResolver.java
+++ b/java/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/util/PositionBoundsResolver.java
@@ -25,8 +25,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import javax.swing.JEditorPane;
 import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
@@ -172,15 +172,13 @@ public class PositionBoundsResolver {
         String lineSep = System.getProperty("line.separator");//NO18N
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(stream, "UTF-8"));//NO18N
+            reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
             String line = reader.readLine();
             while (line != null) {
                 result.append(line);
                 result.append(lineSep);
                 line = reader.readLine();
             }
-        } catch (UnsupportedEncodingException ex) {
-            ErrorManager.getDefault().notify(ex);
         } catch (IOException ex) {
             ErrorManager.getDefault().notify(ex);
         } finally {

--- a/java/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/SourceTestSupport.java
+++ b/java/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/SourceTestSupport.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.JavaDataLoader;
@@ -120,7 +121,7 @@ public abstract class SourceTestSupport extends NbTestCase{
     protected FileObject copyStringToFileObject(FileObject fo, String content) throws Exception {
         OutputStream os = fo.getOutputStream();
         try {
-            InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
             FileUtil.copy(is, os);
             return fo;
         } finally {

--- a/java/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/TestUtilities.java
+++ b/java/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/TestUtilities.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
@@ -56,7 +57,7 @@ public class TestUtilities {
     public static final void copyStringToFileObject(FileObject fo, String contents) throws IOException {
         OutputStream os = fo.getOutputStream();
         try {
-            InputStream is = new ByteArrayInputStream(contents.getBytes("UTF-8"));
+            InputStream is = new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8));
             FileUtil.copy(is, os);
         } finally {
             os.close();
@@ -72,7 +73,7 @@ public class TestUtilities {
     public static final void copyStringToFile(File file, String content) throws IOException {
         OutputStream os = new FileOutputStream(file);
         try {
-            InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
             FileUtil.copy(is, os);
         } finally {
             os.close();
@@ -88,7 +89,7 @@ public class TestUtilities {
     public static final String copyStreamToString(InputStream input) throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         FileUtil.copy(input, output);
-        return Charset.forName("UTF-8").newDecoder().decode(ByteBuffer.wrap(output.toByteArray())).toString();
+        return StandardCharsets.UTF_8.newDecoder().decode(ByteBuffer.wrap(output.toByteArray())).toString();
     }
 
     /**

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerUtil.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerUtil.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -88,7 +89,7 @@ public class JpaControllerUtil {
         if (encoding == null) {
             encoding = FileEncodingQuery.getDefaultEncoding();
             if (encoding == null) {
-                return Charset.forName("UTF-8");
+                return StandardCharsets.UTF_8;
             }
             else {
                 return encoding;

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/PersistenceLibrarySupport.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/PersistenceLibrarySupport.java
@@ -24,6 +24,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -127,7 +128,7 @@ public class PersistenceLibrarySupport {
         PrintWriter out = null;
         try {
             lock = definitionFile.lock();
-            out = new PrintWriter(new OutputStreamWriter(definitionFile.getOutputStream(lock), "UTF-8"));
+            out = new PrintWriter(new OutputStreamWriter(definitionFile.getOutputStream(lock), StandardCharsets.UTF_8));
             out.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");      //NOI18N
             out.println("<!DOCTYPE library PUBLIC \"-//NetBeans//DTD Library Declaration 1.0//EN\" \"http://www.netbeans.org/dtds/library-declaration-1_0.dtd\">"); //NOI18N
             out.println("<library version=\"1.0\">");       			//NOI18N

--- a/java/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/FileEncodingQueryImplTest.java
+++ b/java/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/queries/FileEncodingQueryImplTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.api.common.queries;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.junit.NbTestCase;
@@ -70,7 +71,7 @@ public class FileEncodingQueryImplTest extends NbTestCase {
     }
 
     public void testFileEncodingQuery() throws Exception {
-        final Charset UTF_8 = Charset.forName("UTF-8");
+        final Charset UTF_8 = StandardCharsets.UTF_8;
         final Charset ISO_8859_2 = Charset.forName("ISO-8859-2");
         
         FileObject dummy = projdir.createData("Dummy.java");

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/SourceForBinaryQueryImpl.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/SourceForBinaryQueryImpl.java
@@ -20,9 +20,9 @@
 package org.netbeans.modules.java.freeform;
 
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.queries.SourceForBinaryQuery;
 import org.netbeans.api.project.ProjectManager;
@@ -213,7 +212,7 @@ final class SourceForBinaryQueryImpl implements SourceForBinaryQueryImplementati
                     } else {
                         md5.reset();
                     }
-                    final String digest = str(md5.digest(srcURI.toString().getBytes("UTF-8"))); //NOI18N
+                    final String digest = str(md5.digest(srcURI.toString().getBytes(StandardCharsets.UTF_8)));
                     final File binFile = new File (artBinaries,digest);
                     bin = FileUtil.urlForArchiveOrDir(binFile);
                     artificalBinariesCache.put(srcURI, bin);
@@ -221,7 +220,7 @@ final class SourceForBinaryQueryImpl implements SourceForBinaryQueryImplementati
                 res.add(bin);
             }
             return res;
-        } catch (UnsupportedEncodingException | NoSuchAlgorithmException e) {
+        } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
     }

--- a/java/java.hints.test/src/org/netbeans/modules/java/hints/test/api/HintTest.java
+++ b/java/java.hints.test/src/org/netbeans/modules/java/hints/test/api/HintTest.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -50,17 +51,9 @@ import java.util.logging.Logger;
 import java.util.prefs.AbstractPreferences;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
-import java.util.regex.Pattern;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.Document;
 import javax.tools.Diagnostic;
-import junit.framework.Assert;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNotSame;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.TestCase.assertFalse;
-
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.classpath.JavaClassPathConstants;
@@ -121,7 +114,6 @@ import org.netbeans.spi.lexer.MutableTextInput;
 import org.openide.LifecycleManager;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileStateInvalidException;
 import org.openide.filesystems.FileSystem;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.MultiFileSystem;
@@ -134,6 +126,12 @@ import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.lookup.Lookups;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 /**A support class for writing a test for a Java Hint. A test verifying that correct
  * warnings are produced should look like:
@@ -199,7 +197,7 @@ public class HintTest {
                 layers.add(en.nextElement());
             }
 
-            Assert.assertTrue(layer, found);
+            assertTrue(layer, found);
         }
 
         XMLFileSystem xmlFS = new XMLFileSystem();
@@ -1258,7 +1256,7 @@ public class HintTest {
 
     static {
         System.setProperty("org.openide.util.Lookup", TestLookup.class.getName());
-        Assert.assertEquals(TestLookup.class, Lookup.getDefault().getClass());
+        assertEquals(TestLookup.class, Lookup.getDefault().getClass());
     }
 
     //workdir computation (copied from NbTestCase):
@@ -1450,7 +1448,7 @@ public class HintTest {
 
     private static FileObject copyStringToFile (FileObject f, String content) throws Exception {
         OutputStream os = f.getOutputStream();
-        os.write(content.getBytes("UTF-8"));
+        os.write(content.getBytes(StandardCharsets.UTF_8));
         os.close ();
 
         return f;

--- a/java/java.hints.test/test/unit/src/org/netbeans/modules/java/hints/test/api/HintTestTest.java
+++ b/java/java.hints.test/test/unit/src/org/netbeans/modules/java/hints/test/api/HintTestTest.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import javax.swing.text.Document;
 import org.junit.Assert;
 import org.junit.Test;
@@ -121,9 +122,9 @@ public class HintTestTest {
             try {
                 FileObject resource = ctx.getWorkingCopy().getFileObject().getParent().getFileObject("test.txt");
                 Assert.assertNotNull(resource);
-                Reader r = new InputStreamReader(ctx.getResourceContent(resource), "UTF-8");
+                Reader r = new InputStreamReader(ctx.getResourceContent(resource), StandardCharsets.UTF_8);
                 ByteArrayOutputStream outData = new ByteArrayOutputStream();
-                Writer w = new OutputStreamWriter(outData, "UTF-8");
+                Writer w = new OutputStreamWriter(outData, StandardCharsets.UTF_8);
                 int read;
 
                 while ((read = r.read()) != -1) {

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/CreateSubclassTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/CreateSubclassTest.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.java.hints.suggestions;
 
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 import org.netbeans.modules.java.hints.test.api.HintTest;
 import org.openide.filesystems.FileUtil;
@@ -38,7 +39,7 @@ public class CreateSubclassTest {
         };
         HintTest test = HintTest.create();
         try (OutputStream out = FileUtil.createData(FileUtil.getConfigRoot(), "Templates/Classes/Class.java").getOutputStream()) {
-            out.write("public class New {}\n".getBytes("UTF-8"));
+            out.write("public class New {}\n".getBytes(StandardCharsets.UTF_8));
         }
         test.setCaretMarker('^')
             .input("package test;\n" +
@@ -60,7 +61,7 @@ public class CreateSubclassTest {
         };
         HintTest test = HintTest.create();
         try (OutputStream out = FileUtil.createData(FileUtil.getConfigRoot(), "Templates/Classes/Class.java").getOutputStream()) {
-            out.write("public class New {}\n".getBytes("UTF-8"));
+            out.write("public class New {}\n".getBytes(StandardCharsets.UTF_8));
         }
         test.setCaretMarker('^')
             .input("package test;\n" +
@@ -82,7 +83,7 @@ public class CreateSubclassTest {
         };
         HintTest test = HintTest.create();
         try (OutputStream out = FileUtil.createData(FileUtil.getConfigRoot(), "Templates/Classes/Class.java").getOutputStream()) {
-            out.write("public class New {}\n".getBytes("UTF-8"));
+            out.write("public class New {}\n".getBytes(StandardCharsets.UTF_8));
         }
         test.setCaretMarker('^')
             .input("package test;\n" +

--- a/java/java.j2seembedded/jreprobe/org/netbeans/modules/java/j2seembedded/wizard/JREProbe.java
+++ b/java/java.j2seembedded/jreprobe/org/netbeans/modules/java/j2seembedded/wizard/JREProbe.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -103,7 +104,7 @@ public class JREProbe {
         if (bomFile.canRead()) {
             try {
                 final BufferedReader in = new BufferedReader(new InputStreamReader(
-                    new FileInputStream(bomFile),"UTF-8")); //NOI18N
+                    new FileInputStream(bomFile), StandardCharsets.UTF_8));
                 try {
                     String line;
                     while ((line = in.readLine()) != null) {

--- a/java/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/FileEncodingQueryTest.java
+++ b/java/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/queries/FileEncodingQueryTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.j2seproject.queries;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.queries.FileEncodingQuery;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
@@ -70,7 +71,7 @@ public class FileEncodingQueryTest extends NbTestCase {
     }
 
     public void testFileEncodingQuery () throws Exception {
-        final Charset UTF8 = Charset.forName("UTF-8");
+        final Charset UTF8 = StandardCharsets.UTF_8;
         final Charset ISO15 = Charset.forName("ISO-8859-15");
         final Charset CP1252 = Charset.forName("CP1252");
         FileObject java = sources.createData("a.java");

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/URITranslator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/URITranslator.java
@@ -28,6 +28,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -132,7 +133,7 @@ public final class URITranslator {
                 try {
                     String txt = file.asText("UTF-8");          // NOI18N
                     try (OutputStream os = file.getOutputStream()) {
-                        os.write(txt.getBytes("UTF-8"));        // NOI18N
+                        os.write(txt.getBytes(StandardCharsets.UTF_8));
                     }
                 } catch (IOException ex) {
                     Exceptions.printStackTrace(ex);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbProcessConsole.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbProcessConsole.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 import org.netbeans.modules.java.lsp.server.ui.IOContext;
 import org.openide.util.Exceptions;
@@ -91,7 +92,7 @@ public final class NbProcessConsole extends IOContext {
     public void stdIn(String line) throws IOException {
         synchronized (this) {
             if (inputBuffer == null) {
-                inputBuffer = new BufferedWriter(new OutputStreamWriter(inputSource, "UTF-8"));
+                inputBuffer = new BufferedWriter(new OutputStreamWriter(inputSource, StandardCharsets.UTF_8));
             }
         }
         inputBuffer.write(line);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/htmlui/SimpleServer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/htmlui/SimpleServer.java
@@ -525,7 +525,7 @@ final class SimpleServer extends HttpServer<SimpleServer.ReqRes, SimpleServer.Re
         private final StringBuilder buffer = new StringBuilder();
 
         final ReqRes process(SelectionKey key, ByteBuffer chunk) throws UnsupportedEncodingException {
-            String text = new String(chunk.array(), 0, chunk.limit(), "US-ASCII");
+            String text = new String(chunk.array(), 0, chunk.limit(), StandardCharsets.US_ASCII);
             buffer.append(text);
             int fullHeader = buffer.indexOf("\r\n\r\n");
             if (fullHeader == -1) {
@@ -707,6 +707,6 @@ final class SimpleServer extends HttpServer<SimpleServer.ReqRes, SimpleServer.Re
     }
 
     private static void putString(ByteBuffer bb, String text) throws UnsupportedEncodingException {
-        bb.put(text.getBytes("US-ASCII"));
+        bb.put(text.getBytes(StandardCharsets.US_ASCII));
     }
 }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbProcessConsoleTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbProcessConsoleTest.java
@@ -23,19 +23,21 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.netbeans.modules.java.lsp.server.ui.AbstractLspInputOutputProvider;
 import org.netbeans.modules.java.lsp.server.ui.LspIOAccessor;
 import org.openide.util.Lookup;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -51,7 +53,7 @@ public class NbProcessConsoleTest {
     @Test
     public void testConsoleClose() throws Exception {
         InputStream sin = console.getStdIn();
-        BufferedReader rdr = new BufferedReader(new InputStreamReader(sin, "UTF-8"));
+        BufferedReader rdr = new BufferedReader(new InputStreamReader(sin, StandardCharsets.UTF_8));
         assertReaderClosed(rdr);
     }
     

--- a/java/java.navigation/test/unit/src/org/netbeans/modules/java/navigation/BreadCrumbsNodeImplTest.java
+++ b/java/java.navigation/test/unit/src/org/netbeans/modules/java/navigation/BreadCrumbsNodeImplTest.java
@@ -20,11 +20,11 @@ package org.netbeans.modules.java.navigation;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import static org.junit.Assert.*;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.api.java.source.SourceUtilsTestUtil;
@@ -34,7 +34,6 @@ import org.netbeans.modules.editor.breadcrumbs.spi.BreadcrumbsElement;
 import org.netbeans.spi.queries.FileEncodingQueryImplementation;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
-import org.openide.nodes.Node;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -171,7 +170,7 @@ public class BreadCrumbsNodeImplTest extends NbTestCase {
     @ServiceProvider(service=FileEncodingQueryImplementation.class)
     public static final class FEQImpl extends FileEncodingQueryImplementation {
         @Override public Charset getEncoding(FileObject file) {
-            return Charset.forName("UTF-8");
+            return StandardCharsets.UTF_8;
         }
     }
 }

--- a/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/ClassPathProviderImplTest.java
+++ b/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/ClassPathProviderImplTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.openjdk.project;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.classpath.ClassPath.PathConversionMode;
@@ -211,7 +212,7 @@ public class ClassPathProviderImplTest extends NbTestCase {
 
     private void copyString2File(FileObject file, String content) throws IOException {
         try (OutputStream out = file.getOutputStream()) {
-            out.write(content.getBytes("UTF-8"));
+            out.write(content.getBytes(StandardCharsets.UTF_8));
         }
     }
 

--- a/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/FilterStandardProjectsTest.java
+++ b/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/FilterStandardProjectsTest.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.java.openjdk.project;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
@@ -58,7 +59,7 @@ public class FilterStandardProjectsTest extends NbTestCase {
                        "  <module>\n" +
                        "    <name>java.compiler</name>\n" +
                        "  </module>\n" +
-                       "</modules>\n").getBytes("UTF-8"));
+                       "</modules>\n").getBytes(StandardCharsets.UTF_8));
         }
         FileUtil.createFolder(workDir, "langtools/src/java.compiler/share/classes");
         FileObject langtoolsPrj = FileUtil.createFolder(workDir, "langtools/make/netbeans/langtools");

--- a/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/SourceLevelQueryImplTest.java
+++ b/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/SourceLevelQueryImplTest.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.java.openjdk.project;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.netbeans.api.java.queries.SourceLevelQuery;
 import org.netbeans.api.project.FileOwnerQuery;
@@ -141,7 +142,7 @@ public class SourceLevelQueryImplTest extends NbTestCase {
 
     private void copyString2File(FileObject file, String content) throws IOException {
         try (OutputStream out = file.getOutputStream()) {
-            out.write(content.getBytes("UTF-8"));
+            out.write(content.getBytes(StandardCharsets.UTF_8));
         }
     }
 

--- a/java/java.source.ant/test/unit/src/org/netbeans/modules/java/source/ant/ProjectRunnerImplTest.java
+++ b/java/java.source.ant/test/unit/src/org/netbeans/modules/java/source/ant/ProjectRunnerImplTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -265,7 +266,7 @@ public class ProjectRunnerImplTest extends NbTestCase {
     @ServiceProvider(service=FileEncodingQueryImplementation.class)
     public static final class FEQImpl extends FileEncodingQueryImplementation {
         @Override public Charset getEncoding(FileObject file) {
-            return Charset.forName("UTF-8");
+            return StandardCharsets.UTF_8;
         }
     }
 }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/TreeShimsCopier.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/TreeShimsCopier.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -83,10 +84,10 @@ public class TreeShimsCopier extends AbstractProcessor {
                             baos.write(r);
                         }
                     }
-                    String content = new String(baos.toByteArray(), "UTF-8");
+                    String content = new String(baos.toByteArray(), StandardCharsets.UTF_8);
                     content = content.replace("package org.netbeans.modules.java.source;", "package " + targetPackage + ";");
                     try (OutputStream out = filer.createSourceFile(targetPackage + ".TreeShims", type).openOutputStream()) {
-                        out.write(content.getBytes("UTF-8"));
+                        out.write(content.getBytes(StandardCharsets.UTF_8));
                     }
                 } catch (IOException ex) {
                     throw new IllegalStateException(ex);

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
@@ -33,6 +33,7 @@ import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -405,7 +406,7 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
                         try {
                             final URLConnection uc = resources.nextElement().openConnection();
                             uc.setUseCaches(false);
-                            ins = new BufferedReader(new InputStreamReader(uc.getInputStream(), "UTF-8")); //NOI18N
+                            ins = new BufferedReader(new InputStreamReader(uc.getInputStream(), StandardCharsets.UTF_8));
                             String line;
                             while ((line = ins.readLine()) != null) {
                                 int hash = line.indexOf('#');

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
@@ -34,6 +34,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -875,7 +876,7 @@ public class JavaCustomIndexer extends CustomIndexer {
 
     private static Iterable<String> readRSFile (final File file) throws IOException {
         final LinkedHashSet<String> binaryNames = new LinkedHashSet<String>();
-        BufferedReader in = new BufferedReader (new InputStreamReader ( new FileInputStream (file), "UTF-8")); //NOI18N
+        BufferedReader in = new BufferedReader (new InputStreamReader ( new FileInputStream (file), StandardCharsets.UTF_8));
         try {
             String binaryName;
             while ((binaryName=in.readLine())!=null) {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchive.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchive.java
@@ -24,7 +24,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -408,11 +408,7 @@ public class CachingArchive implements Archive, FileChangeListener {
         }
         byte[] name = new byte[len];
         System.arraycopy(names, off, name, 0, len);
-        try {
-            return new String(name, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new InternalError("No UTF-8");
-        }
+        return new String(name, StandardCharsets.UTF_8);
     }
 
     /*test*/ static long join(int higher, int lower) {
@@ -534,18 +530,14 @@ public class CachingArchive implements Archive, FileChangeListener {
                 indices = newInd;
             }
 
-            try {
-                byte[] bytes = name.getBytes("UTF-8");
-                indices[idx++] = outer.putName(bytes);
-                indices[idx++] = bytes.length;
-                indices[idx++] = (int)(mtime & 0xFFFFFFFF);
-                indices[idx++] = (int)(mtime >> 32);
-                if (delta == 6) {
-                    indices[idx++] = (int)(offset & 0xFFFFFFFF);
-                    indices[idx++] = (int)(offset >> 32);
-                }
-            } catch (UnsupportedEncodingException e) {
-                throw new InternalError("No UTF-8");
+            byte[] bytes = name.getBytes(StandardCharsets.UTF_8);
+            indices[idx++] = outer.putName(bytes);
+            indices[idx++] = bytes.length;
+            indices[idx++] = (int)(mtime & 0xFFFFFFFF);
+            indices[idx++] = (int)(mtime >> 32);
+            if (delta == 6) {
+                indices[idx++] = (int)(offset & 0xFFFFFFFF);
+                indices[idx++] = (int)(offset >> 32);
             }
         }
 

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingPathArchive.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingPathArchive.java
@@ -19,8 +19,8 @@
 package org.netbeans.modules.java.source.parsing;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
@@ -142,11 +142,7 @@ public class CachingPathArchive extends AbstractPathArchive {
     }
 
     private String getName(final int start, final int len) {
-        try {
-            return new String(packedNames, start, len, "UTF-8");    //NOI18N
-        } catch (UnsupportedEncodingException ue) {
-            throw new IllegalStateException(ue);
-        }
+        return new String(packedNames, start, len, StandardCharsets.UTF_8);
     }
 
     @NonNull
@@ -175,7 +171,7 @@ public class CachingPathArchive extends AbstractPathArchive {
                     if (cf.length < co+2) {
                         cf = state.currentFolder = Arrays.copyOfRange(cf, 0, 2 + cf.length<<1);
                     }
-                    final byte[] name = file.getFileName().toString().getBytes("UTF-8");
+                    final byte[] name = file.getFileName().toString().getBytes(StandardCharsets.UTF_8);
                     cf[co] = putName(name);
                     cf[co+1] = name.length;
                     state.currentOffset+=2;

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FastJar.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FastJar.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -207,7 +208,7 @@ public final class FastJar {
     private static final String name(final RandomAccessFile b, final int cennam) throws IOException {
 	byte[] name = new byte[cennam];
 	b.read(name, 0, cennam);
-	return new String(name, "UTF-8");       //NOI18N
+	return new String(name, StandardCharsets.UTF_8);
     }
 
     private static final long getsig(final byte[] b) throws IOException {return get32(b,0);}

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FileObjects.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FileObjects.java
@@ -48,6 +48,7 @@ import java.nio.Buffer;
 import java.nio.CharBuffer;
 import java.nio.channels.CompletionHandler;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -133,7 +134,7 @@ public class FileObjects {
     public static final String MODULE_INFO = "module-info";   //NOI18N
 
     private static final Charset SYSTEM_ENCODING = Charset.defaultCharset();
-    private static final Charset UTF8_ENCODING = Charset.forName("UTF-8");  //NOI18N
+    private static final Charset UTF8_ENCODING = StandardCharsets.UTF_8;
     private static final Pattern MATCHER_PATCH =
                 Pattern.compile("(.+)=(.+)");  //NOI18N
     //todo: If more clients than btrace will need this, create a SPI.

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -45,6 +45,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1316,7 +1317,7 @@ public class JavacParser extends Parser {
         if (f != null) {
             try {
                 OutputStream os = new FileOutputStream(f);
-                try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(os, "UTF-8"))) {   //NOI18N
+                try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8))) {
                     writer.println(src);
                     writer.println("----- Classpath: ---------------------------------------------"); // NOI18N
 

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ProcessorGenerated.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ProcessorGenerated.java
@@ -28,6 +28,7 @@ import java.io.Reader;
 import java.io.Writer;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collection;
@@ -260,7 +261,7 @@ public final class ProcessorGenerated extends TransactionContext.Service {
     private StringBuilder readFile(final File file) {        
         StringBuilder sb = new StringBuilder();
         try {
-            final Reader in = new InputStreamReader (new FileInputStream (file),"UTF-8");   //NOI18N
+            final Reader in = new InputStreamReader (new FileInputStream (file), StandardCharsets.UTF_8);
             try {
                 char[] buffer = new char[1024];
                 int len;
@@ -288,7 +289,7 @@ public final class ProcessorGenerated extends TransactionContext.Service {
     }
     
     private void writeFile (@NonNull final File file, @NonNull final StringBuilder data) throws IOException {        
-        final Writer out = new OutputStreamWriter(new FileOutputStream(file),"UTF-8");    //NOI18N
+        final Writer out = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
         try {
             out.write(data.toString());
         } finally {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/usages/BinaryAnalyser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/usages/BinaryAnalyser.java
@@ -32,6 +32,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
@@ -477,7 +478,7 @@ public class BinaryAnalyser {
         List<Pair<ElementHandle<TypeElement>,Long>> result = new LinkedList<Pair<ElementHandle<TypeElement>, Long>>();
         final File file = new File (indexFolder,CRC);
         if (file.canRead()) {
-            BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(file),"UTF-8"));   //NOI18N
+            BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
 
             try {
                 String line;
@@ -505,7 +506,7 @@ public class BinaryAnalyser {
         if (state.isEmpty()) {
             file.delete();
         } else {
-            final PrintWriter out = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file),"UTF-8"));   //NOI18N
+            final PrintWriter out = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
             try {
                 for (Pair<ElementHandle<TypeElement>,Long> pair : state) {
                     StringBuilder sb = new StringBuilder(pair.first().getBinaryName());
@@ -525,7 +526,7 @@ public class BinaryAnalyser {
             final LongHashMap<String> map = new LongHashMap<String>();
             final File f = new File (cacheRoot, TIME_STAMPS); //NOI18N
             if (f.exists()) {
-                final BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(f), "UTF-8")); //NOI18N
+                final BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8));
                 try {
                     String line;
                     while (null != (line = in.readLine())) {
@@ -554,7 +555,7 @@ public class BinaryAnalyser {
             f.delete();
         } else {
             timeStamps.first().keySet().removeAll(timeStamps.second());
-            final BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(f), "UTF-8")); //NOI18N
+            final BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(f), StandardCharsets.UTF_8));
             try {
                 // write data
                 for(LongHashMap.Entry<String> entry : timeStamps.first().entrySet()) {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/usages/SourceAnalyzerFactory.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/usages/SourceAnalyzerFactory.java
@@ -34,6 +34,7 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.logging.Level;
@@ -148,7 +149,7 @@ public final class SourceAnalyzerFactory {
                         javax.tools.FileObject fo = manager.getFileForOutput(StandardLocation.CLASS_OUTPUT, "", FileObjects.stripExtension(relativePath) + '.' + ext, tuple.jfo);
                         assert fo != null;
                         try {
-                            BufferedReader in = new BufferedReader ( new InputStreamReader (fo.openInputStream(), "UTF-8"));
+                            BufferedReader in = new BufferedReader ( new InputStreamReader (fo.openInputStream(), StandardCharsets.UTF_8));
                             try {
                                 String line;
                                 while ((line = in.readLine())!=null) {
@@ -164,7 +165,7 @@ public final class SourceAnalyzerFactory {
                             //workarond: use manager.getFileForOutput() which may return non existing javac FileObject and
                             //cahch FileNotFoundException when it doens't exist, there is nothing to add into rsList
                         }
-                        PrintWriter rsOut = new PrintWriter( new OutputStreamWriter (fo.openOutputStream(), "UTF-8"));
+                        PrintWriter rsOut = new PrintWriter( new OutputStreamWriter (fo.openOutputStream(), StandardCharsets.UTF_8));
                         try {
                             for (String sig : uv.rsList) {
                                 rsOut.println(sig);

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/ElementsTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/ElementsTest.java
@@ -24,6 +24,7 @@ import com.sun.source.util.TreePath;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
@@ -50,7 +51,7 @@ public class ElementsTest extends NbTestCase {
             @Override
             public Charset getEncoding(FileObject file) {
                 if (file.equals(testFO))
-                    return Charset.forName("UTF-8");
+                    return StandardCharsets.UTF_8;
                 else
                     return null;
             }

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TestUtilities.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TestUtilities.java
@@ -30,6 +30,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
@@ -173,7 +174,7 @@ public final class TestUtilities {
      */
     public static final File copyStringToFile (File f, String content) throws Exception {
         FileOutputStream os = new FileOutputStream(f);
-        InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+        InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
         FileUtil.copy(is, os);
         os.close ();
         is.close();
@@ -190,7 +191,7 @@ public final class TestUtilities {
      */
     public static final FileObject copyStringToFile (FileObject f, String content) throws Exception {
         OutputStream os = f.getOutputStream();
-        InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+        InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
         FileUtil.copy(is, os);
         os.close ();
         is.close();

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CompilationUnitTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/CompilationUnitTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
@@ -155,14 +156,14 @@ public class CompilationUnitTest extends GeneratorTestMDRCompat {
         FileObject classJava = FileUtil.createData(FileUtil.getConfigRoot(), "Templates/Classes/Class.java");
         classJava.setAttribute("template", Boolean.TRUE);
         classJava.setAttribute("verbatim-create-from-template", Boolean.TRUE);
-        Writer w = new OutputStreamWriter(classJava.getOutputStream(), "UTF-8");
+        Writer w = new OutputStreamWriter(classJava.getOutputStream(), StandardCharsets.UTF_8);
         w.write("/*\n * License\n */\npackage zoo;\n\n/**\n * trida\n */\npublic class Template {\n}");
         w.close();
 
         FileObject packageJava = FileUtil.createData(FileUtil.getConfigRoot(), "Templates/Classes/package-info.java");
         packageJava.setAttribute("template", Boolean.TRUE);
         packageJava.setAttribute("verbatim-create-from-template", Boolean.TRUE);
-        Writer w2 = new OutputStreamWriter(packageJava.getOutputStream(), "UTF-8");
+        Writer w2 = new OutputStreamWriter(packageJava.getOutputStream(), StandardCharsets.UTF_8);
         w2.write("/*\n * License\n */\npackage zoo;\n");
         w2.close();
 
@@ -1015,7 +1016,7 @@ public class CompilationUnitTest extends GeneratorTestMDRCompat {
         emptyJava.setAttribute("template", Boolean.TRUE);
         FileObject classJava = FileUtil.createData(FileUtil.getConfigRoot(), "Templates/Classes/Class.java");
         classJava.setAttribute("template", Boolean.TRUE);
-        Writer w = new OutputStreamWriter(classJava.getOutputStream(), "UTF-8");
+        Writer w = new OutputStreamWriter(classJava.getOutputStream(), StandardCharsets.UTF_8);
         w.write("package zoo;\npublic class Template {\n    public Template() {}\n}");
         w.close();
         FileObject testSourceFO = FileUtil.toFileObject(testFile);
@@ -1152,7 +1153,7 @@ public class CompilationUnitTest extends GeneratorTestMDRCompat {
         classJava.setAttribute("template", Boolean.TRUE);
         classJava.setAttribute("verbatim-create-from-template", Boolean.TRUE);
         template = "/*\r\ninitial\r\ncomment\r\n*/\r\npackage zoo;\r\npublic class Template {\r\n    public Template() {}\r\n}\r\n";
-        Writer w = new OutputStreamWriter(classJava.getOutputStream(), "UTF-8");
+        Writer w = new OutputStreamWriter(classJava.getOutputStream(), StandardCharsets.UTF_8);
         w.write(template);
         w.close();
     }
@@ -1255,7 +1256,7 @@ public class CompilationUnitTest extends GeneratorTestMDRCompat {
         emptyJava.setAttribute("template", Boolean.TRUE);
         FileObject classJava = FileUtil.createData(FileUtil.getConfigRoot(), "Templates/Classes/Class.java");
         classJava.setAttribute("template", Boolean.TRUE);
-        Writer w = new OutputStreamWriter(classJava.getOutputStream(), "UTF-8");
+        Writer w = new OutputStreamWriter(classJava.getOutputStream(), StandardCharsets.UTF_8);
         w.write("package zoo;\npublic class Template {\n  \n}");
         w.close();
         FileObject testSourceFO = FileUtil.toFileObject(testFile);

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/support/ReferencesCountTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/support/ReferencesCountTest.java
@@ -24,6 +24,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -181,7 +182,7 @@ public class ReferencesCountTest extends NbTestCase {
         final FileObject file = FileUtil.createData(root, fqn.replace('.', '/')+"."+JavaDataLoader.JAVA_EXTENSION);   //NOI18N
         final FileLock lck = file.lock();
         try {
-            final PrintWriter out = new PrintWriter(new OutputStreamWriter(file.getOutputStream(lck),"UTF-8"));    //NOI18N
+            final PrintWriter out = new PrintWriter(new OutputStreamWriter(file.getOutputStream(lck), StandardCharsets.UTF_8));
             try {
                 out.print(content);
             } finally {
@@ -201,7 +202,7 @@ public class ReferencesCountTest extends NbTestCase {
         @Override
         public Charset getEncoding(FileObject file) {
             if (file == interestedIn || FileUtil.isParentOf(interestedIn, file)) {
-                return Charset.forName("UTF-8"); //NOI18N
+                return StandardCharsets.UTF_8;
             }
             return null;
         }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/ModuleNamesTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/ModuleNamesTest.java
@@ -38,6 +38,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -519,7 +520,7 @@ public class ModuleNamesTest extends NbTestCase {
         return () -> {
             try {
                 final FileObject file = FileUtil.createData(folder, name);
-                try (PrintWriter out = new PrintWriter(new OutputStreamWriter(file.getOutputStream(), "UTF-8"))) {  //NOI18N
+                try (PrintWriter out = new PrintWriter(new OutputStreamWriter(file.getOutputStream(), StandardCharsets.UTF_8))) {
                     out.println(content.get());
                 }
                 return file;

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARCachingFileManagerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARCachingFileManagerTest.java
@@ -18,13 +18,12 @@
  */
 package org.netbeans.modules.java.source.parsing;
 
-import com.sun.tools.javac.code.Source;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -167,7 +166,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
         final StandardJavaFileManager fm = jc.getStandardFileManager(
                 null,
                 Locale.ENGLISH,
-                Charset.forName("UTF-8"));  //NOI18N
+                StandardCharsets.UTF_8);
         fm.setLocation(
                 StandardLocation.CLASS_PATH,
                 Collections.singleton(FileUtil.archiveOrDirForURL(mvCp.entries().get(0).getURL())));
@@ -358,7 +357,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
                     try {
                         final BufferedReader in = new BufferedReader(new InputStreamReader(
                                 jfo.openInputStream(),
-                                Charset.forName("UTF-8"))); //NOI18N
+                                StandardCharsets.UTF_8));
                         return in.readLine();
                     } catch (IOException ioe) {
                         throw new RuntimeException(ioe);
@@ -408,7 +407,7 @@ public class MRJARCachingFileManagerTest extends NbTestCase {
                             path :
                             String.format("%s/%s", prefix[0], path);            //NOI18N
                     jar.putNextEntry(new ZipEntry(pathWithScope));
-                    jar.write(String.format("%s %s", name, prefix[1]).getBytes(Charset.forName("UTF-8")));  //NOI18N
+                    jar.write(String.format("%s %s", name, prefix[1]).getBytes(StandardCharsets.UTF_8));
                     jar.closeEntry();
                 }
             }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARModuleFileManagerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/MRJARModuleFileManagerTest.java
@@ -18,33 +18,27 @@
  */
 package org.netbeans.modules.java.source.parsing;
 
-import com.sun.tools.javac.code.Source;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Locale;
-import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import java.util.zip.ZipEntry;
-import javax.tools.JavaCompiler;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
-import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
-import javax.tools.ToolProvider;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.junit.NbTestCase;
@@ -222,8 +216,7 @@ public class MRJARModuleFileManagerTest extends NbTestCase {
                 .map((jfo) -> {
                     try {
                         final BufferedReader in = new BufferedReader(new InputStreamReader(
-                                jfo.openInputStream(),
-                                Charset.forName("UTF-8"))); //NOI18N
+                                jfo.openInputStream(), StandardCharsets.UTF_8));
                         return in.readLine();
                     } catch (IOException ioe) {
                         throw new RuntimeException(ioe);
@@ -273,7 +266,7 @@ public class MRJARModuleFileManagerTest extends NbTestCase {
                             path :
                             String.format("%s/%s", prefix[0], path);            //NOI18N
                     jar.putNextEntry(new ZipEntry(pathWithScope));
-                    jar.write(String.format("%s %s", name, prefix[1]).getBytes(Charset.forName("UTF-8")));  //NOI18N
+                    jar.write(String.format("%s %s", name, prefix[1]).getBytes(StandardCharsets.UTF_8));  //NOI18N
                     jar.closeEntry();
                 }
             }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ModuleOraculumTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ModuleOraculumTest.java
@@ -23,6 +23,7 @@ import com.sun.tools.javac.util.Options;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -526,7 +527,7 @@ public class ModuleOraculumTest extends NbTestCase {
             fld = root;
         }
         final FileObject file = FileUtil.createData(fld, name);
-        try(PrintWriter out = new PrintWriter(new OutputStreamWriter(file.getOutputStream(), "UTF-8"))) {   //NOI18N
+        try(PrintWriter out = new PrintWriter(new OutputStreamWriter(file.getOutputStream(), StandardCharsets.UTF_8))) {
             out.println(content);
         }
         return file;

--- a/java/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
+++ b/java/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
@@ -89,6 +89,7 @@ import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 
 import com.sun.tools.classfile.ConstantPool.CPInfo;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.ClasspathInfo.PathKind;
@@ -138,7 +139,7 @@ public class CodeGenerator {
             OutputStream out = file.getOutputStream();
 
             try {
-                FileUtil.copy(new ByteArrayInputStream("".getBytes("UTF-8")), out); //NOI18N
+                FileUtil.copy(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)), out); //NOI18N
             } finally {
                 out.close();
             }
@@ -251,7 +252,7 @@ public class CodeGenerator {
                 }
                 out = result[0].getOutputStream();
                 try {
-                    FileUtil.copy(new ByteArrayInputStream(r.getResultingSource(file).getBytes("UTF-8")), out);
+                    FileUtil.copy(new ByteArrayInputStream(r.getResultingSource(file).getBytes(StandardCharsets.UTF_8)), out);
                 } finally {
                     out.close();
                 }

--- a/java/jshell.support/src/org/netbeans/modules/jshell/env/WriterOutputStream.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/env/WriterOutputStream.java
@@ -23,10 +23,10 @@ import java.io.OutputStream;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Stream backed by a Writer. Uses UTF-8 to decode characters from the stream.
@@ -42,7 +42,7 @@ class WriterOutputStream extends OutputStream {
 
     public WriterOutputStream(Writer out) {
         this.writer = out;
-        this.decoder = Charset.forName("UTF-8"). //NOI18N
+        this.decoder = StandardCharsets.UTF_8.
                 newDecoder().
                 onMalformedInput(CodingErrorAction.REPLACE).
                 onUnmappableCharacter(CodingErrorAction.REPLACE).

--- a/java/jshell.support/src/org/netbeans/modules/jshell/parsing/SnippetRegistry.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/parsing/SnippetRegistry.java
@@ -24,6 +24,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -448,7 +449,7 @@ public final class SnippetRegistry {
                 }
             }
             try (OutputStream ostm = pkg.createAndOpen(fn)) {
-                try (OutputStreamWriter ows = new OutputStreamWriter(ostm, "UTF-8")) {
+                try (OutputStreamWriter ows = new OutputStreamWriter(ostm, StandardCharsets.UTF_8)) {
                     ows.append(contents);
                     ows.flush();
                 }

--- a/java/jshell.support/src/org/netbeans/modules/jshell/support/FileHistory.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/support/FileHistory.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.jshell.support;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -221,7 +222,7 @@ public class FileHistory implements ShellHistory {
         }
         
         try (BufferedWriter wr = new BufferedWriter(
-                new OutputStreamWriter(historyFile.getOutputStream(), "UTF-8"))) {
+                new OutputStreamWriter(historyFile.getOutputStream(), StandardCharsets.UTF_8))) {
             for (Item item : itemsToSave) {
                 String s = item2String(item);
                 String[] lines = s.split("\n");

--- a/java/jshell.support/src/org/netbeans/modules/jshell/support/ShellSession.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/support/ShellSession.java
@@ -44,6 +44,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -96,7 +97,6 @@ import org.netbeans.modules.jshell.model.SnippetHandle;
 import org.netbeans.modules.jshell.parsing.ShellAccessBridge;
 import org.netbeans.modules.jshell.parsing.SnippetRegistry;
 import org.netbeans.modules.jshell.project.ShellProjectUtils;
-import static org.netbeans.modules.jshell.tool.JShellLauncher.quote;
 import org.netbeans.modules.jshell.support.ShellHistory.Item;
 import org.netbeans.modules.parsing.api.ParserManager;
 import org.netbeans.modules.parsing.api.ResultIterator;
@@ -120,6 +120,8 @@ import org.openide.util.NbPreferences;
 import org.openide.util.Pair;
 import org.openide.util.RequestProcessor;
 import org.openide.util.Task;
+
+import static org.netbeans.modules.jshell.tool.JShellLauncher.quote;
 
 /**
  * The root object for any JShell session. A shell session consists of:
@@ -395,7 +397,7 @@ public class ShellSession  {
         
         public WriterOutputStream(Writer out) {
             this.writer = out;
-            this.decoder = Charset.forName("UTF-8"). //NOI18N
+            this.decoder = StandardCharsets.UTF_8.
                     newDecoder().
                     onMalformedInput(CodingErrorAction.REPLACE).
                     onUnmappableCharacter(CodingErrorAction.REPLACE).

--- a/java/junit.ant/src/org/netbeans/modules/junit/ant/JUnitOutputReader.java
+++ b/java/junit.ant/src/org/netbeans/modules/junit/ant/JUnitOutputReader.java
@@ -23,7 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.UnsupportedCharsetException;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -33,7 +33,6 @@ import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;
-import static java.util.logging.Level.FINER;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -56,15 +55,6 @@ import org.netbeans.modules.gsf.testrunner.api.TestSuite;
 import org.netbeans.modules.gsf.testrunner.api.Testcase;
 import org.netbeans.modules.gsf.testrunner.api.Trouble;
 import org.netbeans.modules.java.testrunner.JavaRegexpUtils;
-import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.ADD_ERROR_PREFIX;
-import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.ADD_FAILURE_PREFIX;
-import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.END_OF_TEST_PREFIX;
-import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.START_OF_TEST_PREFIX;
-import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.TESTCASE_PREFIX;
-import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.TESTSUITE_PREFIX;
-import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.TESTSUITE_STATS_PREFIX;
-import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.TESTS_COUNT_PREFIX;
-import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.TEST_LISTENER_PREFIX;
 import org.netbeans.modules.java.testrunner.ant.utils.AntProject;
 import org.netbeans.modules.junit.api.JUnitTestSuite;
 import org.netbeans.modules.junit.api.JUnitTestcase;
@@ -76,6 +66,17 @@ import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.Utilities;
 import org.xml.sax.SAXException;
+
+import static java.util.logging.Level.FINER;
+import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.ADD_ERROR_PREFIX;
+import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.ADD_FAILURE_PREFIX;
+import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.END_OF_TEST_PREFIX;
+import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.START_OF_TEST_PREFIX;
+import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.TESTCASE_PREFIX;
+import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.TESTSUITE_PREFIX;
+import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.TESTSUITE_STATS_PREFIX;
+import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.TESTS_COUNT_PREFIX;
+import static org.netbeans.modules.java.testrunner.JavaRegexpUtils.TEST_LISTENER_PREFIX;
 
 /**
  * Obtains events from a single session of an Ant <code>junit</code> task
@@ -896,11 +897,7 @@ final class JUnitOutputReader {
         JUnitTestSuite suite = null;
         try {
             suite = XmlOutputParser.parseXmlOutput(
-                    new InputStreamReader(
-                            new FileInputStream(reportFile),
-                            "UTF-8"), testSession);                                  //NOI18N
-        } catch (UnsupportedCharsetException ex) {
-            assert false;
+                    new InputStreamReader(new FileInputStream(reportFile), StandardCharsets.UTF_8), testSession);
         } catch (SAXException ex) {
             /* This exception has already been handled. */
         } catch (IOException ex) {

--- a/java/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/RemoteAgent.java
+++ b/java/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/RemoteAgent.java
@@ -25,19 +25,17 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.Socket;
-
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.netbeans.lib.jshell.agent.RemoteCodes.*;
-
 import java.util.Map;
 import java.util.TreeMap;
+
+import static org.netbeans.lib.jshell.agent.RemoteCodes.*;
 
 /**
  * The remote agent runs in the execution process (separate from the main JShell
@@ -288,12 +286,8 @@ class RemoteAgent {
         private final OutputStream delegate;
 
         public MultiplexingOutputStream(String name, OutputStream delegate) {
-            try {
-                this.name = name.getBytes("UTF-8");
-                this.delegate = delegate;
-            } catch (UnsupportedEncodingException ex) {
-                throw new IllegalStateException(ex); //should not happen
-            }
+            this.name = name.getBytes(StandardCharsets.UTF_8);
+            this.delegate = delegate;
         }
 
         @Override

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/PomModelUtils.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/PomModelUtils.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -203,7 +204,7 @@ public final class PomModelUtils {
                 if (err.get() != null) {
                     throw new IOException(err.get());
                 } else {
-                    return new ByteArrayInputStream(content.get().getBytes("UTF-8"));
+                    return new ByteArrayInputStream(content.get().getBytes(StandardCharsets.UTF_8));
                 }
             }
             return new FileInputStream(pomFile);

--- a/java/maven.model/src/org/netbeans/modules/maven/model/Utilities.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/Utilities.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.maven.model;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -237,7 +238,7 @@ public class Utilities {
                         }
                         OutputStream os = fo.getOutputStream();
                         try {
-                            os.write(text.getBytes("UTF-8"));
+                            os.write(text.getBytes(StandardCharsets.UTF_8));
                         } finally {
                             os.close();
                         }

--- a/java/maven/mavensrc/org/netbeans/modules/maven/event/NbEventSpy.java
+++ b/java/maven/mavensrc/org/netbeans/modules/maven/event/NbEventSpy.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.maven.event;
 
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.maven.eventspy.AbstractEventSpy;
 import org.apache.maven.execution.ExecutionEvent;
@@ -197,8 +198,8 @@ public class NbEventSpy extends AbstractEventSpy {
                         JSONObject excep = new JSONObject();
                         //all mojo failed events in current codebase are lifecycle execs.
                         String message = exc.getCause().getMessage();
-                        byte[] enc = Base64.encodeBase64(message.getBytes("UTF-8")); //NOW are these conversions correct?
-                        String encString = new String(enc, "UTF-8");
+                        byte[] enc = Base64.encodeBase64(message.getBytes(StandardCharsets.UTF_8)); //NOW are these conversions correct?
+                        String encString = new String(enc, StandardCharsets.UTF_8);
                         excep.put("msg", encString);
                         root.put("exc", excep);
                     }

--- a/java/maven/src/org/netbeans/modules/maven/M2AuxilaryConfigImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/M2AuxilaryConfigImpl.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;

--- a/java/maven/src/org/netbeans/modules/maven/execute/cmd/ExecMojo.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/cmd/ExecMojo.java
@@ -19,9 +19,9 @@
 
 package org.netbeans.modules.maven.execute.cmd;
 
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -70,12 +70,8 @@ public class ExecMojo extends ExecutionEventObject {
         if (exc != null) {
             String message = (String) exc.get("msg");
             if (message != null) {
-                try {
-                    byte[] bytes = Base64.decodeBase64(message.getBytes("UTF-8"));
-                    toRet.setErrorMessage(new String(bytes, "UTF-8"));
-                } catch (UnsupportedEncodingException ex) {
-                    Exceptions.printStackTrace(ex);
-                }
+                byte[] bytes = Base64.decodeBase64(message.getBytes(StandardCharsets.UTF_8));
+                toRet.setErrorMessage(new String(bytes, StandardCharsets.UTF_8));
             }
         }
         JSONObject loc = (JSONObject) mojo.get("loc");

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/execute/MavenExecutionTestBase.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/execute/MavenExecutionTestBase.java
@@ -22,14 +22,13 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
-import static junit.framework.TestCase.assertTrue;
-import static junit.framework.TestCase.fail;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -64,6 +63,7 @@ import org.openide.util.lookup.InstanceContent;
 import org.openide.util.lookup.Lookups;
 import org.openide.util.test.MockLookup;
 import org.openide.windows.InputOutput;
+
 
 /**
  *
@@ -138,7 +138,7 @@ public class MavenExecutionTestBase extends NbTestCase {
             Map<String, String> profileProperties) throws IOException, XmlPullParserException {
         StringBuilder sb = new StringBuilder();
         try (BufferedReader rdr = new BufferedReader(new InputStreamReader(
-                getClass().getResourceAsStream("nbactions-template.xml"), "UTF-8"))) {
+                getClass().getResourceAsStream("nbactions-template.xml"), StandardCharsets.UTF_8))) {
             String l;
             
             while ((l = rdr.readLine()) != null) {

--- a/java/performance/test/unit/src/org/netbeans/performance/scalability/TabSwitchSpeedTest.java
+++ b/java/performance/test/unit/src/org/netbeans/performance/scalability/TabSwitchSpeedTest.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -252,7 +253,7 @@ public class TabSwitchSpeedTest extends NbTestCase {
 
     private static void writeModule(File file, String xml) throws IOException {
         FileOutputStream os = new FileOutputStream(file);
-        os.write(xml.getBytes("UTF-8"));
+        os.write(xml.getBytes(StandardCharsets.UTF_8));
         os.close();
     }
     private static String asString(InputStream is, boolean close) throws IOException {
@@ -264,7 +265,7 @@ public class TabSwitchSpeedTest extends NbTestCase {
         if (close) {
             is.close();
         }
-        return new String(arr, "UTF-8"); // NOI18N
+        return new String(arr, StandardCharsets.UTF_8);
     }
 }
 

--- a/java/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceParser.java
+++ b/java/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/WorkspaceParser.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -283,7 +284,7 @@ final class WorkspaceParser {
         byte[] path = new byte[pathLength];
         int read = is.read(path);
         assert read == pathLength;
-        String pathS = new String(path, "ISO-8859-1"); // NOI18N
+        String pathS = new String(path, StandardCharsets.ISO_8859_1);
         if (pathS.startsWith("URI//")) { // #89577 // NOI18N
             pathS = pathS.substring(pathS.indexOf(':') + 1);
         }

--- a/java/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/TestUtils.java
+++ b/java/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/TestUtils.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.lexer.Language;
 import org.netbeans.api.xml.lexer.XMLTokenId;
 import org.netbeans.editor.BaseDocument;
@@ -75,7 +76,7 @@ public class TestUtils {
     }
 
     public static void copyStringToFile(String string, File path) throws IOException {
-        InputStream inputStream = new ByteArrayInputStream(string.getBytes("UTF-8"));
+        InputStream inputStream = new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8));
         try {
             copyStreamToFile(inputStream, path);
         } finally {
@@ -91,7 +92,7 @@ public class TestUtils {
         } finally {
             inputStream.close();
         }
-        return new String(outputStream.toByteArray(), "UTF-8");
+        return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
     }
 
     private static void copyStreamToFile(InputStream inputStream, File path) throws IOException {

--- a/java/testng.ant/src/org/netbeans/modules/testng/ant/TestNGOutputReader.java
+++ b/java/testng.ant/src/org/netbeans/modules/testng/ant/TestNGOutputReader.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.UnsupportedCharsetException;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.*;
@@ -899,11 +899,7 @@ final class TestNGOutputReader {
         XmlResult reports = null;
         try {
             reports = XmlOutputParser.parseXmlOutput(
-                    new InputStreamReader(
-                    new FileInputStream(reportFile),
-                    "UTF-8"), session);                                  //NOI18N
-        } catch (UnsupportedCharsetException ex) {
-            assert false;
+                    new InputStreamReader(new FileInputStream(reportFile), StandardCharsets.UTF_8), session);
         } catch (SAXException ex) {
             /*
              * This exception has already been handled.

--- a/java/whitelist/src/org/netbeans/spi/whitelist/support/WhiteListImplementationBuilder.java
+++ b/java/whitelist/src/org/netbeans/spi/whitelist/support/WhiteListImplementationBuilder.java
@@ -18,7 +18,7 @@
  */
 package org.netbeans.spi.whitelist.support;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -719,11 +719,7 @@ final class WhiteListImplementationBuilder {
         }
 
         private byte[] decode(String str) {
-            try {
-                return str.getBytes("UTF-8");   //NOI18N
-            } catch (UnsupportedEncodingException e) {
-                throw new IllegalStateException("No UTF-8 supported");  //Should never happen
-            }
+            return str.getBytes(StandardCharsets.UTF_8);
         }
 
         private static class Entry {

--- a/javafx/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/impl/CompletionContextTest.java
+++ b/javafx/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/completion/impl/CompletionContextTest.java
@@ -27,6 +27,7 @@ import java.io.OutputStreamWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -74,7 +75,7 @@ public class CompletionContextTest extends FXMLCompletionTestBase {
         File f = new File(dataDir, CompletionContextTest.class.getPackage().getName().replaceAll("\\.", "/") + 
                 "/" + fname);
         InputStream stream = new FileInputStream(f);
-        InputStreamReader rd = new InputStreamReader(stream, "UTF-8");
+        InputStreamReader rd = new InputStreamReader(stream, StandardCharsets.UTF_8);
         
         StringBuffer sb = new StringBuffer();
         CharBuffer cb = CharBuffer.allocate(10000);

--- a/javafx/maven.htmlui/test/unit/src/org/netbeans/modules/maven/htmlui/MacUtilitiesTest.java
+++ b/javafx/maven.htmlui/test/unit/src/org/netbeans/modules/maven/htmlui/MacUtilitiesTest.java
@@ -21,9 +21,11 @@ package org.netbeans.modules.maven.htmlui;
 import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 public class MacUtilitiesTest {
@@ -40,7 +42,7 @@ public class MacUtilitiesTest {
 "iPhone 8 Plus (11.2) + Apple Watch Series 3 - 42mm (4.2) [76199641-279E-411E-8751-EA504D6B4DA3] (Simulator)\n" +
 "";
         List<Device> result = new ArrayList<>();
-        MacUtilities.parseDevices(result, new ByteArrayInputStream(output.getBytes("UTF-8")));
+        MacUtilities.parseDevices(result, new ByteArrayInputStream(output.getBytes(StandardCharsets.UTF_8)));
         assertEquals("Found three devices", 3, result.size());
         assertEquals("mymac", result.get(0).getName());
         assertEquals("iPhone 6s Plus (11.2)", result.get(1).getName());

--- a/nb/o.n.upgrader/src/org/netbeans/upgrade/XMLStorage.java
+++ b/nb/o.n.upgrader/src/org/netbeans/upgrade/XMLStorage.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -118,7 +119,7 @@ public class XMLStorage {
                     FileLock lock = fo.lock ();
                     try {
                         OutputStream os = fo.getOutputStream (lock);
-                        Writer writer = new OutputStreamWriter (os, "UTF-8"); // NOI18N
+                        Writer writer = new OutputStreamWriter (os, StandardCharsets.UTF_8);
                         try {
                             writer.write (content);
                         } finally {

--- a/nb/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SerParser.java
+++ b/nb/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SerParser.java
@@ -20,6 +20,7 @@
 package org.netbeans.upgrade.systemoptions;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import org.openide.util.NotImplementedException;
 
@@ -225,7 +226,7 @@ public final class SerParser implements ObjectStreamConstants {
         for (int i = 0; i < len; i++) {
             buf[i] = readByte();
         }
-        String s = new String(buf, "UTF-8"); // NOI18N
+        String s = new String(buf, StandardCharsets.UTF_8);
         if (DEBUG) System.err.println("readUTF: " + s); // NOI18N
         return s;
     }

--- a/php/hudson.php/src/org/netbeans/modules/hudson/php/util/BuildXmlUtils.java
+++ b/php/hudson.php/src/org/netbeans/modules/hudson/php/util/BuildXmlUtils.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.hudson.php.util;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ import org.openide.filesystems.FileObject;
 
 public final class BuildXmlUtils {
 
-    static final Charset XML_CHARSET = Charset.forName("UTF-8"); // NOI18N
+    static final Charset XML_CHARSET = StandardCharsets.UTF_8;
 
     private static final String PROJECT_NAME_LINE = "<project name=\"%s\" default=\"build\">"; // NOI18N
     private static final String DIR_LINE = "${basedir}/%s"; // NOI18N

--- a/php/hudson.php/src/org/netbeans/modules/hudson/php/util/PhpUnitUtils.java
+++ b/php/hudson.php/src/org/netbeans/modules/hudson/php/util/PhpUnitUtils.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.hudson.php.util;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ import org.openide.filesystems.FileObject;
 
 public final class PhpUnitUtils {
 
-    static final Charset XML_CHARSET = Charset.forName("UTF-8"); // NOI18N
+    static final Charset XML_CHARSET = StandardCharsets.UTF_8;
 
     private static final String BOOTSTRAP_LINE = "bootstrap=\"tests/bootstrap.php\""; // NOI18N
     private static final String PROJECT_NAME_LINE = "<testsuite name=\"%s\">"; // NOI18N

--- a/php/languages.neon/src/org/netbeans/modules/languages/neon/lexer/NeonLexerUtils.java
+++ b/php/languages.neon/src/org/netbeans/modules/languages/neon/lexer/NeonLexerUtils.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.lexer.Language;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenId;
@@ -44,7 +45,7 @@ public final class NeonLexerUtils {
     public static String getFileContent(File file) throws Exception {
         StringBuilder sb = new StringBuilder();
         String lineSep = "\n"; //NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8")); //NOI18N
+        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
         String line = br.readLine();
         while (line != null) {
             sb.append(line);

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/CodeSnifferReportParser.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/CodeSnifferReportParser.java
@@ -70,7 +70,7 @@ public final class CodeSnifferReportParser extends DefaultHandler {
     public static List<Result> parse(File file) {
         try {
             sanitizeFile(file);
-            try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"))) { // NOI18N
+            try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
                 return create(reader).getResults();
             }
         } catch (IOException | SAXException ex) {

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/CodingStandardsFixerReportParser.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/CodingStandardsFixerReportParser.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -70,7 +71,7 @@ public final class CodingStandardsFixerReportParser extends DefaultHandler {
     @CheckForNull
     public static List<Result> parse(File resultFile, FileObject root) {
         try {
-            try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(resultFile), "UTF-8"))) { // NOI18N
+            try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(resultFile), StandardCharsets.UTF_8))) {
                 return create(reader, root).getResults();
             }
         } catch (IOException | SAXException ex) {

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/MessDetectorReportParser.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/MessDetectorReportParser.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -66,7 +67,7 @@ public final class MessDetectorReportParser extends DefaultHandler {
     @CheckForNull
     public static List<Result> parse(File file) {
         try {
-            try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"))) { // NOI18N
+            try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
                 return create(reader).getResults();
             }
         } catch (IOException | SAXException ex) {

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/PHPStanReportParser.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/PHPStanReportParser.java
@@ -78,7 +78,7 @@ public class PHPStanReportParser extends DefaultHandler {
     public static List<Result> parse(File file, FileObject root, @NullAllowed FileObject workDir) {
         try {
             sanitizeFile(file);
-            try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"))) { // NOI18N
+            try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
                 return create(reader, root, workDir).getResults();
             }
         } catch (IOException | SAXException ex) {

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/TestUtilities.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/TestUtilities.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 
 import org.openide.filesystems.FileObject;
@@ -85,7 +86,7 @@ public final class TestUtilities {
      */
     public static final File copyStringToFile (File f, String content) throws Exception {
         FileOutputStream os = new FileOutputStream(f);
-        InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+        InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
         FileUtil.copy(is, os);
         os.close ();
         is.close();
@@ -102,7 +103,7 @@ public final class TestUtilities {
      */
     public static final FileObject copyStringToFile (FileObject f, String content) throws Exception {
         OutputStream os = f.getOutputStream();
-        InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+        InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
         FileUtil.copy(is, os);
         os.close ();
         is.close();

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/lexer/PHPLexerUtils.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/lexer/PHPLexerUtils.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import junit.framework.TestCase;
@@ -96,7 +97,7 @@ public class PHPLexerUtils extends TestCase {
     public static String getFileContent (File file) throws Exception{
         StringBuffer sb = new StringBuffer();
         String lineSep = "\n";//NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
         String line = br.readLine();
         while (line != null) {
             sb.append(line);
@@ -109,7 +110,7 @@ public class PHPLexerUtils extends TestCase {
     
     public static List<LexerResultItem> getExpectedResults (File file) throws Exception {
         List<LexerResultItem> results = new ArrayList<LexerResultItem>();
-        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
         String line = br.readLine();
         LexerResultItem resultItem = null;
         while (line != null) {

--- a/php/php.latte/test/unit/src/org/netbeans/modules/php/latte/utils/TestUtils.java
+++ b/php/php.latte/test/unit/src/org/netbeans/modules/php/latte/utils/TestUtils.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  *
@@ -35,7 +36,7 @@ public class TestUtils {
      */
     public static String getFileContent(File file) throws IOException {
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
             String line = br.readLine();
             while (line != null) {
                 sb.append(line);

--- a/php/php.nette.tester/src/org/netbeans/modules/php/nette/tester/run/TapParser.java
+++ b/php/php.nette.tester/src/org/netbeans/modules/php/nette/tester/run/TapParser.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.php.nette.tester.run;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -272,7 +273,7 @@ public final class TapParser {
 
         @Override
         public String call() throws IOException {
-            return new String(Files.readAllBytes(Paths.get(filePath)), "UTF-8"); // NOI18N
+            return new String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8);
         }
 
     }

--- a/php/php.nette.tester/test/unit/src/org/netbeans/modules/php/nette/tester/run/TapParserTest.java
+++ b/php/php.nette.tester/test/unit/src/org/netbeans/modules/php/nette/tester/run/TapParserTest.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.php.nette.tester.run;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
@@ -222,7 +223,7 @@ public class TapParserTest extends NbTestCase {
 
     private void putFileContent(String filePath, String content) throws IOException {
         File file = new File(getWorkDir(), filePath);
-        Files.write(file.toPath(), content.getBytes("UTF-8"));
+        Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
     }
 
 }

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/commands/PhpUnit.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/commands/PhpUnit.java
@@ -27,6 +27,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -580,8 +581,8 @@ public final class PhpUnit {
     }
 
     private static void moveAndAdjustBootstrap(PhpModule phpModule, File tmpBootstrap, File finalBootstrap) {
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(tmpBootstrap), "UTF-8")); // NOI18N
-                BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(finalBootstrap), "UTF-8"))) { // NOI18N
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(tmpBootstrap), StandardCharsets.UTF_8));
+                BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(finalBootstrap), StandardCharsets.UTF_8))) {
             String line;
             while ((line = in.readLine()) != null) {
                 if (line.contains("%INCLUDE_PATH%")) { // NOI18N

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/coverage/CoverageProvider.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/coverage/CoverageProvider.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.annotations.common.CheckForNull;
@@ -42,7 +43,7 @@ public class CoverageProvider {
     public Coverage getCoverage() {
         CoverageImpl coverage = new CoverageImpl();
         try {
-            PhpUnitCoverageLogParser.parse(new BufferedReader(new InputStreamReader(new FileInputStream(PhpUnit.COVERAGE_LOG), "UTF-8")), coverage); // NOI18N
+            PhpUnitCoverageLogParser.parse(new BufferedReader(new InputStreamReader(new FileInputStream(PhpUnit.COVERAGE_LOG), StandardCharsets.UTF_8)), coverage);
         } catch (FileNotFoundException ex) {
             assert false;
             LOGGER.info(String.format("File %s not found. If there are no errors in PHPUnit output (verify in Output window), "

--- a/php/php.project/src/org/netbeans/modules/php/project/InternalFilesFileEncodingQuery.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/InternalFilesFileEncodingQuery.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.php.project;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.modules.php.project.util.PhpProjectUtils;
 import org.netbeans.spi.queries.FileEncodingQueryImplementation;
 import org.openide.filesystems.FileObject;
@@ -31,7 +32,7 @@ public final class InternalFilesFileEncodingQuery extends FileEncodingQueryImple
     @Override
     public Charset getEncoding(FileObject file) {
         if (PhpProjectUtils.isInternalFile(file)) {
-            return Charset.forName("UTF-8"); // NOI18N
+            return StandardCharsets.UTF_8;
         }
         return null;
     }

--- a/php/php.project/src/org/netbeans/modules/php/project/connections/sync/TimeStamps.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/connections/sync/TimeStamps.java
@@ -19,7 +19,7 @@
 
 package org.netbeans.modules.php.project.connections.sync;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.LinkedList;
@@ -149,7 +149,7 @@ public final class TimeStamps {
         private String getHash(String input) {
             try {
                 MessageDigest md = MessageDigest.getInstance("MD5"); // NOI18N
-                byte[] hash = md.digest(input.getBytes("UTF-8")); // NOI18N
+                byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
                 StringBuilder sb = new StringBuilder();
                 for (byte b : hash) {
                     sb.append(Integer.toHexString((int) (b & 0xff)));
@@ -157,7 +157,7 @@ public final class TimeStamps {
                 String result = sb.toString();
                 LOGGER.log(Level.FINE, "Hashing \"{0}\" to \"{1}\"", new Object[] {input, result});
                 return result;
-            } catch (NoSuchAlgorithmException | UnsupportedEncodingException ex) {
+            } catch (NoSuchAlgorithmException ex) {
                 LOGGER.log(Level.INFO, null, ex);
             }
             LOGGER.log(Level.FINE, "No hashing for \"{0}\"", input);

--- a/php/php.project/src/org/netbeans/modules/php/project/connections/ui/NewRemoteConnectionPanel.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/connections/ui/NewRemoteConnectionPanel.java
@@ -22,8 +22,7 @@ package org.netbeans.modules.php.project.connections.ui;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.UnsupportedCharsetException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Vector;
@@ -59,23 +58,9 @@ public final class NewRemoteConnectionPanel extends JPanel {
 
     private static final Logger LOGGER = Logger.getLogger(NewRemoteConnectionPanel.class.getName());
 
-    private static final Charset DIGEST_CHARSET;
-
     private final ConfigManager configManager;
     private DialogDescriptor descriptor;
     private NotificationLineSupport notificationLineSupport;
-
-    static {
-        Charset charset;
-        try {
-            charset = Charset.forName("UTF-8"); // NOI18N
-        } catch (UnsupportedCharsetException ex) {
-            // fallback
-            LOGGER.log(Level.WARNING, null, ex);
-            charset = Charset.defaultCharset();
-        }
-        DIGEST_CHARSET = charset;
-    }
 
     public NewRemoteConnectionPanel(ConfigManager configManager) {
         this.configManager = configManager;
@@ -120,7 +105,7 @@ public final class NewRemoteConnectionPanel extends JPanel {
             return getOldConfigName();
         }
 
-        md.update(getConnectionName().getBytes(DIGEST_CHARSET));
+        md.update(getConnectionName().getBytes(StandardCharsets.UTF_8));
         byte[] digest = md.digest();
         BigInteger hash = new BigInteger(1, digest);
         String hashWord = hash.toString(16);

--- a/php/php.symfony2/test/unit/src/org/netbeans/modules/php/symfony2/commands/SymfonyCommandsXmlParserTest.java
+++ b/php/php.symfony2/test/unit/src/org/netbeans/modules/php/symfony2/commands/SymfonyCommandsXmlParserTest.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.netbeans.junit.NbTestCase;
@@ -96,7 +97,7 @@ public class SymfonyCommandsXmlParserTest extends NbTestCase {
     }
 
     public void testIssue232490() throws Exception {
-        Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(new File(getDataDir(), "issue232490.xml")), "UTF-8"));
+        Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(new File(getDataDir(), "issue232490.xml")), StandardCharsets.UTF_8));
 
         List<SymfonyCommandVO> commands = new ArrayList<>();
         SymfonyCommandsXmlParser.parse(reader, commands);

--- a/php/php.twig/test/unit/src/org/netbeans/modules/php/twig/editor/util/TestUtils.java
+++ b/php/php.twig/test/unit/src/org/netbeans/modules/php/twig/editor/util/TestUtils.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Various test utilities.
@@ -37,7 +38,7 @@ public final class TestUtils {
      */
     public static String getFileContent(File file) throws IOException {
         StringBuilder sb = new StringBuilder();
-        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
         try {
             String line = br.readLine();
             while (line != null) {

--- a/php/websvc.saas.codegen.php/src/org/netbeans/modules/websvc/saas/codegen/php/SaasClientPhpAuthenticationGenerator.java
+++ b/php/websvc.saas.codegen.php/src/org/netbeans/modules/websvc/saas/codegen/php/SaasClientPhpAuthenticationGenerator.java
@@ -23,6 +23,7 @@ import java.io.FileReader;
 import org.netbeans.modules.websvc.saas.codegen.*;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -458,7 +459,7 @@ public class SaasClientPhpAuthenticationGenerator extends SaasClientAuthenticati
                 }
                 sb.append(line+"\n");
             }
-            OutputStreamWriter writer = new OutputStreamWriter(fO.getOutputStream(lock), "UTF-8");
+            OutputStreamWriter writer = new OutputStreamWriter(fO.getOutputStream(lock), StandardCharsets.UTF_8);
             try {
                 writer.write(sb.toString());
             } finally {

--- a/platform/api.search/test/unit/src/org/netbeans/modules/search/MatchingObjectTest.java
+++ b/platform/api.search/test/unit/src/org/netbeans/modules/search/MatchingObjectTest.java
@@ -26,6 +26,7 @@ import java.io.OutputStreamWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -283,7 +284,7 @@ public class MatchingObjectTest extends NbTestCase {
     public void testCheckFileLines() throws IOException {
 
         FileSystem fs = FileUtil.createMemoryFileSystem();
-        Charset chs = Charset.forName("UTF-8");
+        Charset chs = StandardCharsets.UTF_8;
         OutputStream os = fs.getRoot().createAndOpen("find.txt");
         try {
             OutputStreamWriter osw = new OutputStreamWriter(os,
@@ -372,7 +373,7 @@ public class MatchingObjectTest extends NbTestCase {
         @Override
         public Charset getEncoding(FileObject file) {
             if (file.getName().equals("utf8file")) {
-                return Charset.forName("UTF-8");
+                return StandardCharsets.UTF_8;
             } else {
                 return null;
             }

--- a/platform/api.search/test/unit/src/org/netbeans/modules/search/matcher/AbstractMatcherTest.java
+++ b/platform/api.search/test/unit/src/org/netbeans/modules/search/matcher/AbstractMatcherTest.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.search.matcher;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.search.SearchPattern;
 import org.netbeans.api.search.provider.SearchListener;
 import org.netbeans.junit.MockServices;
@@ -101,7 +102,7 @@ public class AbstractMatcherTest extends NbTestCase {
         @Override
         public Charset getEncoding(FileObject file) {
             if (file.getName().equals("latin2file")) {
-                return Charset.forName("UTF-8");
+                return StandardCharsets.UTF_8;
             } else {
                 return null;
             }

--- a/platform/api.search/test/unit/src/org/netbeans/modules/search/matcher/LineReaderTest.java
+++ b/platform/api.search/test/unit/src/org/netbeans/modules/search/matcher/LineReaderTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.junit.NbTestCase;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileSystem;
@@ -40,7 +41,7 @@ public class LineReaderTest extends NbTestCase {
     public void testLineReader() throws IOException {
 
         FileSystem fs = FileUtil.createMemoryFileSystem();
-        Charset chs = Charset.forName("UTF-8");
+        Charset chs = StandardCharsets.UTF_8;
         OutputStream os = fs.getRoot().createAndOpen("find.txt");
         try {
             OutputStreamWriter osw = new OutputStreamWriter(os, chs.newEncoder());

--- a/platform/api.templates/test/unit/src/org/netbeans/modules/templates/Bug138973Test.java
+++ b/platform/api.templates/test/unit/src/org/netbeans/modules/templates/Bug138973Test.java
@@ -31,12 +31,10 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
-import java.nio.charset.CoderResult;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.api.editor.mimelookup.test.MockMimeLookup;
@@ -44,7 +42,6 @@ import org.netbeans.api.queries.FileEncodingQuery;
 import org.netbeans.junit.MockServices;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.openide.loaders.DataObjectEncodingQueryImplementation;
-import org.netbeans.modules.templates.ScriptingCreateFromTemplateHandler;
 import org.netbeans.spi.queries.FileEncodingQueryImplementation;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -83,7 +80,7 @@ public class Bug138973Test extends NbTestCase {
                                                       TEMPLATE_NAME_EXT);
         templateFile.setAttribute ("template", Boolean.TRUE);
         templateFile.setAttribute(ScriptingCreateFromTemplateHandler.SCRIPT_ENGINE_ATTR, "js");
-        byte[] templateBytes = TESTING_TEXT.getBytes("ISO-8859-1");
+        byte[] templateBytes = TESTING_TEXT.getBytes(StandardCharsets.ISO_8859_1);
         InputStream source = new ByteArrayInputStream(templateBytes);
         OutputStream target = templateFile.getOutputStream();
         FileUtil.copy(source, target);
@@ -225,12 +222,12 @@ public class Bug138973Test extends NbTestCase {
         @Override
         public CharsetDecoder newDecoder() {
             newDecoder++;
-            return Charset.forName("UTF-8").newDecoder();
+            return StandardCharsets.UTF_8.newDecoder();
         }
         @Override
         public CharsetEncoder newEncoder() {
             newEncoder++;
-            return Charset.forName("UTF-8").newEncoder();
+            return StandardCharsets.UTF_8.newEncoder();
         }
     }
 

--- a/platform/api.templates/test/unit/src/org/netbeans/modules/templates/SCFTHandlerTest.java
+++ b/platform/api.templates/test/unit/src/org/netbeans/modules/templates/SCFTHandlerTest.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -301,7 +302,7 @@ public class SCFTHandlerTest extends NbTestCase {
         Map<String,String> parameters = Collections.singletonMap("type", "empty");
         
         FEQI.fs = root2.getFileSystem();
-        FEQI.result = Charset.forName("UTF-8");
+        FEQI.result = StandardCharsets.UTF_8;
         
         DataObject n = obj.createFromTemplate(folder, "complex", parameters);
         Integer cnt = TwoPartLoader.queried.get(n.getPrimaryFile());
@@ -318,7 +319,7 @@ public class SCFTHandlerTest extends NbTestCase {
             fail("Too small file: " + length + " for " + snd);
         }
         
-        String normRead = readChars(snd, Charset.forName("UTF-8"));
+        String normRead = readChars(snd, StandardCharsets.UTF_8);
 
         txt = txt.replaceAll("print\\('", "").replaceAll("'\\)", "") + "\n";
         

--- a/platform/autoupdate.services/libsrc/org/netbeans/updater/ModuleUpdater.java
+++ b/platform/autoupdate.services/libsrc/org/netbeans/updater/ModuleUpdater.java
@@ -20,6 +20,7 @@
 package org.netbeans.updater;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -613,7 +614,7 @@ public final class ModuleUpdater extends Thread {
         if (executableFilesEntry != null) {
             BufferedReader reader = null;
             try {
-                reader = new BufferedReader(new InputStreamReader(jarFile.getInputStream(executableFilesEntry), "UTF-8"));
+                reader = new BufferedReader(new InputStreamReader(jarFile.getInputStream(executableFilesEntry), StandardCharsets.UTF_8));
                 String s;
                 while ((s = reader.readLine()) != null) {
                     list.add(s);

--- a/platform/autoupdate.services/libsrc/org/netbeans/updater/UpdateTracking.java
+++ b/platform/autoupdate.services/libsrc/org/netbeans/updater/UpdateTracking.java
@@ -20,6 +20,7 @@
 package org.netbeans.updater;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.zip.CRC32;
@@ -925,7 +926,7 @@ public final class UpdateTracking {
             OutputStream os;
             try {
                 os = context.createOS(config);
-                PrintWriter pw = new PrintWriter(new java.io.OutputStreamWriter(os, "UTF-8"));
+                PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
                 // Please make sure formatting matches what the IDE actually spits
                 // out; it could matter.
                 pw.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateInfoParser.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateInfoParser.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -440,8 +441,7 @@ public class AutoupdateInfoParser extends DefaultHandler {
             writer.close();
             String xml = writer.toString();
             
-            InputStream inputStream = new ByteArrayInputStream(xml.getBytes("UTF-8"));  
-            
+            InputStream inputStream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));  
             
             return inputStream;
         } catch (IOException ex) {

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DifferentReleaseVersionsTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DifferentReleaseVersionsTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -113,7 +114,7 @@ public class DifferentReleaseVersionsTest extends NbTestCase {
             catalogFile = File.createTempFile("catalog-", ".xml", tmpDirectory);
             catalogURL = Utilities.toURI(catalogFile).toURL();
         }
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(catalogFile), "UTF-8"));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(catalogFile), StandardCharsets.UTF_8));
         pw.write(res);
         pw.close();
     }
@@ -169,10 +170,10 @@ public class DifferentReleaseVersionsTest extends NbTestCase {
         }
 
         jos.putNextEntry(new ZipEntry(moduleDir + "Bundle.properties"));
-        jos.write(new String(MODULE_NAME_PROP + "=" + moduleName).getBytes("UTF-8"));
+        jos.write(new String(MODULE_NAME_PROP + "=" + moduleName).getBytes(StandardCharsets.UTF_8));
         jos.putNextEntry(new ZipEntry("META-INF/"));
         jos.putNextEntry(new ZipEntry("META-INF/manifest.mf"));
-        jos.write(getManifest(codeName, releaseVersion, implVersion, moduleDir, specVersion, visible, dependency).getBytes("UTF-8"));
+        jos.write(getManifest(codeName, releaseVersion, implVersion, moduleDir, specVersion, visible, dependency).getBytes(StandardCharsets.UTF_8));
         jos.close();
 
         Manifest mf = new Manifest();
@@ -180,7 +181,7 @@ public class DifferentReleaseVersionsTest extends NbTestCase {
         jos = new JarOutputStream(new FileOutputStream(nbm), mf);
         jos.putNextEntry(new ZipEntry("Info/"));
         jos.putNextEntry(new ZipEntry("Info/info.xml"));
-        jos.write(createInfoXML(visible, codeName, releaseVersion, implVersion, moduleName, Utilities.toURI(nbm).toURL().toString(), specVersion, dependency).getBytes("UTF-8"));
+        jos.write(createInfoXML(visible, codeName, releaseVersion, implVersion, moduleName, Utilities.toURI(nbm).toURL().toString(), specVersion, dependency).getBytes(StandardCharsets.UTF_8));
 
         jos.putNextEntry(new ZipEntry("netbeans/"));
         jos.putNextEntry(new ZipEntry("netbeans/modules/"));
@@ -188,7 +189,7 @@ public class DifferentReleaseVersionsTest extends NbTestCase {
         jos.putNextEntry(new ZipEntry("netbeans/config/Modules/"));
         jos.putNextEntry(new ZipEntry("netbeans/config/Modules/" + moduleFile + ".xml"));
 
-        jos.write(getConfigXML(codeName, moduleFile, specVersion).getBytes("UTF-8"));
+        jos.write(getConfigXML(codeName, moduleFile, specVersion).getBytes(StandardCharsets.UTF_8));
 
 
         jos.putNextEntry(new ZipEntry("netbeans/modules/" + moduleFile + ".jar"));

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/InternalUpdatesTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/InternalUpdatesTest.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -114,7 +115,7 @@ public class InternalUpdatesTest extends NbTestCase {
             catalogFile = File.createTempFile("catalog-", ".xml", tmpDirectory);
             catalogURL = Utilities.toURI(catalogFile).toURL();
         }
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(catalogFile), "UTF-8"));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(catalogFile), StandardCharsets.UTF_8));
         pw.write(res);
         pw.close();
     }
@@ -167,10 +168,10 @@ public class InternalUpdatesTest extends NbTestCase {
         }
 
         jos.putNextEntry(new ZipEntry(moduleDir + "Bundle.properties"));
-        jos.write(new String(MODULE_NAME_PROP + "=" + moduleName).getBytes("UTF-8"));
+        jos.write(new String(MODULE_NAME_PROP + "=" + moduleName).getBytes(StandardCharsets.UTF_8));
         jos.putNextEntry(new ZipEntry("META-INF/"));
         jos.putNextEntry(new ZipEntry("META-INF/manifest.mf"));
-        jos.write(getManifest(codeName, moduleDir, specVersion, visible, dependency).getBytes("UTF-8"));
+        jos.write(getManifest(codeName, moduleDir, specVersion, visible, dependency).getBytes(StandardCharsets.UTF_8));
         jos.close();
 
         Manifest mf = new Manifest();
@@ -178,7 +179,7 @@ public class InternalUpdatesTest extends NbTestCase {
         jos = new JarOutputStream(new FileOutputStream(nbm), mf);
         jos.putNextEntry(new ZipEntry("Info/"));
         jos.putNextEntry(new ZipEntry("Info/info.xml"));
-        jos.write(createInfoXML(visible, codeName, moduleName, Utilities.toURI(nbm).toURL().toString(), specVersion, dependency).getBytes("UTF-8"));
+        jos.write(createInfoXML(visible, codeName, moduleName, Utilities.toURI(nbm).toURL().toString(), specVersion, dependency).getBytes(StandardCharsets.UTF_8));
 
         jos.putNextEntry(new ZipEntry("netbeans/"));
         jos.putNextEntry(new ZipEntry("netbeans/modules/"));
@@ -186,7 +187,7 @@ public class InternalUpdatesTest extends NbTestCase {
         jos.putNextEntry(new ZipEntry("netbeans/config/Modules/"));
         jos.putNextEntry(new ZipEntry("netbeans/config/Modules/" + moduleFile + ".xml"));
 
-        jos.write(getConfigXML(codeName, moduleFile, specVersion).getBytes("UTF-8"));
+        jos.write(getConfigXML(codeName, moduleFile, specVersion).getBytes(StandardCharsets.UTF_8));
 
 
         jos.putNextEntry(new ZipEntry("netbeans/modules/" + moduleFile + ".jar"));

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallDisabledModuleTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallDisabledModuleTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.autoupdate.services;
 
 import java.io.File;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import org.netbeans.api.autoupdate.UpdateUnit;
 import org.netbeans.junit.RandomlyFails;
@@ -69,7 +70,7 @@ public class InstallDisabledModuleTest extends OperationsTestImpl {
                 "   <param name='specversion'>1.0</param>\n" +
                 "</module>\n" +
                 "\n";
-        os.write(cfg.getBytes("UTF-8"));
+        os.write(cfg.getBytes(StandardCharsets.UTF_8));
         os.close();
         LOG.info("Config file created");
 

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallOSGiBundleTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/InstallOSGiBundleTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -85,7 +86,7 @@ public class InstallOSGiBundleTest extends NbTestCase {
             catalogFile = File.createTempFile("catalog-", ".xml", tmpDirectory);
             catalogURL = Utilities.toURI(catalogFile).toURL();
         }
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(catalogFile), "UTF-8"));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(catalogFile), StandardCharsets.UTF_8));
         pw.write(res);
         pw.close();
     }

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NbmExternalTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NbmExternalTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -52,6 +53,7 @@ import org.netbeans.updater.UpdateTracking;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
 import org.openide.util.Utilities;
+
 import static org.netbeans.modules.autoupdate.services.Utilities.hexEncode;
 
 public class NbmExternalTest extends NbTestCase {
@@ -126,7 +128,7 @@ public class NbmExternalTest extends NbTestCase {
             catalogFile = File.createTempFile("catalog-", ".xml", tmpDirectory);
             catalogURL = Utilities.toURI(catalogFile).toURL();
         }
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(catalogFile), "UTF-8"));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(catalogFile), StandardCharsets.UTF_8));
         pw.write(res);
         pw.close();
     }
@@ -182,10 +184,10 @@ public class NbmExternalTest extends NbTestCase {
         }
 
         jos.putNextEntry(new ZipEntry(moduleDir + "Bundle.properties"));
-        jos.write(new String(MODULE_NAME_PROP + "=" + moduleName).getBytes("UTF-8"));
+        jos.write(new String(MODULE_NAME_PROP + "=" + moduleName).getBytes(StandardCharsets.UTF_8));
         jos.putNextEntry(new ZipEntry("META-INF/"));
         jos.putNextEntry(new ZipEntry("META-INF/manifest.mf"));
-        jos.write(getManifest(codeName, releaseVersion, implVersion, moduleDir, specVersion, visible, dependency).getBytes("UTF-8"));
+        jos.write(getManifest(codeName, releaseVersion, implVersion, moduleDir, specVersion, visible, dependency).getBytes(StandardCharsets.UTF_8));
         jos.close();
         File ext = new File(jar.getParentFile(), jar.getName() + ".external");
         FileOutputStream os = new FileOutputStream(ext);
@@ -209,7 +211,7 @@ public class NbmExternalTest extends NbTestCase {
         jos = new JarOutputStream(new FileOutputStream(nbm), mf);
         jos.putNextEntry(new ZipEntry("Info/"));
         jos.putNextEntry(new ZipEntry("Info/info.xml"));
-        jos.write(createInfoXML(visible, codeName, releaseVersion, implVersion, moduleName, Utilities.toURI(nbm).toURL().toString(), specVersion, dependency).getBytes("UTF-8"));
+        jos.write(createInfoXML(visible, codeName, releaseVersion, implVersion, moduleName, Utilities.toURI(nbm).toURL().toString(), specVersion, dependency).getBytes(StandardCharsets.UTF_8));
 
         jos.putNextEntry(new ZipEntry("netbeans/"));
         jos.putNextEntry(new ZipEntry("netbeans/modules/"));
@@ -217,7 +219,7 @@ public class NbmExternalTest extends NbTestCase {
         jos.putNextEntry(new ZipEntry("netbeans/config/Modules/"));
         jos.putNextEntry(new ZipEntry("netbeans/config/Modules/" + moduleFile + ".xml"));
 
-        jos.write(getConfigXML(codeName, moduleFile, specVersion).getBytes("UTF-8"));
+        jos.write(getConfigXML(codeName, moduleFile, specVersion).getBytes(StandardCharsets.UTF_8));
 
 
         jos.putNextEntry(new ZipEntry("netbeans/modules/" + moduleFile + ".jar.external"));

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateDisabledModuleTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateDisabledModuleTest.java
@@ -24,6 +24,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.jar.JarOutputStream;
@@ -112,7 +113,7 @@ public class UpdateDisabledModuleTest extends NbTestCase {
 "        <file crc=\"3486416273\" name=\"modules/com-example-testmodule-cluster.jar\"/>\n" +
 "    </module_version>\n" +
 "</module>\n";
-        utos.write(utcfg.getBytes("UTF-8"));
+        utos.write(utcfg.getBytes(StandardCharsets.UTF_8));
         utos.close();
 
         StringBuilder msg = new StringBuilder();
@@ -139,7 +140,7 @@ public class UpdateDisabledModuleTest extends NbTestCase {
                 "   <param name='specversion'>1.0</param>\n" +
                 "</module>\n" +
                 "\n";
-        os.write(cfg.getBytes("UTF-8"));
+        os.write(cfg.getBytes(StandardCharsets.UTF_8));
         os.close();
     }
 

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/updater/UpdateTrackingTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/updater/UpdateTrackingTest.java
@@ -24,6 +24,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.updater.UpdateTracking.Module;
@@ -61,7 +62,7 @@ public class UpdateTrackingTest extends NbTestCase {
 "</module>";
         
         FileOutputStream os = new FileOutputStream(ut);
-        os.write(s.getBytes("UTF-8"));
+        os.write(s.getBytes(StandardCharsets.UTF_8));
         os.close();
 
     }

--- a/platform/core.osgi/src/org/netbeans/core/osgi/Activator.java
+++ b/platform/core.osgi/src/org/netbeans/core/osgi/Activator.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
@@ -304,7 +305,7 @@ public class Activator implements BundleActivator, SynchronousBundleListener {
                     try {
                         InputStream is = entry.openStream();
                         try {
-                            BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+                            BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
                             String line;
                             while ((line = r.readLine()) != null) {
                                 if (!line.isEmpty() && !line.startsWith("#")) {

--- a/platform/core.startup/src/org/netbeans/core/startup/ModuleList.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/ModuleList.java
@@ -35,6 +35,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PushbackInputStream;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -680,7 +681,7 @@ final class ModuleList implements Stamps.Updater {
         if (codeName == null)
             throw new IllegalArgumentException("no code name present"); // NOI18N
 
-        Writer w = new OutputStreamWriter(os, "UTF-8"); // NOI18N
+        Writer w = new OutputStreamWriter(os, StandardCharsets.UTF_8);
         w.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"); // NOI18N
         w.write("<!DOCTYPE module PUBLIC \""); // NOI18N
         w.write(PUBLIC_ID);

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/ModuleListDontDeleteDisabledModulesTest.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/ModuleListDontDeleteDisabledModulesTest.java
@@ -24,6 +24,7 @@ import org.netbeans.ModuleManager;
 import java.util.*;
 import org.openide.modules.*;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.MockEvents;
 import org.netbeans.MockModuleInstaller;
 import org.netbeans.SetupHid;
@@ -95,7 +96,7 @@ public class ModuleListDontDeleteDisabledModulesTest extends SetupHid {
                 "   <param name='specversion'>1.0</param>\n" +
                 "</module>\n" +
                 "\n";
-        os.write(cfg.getBytes("UTF-8"));
+        os.write(cfg.getBytes(StandardCharsets.UTF_8));
         os.close();
         modulesfolder.refresh();
 

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTestBase.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/NbInstallerTestBase.java
@@ -22,6 +22,7 @@ package org.netbeans.core.startup;
 import org.netbeans.SetupHid;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
@@ -40,7 +41,7 @@ abstract class NbInstallerTestBase extends SetupHid {
         byte[] buf = new byte[1024];
         int read;
         while ((read = is.read(buf)) != -1) {
-            text.append(new String(buf, 0, read, "US-ASCII"));
+            text.append(new String(buf, 0, read, StandardCharsets.US_ASCII));
         }
         return text.toString();
     }

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/NbURLStreamHandlerFactoryTest.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/NbURLStreamHandlerFactoryTest.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Locale;
@@ -289,7 +290,7 @@ public class NbURLStreamHandlerFactoryTest extends NbTestCase {
         }
 
         public InputStream getInputStream() throws IOException {
-            return new ByteArrayInputStream(path.getBytes("UTF-8"));
+            return new ByteArrayInputStream(path.getBytes(StandardCharsets.UTF_8));
         }
 
     }

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/layers/CacheManagerTestBaseHid.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/layers/CacheManagerTestBaseHid.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -192,7 +193,7 @@ public abstract class CacheManagerTestBaseHid extends NbTestCase implements Imag
         byte[] buf = new byte[1024];
         int read;
         while ((read = is.read(buf)) != -1) {
-            text.append(new String(buf, 0, read, "US-ASCII"));
+            text.append(new String(buf, 0, read, StandardCharsets.US_ASCII));
         }
         return text.toString();
     }

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/logging/DispatchingHandlerTest.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/logging/DispatchingHandlerTest.java
@@ -20,6 +20,7 @@ package org.netbeans.core.startup.logging;
 
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Formatter;
@@ -92,7 +93,7 @@ public class DispatchingHandlerTest extends NbTestCase {
         dh.setFormatter(my);
         dh.publish(new LogRecord(Level.WARNING, "Ahoj"));
         dh.flush();
-        String res = new String(os.toByteArray(), "UTF-8");
+        String res = new String(os.toByteArray(), StandardCharsets.UTF_8);
         assertEquals("Only the message is written", "Ahoj", res);
         assertEquals("Called once", 1, my.cnt);
     }

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestPreferences.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestPreferences.java
@@ -21,6 +21,7 @@ package org.netbeans.core.startup.preferences;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.prefs.BackingStoreException;
@@ -533,7 +534,7 @@ public class TestPreferences extends NbPreferencesTest.TestBasicSetup {
         assertNotNull(storage.toPropertiesFile());
         
         OutputStream storageOutputStream = storage.toPropertiesFile().getOutputStream();
-        storageOutputStream.write("key1=value1".getBytes("ISO-8859-1"));
+        storageOutputStream.write("key1=value1".getBytes(StandardCharsets.ISO_8859_1));
         storageOutputStream.close();
     }
 

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestPropertiesStorage.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/preferences/TestPropertiesStorage.java
@@ -20,6 +20,7 @@
 package org.netbeans.core.startup.preferences;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.TreeSet;
@@ -147,13 +148,13 @@ public class TestPropertiesStorage extends TestFileStorage {
      private void overrideStorageEntryWithNewValue(String oldValue, String newValue) throws IOException {
          String newText = constructNewEntryText(oldValue, newValue);         
          OutputStream storageOutputStream = storage.toPropertiesFile().getOutputStream();
-         storageOutputStream.write(newText.getBytes("ISO-8859-1"));
+         storageOutputStream.write(newText.getBytes(StandardCharsets.ISO_8859_1));
          storageOutputStream.close();                     
      }
      
      private void overrideStorageEntryWithNewData(String newData) throws IOException {
          OutputStream storageOutputStream = storage.toPropertiesFile(true).getOutputStream();
-         storageOutputStream.write(newData.getBytes("ISO-8859-1"));
+         storageOutputStream.write(newData.getBytes(StandardCharsets.ISO_8859_1));
          storageOutputStream.close();                     
      }
      
@@ -166,7 +167,7 @@ public class TestPropertiesStorage extends TestFileStorage {
          String newText = before.concat(after);
          
          OutputStream storageOutputStream = storage.toPropertiesFile().getOutputStream();
-         storageOutputStream.write(newText.getBytes("ISO-8859-1"));
+         storageOutputStream.write(newText.getBytes(StandardCharsets.ISO_8859_1));
          storageOutputStream.close();                     
      }
 

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/GroupParser.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/GroupParser.java
@@ -31,6 +31,7 @@ import org.xml.sax.*;
 import org.xml.sax.helpers.DefaultHandler;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.logging.Logger;
 
@@ -614,7 +615,7 @@ class GroupParser {
                 try {
                     lock = cfgFOOutput.lock();
                     os = cfgFOOutput.getOutputStream(lock);
-                    osw = new OutputStreamWriter(os, "UTF-8"); // NOI18N
+                    osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
                     osw.write(buff.toString());
                     //if (DEBUG) Debug.log(GroupParser.class, "-- DUMP Group: " + GroupParser.this.getName());
                     //if (DEBUG) Debug.log(GroupParser.class, buff.toString());

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/ModeParser.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/ModeParser.java
@@ -34,6 +34,7 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import java.awt.*;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.List;
 import java.util.logging.Logger;
@@ -1503,7 +1504,7 @@ class ModeParser {
                 try {
                     lock = cfgFOOutput.lock();
                     os = cfgFOOutput.getOutputStream(lock);
-                    osw = new OutputStreamWriter(os, "UTF-8"); // NOI18N
+                    osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
                     osw.write(buff.toString());
                     /*log("-- DUMP Mode:");
                     log(buff.toString());*/

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/TCGroupParser.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/TCGroupParser.java
@@ -30,6 +30,7 @@ import org.xml.sax.*;
 import org.xml.sax.helpers.DefaultHandler;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 
 /**
@@ -397,7 +398,7 @@ class TCGroupParser {
                 try {
                     lock = cfgFOOutput.lock();
                     os = cfgFOOutput.getOutputStream(lock);
-                    osw = new OutputStreamWriter(os, "UTF-8"); // NOI18N
+                    osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
                     osw.write(buff.toString());
                     //log("DUMP TCGroup: " + TCGroupParser.this.getName());
                     //log(buff.toString());

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/TCRefParser.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/TCRefParser.java
@@ -30,6 +30,7 @@ import org.xml.sax.*;
 import org.xml.sax.helpers.DefaultHandler;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 
 /**
@@ -461,7 +462,7 @@ class TCRefParser {
                 try {
                     lock = cfgFOOutput.lock();
                     os = cfgFOOutput.getOutputStream(lock);
-                    osw = new OutputStreamWriter(os, "UTF-8"); // NOI18N
+                    osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
                     osw.write(buff.toString());
                     //log("DUMP TCRef: " + TCRefParser.this.getName());
                     //log(buff.toString());

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/WindowManagerParser.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/WindowManagerParser.java
@@ -34,6 +34,7 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import java.awt.*;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.List;
 import java.util.logging.Logger;
@@ -1821,7 +1822,7 @@ public class WindowManagerParser {
                 try {
                     lock = cfgFOOutput.lock();
                     os = cfgFOOutput.getOutputStream(lock);
-                    osw = new OutputStreamWriter(os, "UTF-8"); // NOI18N
+                    osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
                     osw.write(buff.toString());
                     //if (DEBUG) Debug.log(WindowManagerParser.class, "-- DUMP WindowManager:");
                     //if (DEBUG) Debug.log(WindowManagerParser.class, buff.toString());

--- a/platform/javahelp/src/org/netbeans/modules/javahelp/NbDocsStreamHandler.java
+++ b/platform/javahelp/src/org/netbeans/modules/javahelp/NbDocsStreamHandler.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.javahelp;
 
 import java.io.*;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import org.openide.modules.InstalledFileLocator;
@@ -294,9 +295,9 @@ public final class NbDocsStreamHandler extends URLStreamHandler {
                 if (is != null) {
                     byte [] arr;
                     arr = readData(is);
-                    String s1 = new String(arr,"UTF-8"); // NOI18N
+                    String s1 = new String(arr, StandardCharsets.UTF_8);
                     String s2 = s1.replaceAll("\\{0\\}",moduleName); // NOI18N
-                    arr = s2.getBytes("UTF-8");
+                    arr = s2.getBytes(StandardCharsets.UTF_8);
                     stream = new ByteArrayInputStream(arr);
                 } else {
                     throw new IOException("Info file not found."); // NOI18N

--- a/platform/keyring.impl/src/org/netbeans/modules/keyring/mac/MacProvider.java
+++ b/platform/keyring.impl/src/org/netbeans/modules/keyring/mac/MacProvider.java
@@ -20,12 +20,13 @@
 package org.netbeans.modules.keyring.mac;
 
 import com.sun.jna.Pointer;
-import java.io.UnsupportedEncodingException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.spi.keyring.KeyringProvider;
 import org.openide.util.Utilities;
 import org.openide.util.lookup.ServiceProvider;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 @ServiceProvider(service=KeyringProvider.class, position=200)
 public class MacProvider implements KeyringProvider {
@@ -41,59 +42,46 @@ public class MacProvider implements KeyringProvider {
     }
 
     public char[] read(String key) {
-        try {
-            byte[] serviceName = key.getBytes("UTF-8");
-            byte[] accountName = "NetBeans".getBytes("UTF-8");
-            int[] dataLength = new int[1];
-            Pointer[] data = new Pointer[1];
-            error("find", SecurityLibrary.LIBRARY.SecKeychainFindGenericPassword(null, serviceName.length, serviceName,
-                    accountName.length, accountName, dataLength, data, null));
-            if (data[0] == null) {
-                return null;
-            }
-            byte[] value = data[0].getByteArray(0, dataLength[0]); // XXX ought to call SecKeychainItemFreeContent
-            return new String(value, "UTF-8").toCharArray();
-        } catch (UnsupportedEncodingException x) {
-            LOG.log(Level.WARNING, null, x);
+        byte[] serviceName = key.getBytes(UTF_8);
+        byte[] accountName = "NetBeans".getBytes(UTF_8);
+        int[] dataLength = new int[1];
+        Pointer[] data = new Pointer[1];
+        error("find", SecurityLibrary.LIBRARY.SecKeychainFindGenericPassword(null, serviceName.length, serviceName,
+                accountName.length, accountName, dataLength, data, null));
+        if (data[0] == null) {
             return null;
         }
+        byte[] value = data[0].getByteArray(0, dataLength[0]); // XXX ought to call SecKeychainItemFreeContent
+        return new String(value, UTF_8).toCharArray();
     }
 
     public void save(String key, char[] password, String description) {
-        try {
-            byte[] serviceName = key.getBytes("UTF-8");
-            byte[] accountName = "NetBeans".getBytes("UTF-8");
-            // Keychain Access seems to expect UTF-8, so do not use Utils.chars2Bytes:
-            byte[] data = new String(password).getBytes("UTF-8");
-            Pointer[] itemRef = new Pointer[1];
-            error("find (for save)", SecurityLibrary.LIBRARY.SecKeychainFindGenericPassword(null, serviceName.length, serviceName,
-                    accountName.length, accountName, null, null, itemRef));
-            if (itemRef[0] != null) {
-                error("save (update)", SecurityLibrary.LIBRARY.SecKeychainItemModifyContent(itemRef[0], null, data.length, data));
-                SecurityLibrary.LIBRARY.CFRelease(itemRef[0]);
-            } else {
-                error("save (new)", SecurityLibrary.LIBRARY.SecKeychainAddGenericPassword(null, serviceName.length, serviceName,
-                        accountName.length, accountName, data.length, data, null));
-            }
-        } catch (UnsupportedEncodingException x) {
-            LOG.log(Level.WARNING, null, x);
+        byte[] serviceName = key.getBytes(UTF_8);
+        byte[] accountName = "NetBeans".getBytes(UTF_8);
+        // Keychain Access seems to expect UTF-8, so do not use Utils.chars2Bytes:
+        byte[] data = new String(password).getBytes(UTF_8);
+        Pointer[] itemRef = new Pointer[1];
+        error("find (for save)", SecurityLibrary.LIBRARY.SecKeychainFindGenericPassword(null, serviceName.length, serviceName,
+                accountName.length, accountName, null, null, itemRef));
+        if (itemRef[0] != null) {
+            error("save (update)", SecurityLibrary.LIBRARY.SecKeychainItemModifyContent(itemRef[0], null, data.length, data));
+            SecurityLibrary.LIBRARY.CFRelease(itemRef[0]);
+        } else {
+            error("save (new)", SecurityLibrary.LIBRARY.SecKeychainAddGenericPassword(null, serviceName.length, serviceName,
+                    accountName.length, accountName, data.length, data, null));
         }
         // XXX use description somehow... better to use SecItemAdd with kSecAttrDescription
     }
 
     public void delete(String key) {
-        try {
-            byte[] serviceName = key.getBytes("UTF-8");
-            byte[] accountName = "NetBeans".getBytes("UTF-8");
-            Pointer[] itemRef = new Pointer[1];
-            error("find (for delete)", SecurityLibrary.LIBRARY.SecKeychainFindGenericPassword(null, serviceName.length, serviceName,
-                    accountName.length, accountName, null, null, itemRef));
-            if (itemRef[0] != null) {
-                error("delete", SecurityLibrary.LIBRARY.SecKeychainItemDelete(itemRef[0]));
-                SecurityLibrary.LIBRARY.CFRelease(itemRef[0]);
-            }
-        } catch (UnsupportedEncodingException x) {
-            LOG.log(Level.WARNING, null, x);
+        byte[] serviceName = key.getBytes(UTF_8);
+        byte[] accountName = "NetBeans".getBytes(UTF_8);
+        Pointer[] itemRef = new Pointer[1];
+        error("find (for delete)", SecurityLibrary.LIBRARY.SecKeychainFindGenericPassword(null, serviceName.length, serviceName,
+                accountName.length, accountName, null, null, itemRef));
+        if (itemRef[0] != null) {
+            error("delete", SecurityLibrary.LIBRARY.SecKeychainItemDelete(itemRef[0]));
+            SecurityLibrary.LIBRARY.CFRelease(itemRef[0]);
         }
     }
 

--- a/platform/lib.uihandler/src/org/netbeans/lib/uihandler/MultiPartHandler.java
+++ b/platform/lib.uihandler/src/org/netbeans/lib/uihandler/MultiPartHandler.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.HashMap;
@@ -443,7 +444,7 @@ class MultiPartHandler {
     do {
       result = in.readLine(buf, 0, buf.length);  // does +=
       if (result != -1) {
-        sbuf.append(new String(buf, 0, result, "ISO-8859-1"));
+        sbuf.append(new String(buf, 0, result, StandardCharsets.ISO_8859_1));
       }
     } while (result == buf.length);  // loop only if the buffer was filled
 

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/MIMESupportLoggingTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/MIMESupportLoggingTest.java
@@ -26,6 +26,7 @@ import java.util.logging.LogRecord;
 import org.openide.filesystems.*;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -160,7 +161,7 @@ public class MIMESupportLoggingTest extends NbTestCase {
 
     public static final File copyStringToFile (File f, String content) throws Exception {
         FileOutputStream os = new FileOutputStream(f);
-        InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+        InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
         FileUtil.copy(is, os);
         os.close ();
         is.close();

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.Arrays;
@@ -138,7 +139,7 @@ public class FileObjTest extends NbTestCase {
         fo.addFileChangeListener(listener);
         
         OutputStream os = fo.getOutputStream();
-        os.write("Ahoj everyone!\n".getBytes("UTF-8"));
+        os.write("Ahoj everyone!\n".getBytes(StandardCharsets.UTF_8));
         os.close();
 
         assertEquals("Only one change event should be fired.", 1, listener.check(EventType.CHANGED));

--- a/platform/netbinox/test/unit/src/org/netbeans/SetupHid.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/SetupHid.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -132,7 +133,7 @@ public abstract class SetupHid extends NbTestCase {
             while (it.hasNext()) {
                 Map.Entry entry = (Map.Entry) it.next();
                 String path = (String) entry.getKey();
-                byte[] data = ((String) entry.getValue()).getBytes("UTF-8");
+                byte[] data = ((String) entry.getValue()).getBytes(StandardCharsets.UTF_8);
                 JarEntry je = new JarEntry(path);
                 je.setSize(data.length);
                 CRC32 crc = new CRC32();

--- a/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/BundleResourceTest.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/BundleResourceTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.logging.Level;
@@ -101,7 +102,7 @@ public class BundleResourceTest extends NetigsoHid {
         byte[] arr = new byte[400];
         int len = is.read(arr);
         assertTrue(len > 0);
-        assertEquals(hello, new String(arr, 0, len, "UTF-8"));
+        assertEquals(hello, new String(arr, 0, len, StandardCharsets.UTF_8));
     }
 
 }

--- a/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/BundleURLConnectionTest.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/BundleURLConnectionTest.java
@@ -22,8 +22,8 @@ import java.awt.GraphicsEnvironment;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.logging.Level;
 import junit.framework.Test;
@@ -128,12 +128,7 @@ public class BundleURLConnectionTest extends NbTestCase {
             @Override
             public boolean reject(Object obj) {
                 if (obj instanceof byte[]) {
-                    String s;
-                    try {
-                        s = new String((byte[])obj, "UTF-8");
-                    } catch (UnsupportedEncodingException ex) {
-                        throw new IllegalStateException(ex);
-                    }
+                    String s = new String((byte[])obj, StandardCharsets.UTF_8);
                     if (s.startsWith(text)) {
                         found[0] = s;
                     }

--- a/platform/o.n.bootstrap/src/org/netbeans/PatchByteCode.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/PatchByteCode.java
@@ -22,9 +22,9 @@ package org.netbeans;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,12 +51,8 @@ public final class PatchByteCode {
     private static final String PREFIX_EXTEND = "extend."; // NOI18N
     
     static {
-        try {
-            RUNTIME_INVISIBLE_ANNOTATIONS = "RuntimeInvisibleAnnotations".getBytes("UTF-8"); // NOI18N
-            PATCHED_PUBLIC = DESC_PATCHED_PUBLIC_ANNOTATION.getBytes("UTF-8"); // NOI18N
-        } catch (UnsupportedEncodingException x) {
-            throw new ExceptionInInitializerError(x);
-        }
+        RUNTIME_INVISIBLE_ANNOTATIONS = "RuntimeInvisibleAnnotations".getBytes(StandardCharsets.UTF_8); // NOI18N
+        PATCHED_PUBLIC = DESC_PATCHED_PUBLIC_ANNOTATION.getBytes(StandardCharsets.UTF_8);
     }
     
     /**
@@ -86,7 +82,7 @@ public final class PatchByteCode {
     private void load(URL stream) throws IOException {
         try (InputStream istm = stream.openStream()) {
             Properties props = new Properties();
-            props.load(new InputStreamReader(istm, "UTF-8")); // NOI18N
+            props.load(new InputStreamReader(istm, StandardCharsets.UTF_8));
             
             @SuppressWarnings("unchecked")
             Enumeration<String> en = (Enumeration<String>)props.propertyNames();

--- a/platform/o.n.bootstrap/src/org/netbeans/Stamps.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Stamps.java
@@ -36,6 +36,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -427,7 +428,7 @@ public final class Stamps {
     
     private static boolean compareAndUpdateFile(File file, String content, AtomicLong result) {
         try {
-            byte[] expected = content.getBytes("UTF-8"); // NOI18N
+            byte[] expected = content.getBytes(StandardCharsets.UTF_8);
             byte[] read = new byte[expected.length];
             FileInputStream is = null;
             boolean areCachesOK;

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerGrepTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerGrepTest.java
@@ -20,13 +20,15 @@
 package org.netbeans;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.junit.*;
-import static org.netbeans.CLIHandlerTest.*;
 import org.openide.util.RequestProcessor;
+
+import static org.netbeans.CLIHandlerTest.*;
 
 /**
  * Test the command-line-interface handler ability to send zero output
@@ -101,7 +103,7 @@ public class CLIHandlerGrepTest extends NbTestCase {
                 try {
                     PrintStream ps = new PrintStream(args.getOutputStream());
                     BufferedReader r = new BufferedReader(
-                        new InputStreamReader(args.getInputStream(), "UTF-8")
+                        new InputStreamReader(args.getInputStream(), StandardCharsets.UTF_8)
                     );
                     for (;;) {
                         String line = r.readLine();
@@ -203,11 +205,7 @@ public class CLIHandlerGrepTest extends NbTestCase {
         }
 
         private void pushMsg(String p) {
-            try {
-                pending.offer(p.getBytes("UTF-8"));
-            } catch (UnsupportedEncodingException ex) {
-                throw new IllegalStateException(ex);
-            }
+            pending.offer(p.getBytes(StandardCharsets.UTF_8));
         }
     }
 

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -131,7 +132,7 @@ public abstract class SetupHid extends NbTestCase {
             JarOutputStream jos = new JarOutputStream(os, m);
             for (Map.Entry<String, String> entry : contents.entrySet()) {
                 String path = entry.getKey();
-                byte[] data = entry.getValue().getBytes("UTF-8");
+                byte[] data = entry.getValue().getBytes(StandardCharsets.UTF_8);
                 JarEntry je = new JarEntry(path);
                 je.setSize(data.length);
                 CRC32 crc = new CRC32();

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/PropertiesCustomEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/PropertiesCustomEditor.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.regex.Pattern;
 import javax.swing.JEditorPane;
@@ -86,7 +87,7 @@ public class PropertiesCustomEditor extends JPanel implements DocumentListener {
         Properties v = new Properties();
         boolean loaded = false;
         try {
-            v.load(new ByteArrayInputStream(editorPane.getText().getBytes("ISO-8859-1")));
+            v.load(new ByteArrayInputStream(editorPane.getText().getBytes(StandardCharsets.ISO_8859_1)));
             loaded = true;
         } catch (Exception x) { // IOException, IllegalArgumentException, maybe others
             Color c = UIManager.getColor("nb.errorForeground"); // NOI18N

--- a/platform/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
@@ -30,18 +30,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.lang.management.ManagementFactory;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.Attributes;
@@ -51,7 +50,6 @@ import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.ZipException;
-import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.RequestProcessor.Task;
@@ -1331,12 +1329,7 @@ public class JarFileSystem extends AbstractFileSystem {
                 for (int i = 0; i < ret.length; i++) {
                     byte[] name = new byte[indices[(2 * i) + 1]];
                     System.arraycopy(names, indices[2 * i], name, 0, name.length);
-
-                    try {
-                        ret[i] = new String(name, "UTF-8");
-                    } catch (UnsupportedEncodingException e) {
-                        throw new InternalError("No UTF-8");
-                    }
+                    ret[i] = new String(name, StandardCharsets.UTF_8);
                 }
 
                 return ret;
@@ -1350,13 +1343,9 @@ public class JarFileSystem extends AbstractFileSystem {
                     indices = newInd;
                 }
 
-                try {
-                    byte[] bytes = name.getBytes("UTF-8");
-                    indices[idx++] = putName(bytes);
-                    indices[idx++] = bytes.length;
-                } catch (UnsupportedEncodingException e) {
-                    throw new InternalError("No UTF-8");
-                }
+                byte[] bytes = name.getBytes(StandardCharsets.UTF_8);
+                indices[idx++] = putName(bytes);
+                indices[idx++] = bytes.length;
             }
 
             void trunc() {

--- a/platform/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/UserDefinedMIMETest.java
+++ b/platform/openide.filesystems/test/unit/src/org/netbeans/modules/openide/filesystems/declmime/UserDefinedMIMETest.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.openide.filesystems.declmime;
 
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.junit.NbTestCase;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -57,7 +58,7 @@ public class UserDefinedMIMETest extends NbTestCase {
         
         
         OutputStream os = udmr.getOutputStream();
-        os.write(txt.getBytes("UTF-8"));
+        os.write(txt.getBytes(StandardCharsets.UTF_8));
         os.close();
         udmr.setAttribute("position", 555);
         udmr.setAttribute("user-defined-mime-resolver", Boolean.TRUE);

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
@@ -28,6 +28,7 @@ import java.lang.ref.*;
 import java.io.*;
 import java.util.*;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import org.openide.util.Lookup.Result;
 
@@ -1221,7 +1222,7 @@ public class FileObjectTestHid extends TestBaseHid {
         assertEquals("Same path", ch.getPath(), newCh.getPath());
 
         try (OutputStream os = newCh.getOutputStream()) {
-            os.write("Ahoj".getBytes("UTF-8"));
+            os.write("Ahoj".getBytes(StandardCharsets.UTF_8));
         }
         assertEquals("Ahoj", newCh.asText("UTF-8"));
         assertEquals("Parents are same", ch.getParent(), newCh.getParent());
@@ -1240,7 +1241,7 @@ public class FileObjectTestHid extends TestBaseHid {
         assertFalse("Not valid", ch.isValid());
 
         try (OutputStream os = ch.getOutputStream()) {
-            os.write("Ahoj".getBytes("UTF-8"));
+            os.write("Ahoj".getBytes(StandardCharsets.UTF_8));
         }
 
         if (!ch.isValid()) {
@@ -2770,12 +2771,12 @@ public class FileObjectTestHid extends TestBaseHid {
         try {
             OutputStream os = fo1.getOutputStream();
             String txt = "Ahoj\nJak\nSe\nMas";
-            os.write(txt.getBytes("UTF-8"));
+            os.write(txt.getBytes(StandardCharsets.UTF_8));
             os.close();
             byte[] arr = fo1.asBytes();
             assertNotNull("Arrays is read", arr);
             assertEquals("Right length bytes", txt.length(), arr.length);
-            assertEquals(txt, new String(arr, "UTF-8"));
+            assertEquals(txt, new String(arr, StandardCharsets.UTF_8));
             assertEquals(txt, fo1.asText("UTF-8"));
 
             ArrayList<String> all = new ArrayList<String>();
@@ -2824,7 +2825,7 @@ public class FileObjectTestHid extends TestBaseHid {
 
             OutputStream os = fo1.getOutputStream();
             for (int i = 0; i < 10; i++) {
-                os.write(sb.toString().getBytes("UTF-8"));
+                os.write(sb.toString().getBytes(StandardCharsets.UTF_8));
             }
             os.close();
             if (64 * 1024 > fo1.getSize()) {
@@ -3612,7 +3613,7 @@ public class FileObjectTestHid extends TestBaseHid {
             
             OutputStream os = fo1.getOutputStream();
             String txt = "Ahoj\nJak\nSe\nMas";
-            os.write(txt.getBytes("UTF-8"));
+            os.write(txt.getBytes(StandardCharsets.UTF_8));
             os.close();
 
             

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/JarFileSystemHidden.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/JarFileSystemHidden.java
@@ -32,6 +32,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
@@ -294,7 +295,7 @@ public class JarFileSystemHidden extends NbTestCase {
         try {
             BufferedInputStream bis = new BufferedInputStream(fis);
             try {
-                InputStreamReader isr = new InputStreamReader(bis, "UTF-8");
+                InputStreamReader isr = new InputStreamReader(bis, StandardCharsets.UTF_8);
                 try {
                     char[] buffer = new char[1024];
                     int read;

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/XMLFileSystemTestHid.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/XMLFileSystemTestHid.java
@@ -29,6 +29,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Enumeration;
@@ -790,7 +791,7 @@ public class XMLFileSystemTestHid extends TestBaseHid {
             for (JEntry entry : entries) {
                 JarEntry jarEntry = new JarEntry(entry.name);
                 jarOut.putNextEntry(jarEntry);
-                jarOut.write(entry.content.getBytes("UTF-8"));
+                jarOut.write(entry.content.getBytes(StandardCharsets.UTF_8));
                 jarOut.closeEntry();
             }
         }

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/test/TestFileUtils.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/test/TestFileUtils.java
@@ -23,9 +23,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import static junit.framework.Assert.*;
+import java.nio.charset.StandardCharsets;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Common utility methods for massaging and inspecting files from tests.
@@ -50,7 +52,7 @@ public class TestFileUtils {
         FileObject existing = root.getFileObject(path);
         OutputStream os = existing != null ? existing.getOutputStream() : root.createAndOpen(path);
         try {
-            PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, "UTF-8"));
+            PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
             pw.print(body);
             pw.flush();
         } finally {

--- a/platform/openide.loaders/src/org/openide/loaders/DataShadow.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataShadow.java
@@ -27,6 +27,7 @@ import java.io.*;
 import java.lang.ref.*;
 import java.lang.reflect.InvocationTargetException;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.logging.Level;
@@ -337,7 +338,7 @@ public class DataShadow extends MultiDataObject implements DataObject.Container 
      */
     private static void writeShadowFile(FileObject fo, URL url) throws IOException {
         FileLock lock = fo.lock();
-        Writer os = new OutputStreamWriter(fo.getOutputStream(lock), "UTF-8");
+        Writer os = new OutputStreamWriter(fo.getOutputStream(lock), StandardCharsets.UTF_8);
         try {
             os.write(url.toExternalForm()); // NOI18N
         } finally {
@@ -485,7 +486,7 @@ public class DataShadow extends MultiDataObject implements DataObject.Container 
             try {
                 return MUTEX.readAccess(new Mutex.ExceptionAction<String[]>() {
                     public String[] run() throws IOException {
-                        BufferedReader ois = new BufferedReader(new InputStreamReader(f.getInputStream(), "UTF-8")); // NOI18N
+                        BufferedReader ois = new BufferedReader(new InputStreamReader(f.getInputStream(), StandardCharsets.UTF_8));
                         try {
                             String s = ois.readLine();
                             String fs = ois.readLine();

--- a/platform/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
@@ -24,6 +24,7 @@ import java.beans.PropertyVetoException;
 import java.io.*;
 import java.lang.ref.*;
 import java.lang.reflect.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.logging.*;
 import org.openide.ServiceType;
@@ -1609,7 +1610,7 @@ public class InstanceDataObject extends MultiDataObject implements InstanceCooki
             throw new IOException("missing attribute settings.convertor"); // NOI18N
         }
         ByteArrayOutputStream b = new ByteArrayOutputStream(1024);
-        Writer w = new OutputStreamWriter(b, "UTF-8"); // NOI18N
+        Writer w = new OutputStreamWriter(b, StandardCharsets.UTF_8);
         convertorWriteMethod(convertor, new WriterProvider(w, ctx), inst);
         w.close();
         return b;

--- a/platform/openide.loaders/src/org/openide/loaders/XMLDataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/XMLDataObject.java
@@ -24,6 +24,7 @@ import java.io.*;
 import java.lang.ref.*;
 import java.lang.reflect.*;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.logging.*;
 import javax.xml.parsers.DocumentBuilder;

--- a/platform/openide.modules/src/org/netbeans/modules/openide/modules/PatchedPublicProcessor.java
+++ b/platform/openide.modules/src/org/netbeans/modules/openide/modules/PatchedPublicProcessor.java
@@ -23,6 +23,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -87,7 +88,7 @@ public class PatchedPublicProcessor extends AbstractProcessor {
                     StandardLocation.CLASS_OUTPUT,
                     "", "META-INF/.bytecodePatched",
                     originatingElements.toArray(new Element[originatingElements.size()])).openOutputStream()) {
-                BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+                BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
                 for (Map.Entry<String, String> exEntry : superclasses.entrySet()) {
                     String api = exEntry.getKey();
                     String sup = exEntry.getValue();

--- a/platform/openide.util.lookup/src/org/netbeans/modules/openide/util/NamedServiceProcessor.java
+++ b/platform/openide.util.lookup/src/org/netbeans/modules/openide/util/NamedServiceProcessor.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -249,7 +250,7 @@ public final class NamedServiceProcessor extends AbstractServiceProviderProcesso
             while (en.hasMoreElements()) {
                 URL url = en.nextElement();
                 InputStream is = url.openStream();
-                BufferedReader reader = new BufferedReader(new InputStreamReader(is, "UTF-8")); // NOI18N
+                BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
 
                 // XXX consider using ServiceLoaderLine instead
                 while (true) {

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/MetaInfServicesLookup.java
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/MetaInfServicesLookup.java
@@ -27,6 +27,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -238,7 +239,7 @@ final class MetaInfServicesLookup extends AbstractLookup {
                 InputStream is = url.openStream();
 
                 try {
-                    BufferedReader reader = new BufferedReader(new InputStreamReader(is, "UTF-8")); // NOI18N
+                    BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
 
                     // XXX consider using ServiceLoaderLine instead
                     while (true) {

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/implspi/AbstractServiceProviderProcessor.java
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/implspi/AbstractServiceProviderProcessor.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.annotation.Annotation;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -214,7 +215,7 @@ public abstract class AbstractServiceProviderProcessor extends AbstractProcessor
                     FileObject in = filer.getResource(StandardLocation.CLASS_OUTPUT, "", rsrc);
                     InputStream is = in.openInputStream();
                     try {
-                        ServiceLoaderLine.parse(new InputStreamReader(is, "UTF-8"), lines); // NOI18N
+                        ServiceLoaderLine.parse(new InputStreamReader(is, StandardCharsets.UTF_8), lines);
                     } finally {
                         is.close();
                     }
@@ -300,7 +301,7 @@ public abstract class AbstractServiceProviderProcessor extends AbstractProcessor
                             originatingElementsByProcessor.get(filer).get(entry.getKey()).toArray(new Element[0]));
                     OutputStream os = out.openOutputStream();
                     try {
-                        PrintWriter w = new PrintWriter(new OutputStreamWriter(os, "UTF-8"));
+                        PrintWriter w = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
                         for (ServiceLoaderLine line : entry.getValue()) {
                             line.write(w);
                         }

--- a/platform/openide.util.lookup/test/unit/src/org/netbeans/modules/openide/util/NamedServiceProcessorTest.java
+++ b/platform/openide.util.lookup/test/unit/src/org/netbeans/modules/openide/util/NamedServiceProcessorTest.java
@@ -25,6 +25,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 import org.netbeans.junit.NbTestCase;
 import org.openide.util.Lookup;
@@ -105,7 +106,7 @@ public class NamedServiceProcessorTest extends NbTestCase {
         assertFalse("Compilation fails",
             AnnotationProcessorTestUtils.runJavac(getWorkDir(), null, getWorkDir(), null, os)
         );
-        String err = new String(os.toByteArray(), "UTF-8");
+        String err = new String(os.toByteArray(), StandardCharsets.UTF_8);
         if (err.indexOf("java.lang.Runnable") == -1) {
             fail("The error messages should say something about interface Runnable\n" + err);
         }
@@ -139,7 +140,7 @@ public class NamedServiceProcessorTest extends NbTestCase {
         assertFalse("Compilation fails",
             AnnotationProcessorTestUtils.runJavac(getWorkDir(), null, getWorkDir(), null, os)
         );
-        String err = new String(os.toByteArray(), "UTF-8");
+        String err = new String(os.toByteArray(), StandardCharsets.UTF_8);
         if (err.indexOf("@when()") == -1) {
             fail("The error messages should say something about missing @when\n" + err);
         }
@@ -156,7 +157,7 @@ public class NamedServiceProcessorTest extends NbTestCase {
         assertFalse("Compilation fails",
             AnnotationProcessorTestUtils.runJavac(getWorkDir(), null, getWorkDir(), null, os)
         );
-        String err = new String(os.toByteArray(), "UTF-8");
+        String err = new String(os.toByteArray(), StandardCharsets.UTF_8);
         if (err.indexOf("@when()") == -1) {
             fail("The error messages should say something about missing @when\n" + err);
         }
@@ -173,7 +174,7 @@ public class NamedServiceProcessorTest extends NbTestCase {
         assertFalse("Compilation fails",
             AnnotationProcessorTestUtils.runJavac(getWorkDir(), null, getWorkDir(), null, os)
         );
-        String err = new String(os.toByteArray(), "UTF-8");
+        String err = new String(os.toByteArray(), StandardCharsets.UTF_8);
         if (err.indexOf("where") == -1) {
             fail("The error messages should say something about missing where\n" + err);
         }
@@ -189,7 +190,7 @@ public class NamedServiceProcessorTest extends NbTestCase {
         assertFalse("Compilation fails",
             AnnotationProcessorTestUtils.runJavac(getWorkDir(), null, getWorkDir(), null, os)
         );
-        String err = new String(os.toByteArray(), "UTF-8");
+        String err = new String(os.toByteArray(), StandardCharsets.UTF_8);
         if (err.indexOf("where") == -1) {
             fail("The error messages should say something about missing where\n" + err);
         }
@@ -205,7 +206,7 @@ public class NamedServiceProcessorTest extends NbTestCase {
         assertFalse("Compilation fails",
             AnnotationProcessorTestUtils.runJavac(getWorkDir(), null, getWorkDir(), null, os)
         );
-        String err = new String(os.toByteArray(), "UTF-8");
+        String err = new String(os.toByteArray(), StandardCharsets.UTF_8);
         if (err.indexOf("specify @Retention") == -1) {
             fail("The error messages should say something about missing where\n" + err);
         }
@@ -224,7 +225,7 @@ public class NamedServiceProcessorTest extends NbTestCase {
         assertFalse("Compilation fails",
             AnnotationProcessorTestUtils.runJavac(getWorkDir(), null, getWorkDir(), null, os)
         );
-        String err = new String(os.toByteArray(), "UTF-8");
+        String err = new String(os.toByteArray(), StandardCharsets.UTF_8);
         if (err.indexOf("specify @Retention") != -1) {
             fail("Be silent about Retention\n" + err);
         }

--- a/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesLookupTest.java
+++ b/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/MetaInfServicesLookupTest.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -529,7 +530,7 @@ public class MetaInfServicesLookupTest extends NbTestCase {
 
                                 @Override
                                 public InputStream getInputStream() throws IOException {
-                                    return new ByteArrayInputStream("java.lang.Object\n".getBytes("UTF-8"));
+                                    return new ByteArrayInputStream("java.lang.Object\n".getBytes(StandardCharsets.UTF_8));
                                 }
                             };
                         }
@@ -648,7 +649,7 @@ public class MetaInfServicesLookupTest extends NbTestCase {
                             return new URLConnection(u) {
                                 public void connect() throws IOException {}
                                 public @Override InputStream getInputStream() throws IOException {
-                                    return new ByteArrayInputStream(n.getBytes("UTF-8"));
+                                    return new ByteArrayInputStream(n.getBytes(StandardCharsets.UTF_8));
                                 }
                             };
                         }

--- a/platform/openide.util.ui/test/unit/src/org/openide/util/test/TestFileUtils.java
+++ b/platform/openide.util.ui/test/unit/src/org/openide/util/test/TestFileUtils.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -54,7 +55,7 @@ public class TestFileUtils {
     public static File writeFile(File f, String body) throws IOException {
         f.getParentFile().mkdirs();
         OutputStream os = new FileOutputStream(f);
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, "UTF-8"));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
         pw.print(body);
         pw.flush();
         os.close();
@@ -119,7 +120,7 @@ public class TestFileUtils {
         for (String entry : entries) {
             int colon = entry.indexOf(':');
             assert colon != -1 : entry;
-            binary.put(entry.substring(0, colon), entry.substring(colon + 1).getBytes("UTF-8"));
+            binary.put(entry.substring(0, colon), entry.substring(colon + 1).getBytes(StandardCharsets.UTF_8));
         }
         writeZipFile(os, binary);
     }

--- a/platform/openide.util/src/org/openide/util/EditableProperties.java
+++ b/platform/openide.util/src/org/openide/util/EditableProperties.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.ArrayList;
@@ -39,7 +40,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import org.openide.util.Parameters;
 
 // XXX: consider adding getInitialComment() and setInitialComment() methods
 // (useful e.g. for GeneratedFilesHelper)
@@ -142,7 +142,7 @@ public final class EditableProperties extends AbstractMap<String,String> impleme
      */
     public void load(InputStream stream) throws IOException {
         int parseState = WAITING_FOR_KEY_VALUE;
-        BufferedReader input = new BufferedReader(new InputStreamReader(stream, "ISO-8859-1"));
+        BufferedReader input = new BufferedReader(new InputStreamReader(stream, StandardCharsets.ISO_8859_1));
         List<String> tempList = new LinkedList<String>();
         String line;
         int commentLinesCount = 0;
@@ -189,7 +189,7 @@ public final class EditableProperties extends AbstractMap<String,String> impleme
      */
     public void store(OutputStream stream) throws IOException {
         boolean previousLineWasEmpty = true;
-        BufferedWriter output = new BufferedWriter(new OutputStreamWriter(stream, "ISO-8859-1"));
+        BufferedWriter output = new BufferedWriter(new OutputStreamWriter(stream, StandardCharsets.ISO_8859_1));
         for (Item item : state.items) {
             if (item.isSeparate() && !previousLineWasEmpty) {
                 output.newLine();

--- a/platform/openide.util/test/unit/src/org/openide/util/EditablePropertiesTest.java
+++ b/platform/openide.util/test/unit/src/org/openide/util/EditablePropertiesTest.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -290,7 +291,7 @@ public class EditablePropertiesTest extends NbTestCase {
                 + "k3=whatever\n"
                 + "k5=Label\\:\n";
         EditableProperties p = new EditableProperties(true);
-        p.load(new ByteArrayInputStream(text.getBytes("ISO-8859-1")));
+        p.load(new ByteArrayInputStream(text.getBytes(StandardCharsets.ISO_8859_1)));
         assertEquals("A long line. Broken into pieces.", p.get("k1"));
         assertEquals("whatever", p.get("k3"));
         assertEquals("Label:", p.get("k5"));
@@ -351,7 +352,7 @@ public class EditablePropertiesTest extends NbTestCase {
         String expected = "# \\u0158ekni koment teda!" + lsep + "k=v" + lsep;
         assertEquals("Storing non-Latin chars in comments works", expected, getAsString(p));
         p = new EditableProperties(false);
-        p.load(new ByteArrayInputStream(expected.getBytes("ISO-8859-1")));
+        p.load(new ByteArrayInputStream(expected.getBytes(StandardCharsets.ISO_8859_1)));
         assertEquals("Reading non-Latin chars in comments works", Collections.singletonList("# \u0158ekni koment teda!"), Arrays.asList(p.getComment("k")));
         p.setProperty("k", "v2");
         expected = "# \\u0158ekni koment teda!" + lsep + "k=v2" + lsep;

--- a/platform/openide.util/test/unit/src/org/openide/util/NbBundleTest.java
+++ b/platform/openide.util/test/unit/src/org/openide/util/NbBundleTest.java
@@ -26,6 +26,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,12 +39,13 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.TreeMap;
 import java.util.jar.Attributes;
+import org.openide.util.base.BundleClass;
 import junit.framework.TestCase;
+
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertNotEquals;
-import org.openide.util.base.BundleClass;
 
 // XXX testGetClassBundle
 // XXX testGetLocalizedFile
@@ -347,7 +349,7 @@ public class NbBundleTest extends TestCase {
         // XXX value beginning with \
     }
     private static String debugIS(String s, boolean loc) throws IOException {
-        InputStream dis = new NbBundle.DebugLoader.DebugInputStream(new ByteArrayInputStream(s.getBytes("ISO-8859-1")), 17, loc);
+        InputStream dis = new NbBundle.DebugLoader.DebugInputStream(new ByteArrayInputStream(s.getBytes(StandardCharsets.ISO_8859_1)), 17, loc);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         byte[] buf = new byte[4096];
         int read;

--- a/platform/openide.util/test/unit/src/org/openide/util/test/TestFileUtils.java
+++ b/platform/openide.util/test/unit/src/org/openide/util/test/TestFileUtils.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -54,7 +55,7 @@ public class TestFileUtils {
     public static File writeFile(File f, String body) throws IOException {
         f.getParentFile().mkdirs();
         OutputStream os = new FileOutputStream(f);
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, "UTF-8"));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
         pw.print(body);
         pw.flush();
         os.close();
@@ -119,7 +120,7 @@ public class TestFileUtils {
         for (String entry : entries) {
             int colon = entry.indexOf(':');
             assert colon != -1 : entry;
-            binary.put(entry.substring(0, colon), entry.substring(colon + 1).getBytes("UTF-8"));
+            binary.put(entry.substring(0, colon), entry.substring(colon + 1).getBytes(StandardCharsets.UTF_8));
         }
         writeZipFile(os, binary);
     }

--- a/platform/openide.windows/test/unit/src/org/netbeans/modules/openide/windows/TopComponentProcessorTest.java
+++ b/platform/openide.windows/test/unit/src/org/netbeans/modules/openide/windows/TopComponentProcessorTest.java
@@ -24,6 +24,7 @@ import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import javax.swing.Action;
 import junit.framework.Test;
@@ -126,7 +127,7 @@ public class TopComponentProcessorTest extends  NbTestCase {
     }
     
     private static void assertValidate(String xml) throws Exception {
-        XMLUtil.parse(new InputSource(new ByteArrayInputStream(xml.getBytes("UTF-8"))), false, true, XMLUtil.defaultErrorHandler(), new EntityResolver() {
+        XMLUtil.parse(new InputSource(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))), false, true, XMLUtil.defaultErrorHandler(), new EntityResolver() {
             public @Override InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
                 return new InputSource(new ByteArrayInputStream(new byte[0]));
                 /* XXX when #192595 is implemented, can move DTDs here from core.windows, set validate=true above, and use:

--- a/platform/options.api/test/unit/src/org/netbeans/modules/options/export/OptionsExportModelTest.java
+++ b/platform/options.api/test/unit/src/org/netbeans/modules/options/export/OptionsExportModelTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -312,7 +313,7 @@ public class OptionsExportModelTest extends NbTestCase {
                 ZipEntry zipEntry = (ZipEntry) entries.nextElement();
                 if (zipEntry.getName().equals(OptionsExportModel.ENABLED_ITEMS_INFO)) {
                     InputStream stream = zipFile.getInputStream(zipEntry);
-                    BufferedReader br = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
+                    BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
                     String strLine;
                     while ((strLine = br.readLine()) != null) {
                         assertEquals("Wrong data saved in enabledItems.info", "Category0Item01", strLine);

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/XMLStorage.java
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/XMLStorage.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -110,7 +111,7 @@ public class XMLStorage {
                     FileLock lock = fo.lock ();
                     try {
                         OutputStream os = fo.getOutputStream (lock);
-                        Writer writer = new OutputStreamWriter (os, "UTF-8"); // NOI18N
+                        Writer writer = new OutputStreamWriter (os, StandardCharsets.UTF_8);
                         try {
                             writer.write (content);
                         } finally {

--- a/platform/queries/test/unit/src/org/netbeans/api/queries/FileEncodingQueryTest.java
+++ b/platform/queries/test/unit/src/org/netbeans/api/queries/FileEncodingQueryTest.java
@@ -42,6 +42,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
@@ -88,7 +89,7 @@ public class FileEncodingQueryTest extends NbTestCase {
     public void setUp () throws IOException {
         clearWorkDir();
         MockServices.setServices (ContentBaseEncodingQuery.class, FileTypeBaseEncodingQuery.class);
-        FileTypeBaseEncodingQuery.setExtMap(Collections.<String,Charset>emptyMap(), Charset.forName("UTF-8"));
+        FileTypeBaseEncodingQuery.setExtMap(Collections.<String,Charset>emptyMap(), StandardCharsets.UTF_8);
     }
     
     

--- a/platform/sendopts/test/unit/src/org/netbeans/modules/sendopts/CaptureUsageTest.java
+++ b/platform/sendopts/test/unit/src/org/netbeans/modules/sendopts/CaptureUsageTest.java
@@ -20,9 +20,6 @@ package org.netbeans.modules.sendopts;
 
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertNotEquals;
 import org.junit.Test;
 import org.netbeans.api.sendopts.CommandException;
 import org.netbeans.api.sendopts.CommandLine;
@@ -30,6 +27,10 @@ import org.netbeans.spi.sendopts.Arg;
 import org.netbeans.spi.sendopts.ArgsProcessor;
 import org.netbeans.spi.sendopts.Description;
 import org.netbeans.spi.sendopts.Env;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 
 public class CaptureUsageTest implements ArgsProcessor {
     private static String usage;

--- a/platform/sendopts/test/unit/src/org/netbeans/spi/sendopts/annotations/ForClassTest.java
+++ b/platform/sendopts/test/unit/src/org/netbeans/spi/sendopts/annotations/ForClassTest.java
@@ -26,6 +26,7 @@ import org.netbeans.spi.sendopts.Arg;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.sendopts.CommandException;
 import org.netbeans.api.sendopts.CommandLine;
 import org.netbeans.junit.NbTestCase;
@@ -109,7 +110,7 @@ public class ForClassTest extends NbTestCase {
     public void testHelpOnEnv() throws CommandException, UnsupportedEncodingException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         cmd.process(new String[] { "--tellmehow" }, System.in, os, System.err, null);
-        String out = new String(os.toByteArray(), "UTF-8");
+        String out = new String(os.toByteArray(), StandardCharsets.UTF_8);
         assertTrue("contains additionalParams:\n" + out, out.contains(("MyParams")));
         assertTrue("contains short help:\n" + out, out.contains(("ShorterHelp")));
     }

--- a/platform/settings/src/org/netbeans/modules/settings/InstanceProvider.java
+++ b/platform/settings/src/org/netbeans/modules/settings/InstanceProvider.java
@@ -22,6 +22,8 @@ package org.netbeans.modules.settings;
 import java.beans.PropertyChangeEvent;
 import java.lang.ref.SoftReference;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.modules.settings.convertors.SerialDataNode;
@@ -286,9 +288,7 @@ implements java.beans.PropertyChangeListener, FileSystem.AtomicAction {
             try {
                 synchronized (READWRITE_LOCK) {
                     java.io.Reader r = ContextProvider.createReaderContextProvider(
-                        new java.io.InputStreamReader(settingFO.getInputStream(),"UTF-8"), //NOI18N
-                        getFile()
-                    );
+                        new InputStreamReader(settingFO.getInputStream(), StandardCharsets.UTF_8), getFile());
                     inst = getConvertor().read(r);
                 }
             } catch (IOException ex) {

--- a/platform/settings/src/org/netbeans/modules/settings/SaveSupport.java
+++ b/platform/settings/src/org/netbeans/modules/settings/SaveSupport.java
@@ -21,6 +21,8 @@ package org.netbeans.modules.settings;
 
 import java.beans.*;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -230,9 +232,7 @@ final class SaveSupport {
             if (conv == null) return ;
             java.io.ByteArrayOutputStream b = new java.io.ByteArrayOutputStream(1024);
             java.io.Writer w = ContextProvider.createWriterContextProvider(
-                new java.io.OutputStreamWriter(b, "UTF-8"), // NOI18N
-                SaveSupport.this.file
-            );
+                    new OutputStreamWriter(b, StandardCharsets.UTF_8), SaveSupport.this.file);
             isChanged = false;
             try {
                 conv.write(w, inst);

--- a/platform/settings/src/org/netbeans/modules/settings/convertors/SerialDataConvertor.java
+++ b/platform/settings/src/org/netbeans/modules/settings/convertors/SerialDataConvertor.java
@@ -32,6 +32,7 @@ import java.io.Writer;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.logging.Level;
@@ -807,7 +808,7 @@ implements PropertyChangeListener, FileSystem.AtomicAction {
             if (inst == null) return ;
             
             ByteArrayOutputStream b = new ByteArrayOutputStream(1024);
-            Writer w = new OutputStreamWriter(b, "UTF-8"); // NOI18N
+            Writer w = new OutputStreamWriter(b, StandardCharsets.UTF_8);
             try {
                 isWriting = true;
                 Convertor conv = getConvertor();

--- a/platform/settings/src/org/netbeans/modules/settings/convertors/XMLBeanConvertor.java
+++ b/platform/settings/src/org/netbeans/modules/settings/convertors/XMLBeanConvertor.java
@@ -27,6 +27,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -96,7 +97,7 @@ public final class XMLBeanConvertor extends Convertor implements PropertyChangeL
             Thread.currentThread().setContextClassLoader(ccl);
         }
         e.close();
-        String data = new String(out.toByteArray(), "UTF-8");
+        String data = new String(out.toByteArray(), StandardCharsets.UTF_8);
         data = data.replaceFirst("<java", "<!DOCTYPE xmlbeans PUBLIC \"-//NetBeans//DTD XML beans 1.0//EN\" \"http://www.netbeans.org/dtds/xml-beans-1_0.dtd\">\n<java");
         w.write(data);
     }

--- a/platform/settings/src/org/netbeans/spi/settings/DOMConvertor.java
+++ b/platform/settings/src/org/netbeans/spi/settings/DOMConvertor.java
@@ -20,6 +20,7 @@
 package org.netbeans.spi.settings;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Lookup;

--- a/platform/settings/test/unit/src/org/netbeans/modules/settings/RecognizeInstanceObjectsOnModuleEnablementTest.java
+++ b/platform/settings/test/unit/src/org/netbeans/modules/settings/RecognizeInstanceObjectsOnModuleEnablementTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.settings;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.jar.Attributes;
@@ -76,7 +77,7 @@ public class RecognizeInstanceObjectsOnModuleEnablementTest extends NbTestCase {
         attr.putValue("Manifest-Version", "1.0");
         JarOutputStream os = new JarOutputStream(new FileOutputStream(f), man);
         os.putNextEntry(new JarEntry("META-INF/namedservices/ui/javax.swing.JComponent"));
-        os.write("javax.swing.JButton\n".getBytes("UTF-8"));
+        os.write("javax.swing.JButton\n".getBytes(StandardCharsets.UTF_8));
         os.closeEntry();
         os.close();
         

--- a/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/FactoryMethodTest.java
+++ b/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/FactoryMethodTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.settings.convertors;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.junit.NbTestCase;
 import org.openide.util.test.AnnotationProcessorTestUtils;
 
@@ -61,7 +62,7 @@ public class FactoryMethodTest extends NbTestCase {
         boolean res = AnnotationProcessorTestUtils.runJavac(src, null, dst, null, os);
         
         assertFalse("Compilation fails", res);
-        String out = new String(os.toByteArray(), "UTF-8");
+        String out = new String(os.toByteArray(), StandardCharsets.UTF_8);
         
         if (out.indexOf(" Method named create was not found") == -1) {
             fail("Should warn about missing method\n" + out);
@@ -81,7 +82,7 @@ public class FactoryMethodTest extends NbTestCase {
         boolean res = AnnotationProcessorTestUtils.runJavac(src, null, dst, null, os);
         
         assertFalse("Compilation fails", res);
-        String out = new String(os.toByteArray(), "UTF-8");
+        String out = new String(os.toByteArray(), StandardCharsets.UTF_8);
         
         if (out.indexOf("no parameters") == -1) {
             fail("Should warn about arguments of the method\n" + out);
@@ -100,7 +101,7 @@ public class FactoryMethodTest extends NbTestCase {
         boolean res = AnnotationProcessorTestUtils.runJavac(src, null, dst, null, os);
         
         assertFalse("Compilation fails", res);
-        String out = new String(os.toByteArray(), "UTF-8");
+        String out = new String(os.toByteArray(), StandardCharsets.UTF_8);
         
         if (out.indexOf("has to be static") == -1) {
             fail("Should warn method not being static\n" + out);
@@ -120,7 +121,7 @@ public class FactoryMethodTest extends NbTestCase {
         boolean res = AnnotationProcessorTestUtils.runJavac(src, null, dst, null, os);
         
         assertFalse("Compilation fails", res);
-        String out = new String(os.toByteArray(), "UTF-8");
+        String out = new String(os.toByteArray(), StandardCharsets.UTF_8);
         
         if (out.indexOf("must return Bean") == -1) {
             fail("Should about wrong return type\n" + out);

--- a/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/SerialDataConvertorTest.java
+++ b/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/SerialDataConvertorTest.java
@@ -28,6 +28,7 @@ import java.util.logging.Level;
 import org.openide.modules.ModuleInfo;
 import org.openide.util.*;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -644,7 +645,7 @@ public class SerialDataConvertorTest extends NbTestCase {
 "<settings version=\"1.0\">\n" +
 "  <instance class=\"" + FactoryBase.class.getName() + "\"/>\n" +
 "</settings>\n"
-        ).getBytes("UTF-8"));
+        ).getBytes(StandardCharsets.UTF_8));
         os.close();
         
         InstanceCookie ido = DataObject.find(fo).getCookie(InstanceCookie.class);

--- a/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertorTest.java
+++ b/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertorTest.java
@@ -22,21 +22,16 @@ package org.netbeans.modules.settings.convertors;
 import java.io.*;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
 import org.netbeans.api.settings.ConvertAsProperties;
 import org.netbeans.api.settings.FactoryMethod;
-
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.junit.RandomlyFails;
-
-
 import org.netbeans.spi.settings.Convertor;
 import org.netbeans.spi.settings.Saver;
 import org.openide.cookies.InstanceCookie;
 import org.openide.filesystems.FileLock;
-
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileSystem;
 import org.openide.filesystems.FileUtil;
@@ -400,7 +395,7 @@ public final class XMLPropertiesConvertorTest extends NbTestCase {
 		+ "<!DOCTYPE settings PUBLIC \"-//NetBeans//DTD Session settings 1.0//EN\" \"http://www.netbeans.org/dtds/sessionsettings-1_0.dtd\">\n"
 		+ "<settings version=\"1.0\">\n"
 		+ "  <instance class=\"" + Change.class.getName() + "\"/>\n"
-		+ "</settings>\n").getBytes("UTF-8"));
+		+ "</settings>\n").getBytes(StandardCharsets.UTF_8));
 	os.close();
 
 	DataObject ido = DataObject.find(fo);
@@ -414,7 +409,7 @@ public final class XMLPropertiesConvertorTest extends NbTestCase {
 	assertEquals("Default value in value", "", ch.value);
 
 	os = ido.getPrimaryFile().getOutputStream();
-	os.write(w.toString().getBytes("UTF-8"));
+	os.write(w.toString().getBytes(StandardCharsets.UTF_8));
 	os.close();
 
 	InstanceCookie icNew = ido.getCookie(InstanceCookie.class);

--- a/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/Result.java
+++ b/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/web/Result.java
@@ -19,12 +19,10 @@
 
 package org.netbeans.modules.quicksearch.web;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -52,11 +50,7 @@ final class Result {
     void parse( String html, int currentSearchOffset ) {
         searchFinished = true;
         items.clear();
-        try {
-            html = new String(html.getBytes(), "UTF-8"); //NOI18N
-        } catch (UnsupportedEncodingException ex) {
-            Logger.getLogger(Result.class.getName()).log(Level.FINE, null, ex);
-        }
+        html = new String(html.getBytes(), StandardCharsets.UTF_8);
         Pattern p = Pattern.compile("<a\\s+href\\s*=\\s*\"(.*?)\"[^>]*>(.*?)</a>", //NOI18N
                 Pattern.CASE_INSENSITIVE|Pattern.MULTILINE);
         Matcher m = p.matcher(html);

--- a/platform/uihandler/src/org/netbeans/modules/uihandler/Installer.java
+++ b/platform/uihandler/src/org/netbeans/modules/uihandler/Installer.java
@@ -34,6 +34,7 @@ import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
@@ -736,7 +737,7 @@ public class Installer extends ModuleInstall implements Runnable {
     private static String reportFileContent(File f) {
         BufferedReader br = null;
         try {
-            br = new BufferedReader(new InputStreamReader(new FileInputStream(f), "UTF-8"));
+            br = new BufferedReader(new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8));
             StringWriter sw = new StringWriter();
             String line;
             while ((line = br.readLine()) != null) {
@@ -2439,7 +2440,7 @@ public class Installer extends ModuleInstall implements Runnable {
                 int offset = builder.length();
                 n.setValue("offset", offset); // NOI18N
                 LogRecords.write(os, r);
-                builder.append(os.toString("UTF-8"));
+                builder.append(os.toString("UTF-8")); // NOI18N
             } catch (IOException ex) {
                 Installer.LOG.log(Level.WARNING, null, ex);
             }

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ExportUtils.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ExportUtils.java
@@ -29,6 +29,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ResourceBundle;
 import java.util.concurrent.ExecutorService;
@@ -695,7 +696,7 @@ public final class ExportUtils {
         
         private static Writer createWriter(File file) throws IOException {
             file.toPath(); // will fail for invalid file
-            CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder(); // NOI18N
+            CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
             FileOutputStream out = new FileOutputStream(file);
             return new BufferedWriter(new OutputStreamWriter(out, encoder), WRT_BUF);
         }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StringSegment.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StringSegment.java
@@ -19,7 +19,7 @@
 
 package org.netbeans.lib.profiler.heap;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -79,15 +79,7 @@ class StringSegment extends TagBounds {
         byte[] chars = new byte[len - dumpBuffer.getIDSize()];
         dumpBuffer.get(start + UTF8CharsOffset, chars);
 
-        String s = "Error"; // NOI18N
-
-        try {
-            s = new String(chars, "UTF-8"); // NOI18N
-        } catch (UnsupportedEncodingException ex) {
-            Systems.printStackTrace(ex);
-        }
-
-        return s;
+        return new String(chars, StandardCharsets.UTF_8);
     }
 
     private synchronized long getStringOffsetByID(long stringID) {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/ExportDataDumper.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/ExportDataDumper.java
@@ -23,9 +23,7 @@ import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -55,12 +53,7 @@ public class ExportDataDumper {
 
     public ExportDataDumper(FileOutputStream fw) {
         bos = new BufferedOutputStream(fw, BUFFER_SIZE);
-        try {
-            osw = new OutputStreamWriter(bos, "UTF-8");
-        } catch (UnsupportedEncodingException ex) {
-            numExceptions++;
-            Logger.getLogger(ExportDataDumper.class.getName()).log(Level.SEVERE, null, ex);
-        }
+        osw = new OutputStreamWriter(bos, StandardCharsets.UTF_8);
     }
 
     //~ Methods ------------------------------------------------------------------------------------------------------------------

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/HeapHistogramManager.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/HeapHistogramManager.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -353,7 +354,7 @@ class HeapHistogramManager {
         StringBuffer token;
 
         Scanner(InputStream is) throws UnsupportedEncodingException {
-            reader = new BufferedReader(new InputStreamReader(new FullInputStream(is), "UTF-8"));   // NOI18N
+            reader = new BufferedReader(new InputStreamReader(new FullInputStream(is), StandardCharsets.UTF_8));
             token = new StringBuffer(128);
         }
 

--- a/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapTest.java
+++ b/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapTest.java
@@ -31,6 +31,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -47,6 +48,7 @@ import java.util.TimeZone;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
@@ -346,9 +348,9 @@ public class HeapTest {
     }
 
     private void compareTextFiles(File goledFile, File outFile) throws IOException {
-        InputStreamReader goldenIsr = new InputStreamReader(new FileInputStream(goledFile), "UTF-8");
+        InputStreamReader goldenIsr = new InputStreamReader(new FileInputStream(goledFile), StandardCharsets.UTF_8);
         LineNumberReader goldenReader = new LineNumberReader(goldenIsr);
-        InputStreamReader isr = new InputStreamReader(new FileInputStream(outFile), "UTF-8");
+        InputStreamReader isr = new InputStreamReader(new FileInputStream(outFile), StandardCharsets.UTF_8);
         LineNumberReader reader = new LineNumberReader(isr);
         String goldenLine = "";
         String line = "";

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/JavacDetailsProvider.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/netbeans/JavacDetailsProvider.java
@@ -18,13 +18,12 @@
  */
 package org.netbeans.modules.profiler.heapwalk.details.netbeans;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.netbeans.lib.profiler.heap.Heap;
 import org.netbeans.lib.profiler.heap.Instance;
 import org.netbeans.lib.profiler.heap.PrimitiveArrayInstance;
 import org.netbeans.modules.profiler.heapwalk.details.spi.DetailsProvider;
-import org.openide.util.Exceptions;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -65,11 +64,7 @@ public class JavacDetailsProvider extends DetailsProvider.Basic {
                 String el = (String) elements.get(index+i);
                 data[i] = Byte.valueOf(el).byteValue();
             }
-            try {
-                return new String(data, "UTF-8"); // NOI18N
-            } catch (UnsupportedEncodingException ex) {
-                Exceptions.printStackTrace(ex);
-            }
+            return new String(data, StandardCharsets.UTF_8);
         }
         return null;
     }

--- a/profiler/profiler.j2se/test/unit/src/org/netbeans/modules/profiler/categories/j2se/TestUtilities.java
+++ b/profiler/profiler.j2se/test/unit/src/org/netbeans/modules/profiler/categories/j2se/TestUtilities.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import junit.framework.Assert;
 
@@ -76,7 +77,7 @@ public class TestUtilities extends ProxyLookup {
      {
         OutputStream os = fo.getOutputStream();
         try {
-            InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
             FileUtil.copy(is, os);
             return fo;
         } finally {

--- a/profiler/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/ProjectUtilities.java
+++ b/profiler/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/project/ProjectUtilities.java
@@ -46,8 +46,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -244,14 +244,7 @@ public final class ProjectUtilities {
             }
         }
 
-        try {
-            return new String(data, "UTF-8" //NOI18N
-            ); // According to Issue 65557, build.xml uses UTF-8, not default encoding!
-        } catch (UnsupportedEncodingException ex) {
-            ErrorManager.getDefault().notify(ErrorManager.ERROR, ex);
-
-            return null;
-        }
+        return new String(data, StandardCharsets.UTF_8); // According to Issue 65557, build.xml uses UTF-8, not default encoding!
     }
 
 //    Now available using AntProjectSupport

--- a/profiler/profiler.nbimpl/test/unit/src/org/netbeans/modules/profiler/nbimpl/TestUtilities.java
+++ b/profiler/profiler.nbimpl/test/unit/src/org/netbeans/modules/profiler/nbimpl/TestUtilities.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import junit.framework.Assert;
 
@@ -78,7 +79,7 @@ public class TestUtilities extends ProxyLookup {
      {
         OutputStream os = fo.getOutputStream();
         try {
-            InputStream is = new ByteArrayInputStream(content.getBytes("UTF-8"));
+            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
             FileUtil.copy(is, os);
             return fo;
         } finally {

--- a/profiler/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/ProjectUtilities.java
+++ b/profiler/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/ProjectUtilities.java
@@ -41,13 +41,11 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
-import java.text.MessageFormat;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -188,14 +186,7 @@ public class ProjectUtilities {
             }
         }
 
-        try {
-            return new String(data, "UTF-8" //NOI18N
-                    ); // According to Issue 65557, build.xml uses UTF-8, not default encoding!
-        } catch (UnsupportedEncodingException ex) {
-            ErrorManager.getDefault().notify(ErrorManager.ERROR, ex);
-
-            return null;
-        }
+        return new String(data, StandardCharsets.UTF_8); // According to Issue 65557, build.xml uses UTF-8, not default encoding!
     }
 
 //    public static java.util.List<SimpleFilter> getProjectDefaultInstrFilters(Project project) {

--- a/profiler/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/DataExport.java
+++ b/profiler/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/export/DataExport.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.BorderFactory;
@@ -93,7 +94,7 @@ public final class DataExport {
                 Writer writer = null;
                 TracerProgressObject progress = null;
                 try {
-                    writer = new OutputStreamWriter(new FileOutputStream(file), "UTF-8"); // NOI18N
+                    writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
                     ExportBatch batch = null;
 
                     if (filter == XML_FILTER)

--- a/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AndroidDebugTransport.java
+++ b/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AndroidDebugTransport.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.SelectionKey;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -82,7 +83,7 @@ public class AndroidDebugTransport extends MobileDebugTransport implements WebSo
     @Override
     public void read(SelectionKey key, byte[] message, Integer dataType) {
         final String string;
-        string = new String(message, Charset.forName("UTF-8")).trim(); //NOI18N
+        string = new String(message, StandardCharsets.UTF_8).trim();
         try {
             final Object parse = JSONValue.parseWithException(string);
             if (callBack == null) {

--- a/webcommon/cordova/src/org/netbeans/modules/cordova/project/ConfigUtils.java
+++ b/webcommon/cordova/src/org/netbeans/modules/cordova/project/ConfigUtils.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.openide.filesystems.FileLock;
 import org.openide.filesystems.FileObject;
@@ -66,7 +67,7 @@ public final class ConfigUtils {
         }
         FileLock lock = fo.lock();
         try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(FileUtil.toFile(fo)), Charset.forName("UTF-8")));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(FileUtil.toFile(fo)), StandardCharsets.UTF_8));
             String line;
             StringBuilder sb = new StringBuilder();
             while ((line = reader.readLine()) != null) {
@@ -76,7 +77,7 @@ public final class ConfigUtils {
                 sb.append(line);
                 sb.append("\n");
             }
-            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), "UTF-8");
+            OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), StandardCharsets.UTF_8);
             try {
                 writer.write(sb.toString());
             } finally {

--- a/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/Utils.java
+++ b/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/Utils.java
@@ -33,7 +33,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -52,6 +51,7 @@ import org.openide.util.Utilities;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author ads
@@ -60,8 +60,6 @@ import org.xml.sax.SAXException;
 public final class Utils {
     
     private static final String APPDATA_CMD = "cmd /c echo %AppData%"; // NOI18N
-    
-    public static final Charset UTF_8 = Charset.forName("UTF-8");     // NOI18N
     
     private Utils(){
     }
@@ -97,7 +95,7 @@ public final class Utils {
         BufferedReader reader = null;
         try {
             reader = new BufferedReader(new InputStreamReader( 
-                    new FileInputStream(file), UTF_8)); 
+                    new FileInputStream(file), UTF_8));
             return (JSONObject)JSONValue.parseWithException(reader);
         } catch (ParseException ex) {
             Logger.getLogger( Utils.class.getCanonicalName()).log(Level.FINE,

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/AngularDoc.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/AngularDoc.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -138,9 +139,9 @@ public class AngularDoc {
         synchronized (cacheFile) {
             String tmpFileName = cacheFile.getAbsolutePath() + ".tmp";
             File tmpFile = new File(tmpFileName);
-            try (Writer writer = new OutputStreamWriter(new FileOutputStream(tmpFile), "UTF-8")) { // NOI18N
+            try (Writer writer = new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) { // NOI18N
                 writer.append("<!doctype html><html><head><title>AngularJS documentation</title></head><body>");
-                Utils.loadURL(url, writer, Charset.forName("UTF-8"));
+                Utils.loadURL(url, writer, StandardCharsets.UTF_8);
                 writer.append("</body></html>");
                 writer.close();
                 tmpFile.renameTo(cacheFile);

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/Utils.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/Utils.java
@@ -30,6 +30,7 @@ import java.io.Writer;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.parsing.api.Snapshot;
 
@@ -92,7 +93,7 @@ public class Utils {
     }
     
     public static String getFileContent(File file) throws IOException {
-        Reader r = new InputStreamReader(new FileInputStream(file), "UTF-8"); // NOI18N
+        Reader r = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
         StringBuilder sb = new StringBuilder();
         try {
             char[] buf = new char[2048];

--- a/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/KODoc.java
+++ b/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/KODoc.java
@@ -28,7 +28,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -123,11 +123,11 @@ public class KODoc {
         synchronized (cacheFile) {
             StringWriter sw = new StringWriter();
             //load from the URL
-            KOUtils.loadURL(url, sw, Charset.forName("UTF-8")); //NOI18N
+            KOUtils.loadURL(url, sw, StandardCharsets.UTF_8);
             //strip off the proper content
             String knockoutDocumentationContent = KOUtils.getKnockoutDocumentationContent(sw.getBuffer().toString());
             //save to cache file
-            try (Writer writer = new OutputStreamWriter(new FileOutputStream(cacheFile), "UTF-8")) { // NOI18N
+            try (Writer writer = new OutputStreamWriter(new FileOutputStream(cacheFile), StandardCharsets.UTF_8)) {
                 writer.append("<!doctype html><html><head><title>Knockout documentation</title></head><body>"); //NOI18N
                 writer.append(knockoutDocumentationContent);
                 writer.append("</body></html>"); //NOI18N

--- a/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/KOUtils.java
+++ b/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/KOUtils.java
@@ -30,19 +30,21 @@ import java.io.Writer;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import javax.swing.ImageIcon;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.html.editor.lib.api.HtmlSource;
 import org.netbeans.modules.html.editor.lib.api.SyntaxAnalyzer;
 import org.netbeans.modules.html.editor.lib.api.elements.Element;
-import static org.netbeans.modules.html.editor.lib.api.elements.ElementType.CLOSE_TAG;
-import static org.netbeans.modules.html.editor.lib.api.elements.ElementType.OPEN_TAG;
 import org.netbeans.modules.html.editor.lib.api.elements.OpenTag;
 import org.netbeans.modules.parsing.api.Snapshot;
 import org.netbeans.modules.web.common.api.LexerUtils;
 import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
+
+import static org.netbeans.modules.html.editor.lib.api.elements.ElementType.CLOSE_TAG;
+import static org.netbeans.modules.html.editor.lib.api.elements.ElementType.OPEN_TAG;
 
 /**
  *
@@ -112,7 +114,7 @@ public class KOUtils {
     }
     
     public static String getFileContent(File file) throws IOException {
-        Reader r = new InputStreamReader(new FileInputStream(file), "UTF-8"); // NOI18N
+        Reader r = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
         StringBuilder sb = new StringBuilder();
         try {
             char[] buf = new char[2048];

--- a/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryProvider.java
+++ b/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryProvider.java
@@ -31,6 +31,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collections;
@@ -353,7 +354,7 @@ public final class LibraryProvider {
             URLConnection urlConnection = urlObject.openConnection();
             StringBuilder content = new StringBuilder();
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(
-                urlConnection.getInputStream(), "UTF-8"))) { // NOI18N
+                urlConnection.getInputStream(), StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     content.append(line).append('\n');

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/formatter/Utils.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/formatter/Utils.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  *
@@ -33,7 +34,7 @@ public class Utils {
     public static final int POSSIBLE_SCROLL_BAR_WIDTH = 30;
 
     public static String loadPreviewText(InputStream is) throws IOException {
-            BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8")); // NOI18N
+            BufferedReader r = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             try {
                 StringBuilder sb = new StringBuilder();
                 for (String line = r.readLine(); line != null; line = r.readLine()) {

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsSemanticAnalyzerTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsSemanticAnalyzerTest.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.javascript2.editor;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.spi.queries.FileEncodingQueryImplementation;
 import org.openide.filesystems.FileObject;
 
@@ -38,7 +39,7 @@ public class JsSemanticAnalyzerTest extends JsTestBase {
             new FileEncodingQueryImplementation() {
                 @Override
                 public Charset getEncoding(FileObject file) {
-                    return Charset.forName("UTF-8");
+                    return StandardCharsets.UTF_8;
                 }
             }
         };

--- a/webcommon/javascript2.json/src/org/netbeans/modules/javascript2/json/parser/ParseTreeToXml.java
+++ b/webcommon/javascript2.json/src/org/netbeans/modules/javascript2/json/parser/ParseTreeToXml.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.javascript2.json.parser;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -133,7 +134,7 @@ public class ParseTreeToXml extends JsonBaseVisitor<Document> {
     public static String stringify(@NonNull final Document doc) throws IOException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         XMLUtil.write(doc, out, "UTF-8");   //NOI18N
-        return new String(out.toByteArray(),"UTF-8");   //NOI18N
+        return new String(out.toByteArray(), StandardCharsets.UTF_8);
     }
 
 

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/spi/ModelElementFactory.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/spi/ModelElementFactory.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -89,7 +90,7 @@ public final class ModelElementFactory {
 
     public JsObject loadGlobalObject(InputStream is, String sourceLabel, URL defaultDocURL) throws IOException {
         JsFunction global = newGlobalObject(null, Integer.MAX_VALUE);
-        BufferedReader reader = new BufferedReader(new InputStreamReader(is, "UTF-8")); // NOI18N
+        BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
         try {
             for (JsObject object : Model.readModel(reader, global, sourceLabel, defaultDocURL)) {
                 putGlobalProperty(global, object);

--- a/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsDataProvider.java
+++ b/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsDataProvider.java
@@ -32,6 +32,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -578,7 +579,7 @@ public class NodeJsDataProvider {
     }
 
     private String getFileContent(File file) throws IOException {
-        Reader r = new InputStreamReader(new FileInputStream(file), "UTF-8"); // NOI18N
+        Reader r = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
         StringBuilder sb = new StringBuilder();
         try {
             char[] buf = new char[2048];
@@ -656,8 +657,8 @@ public class NodeJsDataProvider {
         synchronized (cacheFile) {
             String tmpFileName = cacheFile.getAbsolutePath() + ".tmp";  //NOI18N
             File tmpFile = new File(tmpFileName);
-            try (Writer writer = new OutputStreamWriter(new FileOutputStream(tmpFile), "UTF-8")) { // NOI18N
-                loadURL(url, writer, Charset.forName("UTF-8")); //NOI18N
+            try (Writer writer = new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) {
+                loadURL(url, writer, StandardCharsets.UTF_8);
                 writer.close();
                 tmpFile.renameTo(cacheFile);
             } finally {

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/RequireJsDataProvider.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/RequireJsDataProvider.java
@@ -33,6 +33,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -231,8 +232,8 @@ public class RequireJsDataProvider {
         synchronized (cacheFile) {
             String tmpFileName = cacheFile.getAbsolutePath() + ".tmp";
             File tmpFile = new File(tmpFileName);
-            try (Writer writer = new OutputStreamWriter(new FileOutputStream(tmpFile), "UTF-8")) { // NOI18N
-                loadURL(url, writer, Charset.forName("UTF-8")); //NOI18N
+            try (Writer writer = new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) {
+                loadURL(url, writer, StandardCharsets.UTF_8);
                 writer.close();
                 boolean success = tmpFile.renameTo(cacheFile);
                 if (!success) {
@@ -268,7 +269,7 @@ public class RequireJsDataProvider {
     }
 
     private String getFileContent(File file) throws IOException {
-        Reader r = new InputStreamReader(new FileInputStream(file), "UTF-8"); // NOI18N
+        Reader r = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
         StringBuilder sb = new StringBuilder();
         try {
             char[] buf = new char[2048];

--- a/webcommon/languages.apacheconf/src/org/netbeans/modules/languages/apacheconf/lexer/ApacheConfLexerUtils.java
+++ b/webcommon/languages.apacheconf/src/org/netbeans/modules/languages/apacheconf/lexer/ApacheConfLexerUtils.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.api.lexer.Language;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenId;
@@ -41,7 +42,7 @@ public class ApacheConfLexerUtils {
     public static String getFileContent(File file) throws Exception{
         StringBuilder sb = new StringBuilder();
         String lineSep = "\n";//NOI18N
-        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8")); //NOI18N
+        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
         String line = br.readLine();
         while (line != null) {
             sb.append(line);

--- a/webcommon/languages.ini/test/unit/src/org/netbeans/modules/languages/ini/util/TestUtils.java
+++ b/webcommon/languages.ini/test/unit/src/org/netbeans/modules/languages/ini/util/TestUtils.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Various test utilities.
@@ -37,7 +38,7 @@ public final class TestUtils {
      */
     public static String getFileContent(File file) throws IOException {
         StringBuilder sb = new StringBuilder();
-        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
         try {
             String line = br.readLine();
             while (line != null) {

--- a/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/connection/DebuggerConnection.java
+++ b/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/connection/DebuggerConnection.java
@@ -21,6 +21,7 @@ package org.netbeans.lib.v8debug.connection;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  *
@@ -30,7 +31,7 @@ final class DebuggerConnection {
     
     private DebuggerConnection() {}
     
-    public static final Charset CHAR_SET = Charset.forName("UTF-8");            // NOI18N
+    public static final Charset CHAR_SET = StandardCharsets.UTF_8;
     public static final byte[] EOL = new byte[] { 13, 10 }; // \r\n
     public static final String EOL_STR = "\r\n";                                // NOI18N
     public static final String CONTENT_LENGTH_STR = "Content-Length: ";         // NOI18N

--- a/webcommon/web.client.samples/src/org/netbeans/modules/web/client/samples/wizard/iterator/SampleWizardIterator.java
+++ b/webcommon/web.client.samples/src/org/netbeans/modules/web/client/samples/wizard/iterator/SampleWizardIterator.java
@@ -25,7 +25,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -90,8 +90,7 @@ public class SampleWizardIterator extends AbstractWizardIterator {
         FileLock lock = fo.lock();
         try {
             BufferedReader reader = new BufferedReader(new InputStreamReader( 
-                    new FileInputStream(FileUtil.toFile(fo)), 
-                    Charset.forName("UTF-8")));                     // NOI18N
+                    new FileInputStream(FileUtil.toFile(fo)), StandardCharsets.UTF_8));
             String line;
             StringBuilder sb = new StringBuilder();
             while ((line = reader.readLine()) != null) {
@@ -102,7 +101,7 @@ public class SampleWizardIterator extends AbstractWizardIterator {
                 sb.append("\n");
             }
             OutputStreamWriter writer = new OutputStreamWriter(
-                    fo.getOutputStream(lock), "UTF-8");             // NOI18N
+                    fo.getOutputStream(lock), StandardCharsets.UTF_8);
             try {
                 writer.write(sb.toString());
             } finally {

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/sites/SiteZip.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/sites/SiteZip.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
@@ -173,7 +174,7 @@ public class SiteZip implements SiteTemplateImplementation {
         }
         // remote file => calculate hash of its url
         CRC32 crc = new CRC32();
-        crc.update(template.getBytes(Charset.forName("UTF-8")));
+        crc.update(template.getBytes(StandardCharsets.UTF_8));
         String filename = String.valueOf(crc.getValue()) + ".zip"; // NOI18N
         LOGGER.log(Level.INFO, "Remote URL \"{0}\" set, downloaded to {1}", new Object[] {template, filename}); //NOI18N
         return new File(SiteHelper.getJsLibsDirectory(), filename);

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/util/ClientSideProjectUtilities.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/util/ClientSideProjectUtilities.java
@@ -22,8 +22,7 @@ import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.IllegalCharsetNameException;
-import java.nio.charset.UnsupportedCharsetException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -278,16 +277,7 @@ public final class ClientSideProjectUtilities {
 
     // #217970
     private static Charset getDefaultProjectCharset() {
-        try {
-            return Charset.forName("UTF-8"); // NOI18N
-        } catch (IllegalCharsetNameException exception) {
-            // fallback
-            LOGGER.log(Level.INFO, "UTF-8 charset not supported, falling back to the default charset.", exception);
-        } catch (UnsupportedCharsetException exception) {
-            // fallback
-            LOGGER.log(Level.INFO, "UTF-8 charset not supported, falling back to the default charset.", exception);
-        }
-        return Charset.defaultCharset();
+        return StandardCharsets.UTF_8;
     }
 
     /**

--- a/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/files/Files.java
+++ b/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/files/Files.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
@@ -99,7 +100,7 @@ public final class Files {
         InputStream stream = Files.class.getResourceAsStream(resourceName);
         String content = null;
         if (stream != null) {
-            BufferedReader br = new BufferedReader(new InputStreamReader(stream, Charset.forName("UTF-8"))); // NOI18N
+            BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
             try {
                 StringBuilder sb = new StringBuilder(stream.available());
                 String line;


### PR DESCRIPTION
project wide refactoring using this [jackpot inspection](https://github.com/mbien/jackpot-inspections/blob/master/UseStandardCharsets.hint)

`Charset`s defined in `StandardCharsets` are always supported by the runtime, which means:
 - less handling of the checked`UnsupportedEncodingException`
 - potentially slightly better performance in some cases since no lookup is needed

static imports are only used in a handful of classes with many occurrences of the fields.

Each commit contains at least one cluster so that reviewers don't have to review everything (please mention what you reviewed).

going to squash everything before merge.