### PR TITLE
Fixing user home in project wizard and filtering outgoing messages fr…

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
@@ -224,7 +224,7 @@ final class LspTemplateUI {
     }
 
     private static String suggestWorkspaceRoot(List<WorkspaceFolder> folders) throws IllegalArgumentException {
-        String suggestion = System.getProperty("user.dir");
+        String suggestion = System.getProperty("user.home");
         if (folders != null && !folders.isEmpty()) try {
             suggestion = Utilities.toFile(new URI(folders.get(0).getUri())).getParent();
         } catch (URISyntaxException ex) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -72,6 +72,7 @@ import org.eclipse.lsp4j.TextDocumentSyncOptions;
 import org.eclipse.lsp4j.WorkDoneProgressCancelParams;
 import org.eclipse.lsp4j.WorkDoneProgressParams;
 import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.jsonrpc.Endpoint;
 import org.eclipse.lsp4j.jsonrpc.JsonRpcException;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
@@ -195,6 +196,9 @@ public final class Server {
         public MessageConsumer attachLookup(MessageConsumer delegate) {
             // PENDING: allow for message consumer wrappers to be registered to add pre/post processing for
             // the request plus build the request's default Lookup contents.
+            if (!(delegate instanceof Endpoint)) {
+                return delegate; 
+            }
             return new MessageConsumer() {
                 @Override
                 public void consume(Message msg) throws MessageIssueException, JsonRpcException {


### PR DESCRIPTION
This PR contains two simple fixes. 

1) The suggested folder for new java project in VSCode (new java project wizard) was taken from `user.dir` system property. This means that was something like `{user_home}/.config/Code/User/globalStorage/asf.apache-netbeans-java/userdir` . The change in `LspTemplateUI` correct this and the suggested folder should be in this case `user.home` folder. 

2) The change in `Server.java` file prevents processing outgoing messages wiht MessageConsumer that is targeted for incomming messages. As a side effects for every outgoing message was created `ProxyLookup` and `OperationContext`, which are useless for outgoing messeges. 