### PR TITLE
Sync fixes: currentP can be seen as null by workers.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/navigator/TasksPanel.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/navigator/TasksPanel.java
@@ -61,7 +61,7 @@ import org.openide.util.lookup.Lookups;
  *
  * @author Laszlo Kishalmi
  */
-public class TasksPanel extends javax.swing.JPanel implements ExplorerManager.Provider, Runnable {
+public class TasksPanel extends javax.swing.JPanel implements ExplorerManager.Provider {
 
     @StaticResource
     private static final String GRADLE_ICON = "org/netbeans/modules/gradle/resources/gradle.png"; //NOI18
@@ -72,7 +72,7 @@ public class TasksPanel extends javax.swing.JPanel implements ExplorerManager.Pr
     private Project currentP;
     private final PropertyChangeListener pchadapter = (PropertyChangeEvent evt) -> {
         if (NbGradleProject.PROP_PROJECT_INFO.equals(evt.getPropertyName())) {
-            RequestProcessor.getDefault().post(TasksPanel.this);
+            RequestProcessor.getDefault().post(() -> update(currentP));
         }
     };
 
@@ -98,9 +98,6 @@ public class TasksPanel extends javax.swing.JPanel implements ExplorerManager.Pr
     }
 
     void navigate(DataObject d) {
-        if (current != null) {
-            current.removePropertyChangeListener(pchadapter);
-        }
         NbGradleProject n = null;
 
         FileObject f = d.getPrimaryFile();
@@ -117,75 +114,83 @@ public class TasksPanel extends javax.swing.JPanel implements ExplorerManager.Pr
             //Ignore we can't really do anything about this.
         }
 
-        if (n == null) {
-            release();
+        synchronized (this) {
+            if (current != null) {
+                current.removePropertyChangeListener(pchadapter);
+            }
+            if (n == null) {
+                release();
+                return;
+            }
+            current = n;
+            currentP = p;
+            current.addPropertyChangeListener(pchadapter);
+        }
+        RequestProcessor.getDefault().post(() -> update(currentP));
+    }
+
+    public void update(Project updateP) {
+        synchronized (this) {
+            if (updateP != this.currentP) {
+                return;
+            }
+            if (updateP == null) {
+                return;
+            }
+        }
+        GradleBaseProject prj = GradleBaseProject.get(updateP);
+        if (prj != null) {
+            final Children taskGroups = new Children.Array();
+            ArrayList<String> glist = new ArrayList<>(prj.getTaskGroups());
+            glist.remove(GradleBaseProject.PRIVATE_TASK_GROUP);
+            Collections.sort(glist, String.CASE_INSENSITIVE_ORDER);
+
+            for (String group : glist) {
+                taskGroups.add(new Node[]{new TaskGroupNode(group, prj, updateP)});
+            }
+            taskGroups.add(new Node[]{new TaskGroupNode(GradleBaseProject.PRIVATE_TASK_GROUP, prj, updateP)});
+
+            AbstractNode tasksNode = new AbstractNode(taskGroups, Lookups.singleton(updateP)) {
+                @Override
+                public Action[] getActions(boolean context) {
+                    return new Action[0];
+                }
+
+            };
+            tasksNode.setName("tasks"); //NOI18N
+            tasksNode.setDisplayName(Bundle.LBL_Tasks(ProjectUtils.getInformation(updateP).getDisplayName()));
+            tasksNode.setIconBaseWithExtension(GRADLE_ICON);
+
+            AbstractNode favoritesNode = new AbstractNode(new FavoritesChildren()) {
+                @Override
+                public Action[] getActions(boolean context) {
+                    return new Action[0];
+                }
+
+            };
+            favoritesNode.setName("favorites"); //NOI18N
+            favoritesNode.setDisplayName(Bundle.LBL_Favorites());
+            favoritesNode.setIconBaseWithExtension(GRADLE_ICON);
+
+            final Children rootKids = new Children.Array();
+            rootKids.add(new Node[]{favoritesNode, tasksNode});
+            SwingUtilities.invokeLater(() -> {
+                treeView.setScrollsOnExpand(false);
+                treeView.setRootVisible(false);
+                manager.setRootContext(new AbstractNode(rootKids));
+                treeView.expandAll();
+                treeView.setScrollsOnExpand(true);
+            });
             return;
         }
 
-        current = n;
-        currentP = p;
-        current.addPropertyChangeListener(pchadapter);
-        RequestProcessor.getDefault().post(this);
-    }
-
-    @Override
-    public void run() {
-        if (currentP != null) {
-
-            GradleBaseProject prj = GradleBaseProject.get(currentP);
-            if (prj != null) {
-                final Children taskGroups = new Children.Array();
-                ArrayList<String> glist = new ArrayList<>(prj.getTaskGroups());
-                glist.remove(GradleBaseProject.PRIVATE_TASK_GROUP);
-                Collections.sort(glist, String.CASE_INSENSITIVE_ORDER);
-
-                for (String group : glist) {
-                    taskGroups.add(new Node[]{new TaskGroupNode(group, prj)});
-                }
-                taskGroups.add(new Node[]{new TaskGroupNode(GradleBaseProject.PRIVATE_TASK_GROUP, prj)});
-
-                AbstractNode tasksNode = new AbstractNode(taskGroups, Lookups.singleton(currentP)) {
-                    @Override
-                    public Action[] getActions(boolean context) {
-                        return new Action[0];
-                    }
-                    
-                };
-                tasksNode.setName("tasks"); //NOI18N
-                tasksNode.setDisplayName(Bundle.LBL_Tasks(ProjectUtils.getInformation(currentP).getDisplayName()));
-                tasksNode.setIconBaseWithExtension(GRADLE_ICON);
-
-                AbstractNode favoritesNode = new AbstractNode(new FavoritesChildren()) {
-                    @Override
-                    public Action[] getActions(boolean context) {
-                        return new Action[0];
-                    }
-
-                };
-                favoritesNode.setName("favorites"); //NOI18N
-                favoritesNode.setDisplayName(Bundle.LBL_Favorites());
-                favoritesNode.setIconBaseWithExtension(GRADLE_ICON);
-
-                final Children rootKids = new Children.Array();
-                rootKids.add(new Node[]{favoritesNode, tasksNode});
-                SwingUtilities.invokeLater(() -> {
-                    treeView.setScrollsOnExpand(false);
-                    treeView.setRootVisible(false);
-                    manager.setRootContext(new AbstractNode(rootKids));
-                    treeView.expandAll();
-                    treeView.setScrollsOnExpand(true);
-                });
-                return;
-            }
-
-        }
         SwingUtilities.invokeLater(() -> {
             treeView.setRootVisible(false);
             manager.setRootContext(createEmptyNode());
         });
     }
 
-    void release() {
+    synchronized void release() {
         if (current != null) {
             current.removePropertyChangeListener(pchadapter);
         }
@@ -202,13 +207,13 @@ public class TasksPanel extends javax.swing.JPanel implements ExplorerManager.Pr
     }
 
     private class TaskGroupNode extends AbstractNode {
-
+        
         @Messages({
             "LBL_PrivateTasks=Other Tasks"
         })
         @SuppressWarnings("OverridableMethodCallInConstructor")
-        public TaskGroupNode(String group, GradleBaseProject project) {
-            super(new TaskGroupChildren(group, project), Lookup.EMPTY);
+        public TaskGroupNode(String group, GradleBaseProject project, Project genericProject) {
+            super(new TaskGroupChildren(group, project, genericProject), Lookup.EMPTY);
             setName(group);
             String displayName = GradleBaseProject.PRIVATE_TASK_GROUP.equals(group)
                     ? LBL_PrivateTasks()
@@ -238,12 +243,15 @@ public class TasksPanel extends javax.swing.JPanel implements ExplorerManager.Pr
     }
 
     private FavoriteTaskManager getFavoriteTaskManager() {
-        return currentP != null ? currentP.getLookup().lookup(FavoriteTaskManager.class) : null;
+        Project p = currentP;
+        return p != null ? p.getLookup().lookup(FavoriteTaskManager.class) : null;
     }
 
     private class TaskGroupChildren extends Children.Keys<GradleTask> {
-
-        public TaskGroupChildren(String group, GradleBaseProject project) {
+        final Project genericProject;
+        
+        public TaskGroupChildren(String group, GradleBaseProject project, Project genericProject) {
+            this.genericProject = genericProject;
             ArrayList<GradleTask> keys = new ArrayList<>(project.getTasks(group));
             Collections.sort(keys, Comparator.comparing(GradleTask::getName, String.CASE_INSENSITIVE_ORDER));
             setKeys(keys);
@@ -251,7 +259,7 @@ public class TasksPanel extends javax.swing.JPanel implements ExplorerManager.Pr
 
         @Override
         protected Node[] createNodes(GradleTask key) {
-            return new Node[] {new TaskNode(currentP, key)};
+            return new Node[] {new TaskNode(genericProject, key)};
         }
 
     }


### PR DESCRIPTION
The shared variable `currentP` can be sometimes turned to `null` when a worker is already planned (but did not execute, or is executing) to the RP. 
The PR should pass the `currentP` to the worker task, and the task checks if its view of what is `currentP` is still accurate before executing.