### PR TITLE
version bump: require javac 18.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
@@ -34,21 +34,22 @@ import org.openide.modules.OnStart;
  */
 public class NoJavacHelper {
 
-    private static final boolean hasWorkingJavac;
+    public static final int REQUIRED_JAVAC_VERSION = 18; // <- TODO: increment on every release
+    private static final boolean HAS_WORKING_JAVAC;
 
     static {
         boolean res;
         try {
-            SourceVersion.valueOf("RELEASE_17");
+            SourceVersion.valueOf("RELEASE_"+REQUIRED_JAVAC_VERSION);
             res = true;
         } catch (IllegalArgumentException ex) {
             res = false;
         }
-        hasWorkingJavac = res;
+        HAS_WORKING_JAVAC = res;
     }
 
     public static boolean hasWorkingJavac() {
-        return hasWorkingJavac;
+        return HAS_WORKING_JAVAC;
     }
 
     // safety net if someone manages to start NB on JDK 8 with nb-javac uninstalled

--- a/java/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
+++ b/java/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
@@ -62,7 +62,7 @@ public class JBrowseModule extends ModuleInstall {
                              " Please either:" +
                              "<ul>" +
                                  "<li>install nb-javac library (<b>highly recommended</b>)</li>" +
-                                 "<li>run NetBeans on JDK 17 or later</li>" +
+                                 "<li>run NetBeans on JDK "+NoJavacHelper.REQUIRED_JAVAC_VERSION+" or later</li>" +
                              "</ul>",
         "BN_Install=Install nb-javac",
         "DN_nbjavac=nb-javac library",


### PR DESCRIPTION
NetBeans 14 expects javac 18 which means we have to increment the version for the javac checks too.