### PR TITLE
SQL History loss: Reimplement atomatic saving by writing to tempfile and moving to target

### DIFF
--- a/ide/db.core/src/org/netbeans/modules/db/sql/history/SQLHistoryManager.java
+++ b/ide/db.core/src/org/netbeans/modules/db/sql/history/SQLHistoryManager.java
@@ -101,7 +101,7 @@ public class SQLHistoryManager  {
         return NbPreferences.forModule(SQLHistoryPanel.class).getInt("OPT_SQL_STATEMENTS_SAVED_FOR_HISTORY", DEFAULT_SQL_STATEMENTS_SAVED_FOR_HISTORY);
     }
 
-    private FileObject getHistoryRoot(boolean create) throws IOException {
+    protected FileObject getHistoryRoot(boolean create) throws IOException {
         FileObject result = null;
         FileObject historyRootDir = getConfigRoot().getFileObject(getRelativeHistoryPath());
         if (historyRootDir != null || create) {
@@ -120,11 +120,11 @@ public class SQLHistoryManager  {
         return result;
     }
 
-    private FileObject getConfigRoot() {
+    protected FileObject getConfigRoot() {
         return FileUtil.getConfigRoot();
     }
 
-    private String getRelativeHistoryPath() {
+    protected String getRelativeHistoryPath() {
         return SQL_HISTORY_DIRECTORY;
     }
 


### PR DESCRIPTION
It was observed, that sometimes the sql history was lost and it is
assumed, that writing the new history began (emptying the file as the
first step) and was not completed. By using a temporary file, the file
is either written completely or not. It is assumed, that a move
operation inside the same directory is atomic on all OSes.
