### PR TITLE
GroovyVirtualSourceProvider should run GroovyParser in 'indexing' mode.

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
@@ -82,7 +82,6 @@ import org.netbeans.modules.parsing.api.Task;
 import org.netbeans.modules.parsing.spi.ParseException;
 import org.netbeans.modules.parsing.spi.Parser;
 import org.netbeans.modules.parsing.spi.SourceModificationEvent;
-import org.netbeans.modules.parsing.spi.indexing.support.IndexingSupport;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -152,7 +151,7 @@ public class GroovyParser extends Parser {
         cancelled.set(false);
         
         if (!GroovyUtils.isIndexingEnabled()) {
-            if (IndexingSupport.isIndexingTask(task)) { // NOI18N
+            if (GroovyUtils.isIndexingTask(task)) {
                 lastResult = createParseResult(snapshot, null, null);
                 return;
             }
@@ -640,7 +639,7 @@ public class GroovyParser extends Parser {
             );
         }
 
-        boolean indexing = IndexingSupport.isIndexingTask(context.parserTask);
+        boolean indexing = GroovyUtils.isIndexingTask(context.parserTask);
         configuration = makeConfiguration(configuration, context, indexing);
         CU compilationUnit = new CU(indexing, this, configuration,
                 null, classLoader, transformationLoader, cpInfo, classNodeCache,
@@ -803,7 +802,7 @@ public class GroovyParser extends Parser {
             return sanitize(context, sanitizing);
         }
     }
-    
+
     private static void logParsingTime(Context context, long start, boolean cancelled) {
         long diff = System.currentTimeMillis() - start;
         long full = PARSING_TIME.addAndGet(diff);

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/GroovyIndexingTask.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/GroovyIndexingTask.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.compiler;
+
+public interface GroovyIndexingTask {
+}

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/SimpleTransformationCustomizer.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/SimpleTransformationCustomizer.java
@@ -34,7 +34,7 @@ import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.transform.ASTTransformation;
 import org.codehaus.groovy.transform.GroovyASTTransformation;
 import org.netbeans.modules.groovy.editor.api.parser.ApplyGroovyTransformation;
-import org.netbeans.modules.parsing.spi.indexing.support.IndexingSupport;
+import org.netbeans.modules.groovy.editor.utils.GroovyUtils;
 
 /**
  * Simple {@link ParsingCompilerCustomizer} implementation: adds or disables Groovy AST
@@ -88,8 +88,7 @@ public final class SimpleTransformationCustomizer implements ParsingCompilerCust
 
     @Override
     public CompilerConfiguration configureParsingCompiler(Context ctx, CompilerConfiguration cfg) {
-        Cfg c = IndexingSupport.isIndexingTask(ctx.getConsumerTask()) ?
-                indexing : parsing;
+        Cfg c = GroovyUtils.isIndexingTask(ctx.getConsumerTask()) ? indexing : parsing;
         if (!c.disableTransformations.isEmpty()) {
             Set<String> disabled = cfg.getDisabledGlobalASTTransformations();
             if (disabled == null) {
@@ -105,8 +104,7 @@ public final class SimpleTransformationCustomizer implements ParsingCompilerCust
     
     @Override
     public void decorateCompilation(Context ctx, CompilationUnit cu) {
-        Cfg c = IndexingSupport.isIndexingTask(ctx.getConsumerTask()) ?
-                indexing : parsing;
+        Cfg c = GroovyUtils.isIndexingTask(ctx.getConsumerTask()) ? indexing : parsing;
         GroovyClassLoader transformLoader = cu.getTransformLoader();
         Collection<String> clist = c.addTransformations;
         if (clist == null || clist.isEmpty()) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/utils/GroovyUtils.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/utils/GroovyUtils.java
@@ -22,9 +22,11 @@ package org.netbeans.modules.groovy.editor.utils;
 import javax.swing.text.BadLocationException;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassNode;
-import org.codehaus.groovy.ast.GenericsType;
 import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.transform.stc.StaticTypesMarker;
+import org.netbeans.modules.groovy.editor.compiler.GroovyIndexingTask;
+import org.netbeans.modules.parsing.api.Task;
+import org.netbeans.modules.parsing.spi.indexing.support.IndexingSupport;
 
 /**
  *
@@ -306,4 +308,7 @@ public final class GroovyUtils {
         return indexingEnabled;
     }
 
+    public static boolean isIndexingTask(Task t) {
+        return IndexingSupport.isIndexingTask(t) || t instanceof GroovyIndexingTask;
+    }
 }


### PR DESCRIPTION
GroovyVirtualSourceProvider should run GroovyParser in 'indexing' mode. Otherwise, the Spock transformations are omitted leaving generated stub classes in a state not compilable by Java (e.g. generated virtual Java sources contain spaces in method names, etc).
