### PR TITLE
[3803]Fixing printing of type names for captured types with type variables.

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/editor/java/AutoImport.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/AutoImport.java
@@ -144,8 +144,6 @@ public class AutoImport extends SimpleTypeVisitor6<Void, Void> {
             bound = type.getUpperBound();
             if (bound != null && bound.getKind() != TypeKind.NULL) {
                 builder.append(" extends "); //NOI18N
-                if (bound.getKind() == TypeKind.TYPEVAR)
-                    bound = ((TypeVariable)bound).getLowerBound();
                 visit(bound);
             }
         }

--- a/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaCodeTemplateProcessorTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaCodeTemplateProcessorTest.java
@@ -203,6 +203,28 @@ public class JavaCodeTemplateProcessorTest extends NbTestCase {
                              "}");
     }
 
+    public void testInfiteLoop() throws Exception {
+         doTestTemplateInsert("for (${IT_TYPE rightSideType type=\"java.util.Iterator\" default=\"Iterator\" editable=false} ${IT newVarName default=\"it\"} = ${COL instanceof=\"java.util.Collection\" default=\"col\"}.iterator(); ${IT}.hasNext();) {\n" +
+                              "    ${TYPE rightSideType default=\"Object\"} ${ELEM newVarName default=\"elem\"} = ${TYPE_CAST cast default=\"\" editable=false}${IT}.next();\n" +
+                              "    ${selection}${cursor}\n" +
+                              "}\n",
+                             "import java.util.Collection;\n" +
+                             "public class Test<E> {\n" +
+                             "    private void t(Collection<? extends E> c) {\n" +
+                             "        |\n" +
+                             "    }\n" +
+                             "}",
+                             "import java.util.Collection;\n" +
+                             "public class Test<E> {\n" +
+                             "    private void t(Collection<? extends E> c) {\n" +
+                             "        for (Iterator<? extends E> iterator| = c.iterator(); iterator.hasNext();) {\n" +
+                             "            E next = iterator.next();\n" +
+                             "            \n" +
+                             "        }\n" +
+                             "    }\n" +
+                             "}");
+    }
+
     private void assertFileObjectTextMatchesRegex(String regex) throws IOException {
         String text = testFile.asText();
         assertTrue("The file text must match the regular expression", text.matches(regex));

--- a/java/java.source.base/src/org/netbeans/api/java/source/TypeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TypeUtilities.java
@@ -424,8 +424,6 @@ public final class TypeUtilities {
                     bound = t.getUpperBound();
                     if (bound != null && bound.getKind() != TypeKind.NULL) {
                         DEFAULT_VALUE.append(" extends "); //NOI18N
-                        if (bound.getKind() == TypeKind.TYPEVAR)
-                            bound = ((TypeVariable)bound).getLowerBound();
                         visit(bound, p);
                     }
                 }


### PR DESCRIPTION
An attempt to fix:
https://github.com/apache/netbeans/issues/3803

Printing/handling of captured type which contain type variables feels weird, this is trying to improve that, although I am not sure what (if anything) will be broken by it.



---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

