### PR TITLE
Cleanup the use of Float primitive wrapper.

### DIFF
--- a/ide/api.debugger/src/org/netbeans/api/debugger/Properties.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/Properties.java
@@ -1478,7 +1478,7 @@ public abstract class Properties {
                 } else if (classNames[5].equals(className)) {
                     return new Long(properties.getLong(propertyName, 0l));
                 } else if (classNames[6].equals(className)) {
-                    return new Float(properties.getFloat(propertyName, 0f));
+                    return properties.getFloat(propertyName, 0f);
                 } else if (classNames[7].equals(className)) {
                     return new Double(properties.getDouble(propertyName, 0d));
                 }

--- a/ide/css.lib/src/org/netbeans/modules/css/lib/api/properties/TokenAcceptor.java
+++ b/ide/css.lib/src/org/netbeans/modules/css/lib/api/properties/TokenAcceptor.java
@@ -312,7 +312,7 @@ public abstract class TokenAcceptor {
             Float f = super.getNumberValue(image);
             if(f == null) {
                 if(image.length() > 0 && image.charAt(0) == '0') {
-                    f = new Float(0);
+                    f = 0F;
                 }
             } 
             return f;

--- a/ide/db.dataview/src/org/netbeans/modules/db/dataview/util/DBReadWriteHelper.java
+++ b/ide/db.dataview/src/org/netbeans/modules/db/dataview/util/DBReadWriteHelper.java
@@ -445,7 +445,7 @@ public class DBReadWriteHelper {
 
                 case Types.FLOAT:
                 case Types.REAL:
-                    return valueObj instanceof Float ? valueObj : new Float(valueObj.toString());
+                    return valueObj instanceof Float ? valueObj : Float.valueOf(valueObj.toString());
 
                 case Types.DECIMAL:
                 case Types.NUMERIC:

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/Common.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/Common.java
@@ -385,7 +385,7 @@ public class Common {
             case Common.TYPE_LONG:
                 return new Long(0);
             case Common.TYPE_FLOAT:
-                return new Float(0.0);
+                return 0.0F;
             case Common.TYPE_DOUBLE:
                 return new Double(0.0);
             default:

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/GraphManager.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/GraphManager.java
@@ -898,7 +898,7 @@ public class GraphManager extends Object {
 	    case Common.TYPE_LONG:
 		return new Long(0);
 	    case Common.TYPE_FLOAT:
-		return new Float(0.0);
+		return 0.0F;
 	    case Common.TYPE_DOUBLE:
 		return new Double(0.0);
 	    default:

--- a/java/classfile/src/org/netbeans/modules/classfile/CPFloatInfo.java
+++ b/java/classfile/src/org/netbeans/modules/classfile/CPFloatInfo.java
@@ -32,7 +32,7 @@ public final class CPFloatInfo extends CPEntry {
 
     CPFloatInfo(ConstantPool pool, float v) {
 	super(pool);
-        value = new Float(v);
+        value = v;
     }
 
     public final int getTag() {

--- a/java/performance/benchmarks/src/org/netbeans/performance/benchmarks/XMLReporter.java
+++ b/java/performance/benchmarks/src/org/netbeans/performance/benchmarks/XMLReporter.java
@@ -58,7 +58,7 @@ public class XMLReporter implements Reporter {
         Map methods = getSubMap( classes, className );
         Map args = getSubMap( methods, methodName );
         List samples = getSubList( args, argument2String(argument) );
-        samples.add( new Float( value ) );
+        samples.add(value);
     }
 
     public void flush() {

--- a/java/performance/sparrow/src/org/netbeans/performance/impl/logparsing/GcLog.java
+++ b/java/performance/sparrow/src/org/netbeans/performance/impl/logparsing/GcLog.java
@@ -23,9 +23,11 @@
  */
 
 package org.netbeans.performance.impl.logparsing;
+
 import org.netbeans.performance.spi.html.*;
 import org.netbeans.performance.spi.*;
 import java.util.*;
+
 /**Wrapper class for a JDK garbage collection log.  This wrapper parses the log
  * and comes up with statistics representing data from it.  It does not hold onto
  * all of the GC events in a garbage collection log.  For a log wrapper that can
@@ -139,21 +141,21 @@ public class GcLog extends AbstractLogFile {
                 }
             }
             
-            addElement (new NameValueLogElement (GC_SECONDS, new Float(totalGcTime)));
+            addElement (new NameValueLogElement (GC_SECONDS, totalGcTime));
             addElement (new NameValueLogElement (GC_TOTAL, new Integer(gcs.size())));
             addElement (new NameValueLogElement (GC_FULLTOTAL, new Integer(fullGcCount)));
             addElement (new NameValueLogElement (GC_MINORTOTAL, new Integer(gcs.size() - fullGcCount)));
             addElement (new NameValueLogElement (GC_TOTALGARBAGE, new Long(totalCollected)));
             addElement (new NameValueLogElement (GC_HGES, new Integer(heapChangeCount)));
             addElement (new NameValueLogElement (GC_AVGCOLLECTEDPERGC, new Long(totalCollected / gcs.size())));
-            addElement (new NameValueLogElement (GC_SECSMAJOR, new Float(totalMajorGcTime)));
-            addElement (new NameValueLogElement (GC_SECSMINOR, new Float(totalMinorGcTime)));
+            addElement (new NameValueLogElement (GC_SECSMAJOR, totalMajorGcTime));
+            addElement (new NameValueLogElement (GC_SECSMINOR, totalMinorGcTime));
             if (fullGcCount != 0) {
-                addElement (new NameValueLogElement (GC_AVGMILLISMAJOR, new Float((totalMajorGcTime / fullGcCount) * 1000)));
+                addElement (new NameValueLogElement (GC_AVGMILLISMAJOR, (float)((totalMajorGcTime / fullGcCount) * 1000)));
             } else {
-                addElement (new NameValueLogElement (GC_AVGMILLISMAJOR, new Float (0)));
+                addElement (new NameValueLogElement (GC_AVGMILLISMAJOR, 0F));
             }
-            addElement (new NameValueLogElement (GC_AVGMILLISMINOR, new Float((totalMinorGcTime / (gcs.size() - fullGcCount))*1000)));
+            addElement (new NameValueLogElement (GC_AVGMILLISMINOR, (float)((totalMinorGcTime / (gcs.size() - fullGcCount))*1000)));
             
         }
     }

--- a/java/performance/sparrow/src/org/netbeans/performance/spi/AveragedNameValueLogElement.java
+++ b/java/performance/sparrow/src/org/netbeans/performance/spi/AveragedNameValueLogElement.java
@@ -78,14 +78,14 @@ public class AveragedNameValueLogElement extends NameValueLogElement implements 
      * used to create this element.
      * the set of values used to create this element. */
     public Float getMin() {
-        return new Float (samples[0]);
+        return samples[0];
     }
     
     /** Returns the highest value in the set of values
      * used to create this element.
      * the set of values used to create this element. */
     public Float getMax() {
-        return new Float(samples[samples.length-1]);
+        return samples[samples.length-1];
     }
     
     /** Returns the mean, or arithmetic average of 
@@ -105,7 +105,7 @@ public class AveragedNameValueLogElement extends NameValueLogElement implements 
         } else {
             result = samples[samples.length/2];
         }
-        return new Float(result);
+        return result;
     }
     
     /** Returns the values used to create this element.     */

--- a/nb/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SerParser.java
+++ b/nb/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SerParser.java
@@ -501,7 +501,7 @@ public final class SerParser implements ObjectStreamConstants {
             } else if (aw.classdesc.name.equals("[J")) { // NOI18N
                 aw.values.add(new Long(readLong()));
             } else if (aw.classdesc.name.equals("[F")) { // NOI18N
-                aw.values.add(new Float(Float.intBitsToFloat(readInt())));
+                aw.values.add(Float.intBitsToFloat(readInt()));
             } else if (aw.classdesc.name.equals("[D")) { // NOI18N
                 aw.values.add(new Double(Double.longBitsToDouble(readLong())));
             } else if (aw.classdesc.name.equals("[C")) { // NOI18N
@@ -565,7 +565,7 @@ public final class SerParser implements ObjectStreamConstants {
             } else if (fd.type.equals("J")) { // NOI18N
                 values.add(new NameValue(fd, new Long(readLong())));
             } else if (fd.type.equals("F")) { // NOI18N
-                values.add(new NameValue(fd, new Float(Float.intBitsToFloat(readInt()))));
+                values.add(new NameValue(fd, Float.intBitsToFloat(readInt())));
             } else if (fd.type.equals("D")) { // NOI18N
                 values.add(new NameValue(fd, new Double(Double.longBitsToDouble(readLong()))));
             } else if (fd.type.equals("C")) { // NOI18N

--- a/platform/o.n.swing.tabcontrol/demosrc/org/netbeans/swing/tabcontrol/demo/TestFrame.java
+++ b/platform/o.n.swing.tabcontrol/demosrc/org/netbeans/swing/tabcontrol/demo/TestFrame.java
@@ -50,23 +50,6 @@ public class TestFrame extends javax.swing.JFrame {
     public TestFrame() {
         setDefaultCloseOperation (javax.swing.WindowConstants.EXIT_ON_CLOSE);
         initComponents();
-        /*
-        try {
-            
-            System.setProperty("os.version", new Float(3.5).toString());
-            Method m = Toolkit.class.getDeclaredMethod("setDesktopProperty",
-            new Class[] {String.class, Object.class});
-            m.setAccessible(true);
-            m.invoke(java.awt.Toolkit.getDefaultToolkit(),
-            new Object[]  {"win.xpstyle.themeActive", Boolean.FALSE });
- 
-            
-            UIManager.setLookAndFeel(new PseudoWin());
-//            UIManager.setLookAndFeel(new javax.swing.plaf.metal.MetalLookAndFeel());
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-         */
         
         try {
 //            UIManager.setLookAndFeel(new javax.swing.plaf.metal.MetalLookAndFeel());

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/IndexedPropertyEditor.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/IndexedPropertyEditor.java
@@ -364,7 +364,7 @@ class IndexedPropertyEditor extends Object implements ExPropertyEditor {
             }
 
             if (getConvertedType().equals(Float.class)) {
-                value = new Float(0f);
+                value = 0f;
             }
 
             if (getConvertedType().equals(Long.class)) {

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
@@ -926,7 +926,7 @@ final class XMLMapAttr implements Map {
                     case 3:
                         return new Long(value);
                     case 4:
-                        return new Float(value);
+                        return Float.valueOf(value);
                     case 5:
                         return new Double(value);
                     case 6:

--- a/platform/openide.options/src/org/openide/text/PrintSettings.java
+++ b/platform/openide.options/src/org/openide/text/PrintSettings.java
@@ -208,7 +208,7 @@ public final class PrintSettings extends ContextSystemOption {
     */
     public void setLineAscentCorrection(float correction) {
         PrintPreferences.setLineAscentCorrection(correction);
-        firePropertyChange(PROP_LINE_ASCENT_CORRECTION, null, new Float(correction));
+        firePropertyChange(PROP_LINE_ASCENT_CORRECTION, null, correction);
     }
 
     public void writeExternal(ObjectOutput obtos) throws IOException {

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CCTDisplay.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/CCTDisplay.java
@@ -409,31 +409,6 @@ public class CCTDisplay extends SnapshotCPUResultsPanel implements ScreenshotPro
                     return columnToolTips[col];
                 }
 
-//                private Float getNodeTimeRel(PrestimeCPUCCTNode pNode) {
-//                    return new Float(pNode.getTotalTime0InPerCent());
-//                }
-//
-//                private String getNodeTime(PrestimeCPUCCTNode pNode) {
-//                    return StringUtils.mcsTimeToString(pNode.getTotalTime0()) + " ms (" // NOI18N
-//                           + percentFormat.format(pNode.getTotalTime0InPerCent() / 100) + ")"; // NOI18N
-//                }
-//
-//                private String getNodeWaitTime(PrestimeCPUCCTNode pNode) {
-//                    return StringUtils.mcsTimeToString(pNode.getWaitTime0()) + " ms"; // NOI18N
-//                }
-//
-//                private String getNodeSleepTime(PrestimeCPUCCTNode pNode) {
-//                    return StringUtils.mcsTimeToString(pNode.getSleepTime0()) + " ms"; // NOI18N
-//                }
-//
-//                private String getNodeSecondaryTime(PrestimeCPUCCTNode pNode) {
-//                    return StringUtils.mcsTimeToString(pNode.getTotalTime1()) + " ms"; // NOI18N
-//                }
-//
-//                private Integer getNodeInvocations(PrestimeCPUCCTNode pNode) {
-//                    return Integer.valueOf(pNode.getNCalls());
-//                }
-
                 private Integer getNodeMethodId(PrestimeCPUCCTNode pNode) {
                     return Integer.valueOf(pNode.getMethodId());
                 }
@@ -630,7 +605,7 @@ public class CCTDisplay extends SnapshotCPUResultsPanel implements ScreenshotPro
     }
     
     protected Float getNodeTimeRel(long time, float percent) {
-        return new Float(percent);
+        return percent;
     }
 
     protected String getNodeTime(long time, float percent) {

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/DiffCCTDisplay.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/DiffCCTDisplay.java
@@ -45,7 +45,7 @@ public class DiffCCTDisplay extends CCTDisplay {
     
     
     protected Float getNodeTimeRel(long time, float percent) {
-        return new Float(time);
+        return (float)time;
     }
 
     protected String getNodeTime(long time, float percent) {

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/DiffFlatProfilePanel.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/DiffFlatProfilePanel.java
@@ -50,7 +50,7 @@ public class DiffFlatProfilePanel extends SnapshotFlatProfilePanel {
             case 0:
                 return flatProfileContainer.getMethodNameAtRow(row);
             case 1:
-                return new Float(flatProfileContainer.getTimeInMcs0AtRow(row));
+                return (float)flatProfileContainer.getTimeInMcs0AtRow(row);
             case 2:
                 value = flatProfileContainer.getTimeInMcs0AtRow(row);
                 return (value > 0 ? "+" : "") + StringUtils.mcsTimeToString(value) + " ms"; // NOI18N

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/FlatProfilePanel.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/FlatProfilePanel.java
@@ -908,7 +908,7 @@ public abstract class FlatProfilePanel extends CPUResultsPanel {
             case 0:
                 return flatProfileContainer.getMethodNameAtRow(row);
             case 1:
-                return new Float(flatProfileContainer.getPercentAtRow(row));
+                return flatProfileContainer.getPercentAtRow(row);
             case 2:
                 return StringUtils.mcsTimeToString(flatProfileContainer.getTimeInMcs0AtRow(row)) + " ms (" // NOI18N
                         + percentFormat.format(flatProfileContainer.getPercentAtRow(row) / 100) + ")"; // NOI18N

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/ReverseCallGraphPanel.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/ReverseCallGraphPanel.java
@@ -366,7 +366,7 @@ public class ReverseCallGraphPanel extends SnapshotCPUResultsPanel implements Sc
                 }
 
                 private Float getNodeTimeRel(PrestimeCPUCCTNode pNode) {
-                    return new Float(pNode.getTotalTime0InPerCent());
+                    return pNode.getTotalTime0InPerCent();
                 }
 
                 private String getNodeTime(PrestimeCPUCCTNode pNode) {

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/SubtreeCallGraphPanel.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/SubtreeCallGraphPanel.java
@@ -365,7 +365,7 @@ public class SubtreeCallGraphPanel extends SnapshotCPUResultsPanel implements Sc
                 }
 
                 private Float getNodeTimeRel(PrestimeCPUCCTNode pNode) {
-                    return new Float(pNode.getTotalTime0InPerCent());
+                    return pNode.getTotalTime0InPerCent();
                 }
 
                 private String getNodeTime(PrestimeCPUCCTNode pNode) {

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/ParameterInfo.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/ParameterInfo.java
@@ -183,7 +183,7 @@ public class ParameterInfo {
         } else if (type == Long.class || type == Long.TYPE) {
             return new Long(0);
         } else if (type == Float.class || type == Float.TYPE) {
-            return new Float(0);
+            return 0F;
         } else if (type == Double.class || type == Double.TYPE) {
             return new Double(0);
         } else if (type == Boolean.class || type == Boolean.TYPE) {


### PR DESCRIPTION
As of Java 9, the VM can do a better job of handling the conversion from a float primitive to a Float Object or vice versa.

This is an extension of the work done in #2498.

No tests have been touched as those expressly need to manage the conversion.

Lastly, these changes are project wide and not module specific.


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

