### PR TITLE
cancel previous CI run on repeated PR update.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,12 @@ on:
   push:
   pull_request:
 
+# cancel PR workflow run if PR is updated while jobs are still running
+# if this is not a PR run (no github.head_ref defined), it won't be affected
+concurrency: 
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
     
 # primary build job, most other jobs use the artifact produced here


### PR DESCRIPTION
testing...
looks like it worked

I force pushed while this was running:
https://github.com/apache/netbeans/actions/runs/2097239880
which got canceled and the next run started:
https://github.com/apache/netbeans/actions/runs/2097326632

possible risks:
- the new run will remain queued while the old is being canceled, it might not be able to kill all jobs right away
- you will get a mail :)