### PR TITLE
Action to create a method breakpoint on a stackframe

### DIFF
--- a/java/debugger.jpda.ui/nbproject/project.properties
+++ b/java/debugger.jpda.ui/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 cp.extra=${tools.jar}
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 requires.nb.javac=true
 

--- a/java/debugger.jpda.ui/nbproject/project.xml
+++ b/java/debugger.jpda.ui/nbproject/project.xml
@@ -227,7 +227,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>6.2</specification-version>
+                        <specification-version>7.61</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/CallStackActionsProvider.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/CallStackActionsProvider.java
@@ -58,10 +58,11 @@ public class CallStackActionsProvider implements NodeActionsProvider {
     
     private JPDADebugger    debugger;
     private ContextProvider lookupProvider;
-    private Action          POP_TO_HERE_ACTION;
-    private Action          MAKE_CURRENT_ACTION;
-    private Action          COPY_TO_CLBD_ACTION;
-    private Action          GO_TO_SOURCE_ACTION;
+    private final Action POP_TO_HERE_ACTION;
+    private final Action MAKE_CURRENT_ACTION;
+    private final Action COPY_TO_CLBD_ACTION;
+    private final Action GO_TO_SOURCE_ACTION;
+    private final Action ADD_BREAKPOINT_ACTION;
 
 
     public CallStackActionsProvider (ContextProvider lookupProvider) {
@@ -72,6 +73,7 @@ public class CallStackActionsProvider implements NodeActionsProvider {
         MAKE_CURRENT_ACTION = createMAKE_CURRENT_ACTION(requestProcessor);
         COPY_TO_CLBD_ACTION = createCOPY_TO_CLBD_ACTION(requestProcessor);
         GO_TO_SOURCE_ACTION = DebuggingActionsProvider.createGO_TO_SOURCE_ACTION(requestProcessor);
+        ADD_BREAKPOINT_ACTION = DebuggingActionsProvider.createBREAKPOINT(requestProcessor);
     }
     
 
@@ -133,12 +135,14 @@ public class CallStackActionsProvider implements NodeActionsProvider {
             return new Action [] {
                 MAKE_CURRENT_ACTION,
                 POP_TO_HERE_ACTION,
+                ADD_BREAKPOINT_ACTION,
                 GO_TO_SOURCE_ACTION,
                 COPY_TO_CLBD_ACTION
             };
         } else {
             return new Action [] {
                 MAKE_CURRENT_ACTION,
+                ADD_BREAKPOINT_ACTION,
                 GO_TO_SOURCE_ACTION,
                 COPY_TO_CLBD_ACTION
             };

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingActionsProvider.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingActionsProvider.java
@@ -25,14 +25,15 @@ import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JRadioButtonMenuItem;
-import javax.swing.SwingUtilities;
 import org.netbeans.api.debugger.DebuggerEngine;
 import org.netbeans.api.debugger.DebuggerManager;
 import org.netbeans.api.debugger.Session;
@@ -40,8 +41,10 @@ import org.netbeans.api.debugger.jpda.CallStackFrame;
 import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.api.debugger.jpda.JPDAThread;
 import org.netbeans.api.debugger.jpda.JPDAThreadGroup;
+import org.netbeans.api.debugger.jpda.MethodBreakpoint;
 import org.netbeans.modules.debugger.jpda.models.JPDAThreadImpl;
 import org.netbeans.modules.debugger.jpda.ui.SourcePath;
+import org.netbeans.modules.debugger.jpda.ui.breakpoints.MethodBreakpointPanel;
 import org.netbeans.modules.debugger.jpda.ui.debugging.JPDADVThread;
 import org.netbeans.modules.debugger.jpda.ui.debugging.JPDADVThreadGroup;
 import org.netbeans.spi.debugger.ContextProvider;
@@ -52,10 +55,14 @@ import org.netbeans.spi.viewmodel.Models;
 import org.netbeans.spi.viewmodel.NodeActionsProvider;
 import org.netbeans.spi.viewmodel.TreeModel;
 import org.netbeans.spi.viewmodel.UnknownTypeException;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 import org.openide.awt.Mnemonics;
+import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.actions.Presenter;
+import static org.netbeans.modules.debugger.jpda.ui.models.Bundle.*;
 
 
 /**
@@ -69,14 +76,15 @@ public class DebuggingActionsProvider implements NodeActionsProvider {
     private JPDADebugger debugger;
     private Session session;
     private RequestProcessor requestProcessor;
-    private Action POP_TO_HERE_ACTION;
-    private Action MAKE_CURRENT_ACTION;
-    private Action SUSPEND_ACTION;
-    private Action RESUME_ACTION;
-    private Action INTERRUPT_ACTION;
-    private Action COPY_TO_CLBD_ACTION;
-    private Action LANGUAGE_SELECTION;
-    private Action GO_TO_SOURCE_ACTION;
+    private final Action POP_TO_HERE_ACTION;
+    private final Action MAKE_CURRENT_ACTION;
+    private final Action SUSPEND_ACTION;
+    private final Action RESUME_ACTION;
+    private final Action INTERRUPT_ACTION;
+    private final Action COPY_TO_CLBD_ACTION;
+    private final Action LANGUAGE_SELECTION;
+    private final Action GO_TO_SOURCE_ACTION;
+    private final Action ADD_BREAKPOINT_ACTION;
 
 
     public DebuggingActionsProvider (ContextProvider lookupProvider) {
@@ -91,6 +99,7 @@ public class DebuggingActionsProvider implements NodeActionsProvider {
         POP_TO_HERE_ACTION = createPOP_TO_HERE_ACTION(requestProcessor);
         LANGUAGE_SELECTION = new LanguageSelection(session);
         GO_TO_SOURCE_ACTION = createGO_TO_SOURCE_ACTION(requestProcessor);
+        ADD_BREAKPOINT_ACTION = createBREAKPOINT(requestProcessor);
     }
     
 
@@ -190,6 +199,55 @@ public class DebuggingActionsProvider implements NodeActionsProvider {
                             goToSource((CallStackFrame) nodes [0]);
                         }
                     });
+                }
+            },
+            Models.MULTISELECTION_TYPE_EXACTLY_ONE
+
+        );
+    }
+
+    @NbBundle.Messages({
+        "CTL_CallstackAction_Breakpoint_Label=Add &Breakpoint...",
+        "CTL_CallstackAction_Breakpoint_Title=Add a breakpoint",
+    })
+    static final Action createBREAKPOINT(final RequestProcessor async) {
+        return Models.createAction (CTL_CallstackAction_Breakpoint_Label(),
+            new Models.ActionPerformer () {
+                @Override
+                public boolean isEnabled (Object node) {
+                    return node instanceof CallStackFrame;
+                }
+
+                @Override
+                public void perform (final Object[] nodes) {
+                    if (nodes.length == 1 && nodes[0] instanceof CallStackFrame) {
+                        final CompletableFuture<MethodBreakpoint> prepareBreakpoint = CompletableFuture.completedFuture((CallStackFrame) nodes[0]).thenApplyAsync((csf) -> {
+                            final MethodBreakpoint mb = MethodBreakpoint.create(csf.getClassName(), csf.getMethodName());
+                            mb.setMethodName(csf.getMethodName());
+                            mb.setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY | MethodBreakpoint.TYPE_METHOD_EXIT);
+                            return mb;
+                        }, async);
+                        final CompletableFuture<NotifyDescriptor> prepareDialog = prepareBreakpoint.thenComposeAsync((mb) -> {
+                            final MethodBreakpointPanel p = new MethodBreakpointPanel(mb);
+                            final NotifyDescriptor nd = new NotifyDescriptor(p,
+                                    Bundle.CTL_CallstackAction_Breakpoint_Title(),
+                                    NotifyDescriptor.OK_CANCEL_OPTION,
+                                    NotifyDescriptor.QUESTION_MESSAGE,
+                                    null, null
+                            );
+                            return DialogDisplayer.getDefault().notifyFuture(nd);
+                        }, Mutex.EVENT::writeAccess);
+                        prepareDialog.thenAcceptBoth(prepareBreakpoint, (NotifyDescriptor nd, MethodBreakpoint mb) -> {
+                            final MethodBreakpointPanel p = (MethodBreakpointPanel) nd.getMessage();
+                            if (nd.getValue() == NotifyDescriptor.OK_OPTION) {
+                                if (p.ok()) {
+                                    DebuggerManager.getDebuggerManager ().addBreakpoint (mb);
+                                }
+                            } else {
+                                p.cancel();
+                            }
+                        });
+                    }
                 }
             },
             Models.MULTISELECTION_TYPE_EXACTLY_ONE
@@ -422,12 +480,14 @@ public class DebuggingActionsProvider implements NodeActionsProvider {
                 return new Action [] {
                     MAKE_CURRENT_ACTION,
                     POP_TO_HERE_ACTION,
+                    ADD_BREAKPOINT_ACTION,
                     GO_TO_SOURCE_ACTION,
                     COPY_TO_CLBD_ACTION,
                 };
             } else {
                 return new Action [] {
                     MAKE_CURRENT_ACTION,
+                    ADD_BREAKPOINT_ACTION,
                     GO_TO_SOURCE_ACTION,
                     COPY_TO_CLBD_ACTION,
                 };


### PR DESCRIPTION
Often, when debugging, I hit a breakpoint, but I'd like to know what is going to happen later, when the method call returns. Stepping out, is an option, but not really pleasant when there is a deep stack in between top place and the desired frame. NetBeans already supports _method breakpoint_ - just placing it is a huge pain. This PR simplifies that by adding _Add breakpoint..._ action to each `CallStackFrame`:

![image](https://user-images.githubusercontent.com/1842422/162581081-b85fd3c7-b956-4c03-9118-9ce66eb06d1a.png)

One the action is invoked a classical method breakpoint dialog is shown, but with pre-filled class and method names:

![image](https://user-images.githubusercontent.com/1842422/162581138-200bfd29-7aaa-46c2-b287-a842b3d3162e.png)

all one needs to do is to fill for example condition `n == 4` and press OK. When the execution continues, it stops in the desired frame.

This is particularly useful when debugging application without a source code, or written in a different language than Java.
