### PR TITLE
Support invocation expressions in LSP Call Hierarchy; bugfixes

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -2221,7 +2221,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
         HierarchyTask<CallHierarchyOutgoingCall> t =  new HierarchyTask<CallHierarchyOutgoingCall>(params.getItem()) {
             @Override
             protected CompletableFuture<List<CallHierarchyEntry.Call>> callProvider(CallHierarchyProvider p, CallHierarchyEntry e) {
-                return p.findIncomingCalls(e);
+                return p.findOutgoingCalls(e);
             }
 
             @Override

--- a/java/java.sourceui/apichanges.xml
+++ b/java/java.sourceui/apichanges.xml
@@ -84,6 +84,18 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="StructureElement_convert">
+            <api name="general"/>
+            <summary>A variant conversion that works for both source and binary elements.</summary>
+            <version major="1" minor="64"/>
+            <date day="11" month="4" year="2022"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes"/>
+            <description>
+                Binary-only javac Elements can be converted to StructureElement, avoids fetching the source.
+            </description>
+            <class package="org.netbeans.api.java.source.ui" name="ElementHeaders"/>
+        </change>
         <change id="StructureElement">
             <api name="general"/>
             <summary>Added conversion from javac Elements to LSP structures.</summary>

--- a/java/java.sourceui/nbproject/project.properties
+++ b/java/java.sourceui/nbproject/project.properties
@@ -18,7 +18,7 @@ javadoc.apichanges=${basedir}/apichanges.xml
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
-spec.version.base=1.63.0
+spec.version.base=1.64.0
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementHeaders.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementHeaders.java
@@ -27,8 +27,6 @@ import com.sun.source.util.TreePath;
 import java.util.concurrent.CompletableFuture;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.Name;
-import javax.lang.model.type.TypeMirror;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.java.queries.SourceJavadocAttacher;
 import org.netbeans.api.java.source.CompilationInfo;
@@ -225,15 +223,29 @@ public final class ElementHeaders {
      * is returned for Elements outside that have no source associated when {@code resolveSources} is false.
      * <p>
      * Calling {@link CompletableFuture#cancel} on the returned value performs cancel on the possible long-running task(s) in a best-effort way: it is
-     * not guaranteed that the already started processes interrupt.
+     * not guaranteed that the already started processes interrupts.
      * @param info compilation
      * @param el the element to convert
      * @param resolveSources 
      * @return completion handle for the StructureElement
-    * @since 1.63
+     * @since 1.63
      */
     public static CompletableFuture<StructureElement> resolveStructureElement(CompilationInfo info, Element el, boolean resolveSources) {
         return LspElementUtils.createStructureElement(info, el, resolveSources);
+    }
+
+    /**
+     * Describes a javac {@link Element} as LSP {@link StructureElement}. Source file and position information may not be provided, but 
+     * the other fields of the {@link StructureElement} will be filled. If `allowBinaries' is true, the file member of the {@link StructureElement} may
+     * be filled with FileObject of binary that defines the {@link Element}; source FileObject is always preferred, if available.
+     * 
+     * @param info compilation
+     * @param el the element to convert
+     * @return created item
+     * @since 1.64
+     */
+    public static StructureElement convertElement(CompilationInfo info, Element el, ElementUtilities.ElementAcceptor childAcceptor, boolean allowBinary) {
+        return LspElementUtils.describeElement(info, el, childAcceptor, allowBinary);
     }
 
     /**

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/LspElementUtils.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/LspElementUtils.java
@@ -42,6 +42,8 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.java.source.ElementUtilities.ElementAcceptor;
@@ -60,19 +62,36 @@ import org.openide.filesystems.FileObject;
  */
 public class LspElementUtils {
     
-    public  static StructureElement element2StructureElement(CompilationInfo info, Element el, ElementAcceptor childAcceptor) {
+    public static StructureElement element2StructureElement(CompilationInfo info, Element el, ElementAcceptor childAcceptor, 
+            boolean allowResources, boolean bypassOpen, FileObject parentFile) {
         TreePath path = info.getTrees().getPath(el);
-        if (path == null) {
-            return null;
-        }
-        TreeUtilities tu = info.getTreeUtilities();
-        if (tu.isSynthetic(path)) {
-            return null;
+        if (!allowResources) {
+            if (path == null) {
+                return null;
+            }
+            TreeUtilities tu = info.getTreeUtilities();
+            if (tu.isSynthetic(path)) {
+                return null;
+            }
         }
 
         StructureProvider.Builder builder = StructureProvider.newBuilder(createName(info, el), ElementHeaders.javaKind2Structure(el));
         builder.detail(createDetail(info, el));
-        setOffsets(info, el, builder);
+        FileObject f;
+        FileObject owner;
+        if (!bypassOpen) {
+            Object[] oi = setOffsets(info, el, builder);
+            owner = f = (FileObject)oi[0]; 
+        } else {
+            f = null;
+            owner = parentFile;
+        }
+        if (owner == null && !bypassOpen && allowResources) {
+            owner = findOwnerResource(info, el);
+        }
+        if (f == null && owner != null) {
+            builder.file(owner);
+        }
         if (info.getElements().isDeprecated(el)) {
             builder.addTag(StructureElement.Tag.Deprecated);
         }
@@ -80,24 +99,72 @@ public class LspElementUtils {
         if (childAcceptor != null) {
             for (Element child : el.getEnclosedElements()) {
                 TreePath p = info.getTrees().getPath(child);
-                if (p == null) {
-                    continue;
+                if (!allowResources) {
+                    if (p == null) {
+                        continue;
+                    }
                 }
-                TypeMirror m = info.getTrees().getTypeMirror(p);
+                TypeMirror m = child.asType();
                 if (childAcceptor.accept(child, m)) {
-                    StructureElement jse = element2StructureElement(info, child, childAcceptor);
+                    StructureElement jse = element2StructureElement(info, child, childAcceptor, allowResources, f == null, owner);
                     if (jse != null) {
                         builder.children(jse);
                     }
                 }
             }
-            if (path.getLeaf().getKind() == Tree.Kind.METHOD || path.getLeaf().getKind() == Tree.Kind.VARIABLE) {
-                getAnonymousInnerClasses(info, path, builder, childAcceptor);
+            if (path != null) {
+                if (path.getLeaf().getKind() == Tree.Kind.METHOD || path.getLeaf().getKind() == Tree.Kind.VARIABLE) {
+                    getAnonymousInnerClasses(info, path, builder, childAcceptor);
+                }
             }
             // ensure children is always filled, if the caller requested traversal, force creation of the list.
             builder.children();
         }
         return builder.build();
+    }
+    
+    public static StructureElement element2StructureElement(CompilationInfo info, Element el, ElementAcceptor childAcceptor) {
+        return element2StructureElement(info, el, childAcceptor, false, false, null);
+    }
+    
+    static FileObject findOwnerResource(CompilationInfo info, Element el) {
+        ElementKind ek = el.getKind();
+        if (ek == ElementKind.MODULE) {
+            // not supported at the moment
+            return null;
+        }
+        Element parent = el;
+        if (!(ek.isClass() || ek.isInterface())) {
+            parent = el.getEnclosingElement();
+            if (!(parent.getKind().isClass() || parent.getKind().isInterface())) {
+                return null;
+            }
+        }
+        ElementHandle h = ElementHandle.create(parent);
+        String s = h.getBinaryName();
+        int lastSlash = s.lastIndexOf('.');
+        int dollar = s.substring(lastSlash + 1).indexOf('$');
+        
+        String resourceName = s.substring(0, dollar >= 0 ? lastSlash + 1 + dollar : s.length()).replace(".", "/"); // NOI18N
+        ClasspathInfo cpInfo = info.getClasspathInfo();
+        final ClassPath[] cps = 
+            new ClassPath[] {
+                cpInfo.getClassPath(ClasspathInfo.PathKind.SOURCE),
+                cpInfo.getClassPath(ClasspathInfo.PathKind.OUTPUT),
+                cpInfo.getClassPath(ClasspathInfo.PathKind.BOOT),                    
+                cpInfo.getClassPath(ClasspathInfo.PathKind.COMPILE)
+            };
+        for (ClassPath cp : cps) {
+            FileObject f = cp.findResource(resourceName);
+            if (f != null) {
+                return f;
+            }
+        }
+        return null;
+    }
+    
+    public  static StructureElement describeElement(CompilationInfo info, Element el, ElementAcceptor childAcceptor, boolean allowBinary) {
+        return element2StructureElement(info, el, childAcceptor, allowBinary, false, null);
     }
     
     public static CompletableFuture<StructureElement> createStructureElement(CompilationInfo info, Element el, boolean resolveSources) {
@@ -282,9 +349,11 @@ public class LspElementUtils {
             info -> processOffsetInfo(info, builder));
     }
     
-    private static void setOffsets(CompilationInfo ci, Element original, StructureProvider.Builder builder) {
+    private static Object[] setOffsets(CompilationInfo ci, Element original, StructureProvider.Builder builder) {
         ElementHandle<Element> h = ElementHandle.create(original);
-        processOffsetInfo(ElementOpenAccessor.getInstance().getOpenInfo(ci.getClasspathInfo(), h, new AtomicBoolean()), builder);
+        Object[] openInfo = ElementOpenAccessor.getInstance().getOpenInfo(ci.getClasspathInfo(), h, new AtomicBoolean());
+        processOffsetInfo(openInfo, builder);
+        return openInfo;
     }
     
     private static void getAnonymousInnerClasses(CompilationInfo info, TreePath path, StructureProvider.Builder builder, ElementAcceptor childAcceptor) {

--- a/java/refactoring.java/nbproject/project.xml
+++ b/java/refactoring.java/nbproject/project.xml
@@ -206,7 +206,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.5</specification-version>
+                        <specification-version>1.64</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/LspCallHierarchyProvider.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/LspCallHierarchyProvider.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.refactoring.java.callhierarchy;
 
+import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import java.io.IOException;
@@ -30,7 +31,13 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
 import javax.swing.text.Document;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
 import org.netbeans.api.java.source.CompilationController;
@@ -64,16 +71,39 @@ import org.openide.util.RequestProcessor;
  */
 @MimeRegistration(mimeType = "text/x-java", service = CallHierarchyProvider.class)
 public class LspCallHierarchyProvider implements CallHierarchyProvider {
+    private static final Logger LOG = Logger.getLogger(LspCallHierarchyProvider.class.getName());
+    
     private static final RequestProcessor HIERARCHY_RP = new RequestProcessor();
     
-    private static final Element findEclosingExecutable(CompilationInfo ci, TreePath tp) {
+    private static TreePath findEnclosingMethorOrInvocation(CompilationInfo ci, TreePath tp) {
+        boolean immediateBody = false;
         while (tp != null && tp.getLeaf().getKind() != Tree.Kind.COMPILATION_UNIT) {
             switch (tp.getLeaf().getKind()) {
                 case METHOD:
+                case METHOD_INVOCATION:
+                    return tp;
                 case CLASS:
                 case ENUM:
                 case INTERFACE:
-                    return ci.getTrees().getElement(tp);
+                    return null;
+                    
+                case BLOCK:
+                    if (immediateBody) {
+                        return null;
+                    }
+                    // permit position inside method braces, but not on statements
+                    immediateBody = true;
+                    break;
+                    
+                case NEW_CLASS:
+                    return tp;
+                    
+                default:
+                    if (tp.getLeaf() instanceof StatementTree) {
+                        return null;
+                    }
+                    immediateBody = false;
+                    break;
             }
             tp = tp.getParentPath();
         }
@@ -104,12 +134,28 @@ public class LspCallHierarchyProvider implements CallHierarchyProvider {
                         return;
                     }
                     
-                    Element e = findEclosingExecutable(ci, tp);
-                    if (e == null) {
+                    TreePath origin = findEnclosingMethorOrInvocation(ci, tp);
+                    if (origin == null) {
+                        control.complete(null);
                         return;
                     }
+                    Element e = ci.getTrees().getElement(origin);
+                    if (e == null || !(e.getKind() == ElementKind.CONSTRUCTOR || e.getKind() == ElementKind.METHOD)) {
+                        control.complete(null);
+                        return;
+                    }
+                    ExecutableElement exec = (ExecutableElement)e;
+                    String name;
+                    if (e.getKind() == ElementKind.CONSTRUCTOR) {
+                        name = e.getEnclosingElement().getSimpleName().toString();
+                    } else {
+                        name = e.getSimpleName().toString();
+                    }
                     
-                    StructureElement se = ElementHeaders.toStructureElement(ci, e, null);
+                    StructureElement se = ElementHeaders.convertElement(ci, e, (che, t) -> false, true);
+                    if (se == null) {
+                        control.complete(null);
+                    }
                     CallHierarchyEntry item = new CallHierarchyEntry(se, signature(e));
                     control.complete(Collections.singletonList(item));
                     return;
@@ -155,9 +201,13 @@ public class LspCallHierarchyProvider implements CallHierarchyProvider {
         }
     }
     
+    private static final String CUSTOM_DATA_SEPARATOR = "##"; // NOI18N
+    
     private static String signature(Element e) {
         ElementHandle h = ElementHandle.create(e);
-        String extra = h.getKind().name() + "/" + String.join("/", SourceUtils.getJVMSignature(h));
+        Element parent = e.getEnclosingElement();
+        String k = parent == null ? "" : parent.getKind().name();
+        String extra = h.getKind().name() + CUSTOM_DATA_SEPARATOR + k + CUSTOM_DATA_SEPARATOR + String.join(CUSTOM_DATA_SEPARATOR, SourceUtils.getJVMSignature(h));
         return extra;
     }
     
@@ -184,29 +234,62 @@ public class LspCallHierarchyProvider implements CallHierarchyProvider {
         }
         
         public void run(CompilationController parameter) throws Exception {
-            List<CallHierarchyEntry.Call> calls = new ArrayList<>();
+            if (callTarget.getCustomData() == null) {
+                res.complete(null);
+                return;
+            }
+            String[] data = callTarget.getCustomData().split(CUSTOM_DATA_SEPARATOR);
+            if (data.length < 3) {
+                res.complete(null);
+                return;
+            }
+            if (data[1].equals("")) {
+                res.complete(null);
+                return;
+            }
+            ElementKind targetKind;
+            try {
+                targetKind = ElementKind.valueOf(data[1]);
+            } catch (IllegalArgumentException ex) {
+                LOG.log(Level.SEVERE, "Unexpected call entry kind: {0}", data[1]);
+                res.complete(null);
+                return;
+            }
+            ElementHandle<TypeElement> typeHandle;
+            try {
+                typeHandle = ElementHandle.createTypeElementHandle(targetKind, data[2]);
+            } catch (IllegalArgumentException ex) {
+                LOG.log(Level.SEVERE, "Could not convert signature {0} to Element", callTarget.getCustomData());
+                LOG.log(Level.SEVERE, "Exception thrown:", ex);
+                res.complete(null);
+                return;
+            }
+            
             int s = callTarget.getElement().getSelectionStartOffset();
             parameter.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
             TreePath p = parameter.getTreeUtilities().pathFor(s);
-            Element e = null;
-
-            if (p != null) {
-                Element candidate = parameter.getTrees().getElement(p);
-                if (candidate != null) {
-                    // just do a sanity check
-                    if (callTarget.getCustomData() == null ||
-                        callTarget.getCustomData().equals(signature(candidate))) {
-                        e = candidate;
-                    }
-                }
+            TypeElement typeEl = typeHandle.resolve(parameter);
+            
+            ExecutableElement e;
+            if (callTarget.getElement().getKind() == StructureElement.Kind.Method) {
+                e = ElementFilter.methodsIn(typeEl.getEnclosedElements()).stream().
+                        filter(m -> callTarget.getCustomData().equals(signature(m))).
+                        findFirst().orElse(null);
+            } else {
+                e = ElementFilter.constructorsIn(typeEl.getEnclosedElements()).stream().
+                        filter(m -> callTarget.getCustomData().equals(signature(m))).
+                        findFirst().orElse(null);
             }
 
-            if (e == null) {
+            if (e == null || !(e.getKind() == ElementKind.METHOD || e.getKind() == ElementKind.CONSTRUCTOR)) {
                 res.complete(null);
                 return;
             }
             TreePathHandle tph = TreePathHandle.create(e, parameter);
-
+            if (tph == null) {
+                res.complete(null);
+                return;
+            }
             CallHierarchyTasks.RootResolver rr = new CallHierarchyTasks.RootResolver(tph, true, true);
             rr.run(parameter);
 
@@ -215,7 +298,18 @@ public class LspCallHierarchyProvider implements CallHierarchyProvider {
             m.replaceRoot(rr.getRoot());
 
             Call rootCall = m.getRoot();
-            m.computeCalls(m.getRoot(), () -> processComputedCall(parameter, rootCall));
+            m.computeCalls(m.getRoot(), () -> {
+                JavaSource js = JavaSource.forFileObject(fo);
+                if (js == null) {
+                    res.complete(null);
+                    return;
+                }
+                try {
+                    js.runUserActionTask((nested) -> processComputedCall(nested, rootCall), true);
+                } catch (IOException ex) {
+                    res.completeExceptionally(ex);
+                }
+            });
         }
         
         protected abstract CallHierarchyEntry.Call createCall(StructureElement se, Call c, String signature);
@@ -346,27 +440,6 @@ public class LspCallHierarchyProvider implements CallHierarchyProvider {
                 }
                 return new CallHierarchyEntry.Call(i, ranges);
             }
-            
-            /*
-            @Override
-            protected void processComputedCall(CompilationInfo info, Call rootCall) {
-                List<CallHierarchyEntry.Call> calls = new ArrayList<>();
-                List<Call> refs = rootCall.getReferences();
-                
-                if (cancelled.get()) {
-                    return;
-                }
-                toCancel = processAsync(info, refs, calls);
-                toCancel.handle((r, ex) -> {
-                    if (ex != null) { 
-                        res.completeExceptionally((Throwable)ex);
-                    } else {
-                        res.complete(calls);
-                    }
-                    return null;
-                });
-            }
-            */
         }
         return new T(callSource).process();
     } 


### PR DESCRIPTION
Call hierarchy implementation for LSP throws an exception:
```
java.lang.NullPointerException
	at org.netbeans.modules.refactoring.java.callhierarchy.CallHierarchyTasks$CallersTask.runTask(CallHierarchyTasks.java:313)
[catch] at org.netbeans.modules.refactoring.java.callhierarchy.CallHierarchyTasks$CallTaskBase.run(CallHierarchyTasks.java:288)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)
```
on a trivial source:
```
package org.yourcompany.yourproject;

public class Locations {

    private void m1() {
        m2();
    }

    private void m2() {
        m3();
    }

    private void m3() {
        throw new UnsupportedOperationException("Not supported yet.");
    }

}
```
when the caret is positioned at stuff outside of method scope. It does not show any results on method invocations.

---
My bad, the implementation was oversimplified as the code only searched for the enclosing method. This PR extends that to method invocation and new expressions. Some other bugs were also fixed.

