### PR TITLE
ci pipeline improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,16 +55,16 @@ jobs:
       - name: Build NetBeans
         run: ant -Dcluster.config=release build-nozip
 
-      - name: Archive Build
+      - name: Prepare Artifact
         if: ${{ matrix.java == '11' }}
-        run: tar -czf /tmp/build.tar.gz --exclude ".git" .
+        run: tar -I 'zstd -9 -T0' -cf /tmp/build.tar.zst --exclude ".git" .
 
       - name: Upload Build
         if: ${{ matrix.java == '11' }}
         uses: actions/upload-artifact@v3
         with:
           name: build
-          path: /tmp/build.tar.gz
+          path: /tmp/build.tar.zst
           retention-days: 1
           if-no-files-found: error
 
@@ -94,7 +94,7 @@ jobs:
           name: build
 
       - name: Extract
-        run: tar -xzf build.tar.gz --exclude nbbuild/build/test
+        run: tar --zstd -xf build.tar.zst
         
       - name: SM config
         if: ${{ matrix.java == '19-ea' }}
@@ -130,7 +130,7 @@ jobs:
           name: build
 
       - name: Extract
-        run: tar -xzf build.tar.gz --exclude nbbuild/build/test
+        run: tar --zstd -xf build.tar.zst
 
       - name: Test Netbeans Build System
         run: ant -Dcluster.config=release localtest
@@ -158,7 +158,7 @@ jobs:
           name: build
 
       - name: Extract
-        run: tar -xzf build.tar.gz --exclude nbbuild/build/test
+        run: tar --zstd -xf build.tar.zst
 
       - name: Get maven coordinates
         run: ant getallmavencoordinates
@@ -200,8 +200,9 @@ jobs:
         with:
           name: build
 
+      # tar on MacOS is not aware of zstd "tar --zstd -xf build.tar.zst" isn't working
       - name: Extract
-        run: tar -xzf build.tar.gz --exclude nbbuild/build/test
+        run: unzstd -c build.tar.zst | tar -x
 
       - run: brew install ant
 
@@ -211,7 +212,7 @@ jobs:
       - name: Test platform/core.network
         run: ant -f platform/core.network test
 
-      - name: Validate consistency and basic tests
+      - name: Commit Validation tests
         run: ant -Dcluster.config=release commit-validation
 
   php:
@@ -259,7 +260,7 @@ jobs:
           name: build
 
       - name: Extract
-        run: tar -xzf build.tar.gz --exclude nbbuild/build/test
+        run: tar --zstd -xf build.tar.zst
 
       - name: Test Platform Core Network
         run: ant $OPTS -f platform/core.network test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
         run: tar -I 'zstd -9 -T0' -cf /tmp/build.tar.zst --exclude ".git" .
 
       - name: Upload Build
-        if: ${{ matrix.java == '11' }}
+        if: ${{ (matrix.java == '11') && success() }}
         uses: actions/upload-artifact@v3
         with:
           name: build
@@ -356,7 +356,9 @@ jobs:
   cleanup:
     name: Cleanup Workflow Artifacts
     needs: [base-build, linux-commit-validation, linux-build-system-test, linux-javadoc, macos, php]
-    if: ${{ always() }}
+    # don't cleanup on failure() or always(), because someone might want to restart an unreliable secondary job
+    # if primary jobs fail there won't be anything to cleanup anyway.
+    if: success() || cancelled()
     runs-on: ubuntu-latest
     steps:
 
@@ -370,3 +372,4 @@ jobs:
         name: Delete build Artifact
         with:
           name: build
+          failOnError: true


### PR DESCRIPTION
PR tests some optimizations / improvements.

**use Zstandard compression for pipeline artifacts.**

 - faster compression (multithreaded) and extraction compared to gz
 - smaller artifact footprint (with `-9` setting, seems to be the sweet spot in my experience from other deployments)
 - all github nodes support it [out of the box](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#preinstalled-software)
 - cumulative performance improvement due to the nature of the pipeline

Local test using 2 threads to simulate a gh node. Tested in a ramdisk. The actual code uses `-T0` to be forward compatible.
```bash 
# compression
time tar -czf /tmp/build.tar.gz --exclude ".git" .
real    1m12,641s
user    1m18,657s
sys     0m3,167s

# uses two threads to simmulate CI node
time tar -I 'zstd -9 -T2' -cf /tmp/build.tar.zst --exclude ".git" .
real	0m22,993s
user	0m50,221s
sys	0m3,018s


# archive sizes
ls -l /tmp/build*
-rw-r--r-- 1 mbien mbien 1575854860 31. Mär 01:21 /tmp/build.tar.gz
-rw-r--r-- 1 mbien mbien 1431884800 31. Mär 01:25 /tmp/build.tar.zst


# extraction
time tar -xzf /tmp/build.tar.gz
real    0m14,681s
user    0m15,051s
sys     0m3,438s

time tar --zstd -xf /tmp/build.tar.zst
real    0m3,747s
user    0m2,399s
sys     0m3,006s

```
outside of gh actions I would have combined compression + upload in one step (same for download + extraction). But this isn't possible while using the default upload action.

**second commit: don't cleanup on failure**
 - don't trigger on failure since someone might want to restart a job
 - updated trigger is success() || cancelled()
 - retention period remains set to 1 day for missed cleanups
 - there is also the option to manually remove uploads if needed