### PR TITLE
ide/lsp.client threading & semantic token types

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LanguageClientImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LanguageClientImpl.java
@@ -81,10 +81,7 @@ import org.netbeans.spi.editor.hints.Severity;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.URLMapper;
-import org.openide.text.NbDocument;
 import org.openide.util.Exceptions;
-import org.openide.util.NbBundle.Messages;
-import org.openide.util.RequestProcessor;
 
 /**
  *
@@ -93,8 +90,6 @@ import org.openide.util.RequestProcessor;
 public class LanguageClientImpl implements LanguageClient {
 
     private static final Logger LOG = Logger.getLogger(LanguageClientImpl.class.getName());
-    private static final RequestProcessor WORKER = new RequestProcessor(LanguageClientImpl.class.getName(), 1, false, false);
-
     private LSPBindings bindings;
     private boolean allowCodeActions;
 
@@ -209,7 +204,7 @@ public class LanguageClientImpl implements LanguageClient {
     @Override
     public CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams) {
         CompletableFuture<List<Object>> result = new CompletableFuture<>();
-        WORKER.post(() -> {
+        bindings.worker.post(() -> {
             List<Object> outcome = new ArrayList<>();
             for (ConfigurationItem ci : configurationParams.getItems()) {
                 outcome.add(null);


### PR DESCRIPTION
This one:
- Admits all `SemanticTokenTypes` and `SemanticTokenModifiers` in the LSP specification.
- Adds a RequestProcessor in LSPBindings so:
    - requests to different LSP servers (say TypeScript and C++) are handled independently in different threads and don't block each other 
    - and requests to the same LSP server (say Typescript) are properly sequenced (so `LSPBindings`, `BreadcrumbsImpl`, `LanguageClientImpl` and `TextDocumentSyncServerCapabilityHandler` work together in harmony, closing #3812 ).