### PR TITLE
[3911] Filter source roots to avoids clashes between module-info files.

### DIFF
--- a/java/java.platform/src/org/netbeans/modules/java/platform/classpath/PlatformClassPathProvider.java
+++ b/java/java.platform/src/org/netbeans/modules/java/platform/classpath/PlatformClassPathProvider.java
@@ -78,9 +78,13 @@ public class PlatformClassPathProvider implements ClassPathProvider {
             ClassPath libraryPath = jp.getStandardLibraries();
             ClassPath sourcePath = jp.getSourceFolders();
             FileObject root = null;
+            boolean jdk9 = JAVA_9.compareTo(jp.getSpecification().getVersion()) <= 0;
             if (ClassPath.SOURCE.equals(type) && sourcePath != null &&
                 (root = sourcePath.findOwnerRoot(fo))!=null) {
                 this.setLastUsedPlatform (root,jp);
+                if (jdk9) {
+                    return ClassPathSupport.createClassPath(root);
+                }
                 return sourcePath;
             } else if (ClassPath.BOOT.equals(type) &&
                     (root = getArtefactOwner(fo, bootClassPath, libraryPath, sourcePath)) != null ) {
@@ -96,7 +100,7 @@ public class PlatformClassPathProvider implements ClassPathProvider {
                     return this.getEmptyClassPath ();
                 }
             } else if (JavaClassPathConstants.MODULE_BOOT_PATH.equals(type)  &&
-                    JAVA_9.compareTo(jp.getSpecification().getVersion()) <= 0 &&
+                    jdk9 &&
                     (root = getArtefactOwner(fo, bootClassPath, libraryPath, sourcePath)) != null) {
                 this.setLastUsedPlatform (root,jp);
                 return bootClassPath;


### PR DESCRIPTION
The source path currently contains directories for all modules, and the compiler is confused and reads wrong `module-info.java`. As an attempt to fix this, lets try to filter the source path to contain only the one appropriate source root, and lets see how it works.
