### PR TITLE
Cleanup raw type warnings related to WeakReference.

### DIFF
--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/web/DDProvider.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/web/DDProvider.java
@@ -107,7 +107,7 @@ public final class DDProvider {
                         // preparsing
                         error = parse(fo);
                         original = DDUtils.createWebApp(fo, version);
-                        baseBeanMap.put(fo.toURL(), new WeakReference(original));
+                        baseBeanMap.put(fo.toURL(), new WeakReference<>(original));
                         errorMap.put(fo.toURL(), error);
                     }
                 } else {
@@ -155,7 +155,7 @@ public final class DDProvider {
             if (cached != null) {
                 return cached;
             }
-            ddMap.put(fo.toURL(), new WeakReference(webApp));
+            ddMap.put(fo.toURL(), new WeakReference<>(webApp));
         }
         return webApp;
     }
@@ -189,7 +189,7 @@ public final class DDProvider {
     }
     
     private WebAppProxy getFromCache(FileObject fo) throws IOException {
-        WeakReference wr = (WeakReference) ddMap.get(fo.toURL());
+        WeakReference<WebAppProxy> wr = ddMap.get(fo.toURL());
         if (wr == null) {
             return null;
         }
@@ -201,7 +201,7 @@ public final class DDProvider {
     }
     
     private WebApp getOriginalFromCache(FileObject fo) throws IOException {
-        WeakReference wr = (WeakReference) baseBeanMap.get(fo.toURL());
+        WeakReference<WebApp> wr = baseBeanMap.get(fo.toURL());
         if (wr == null) {
             return null;
         }        
@@ -290,7 +290,7 @@ public final class DDProvider {
                                     webApp.setStatus(WebApp.STATE_INVALID_OLD_VERSION);
                                     webApp.setError(null);
                                 }
-                                baseBeanMap.put(fo.toURL(), new WeakReference(original));
+                                baseBeanMap.put(fo.toURL(), new WeakReference<>(original));
                                 errorMap.put(fo.toURL(), webApp.getError());
                                 webApp.merge(original, WebApp.MERGE_UPDATE);
                             } catch (SAXException ex) {
@@ -314,7 +314,7 @@ public final class DDProvider {
                                     if (original.getClass().equals(orig.getClass())) {
                                         orig.merge(original,WebApp.MERGE_UPDATE);
                                     } else {
-                                        baseBeanMap.put(fo.toURL(), new WeakReference(original));
+                                        baseBeanMap.put(fo.toURL(), new WeakReference<>(original));
                                     }
                                 }
                             } catch (SAXException ex) {

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/DDMultiViewDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/DDMultiViewDataObject.java
@@ -48,7 +48,6 @@ public abstract class DDMultiViewDataObject extends XmlMultiViewDataObject
         implements DDProviderDataObject {
 
 
-    private WeakReference transactionReference = null;
     private static final int HANDLE_UNPARSABLE_TIMEOUT = 2000;
     private DDMultiViewDataObject.ModelSynchronizer modelSynchronizer;
 
@@ -91,9 +90,6 @@ public abstract class DDMultiViewDataObject extends XmlMultiViewDataObject
     }
 
     public void writeModel(RootInterface model) throws IOException {
-        if (transactionReference != null && transactionReference.get() != null) {
-            return;
-        }
         FileLock dataLock = waitForLock();
         if (dataLock == null) {
             return;
@@ -168,27 +164,6 @@ public abstract class DDMultiViewDataObject extends XmlMultiViewDataObject
      * Method is called before switching to the design view from XML view when the document isn't parseable.
      */
     protected abstract boolean isDocumentParseable();
-
-//    public Transaction openTransaction() {
-//        final XmlMultiViewDataSynchronizer.Transaction synchronizerTransaction = getModelSynchronizer().openTransaction();
-//        if (synchronizerTransaction == null) {
-//            return null;
-//        } else {
-//            Transaction transaction = new Transaction() {
-//                public void rollback() {
-//                    synchronizerTransaction.rollback();
-//                    transactionReference = null;
-//                }
-//
-//                public void commit() throws IOException {
-//                    synchronizerTransaction.commit();
-//                    transactionReference = null;
-//                }
-//            };
-//            transactionReference = new WeakReference(transaction);
-//            return transaction;
-//        }
-//    }
 
     private class ModelSynchronizer extends XmlMultiViewDataSynchronizer {
         private long handleUnparseableTimeout = 0;

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/AbstractDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/AbstractDiskCache.java
@@ -67,7 +67,7 @@ public abstract class AbstractDiskCache<K, T extends Serializable> {
     public final synchronized void storeData(T data) {
         CacheEntry<T> entry = new CacheEntry<>(this, data);
         if (doStoreEntry(entry)) {
-            entryRef = new WeakReference(entry);        
+            entryRef = new WeakReference<>(entry);        
         }
     }
 

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/RepositoryImpl.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/RepositoryImpl.java
@@ -521,7 +521,7 @@ public final class RepositoryImpl<R, Q, I> {
             return w;
         }
         
-        public WeakReference get(DATA key, WRAPPER w) {
+        public WeakReference<WRAPPER> get(DATA key, WRAPPER w) {
             return super.put(key, new MapReference(key, w)); 
         }
         

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataObject.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataObject.java
@@ -66,7 +66,7 @@ public abstract class XmlMultiViewDataObject extends MultiDataObject implements 
     private final DataCache dataCache = new DataCache();
     private EncodingHelper encodingHelper = new EncodingHelper();
     private transient long timeStamp = 0;
-    private transient WeakReference lockReference;
+    private transient WeakReference<FileLock> lockReference;
     
     
     private MultiViewElement activeMVElement;
@@ -497,7 +497,7 @@ public abstract class XmlMultiViewDataObject extends MultiDataObject implements 
                     throw new FileAlreadyLockedException("File is already locked by [" + current + "]."); // NO18N
                 }
                 FileLock l = new FileLock();
-                lockReference = new WeakReference(l);
+                lockReference = new WeakReference<>(l);
                 return l;
             }
         }

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookieImpl.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookieImpl.java
@@ -530,7 +530,7 @@ public class TreeEditorCookieImpl implements TreeEditorCookie, UpdateDocumentCoo
     /*
      * Reference which remembers which editor created stored TreeDocumentRoot.
      */
-    private class TreeReference extends WeakReference implements Runnable {
+    private class TreeReference extends WeakReference<TreeDocumentRoot> implements Runnable {
         
         TreeReference (TreeDocumentRoot root) {
             super(root, Utilities.activeReferenceQueue());
@@ -564,7 +564,7 @@ public class TreeEditorCookieImpl implements TreeEditorCookie, UpdateDocumentCoo
 
     public static class CookieFactoryImpl extends CookieFactory {
     
-        private WeakReference editor;
+        private WeakReference<TreeEditorCookieImpl> editor;
 
         private final XMLDataObjectLook dobj;   // used while creating the editor
         
@@ -604,7 +604,7 @@ public class TreeEditorCookieImpl implements TreeEditorCookie, UpdateDocumentCoo
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("Initializing TreeEditorCookieImpl ..."); // NOI18N
 
             TreeEditorCookieImpl cake = new TreeEditorCookieImpl (dobj);
-            editor = new WeakReference (cake);
+            editor = new WeakReference<>(cake);
             return cake;
         }
 

--- a/ide/xml/src/org/netbeans/modules/xml/DTDDataObject.java
+++ b/ide/xml/src/org/netbeans/modules/xml/DTDDataObject.java
@@ -59,7 +59,7 @@ public final class DTDDataObject extends MultiDataObject implements XMLDataObjec
     private static final long serialVersionUID = 2890472952957502631L;
 
     /** Synchronization implementation delegate. */
-    private Reference<XMLSyncSupport> refSync;
+    private Reference<Synchronizator> refSync;
     
     /** Cookie Manager */
     private final DataObjectCookieManager cookieManager;
@@ -143,7 +143,7 @@ public final class DTDDataObject extends MultiDataObject implements XMLDataObjec
             return sync;
         }
         sync = new DTDSyncSupport(this);       
-        refSync = new WeakReference(sync);
+        refSync = new WeakReference<>(sync);
         return sync;
     }
 

--- a/ide/xml/src/org/netbeans/modules/xml/XMLDataObject.java
+++ b/ide/xml/src/org/netbeans/modules/xml/XMLDataObject.java
@@ -80,7 +80,7 @@ public final class XMLDataObject extends org.openide.loaders.XMLDataObject
     private static final long serialVersionUID = 9153823984913876866L;
     
     /** Synchronization implementation delegate. */
-    private Reference<XMLSyncSupport> refSync;
+    private Reference<Synchronizator> refSync;
     
     /** Cookie Manager */
     private final DataObjectCookieManager cookieManager;
@@ -256,7 +256,7 @@ public final class XMLDataObject extends org.openide.loaders.XMLDataObject
             return sync;
         }
         sync = new XMLSyncSupport(this);
-        refSync = new WeakReference(sync);
+        refSync = new WeakReference<>(sync);
         return sync;
     }
 

--- a/ide/xml/src/org/netbeans/modules/xml/text/TextEditorSupport.java
+++ b/ide/xml/src/org/netbeans/modules/xml/text/TextEditorSupport.java
@@ -703,7 +703,7 @@ public class TextEditorSupport extends DataEditorSupport implements EditorCookie
      */
     public static class TextEditorSupportFactory implements CookieSet.Factory {
         /** */
-        private WeakReference editorRef;
+        private WeakReference<TextEditorSupport> editorRef;
         /** */
         private final XMLDataObjectLook dataObject; // used while creating the editor
         /** */
@@ -768,7 +768,7 @@ public class TextEditorSupport extends DataEditorSupport implements EditorCookie
                     return editorSupport;
                 }
                 editorSupport = prepareEditor();
-                editorRef = new WeakReference(editorSupport);
+                editorRef = new WeakReference<>(editorSupport);
             }
             editorSupport.syncMimeType();
             return editorSupport;

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
@@ -284,14 +284,14 @@ public class DebuggerAntLogger extends AntLogger {
     private Map<AntDebugger, AntSession> runningDebuggers2 = new HashMap<>();
     private Set<File> filesToDebug = new HashSet<>();
     /** File => WeakReference -> ExecutorTask */
-    private Map<File, WeakReference> fileExecutors = new HashMap<>();
+    private Map<File, WeakReference<ExecutorTask>> fileExecutors = new HashMap<>();
     
     void debugFile (File f) {
         filesToDebug.add (f);
     }
     
     void fileExecutor(File f, ExecutorTask execTask) {
-        fileExecutors.put(f, new WeakReference(execTask));
+        fileExecutors.put(f, new WeakReference<>(execTask));
     }
     
     private void finishDebugging (

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataProvider.java
@@ -53,7 +53,7 @@ public class DBMetaDataProvider {
     // must be a weak reference -- we don't want to prevent the connection from being GCd
     // it is OK to be a weak reference -- the connection is hold strongly by the DB Explorer
     // while connected
-    private final Reference/*<Connection>*/ conn;
+    private final Reference<Connection> conn;
     private final String driverClass;
     
     private Map/*<String, Catalog>*/ catalogs;
@@ -76,7 +76,7 @@ public class DBMetaDataProvider {
     }
     
     public DBMetaDataProvider(Connection conn, String driverClass) {
-        this.conn = new WeakReference(conn);
+        this.conn = new WeakReference<>(conn);
         this.driverClass = driverClass;
     }
     

--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParser.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParser.java
@@ -399,7 +399,7 @@ public class DeclarativeHintsParser {
     /**
      * Marker that javac api is not available.
      */
-    private static final Reference<ClassPath> NONE = new WeakReference(null);
+    private static final Reference<ClassPath> NONE = new WeakReference<>(null);
     
     private static ClassPath getJavacApiJarClasspath() {
         Reference<ClassPath> r = javacApiClasspath;

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/OpenProjectFastIndex.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/OpenProjectFastIndex.java
@@ -129,7 +129,7 @@ class OpenProjectFastIndex implements ClassIndexManagerListener {
      * will be released. The collection is shared between all scheduled Watchers.
      */
     // @GuardedBy(self)
-    private Reference<Set<FileObject>> removedRoots;
+    private Reference<Collection<FileObject>> removedRoots;
     
     /**
      * Cached project information. Added at the first request for project icon or name,
@@ -287,9 +287,11 @@ class OpenProjectFastIndex implements ClassIndexManagerListener {
         if (watcher != null) {
             return watcher;
         }
-        Collection removed = removedRoots == null ? null : removedRoots.get();
+
+        Collection<FileObject> removed = removedRoots == null ? null : removedRoots.get();
+
         if (removed == null) {
-            removedRoots = new WeakReference(removed = new HashSet<FileObject>());
+            removedRoots = new WeakReference<Collection<FileObject>>(removed = new HashSet<>());
         }
         watcher = new ProjectOpenWatcher(f, removed);
         watchCount++;
@@ -552,7 +554,7 @@ class OpenProjectFastIndex implements ClassIndexManagerListener {
         
         NameIndex(Project p, FileObject root, String files, List<Object[]> indices) {
             this.project = p;
-            this.root = new WeakReference(root);
+            this.root = new WeakReference<>(root);
             this.size = indices.size();
             this.fileNames = files;
             

--- a/platform/openide.compat/src/org/openide/util/WeakListener.java
+++ b/platform/openide.compat/src/org/openide/util/WeakListener.java
@@ -918,14 +918,14 @@ public abstract class WeakListener implements java.util.EventListener {
 
     /** Reference that also holds ref to WeakListener.
     */
-    private static final class ListenerReference extends WeakReference implements Runnable {
+    private static final class ListenerReference<T> extends WeakReference<T> implements Runnable {
         private static Class lastClass;
         private static String lastMethodName;
         private static Method lastRemove;
         private static Object LOCK = new Object();
         final WeakListener weakListener;
 
-        public ListenerReference(Object ref, WeakListener weakListener) {
+        public ListenerReference(T ref, WeakListener weakListener) {
             super(ref, Utilities.activeReferenceQueue());
             this.weakListener = weakListener;
         }

--- a/platform/openide.filesystems/src/org/openide/filesystems/Repository.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/Repository.java
@@ -441,7 +441,7 @@ public class Repository implements Serializable {
             synchronized (Repository.class) {
                 if (lastDefLookup == c) {
                     lastLocalProvider = q;
-                    lastDefLookup = new WeakReference(lkp);
+                    lastDefLookup = new WeakReference<>(lkp);
                 }
             }
         }
@@ -459,7 +459,7 @@ public class Repository implements Serializable {
     static synchronized void reset() {
         repository = null;
         lastLocalProvider = null;
-        lastDefLookup = new WeakReference(null);
+        lastDefLookup = new WeakReference<>(null);
     }
     private static final ThreadLocal<FileSystem[]> ADD_FS = new ThreadLocal<FileSystem[]>();
     private static boolean addFileSystemDelayed(FileSystem fs) {

--- a/platform/sampler/src/org/netbeans/modules/sampler/SamplesOutputStream.java
+++ b/platform/sampler/src/org/netbeans/modules/sampler/SamplesOutputStream.java
@@ -195,7 +195,7 @@ class SamplesOutputStream {
                 stack[i] = oldStackRef.get();
                 assert stack[i] != null;
             } else {
-                steCache.put(ste, new WeakReference(ste));
+                steCache.put(ste, new WeakReference<>(ste));
             }
         }
     }

--- a/websvccommon/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModelerFactory.java
+++ b/websvccommon/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModelerFactory.java
@@ -34,7 +34,7 @@ public class WsdlModelerFactory {
     
     /** Creates a new instance of WsdlModelerFactory */
     private WsdlModelerFactory() {
-        modelers = new WeakHashMap<URL, WeakReference<WsdlModeler>>(5);
+        modelers = new WeakHashMap<>(5);
     }
     
     /**
@@ -56,7 +56,7 @@ public class WsdlModelerFactory {
                 return modeler;
             }
             modeler = new WsdlModeler(wsdlUrl);
-            modelers.put(wsdlUrl, new WeakReference<WsdlModeler>(modeler));
+            modelers.put(wsdlUrl, new WeakReference<>(modeler));
         }
         return modeler;
     }
@@ -65,7 +65,7 @@ public class WsdlModelerFactory {
         if (url == null) {
             return null;
         }
-        WeakReference wr = modelers.get(url);
+        WeakReference<WsdlModeler> wr = modelers.get(url);
         if (wr == null) {
             return null;
         }


### PR DESCRIPTION
Cleanup raw type warnings related to WeakReference.

   [repeat] /home/bwalker/src/netbeans/platform/openide.compat/src/org/openide/util/WeakListener.java:921: warning: [rawtypes] found raw type: WeakReference
   [repeat]     private static final class ListenerReference extends WeakReference implements Runnable {
   [repeat]                                                          ^
   [repeat]   missing type arguments for generic class WeakReference<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in class WeakReference
   [repeat] /home/bwalker/src/netbeans/platform/openide.compat/src/org/openide/util/WeakListener.java:922: warning: [rawtypes] found raw type: Class
   [repeat]         private static Class lastClass;
   [repeat]                        ^
   [repeat]   missing type arguments for generic class Class<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in class Class

This work is done project wide. There are 3 remaining warnings that I was unable to get resolved. They will have to wait until later.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

