### PR TITLE
PHPStan alternative configuration file

### DIFF
--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ImportantFilesImpl.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ImportantFilesImpl.java
@@ -41,7 +41,8 @@ public final class ImportantFilesImpl implements ImportantFilesImplementation {
             CodingStandardsFixer.CONFIG_FILE_NAME_V3,
             CodingStandardsFixer.DIST_CONFIG_FILE_NAME_V3,
             PHPStan.CONFIG_FILE_NAME,
-            PHPStan.DIST_CONFIG_FILE_NAME};
+            PHPStan.DIST_CONFIG_FILE_NAME,
+            PHPStan.ALTERNATIVE_DIST_CONFIG_FILE_NAME};
 
     private final ImportantFilesSupport support;
 

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/PHPStan.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/PHPStan.java
@@ -78,6 +78,7 @@ public final class PHPStan {
      // configuration files
     public static final String CONFIG_FILE_NAME = "phpstan.neon";  // NOI18N
     public static final String DIST_CONFIG_FILE_NAME = "phpstan.neon.dist";  // NOI18N
+    public static final String ALTERNATIVE_DIST_CONFIG_FILE_NAME = "phpstan.dist.neon";  // NOI18N
 
     private final String phpStanPath;
     private int analyzeGroupCounter = 1;


### PR DESCRIPTION
This change adds `phpstan.dist.neon` to Important files.

PHPStan 1.4.7 added `phpstan.dist.neon` as configuration file.
https://github.com/phpstan/phpstan/releases/tag/1.4.7





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

