### PR TITLE
Remove IDE defaults from NBLS distribution.

### DIFF
--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -122,6 +122,7 @@ disabled.modules=\
     org.netbeans.modules.debugger.jpda.kit,\
     org.netbeans.modules.debugger.jpda.trufflenode,\
     org.netbeans.modules.debugger.jpda.visual,\
+    org.netbeans.modules.default,\
     org.netbeans.modules.derby,\
     org.netbeans.modules.dlight.nativeexecution.nb,\
     org.netbeans.modules.dlight.terminal,\


### PR DESCRIPTION
This is a very simple change - just removing `ide/defaults` module from NBLS distribution. The module contains shortcuts and color definitions, which are not needed at all in the headless case. But those definitions reference actual actions that might not be included and they print exceptions to log in various situations where the registrations are lazy-loaded.

