### PR TITLE
readme updates (fixed links) + new log/config/cache section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Apache NetBeans is an open source development environment, tooling platform, and
 
 ### Build status
    * GitHub actions
-     * [![Build Status](https://github.com/apache/netbeans/actions/workflows/main.yml/badge.svg)](https://github.com/apache/netbeans/actions/workflows/main.yml)
-     * [![Profiler Lib Native Binaries](https://github.com/apache/netbeans/actions/workflows/native-binary-build-lib.profiler.yml/badge.svg)](https://github.com/apache/netbeans/actions/workflows/native-binary-build-lib.profiler.yml)
+     * [![Build Status](https://github.com/apache/netbeans/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/apache/netbeans/actions/workflows/main.yml)
+     * [![Profiler Lib Native Binaries](https://github.com/apache/netbeans/actions/workflows/native-binary-build-lib.profiler.yml/badge.svg?branch=master)](https://github.com/apache/netbeans/actions/workflows/native-binary-build-lib.profiler.yml)
    * TravisCI:
      * [![Build Status](https://app.travis-ci.com/apache/netbeans.svg?branch=master)](https://app.travis-ci.com/apache/netbeans)
    * Apache Jenkins:
@@ -39,8 +39,7 @@ Apache NetBeans is an open source development environment, tooling platform, and
 
   * Git
   * Ant 1.9.9 or above
-  * JDK 11 (to build NetBeans)
-  * JDK 11 or above (to run NetBeans)
+  * JDK 11 or above (to build and run NetBeans)
   * MinGW (optional), to build Windows Launchers
 
 #### Notes:
@@ -112,13 +111,26 @@ $ ant tryme
 
 ### Download
 
-Developer builds can be downloaded: [Latest build (netbeans-xxx.zip)](https://ci-builds.apache.org/job/Netbeans/job/netbeans-linux/lastSuccessfulBuild/artifact/nbbuild/NetBeans-dev-Netbeans/).
+Developer builds can be downloaded: [Latest build (netbeans-xxx.zip)](https://ci-builds.apache.org/job/Netbeans/job/netbeans-linux/lastSuccessfulBuild/artifact/nbbuild/).
 
-Convenience binary of released source artifacts: https://netbeans.apache.org/download/index.html.
+Latest release (convenience binary of released source artifacts): https://netbeans.apache.org/download/index.html.
 
 ### Reporting Bugs
 
-Bugs should be reported to https://issues.apache.org/jira/projects/NETBEANS/issues/
+Bugs should be reported to https://github.com/apache/netbeans/issues
+
+### Log, Config and Cache Locations
+
+ * start config (JVM settings, default JDK, userdir, cachedir location and more):  
+   `netbeans/etc/netbeans.conf`
+ * user settings storage (preferences, installed plugins, logs):  
+   system dependent, see `Help -> About` for concrete location
+ * cache files (maven index, search index etc):  
+   system dependent, see `Help -> About` for concrete location
+ * default log location (tip: can be inspected via `View -> IDE Log`):  
+   `$DEFAULT_USERDIR_ROOT/var/log/messages.log`
+
+**Note:** removing/changing the user settings directory will reset NetBeans to first launch defaults
 
 ### Full History
 


### PR DESCRIPTION
added section to the readme which lists config/log/cache locations. Easily linkable to users which have configuration issues. Fixed some old or broken links.

preview link: https://github.com/mbien/netbeans/tree/readme-updates#log-config-and-cache-locations