### PR TITLE
Update asm from 9.2 to 9.3

### DIFF
--- a/harness/apisupport.harness/build.xml
+++ b/harness/apisupport.harness/build.xml
@@ -39,13 +39,13 @@
                 <pathelement location="${cluster}/tasks.jar"></pathelement>
             </classpath>
         </taskdef>
-        <echo file="build/binaries-list">81A03F76019C67362299C40E0BA13405F5467BFF org.ow2.asm:asm:9.2</echo>
+        <echo file="build/binaries-list">8E6300EF51C1D801A7ED62D07CD221ACA3A90640 org.ow2.asm:asm:9.3</echo>
         <TestDownload>
             <manifest dir="build">
                 <include name="binaries-list"/>
             </manifest>
         </TestDownload>
-        <delete file="build/asm-9.2.jar"/>
+        <delete file="build/asm-9.3.jar"/>
     </target>
 
     <target name="compile-jnlp-launcher" depends="init,compile">

--- a/java/lib.jshell.agent/nbproject/project.properties
+++ b/java/lib.jshell.agent/nbproject/project.properties
@@ -21,5 +21,5 @@ javac.compilerargs=-Xlint -Xlint:-serial
 extra.module.files=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 jnlp.indirect.jars=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 
-agentsrc.asm.cp=${libs.asm.dir}/core/asm-9.2.jar
+agentsrc.asm.cp=${libs.asm.dir}/core/asm-9.3.jar
 agentsrc.jshell.cp=${nb_all}/java/libs.jshell.compile/external/jshell-9.jar

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -85,9 +85,9 @@ extide/gradle/external/gradle-7.4-bin.zip platform/libs.testng/external/jcommand
 extide/gradle/external/gradle-7.4-bin.zip platform/o.apache.commons.io/external/commons-io-2.6.jar
 extide/gradle/external/gradle-7.4-bin.zip enterprise/cloud.oracle/external/jsr305-3.0.2.jar
 extide/gradle/external/gradle-7.4-bin.zip platform/o.apache.commons.codec/external/commons-codec-1.15.jar
-extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-9.2.jar
-extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-commons-9.2.jar
-extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-tree-9.2.jar
+extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-9.3.jar
+extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-commons-9.3.jar
+extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-tree-9.3.jar
 extide/gradle/external/gradle-7.4-bin.zip platform/libs.batik.read/external/xml-apis-1.4.01.jar
 
 # These are the endorsed version of the javaee apis and create libraries, so they are better kept separate

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -79,10 +79,10 @@
         <tstamp>
             <format property="module.build.started.time" pattern="yyyy-MM-dd'T'HH:mm:ss.SSSZ"/>
         </tstamp>
-        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-9.2.jar">
-            <available file="${nbplatform.active.dir}/platform/core/asm-9.2.jar"/>
+        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-9.3.jar">
+            <available file="${nbplatform.active.dir}/platform/core/asm-9.3.jar"/>
         </condition>
-        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-9.2.jar"/>
+        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-9.3.jar"/>
         <property name="tsaurl" value=""/>
         <property name="tsacert" value=""/>
     </target>

--- a/platform/libs.asm/external/asm-9.3-license.txt
+++ b/platform/libs.asm/external/asm-9.3-license.txt
@@ -1,6 +1,6 @@
 Name: OW2 ASM
-Version: 9.2
-Files: asm-tree-9.2.jar asm-commons-9.2.jar asm-9.2.jar
+Version: 9.3
+Files: asm-tree-9.3.jar asm-commons-9.3.jar asm-9.3.jar
 License: BSD-INRIA
 Origin: OW2 Consortium
 URL: https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/

--- a/platform/libs.asm/external/binaries-list
+++ b/platform/libs.asm/external/binaries-list
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-81A03F76019C67362299C40E0BA13405F5467BFF org.ow2.asm:asm:9.2
-D96C99A30F5E1A19B0E609DBB19A44D8518AC01E org.ow2.asm:asm-tree:9.2
-F4D7F0FC9054386F2893B602454D48E07D4FBEAD org.ow2.asm:asm-commons:9.2
+8E6300EF51C1D801A7ED62D07CD221ACA3A90640 org.ow2.asm:asm:9.3
+78D2ECD61318B5A58CD04FB237636C0E86B77D97 org.ow2.asm:asm-tree:9.3
+1F2A432D1212F5C352AE607D7B61DCAE20C20AF5 org.ow2.asm:asm-commons:9.3

--- a/platform/libs.asm/nbproject/project.properties
+++ b/platform/libs.asm/nbproject/project.properties
@@ -19,7 +19,7 @@ javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 module.jar.dir=core
 
-release.external/asm-9.2.jar=core/asm-9.2.jar
-release.external/asm-tree-9.2.jar=core/asm-tree-9.2.jar
-release.external/asm-commons-9.2.jar=core/asm-commons-9.2.jar
-license.file=../external/asm-9.2-license.txt
+release.external/asm-9.3.jar=core/asm-9.3.jar
+release.external/asm-tree-9.3.jar=core/asm-tree-9.3.jar
+release.external/asm-commons-9.3.jar=core/asm-commons-9.3.jar
+license.file=../external/asm-9.3-license.txt

--- a/platform/libs.asm/nbproject/project.xml
+++ b/platform/libs.asm/nbproject/project.xml
@@ -29,16 +29,16 @@
                 <subpackages>org</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>asm-9.2.jar</runtime-relative-path>
-                <binary-origin>external/asm-9.2.jar</binary-origin>
+                <runtime-relative-path>asm-9.3.jar</runtime-relative-path>
+                <binary-origin>external/asm-9.3.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>asm-tree-9.2.jar</runtime-relative-path>
-                <binary-origin>external/asm-tree-9.2.jar</binary-origin>
+                <runtime-relative-path>asm-tree-9.3.jar</runtime-relative-path>
+                <binary-origin>external/asm-tree-9.3.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>asm-commons-9.2.jar</runtime-relative-path>
-                <binary-origin>external/asm-commons-9.2.jar</binary-origin>
+                <runtime-relative-path>asm-commons-9.3.jar</runtime-relative-path>
+                <binary-origin>external/asm-commons-9.3.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Library Notes:
- JDK 19 support
- Bug fixes
  - 317949: fix javadoc errors
  - remap invokedynamic field handles properly
  - add missing left curly brace in ASMifier output of visitModule

Testing:
- Full build done
- Verify successful execution of libraries and licenses Ant test

[ASM Web Page](https://asm.ow2.io/index.html)
[Release Notes](https://asm.ow2.io/versions.html)