### PR TITLE
[#3728] Only enable VerifyPartialReparse if assertions are enabled

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/VanillaPartialReparser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/VanillaPartialReparser.java
@@ -163,6 +163,7 @@ public class VanillaPartialReparser implements PartialReparser {
     }
 
     @Override
+    @SuppressWarnings({"AssertWithSideEffects", "NestedAssignment"})
     public boolean reparseMethod (final CompilationInfoImpl ci,
             final Snapshot snapshot,
             final MethodTree orig,
@@ -328,9 +329,9 @@ public class VanillaPartialReparser implements PartialReparser {
             if (t instanceof ThreadDeath) {
                 throw (ThreadDeath) t;
             }
-            boolean a = false;
-            assert a = true;
-            if (a) {
+            boolean enableDumpSource = false;
+            assert enableDumpSource = true; // Only dump sources with assertions enabled
+            if (enableDumpSource) {
                 JavacParser.dumpSource(ci, t);
             }
             t.printStackTrace();
@@ -607,8 +608,15 @@ public class VanillaPartialReparser implements PartialReparser {
         public static final class FactoryImpl extends TaskFactory {
 
             @Override
+            @SuppressWarnings({"AssertWithSideEffects", "NestedAssignment"})
             public Collection<? extends SchedulerTask> create(Snapshot snapshot) {
-                return Collections.singletonList(new VerifyPartialReparse());
+                boolean enableVerifier = false;
+                assert enableVerifier = true;  // Only enable verifier if assertions are enabled
+                if (enableVerifier) {
+                    return Collections.singletonList(new VerifyPartialReparse());
+                } else {
+                    return Collections.emptyList();
+                }
             }
 
         }


### PR DESCRIPTION
It was observed, that NetBeans can create an excessive number of source
dump files in situations, where the partial reparse verifier bails out.

The VanillaPartialReparser already suppresses dumping of source files
in case of exceptions if assertions are not enabled. The same logic is
now applied to the activation of VerifyPartialReparse.
VerifyPartialReparse has no side effects and thus can be disabled if
dumping should be turned off.
