### PR TITLE
[NETBEANS-5599] PHP 8.1 Support: Pure intersection types

### DIFF
--- a/php/php.api.phpmodule/manifest.mf
+++ b/php/php.api.phpmodule/manifest.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.php.api.phpmodule
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/api/phpmodule/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.82
+OpenIDE-Module-Specification-Version: 2.83

--- a/php/php.api.phpmodule/src/org/netbeans/modules/php/api/util/StringUtils.java
+++ b/php/php.api.phpmodule/src/org/netbeans/modules/php/api/util/StringUtils.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
+import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
 import org.openide.util.Parameters;
 
@@ -202,6 +203,60 @@ public final class StringUtils {
     public static String decapitalize(String input) {
         Parameters.notEmpty("input", input); //NOI18N
         return input.substring(0, 1).toLowerCase() + input.substring(1);
+    }
+
+    /**
+     * Truncates the string with specific width. The trancated string contains
+     * the marker's length.
+     *
+     * <p>
+     * Example:<br>
+     * "0123456789", start:1, width:5, marker: "..." -&gt; "12..."<br>
+     * "0123456789", start:1, width:-4, marker: "..." -&gt; "12..."<br>
+     * "0123456789", start:-9, width:5, marker: "..." -&gt; "12..."<br>
+     * "0123456789", start:-9, width:-4, marker: "..." -&gt; "12..."<br>
+     * "0123456789", start:-7, width:6, marker: "..." -&gt; "345..."<br>
+     * "0123456789", start:0, width:-4, marker: "..." -&gt; "012..."<br>
+     * "0123456789", start:4, width:6, marker: "..." -&gt; "456789"<br>
+     *
+     * @param string text to be truncated, never {@code null}
+     * @param start the start position. if it's negative, the position from the
+     * end of the string
+     * @param width the width of the truncated string. it contains the marker's
+     * length. if it's negative, truncates the width from the end of the string
+     * @param marker the marker, can be null, if it's {@code null}, "..." is
+     * used
+     * @return the truncated string with specific width and the marker
+     * @since 2.83
+     */
+    public static String truncate(@NonNull String string, int start, int width, @NullAllowed String marker) {
+        Parameters.notNull("input", string); // NOI18N
+        String trimMarker = "..."; // NOI18N
+        if (marker != null) {
+            trimMarker = marker;
+        }
+        int trimStart = start;
+        if (trimStart < 0) {
+            trimStart += string.length();
+        }
+        int trimWidth = width;
+        if (trimWidth < 0) {
+            trimWidth = string.length() + trimWidth - trimStart;
+        }
+        if (trimStart < 0
+                || trimWidth < 0
+                || string.length() < trimStart
+                || trimWidth < trimMarker.length()) {
+            // invalid range
+            return string;
+        }
+        boolean addMarker = trimStart + trimWidth < string.length();
+        int trimEnd = !addMarker ? string.length() : trimStart + trimWidth;
+        String trimedString = string.substring(trimStart, trimEnd);
+        if (addMarker) {
+            trimedString = trimedString.substring(0, trimedString.length() - trimMarker.length()) + trimMarker;
+        }
+        return trimedString;
     }
 
     private static Pattern getPattern0(String text, String prefix, String suffix) {

--- a/php/php.api.phpmodule/test/unit/src/org/netbeans/modules/php/api/util/StringUtilsTest.java
+++ b/php/php.api.phpmodule/test/unit/src/org/netbeans/modules/php/api/util/StringUtilsTest.java
@@ -148,4 +148,80 @@ public class StringUtilsTest extends NbTestCase {
         }
     }
 
+    public void testTruncate() {
+        String string = "0123456789";
+        int length = string.length(); // 10
+
+        assertEquals(string, StringUtils.truncate(string, 0, 0, "..."));
+        assertEquals(string, StringUtils.truncate(string, 0, 2, "..."));
+
+        assertEquals("...", StringUtils.truncate(string, 0, 3, "..."));
+        assertEquals("...", StringUtils.truncate(string, 0, -7, "..."));
+
+        assertEquals("0...", StringUtils.truncate(string, 0, 4, "..."));
+        assertEquals("0...", StringUtils.truncate(string, 0, 4, null));
+        assertEquals("0...", StringUtils.truncate(string, 0, -6, "..."));
+        assertEquals("0...", StringUtils.truncate(string, 0, -6, null));
+
+        assertEquals("1...", StringUtils.truncate(string, 1, 4, "..."));
+        assertEquals("1...", StringUtils.truncate(string, -9, 4, "..."));
+        assertEquals("1...", StringUtils.truncate(string, 1, -5, "..."));
+        assertEquals("1...", StringUtils.truncate(string, -9, -5, "..."));
+
+        assertEquals("01234...", StringUtils.truncate(string, 0, 8, "..."));
+        assertEquals("01234...", StringUtils.truncate(string, 0, -2, "..."));
+
+        assertEquals("123456789", StringUtils.truncate(string, 1, 9, "..."));
+        assertEquals("123456789", StringUtils.truncate(string, -9, 9, "..."));
+
+        assertEquals("12345...", StringUtils.truncate(string, 1, 8, "..."));
+        assertEquals("12345...", StringUtils.truncate(string, -9, 8, "..."));
+        assertEquals("12345...", StringUtils.truncate(string, 1, -1, "..."));
+        assertEquals("12345...", StringUtils.truncate(string, -9, -1, "..."));
+
+        assertEquals(string, StringUtils.truncate(string, 0, length, "..."));
+        assertEquals(string, StringUtils.truncate(string, 0, length + 1, "..."));
+
+        assertEquals("123456789", StringUtils.truncate(string, 1, length + 1, "..."));
+        assertEquals("123456789", StringUtils.truncate(string, -9, length + 1, "..."));
+
+        assertEquals("9", StringUtils.truncate(string, 9, 3, "..."));
+        assertEquals("9", StringUtils.truncate(string, -1, 3, "..."));
+
+        assertEquals(string, StringUtils.truncate(string, -length - 1, 3, "..."));
+        assertEquals(string, StringUtils.truncate(string, 0, -length -1, "..."));
+
+        assertEquals("", StringUtils.truncate(string, 0, 0, ""));
+        assertEquals("012", StringUtils.truncate(string, 0, 3, ""));
+        assertEquals("012", StringUtils.truncate(string, 0, -7, ""));
+
+        assertEquals("23456", StringUtils.truncate(string, 2, 5, ""));
+        assertEquals("23456", StringUtils.truncate(string, -8, 5, ""));
+        assertEquals("23456", StringUtils.truncate(string, 2, -3, ""));
+        assertEquals("23456", StringUtils.truncate(string, -8, -3, ""));
+
+        assertEquals("012345678", StringUtils.truncate(string, 0, length - 1, ""));
+        assertEquals(string, StringUtils.truncate(string, 0, length, ""));
+        assertEquals(string, StringUtils.truncate(string, 0, length + 1, ""));
+
+        assertEquals("", StringUtils.truncate("", 0, 0, "..."));
+        assertEquals("", StringUtils.truncate("", 0, 3, "..."));
+        assertEquals("", StringUtils.truncate("", 0, 4, "..."));
+        assertEquals("", StringUtils.truncate("", 0, -1, "..."));
+        assertEquals("", StringUtils.truncate("", 1, 0, "..."));
+        assertEquals("", StringUtils.truncate("", 1, -1, "..."));
+        assertEquals("", StringUtils.truncate("", -1, 0, "..."));
+        assertEquals("", StringUtils.truncate("", -1, 1, "..."));
+        assertEquals("", StringUtils.truncate("", -1, -1, "..."));
+
+        assertEquals("", StringUtils.truncate("", 0, 0, ""));
+        assertEquals("", StringUtils.truncate("", 0, 3, ""));
+        assertEquals("", StringUtils.truncate("", 0, 4, ""));
+        assertEquals("", StringUtils.truncate("", 0, -1, ""));
+        assertEquals("", StringUtils.truncate("", 1, 0, ""));
+        assertEquals("", StringUtils.truncate("", 1, -1, ""));
+        assertEquals("", StringUtils.truncate("", -1, 0, ""));
+        assertEquals("", StringUtils.truncate("", -1, 1, ""));
+        assertEquals("", StringUtils.truncate("", -1, -1, ""));
+    }
 }

--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -20,7 +20,7 @@ build.compiler=extJavac
 nbjavac.ignore.missing.enclosing=**/CUP$ASTPHP5Parser$actions.class
 javac.compilerargs=-J-Xmx512m
 nbm.needs.restart=true
-spec.version.base=2.10.0
+spec.version.base=2.11.0
 release.external/predefined_vars-1.0.zip=docs/predefined_vars.zip
 sigtest.gen.fail.on.error=false
 

--- a/php/php.editor/nbproject/project.xml
+++ b/php/php.editor/nbproject/project.xml
@@ -304,7 +304,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>2.81</specification-version>
+                        <specification-version>2.83</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
@@ -51,6 +51,7 @@ import org.netbeans.modules.php.editor.parser.astnodes.FunctionName;
 import org.netbeans.modules.php.editor.parser.astnodes.GroupUseStatementPart;
 import org.netbeans.modules.php.editor.parser.astnodes.Identifier;
 import org.netbeans.modules.php.editor.parser.astnodes.InfixExpression;
+import org.netbeans.modules.php.editor.parser.astnodes.IntersectionType;
 import org.netbeans.modules.php.editor.parser.astnodes.MethodDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.MethodInvocation;
 import org.netbeans.modules.php.editor.parser.astnodes.NamespaceName;
@@ -272,7 +273,8 @@ public final class CodeUtils {
      *
      * @param typeName The type name
      * @return The type name. If it is a nullable type, the name is returned
-     * with "?". If it's union type, type names separated by "|" are returned
+     * with "?". If it's a union type, type names separated by "|" are returned.
+     * If it's an intersection type, type names separated by "&" are returned.
      */
     @CheckForNull
     public static String extractQualifiedName(Expression typeName) {
@@ -290,6 +292,16 @@ public final class CodeUtils {
             for (Expression type : unionType.getTypes()) {
                 if (sb.length() > 0) {
                     sb.append(Type.SEPARATOR);
+                }
+                sb.append(extractQualifiedName(type));
+            }
+            return sb.toString();
+        } else if (typeName instanceof IntersectionType) {
+            IntersectionType intersectionType = (IntersectionType) typeName;
+            StringBuilder sb = new StringBuilder();
+            for (Expression type : intersectionType.getTypes()) {
+                if (sb.length() > 0) {
+                    sb.append(Type.SEPARATOR_INTERSECTION);
                 }
                 sb.append(extractQualifiedName(type));
             }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/api/elements/FieldElement.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/api/elements/FieldElement.java
@@ -28,4 +28,6 @@ public interface FieldElement extends TypedInstanceElement, TypeMemberElement {
     PhpElementKind KIND = PhpElementKind.FIELD;
     String getName(boolean dollared);
     boolean isAnnotation();
+    boolean isUnionType();
+    boolean isIntersectionType();
 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSInfo.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSInfo.java
@@ -62,6 +62,7 @@ import org.netbeans.modules.php.editor.parser.astnodes.Comment;
 import org.netbeans.modules.php.editor.parser.astnodes.FieldsDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.FormalParameter;
 import org.netbeans.modules.php.editor.parser.astnodes.Identifier;
+import org.netbeans.modules.php.editor.parser.astnodes.IntersectionType;
 import org.netbeans.modules.php.editor.parser.astnodes.MethodDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.NullableType;
 import org.netbeans.modules.php.editor.parser.astnodes.PHPDocBlock;
@@ -365,6 +366,9 @@ public final class CGSInfo {
                 // PHP 7.4 or newer
                 if (fieldsDeclaration.getFieldType() instanceof UnionType) {
                     type = VariousUtils.getUnionType((UnionType) fieldsDeclaration.getFieldType());
+                } else if (fieldsDeclaration.getFieldType() instanceof IntersectionType) {
+                    // NETBEANS-5599 PHP 8.1 Pure intersection types
+                    type = VariousUtils.getIntersectionType((IntersectionType) fieldsDeclaration.getFieldType());
                 } else {
                     QualifiedName qualifiedName = QualifiedName.create(fieldsDeclaration.getFieldType());
                     if (qualifiedName != null) {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
@@ -126,6 +126,7 @@ public abstract class PHPCompletionItem implements CompletionProposal {
     @StaticResource
     private static final String PHP_KEYWORD_ICON = "org/netbeans/modules/php/editor/resources/php16Key.png"; //NOI18N
     protected static final ImageIcon KEYWORD_ICON = new ImageIcon(ImageUtilities.loadImage(PHP_KEYWORD_ICON));
+    private static final int TYPE_NAME_MAX_LENGTH = Integer.getInteger("nb.php.editor.ccTypeNameMaxLength", 30); // NOI18N
     final CompletionRequest request;
     private final ElementHandle element;
     private QualifiedNameKind generateAs;
@@ -885,17 +886,35 @@ public abstract class PHPCompletionItem implements CompletionProposal {
         @Override
         protected String getTypeName() {
             Set<TypeResolver> types = getField().getInstanceTypes();
-            String typeName = types.isEmpty() ? "?" : types.size() > 1 ? Type.MIXED : "?"; //NOI18N
-            if (types.size() == 1) {
-                TypeResolver typeResolver = types.iterator().next();
-                if (typeResolver.isResolved()) {
-                    QualifiedName qualifiedName = typeResolver.getTypeName(false);
+            List<String> typeNames = new ArrayList<>();
+            for (TypeResolver type : types) {
+                String typeName = "?"; //NOI18N
+                if (type.isResolved()) {
+                    QualifiedName qualifiedName = type.getTypeName(false);
                     if (qualifiedName != null) {
                         typeName = qualifiedName.toString();
+                        if (type.isNullableType()) {
+                            typeName = CodeUtils.NULLABLE_TYPE_PREFIX + typeName;
+                        }
                     }
                 }
+                typeNames.add(typeName);
             }
-            return typeName;
+            String typeName;
+            if (typeNames.isEmpty()) {
+                typeName = "?"; // NOI18N
+            } else if (typeNames.size() == 1) {
+                typeName = typeNames.get(0);
+            } else {
+                if (getField().isUnionType()) {
+                    typeName = StringUtils.implode(typeNames, Type.SEPARATOR);
+                } else if (getField().isIntersectionType()) {
+                    typeName = StringUtils.implode(typeNames, Type.SEPARATOR_INTERSECTION);
+                } else {
+                    typeName = StringUtils.implode(typeNames, Type.SEPARATOR);
+                }
+            }
+            return StringUtils.truncate(typeName, 0, TYPE_NAME_MAX_LENGTH, "..."); // NOI18N
         }
 
         @Override

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
@@ -1073,7 +1073,9 @@ public abstract class PHPCompletionItem implements CompletionProposal {
                     Collection<TypeResolver> returnTypes = getBaseFunctionElement().getReturnTypes();
                     // we can also write a union type in phpdoc e.g. @return int|float
                     // check whether the union type is actual declared return type to avoid adding the union type for phpdoc
-                    if (returnTypes.size() == 1 || getBaseFunctionElement().isReturnUnionType()) {
+                    if (returnTypes.size() == 1
+                            || getBaseFunctionElement().isReturnUnionType()
+                            || getBaseFunctionElement().isReturnIntersectionType()) {
                         String returnType = getBaseFunctionElement().asString(PrintAs.ReturnTypes, typeNameResolver, phpVersion);
                         if (StringUtils.hasText(returnType)) {
                             boolean nullableType = CodeUtils.isNullableType(returnType);

--- a/php/php.editor/src/org/netbeans/modules/php/editor/elements/BaseFunctionElementSupport.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/elements/BaseFunctionElementSupport.java
@@ -139,17 +139,13 @@ public class BaseFunctionElementSupport  {
                     if (typeResolver.isResolved()) {
                         QualifiedName typeName = typeResolver.getTypeName(false);
                         if (typeName != null) {
-                            if (template.length() > 0) {
-                                template.append(Type.SEPARATOR);
-                            }
+                            appendSeparator(template);
                             template.append(typeNameResolver.resolve(typeName).toString());
                         }
                     } else {
                         String typeName = typeResolver.getRawTypeName();
                         if (typeName != null) {
-                            if (template.length() > 0) {
-                                template.append(Type.SEPARATOR);
-                            }
+                            appendSeparator(template);
                             template.append(typeName);
                         }
                     }
@@ -161,9 +157,7 @@ public class BaseFunctionElementSupport  {
                     if (typeResolver.isResolved()) {
                         QualifiedName typeName = typeResolver.getTypeName(false);
                         if (typeName != null) {
-                            if (template.length() > 0) {
-                                template.append(Type.SEPARATOR);
-                            }
+                            appendSeparator(template);
                             if (typeResolver.isNullableType()) {
                                 template.append(CodeUtils.NULLABLE_TYPE_PREFIX);
                             }
@@ -204,6 +198,17 @@ public class BaseFunctionElementSupport  {
                 assert false : as;
         }
         return template.toString();
+    }
+
+    private void appendSeparator(StringBuilder template) {
+        if (template.length() == 0) {
+            return;
+        }
+        if (isReturnIntersectionType()) {
+            template.append(Type.SEPARATOR_INTERSECTION);
+        } else {
+            template.append(Type.SEPARATOR);
+        }
     }
 
     private static String parameters2String(final BaseFunctionElement element, final List<ParameterElement> parameterList, OutputType stringOutputType, TypeNameResolver typeNameResolver) {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/elements/BaseFunctionElementSupport.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/elements/BaseFunctionElementSupport.java
@@ -101,7 +101,7 @@ public class BaseFunctionElementSupport  {
                     Collection<TypeResolver> returns1 = getReturnTypes();
                     // we can also write the union type in phpdoc e.g. @return int|float
                     // check whether the union type is the actual declared return type to avoid adding the union type for phpdoc
-                    if (returns1.size() == 1 || isReturnUnionType()) {
+                    if (returns1.size() == 1 || isReturnUnionType() || isReturnIntersectionType()) {
                         String returnType = asString(PrintAs.ReturnTypes, element, typeNameResolver, phpVersion);
                         if (StringUtils.hasText(returnType)) {
                             boolean isNullableType = CodeUtils.isNullableType(returnType);

--- a/php/php.editor/src/org/netbeans/modules/php/editor/elements/TypeResolverImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/elements/TypeResolverImpl.java
@@ -47,7 +47,7 @@ public final class TypeResolverImpl implements TypeResolver {
         // avoid being changed type order(e.g. int|float|Foo|Bar) when an override method is generated
         Set<TypeResolver> retval = new LinkedHashSet<>();
         if (typeSignature != null && typeSignature.length() > 0) {
-            final String regexp = String.format("\\%s", Separator.PIPE.toString()); //NOI18N
+            final String regexp = "[|&]"; // NOI18N
             for (String type : typeSignature.split(regexp)) {
                 String typeName = type;
                 boolean isNullableType = CodeUtils.isNullableType(typeName);

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/FieldElementImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/FieldElementImpl.java
@@ -161,7 +161,7 @@ class FieldElementImpl extends ScopeImpl implements FieldElement {
     public Collection<? extends TypeScope> getDefaultTypes() {
         Collection<TypeScope> typeScopes = new HashSet<>();
         if (defaultFQType != null && defaultFQType.length() > 0) {
-            String[] allTypeNames = defaultFQType.split("\\|");
+            String[] allTypeNames = defaultFQType.split("\\&|\\|"); // NOI18N
             for (String typeName : allTypeNames) {
                 String modifiedTypeName = typeName;
                 if (typeName.indexOf("[") != -1) {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/Type.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/Type.java
@@ -29,6 +29,37 @@ import org.netbeans.modules.php.api.util.StringUtils;
  */
 public final class Type {
 
+    public enum Kind {
+        NORMAL(""), // NOI18N
+        NULLABLE("?"), // NOI18N
+        UNION(SEPARATOR),
+        INTERSECTION(SEPARATOR_INTERSECTION),
+        ;
+
+        private final String sign;
+
+        private Kind(String sing) {
+            this.sign = sing;
+        }
+
+        public String getSign() {
+            return sign;
+        }
+
+        public static Kind fromTypes(String types) {
+            Kind kind = NORMAL;
+            if (types.contains(SEPARATOR)) {
+                kind = UNION;
+            } else if (types.contains(SEPARATOR_INTERSECTION)) {
+                kind = INTERSECTION;
+            } else if (types.contains(NULLABLE.getSign())) {
+                kind = NULLABLE;
+            }
+            return kind;
+        }
+
+    }
+
     private Type() {
     }
 

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParser.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParser.java
@@ -294,8 +294,8 @@ public class PHPDocCommentParser {
         }
         ArrayList<String> types = new ArrayList<>();
         if (tokens.length > 0 && (isReturnTag || !tokens[0].startsWith("$"))) { //NOI18N
-            if (tokens[0].indexOf('|') > -1) {
-                String[] ttokens = tokens[0].split("[|]"); //NOI18N
+            if (tokens[0].indexOf('|') > -1 || tokens[0].indexOf('&') > -1) {
+                String[] ttokens = tokens[0].split("[|&]"); //NOI18N
                 for (String ttoken : ttokens) {
                     types.add(ttoken.trim());
                 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGenerator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGenerator.java
@@ -67,6 +67,7 @@ import org.netbeans.modules.php.editor.parser.astnodes.FormalParameter;
 import org.netbeans.modules.php.editor.parser.astnodes.FunctionDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.GlobalStatement;
 import org.netbeans.modules.php.editor.parser.astnodes.Identifier;
+import org.netbeans.modules.php.editor.parser.astnodes.IntersectionType;
 import org.netbeans.modules.php.editor.parser.astnodes.LambdaFunctionDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.MethodDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.NamespaceName;
@@ -91,7 +92,7 @@ import org.openide.util.RequestProcessor;
 public final class PhpCommentGenerator {
 
     static final RequestProcessor RP = new RequestProcessor("Generating Bracket Completer", 1); //NOI18N
-    static final String TYPE_PLACEHOLDER = "type";
+    static final String TYPE_PLACEHOLDER = "type"; // NOI18N
 
     private PhpCommentGenerator() {
     }
@@ -198,6 +199,8 @@ public final class PhpCommentGenerator {
         String typeName;
         if (declaredType instanceof UnionType) {
             typeName = VariousUtils.getUnionType((UnionType) declaredType);
+        } else if (declaredType instanceof IntersectionType) {
+            typeName = VariousUtils.getIntersectionType((IntersectionType) declaredType);
         } else {
             QualifiedName name = QualifiedName.create(declaredType);
             assert name != null : declaredType;

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/ImplementAbstractMethodsHintError.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/ImplementAbstractMethodsHintError.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesConstructor/testIntersectionTypesConstructor.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesConstructor/testIntersectionTypesConstructor.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class IntersectionTypes
+{
+    private Foo&Bar $fooBar;
+    private Foo&Bar&Baz $fooBarBaz;
+    private Foo $foo;
+    private static Foo&Bar $staticFooBar;
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesConstructor/testIntersectionTypesConstructor.php.testIntersectionTypesConstructor.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesConstructor/testIntersectionTypesConstructor.php.testIntersectionTypesConstructor.codegen
@@ -1,0 +1,5 @@
+public function __construct(Foo&Bar $fooBar, Foo&Bar&Baz $fooBarBaz, Foo $foo) {
+$$this->fooBar = $fooBar;
+$$this->fooBarBaz = $fooBarBaz;
+$$this->foo = $foo;${cursor}
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesGetter/testIntersectionTypesGetter.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesGetter/testIntersectionTypesGetter.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class IntersectionTypes
+{
+    private Foo&Bar $fooBar;
+    private Foo&Bar&Baz $fooBarBaz;
+    private Foo $foo;
+    private static Foo&Bar $staticFooBar;
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesGetter/testIntersectionTypesGetter.php.testIntersectionTypesGetter.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesGetter/testIntersectionTypesGetter.php.testIntersectionTypesGetter.codegen
@@ -1,0 +1,16 @@
+public  function getFooBar(): Foo&Bar  {
+return $$this->fooBar;
+}
+
+public  function getFooBarBaz(): Foo&Bar&Baz  {
+return $$this->fooBarBaz;
+}
+
+public  function getFoo(): Foo  {
+return $$this->foo;
+}
+
+public static function getStaticFooBar(): Foo&Bar  {
+return self::$$staticFooBar;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod01/testIntersectionTypesImplementMethod01.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod01/testIntersectionTypesImplementMethod01.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+interface ImplementMethodTest {
+
+    public function testMethod(Foo&Bar $param): Foo&Bar;
+    /**
+     * @param Foo&Bar $param test
+     * @return Foo&Bar test
+     */
+    public function testPHPDoc($param): object;
+}
+
+class Implement implements ImplementMethodTest {
+
+}
+
+class Foo {}
+class Bar {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod01/testIntersectionTypesImplementMethod01.php.testIntersectionTypesImplementMethod01.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod01/testIntersectionTypesImplementMethod01.php.testIntersectionTypesImplementMethod01.codegen
@@ -1,0 +1,4 @@
+public function testMethod(Foo&Bar $param): Foo&Bar{
+}
+public function testPHPDoc($param): object{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod02/testIntersectionTypesImplementMethod02.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod02/testIntersectionTypesImplementMethod02.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+
+    interface ImplementMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar;
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod02/testIntersectionTypesImplementMethod02.php.testIntersectionTypesImplementMethod02.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod02/testIntersectionTypesImplementMethod02.php.testIntersectionTypesImplementMethod02.codegen
@@ -1,0 +1,2 @@
+public function testMethod(Foo&Bar $param): Foo&Bar{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod03/testIntersectionTypesImplementMethod03.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod03/testIntersectionTypesImplementMethod03.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    interface ImplementMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar;
+    }
+
+    class Foo {}
+    class Bar {}
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+    }
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod03/testIntersectionTypesImplementMethod03.php.testIntersectionTypesImplementMethod03.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod03/testIntersectionTypesImplementMethod03.php.testIntersectionTypesImplementMethod03.codegen
@@ -1,0 +1,2 @@
+public function testMethod(\Test1\Foo&\Test1\Bar $param): \Test1\Foo&\Test1\Bar{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod04/testIntersectionTypesImplementMethod04.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod04/testIntersectionTypesImplementMethod04.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+abstract class ImplementMethodTest {
+
+    abstract public function testMethod(Foo&Bar $param): Foo&Bar;
+}
+
+class Implement extends ImplementMethodTest {
+
+}
+
+class Foo {}
+class Bar {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod04/testIntersectionTypesImplementMethod04.php.testIntersectionTypesImplementMethod04.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesImplementMethod04/testIntersectionTypesImplementMethod04.php.testIntersectionTypesImplementMethod04.codegen
@@ -1,0 +1,2 @@
+public function testMethod(Foo&Bar $param): Foo&Bar{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod01/testIntersectionTypesOverrideMethod01.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod01/testIntersectionTypesOverrideMethod01.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+class OverrideMethodTest {
+
+    public function testMethod(Foo&Bar $param): Foo&Bar {
+        return new Foo();
+    }
+}
+
+class Child extends OverrideMethodTest {
+
+}
+
+class Foo {}
+class Bar {}
+
+$instance = new Child();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod01/testIntersectionTypesOverrideMethod01.php.testIntersectionTypesOverrideMethod01.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod01/testIntersectionTypesOverrideMethod01.php.testIntersectionTypesOverrideMethod01.codegen
@@ -1,0 +1,3 @@
+public function testMethod(Foo&Bar $param): Foo&Bar{
+return parent::testMethod($param);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod02/testIntersectionTypesOverrideMethod02.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod02/testIntersectionTypesOverrideMethod02.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+
+    class OverrideMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar {
+            return new Foo();
+        }
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\OverrideMethodTest;
+
+    class Child extends OverrideMethodTest {
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    $instance = new Child();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod02/testIntersectionTypesOverrideMethod02.php.testIntersectionTypesOverrideMethod02.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod02/testIntersectionTypesOverrideMethod02.php.testIntersectionTypesOverrideMethod02.codegen
@@ -1,0 +1,3 @@
+public function testMethod(Foo&Bar $param): Foo&Bar{
+return parent::testMethod($param);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod03/testIntersectionTypesOverrideMethod03.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod03/testIntersectionTypesOverrideMethod03.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    class OverrideMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar {
+            return new Foo();
+        }
+    }
+
+    class Foo {}
+    class Bar {}
+
+}
+
+namespace Test2 {
+
+    use Test1\OverrideMethodTest;
+
+    class Child extends OverrideMethodTest {
+    }
+
+    $instance = new Child();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod03/testIntersectionTypesOverrideMethod03.php.testIntersectionTypesOverrideMethod03.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesOverrideMethod03/testIntersectionTypesOverrideMethod03.php.testIntersectionTypesOverrideMethod03.codegen
@@ -1,0 +1,3 @@
+public function testMethod(\Test1\Foo&\Test1\Bar $param): \Test1\Foo&\Test1\Bar{
+return parent::testMethod($param);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesSetter/testIntersectionTypesSetter.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesSetter/testIntersectionTypesSetter.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class IntersectionTypes
+{
+    private Foo&Bar $fooBar;
+    private Foo&Bar&Baz $fooBarBaz;
+    private Foo $foo;
+    private static Foo&Bar $staticFooBar;
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesSetter/testIntersectionTypesSetter.php.testIntersectionTypesSetter.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testIntersectionTypesSetter/testIntersectionTypesSetter.php.testIntersectionTypesSetter.codegen
@@ -1,0 +1,16 @@
+public  function setFooBar(Foo&Bar $$fooBar): void {
+$$this->fooBar = $fooBar;
+}
+
+public  function setFooBarBaz(Foo&Bar&Baz $$fooBarBaz): void {
+$$this->fooBarBaz = $fooBarBaz;
+}
+
+public  function setFoo(Foo $$foo): void {
+$$this->foo = $foo;
+}
+
+public static function setStaticFooBar(Foo&Bar $$staticFooBar): void {
+self::$$staticFooBar = $staticFooBar;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/fieldWithoutPhpDoc.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/fieldWithoutPhpDoc.php
@@ -24,10 +24,14 @@ class TestField
     public int $typed;
     private ?string $nullable;
     protected static Foo|Bar|\Test\Baz $unionType;
+    public Foo&Bar&\Test\Baz $intersectionType;
+    public Foo&Bar&Looooooooooooooooooooooooooong $longNameType;
 
     public function test(): void {
         $this->typed;
         $this->nullable;
         self::$unionType;
+        $this->intersectionType;
+        $this->longNameType;
     }
 }

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/fieldWithoutPhpDoc.php.testFieldIntersectionTypeWithoutPhpDoc.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/fieldWithoutPhpDoc.php.testFieldIntersectionTypeWithoutPhpDoc.html
@@ -1,0 +1,9 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->interse|ctionType;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   Foo&Bar&\Test\Baz intersection  [PUBLIC]   TestField
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$intersectionType</b><br/><br/><br />
+<table>
+<tr><th align="left">Type:</th><td>Foo & Bar & \Test\Baz</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/fieldWithoutPhpDoc.php.testFieldLongNameTypeWithoutPhpDoc.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/fieldWithoutPhpDoc.php.testFieldLongNameTypeWithoutPhpDoc.html
@@ -1,0 +1,9 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->longNameT|ype;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   Foo&Bar&Loooooooooooooooooo...  [PUBLIC]   TestField
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$longNameType</b><br/><br/><br />
+<table>
+<tr><th align="left">Type:</th><td>Foo & Bar & Looooooooooooooooooooooooooong</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/fieldWithoutPhpDoc.php.testFieldNullableTypeWithoutPhpDoc.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/fieldWithoutPhpDoc.php.testFieldNullableTypeWithoutPhpDoc.html
@@ -2,7 +2,7 @@
 <pre>Code completion result for source line:
 $this->nullabl|e;
 (QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
-VARIABLE   string nullable                 [PRIVATE]  TestField
+VARIABLE   ?string nullable                [PRIVATE]  TestField
 </pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$nullable</b><br/><br/><br />
 <table>
 <tr><th align="left">Type:</th><td>?string</td></tr></table>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/fieldWithoutPhpDoc.php.testFieldUnionTypeWithoutPhpDoc.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/fieldWithoutPhpDoc.php.testFieldUnionTypeWithoutPhpDoc.html
@@ -2,7 +2,7 @@
 <pre>Code completion result for source line:
 self::$union|Type;
 (QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
-VARIABLE   mixed $unionType                [PROTECTE  TestField
+VARIABLE   Foo|Bar|\Test\Baz $unionType    [PROTECTE  TestField
 </pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$unionType</b><br/><br/><br />
 <table>
 <tr><th align="left">Type:</th><td>Foo | Bar | \Test\Baz</td></tr></table>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/functionWithoutPhpDoc.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/functionWithoutPhpDoc.php
@@ -30,6 +30,9 @@ class TestClass
 
     public function testUnionType(int|float $param1, Foo|Bar $param2, \Test\Foo|\Test\Bar $param3): int|Foo|\Test\Bar {
     }
+
+    public function testIntersectionType(Foo&Bar $param1, \Test\Foo&\Test\Bar $param2): Foo&\Test\Bar {
+    }
 }
 
 function testTyped(int $param1, Baz $param2, \Test\Bar $param3): Foo {
@@ -41,11 +44,16 @@ function testNullableType(?int $param1, ?Foo $param2, ?\Test\Bar $param3): ?\Tes
 function testUnionType(int|float $param1, Foo|Bar $param2, \Test\Foo|\Test\Bar $param3): int|Foo|\Test\Bar {
 }
 
+function testIntersectionType(Foo&Bar $param1, \Test\Foo&\Test\Bar $param2): Foo&\Test\Bar {
+}
+
 $instance = new TestClass();
 $instance->testTyped(1, null, null);
 TestClass::testNullableType(null, null, null);
 $instance->testUnionType(1, null, null);
+$instance->testIntersectionType(null, null);
 
 testTyped(2, null, null);
 testNullableType(2, null, null);
 testUnionType(2, null, null);
+testIntersectionType(null, null); // function

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/functionWithoutPhpDoc.php.testFunctionIntersectionTypeWithoutPhpDoc.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/functionWithoutPhpDoc.php.testFunctionIntersectionTypeWithoutPhpDoc.html
@@ -1,0 +1,14 @@
+<html><body>
+<pre>Code completion result for source line:
+testIntersectionTy|pe(null, null); // function
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+METHOD     testIntersectionType(Foo&Bar $  [PUBLIC]   functionWithoutPhpDoc.php
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>testIntersectionType</b><br/><br/><br />
+<h3>Parameters:</h3>
+<table cellspacing=0 style="border: 0px; width: 100%;">
+<tr><td>&nbsp;</td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr>Foo & Bar</nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr><b>$param1</b></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;width:80%;" >PHPDoc not found</td></tr>
+<tr><td>&nbsp;</td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr>\Test\Foo & \Test\Bar</nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr><b>$param2</b></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;width:80%;" >PHPDoc not found</td></tr>
+</table>
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>\Foo & \Test\Bar</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/functionWithoutPhpDoc.php.testMethodIntersectionTypeWithoutPhpDoc.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/functionWithoutPhpDoc.php.testMethodIntersectionTypeWithoutPhpDoc.html
@@ -1,0 +1,14 @@
+<html><body>
+<pre>Code completion result for source line:
+$instance->testIntersectio|nType(null, null);
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+METHOD     testIntersectionType(Foo&Bar $  [PUBLIC]   TestClass
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>testIntersectionType</b><br/><br/><br />
+<h3>Parameters:</h3>
+<table cellspacing=0 style="border: 0px; width: 100%;">
+<tr><td>&nbsp;</td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr>Foo & Bar</nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr><b>$param1</b></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;width:80%;" >PHPDoc not found</td></tr>
+<tr><td>&nbsp;</td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr>\Test\Foo & \Test\Bar</nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr><b>$param2</b></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;width:80%;" >PHPDoc not found</td></tr>
+</table>
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>\Foo & \Test\Bar</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/mixedtypes_1.php.testMixedType01_1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/mixedtypes_1.php.testMixedType01_1.completion
@@ -3,5 +3,5 @@ getBookMagazine()->|pages;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     createBook_1($title)            [STATIC]   Book_1
 VARIABLE   ? pages                         [PUBLIC]   Magazine_1
-VARIABLE   mixed author                    [PUBLIC]   Book_1
+VARIABLE   Author_1|null author            [PUBLIC]   Book_1
 VARIABLE   string title                    [PUBLIC]   Book_1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/mixedtypes_1.php.testMixedType02_1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/mixedtypes_1.php.testMixedType02_1.completion
@@ -3,5 +3,5 @@ $bm->|author;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     createBook_1($title)            [STATIC]   Book_1
 VARIABLE   ? pages                         [PUBLIC]   Magazine_1
-VARIABLE   mixed author                    [PUBLIC]   Book_1
+VARIABLE   Author_1|null author            [PUBLIC]   Book_1
 VARIABLE   string title                    [PUBLIC]   Book_1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/mixedtypes_1.php.testMixedType03_1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/mixedtypes_1.php.testMixedType03_1.completion
@@ -2,5 +2,5 @@ Code completion result for source line:
 getBook()->|author;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     createBook_1($title)            [STATIC]   Book_1
-VARIABLE   mixed author                    [PUBLIC]   Book_1
+VARIABLE   Author_1|null author            [PUBLIC]   Book_1
 VARIABLE   string title                    [PUBLIC]   Book_1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20WithSpecialTypes/typedProperties20WithSpecialTypes.php.testTypedProperties20WithSpecialTypes_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20WithSpecialTypes/typedProperties20WithSpecialTypes.php.testTypedProperties20WithSpecialTypes_01.completion
@@ -6,6 +6,6 @@ METHOD     childMethodSelf(self $param)    [PUBLIC]   \TypedProperties1\TypedPro
 METHOD     parentMethod()                  [PUBLIC]   \TypedProperties1\TypedPropertiesParent
 METHOD     testMethod()                    [PUBLIC]   \TypedProperties1\TypedPropertiesChild
 METHOD     traitMethod(self $param)        [PUBLIC]   \TypedProperties1\TypedPropertiesTrait
+VARIABLE   ?parent nullableParent          [PRIVATE]  \TypedProperties1\TypedPropertiesChild
+VARIABLE   ?self nullableSelf              [PRIVATE]  \TypedProperties1\TypedPropertiesChild
 VARIABLE   object parentField              [PROTECTE  \TypedProperties1\TypedPropertiesParent
-VARIABLE   parent nullableParent           [PRIVATE]  \TypedProperties1\TypedPropertiesChild
-VARIABLE   self nullableSelf               [PRIVATE]  \TypedProperties1\TypedPropertiesChild

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20WithSpecialTypes/typedProperties20WithSpecialTypes.php.testTypedProperties20WithSpecialTypes_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20WithSpecialTypes/typedProperties20WithSpecialTypes.php.testTypedProperties20WithSpecialTypes_03.completion
@@ -6,6 +6,6 @@ METHOD     childMethodSelf(self $param)    [PUBLIC]   \TypedProperties1\TypedPro
 METHOD     parentMethod()                  [PUBLIC]   \TypedProperties1\TypedPropertiesParent
 METHOD     testMethod()                    [PUBLIC]   \TypedProperties1\TypedPropertiesChild
 METHOD     traitMethod(self $param)        [PUBLIC]   \TypedProperties1\TypedPropertiesTrait
+VARIABLE   ?parent nullableParent          [PRIVATE]  \TypedProperties1\TypedPropertiesChild
+VARIABLE   ?self nullableSelf              [PRIVATE]  \TypedProperties1\TypedPropertiesChild
 VARIABLE   object parentField              [PROTECTE  \TypedProperties1\TypedPropertiesParent
-VARIABLE   parent nullableParent           [PRIVATE]  \TypedProperties1\TypedPropertiesChild
-VARIABLE   self nullableSelf               [PRIVATE]  \TypedProperties1\TypedPropertiesChild

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20WithSpecialTypes/typedProperties20WithSpecialTypes.php.testTypedProperties20WithSpecialTypes_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20WithSpecialTypes/typedProperties20WithSpecialTypes.php.testTypedProperties20WithSpecialTypes_05.completion
@@ -6,6 +6,6 @@ METHOD     childMethodSelf(self $param)    [PUBLIC]   \TypedProperties1\TypedPro
 METHOD     parentMethod()                  [PUBLIC]   \TypedProperties1\TypedPropertiesParent
 METHOD     testMethod()                    [PUBLIC]   \TypedProperties1\TypedPropertiesChild
 METHOD     traitMethod(self $param)        [PUBLIC]   \TypedProperties1\TypedPropertiesTrait
+VARIABLE   ?parent nullableParent          [PRIVATE]  \TypedProperties1\TypedPropertiesChild
+VARIABLE   ?self nullableSelf              [PRIVATE]  \TypedProperties1\TypedPropertiesChild
 VARIABLE   object parentField              [PROTECTE  \TypedProperties1\TypedPropertiesParent
-VARIABLE   parent nullableParent           [PRIVATE]  \TypedProperties1\TypedPropertiesChild
-VARIABLE   self nullableSelf               [PRIVATE]  \TypedProperties1\TypedPropertiesChild

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNullsafeOperator/nullsafeOperator.php.testNullsafeOperator_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNullsafeOperator/nullsafeOperator.php.testNullsafeOperator_01.completion
@@ -7,6 +7,6 @@ METHOD     privateMethod()                 [PRIVATE]  User
 METHOD     protectedMethod()               [PROTECTE  User
 METHOD     test()                          [STATIC]   User
 VARIABLE   ? protectedField                [PROTECTE  User
-VARIABLE   Address address                 [PRIVATE]  User
+VARIABLE   ?Address address                [PRIVATE]  User
 VARIABLE   int id                          [PUBLIC]   User
 VARIABLE   string name                     [PRIVATE]  User

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNullsafeOperator/nullsafeOperator.php.testNullsafeOperator_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNullsafeOperator/nullsafeOperator.php.testNullsafeOperator_02.completion
@@ -2,4 +2,4 @@ Code completion result for source line:
 $country = $session?->|user?->getAddress()?->country;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     getUser()                       [PUBLIC]   Session
-VARIABLE   User user                       [PUBLIC]   Session
+VARIABLE   ?User user                      [PUBLIC]   Session

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_01.completion
@@ -6,5 +6,5 @@ METHOD     publicMethodTrait1(Class2|Clas  [PUBLIC]   \UnionTypes1\Trait1
 METHOD     publicStaticMethodTrait1()      [STATIC]   \UnionTypes1\Trait1
 METHOD     testMethodPhpDoc($object)       [PUBLIC]   \UnionTypes1\InterfaceImpl
 METHOD     testWithWhitespaces(Class1|Cla  [PUBLIC]   \UnionTypes1\InterfaceImpl
-VARIABLE   mixed publicFieldInterfaceImpl  [PUBLIC]   \UnionTypes1\InterfaceImpl
-VARIABLE   mixed publicFieldTrait1         [PUBLIC]   \UnionTypes1\Trait1
+VARIABLE   Class1|Class2 publicFieldInter  [PUBLIC]   \UnionTypes1\InterfaceImpl
+VARIABLE   Class1|Class2 publicFieldTrait  [PUBLIC]   \UnionTypes1\Trait1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_02.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \UnionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \UnionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \UnionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_03.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \UnionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \UnionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \UnionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_04.completion
@@ -2,6 +2,6 @@ Code completion result for source line:
 self::|$publicStaticFieldInterfaceImpl->publicMethodClass1();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodTrait1()      [STATIC]   \UnionTypes1\Trait1
-VARIABLE   mixed $publicStaticFieldInterf  [STATIC]   \UnionTypes1\InterfaceImpl
-VARIABLE   mixed $publicStaticFieldTrait1  [STATIC]   \UnionTypes1\Trait1
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\InterfaceImpl
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Trait1
 CONSTANT   class \UnionTypes1\InterfaceIm  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_05.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \UnionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \UnionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \UnionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_06.completion
@@ -3,8 +3,8 @@ self::$publicStaticFieldInterfaceImpl::|CONST_CLASS1;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \UnionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \UnionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \UnionTypes1\Class2
 CONSTANT   class \UnionTypes1\Class1       [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_07.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \UnionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \UnionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \UnionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_08.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \UnionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \UnionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \UnionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_09.completion
@@ -3,8 +3,8 @@ $object->publicMethodClass1()::|CONST_CLASS2;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \UnionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \UnionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \UnionTypes1\Class2
 CONSTANT   class \UnionTypes1\Class1       [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_10.completion
@@ -3,8 +3,8 @@ $object::|$publicFieldClass1->publicMethodClass1();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \UnionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \UnionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \UnionTypes1\Class2
 CONSTANT   class \UnionTypes1\Class1       [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_11.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \UnionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \UnionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \UnionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_12.completion
@@ -3,8 +3,8 @@ $object::$publicFieldClass1::|publicStaticMethodClass1();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \UnionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \UnionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \UnionTypes1\Class2
 CONSTANT   class \UnionTypes1\Class1       [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_13.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_13.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \UnionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \UnionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \UnionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_14.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_14.completion
@@ -3,8 +3,8 @@ $object::|publicStaticMethodClass2(); // phpdoc
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \UnionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \UnionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \UnionTypes1\Class2
 CONSTANT   class \UnionTypes1\Class1       [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_15.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_15.completion
@@ -2,6 +2,6 @@ Code completion result for source line:
 $this::|$publicStaticFieldTrait1->publicMethodClass1();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodTrait1()      [STATIC]   \UnionTypes1\Trait1
-VARIABLE   mixed $publicStaticFieldInterf  [STATIC]   \UnionTypes1\InterfaceImpl
-VARIABLE   mixed $publicStaticFieldTrait1  [STATIC]   \UnionTypes1\Trait1
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\InterfaceImpl
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Trait1
 CONSTANT   class \UnionTypes1\InterfaceIm  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_16.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_16.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \UnionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \UnionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \UnionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_17.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_17.completion
@@ -3,8 +3,8 @@ $this::publicStaticMethodTrait1()::|publicStaticMethodClass1();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \UnionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \UnionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \UnionTypes1\Class2
 CONSTANT   class \UnionTypes1\Class1       [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_18.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_18.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \UnionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \UnionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \UnionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 publicFieldClass  [PUBLIC]   \UnionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_19.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypes/unionTypes.php.testUnionTypes_19.completion
@@ -3,8 +3,8 @@ $object::|publicStaticMethodClass1(); // with whitespaces
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \UnionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \UnionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \UnionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \UnionTypes1\Class2
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class1
+VARIABLE   Class1|Class2 $publicStaticFie  [STATIC]   \UnionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \UnionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \UnionTypes1\Class2
 CONSTANT   class \UnionTypes1\Class1       [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesWithSpecialTypes/unionTypesWithSpecialTypes.php.testUnionTypesWithSpecialTypes_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesWithSpecialTypes/unionTypesWithSpecialTypes.php.testUnionTypesWithSpecialTypes_01.completion
@@ -6,5 +6,5 @@ METHOD     childMethodParent(parent|null   [PUBLIC]   \UnionTypes1\UnionChild
 METHOD     parentMethod()                  [PUBLIC]   \UnionTypes1\UnionParent
 METHOD     testMethod()                    [PUBLIC]   \UnionTypes1\UnionChild
 METHOD     traitMethod(self|parent $param  [PUBLIC]   \UnionTypes1\UnionTrait
-VARIABLE   mixed union                     [PRIVATE]  \UnionTypes1\UnionChild
 VARIABLE   object parentField              [PROTECTE  \UnionTypes1\UnionParent
+VARIABLE   self|parent union               [PRIVATE]  \UnionTypes1\UnionChild

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesWithSpecialTypes/unionTypesWithSpecialTypes.php.testUnionTypesWithSpecialTypes_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesWithSpecialTypes/unionTypesWithSpecialTypes.php.testUnionTypesWithSpecialTypes_03.completion
@@ -6,5 +6,5 @@ METHOD     childMethodParent(parent|null   [PUBLIC]   \UnionTypes1\UnionChild
 METHOD     parentMethod()                  [PUBLIC]   \UnionTypes1\UnionParent
 METHOD     testMethod()                    [PUBLIC]   \UnionTypes1\UnionChild
 METHOD     traitMethod(self|parent $param  [PUBLIC]   \UnionTypes1\UnionTrait
-VARIABLE   mixed union                     [PRIVATE]  \UnionTypes1\UnionChild
 VARIABLE   object parentField              [PROTECTE  \UnionTypes1\UnionParent
+VARIABLE   self|parent union               [PRIVATE]  \UnionTypes1\UnionChild

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesWithSpecialTypes/unionTypesWithSpecialTypes.php.testUnionTypesWithSpecialTypes_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesWithSpecialTypes/unionTypesWithSpecialTypes.php.testUnionTypesWithSpecialTypes_04.completion
@@ -6,5 +6,5 @@ METHOD     childMethodParent(parent|null   [PUBLIC]   \UnionTypes1\UnionChild
 METHOD     parentMethod()                  [PUBLIC]   \UnionTypes1\UnionParent
 METHOD     testMethod()                    [PUBLIC]   \UnionTypes1\UnionChild
 METHOD     traitMethod(self|parent $param  [PUBLIC]   \UnionTypes1\UnionTrait
-VARIABLE   mixed union                     [PRIVATE]  \UnionTypes1\UnionChild
 VARIABLE   object parentField              [PROTECTE  \UnionTypes1\UnionParent
+VARIABLE   self|parent union               [PRIVATE]  \UnionTypes1\UnionChild

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesWithSpecialTypes/unionTypesWithSpecialTypes.php.testUnionTypesWithSpecialTypes_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesWithSpecialTypes/unionTypesWithSpecialTypes.php.testUnionTypesWithSpecialTypes_06.completion
@@ -6,5 +6,5 @@ METHOD     childMethodParent(parent|null   [PUBLIC]   \UnionTypes1\UnionChild
 METHOD     parentMethod()                  [PUBLIC]   \UnionTypes1\UnionParent
 METHOD     testMethod()                    [PUBLIC]   \UnionTypes1\UnionChild
 METHOD     traitMethod(self|parent $param  [PUBLIC]   \UnionTypes1\UnionTrait
-VARIABLE   mixed union                     [PRIVATE]  \UnionTypes1\UnionChild
 VARIABLE   object parentField              [PROTECTE  \UnionTypes1\UnionParent
+VARIABLE   self|parent union               [PRIVATE]  \UnionTypes1\UnionChild

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace IntersectionTypes1;
+
+interface Interface1
+{
+    public function interfaceMethod(Class1&Class2 $param): Class2&Class1;
+}
+
+class InterfaceImpl implements Interface1
+{
+
+    use Trait1;
+
+    public Class1&Class2 $publicFieldInterfaceImpl;
+    public static Class1&Class2 $publicStaticFieldInterfaceImpl;
+
+    public function interfaceMethod(Class1&Class2 $object): Class2&Class1 {
+        $this->publicFieldInterfaceImpl->publicMethodClass1();
+        $this->publicFieldTrait1->publicMethodClass1();
+        $this::$publicStaticFieldTrait1->publicMethodClass1();
+        $this::publicStaticMethodTrait1()::publicStaticMethodClass1();
+        self::$publicStaticFieldInterfaceImpl->publicMethodClass1();
+        self::$publicStaticFieldInterfaceImpl::CONST_CLASS1;
+        $object->publicMethodClass1()->publicMethodClass2();
+        $object->publicMethodClass1()::CONST_CLASS2;
+        $object::$publicFieldClass1->publicMethodClass1();
+        $object::$publicFieldClass1::publicStaticMethodClass1();
+        return new Class1();
+    }
+
+    /**
+     * @param Class1&Class2 $object
+     * @return Class2&Class1
+     */
+    public function testMethodPhpDoc($object) {
+        $object->publicMethodClass2(); // phpdoc
+        $object::publicStaticMethodClass2(); // phpdoc
+    }
+
+    public function testWithWhitespaces(Class1 & Class2 $object): Class2&Class1 {
+        $object->publicMethodClass1(); // with whitespaces
+        $object::publicStaticMethodClass1(); // with whitespaces
+    }
+}
+
+class Class1
+{
+
+    public Class1&Class2 $publicFieldClass1;
+
+    public const CONST_CLASS1 = "constant";
+
+    public static Class1&Class2 $publicStaticFieldClass1;
+
+    public function publicMethodClass1(): Class1 & Class2 { // with whitespaces
+        return new Class2();
+    }
+
+    public static function publicStaticMethodClass1(): Class1&Class2 {
+        return new Class2();
+    }
+
+}
+
+class Class2
+{
+
+    public Class1&Class2 $publicFieldClass2;
+
+    public const CONST_CLASS2 = "constant";
+
+    public static Class1&Class2 $publicStaticFieldClass2;
+
+    public function publicMethodClass2(): Class1&Class2 {
+        return new Class2();
+    }
+
+    public static function publicStaticMethodClass2(): Class1&Class2 {
+        return new Class2();
+    }
+
+}
+
+trait Trait1
+{
+
+    public Class1 & Class2 $publicFieldTrait1; // with whitespaces
+    public static Class1&Class2 $publicStaticFieldTrait1;
+
+    public function publicMethodTrait1(
+            Class2&Class1 $object
+    ): Class2&Class1 {
+        return new Class1();
+    }
+
+    public static function publicStaticMethodTrait1(): Class1&Class2 {
+        return new Class2();
+    }
+
+}
+
+$instance = new InterfaceImpl();
+var_dump($instance->interfaceMethod(new Class1())->publicMethodClass1());

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_01.completion
@@ -6,5 +6,5 @@ METHOD     publicMethodTrait1(Class2&Clas  [PUBLIC]   \IntersectionTypes1\Trait1
 METHOD     publicStaticMethodTrait1()      [STATIC]   \IntersectionTypes1\Trait1
 METHOD     testMethodPhpDoc($object)       [PUBLIC]   \IntersectionTypes1\InterfaceImpl
 METHOD     testWithWhitespaces(Class1&Cla  [PUBLIC]   \IntersectionTypes1\InterfaceImpl
-VARIABLE   mixed publicFieldInterfaceImpl  [PUBLIC]   \IntersectionTypes1\InterfaceImpl
-VARIABLE   mixed publicFieldTrait1         [PUBLIC]   \IntersectionTypes1\Trait1
+VARIABLE   Class1&Class2 publicFieldInter  [PUBLIC]   \IntersectionTypes1\InterfaceImpl
+VARIABLE   Class1&Class2 publicFieldTrait  [PUBLIC]   \IntersectionTypes1\Trait1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_01.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+$this->|publicFieldInterfaceImpl->publicMethodClass1();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     interfaceMethod(Class1&Class2   [PUBLIC]   \IntersectionTypes1\InterfaceImpl
+METHOD     publicMethodTrait1(Class2&Clas  [PUBLIC]   \IntersectionTypes1\Trait1
+METHOD     publicStaticMethodTrait1()      [STATIC]   \IntersectionTypes1\Trait1
+METHOD     testMethodPhpDoc($object)       [PUBLIC]   \IntersectionTypes1\InterfaceImpl
+METHOD     testWithWhitespaces(Class1&Cla  [PUBLIC]   \IntersectionTypes1\InterfaceImpl
+VARIABLE   mixed publicFieldInterfaceImpl  [PUBLIC]   \IntersectionTypes1\InterfaceImpl
+VARIABLE   mixed publicFieldTrait1         [PUBLIC]   \IntersectionTypes1\Trait1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_02.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+$this->publicFieldInterfaceImpl->|publicMethodClass1();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
+METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_02.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_03.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+$this->publicFieldTrait1->|publicMethodClass1();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
+METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_03.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_04.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+self::|$publicStaticFieldInterfaceImpl->publicMethodClass1();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticMethodTrait1()      [STATIC]   \IntersectionTypes1\Trait1
+VARIABLE   mixed $publicStaticFieldInterf  [STATIC]   \IntersectionTypes1\InterfaceImpl
+VARIABLE   mixed $publicStaticFieldTrait1  [STATIC]   \IntersectionTypes1\Trait1
+CONSTANT   class \IntersectionTypes1\Inte  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_04.completion
@@ -2,6 +2,6 @@ Code completion result for source line:
 self::|$publicStaticFieldInterfaceImpl->publicMethodClass1();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodTrait1()      [STATIC]   \IntersectionTypes1\Trait1
-VARIABLE   mixed $publicStaticFieldInterf  [STATIC]   \IntersectionTypes1\InterfaceImpl
-VARIABLE   mixed $publicStaticFieldTrait1  [STATIC]   \IntersectionTypes1\Trait1
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\InterfaceImpl
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Trait1
 CONSTANT   class \IntersectionTypes1\Inte  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_05.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+self::$publicStaticFieldInterfaceImpl->|publicMethodClass1();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
+METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_05.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_06.completion
@@ -3,8 +3,8 @@ self::$publicStaticFieldInterfaceImpl::|CONST_CLASS1;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
 CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_06.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+self::$publicStaticFieldInterfaceImpl::|CONST_CLASS1;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
+CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_07.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+$object->|publicMethodClass1()->publicMethodClass2();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
+METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_07.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_08.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+$object->publicMethodClass1()->|publicMethodClass2();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
+METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_08.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_09.completion
@@ -3,8 +3,8 @@ $object->publicMethodClass1()::|CONST_CLASS2;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
 CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_09.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+$object->publicMethodClass1()::|CONST_CLASS2;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
+CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_10.completion
@@ -3,8 +3,8 @@ $object::|$publicFieldClass1->publicMethodClass1();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
 CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_10.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+$object::|$publicFieldClass1->publicMethodClass1();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
+CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_11.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+$object::$publicFieldClass1->|publicMethodClass1();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
+METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_11.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_12.completion
@@ -3,8 +3,8 @@ $object::$publicFieldClass1::|publicStaticMethodClass1();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
 CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_12.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+$object::$publicFieldClass1::|publicStaticMethodClass1();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
+CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_13.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_13.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+$object->|publicMethodClass2(); // phpdoc
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
+METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_13.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_13.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_14.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_14.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+$object::|publicStaticMethodClass2(); // phpdoc
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
+CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_14.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_14.completion
@@ -3,8 +3,8 @@ $object::|publicStaticMethodClass2(); // phpdoc
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
 CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_15.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_15.completion
@@ -2,6 +2,6 @@ Code completion result for source line:
 $this::|$publicStaticFieldTrait1->publicMethodClass1();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodTrait1()      [STATIC]   \IntersectionTypes1\Trait1
-VARIABLE   mixed $publicStaticFieldInterf  [STATIC]   \IntersectionTypes1\InterfaceImpl
-VARIABLE   mixed $publicStaticFieldTrait1  [STATIC]   \IntersectionTypes1\Trait1
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\InterfaceImpl
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Trait1
 CONSTANT   class \IntersectionTypes1\Inte  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_15.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_15.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+$this::|$publicStaticFieldTrait1->publicMethodClass1();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticMethodTrait1()      [STATIC]   \IntersectionTypes1\Trait1
+VARIABLE   mixed $publicStaticFieldInterf  [STATIC]   \IntersectionTypes1\InterfaceImpl
+VARIABLE   mixed $publicStaticFieldTrait1  [STATIC]   \IntersectionTypes1\Trait1
+CONSTANT   class \IntersectionTypes1\Inte  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_16.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_16.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+$this::$publicStaticFieldTrait1->|publicMethodClass1();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
+METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_16.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_16.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_17.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_17.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+$this::publicStaticMethodTrait1()::|publicStaticMethodClass1();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
+CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_17.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_17.completion
@@ -3,8 +3,8 @@ $this::publicStaticMethodTrait1()::|publicStaticMethodClass1();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
 CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_18.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_18.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+$object->|publicMethodClass1(); // with whitespaces
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
+METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_18.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_18.completion
@@ -5,5 +5,5 @@ METHOD     publicMethodClass1()            [PUBLIC]   \IntersectionTypes1\Class1
 METHOD     publicMethodClass2()            [PUBLIC]   \IntersectionTypes1\Class2
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed publicFieldClass1         [PUBLIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed publicFieldClass2         [PUBLIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 publicFieldClass  [PUBLIC]   \IntersectionTypes1\Class2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_19.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_19.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+$object::|publicStaticMethodClass1(); // with whitespaces
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
+METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
+CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant
+CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_19.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypes/intersectionTypes.php.testIntersectionTypes_19.completion
@@ -3,8 +3,8 @@ $object::|publicStaticMethodClass1(); // with whitespaces
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     publicStaticMethodClass1()      [STATIC]   \IntersectionTypes1\Class1
 METHOD     publicStaticMethodClass2()      [STATIC]   \IntersectionTypes1\Class2
-VARIABLE   mixed $publicStaticFieldClass1  [STATIC]   \IntersectionTypes1\Class1
-VARIABLE   mixed $publicStaticFieldClass2  [STATIC]   \IntersectionTypes1\Class2
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class1
+VARIABLE   Class1&Class2 $publicStaticFie  [STATIC]   \IntersectionTypes1\Class2
 CONSTANT   CONST_CLASS1 "constant"         [PUBLIC]   \IntersectionTypes1\Class1
 CONSTANT   CONST_CLASS2 "constant"         [PUBLIC]   \IntersectionTypes1\Class2
 CONSTANT   class \IntersectionTypes1\Clas  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields01/intersectionTypesFields01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields01/intersectionTypesFields01.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test1;
+
+interface IntersectionTypes1{}
+interface IntersectionTypes2{}
+
+namespace Test2;
+class Test
+{
+    private IntersectionTypes1&
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields01/intersectionTypesFields01.php.testIntersectionTypesFields01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields01/intersectionTypesFields01.php.testIntersectionTypesFields01.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+private IntersectionTypes1&|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      IntersectionTypes1              [PUBLIC]   Test1
+CLASS      IntersectionTypes2              [PUBLIC]   Test1
+CLASS      Test                            [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields02/intersectionTypesFields02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields02/intersectionTypesFields02.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test1;
+
+class IntersectionTypes1{}
+class IntersectionTypes2{}
+
+namespace Test2;
+class Test
+{
+    private IntersectionTypes1&\Test1\
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields02/intersectionTypesFields02.php.testIntersectionTypesFields02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields02/intersectionTypesFields02.php.testIntersectionTypesFields02.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+private IntersectionTypes1&\Test1\|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      IntersectionTypes1              [PUBLIC]   Test1
+CLASS      IntersectionTypes2              [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields03/intersectionTypesFields03.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields03/intersectionTypesFields03.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test1;
+
+class IntersectionTypes1{}
+class IntersectionTypes2{}
+
+namespace Test2;
+class Test
+{
+    private Test&\Test1\IntersectionTypes2&
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields03/intersectionTypesFields03.php.testIntersectionTypesFields03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields03/intersectionTypesFields03.php.testIntersectionTypesFields03.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+private Test&\Test1\IntersectionTypes2&|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      IntersectionTypes1              [PUBLIC]   Test1
+CLASS      IntersectionTypes2              [PUBLIC]   Test1
+CLASS      Test                            [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields04/intersectionTypesFields04.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields04/intersectionTypesFields04.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test1;
+
+interface IntersectionTypes1{}
+interface IntersectionTypes2{}
+
+namespace Test2;
+class Test
+{
+    private Test&\Test1\IntersectionTypes2&\Test1\IntersectionTypes2 $test;
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields04/intersectionTypesFields04.php.testIntersectionTypesFields04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields04/intersectionTypesFields04.php.testIntersectionTypesFields04.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+private Test&\Test1\IntersectionTypes2&\Test1\IntersectionT|ypes2 $test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      IntersectionTypes1              [PUBLIC]   Test1
+CLASS      IntersectionTypes2              [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields05/intersectionTypesFields05.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields05/intersectionTypesFields05.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test1;
+
+class IntersectionTypes1{}
+class IntersectionTypes2{}
+
+namespace Test2;
+class Test
+{
+    private Test&\Test1\IntersectionTypes2&&\Test1\IntersectionTypes1 $test;
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields05/intersectionTypesFields05.php.testIntersectionTypesFields05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields05/intersectionTypesFields05.php.testIntersectionTypesFields05.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+private Test&\Test1\IntersectionTypes2&|&\Test1\IntersectionTypes1 $test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      IntersectionTypes1              [PUBLIC]   Test1
+CLASS      IntersectionTypes2              [PUBLIC]   Test1
+CLASS      Test                            [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields06/intersectionTypesFields06.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields06/intersectionTypesFields06.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test1;
+
+interface IntersectionTypes1{}
+interface IntersectionTypes2{}
+
+namespace Test2;
+class Test
+{
+    private static Test&\Test1\IntersectionTypes2&\Test1\IntersectionTypes1 $test;
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields06/intersectionTypesFields06.php.testIntersectionTypesFields06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFields06/intersectionTypesFields06.php.testIntersectionTypesFields06.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+private static Test&\Test1\IntersectionTypes2&|\Test1\IntersectionTypes1 $test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      IntersectionTypes1              [PUBLIC]   Test1
+CLASS      IntersectionTypes2              [PUBLIC]   Test1
+CLASS      Test                            [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType01/intersectionTypesFunctionParameterType01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType01/intersectionTypesFunctionParameterType01.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+interface IntersectionTypes1{}
+interface IntersectionTypes2{}
+
+function intersection_types(IntersectionTypes1&)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType01/intersectionTypesFunctionParameterType01.php.testIntersectionTypesFunctionParameterType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType01/intersectionTypesFunctionParameterType01.php.testIntersectionTypesFunctionParameterType01.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&|)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType02/intersectionTypesFunctionParameterType02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType02/intersectionTypesFunctionParameterType02.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+class IntersectionTypes1{}
+class IntersectionTypes2{}
+
+function intersection_types(IntersectionTypes1&\Test\I)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType02/intersectionTypesFunctionParameterType02.php.testIntersectionTypesFunctionParameterType02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType02/intersectionTypesFunctionParameterType02.php.testIntersectionTypesFunctionParameterType02.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&\Test\I|)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType03/intersectionTypesFunctionParameterType03.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType03/intersectionTypesFunctionParameterType03.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+interface IntersectionTypes1 {}
+interface IntersectionTypes2 {}
+
+function intersection_types(IntersectionTypes1&\Test\IntersectionTypes2&)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType03/intersectionTypesFunctionParameterType03.php.testIntersectionTypesFunctionParameterType03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType03/intersectionTypesFunctionParameterType03.php.testIntersectionTypesFunctionParameterType03.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&\Test\IntersectionTypes2&|)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType04/intersectionTypesFunctionParameterType04.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType04/intersectionTypesFunctionParameterType04.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+class IntersectionTypes1 {}
+class IntersectionTypes2 {}
+
+function intersection_types(IntersectionTypes1&&\Test\IntersectionTypes2)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType04/intersectionTypesFunctionParameterType04.php.testIntersectionTypesFunctionParameterType04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType04/intersectionTypesFunctionParameterType04.php.testIntersectionTypesFunctionParameterType04.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&|&\Test\IntersectionTypes2)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType05/intersectionTypesFunctionParameterType05.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType05/intersectionTypesFunctionParameterType05.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+class IntersectionTypes1 {}
+class IntersectionTypes2 {}
+
+function intersection_types(IntersectionTypes1&) {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType05/intersectionTypesFunctionParameterType05.php.testIntersectionTypesFunctionParameterType05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType05/intersectionTypesFunctionParameterType05.php.testIntersectionTypesFunctionParameterType05.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&|) {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType06/intersectionTypesFunctionParameterType06.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType06/intersectionTypesFunctionParameterType06.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+interface IntersectionTypes1 {}
+interface IntersectionTypes2 {}
+
+function intersection_types(IntersectionTypes1&Inte) {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType06/intersectionTypesFunctionParameterType06.php.testIntersectionTypesFunctionParameterType06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType06/intersectionTypesFunctionParameterType06.php.testIntersectionTypesFunctionParameterType06.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&Inte|) {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType07/intersectionTypesFunctionParameterType07.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType07/intersectionTypesFunctionParameterType07.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+class IntersectionTypes1 {}
+class IntersectionTypes2 {}
+
+function intersection_types(IntersectionTypes1&IntersectionTypes2 $param, IntersectionTypes1&IntersectionTypes2&) {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType07/intersectionTypesFunctionParameterType07.php.testIntersectionTypesFunctionParameterType07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType07/intersectionTypesFunctionParameterType07.php.testIntersectionTypesFunctionParameterType07.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&IntersectionTypes2 $param, IntersectionTypes1&IntersectionTypes2&|) {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType08/intersectionTypesFunctionParameterType08.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType08/intersectionTypesFunctionParameterType08.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+class IntersectionTypes1 {}
+class IntersectionTypes2 {}
+
+function intersection_types(IntersectionTypes1&IntersectionTypes2 $param, IntersectionTypes1&IntersectionTypes2&\Test\) {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType08/intersectionTypesFunctionParameterType08.php.testIntersectionTypesFunctionParameterType08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType08/intersectionTypesFunctionParameterType08.php.testIntersectionTypesFunctionParameterType08.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&IntersectionTypes2 $param, IntersectionTypes1&IntersectionTypes2&\Test\|) {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType09/intersectionTypesFunctionParameterType09.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType09/intersectionTypesFunctionParameterType09.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+interface IntersectionTypes1 {}
+interface IntersectionTypes2 {}
+
+function intersection_types(IntersectionTypes1&IntersectionTypes2 $param, IntersectionTypes1&IntersectionTypes2&\Test\Inter) {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType09/intersectionTypesFunctionParameterType09.php.testIntersectionTypesFunctionParameterType09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionParameterType09/intersectionTypesFunctionParameterType09.php.testIntersectionTypesFunctionParameterType09.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&IntersectionTypes2 $param, IntersectionTypes1&IntersectionTypes2&\Test\Inter|) {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType01/intersectionTypesFunctionReturnType01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType01/intersectionTypesFunctionReturnType01.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+class IntersectionTypes1{}
+class IntersectionTypes2{}
+
+function intersection_types(IntersectionTypes1&\Test\IntersectionTypes2 $param): IntersectionTypes1&

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType01/intersectionTypesFunctionReturnType01.php.testIntersectionTypesFunctionReturnType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType01/intersectionTypesFunctionReturnType01.php.testIntersectionTypesFunctionReturnType01.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&\Test\IntersectionTypes2 $param): IntersectionTypes1&|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType02/intersectionTypesFunctionReturnType02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType02/intersectionTypesFunctionReturnType02.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+class IntersectionTypes1{}
+class IntersectionTypes2{}
+
+function intersection_types(IntersectionTypes1&\Test\IntersectionTypes2 $param): IntersectionTypes1&\Test\

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType02/intersectionTypesFunctionReturnType02.php.testIntersectionTypesFunctionReturnType02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType02/intersectionTypesFunctionReturnType02.php.testIntersectionTypesFunctionReturnType02.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&\Test\IntersectionTypes2 $param): IntersectionTypes1&\Test\|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType03/intersectionTypesFunctionReturnType03.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType03/intersectionTypesFunctionReturnType03.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+class IntersectionTypes1{}
+class IntersectionTypes2{}
+
+function intersection_types(IntersectionTypes1&\Test\IntersectionTypes2 $param): IntersectionTypes1&\Test\IntersectionTypes2&In

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType03/intersectionTypesFunctionReturnType03.php.testIntersectionTypesFunctionReturnType03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType03/intersectionTypesFunctionReturnType03.php.testIntersectionTypesFunctionReturnType03.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&\Test\IntersectionTypes2 $param): IntersectionTypes1&\Test\IntersectionTypes2&In|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType04/intersectionTypesFunctionReturnType04.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType04/intersectionTypesFunctionReturnType04.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+class IntersectionTypes1{}
+class IntersectionTypes2{}
+
+function intersection_types(IntersectionTypes1&\Test\IntersectionTypes2 $param): IntersectionTypes1&&\Test\IntersectionTypes2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType04/intersectionTypesFunctionReturnType04.php.testIntersectionTypesFunctionReturnType04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctionReturnType04/intersectionTypesFunctionReturnType04.php.testIntersectionTypesFunctionReturnType04.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+function intersection_types(IntersectionTypes1&\Test\IntersectionTypes2 $param): IntersectionTypes1&|&\Test\IntersectionTypes2
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      IntersectionTypes1              [PUBLIC]   Test
+CLASS      IntersectionTypes2              [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+interface Intersection1 {}
+interface Intersection2 {}
+interface Intersection3 {}
+
+function intersection_types(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): Intersection1& Intersection3 {
+}
+
+$closure = function(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1& Intersection2 $param): Intersection1&Intersection2 {
+};
+
+$arrow = fn(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): \Test\Intersection1&\Test\Intersection2&Intersection3 {
+};

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_01.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+function intersection_types(Intersect|ion1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): Intersection1& Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_02.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+function intersection_types(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&|Intersection2 $param): Intersection1& Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_03.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+function intersection_types(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersect|ion2 $param): Intersection1& Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_04.completion
@@ -1,0 +1,21 @@
+Code completion result for source line:
+function intersection_types(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): |Intersection1& Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    callable                                   null
+KEYWORD    false                                      null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    never                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    string                                     null
+KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_05.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+function intersection_types(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): Intersection1& |Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_06.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+function intersection_types(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): Intersection1& Intersec|tion3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_07.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+$closure = function(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersecti|on1& Intersection2 $param): Intersection1&Intersection2 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_08.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+$closure = function(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1& |Intersection2 $param): Intersection1&Intersection2 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_09.completion
@@ -1,0 +1,21 @@
+Code completion result for source line:
+$closure = function(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1& Intersection2 $param): |Intersection1&Intersection2 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    callable                                   null
+KEYWORD    false                                      null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    never                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    string                                     null
+KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_10.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+$closure = function(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1& Intersection2 $param): Intersection1&|Intersection2 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_11.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+$closure = function(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1& Intersection2 $param): Intersection1&Intersec|tion2 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_12.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+$arrow = fn(Intersection1&Intersection2&|\Test\Intersection3 $param1, Intersection1&Intersection2 $param): \Test\Intersection1&\Test\Intersection2&Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_13.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_13.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+$arrow = fn(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&|Intersection2 $param): \Test\Intersection1&\Test\Intersection2&Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_14.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_14.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+$arrow = fn(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2| $param): \Test\Intersection1&\Test\Intersection2&Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection2                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_15.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_15.completion
@@ -1,0 +1,21 @@
+Code completion result for source line:
+$arrow = fn(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): |\Test\Intersection1&\Test\Intersection2&Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    callable                                   null
+KEYWORD    false                                      null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    never                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    string                                     null
+KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_16.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_16.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+$arrow = fn(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): \Test\Inte|rsection1&\Test\Intersection2&Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_17.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_17.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+$arrow = fn(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): \Test\Intersection1&|\Test\Intersection2&Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_18.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_18.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+$arrow = fn(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): \Test\Intersection1&\Test\|Intersection2&Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_19.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_19.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+$arrow = fn(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): \Test\Intersection1&\Test\Intersection2&|Intersection3 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test                            [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test
+CLASS      Intersection2                   [PUBLIC]   Test
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_20.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_20.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+$arrow = fn(Intersection1&Intersection2&\Test\Intersection3 $param1, Intersection1&Intersection2 $param): \Test\Intersection1&\Test\Intersection2&Intersection3| {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection3                   [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod01/testIntersectionTypesImplementMethod01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod01/testIntersectionTypesImplementMethod01.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+class Foo {}
+class Bar {}
+class Baz {}
+
+interface ImplementMethodTest {
+
+    public function testMethod(Foo&Bar&Baz $param): Foo&Bar;
+}
+
+class Implement implements ImplementMethodTest {
+    test
+}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod01/testIntersectionTypesImplementMethod01.php.testIntersectionTypesImplementMethod01.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod01/testIntersectionTypesImplementMethod01.php.testIntersectionTypesImplementMethod01.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(Foo&Bar&Baz $param): Foo&Bar {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod02/testIntersectionTypesImplementMethod02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod02/testIntersectionTypesImplementMethod02.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+
+    interface ImplementMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar;
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+        test
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod02/testIntersectionTypesImplementMethod02.php.testIntersectionTypesImplementMethod02.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod02/testIntersectionTypesImplementMethod02.php.testIntersectionTypesImplementMethod02.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(Foo&Bar $param): Foo&Bar {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod03/testIntersectionTypesImplementMethod03.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod03/testIntersectionTypesImplementMethod03.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    interface ImplementMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar;
+    }
+
+    class Foo {}
+    class Bar {}
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+        test
+    }
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod03/testIntersectionTypesImplementMethod03.php.testIntersectionTypesImplementMethod03.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod03/testIntersectionTypesImplementMethod03.php.testIntersectionTypesImplementMethod03.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(\Test1\Foo&\Test1\Bar $param): \Test1\Foo&\Test1\Bar {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod04/testIntersectionTypesImplementMethod04.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod04/testIntersectionTypesImplementMethod04.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+abstract class ImplementMethodTest {
+
+    abstract public function testMethod(Foo&Bar $param): Foo&Bar;
+}
+
+class Implement extends ImplementMethodTest {
+    test
+}
+
+class Foo {}
+class Bar {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod04/testIntersectionTypesImplementMethod04.php.testIntersectionTypesImplementMethod04.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesImplementMethod04/testIntersectionTypesImplementMethod04.php.testIntersectionTypesImplementMethod04.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(Foo&Bar $param): Foo&Bar {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test1;
+
+class Intersection1{}
+class Intersection2{}
+
+namespace Test2;
+class TestClass
+{
+    public function classMethod(
+            \Test1\Intersection1&TestClass $object,
+            TestClass&\Test1\Intersection1 $param,
+    ): \Test1\Intersection2&\Test1\Intersection1 {
+        
+    }
+
+    public static function classStaticMethod(
+            \Test1\Intersection1&TestClass $object, // static
+            TestClass&\Test1\Intersection1 $param, // static
+    ): \Test1\Intersection2&TestClass {
+        
+    }
+}
+
+class TestChildClass extends TestClass
+{
+    public function childClassMethod(TestClass&\Test1\Intersection1 $object, TestClass&\Test1\Intersection1 $object2): TestClass&\Test1\Intersection1 {
+        
+    }
+}
+
+interface TestInterface
+{
+    public function interfaceMethod(\Test1\Intersection1&TestClass $object, TestClass&\Test1\Intersection1 $param, ): TestClass&\Test1\Intersection1;
+}
+
+abstract class TestAbstractClass
+{
+    abstract protected function abstractClassMethod(TestClass&\Test1\Intersection1 $param, TestInerface&TestClass $object,): TestClass&\Test1\Intersection1;
+}
+
+trait TestTrait
+{
+    private function traitMethod(TestInterface&\Test1\Intersection2 $object, TestClass&\Test1\Intersection1 $param): TestInterface&TestClass {
+        
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_01.completion
@@ -1,0 +1,25 @@
+Code completion result for source line:
+|\Test1\Intersection1&TestClass $object,
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1
+CLASS      TestAbstractClass               [PUBLIC,   Test2
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2
+CLASS      TestInterface                   [PUBLIC]   Test2
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    callable                                   null
+KEYWORD    false                                      null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    parent                                     null
+KEYWORD    self                                       null
+KEYWORD    string                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_02.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+\Test1\|Intersection1&TestClass $object,
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_03.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+\Test1\Intersection1&|TestClass $object,
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1
+CLASS      TestAbstractClass               [PUBLIC,   Test2
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2
+CLASS      TestInterface                   [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_04.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+\Test1\Intersection1&Test|Class $object,
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      TestAbstractClass               [PUBLIC,   Test2
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2
+CLASS      TestInterface                   [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_05.completion
@@ -1,0 +1,25 @@
+Code completion result for source line:
+|TestClass&\Test1\Intersection1 $param,
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1
+CLASS      TestAbstractClass               [PUBLIC,   Test2
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2
+CLASS      TestInterface                   [PUBLIC]   Test2
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    callable                                   null
+KEYWORD    false                                      null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    parent                                     null
+KEYWORD    self                                       null
+KEYWORD    string                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_06.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+TestClass&\Test1\Inters|ection1 $param,
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_07.completion
@@ -1,0 +1,28 @@
+Code completion result for source line:
+): |\Test1\Intersection2&\Test1\Intersection1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1
+CLASS      TestAbstractClass               [PUBLIC,   Test2
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2
+CLASS      TestInterface                   [PUBLIC]   Test2
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    callable                                   null
+KEYWORD    false                                      null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    never                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    parent                                     null
+KEYWORD    self                                       null
+KEYWORD    static                                     null
+KEYWORD    string                                     null
+KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_08.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+): \Test1\Intersection2&|\Test1\Intersection1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1
+CLASS      TestAbstractClass               [PUBLIC,   Test2
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2
+CLASS      TestInterface                   [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_09.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+): \Test1\Intersection2&\Test1\Intersect|ion1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_10.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+\Test1\Intersection1&TestC|lass $object, // static
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_11.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+TestClass&\Test1\Intersec|tion1 $param, // static
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_12.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+): \Test1\Intersection2&|TestClass {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1
+CLASS      TestAbstractClass               [PUBLIC,   Test2
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2
+CLASS      TestInterface                   [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_13.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_13.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+): \Test1\Intersection2&TestC|lass {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_14.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_14.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+public function childClassMethod(TestClass&\Test1\Intersection1 $object, TestClass&|\Test1\Intersection1 $object2): TestClass&\Test1\Intersection1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    Test1                           [PUBLIC]   null
+PACKAGE    Test2                           [PUBLIC]   null
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1
+CLASS      TestAbstractClass               [PUBLIC,   Test2
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2
+CLASS      TestInterface                   [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_15.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_15.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+public function childClassMethod(TestClass&\Test1\Intersection1 $object, TestClass&\Test1\In|tersection1 $object2): TestClass&\Test1\Intersection1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_16.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_16.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+public function childClassMethod(TestClass&\Test1\Intersection1 $object, TestClass&\Test1\Intersection1 $object2): TestClass&\Test1\Intersec|tion1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_17.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_17.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+public function interfaceMethod(\Test1\Intersection1&TestClass $object, TestClass&\Test1\Intersectio|n1 $param, ): TestClass&\Test1\Intersection1;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_18.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_18.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+public function interfaceMethod(\Test1\Intersection1&TestClass $object, TestClass&\Test1\Intersection1 $param, ): TestClass&\Test1\Intersec|tion1;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_19.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_19.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+abstract protected function abstractClassMethod(TestClass&\Test1\Intersection1 $param, TestInerface&TestC|lass $object,): TestClass&\Test1\Intersection1;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_20.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_20.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+abstract protected function abstractClassMethod(TestClass&\Test1\Intersection1 $param, TestInerface&TestClass $object,): TestClass&\Test1\Intersect|ion1;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_21.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_21.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+private function traitMethod(TestInterface&\Test1\Intersection2 $object, TestClass&\Test1\Intersec|tion1 $param): TestInterface&TestClass {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Intersection1                   [PUBLIC]   Test1
+CLASS      Intersection2                   [PUBLIC]   Test1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_22.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_22.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+private function traitMethod(TestInterface&\Test1\Intersection2 $object, TestClass&\Test1\Intersection1 $param): TestInterface&TestC|lass {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TestChildClass                  [PUBLIC]   Test2
+CLASS      TestClass                       [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod01/testIntersectionTypesOverrideMethod01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod01/testIntersectionTypesOverrideMethod01.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+class OverrideMethodTest {
+
+    public function testMethod(Foo&Bar $param): Foo&Bar {
+        return new Foo();
+    }
+}
+
+class Child extends OverrideMethodTest {
+    test
+}
+
+interface Foo {}
+interface Bar {}
+
+$instance = new Child();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod01/testIntersectionTypesOverrideMethod01.php.testIntersectionTypesOverrideMethod01.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod01/testIntersectionTypesOverrideMethod01.php.testIntersectionTypesOverrideMethod01.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(Foo&Bar $param): Foo&Bar {
+${cursor}parent::testMethod($param);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod02/testIntersectionTypesOverrideMethod02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod02/testIntersectionTypesOverrideMethod02.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+
+    class OverrideMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar {
+            return new Foo();
+        }
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\OverrideMethodTest;
+
+    class Child extends OverrideMethodTest {
+        test
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    $instance = new Child();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod02/testIntersectionTypesOverrideMethod02.php.testIntersectionTypesOverrideMethod02.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod02/testIntersectionTypesOverrideMethod02.php.testIntersectionTypesOverrideMethod02.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(Foo&Bar $param): Foo&Bar {
+${cursor}parent::testMethod($param);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod03/testIntersectionTypesOverrideMethod03.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod03/testIntersectionTypesOverrideMethod03.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    class OverrideMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar {
+            return new Foo();
+        }
+    }
+
+    class Foo {}
+    class Bar {}
+
+}
+
+namespace Test2 {
+
+    use Test1\OverrideMethodTest;
+
+    class Child extends OverrideMethodTest {
+        test
+    }
+
+    $instance = new Child();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod03/testIntersectionTypesOverrideMethod03.php.testIntersectionTypesOverrideMethod03.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesOverrideMethod03/testIntersectionTypesOverrideMethod03.php.testIntersectionTypesOverrideMethod03.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(\Test1\Foo&\Test1\Bar $param): \Test1\Foo&\Test1\Bar {
+${cursor}parent::testMethod($param);
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod01.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+interface ImplementMethodTest {
+
+    public function testMethod(Foo&Bar $param): Foo&Bar;
+}
+
+class Implement implements ImplementMethodTest {
+
+}
+
+class Foo {}
+class Bar {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod01.php.testIntersectionTypesFix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod01.php.testIntersectionTypesFix_01.fixed
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+interface ImplementMethodTest {
+
+    public function testMethod(Foo&Bar $param): Foo&Bar;
+}
+
+class Implement implements ImplementMethodTest {
+    public function testMethod(Foo&Bar $param): Foo&Bar {
+        
+    }
+
+}
+
+class Foo {}
+class Bar {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod01.php.testIntersectionTypes_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod01.php.testIntersectionTypes_01.hints
@@ -1,0 +1,5 @@
+class Implement implements ImplementMethodTest {
+      ---------
+HINT:\Test\Implement is not abstract and does not override abstract method  testMethod(Foo&Bar $param) in \Test\ImplementMethodTest
+FIX:Implement All Abstract Methods
+FIX:Declare Abstract Class

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod02.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod02.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+
+    interface ImplementMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar;
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod02.php.testIntersectionTypesFix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod02.php.testIntersectionTypesFix_02.fixed
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+
+    interface ImplementMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar;
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+        public function testMethod(Foo&Bar $param): Foo&Bar {
+            
+        }
+
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod02.php.testIntersectionTypes_02.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod02.php.testIntersectionTypes_02.hints
@@ -1,0 +1,5 @@
+    class Implement implements ImplementMethodTest {
+          ---------
+HINT:\Test2\Implement is not abstract and does not override abstract method  testMethod(Foo&Bar $param) in \Test1\ImplementMethodTest
+FIX:Implement All Abstract Methods
+FIX:Declare Abstract Class

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod03.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod03.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    interface ImplementMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar;
+    }
+
+    class Foo {}
+    class Bar {}
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+    }
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod03.php.testIntersectionTypesFix_03.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod03.php.testIntersectionTypesFix_03.fixed
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    interface ImplementMethodTest {
+
+        public function testMethod(Foo&Bar $param): Foo&Bar;
+    }
+
+    class Foo {}
+    class Bar {}
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+        public function testMethod(\Test1\Foo&\Test1\Bar $param): \Test1\Foo&\Test1\Bar {
+            
+        }
+
+    }
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod03.php.testIntersectionTypes_03.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod03.php.testIntersectionTypes_03.hints
@@ -1,0 +1,5 @@
+    class Implement implements ImplementMethodTest {
+          ---------
+HINT:\Test2\Implement is not abstract and does not override abstract method  testMethod(Foo&Bar $param) in \Test1\ImplementMethodTest
+FIX:Implement All Abstract Methods
+FIX:Declare Abstract Class

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod04.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod04.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+abstract class ImplementMethodTest {
+
+    abstract public function testMethod(Foo&Bar $param): Foo&Bar;
+}
+
+class Implement extends ImplementMethodTest {
+}
+
+class Foo {}
+class Bar {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod04.php.testIntersectionTypesFix_04.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod04.php.testIntersectionTypesFix_04.fixed
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+abstract class ImplementMethodTest {
+
+    abstract public function testMethod(Foo&Bar $param): Foo&Bar;
+}
+
+class Implement extends ImplementMethodTest {
+    public function testMethod(Foo&Bar $param): Foo&Bar {
+        
+    }
+
+}
+
+class Foo {}
+class Bar {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod04.php.testIntersectionTypes_04.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testIntersectionTypesImplementMethod04.php.testIntersectionTypes_04.hints
@@ -1,0 +1,5 @@
+class Implement extends ImplementMethodTest {
+      ---------
+HINT:\Test\Implement is not abstract and does not override abstract method  testMethod(Foo&Bar $param) in \Test\ImplementMethodTest
+FIX:Implement All Abstract Methods
+FIX:Declare Abstract Class

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/intersectionTypes_01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/intersectionTypes_01.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace InitializeField;
+use \Test\Foo;
+use \Test\Bar;
+
+class IntersectionTypes
+{
+    function __construct(
+            Foo&Bar $param1,
+            \Test\Foo&Bar $param2,
+    ) {
+    }
+}
+
+new IntersectionTypes(new Foo(), new Bar());
+
+
+namespace Test;
+
+class Foo {}
+class Bar {}

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/intersectionTypes_01.php.testIntersectionTypesFix_01a.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/intersectionTypes_01.php.testIntersectionTypesFix_01a.fixed
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace InitializeField;
+use \Test\Foo;
+use \Test\Bar;
+
+class IntersectionTypes
+{
+
+    private Foo&Bar $param1;
+
+    function __construct(
+            Foo&Bar $param1,
+            \Test\Foo&Bar $param2,
+    ) {
+        $this->param1 = $param1;
+    }
+}
+
+new IntersectionTypes(new Foo(), new Bar());
+
+
+namespace Test;
+
+class Foo {}
+class Bar {}

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/intersectionTypes_01.php.testIntersectionTypesFix_01b.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/intersectionTypes_01.php.testIntersectionTypesFix_01b.fixed
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace InitializeField;
+use \Test\Foo;
+use \Test\Bar;
+
+class IntersectionTypes
+{
+
+    private \Test\Foo&Bar $param2;
+
+    function __construct(
+            Foo&Bar $param1,
+            \Test\Foo&Bar $param2,
+    ) {
+        $this->param2 = $param2;
+    }
+}
+
+new IntersectionTypes(new Foo(), new Bar());
+
+
+namespace Test;
+
+class Foo {}
+class Bar {}

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/intersectionTypes_01.php.testIntersectionTypes_01a.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/intersectionTypes_01.php.testIntersectionTypes_01a.hints
@@ -1,0 +1,8 @@
+            Foo&Bar $para^m1,
+            ---------------
+HINT:Initialize Field: $param1
+FIX:Initialize Field: $param1
+            \Test\Foo&Bar $param2,
+            ---------------------
+HINT:Initialize Field: $param2
+FIX:Initialize Field: $param2

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/intersectionTypes_01.php.testIntersectionTypes_01b.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/intersectionTypes_01.php.testIntersectionTypes_01b.hints
@@ -1,0 +1,8 @@
+            Foo&Bar $param1,
+            ---------------
+HINT:Initialize Field: $param1
+FIX:Initialize Field: $param1
+            \Test\Foo&Bar $par^am2,
+            ---------------------
+HINT:Initialize Field: $param2
+FIX:Initialize Field: $param2

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testIntersectionTypes_01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testIntersectionTypes_01.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function testReturnArray(): array&Iterator {}
+function testReturnBool(): bool&Iterator {}
+function testReturnCallable(): callable&Iterator {}
+function testReturnFalse(): false&Iterator {}
+function testReturnFloat(): float&Iterator {}
+function testReturnInt(): int&Iterator {}
+function testReturnIterable(): iterable&Iterator {}
+function testReturnMixed(): mixed&Iterator {}
+function testReturnNever(): never&Iterator {}
+function testReturnNull(): null&Iterator {}
+function testReturnObject(): object&Iterator {}
+function testReturnParent(): parent&Iterator {}
+function testReturnSelf(): self&Iterator {}
+function testReturnStatic(): static&Iterator {}
+function testReturnString(): string&Iterator {}
+function testReturnVoid(): void&Iterator {}
+
+function testParamArray(Iterator&array $param): Iterator {}
+function testParamBool(Iterator&bool $param): Iterator {}
+function testParamCallable(Iterator&callable $param): Iterator {}
+function testParamFalse(Iterator&false $param): Iterator {}
+function testParamFloat(Iterator&float $param): float {}
+function testParamInt(Iterator&int $param): int {}
+function testParamIterable(Iterator&iterable $param): iterable {}
+function testParamMixed(Iterator&mixed $param): mixed {}
+function testParamNever(Iterator&never $param): never {}
+function testParamNull(Iterator&null $param): void {}
+function testParamObject(Iterator&object $param): object {}
+function testParamParent(Iterator&parent $param): parent {}
+function testParamSelf(Iterator&self $param): self {}
+//function testParamStatic(Iterator&static $param): void {} // syntax error
+function testParamString(Iterator&string $param): string {}
+function testParamVoid(Iterator&void $param): void {}
+//function testReturnNullable(): ?Test&Iterator {} // syntax erro
+
+function testReturnDuplicate(): Iterator&Iterator {}
+function testParamDuplicate(Iterator&Iterator $param): void {}
+
+class InvalidField {
+    public array&Iterator $array;
+    public bool&Iterator $bool;
+    public callable&Iterator $callable;
+    public false&Iterator $false;
+    public float&Iterator $flaot;
+    public int&Iterator $int;
+    public iterable&Iterator $iterable;
+    public mixed&Iterator $mixed;
+    public never&Iterator $never;
+    public null&Iterator $null;
+    public object&Iterator $object;
+    public parent&Iterator $parent;
+    public self&Iterator $self;
+//    public static&Iterator $static; // syntax error
+    public string&Iterator $string;
+    public void&Iterator $void;
+    public Iterator&Iterator $duplicate;
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testIntersectionTypes_01.php.testIntersectionTypes_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testIntersectionTypes_01.php.testIntersectionTypes_01.hints
@@ -1,0 +1,147 @@
+function testReturnArray(): array&Iterator {}
+                            -----
+HINT:"array" cannot be used as an intersection type.
+function testReturnBool(): bool&Iterator {}
+                           ----
+HINT:"bool" cannot be used as an intersection type.
+function testReturnCallable(): callable&Iterator {}
+                               --------
+HINT:"callable" cannot be used as an intersection type.
+function testReturnFalse(): false&Iterator {}
+                            -----
+HINT:"false" cannot be used as an intersection type.
+function testReturnFloat(): float&Iterator {}
+                            -----
+HINT:"float" cannot be used as an intersection type.
+function testReturnInt(): int&Iterator {}
+                          ---
+HINT:"int" cannot be used as an intersection type.
+function testReturnIterable(): iterable&Iterator {}
+                               --------
+HINT:"iterable" cannot be used as an intersection type.
+function testReturnMixed(): mixed&Iterator {}
+                            -----
+HINT:"mixed" cannot be used as an intersection type.
+function testReturnNever(): never&Iterator {}
+                            -----
+HINT:"never" cannot be used as an intersection type.
+function testReturnNull(): null&Iterator {}
+                           ----
+HINT:"null" cannot be used as an intersection type.
+function testReturnObject(): object&Iterator {}
+                             ------
+HINT:"object" cannot be used as an intersection type.
+function testReturnParent(): parent&Iterator {}
+                             ------
+HINT:"parent" cannot be used as an intersection type.
+function testReturnSelf(): self&Iterator {}
+                           ----
+HINT:"self" cannot be used as an intersection type.
+function testReturnStatic(): static&Iterator {}
+                             ------
+HINT:"static" cannot be used as an intersection type.
+function testReturnString(): string&Iterator {}
+                             ------
+HINT:"string" cannot be used as an intersection type.
+function testReturnVoid(): void&Iterator {}
+                           ----
+HINT:"void" cannot be used as an intersection type.
+function testParamArray(Iterator&array $param): Iterator {}
+                                 -----
+HINT:"array" cannot be used as an intersection type.
+function testParamBool(Iterator&bool $param): Iterator {}
+                                ----
+HINT:"bool" cannot be used as an intersection type.
+function testParamCallable(Iterator&callable $param): Iterator {}
+                                    --------
+HINT:"callable" cannot be used as an intersection type.
+function testParamFalse(Iterator&false $param): Iterator {}
+                                 -----
+HINT:"false" cannot be used as an intersection type.
+function testParamFloat(Iterator&float $param): float {}
+                                 -----
+HINT:"float" cannot be used as an intersection type.
+function testParamInt(Iterator&int $param): int {}
+                               ---
+HINT:"int" cannot be used as an intersection type.
+function testParamIterable(Iterator&iterable $param): iterable {}
+                                    --------
+HINT:"iterable" cannot be used as an intersection type.
+function testParamMixed(Iterator&mixed $param): mixed {}
+                                 -----
+HINT:"mixed" cannot be used as an intersection type.
+function testParamNever(Iterator&never $param): never {}
+                                 -----
+HINT:"never" cannot be used as an intersection type.
+function testParamNull(Iterator&null $param): void {}
+                                ----
+HINT:"null" cannot be used as an intersection type.
+function testParamObject(Iterator&object $param): object {}
+                                  ------
+HINT:"object" cannot be used as an intersection type.
+function testParamParent(Iterator&parent $param): parent {}
+                                  ------
+HINT:"parent" cannot be used as an intersection type.
+function testParamSelf(Iterator&self $param): self {}
+                                ----
+HINT:"self" cannot be used as an intersection type.
+function testParamString(Iterator&string $param): string {}
+                                  ------
+HINT:"string" cannot be used as an intersection type.
+function testParamVoid(Iterator&void $param): void {}
+                                ----
+HINT:"void" cannot be used as an intersection type.
+function testReturnDuplicate(): Iterator&Iterator {}
+                                         --------
+HINT:Type "Iterator" is duplicated.
+function testParamDuplicate(Iterator&Iterator $param): void {}
+                                     --------
+HINT:Type "Iterator" is duplicated.
+    public array&Iterator $array;
+           -----
+HINT:"array" cannot be used as an intersection type.
+    public bool&Iterator $bool;
+           ----
+HINT:"bool" cannot be used as an intersection type.
+    public callable&Iterator $callable;
+           --------
+HINT:"callable" cannot be used as an intersection type.
+    public false&Iterator $false;
+           -----
+HINT:"false" cannot be used as an intersection type.
+    public float&Iterator $flaot;
+           -----
+HINT:"float" cannot be used as an intersection type.
+    public int&Iterator $int;
+           ---
+HINT:"int" cannot be used as an intersection type.
+    public iterable&Iterator $iterable;
+           --------
+HINT:"iterable" cannot be used as an intersection type.
+    public mixed&Iterator $mixed;
+           -----
+HINT:"mixed" cannot be used as an intersection type.
+    public never&Iterator $never;
+           -----
+HINT:"never" cannot be used as an intersection type.
+    public null&Iterator $null;
+           ----
+HINT:"null" cannot be used as an intersection type.
+    public object&Iterator $object;
+           ------
+HINT:"object" cannot be used as an intersection type.
+    public parent&Iterator $parent;
+           ------
+HINT:"parent" cannot be used as an intersection type.
+    public self&Iterator $self;
+           ----
+HINT:"self" cannot be used as an intersection type.
+    public string&Iterator $string;
+           ------
+HINT:"string" cannot be used as an intersection type.
+    public void&Iterator $void;
+           ----
+HINT:"void" cannot be used as an intersection type.
+    public Iterator&Iterator $duplicate;
+                    --------
+HINT:Type "Iterator" is duplicated.

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
@@ -655,4 +655,87 @@ public class SelectedPropertyMethodsCreatorTest extends PHPTestBase {
                 new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
         ));
     }
+
+    // NETBEANS-5599 PHP 8.1
+    public void testIntersectionTypesConstructor() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_81);
+        cgsInfo.setPublicModifier(true);
+        selectAllProperties(cgsInfo.getInstanceProperties());
+        checkResult(CGSGenerator.GenType.CONSTRUCTOR.getTemplateText(cgsInfo));
+    }
+
+    public void testIntersectionTypesGetter() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_81);
+        cgsInfo.setPublicModifier(true);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectAllProperties(cgsInfo.getPossibleGetters()),
+                new SinglePropertyMethodCreator.SingleGetterCreator(cgsInfo)
+        ));
+    }
+
+    public void testIntersectionTypesSetter() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_81);
+        cgsInfo.setPublicModifier(true);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectAllProperties(cgsInfo.getPossibleSetters()),
+                new SinglePropertyMethodCreator.SingleSetterCreator(cgsInfo)
+        ));
+    }
+
+    public void testIntersectionTypesOverrideMethod01() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Child extends OverrideMethodTest {^", PhpVersion.PHP_81);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testIntersectionTypesOverrideMethod02() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Child extends OverrideMethodTest {^", PhpVersion.PHP_81);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testIntersectionTypesOverrideMethod03() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Child extends OverrideMethodTest {^", PhpVersion.PHP_81);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testIntersectionTypesImplementMethod01() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Implement implements ImplementMethodTest {^", PhpVersion.PHP_81);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "test"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testIntersectionTypesImplementMethod02() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Implement implements ImplementMethodTest {^", PhpVersion.PHP_81);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testIntersectionTypesImplementMethod03() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Implement implements ImplementMethodTest {^", PhpVersion.PHP_81);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testIntersectionTypesImplementMethod04() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Implement extends ImplementMethodTest {^", PhpVersion.PHP_81);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP81CodeCompletionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP81CodeCompletionTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.Map;
 import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.api.PhpVersion;
 import org.netbeans.modules.php.project.api.PhpSourcePath;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
@@ -412,4 +413,358 @@ public class PHP81CodeCompletionTest extends PHPCodeCompletionTestBase {
         checkCompletion("newInInitializersAttributeTyping03", "#[AnAttribute(new Fo^)]");
     }
 
+    public void testIntersectionTypes_01() throws Exception {
+        checkCompletion("intersectionTypes", "        $this->^publicFieldInterfaceImpl->publicMethodClass1();");
+    }
+
+    public void testIntersectionTypes_02() throws Exception {
+        checkCompletion("intersectionTypes", "        $this->publicFieldInterfaceImpl->^publicMethodClass1();");
+    }
+
+    public void testIntersectionTypes_03() throws Exception {
+        checkCompletion("intersectionTypes", "        $this->publicFieldTrait1->^publicMethodClass1();");
+    }
+
+    public void testIntersectionTypes_04() throws Exception {
+        checkCompletion("intersectionTypes", "        self::^$publicStaticFieldInterfaceImpl->publicMethodClass1();");
+    }
+
+    public void testIntersectionTypes_05() throws Exception {
+        checkCompletion("intersectionTypes", "        self::$publicStaticFieldInterfaceImpl->^publicMethodClass1();");
+    }
+
+    public void testIntersectionTypes_06() throws Exception {
+        checkCompletion("intersectionTypes", "        self::$publicStaticFieldInterfaceImpl::^CONST_CLASS1;");
+    }
+
+    public void testIntersectionTypes_07() throws Exception {
+        checkCompletion("intersectionTypes", "        $object->^publicMethodClass1()->publicMethodClass2();");
+    }
+
+    public void testIntersectionTypes_08() throws Exception {
+        checkCompletion("intersectionTypes", "        $object->publicMethodClass1()->^publicMethodClass2();");
+    }
+
+    public void testIntersectionTypes_09() throws Exception {
+        checkCompletion("intersectionTypes", "        $object->publicMethodClass1()::^CONST_CLASS2;");
+    }
+
+    public void testIntersectionTypes_10() throws Exception {
+        checkCompletion("intersectionTypes", "        $object::^$publicFieldClass1->publicMethodClass1();");
+    }
+
+    public void testIntersectionTypes_11() throws Exception {
+        checkCompletion("intersectionTypes", "        $object::$publicFieldClass1->^publicMethodClass1();");
+    }
+
+    public void testIntersectionTypes_12() throws Exception {
+        checkCompletion("intersectionTypes", "        $object::$publicFieldClass1::^publicStaticMethodClass1();");
+    }
+
+    public void testIntersectionTypes_13() throws Exception {
+        checkCompletion("intersectionTypes", "        $object->^publicMethodClass2(); // phpdoc");
+    }
+
+    public void testIntersectionTypes_14() throws Exception {
+        checkCompletion("intersectionTypes", "        $object::^publicStaticMethodClass2(); // phpdoc");
+    }
+
+    public void testIntersectionTypes_15() throws Exception {
+        checkCompletion("intersectionTypes", "        $this::^$publicStaticFieldTrait1->publicMethodClass1();");
+    }
+
+    public void testIntersectionTypes_16() throws Exception {
+        checkCompletion("intersectionTypes", "        $this::$publicStaticFieldTrait1->^publicMethodClass1();");
+    }
+
+    public void testIntersectionTypes_17() throws Exception {
+        checkCompletion("intersectionTypes", "        $this::publicStaticMethodTrait1()::^publicStaticMethodClass1();");
+    }
+
+    public void testIntersectionTypes_18() throws Exception {
+        checkCompletion("intersectionTypes", "        $object->^publicMethodClass1(); // with whitespaces");
+    }
+
+    public void testIntersectionTypes_19() throws Exception {
+        checkCompletion("intersectionTypes", "        $object::^publicStaticMethodClass1(); // with whitespaces");
+    }
+
+    public void testIntersectionTypesFields01() throws Exception {
+        checkCompletion("intersectionTypesFields01", "    private IntersectionTypes1&^");
+    }
+
+    public void testIntersectionTypesFields02() throws Exception {
+        checkCompletion("intersectionTypesFields02", "    private IntersectionTypes1&\\Test1\\^");
+    }
+
+    public void testIntersectionTypesFields03() throws Exception {
+        checkCompletion("intersectionTypesFields03", "    private Test&\\Test1\\IntersectionTypes2&^");
+    }
+
+    public void testIntersectionTypesFields04() throws Exception {
+        checkCompletion("intersectionTypesFields04", "    private Test&\\Test1\\IntersectionTypes2&\\Test1\\IntersectionT^ypes2 $test;");
+    }
+
+    public void testIntersectionTypesFields05() throws Exception {
+        checkCompletion("intersectionTypesFields05", "    private Test&\\Test1\\IntersectionTypes2&^&\\Test1\\IntersectionTypes1 $test;");
+    }
+
+    public void testIntersectionTypesFields06() throws Exception {
+        checkCompletion("intersectionTypesFields06", "    private static Test&\\Test1\\IntersectionTypes2&^\\Test1\\IntersectionTypes1 $test;");
+    }
+
+    public void testIntersectionTypesFunctionParameterType01() throws Exception {
+        checkCompletion("intersectionTypesFunctionParameterType01", "function intersection_types(IntersectionTypes1&^)");
+    }
+
+    public void testIntersectionTypesFunctionParameterType02() throws Exception {
+        checkCompletion("intersectionTypesFunctionParameterType02", "function intersection_types(IntersectionTypes1&\\Test\\I^)");
+    }
+
+    public void testIntersectionTypesFunctionParameterType03() throws Exception {
+        checkCompletion("intersectionTypesFunctionParameterType03", "function intersection_types(IntersectionTypes1&\\Test\\IntersectionTypes2&^)");
+    }
+
+    public void testIntersectionTypesFunctionParameterType04() throws Exception {
+        checkCompletion("intersectionTypesFunctionParameterType04", "function intersection_types(IntersectionTypes1&^&\\Test\\IntersectionTypes2)");
+    }
+
+    public void testIntersectionTypesFunctionParameterType05() throws Exception {
+        checkCompletion("intersectionTypesFunctionParameterType05", "function intersection_types(IntersectionTypes1&^) {");
+    }
+
+    public void testIntersectionTypesFunctionParameterType06() throws Exception {
+        checkCompletion("intersectionTypesFunctionParameterType06", "function intersection_types(IntersectionTypes1&Inte^) {");
+    }
+
+    public void testIntersectionTypesFunctionParameterType07() throws Exception {
+        checkCompletion("intersectionTypesFunctionParameterType07", "function intersection_types(IntersectionTypes1&IntersectionTypes2 $param, IntersectionTypes1&IntersectionTypes2&^) {");
+    }
+
+    public void testIntersectionTypesFunctionParameterType08() throws Exception {
+        checkCompletion("intersectionTypesFunctionParameterType08", "function intersection_types(IntersectionTypes1&IntersectionTypes2 $param, IntersectionTypes1&IntersectionTypes2&\\Test\\^) {");
+    }
+
+    public void testIntersectionTypesFunctionParameterType09() throws Exception {
+        checkCompletion("intersectionTypesFunctionParameterType09", "function intersection_types(IntersectionTypes1&IntersectionTypes2 $param, IntersectionTypes1&IntersectionTypes2&\\Test\\Inter^) {");
+    }
+
+    public void testIntersectionTypesFunctionReturnType01() throws Exception {
+        checkCompletion("intersectionTypesFunctionReturnType01", "function intersection_types(IntersectionTypes1&\\Test\\IntersectionTypes2 $param): IntersectionTypes1&^");
+    }
+
+    public void testIntersectionTypesFunctionReturnType02() throws Exception {
+        checkCompletion("intersectionTypesFunctionReturnType02", "function intersection_types(IntersectionTypes1&\\Test\\IntersectionTypes2 $param): IntersectionTypes1&\\Test\\^");
+    }
+
+    public void testIntersectionTypesFunctionReturnType03() throws Exception {
+        checkCompletion("intersectionTypesFunctionReturnType03", "function intersection_types(IntersectionTypes1&\\Test\\IntersectionTypes2 $param): IntersectionTypes1&\\Test\\IntersectionTypes2&In^");
+    }
+
+    public void testIntersectionTypesFunctionReturnType04() throws Exception {
+        checkCompletion("intersectionTypesFunctionReturnType04", "function intersection_types(IntersectionTypes1&\\Test\\IntersectionTypes2 $param): IntersectionTypes1&^&\\Test\\IntersectionTypes2");
+    }
+
+    public void testIntersectionTypesFunctions_01() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "function intersection_types(Intersect^ion1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersection2 $param): Intersection1& Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_02() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "function intersection_types(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&^Intersection2 $param): Intersection1& Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_03() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "function intersection_types(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersect^ion2 $param): Intersection1& Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_04() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "function intersection_types(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersection2 $param): ^Intersection1& Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_05() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "function intersection_types(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersection2 $param): Intersection1& ^Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_06() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "function intersection_types(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersection2 $param): Intersection1& Intersec^tion3 {");
+    }
+
+    public void testIntersectionTypesFunctions_07() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$closure = function(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersecti^on1& Intersection2 $param): Intersection1&Intersection2 {");
+    }
+
+    public void testIntersectionTypesFunctions_08() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$closure = function(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1& ^Intersection2 $param): Intersection1&Intersection2 {");
+    }
+
+    public void testIntersectionTypesFunctions_09() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$closure = function(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1& Intersection2 $param): ^Intersection1&Intersection2 {");
+    }
+
+    public void testIntersectionTypesFunctions_10() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$closure = function(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1& Intersection2 $param): Intersection1&^Intersection2 {");
+    }
+
+    public void testIntersectionTypesFunctions_11() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$closure = function(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1& Intersection2 $param): Intersection1&Intersec^tion2 {");
+    }
+
+    public void testIntersectionTypesFunctions_12() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$arrow = fn(Intersection1&Intersection2&^\\Test\\Intersection3 $param1, Intersection1&Intersection2 $param): \\Test\\Intersection1&\\Test\\Intersection2&Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_13() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$arrow = fn(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&^Intersection2 $param): \\Test\\Intersection1&\\Test\\Intersection2&Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_14() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$arrow = fn(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersection2^ $param): \\Test\\Intersection1&\\Test\\Intersection2&Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_15() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$arrow = fn(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersection2 $param): ^\\Test\\Intersection1&\\Test\\Intersection2&Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_16() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$arrow = fn(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersection2 $param): \\Test\\Inte^rsection1&\\Test\\Intersection2&Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_17() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$arrow = fn(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersection2 $param): \\Test\\Intersection1&^\\Test\\Intersection2&Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_18() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$arrow = fn(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersection2 $param): \\Test\\Intersection1&\\Test\\^Intersection2&Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_19() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$arrow = fn(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersection2 $param): \\Test\\Intersection1&\\Test\\Intersection2&^Intersection3 {");
+    }
+
+    public void testIntersectionTypesFunctions_20() throws Exception {
+        checkCompletion("intersectionTypesFunctions", "$arrow = fn(Intersection1&Intersection2&\\Test\\Intersection3 $param1, Intersection1&Intersection2 $param): \\Test\\Intersection1&\\Test\\Intersection2&Intersection3^ {");
+    }
+
+    public void testIntersectionTypesImplementMethod01() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testIntersectionTypesImplementMethod01"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_81, "test"), true);
+    }
+
+    public void testIntersectionTypesImplementMethod02() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testIntersectionTypesImplementMethod02"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_81, "test"), true);
+    }
+
+    public void testIntersectionTypesImplementMethod03() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testIntersectionTypesImplementMethod03"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_81, "test"), true);
+    }
+
+    public void testIntersectionTypesImplementMethod04() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testIntersectionTypesImplementMethod04"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_81, "test"), true);
+    }
+
+    public void testIntersectionTypesMethods_01() throws Exception {
+        checkCompletion("intersectionTypesMethods", "           ^\\Test1\\Intersection1&TestClass $object,");
+    }
+
+    public void testIntersectionTypesMethods_02() throws Exception {
+        checkCompletion("intersectionTypesMethods", "            \\Test1\\^Intersection1&TestClass $object,");
+    }
+
+    public void testIntersectionTypesMethods_03() throws Exception {
+        checkCompletion("intersectionTypesMethods", "            \\Test1\\Intersection1&^TestClass $object,");
+    }
+
+    public void testIntersectionTypesMethods_04() throws Exception {
+        checkCompletion("intersectionTypesMethods", "            \\Test1\\Intersection1&Test^Class $object,");
+    }
+
+    public void testIntersectionTypesMethods_05() throws Exception {
+        checkCompletion("intersectionTypesMethods", "            ^TestClass&\\Test1\\Intersection1 $param,");
+    }
+
+    public void testIntersectionTypesMethods_06() throws Exception {
+        checkCompletion("intersectionTypesMethods", "            TestClass&\\Test1\\Inters^ection1 $param,");
+    }
+
+    public void testIntersectionTypesMethods_07() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    ): ^\\Test1\\Intersection2&\\Test1\\Intersection1 {");
+    }
+
+    public void testIntersectionTypesMethods_08() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    ): \\Test1\\Intersection2&^\\Test1\\Intersection1 {");
+    }
+
+    public void testIntersectionTypesMethods_09() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    ): \\Test1\\Intersection2&\\Test1\\Intersect^ion1 {");
+    }
+
+    public void testIntersectionTypesMethods_10() throws Exception {
+        checkCompletion("intersectionTypesMethods", "            \\Test1\\Intersection1&TestC^lass $object, // static");
+    }
+
+    public void testIntersectionTypesMethods_11() throws Exception {
+        checkCompletion("intersectionTypesMethods", "TestClass&\\Test1\\Intersec^tion1 $param, // static");
+    }
+
+    public void testIntersectionTypesMethods_12() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    ): \\Test1\\Intersection2&^TestClass {");
+    }
+
+    public void testIntersectionTypesMethods_13() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    ): \\Test1\\Intersection2&TestC^lass {");
+    }
+
+    public void testIntersectionTypesMethods_14() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    public function childClassMethod(TestClass&\\Test1\\Intersection1 $object, TestClass&^\\Test1\\Intersection1 $object2): TestClass&\\Test1\\Intersection1 {");
+    }
+
+    public void testIntersectionTypesMethods_15() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    public function childClassMethod(TestClass&\\Test1\\Intersection1 $object, TestClass&\\Test1\\In^tersection1 $object2): TestClass&\\Test1\\Intersection1 {");
+    }
+
+    public void testIntersectionTypesMethods_16() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    public function childClassMethod(TestClass&\\Test1\\Intersection1 $object, TestClass&\\Test1\\Intersection1 $object2): TestClass&\\Test1\\Intersec^tion1 {");
+    }
+
+    public void testIntersectionTypesMethods_17() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    public function interfaceMethod(\\Test1\\Intersection1&TestClass $object, TestClass&\\Test1\\Intersectio^n1 $param, ): TestClass&\\Test1\\Intersection1;");
+    }
+
+    public void testIntersectionTypesMethods_18() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    public function interfaceMethod(\\Test1\\Intersection1&TestClass $object, TestClass&\\Test1\\Intersection1 $param, ): TestClass&\\Test1\\Intersec^tion1;");
+    }
+
+    public void testIntersectionTypesMethods_19() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    abstract protected function abstractClassMethod(TestClass&\\Test1\\Intersection1 $param, TestInerface&TestC^lass $object,): TestClass&\\Test1\\Intersection1;");
+    }
+
+    public void testIntersectionTypesMethods_20() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    abstract protected function abstractClassMethod(TestClass&\\Test1\\Intersection1 $param, TestInerface&TestClass $object,): TestClass&\\Test1\\Intersect^ion1;");
+    }
+
+    public void testIntersectionTypesMethods_21() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    private function traitMethod(TestInterface&\\Test1\\Intersection2 $object, TestClass&\\Test1\\Intersec^tion1 $param): TestInterface&TestClass {");
+    }
+
+    public void testIntersectionTypesMethods_22() throws Exception {
+        checkCompletion("intersectionTypesMethods", "    private function traitMethod(TestInterface&\\Test1\\Intersection2 $object, TestClass&\\Test1\\Intersection1 $param): TestInterface&TestC^lass {");
+    }
+
+    public void testIntersectionTypesOverrideMethod01() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testIntersectionTypesOverrideMethod01"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_81, "test"), true);
+    }
+
+    public void testIntersectionTypesOverrideMethod02() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testIntersectionTypesOverrideMethod02"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_81, "test"), true);
+    }
+
+    public void testIntersectionTypesOverrideMethod03() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testIntersectionTypesOverrideMethod03"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_81, "test"), true);
+    }
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
@@ -167,6 +167,14 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
         checkCompletionDocumentation("testfiles/completion/documentation/fieldWithoutPhpDoc.php", "self::$union^Type", false, "");
     }
 
+    public void testFieldIntersectionTypeWithoutPhpDoc() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/fieldWithoutPhpDoc.php", "$this->interse^ctionType;", false, "");
+    }
+
+    public void testFieldLongNameTypeWithoutPhpDoc() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/fieldWithoutPhpDoc.php", "$this->longNameT^ype;", false, "");
+    }
+
     public void testMethodTypedWithoutPhpDoc() throws Exception {
         checkCompletionDocumentation("testfiles/completion/documentation/functionWithoutPhpDoc.php", "$instance->testTy^ped(1, null, null);", false, "");
     }
@@ -179,6 +187,10 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
         checkCompletionDocumentation("testfiles/completion/documentation/functionWithoutPhpDoc.php", "$instance->testUnionTy^pe(1, null, null);", false, "");
     }
 
+    public void testMethodIntersectionTypeWithoutPhpDoc() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/functionWithoutPhpDoc.php", "$instance->testIntersectio^nType(null, null);", false, "");
+    }
+
     public void testFunctionTypedWithoutPhpDoc() throws Exception {
         checkCompletionDocumentation("testfiles/completion/documentation/functionWithoutPhpDoc.php", "testTyp^ed(2, null, null);", false, "");
     }
@@ -189,6 +201,10 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
 
     public void testFunctionUnionTypeWithoutPhpDoc() throws Exception {
         checkCompletionDocumentation("testfiles/completion/documentation/functionWithoutPhpDoc.php", "testUnionTy^pe(2, null, null);", false, "");
+    }
+
+    public void testFunctionIntersectionTypeWithoutPhpDoc() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/functionWithoutPhpDoc.php", "testIntersectionTy^pe(null, null); // function", false, "");
     }
 
     @Override

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGeneratorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGeneratorTest.java
@@ -733,6 +733,101 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
         );
     }
 
+    public void testIntersectionTypes01() throws Exception {
+        insertBreak(
+                // original
+                ""
+                + "<?php\n"
+                + "class Class1{}\n"
+                + "class Class2{}\n"
+                + "/**^\n"
+                + "function test(Class1&Class2 $param): Class1&Class2 {\n"
+                + "}",
+
+                // expected
+                ""
+                + "<?php\n"
+                + "class Class1{}\n"
+                + "class Class2{}\n"
+                + "/**\n"
+                + " * \n"
+                + " * @param Class1&Class2 $param\n"
+                + " * @return Class1&Class2^\n"
+                + " */\n"
+                + "function test(Class1&Class2 $param): Class1&Class2 {\n"
+                + "}"
+        );
+    }
+
+    public void testIntersectionTypes02() throws Exception {
+        insertBreak(
+                // original
+                ""
+                + "<?php\n"
+                + "namespace Test1;\n"
+                + "/**^\n"
+                + "function test(Class1&Class2 $param): Class1&Class2 {\n"
+                + "}\n\n"
+                + "namespace Test2;\n"
+                + "class Class1{}\n"
+                + "class Class2{}\n",
+                // expected
+                ""
+                + "<?php\n"
+                + "namespace Test1;\n"
+                + "/**\n"
+                + " * \n"
+                + " * @param Class1&Class2 $param\n"
+                + " * @return Class1&Class2^\n"
+                + " */\n"
+                + "function test(Class1&Class2 $param): Class1&Class2 {\n"
+                + "}\n\n"
+                + "namespace Test2;\n"
+                + "class Class1{}\n"
+                + "class Class2{}\n"
+        );
+    }
+
+    public void testIntersectionTypes03() throws Exception {
+        insertBreak(
+                // original
+                ""
+                + "<?php\n"
+                + "namespace Test1;\n"
+                + "use Test2\\Class2;\n"
+                + "\n"
+                + "class Class1 {\n"
+                + "\n"
+                + "    /**^\n"
+                + "    public Class1&Class2 $test;\n"
+                + "\n"
+                + "}\n"
+                + "\n"
+                + "\n"
+                + "namespace Test2;\n"
+                + "class Class2 {}",
+                // expected
+                ""
+                + "<?php\n"
+                + "namespace Test1;\n"
+                + "use Test2\\Class2;\n"
+                + "\n"
+                + "class Class1 {\n"
+                + "\n"
+                + "    /**\n"
+                + "     * \n"
+                + "     * @var Class1&Class2^\n"
+                + "     */\n"
+                + "    public Class1&Class2 $test;\n"
+                + "\n"
+                + "}\n"
+                + "\n"
+                + "\n"
+                + "namespace Test2;\n"
+                + "class Class2 {}"
+        );
+    }
+
     @Override
     public void insertNewline(String source, String reformatted, IndentPrefs preferences) throws Exception {
         int sourcePos = source.indexOf('^');

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ImplementAbstractMethodsHintErrorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ImplementAbstractMethodsHintErrorTest.java
@@ -229,6 +229,38 @@ public class ImplementAbstractMethodsHintErrorTest extends PHPHintsTestBase {
         applyHint(new ImplementAbstractMethodsHintError(), "testNetbeans5370.php", "class TestCl^ass2 implements TestInterface", "Implement");
     }
 
+    public void testIntersectionTypes_01() throws Exception {
+        checkHints(new ImplementAbstractMethodsHintError(), "testIntersectionTypesImplementMethod01.php");
+    }
+
+    public void testIntersectionTypes_02() throws Exception {
+        checkHints(new ImplementAbstractMethodsHintError(), "testIntersectionTypesImplementMethod02.php");
+    }
+
+    public void testIntersectionTypes_03() throws Exception {
+        checkHints(new ImplementAbstractMethodsHintError(), "testIntersectionTypesImplementMethod03.php");
+    }
+
+    public void testIntersectionTypes_04() throws Exception {
+        checkHints(new ImplementAbstractMethodsHintError(), "testIntersectionTypesImplementMethod04.php");
+    }
+
+    public void testIntersectionTypesFix_01() throws Exception {
+        applyHint(new ImplementAbstractMethodsHintError(), "testIntersectionTypesImplementMethod01.php", "class Impleme^nt", "Implement");
+    }
+
+    public void testIntersectionTypesFix_02() throws Exception {
+        applyHint(new ImplementAbstractMethodsHintError(), "testIntersectionTypesImplementMethod02.php", "class Impleme^nt", "Implement");
+    }
+
+    public void testIntersectionTypesFix_03() throws Exception {
+        applyHint(new ImplementAbstractMethodsHintError(), "testIntersectionTypesImplementMethod03.php", "class Impleme^nt", "Implement");
+    }
+
+    public void testIntersectionTypesFix_04() throws Exception {
+        applyHint(new ImplementAbstractMethodsHintError(), "testIntersectionTypesImplementMethod04.php", "class Impleme^nt extends ImplementMethodTest {", "Implement");
+    }
+
     //~ Inner classes
     private static final class ImplementAbstractMethodsHintErrorStub extends ImplementAbstractMethodsHintError {
 

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/InitializeFieldsSuggestionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/InitializeFieldsSuggestionTest.java
@@ -207,6 +207,22 @@ public class InitializeFieldsSuggestionTest extends PHPHintsTestBase {
         applyHint(new InitializeFieldSuggestionStub(PhpVersion.PHP_73), "unionTypes_01.php", "            \\Test\\Foo|Bar $mi^xed,", "Initialize Field");
     }
 
+    public void testIntersectionTypes_01a() throws Exception {
+        checkHints(new InitializeFieldSuggestion(), "intersectionTypes_01.php", "            Foo&Bar $para^m1,");
+    }
+
+    public void testIntersectionTypes_01b() throws Exception {
+        checkHints(new InitializeFieldSuggestion(), "intersectionTypes_01.php", "            \\Test\\Foo&Bar $par^am2,");
+    }
+
+    public void testIntersectionTypesFix_01a() throws Exception {
+        applyHint(new InitializeFieldSuggestionStub(PhpVersion.PHP_81), "intersectionTypes_01.php", "            Foo&Bar $par^am1,", "Initialize Field");
+    }
+
+    public void testIntersectionTypesFix_01b() throws Exception {
+        applyHint(new InitializeFieldSuggestionStub(PhpVersion.PHP_81), "intersectionTypes_01.php", "            \\Test\\Foo&Bar $par^am2,", "Initialize Field");
+    }
+
     //~ Inner classes
     private static class InitializeFieldSuggestionStub extends InitializeFieldSuggestion {
 

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/UnusableTypesHintErrorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/UnusableTypesHintErrorTest.java
@@ -48,6 +48,10 @@ public class UnusableTypesHintErrorTest extends PHPHintsTestBase {
         checkHints(new UnusableTypesHintError(), "testNeverTypes_01.php");
     }
 
+    public void testIntersectionTypes_01() throws Exception {
+        checkHints(new UnusableTypesHintError(), "testIntersectionTypes_01.php");
+    }
+
     @Override
     protected String getTestDirectory() {
         return TEST_DIRECTORY + "UnusableTypesHintError/";


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/NETBEANS-5599
- RFC: https://wiki.php.net/rfc/pure-intersection-types

Part 3:
- Fix the code completion feature

Part 4:
- Fix `ImplementAbstractMethodsHintError`, `InitializeFieldSuggestion`, and `UnusableTypesHintError`

![nb-php81-pure-intersection-types-hint1](https://user-images.githubusercontent.com/738383/160235350-9f5ba572-dbea-4058-86e1-8e73a6346964.png)

![nb-php81-pure-intersection-types-hint2](https://user-images.githubusercontent.com/738383/160235430-e6b9b8b5-d14c-4837-93d8-bd85ad1a9f37.png)


Part 5:
- Fix code generation features (generate getter, setter, constructor, override/implement methods)
- Fix the `PhpCommentGenerator`

Part 6:
- Fix the `DocRenderer` to show intersection types
- `mixed` type means special one of the union types since PHP 8.0,
so show the type names as it is if the type name is a union type or an intersection type
- Add the `truncate` method to the `StringUtils` to avoid showing long type names as it is

![nb-php81-pure-intersection-types-field-type-names](https://user-images.githubusercontent.com/738383/160235200-9f90b2aa-7d1f-476f-86af-ff08ee884da7.png)

