### PR TITLE
Save cause of download error for BuildException

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
@@ -312,7 +312,8 @@ public class DownloadBinaries extends Task {
                 log("Trying: " + url, Project.MSG_VERBOSE);
                 return downloadFromServer(this, url);
             } catch (IOException ex) {
-                //Try the next URL
+                // Saves the exception and tries the next URL, if present
+                firstProblem = ex;
             }
         }
         throw new BuildException("Could not download " + cacheName + " from " + server + ": " + firstProblem, firstProblem, getLocation());


### PR DESCRIPTION
When downloading external binaries, save any `IOException` for the `cause` parameter of the `BuildException`. Otherwise, the root cause of the build failure is always `null`.
