### PR TITLE
Minor bug fixes.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
@@ -474,9 +474,10 @@ final class VanillaCompileWorker extends CompileWorker {
 
             for (FileObject f : listed) {
                 String name = f.getNameExt();
-                if (name.endsWith(".class"))
+                if (name.endsWith(".class")) {
                     name = name.substring(0, name.length() - FileObjects.CLASS.length()) + FileObjects.SIG;
-                copyRecursively(f, targetRoot, new File(target, name), filter, fmtx, copied);
+                    copyRecursively(f, targetRoot, new File(target, name), filter, fmtx, copied);
+                }
             }
         } else {
             if (target.isDirectory()) {

--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
@@ -515,13 +515,13 @@ public final class ElementOpen {
                         return;
                     }
 
-                    FindDeclarationVisitor v = new FindDeclarationVisitor(el, info);
+                    result[6] = TreePathHandle.create(el, info);
 
+                    FindDeclarationVisitor v = new FindDeclarationVisitor(el, info);
                     CompilationUnitTree cu = info.getCompilationUnit();
 
                     v.scan(cu, null);
                     Tree elTree = v.declTree;
-                    result[6] = TreePathHandle.create(el, info);
                     if (elTree != null) {
                         result[1] = (int)info.getTrees().getSourcePositions().getStartPosition(cu, elTree);
                         result[2] = (int)info.getTrees().getSourcePositions().getEndPosition(cu, elTree);

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/LspElementUtils.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/LspElementUtils.java
@@ -237,20 +237,22 @@ public class LspElementUtils {
         }
         TreePathHandle pathHandle = (TreePathHandle)info[6];
         FileObject f = (FileObject)info[0];
-        boolean[] synthetic = new boolean[1];
+        boolean[] synthetic = new boolean[] { false };
         if (f != null) {
             builder.file(f);
-            try {
-                JavaSource js = JavaSource.forFileObject(f);
-                if (js == null) {
-                    return null;
+            if (pathHandle != null) {
+                try {
+                    JavaSource js = JavaSource.forFileObject(f);
+                    if (js == null) {
+                        return null;
+                    }
+                    js.runUserActionTask((cc) -> {
+                        TreePath path = pathHandle.resolve(cc);
+                        synthetic[0] = cc.getTreeUtilities().isSynthetic(path);
+                    }, true);
+                } catch (IOException ex) {
+                    // ignore
                 }
-                js.runUserActionTask((cc) -> {
-                    TreePath path = pathHandle.resolve(cc);
-                    synthetic[0] = cc.getTreeUtilities().isSynthetic(path);
-                }, true);
-            } catch (IOException ex) {
-                // ignore
             }
         }
         if (synthetic[0]) {
@@ -258,7 +260,7 @@ public class LspElementUtils {
         }
         builder.expandedStartOffset((int)info[1]).expandedEndOffset((int)info[2]);
         builder.selectionStartOffset(selStart).selectionEndOffset(selEnd);
-       return builder; 
+       return builder;
     }
     
     private static CompletableFuture<StructureProvider.Builder> setFutureOffsets(CompilationInfo ci, Element original, 


### PR DESCRIPTION
- TreePathHandles cannot be created for PackageElements. Code in `LspElementUtils` should respect this fact.
- `VanillaCompileWorker.fallbackCopyExistingClassFiles(...)` should be limited to class files only to prevent subsequent errors thrown from `BinaryAnalyser`