### PR TITLE
Extract and display original file name from disassembled .class

### DIFF
--- a/java/java.source/src/org/netbeans/modules/java/classfile/AttachSourcePanel.form
+++ b/java/java.source/src/org/netbeans/modules/java/classfile/AttachSourcePanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 
@@ -58,8 +58,8 @@
   <SubComponents>
     <Component class="javax.swing.JLabel" name="jLabel1">
       <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/java/classfile/Bundle.properties" key="AttachSourcePanel.jLabel1.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="org.openide.util.NbBundle.getMessage(AttachSourcePanel.class, &quot;AttachSourcePanel.jLabel1.text&quot;, sourceFile)" type="code"/>
         </Property>
       </Properties>
     </Component>

--- a/java/java.source/src/org/netbeans/modules/java/classfile/AttachSourcePanel.java
+++ b/java/java.source/src/org/netbeans/modules/java/classfile/AttachSourcePanel.java
@@ -65,17 +65,21 @@ public class AttachSourcePanel extends javax.swing.JPanel {
     private final URL root;
     private final URL file;
     private final String binaryName;
+    private final String sourceFile;
 
     public AttachSourcePanel(
             @NonNull final URL root,
             @NonNull final URL file,
-            @NonNull final String binaryName) {
+            @NonNull final String binaryName,
+            @NonNull final String sourceFile
+    ) {
         assert root != null;
         assert file != null;
         assert binaryName != null;
         this.root = root;
         this.file = file;
         this.binaryName = binaryName;
+        this.sourceFile = sourceFile;
         initComponents();
     }
 
@@ -91,7 +95,7 @@ public class AttachSourcePanel extends javax.swing.JPanel {
         jLabel1 = new javax.swing.JLabel();
         jButton1 = new javax.swing.JButton();
 
-        jLabel1.setText(org.openide.util.NbBundle.getMessage(AttachSourcePanel.class, "AttachSourcePanel.jLabel1.text")); // NOI18N
+        jLabel1.setText(org.openide.util.NbBundle.getMessage(AttachSourcePanel.class, "AttachSourcePanel.jLabel1.text", sourceFile));
 
         jButton1.setText(org.openide.util.NbBundle.getMessage(AttachSourcePanel.class, "AttachSourcePanel.jButton1.text")); // NOI18N
         jButton1.addActionListener(new java.awt.event.ActionListener() {

--- a/java/java.source/src/org/netbeans/modules/java/classfile/Bundle.properties
+++ b/java/java.source/src/org/netbeans/modules/java/classfile/Bundle.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-AttachSourcePanel.jLabel1.text=Showing generated source file. No sources are attached to class' JAR file.
+AttachSourcePanel.jLabel1.text=No sources found. Showing generated code for {0}.
 AttachSourcePanel.jButton1.text=Attach Sources...
 TXT_OpenAttachedSource=Opening the Attached Source

--- a/java/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
+++ b/java/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
@@ -88,7 +88,7 @@ import javax.lang.model.util.AbstractElementVisitor9;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 
-import com.sun.tools.classfile.ConstantPool.CPInfo;
+import com.sun.tools.classfile.SourceFile_attribute;
 import java.nio.charset.StandardCharsets;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.source.ClasspathInfo;
@@ -128,6 +128,7 @@ public class CodeGenerator {
     private static final String DISABLE_ERRORS = "disable-java-errors"; //NOI18N
     static final String CLASSFILE_ROOT = "classfile-root";              //NOI18N
     static final String CLASSFILE_BINNAME = "classfile-binaryName";     //NOI18N
+    static final String CLASSFILE_SOURCEFILE = "classfile-sourcefile";    //NOI18N
 
     public static FileObject generateCode(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> toOpenHandle) {
 	if (UNUSABLE_KINDS.contains(toOpenHandle.getKind())) {
@@ -230,7 +231,8 @@ public class CodeGenerator {
                             return;
                         }
                     }
-                    final CompilationUnitTree cut = generateCode(wc, toOpen);
+                    final String[] betterName = { null };
+                    final CompilationUnitTree cut = generateCode(wc, toOpen, betterName);
                     wc.rewrite(wc.getCompilationUnit(), cut);
                     if (source == null) {
                         result[0] = FileUtil.createData(sourceRootFO, path);
@@ -240,6 +242,9 @@ public class CodeGenerator {
                     }
 
                     result[0].setAttribute(HASH_ATTRIBUTE_NAME, hash);
+                    if (betterName[0] != null) {
+                        result[0].setAttribute(CLASSFILE_SOURCEFILE, betterName[0]);
+                    }
                     
                     sourceGenerated[0] = true;
                 }
@@ -271,15 +276,17 @@ public class CodeGenerator {
         }
     }
 
-    static CompilationUnitTree generateCode(WorkingCopy wc, Element te) {
+    static CompilationUnitTree generateCode(WorkingCopy wc, Element te, String[] name) {
         TreeMaker make = wc.getTreeMaker();
-        Tree clazz = new TreeBuilder(make, wc).visit(te);
+        final TreeBuilder b = new TreeBuilder(make, wc);
+        Tree clazz = b.visit(te);
         CompilationUnitTree cut = make.CompilationUnit(
                 te.getKind() == ElementKind.MODULE ? null : make.Identifier(((PackageElement) te.getEnclosingElement()).getQualifiedName()),
                 Collections.<ImportTree>emptyList(),
                 Collections.singletonList(clazz),
                 wc.getCompilationUnit().getSourceFile());
 
+        name[0] = b.sourceFileName;
         return cut;
     }
 
@@ -289,6 +296,7 @@ public class CodeGenerator {
         private final WorkingCopy wc;
         private ClassFile cf;
         private Map<String, Method> sig2Method;
+        String sourceFileName;
 
         public TreeBuilder(TreeMaker make, WorkingCopy wc) {
             this.make = make;
@@ -349,6 +357,11 @@ public class CodeGenerator {
                         
                         try {
                             cf = ClassFile.read(in);
+                            Attribute sfaRaw = cf.getAttribute(Attribute.SourceFile);
+                            if (sfaRaw instanceof SourceFile_attribute) {
+                                SourceFile_attribute sfa = (SourceFile_attribute) sfaRaw;
+                                sourceFileName = sfa.getSourceFile(cf.constant_pool);
+                            }
                             for (Method m : cf.methods) {
                                 sig2Method.put(cf.constant_pool.getUTF8Value(m.name_index) + ":" + cf.constant_pool.getUTF8Value(m.descriptor.index), m);
                             }

--- a/java/java.source/src/org/netbeans/modules/java/classfile/SideBarFactoryImpl.java
+++ b/java/java.source/src/org/netbeans/modules/java/classfile/SideBarFactoryImpl.java
@@ -24,9 +24,7 @@ import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import org.netbeans.editor.SideBarFactory;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileStateInvalidException;
 import org.openide.loaders.DataObject;
-import org.openide.util.Exceptions;
 
 /**
  *
@@ -50,18 +48,25 @@ public class SideBarFactoryImpl implements SideBarFactory {
 
         Object classFileRoot;
         Object binaryName;
+        Object sourceFile;
         if (originFile != null) {
             classFileRoot = originFile.getAttribute(CodeGenerator.CLASSFILE_ROOT);
             binaryName = originFile.getAttribute(CodeGenerator.CLASSFILE_BINNAME);
+            sourceFile = originFile.getAttribute(CodeGenerator.CLASSFILE_SOURCEFILE);
+            if (sourceFile == null) {
+                sourceFile = originFile.getNameExt();
+            }
         } else {
-            classFileRoot = binaryName = null;
+            classFileRoot = binaryName = sourceFile = null;
         }
 
-        if (classFileRoot instanceof URL && binaryName instanceof String) {
+        if (classFileRoot instanceof URL && binaryName instanceof String && sourceFile instanceof String) {
             return new AttachSourcePanel(
                 (URL) classFileRoot,
                 originFile.toURL(),
-                (String) binaryName);
+                (String) binaryName,
+                (String) sourceFile
+            );
         }
         return null;
     }

--- a/java/java.source/test/unit/src/org/netbeans/modules/java/classfile/CodeGeneratorTest.java
+++ b/java/java.source/test/unit/src/org/netbeans/modules/java/classfile/CodeGeneratorTest.java
@@ -125,34 +125,29 @@ public class CodeGeneratorTest extends ClassIndexTestCase {
                     "}\n");
     }
     
-    //this test depends too much on the details how javap decompiles classes, and
-    //is not well suited to work with javap from the JDK, disabled for now:
-    public void DISABLEtestDecompile1() throws Exception {
+    public void testDecompile1() throws Exception {
         performFromClassTest("package test; class Test {\n" +
                              "    private void test() {\n" +
                              "        System.out.println(100000);\n" +
                              "    }\n" +
                              "}\n",
-                             "package test;\n" +
-                             "class Test {\n" +
-                             "    Test() {\n" +
-                             "        // <editor-fold defaultstate=\"collapsed\" desc=\"Compiled Code\">\n" +
-                             "        /* 0: aload_0\n" +
-                             "         * 1: invokespecial java/lang/Object.\"<init>\":()V\n" +
-                             "         * 4: return\n" +
-                             "         *  */\n" +
-                             "        // </editor-fold>\n" +
-                             "    }\n" +
-                             "    private void test() {\n" +
-                             "        // <editor-fold defaultstate=\"collapsed\" desc=\"Compiled Code\">\n" +
-                             "        /* 0: getstatic     java/lang/System.out:Ljava/io/PrintStream;\n" +
-                             "         * 3: ldc           100000\n" +
-                             "         * 5: invokevirtual java/io/PrintStream.println:(I)V\n" +
-                             "         * 8: return\n" +
-                             "         *  */\n" +
-                             "        // </editor-fold>\n" +
-                             "    }\n" +
-                             "}\n");
+                             "package test;",
+                             "class Test {",
+                             "Test() {",
+                             "// <editor-fold defaultstate=\"collapsed\" desc=\"Compiled Code\">",
+                             "aload_0",
+                             "return",
+                             "// </editor-fold>",
+                             "}",
+                             "private void test() {",
+                             "// <editor-fold defaultstate=\"collapsed\" desc=\"Compiled Code\">",
+                             "getstatic", "java/lang/System.out:Ljava/io/PrintStream;",
+                             "ldc", "100000",
+                             "invokevirtual", "java/io/PrintStream.println:(I)V",
+                             "return",
+                             "</editor-fold>",
+                             "}",
+                             "}");
     }
 
     private void performTest(String test, final String golden) throws Exception {
@@ -172,6 +167,7 @@ public class CodeGeneratorTest extends ClassIndexTestCase {
         TestUtilities.copyStringToFile(testFile, test);
         final ClasspathInfo cpInfo = ClasspathInfoAccessor.getINSTANCE().create(testOutFile, null, true, true, false, true);
         JavaSource testSource = JavaSource.create(cpInfo, testOutFile);
+        final String[] betterName = new String[1];
         Task<WorkingCopy> task = new Task<WorkingCopy>() {
             @Override
             public void run(final WorkingCopy workingCopy) throws IOException {
@@ -182,7 +178,7 @@ public class CodeGeneratorTest extends ClassIndexTestCase {
 
                 assertNotNull(t);
 
-                workingCopy.rewrite(workingCopy.getCompilationUnit(), CodeGenerator.generateCode(workingCopy, t));
+                workingCopy.rewrite(workingCopy.getCompilationUnit(), CodeGenerator.generateCode(workingCopy, t, betterName));
             }
         };
 
@@ -191,7 +187,7 @@ public class CodeGeneratorTest extends ClassIndexTestCase {
         mr.commit();
 
         assertEquals(normalizeWhitespaces(golden), normalizeWhitespaces(TestUtilities.copyFileToString(FileUtil.toFile(testOutFile))));
-
+        assertNull("No better name suggested for source", betterName[0]);
         testSource.runUserActionTask(new Task<CompilationController>() {
             @Override
             public void run(CompilationController cc) throws Exception {
@@ -201,7 +197,7 @@ public class CodeGeneratorTest extends ClassIndexTestCase {
         }, true);
     }
 
-    private void performFromClassTest(String test, final String golden) throws Exception {
+    private void performFromClassTest(String test, final String... lines) throws Exception {
         clearWorkDir();
         beginTx();
         FileObject wd = FileUtil.toFileObject(getWorkDir());
@@ -213,12 +209,13 @@ public class CodeGeneratorTest extends ClassIndexTestCase {
         FileObject cache = FileUtil.createFolder(wd, "cache");
 
         SourceUtilsTestUtil.prepareTest(src, build, cache);
-        FileObject testFile = FileUtil.createData(src, "test/Test.java");
+        FileObject testFile = FileUtil.createData(src, "test/TestSourceToCompile.java");
         TestUtilities.copyStringToFile(testFile, test);
         SourceUtilsTestUtil.compileRecursively(src);
         final FileObject testOutFile = FileUtil.createData(src, "out/Test.java");
         final ClasspathInfo cpInfo = ClasspathInfoAccessor.getINSTANCE().create(testOutFile, null, true, true, false, true);
         JavaSource testSource = JavaSource.create(cpInfo, testOutFile);
+        final String[] betterName = new String[1];
         Task<WorkingCopy> task = new Task<WorkingCopy>() {
             @Override
             public void run(final WorkingCopy workingCopy) throws IOException {
@@ -228,7 +225,7 @@ public class CodeGeneratorTest extends ClassIndexTestCase {
 
                 assertNotNull(t);
 
-                workingCopy.rewrite(workingCopy.getCompilationUnit(), CodeGenerator.generateCode(workingCopy, t));
+                workingCopy.rewrite(workingCopy.getCompilationUnit(), CodeGenerator.generateCode(workingCopy, t, betterName));
             }
         };
 
@@ -236,7 +233,13 @@ public class CodeGeneratorTest extends ClassIndexTestCase {
 
         mr.commit();
 
-        assertEquals(normalizeWhitespaces(golden), normalizeWhitespaces(TestUtilities.copyFileToString(FileUtil.toFile(testOutFile))));
+        final String generatedText = normalizeWhitespaces(TestUtilities.copyFileToString(FileUtil.toFile(testOutFile)));
+        for (String expLine : lines) {
+            if (!generatedText.contains(expLine)) {
+                fail("Expecting: " + expLine + ", but found:\n" + generatedText);
+            }
+        }
+        assertEquals(testFile.getNameExt(), betterName[0]);
     }
 
     private static String normalizeWhitespaces(String text) {

--- a/java/java.source/test/unit/src/org/netbeans/modules/java/classfile/CodeGeneratorTest.java
+++ b/java/java.source/test/unit/src/org/netbeans/modules/java/classfile/CodeGeneratorTest.java
@@ -234,10 +234,13 @@ public class CodeGeneratorTest extends ClassIndexTestCase {
         mr.commit();
 
         final String generatedText = normalizeWhitespaces(TestUtilities.copyFileToString(FileUtil.toFile(testOutFile)));
+        int at = 0;
         for (String expLine : lines) {
-            if (!generatedText.contains(expLine)) {
-                fail("Expecting: " + expLine + ", but found:\n" + generatedText);
+            int found = generatedText.indexOf(expLine, at);
+            if (found == -1) {
+                fail("Expecting: " + expLine + ", but found:\n" + generatedText.substring(at));
             }
+            at = found;
         }
         assertEquals(testFile.getNameExt(), betterName[0]);
     }


### PR DESCRIPTION
While working with scala libraries I found it misleading that the original source is assumed to be `.java`. The source name is usually encoded in the `.class` file and this PR extracts it, when available:

![image](https://user-images.githubusercontent.com/1842422/162601430-719113c4-187e-4a49-a31d-d351058a5812.png)

Seeing the `IR.scala` name can help the developer locate the right file on disk.