### PR TITLE
Handle the case when the connection name is not known before wallet download

### DIFF
--- a/enterprise/cloud.oracle/licenseinfo.xml
+++ b/enterprise/cloud.oracle/licenseinfo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<licenseinfo>
+    <fileset>
+        <file>test/unit/src/org/netbeans/modules/cloud/oracle/actions/tnsnames.ora</file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="COMMENT_UNSUPPORTED" />
+    </fileset>
+</licenseinfo>

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
@@ -20,10 +20,17 @@ package org.netbeans.modules.cloud.oracle.actions;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.netbeans.api.db.explorer.ConnectionManager;
 import org.netbeans.api.db.explorer.DatabaseConnection;
 import org.netbeans.api.db.explorer.DatabaseException;
@@ -61,8 +68,8 @@ import org.openide.util.NbBundle;
     "LBL_SaveWallet=Save DB Wallet",
     "CTL_DownloadWalletAction=Download Wallet",
     "MSG_WalletDownloaded=Database Wallet was downloaded to {0}",
-    "MSG_WalletDownloadedPassword=Database Wallet was downloaded. \nGenerated wallet password is: {0}"
-    
+    "MSG_WalletDownloadedPassword=Database Wallet was downloaded. \nGenerated wallet password is: {0}",
+    "MSG_WalletNoConnection=Wallet doesn't contain any connection"
 })
 public class DownloadWalletAction implements ActionListener {
     
@@ -83,6 +90,16 @@ public class DownloadWalletAction implements ActionListener {
                     
                     JDBCDriver[] drivers = JDBCDriverManager.getDefault().getDrivers("oracle.jdbc.OracleDriver"); //NOI18N
                     if (drivers.length > 0) {
+                        String connectionName = context.getConnectionName();
+                        if (connectionName == null) {
+                            Optional<String> n = parseConnectionNames(walletPath).stream().findFirst();
+                            if (n.isPresent()) {
+                                connectionName = n.get();
+                            } else {
+                                StatusDisplayer.getDefault().setStatusText(Bundle.MSG_WalletNoConnection());
+                                return;
+                            }
+                        }
                         String dbUrl = MessageFormat.format(URL_TEMPLATE, context.getConnectionName(), walletPath);
                         DatabaseConnection dbConn = DatabaseConnection.create(
                                 drivers[0], 
@@ -107,4 +124,16 @@ public class DownloadWalletAction implements ActionListener {
         });
     }
     
+    protected List<String> parseConnectionNames(Path wallet) {
+        Path tns = wallet.resolve("tnsnames.ora"); //NOI18N
+        try {
+            return Files.newBufferedReader(tns).lines()
+                    .filter(l -> l.contains("=")) //NOI18N
+                    .map(l -> l.substring(0, l.indexOf("=")).trim()) //NOI18N
+                    .collect(Collectors.toList());
+        } catch (IOException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        return Collections.emptyList();
+    }
 }

--- a/enterprise/cloud.oracle/test/unit/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletActionTest.java
+++ b/enterprise/cloud.oracle/test/unit/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletActionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.cloud.oracle.actions;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Jan Horvath
+ */
+public class DownloadWalletActionTest {
+    
+    public DownloadWalletActionTest() {
+    }
+
+    /**
+     * Test of actionPerformed method, of class DownloadWalletAction.
+     */
+    @Test
+    public void testActionPerformed() throws URISyntaxException {
+        URL r = getClass().getResource("tnsnames.ora");
+        Path p = Paths.get(r.toURI());
+        DownloadWalletAction action = new DownloadWalletAction(null);
+        Optional<String> f = action.parseConnectionNames(p.getParent()).stream().findFirst();
+        assertEquals("db202105110822_high", f.get());
+    }
+    
+}

--- a/enterprise/cloud.oracle/test/unit/src/org/netbeans/modules/cloud/oracle/actions/tnsnames.ora
+++ b/enterprise/cloud.oracle/test/unit/src/org/netbeans/modules/cloud/oracle/actions/tnsnames.ora
@@ -1,0 +1,9 @@
+db202105110822_high = (description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=adb.us-phoenix-1.oraclecloud.com))(connect_data=(service_name=scxgohtjr72xgms_db202105110822_high.adb.oraclecloud.com))(security=(ssl_server_cert_dn="CN=adwc.uscom-east-1.oraclecloud.com, OU=Oracle BMCS US, O=Oracle Corporation, L=Redwood City, ST=California, C=US")))
+
+db202105110822_low = (description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=adb.us-phoenix-1.oraclecloud.com))(connect_data=(service_name=scxgohtjr72xgms_db202105110822_low.adb.oraclecloud.com))(security=(ssl_server_cert_dn="CN=adwc.uscom-east-1.oraclecloud.com, OU=Oracle BMCS US, O=Oracle Corporation, L=Redwood City, ST=California, C=US")))
+
+db202105110822_medium = (description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=adb.us-phoenix-1.oraclecloud.com))(connect_data=(service_name=scxgohtjr72xgms_db202105110822_medium.adb.oraclecloud.com))(security=(ssl_server_cert_dn="CN=adwc.uscom-east-1.oraclecloud.com, OU=Oracle BMCS US, O=Oracle Corporation, L=Redwood City, ST=California, C=US")))
+
+
+
+


### PR DESCRIPTION
In case the connection name is not known before the DB Wallet is downloaded, parse wallet's `tnsnames.ora` and take one from there.