### PR TITLE
Fix project load caching

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -477,9 +477,10 @@ public final class NbGradleProjectImpl implements Project {
                     this.loading = null;
                 }
             }
+            f.complete(prj);
             LOG.log(Level.FINER, "Firing changes/reload synchronously");
             ACCESSOR.doFireReload(watcher);
-            return CompletableFuture.completedFuture(prj);
+            return f;
         } else {
             LOG.log(Level.FINER, "Firing changes/reload in RP");
             RELOAD_RP.post(() -> callAccessorReload(f, prj));
@@ -494,8 +495,8 @@ public final class NbGradleProjectImpl implements Project {
                     this.loading = null;
                 }
             }
-            ACCESSOR.doFireReload(watcher);
             f.complete(prj);
+            ACCESSOR.doFireReload(watcher);
         } catch (ThreadDeath t) {
             throw t;
         } catch (RuntimeException | Error ex) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
@@ -156,10 +156,19 @@ class GradleBaseProjectBuilder implements ProjectInfoExtractor.Result {
 
         Map<String, Set<File>> arts = (Map<String, Set<File>>) info.get("resolved_jvm_artifacts");
         arts = arts != null ? arts : Collections.<String, Set<File>>emptyMap();
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.log(Level.FINER, "Resolved JVM artifacts: {0}", arts.toString().replace(",", "\n\t"));
+        }
         Map<String, Set<File>> sources = (Map<String, Set<File>>) info.get("resolved_sources_artifacts");
         sources = sources != null ? sources : Collections.<String, Set<File>>emptyMap();
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.log(Level.FINER, "Resolved source artifacts: {0}", sources.toString().replace(",", "\n\t"));
+        }
         Map<String, Set<File>> javadocs = (Map<String, Set<File>>) info.get("resolved_javadoc_artifacts");
         javadocs = javadocs != null ? javadocs : Collections.<String, Set<File>>emptyMap();
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.log(Level.FINER, "Resolved javadoc artifacts: {0}", javadocs.toString().replace(",", "\n\t"));
+        }
 
         Map<String, String> unresolvedProblems = (Map<String, String>) info.get("unresolved_problems");
         unresolvedProblems = unresolvedProblems != null ? unresolvedProblems : Collections.<String, String>emptyMap();
@@ -171,33 +180,56 @@ class GradleBaseProjectBuilder implements ProjectInfoExtractor.Result {
         GradleArtifactStore store = GradleArtifactStore.getDefault();
         for (Map.Entry<String, Set<File>> entry : arts.entrySet()) {
             String componentId = entry.getKey();
+            LOG.log(Level.FINER, "Resolving JVM artifact {0}", componentId);
             // Looking at cache first as we might have the chance to find Sources and Javadocs
             ModuleDependency dep = resolveModuleDependency(gradleUserHome, componentId);
             if (!dep.getArtifacts().equals(entry.getValue())) {
+                if (LOG.isLoggable(Level.FINER)) {
+                    LOG.log(Level.FINER, "Created component {0} from JVM artifacts: {1}", new Object[] { componentId, entry.getValue() });
+                }
                 dep = new ModuleDependency(componentId, entry.getValue());
             }
             components.put(componentId, dep);
+            if (LOG.isLoggable(Level.FINER) && dep.sources != null && !dep.sources.isEmpty()) {
+                LOG.log(Level.FINER, "Replacing sources for {0} sources from {1}, used to be {2}", new Object[] {
+                    componentId, sources.containsKey(componentId) ? "resolvedSources" : "artifactStore", dep.sources
+                });
+            }
             if (sources.containsKey(componentId)) {
                 dep.sources = sources.get(entry.getKey());
             } else {
                 dep.sources = store.getSources(entry.getValue());
+            }
+            if (LOG.isLoggable(Level.FINER) && dep.javadoc != null && !dep.javadoc.isEmpty()) {
+                LOG.log(Level.FINER, "Replacing javadocs for {0} from {1}, used to be {2}", new Object[] {
+                    componentId, javadocs.containsKey(componentId) ? "resolvedJavadocs" : "artifactStore", dep.javadoc
+                });
             }
             if (javadocs.containsKey(componentId)) {
                 dep.javadoc = javadocs.get(entry.getKey());
             } else {
                 dep.javadoc = store.getJavadocs(entry.getValue());                
             }
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.log(Level.FINER, "Done component: {0} -> {1}", new Object[] { componentId, dep });
+            }
         }
         Map<String, ProjectDependency> projects = new HashMap<>();
         for (Map.Entry<String, File> entry : prjs.entrySet()) {
             ProjectDependency dep = new ProjectDependency(entry.getKey(), entry.getValue());
             projects.put(entry.getKey(), dep);
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.log(Level.FINER, "Added project dependency: {0} -> {1} ", new Object[] { entry.getKey(), dep });
+            }
         }
         Map<String, UnresolvedDependency> unresolved = new HashMap<>();
         for (Map.Entry<String, String> entry : unresolvedProblems.entrySet()) {
             UnresolvedDependency dep = new UnresolvedDependency(entry.getKey());
             dep.problem = entry.getValue();
             unresolved.put(entry.getKey(), dep);
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.log(Level.FINER, "Adding UNRESOLVED dependency: {0} -> {1}", new Object[] { entry.getKey(), dep });
+            }
         }
         if (configurationNames != null) {
             for (String name : configurationNames) {
@@ -210,9 +242,11 @@ class GradleBaseProjectBuilder implements ProjectInfoExtractor.Result {
                     for (String c : requiredComponents) {
                         ModuleDependency dep = components.get(c);
                         if (dep != null) {
+                            LOG.log(Level.FINER, "Configuration {0}, known component {1}", new Object[] { conf.getName(), dep });
                             conf.modules.add(dep);
                         } else {
                             dep = resolveModuleDependency(gradleUserHome, c);
+                            LOG.log(Level.FINER, "Configuration {0}, resolved to {1}", new Object[] { conf.getName(), dep });
                             if (dep != null) {
                                 components.put(c, dep);
                                 conf.modules.add(dep);
@@ -289,13 +323,24 @@ class GradleBaseProjectBuilder implements ProjectInfoExtractor.Result {
             GradleModuleFileCache21.CachedArtifactVersion artVersion = moduleCache.resolveModule(c);
             Set<File> binaries = artifactSore.getBinaries(c);
             if (((binaries == null) || binaries.isEmpty()) && (artVersion.getBinary() != null)) {
+                LOG.log(Level.FINER, "Resolving component {0} from module21: {0}", artVersion.getBinary());
                 binaries = Collections.singleton(artVersion.getBinary().getPath().toFile());
+            } else {
+                if (LOG.isLoggable(Level.FINER)) {
+                    LOG.log(Level.FINER, "Resolving component {0} from artifactstore: {0}", new Object[] { c, binaries });
+                }
             }
             ModuleDependency ret = new ModuleDependency(c, binaries);
             if (artVersion.getSources() != null) {
+                if (LOG.isLoggable(Level.FINER)) {
+                    LOG.log(Level.FINER, "Resolving sources {0} from module21: {0}", new Object[] { c, artVersion.getSources().getPath() });
+                }
                 ret.sources = Collections.singleton(artVersion.getSources().getPath().toFile());
             }
             if (artVersion.getJavaDoc() != null) {
+                if (LOG.isLoggable(Level.FINER)) {
+                    LOG.log(Level.FINER, "Resolving javadoc {0} from module21: {0}", new Object[] { c, artVersion.getJavaDoc().getPath() });
+                }
                 ret.javadoc = Collections.singleton(artVersion.getJavaDoc().getPath().toFile());
             }
             return ret;

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleArtifactStore.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleArtifactStore.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -147,8 +148,9 @@ public class GradleArtifactStore {
                 Set<File> oldBins = binaries.get(module.getId());
                 Set<File> newBins = module.getArtifacts();
                 gavs.add(module.getId());
-                if (oldBins != newBins) {
+                if (!Objects.equals(oldBins, newBins)) {
                     binaries.put(module.getId(), newBins);
+                    LOG.log(Level.FINER, "Updating JAR {0} to {1}", new Object[] { module.getId(), newBins });
                     changed = true;
                 }
                 if (module.getArtifacts().size() == 1) {
@@ -157,14 +159,21 @@ public class GradleArtifactStore {
                         File source = module.getSources().iterator().next();
                         if (binary.isFile() && source.isFile()) {
                             File old = sources.put(binary, source);
-                            changed |= (old == null) || !old.equals(source);
+                            boolean c = (old == null) || !old.equals(source);
+                            if (c && LOG.isLoggable(Level.FINER)) {
+                                LOG.log(Level.FINER, "Updating source {0} to {1}", new Object[] { module.getId(), source });
+                            }
+                            changed |= c;
                         }
                     }
                     if (module.getJavadoc().size() == 1) {
                         File javadoc = module.getJavadoc().iterator().next();
                         if (binary.isFile() && javadoc.isFile()) {
                             File old = javadocs.put(binary, javadoc);
-                            changed |= (old == null) || !old.equals(javadoc);
+                            boolean c = (old == null) || !old.equals(javadoc);
+                            if (c && LOG.isLoggable(Level.FINER)) {
+                                LOG.log(Level.FINER, "Updating javadoc {0} to {1}", new Object[] { module.getId(), javadoc });
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The goal of this PR is to ensure that sample project (`micronaut-core` was used) is loaded through Gradle daemon just for the first time and second time it is opened is loaded solely from the cache, provided the buildscripts did not change.

In fact currently the project loads each time because of several issues - explanations are done inline in the diff. Please review carefully. Overview:
- race condition in project load. 2nd opinion of fix strategy is needed here.
- excluded more configuration, useless from the (current state of the) IDE - we have only rudimentary support for Kotlin
- artifacts files fetched recursively, similar to modules, to populate `jvm_resolved_artifacts`
- excluded abstract modules that only serve as variant selectors
- artifact cache logic fixes

I've added a 'development feature' - if the loglevel is set to FINER or above, the output from the Gradle daemon will be redirected to IDE's log. If eventually the `NbProjectInfoBuilder` prints some diagnostic messages, they will be visible in the log. If the log is set to `FINEST`, gradle daemon gets `--debug` to spam the log with gradle's own debugging.
