### PR TITLE
Relax serialized project cache checks

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -445,6 +445,16 @@ class NbProjectInfoBuilder {
                             if(!ignoreUnresolvable && (it.isVisible() || it.isCanBeConsumed())) {
                                 // hidden configurations like 'testCodeCoverageReportExecutionData' might contain unresolvable artifacts.
                                 // do not report problems here
+                                Throwable failure = ((UnresolvedDependencyResult) it2).getFailure();
+                                if (project.getGradle().getStartParameter().isOffline()) {
+                                    // if the unresolvable is bcs. offline mode, throw an exception to get retry in online mode.
+                                    Throwable prev = null;
+                                    for (Throwable t = failure; t != prev && t != null; prev = t, t = t.getCause()) {
+                                        if (t.getMessage().contains("available for offline")) {
+                                            throw new NeedOnlineModeException("Need online mode", failure);
+                                        }
+                                    }
+                                }
                                 unresolvedProblems.put(id, ((UnresolvedDependencyResult) it2).getFailure().getMessage());
                             }
                         }

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NeedOnlineModeException.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NeedOnlineModeException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.tooling;
+
+import org.gradle.api.GradleException;
+
+/**
+ *
+ * @author sdedic
+ */
+public class NeedOnlineModeException extends GradleException {
+
+    public NeedOnlineModeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+}

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansToolingPlugin.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansToolingPlugin.java
@@ -92,6 +92,8 @@ public class NetBeansToolingPlugin implements Plugin<Project> {
                     }
                 }
                 return model;
+            } catch (NeedOnlineModeException ex) {
+                throw ex;
             } catch (RuntimeException ex) {
                 StringWriter sw = new StringWriter();
                 PrintWriter pw = new PrintWriter(sw);

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -234,6 +234,7 @@ public final class NbGradleProjectImpl implements Project {
     }
 
     synchronized void dumpProject() {
+        loading = null;
         project = null;
         attemptedQuality = null;
         loadedProjectSerial = 0;
@@ -370,6 +371,39 @@ public final class NbGradleProjectImpl implements Project {
     CompletableFuture<GradleProject> loadOwnProject(String desc, boolean ignoreCache, boolean interactive, Quality aim, String... args) {
         return loadOwnProject0(desc, ignoreCache, interactive, aim, false, true, args);
     }
+
+    /**
+     * Future that is present during project load. Other load requests can be satisfied by this Future if they do not contain
+     * the 'force' flag.
+     */
+    // @GuardedBy(this)
+    private LoadingCF loading;
+    
+    private static class LoadingCF extends CompletableFuture<GradleProject> {
+        private final Quality aim;
+        private final boolean ignoreCache;
+        private final boolean interactive;
+        private final boolean sync;
+        private final List<String> args;
+
+        public LoadingCF(Quality aim, boolean ignoreCache, boolean interactive, boolean sync, List<String> args) {
+            this.aim = aim;
+            this.ignoreCache = ignoreCache;
+            this.interactive = interactive;
+            this.sync = sync;
+            this.args = args;
+        }
+     
+        public boolean satisifes(LoadingCF other) {
+            if (aim.worseThan(other.aim)) {
+                return false;
+            }
+            if (ignoreCache != other.ignoreCache || interactive != other.interactive || sync != other.sync) {
+                return false;
+            }
+            return args.equals(other.args);
+        }
+    }
     
     /**
      * Loads a project. After load, dispatches reload events. If "sync" is false (= asynchronous), dispatches events
@@ -392,7 +426,17 @@ public final class NbGradleProjectImpl implements Project {
         if (loader == null) {
             throw new IllegalStateException("No loader implementation is present!");
         }
-
+        LoadingCF f = new LoadingCF(aim, ignoreCache, interactive, sync, Arrays.asList(args));
+        synchronized (this) {
+            if (this.loading != null && this.loading.satisifes(f)) {
+                if (!force) {
+                    LOG.log(Level.FINER, "Project {2} is already loading to quality {0}, now attempted {1}, returning existing handle", new 
+                            Object[] { this.loading.aim, aim, this });
+                    return this.loading;
+                }
+            }
+            this.loading = f;
+        }
         int s = currentSerial.incrementAndGet();
         // do not block during project load.
         LOG.log(Level.FINER, "Starting project {2} load, serial {0}, attempted quality {1}", new Object[] { s, aim, this });
@@ -428,11 +472,15 @@ public final class NbGradleProjectImpl implements Project {
         }
         // notify the project has been changed.
         if (sync || RELOAD_RP.isRequestProcessorThread()) {
+            synchronized (this) {
+                if (this.loading == f) {
+                    this.loading = null;
+                }
+            }
             LOG.log(Level.FINER, "Firing changes/reload synchronously");
             ACCESSOR.doFireReload(watcher);
             return CompletableFuture.completedFuture(prj);
         } else {
-            CompletableFuture<GradleProject> f = new CompletableFuture<>();
             LOG.log(Level.FINER, "Firing changes/reload in RP");
             RELOAD_RP.post(() -> callAccessorReload(f, prj));
             return f;
@@ -441,6 +489,11 @@ public final class NbGradleProjectImpl implements Project {
     
     private CompletableFuture<GradleProject> callAccessorReload(CompletableFuture<GradleProject> f, GradleProject prj) {
         try {
+            synchronized (this) {
+                if (this.loading == f) {
+                    this.loading = null;
+                }
+            }
             ACCESSOR.doFireReload(watcher);
             f.complete(prj);
         } catch (ThreadDeath t) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
@@ -164,6 +164,11 @@ class GradleBaseProjectBuilder implements ProjectInfoExtractor.Result {
         Map<String, String> unresolvedProblems = (Map<String, String>) info.get("unresolved_problems");
         unresolvedProblems = unresolvedProblems != null ? unresolvedProblems : Collections.<String, String>emptyMap();
         Map<String, ModuleDependency> components = new HashMap<>();
+        
+        // supplement project info with cache data as in online mode javadocs and sources are NOT queried. Especially
+        // when doing a refresh / download, the project info is just partial, although Gradle has relevant artifacts in
+        // its caches.
+        GradleArtifactStore store = GradleArtifactStore.getDefault();
         for (Map.Entry<String, Set<File>> entry : arts.entrySet()) {
             String componentId = entry.getKey();
             // Looking at cache first as we might have the chance to find Sources and Javadocs
@@ -174,9 +179,13 @@ class GradleBaseProjectBuilder implements ProjectInfoExtractor.Result {
             components.put(componentId, dep);
             if (sources.containsKey(componentId)) {
                 dep.sources = sources.get(entry.getKey());
+            } else {
+                dep.sources = store.getSources(entry.getValue());
             }
             if (javadocs.containsKey(componentId)) {
                 dep.javadoc = javadocs.get(entry.getKey());
+            } else {
+                dep.javadoc = store.getJavadocs(entry.getValue());                
             }
         }
         Map<String, ProjectDependency> projects = new HashMap<>();

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleArtifactStore.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleArtifactStore.java
@@ -30,6 +30,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -85,6 +86,24 @@ public class GradleArtifactStore {
     public Set<File> getBinaries(String id) {
         Set<File> ret = binaries.get(id);
         return ret;
+    }
+    
+    public Set<File> getSources(Set<File> binaries) {
+        if (binaries.size() != 1) {
+            return null;
+        } else {
+            File f = sources.get(binaries.iterator().next());
+            return f == null ? null : Collections.singleton(f);
+        }
+    }
+    
+    public Set<File> getJavadocs(Set<File> binaries) {
+        if (binaries.size() != 1) {
+            return null;
+        } else {
+            File f = javadocs.get(binaries.iterator().next());
+            return f == null ? null : Collections.singleton(f);
+        }
     }
     
     public File getSources(File binary) {
@@ -186,13 +205,22 @@ public class GradleArtifactStore {
         for (GradleConfiguration conf : gp.getBaseProject().getConfigurations().values()) {
             for (GradleDependency.ModuleDependency module : conf.getModules()) {
                 Set<File> oldBins = binaries.get(module.getId());
-                if (oldBins == null || oldBins.isEmpty()) {
+                boolean empty = module.getArtifacts() == null || module.getArtifacts().isEmpty();
+                boolean binsEmpty = oldBins == null || oldBins.isEmpty();
+                boolean cacheEmpty;
+                GradleModuleFileCache21.CachedArtifactVersion cav = modCache.resolveModule(module.getId());
+                if (cav != null && cav.getBinary() != null) {
+                    // possibly trigger project reload if the artifact store does not match the GradleModuleFileCache21.
+                    cacheEmpty = !Files.exists(cav.getBinary().getPath());
+                } else {
+                    cacheEmpty = true;
+                }
+                if (empty != (cacheEmpty && binsEmpty)) {
                     LOG.log(Level.FINE, "Checking {0}: Module dependency {1} not found in cache.", new Object[] { gp.getBaseProject().getProjectDir(), module.getId() });
                     return false;
                 }
-                if (oldBins.size() == 1) {
+                if (!binsEmpty && oldBins.size() == 1) {
                     File binary = oldBins.iterator().next();
-                    GradleModuleFileCache21.CachedArtifactVersion cav = modCache.resolveModule(module.getId());
                     if (cav == null) {
                         LOG.log(Level.FINE, "Checking {0}: Cached artifact not found for {1}", new Object[] { gp.getBaseProject().getProjectDir(), module.getId() });
                         return false;
@@ -201,14 +229,14 @@ public class GradleArtifactStore {
                     GradleModuleFileCache21.CachedArtifactVersion.Entry sourceEntry = cav.getSources();
                     if (sourceEntry != null && Files.exists(sourceEntry.getPath())) {
                         File check = sources.get(binary);
-                        if (check == null || !check.toPath().equals(sourceEntry.getPath())) {
+                        if (check != null && !check.toPath().equals(sourceEntry.getPath())) {
                             LOG.log(Level.FINE, "Checking {0}: cache does not list CachedArtifact for source {2}", new Object[] { gp.getBaseProject().getProjectDir(), module.getId(), sourceEntry.getPath() });
                             return false;
                         }
                     }
                     if (javadocEntry != null && Files.exists(javadocEntry.getPath())) {
                         File check = javadocs.get(binary);
-                        if (check == null || !check.toPath().equals(javadocEntry.getPath())) {
+                        if (check != null && !check.toPath().equals(javadocEntry.getPath())) {
                             LOG.log(Level.FINE, "Checking {0}: cache does not list CachedArtifact for javadoc {2}", new Object[] { gp.getBaseProject().getProjectDir(), module.getId(), javadocEntry.getPath() });
                             return false;
                         }


### PR DESCRIPTION
The idea in #3375 to check the global Artifact store was good in general, BUT ...

it turned out that when the project is loading in FULL_ONLINE mode (implies no --offline switch), the NBTooling plugin [will **not** report back](https://github.com/apache/netbeans/blob/master/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java#L514) any javadocs or sources even though they may exist in the local `~/.gradle` jar cache. OK, after that the project is saved without any such artifacts, and the artifact store is updated with this imprecise info: no sources / javadocs would be registered (so eventually sources/javadocs maps can be completely empty). Consider, for example, if the `var/cache` in userdir is cleared, but the gradle (`~/.gradle`) caches are intact.

In some future run of the IDE, the project is fetched from the cache (without any source / javadoc), but `GradleModuleFileCache21` can find them from their binary .jar - and the cached project is deemed invalid as info in IDE's artifact store differs from the gradle's caches. So, the project **is not loaded from the cache**, but again through Gradle daemon. This time, the `FULL` level is sufficient - and that one will load even source + javadoc info - that's stored in the project cache AND in the artifact store. But if eventually the project file contains some real problems and ONLINE mode activates, no source/javadoc update goes to the artifact store.

In addition, there are BOM-like projects, which do not have any binaries, just pom, for example. Such projects are always rejected, as binaries are always empty. It is sufficient for a project to have a dependency on just one POM-like module for the disk cache to be rejected.

This PR relaxes the checks, assuming that if the project does not contain any info for sources | javadocs, it's OK. The info will eventually accumulate.  The jar/binary is still used to detect inconsistency between the cached state and gradle cache: if the cached project does not contain JAR artifacts, which are in `gradle` local cache, the project is most probably wrong and should be reloaded.

The PR improves diagnostics by logging problems encountered during project load; problems are printed with FINE level, so one could find out why a project is reloaded, not cached etc.

During debugging, I've found out that certain resolution errors are reported in offline mode as problems - but do not throw an exception that is caught in `LegacyProjectLoader` and cause re-load in online mode. The tooling now throws a specific exception in such case that is allowed to pass to the Loader.

