### PR TITLE
[vscode] Project View synchronizes with the active editor.

### DIFF
--- a/java/java.lsp.server/nbproject/project.properties
+++ b/java/java.lsp.server/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=1.19.0
+spec.version.base=1.20.0
 javadoc.arch=${basedir}/arch.xml
 requires.nb.javac=true
 lsp.build.dir=vscode/nbcode

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/PathFinder.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/PathFinder.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.explorer;
+
+import org.openide.nodes.Node;
+
+/**
+ * Originally a project UI API, but is a good candidate for a path-searching SPI for
+ * general explorers.
+ */
+public interface PathFinder {
+
+    /**
+    * Try to find a given node in the logical view.
+    * If some node within the logical view tree has the supplied object
+    * in its lookup, it ought to be returned if that is practical.
+    * If there are multiple such nodes, the one most suitable for display
+    * to the user should be returned.<BR>
+    * This may be used to select nodes corresponding to files, etc.
+    * The following constraint should hold:
+    * <pre>
+    * private static boolean isAncestor(Node root, Node n) {
+    *     if (n == null) return false;
+    *     if (n == root) return true;
+    *     return isAncestor(root, n.getParentNode());
+    * }
+    * // ...
+    * Node root = ...;
+    * Object target = ...;
+    * LogicalViewProvider lvp = ...;
+    * Node n = lvp.findPath(root, target);
+    * if (n != null) {
+    *     assert isAncestor(root, n);
+    *     Lookup.Template tmpl = new Lookup.Template(null, null, target);
+    *     Collection res = n.getLookup().lookup(tmpl).allInstances();
+    *     assert Collections.singleton(target).equals(new HashSet(res));
+    * }
+    * </pre>
+    * @param root a root node. E.g. a node from {@link #createLogicalView} or some wapper
+    *        (FilterNode) around the node. The provider of the functionality is
+    *        responsible for finding the appropriate node in the wrapper's children.
+    * @param target a target cookie, such as a {@link org.openide.loaders.DataObject}
+    * @return a subnode with that cookie, or null
+    */
+    Node findPath(Node root, Object target);
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/FindPathParams.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/FindPathParams.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.explorer.api;
+
+import java.net.URI;
+import org.eclipse.xtext.xbase.lib.Pure;
+
+/**
+ *
+ * @author sdedic
+ */
+public class FindPathParams {
+    private Object  selectData;
+    private int     rootNodeId;
+
+    public FindPathParams(int rootNodeId, Object selectData) {
+        this.rootNodeId = rootNodeId;
+        this.selectData = selectData;
+    }
+
+    public FindPathParams() {
+    }
+
+    @Pure
+    public Object getSelectData() {
+        return selectData;
+    }
+
+    public void setSelectData(Object selectData) {
+        this.selectData = selectData;
+    }
+
+    @Pure
+    public int getRootNodeId() {
+        return rootNodeId;
+    }
+
+    public void setRootNodeId(int rootNodeId) {
+        this.rootNodeId = rootNodeId;
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/TreeViewService.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/TreeViewService.java
@@ -48,4 +48,7 @@ public interface TreeViewService {
     
     @JsonRequest("getresource")
     public CompletableFuture<ResourceData> getResource(GetResourceParams params);
+    
+    @JsonRequest("findpath")
+    public CompletableFuture<int[]> findPath(FindPathParams params);
 }

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -119,6 +119,11 @@
 					"default": true,
 					"description": "Avoid conflicts with other Java extensions"
 				},
+				"netbeans.revealActiveInProjects": {
+					"type": "boolean",
+					"default": true,
+					"description": "Reveals active text editor in Projects view"
+				},
 				"java.test.editor.enableShortcuts": {
 					"type": "boolean",
 					"default": false,
@@ -525,6 +530,11 @@
 				"command": "java.db.set.env",
 				"title": "Set Database Environment Variables",
 				"category": "Database"
+			},
+			{
+				"command": "java.select.editor.projects",
+				"title": "Reveal active editor in Projects",
+				"category": "Project"
 			}
 		],
 		"keybindings": [

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -121,7 +121,7 @@
 				},
 				"netbeans.revealActiveInProjects": {
 					"type": "boolean",
-					"default": true,
+					"default": false,
 					"description": "Reveals active text editor in Projects view"
 				},
 				"java.test.editor.enableShortcuts": {

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -965,14 +965,16 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
 
         ctx.subscriptions.push(window.onDidChangeActiveTextEditor(ed => {
             const netbeansConfig = workspace.getConfiguration('netbeans');
-            if (netbeansConfig.get("revealActiveInProjects", true)) {
+            if (netbeansConfig.get("revealActiveInProjects")) {
                 revealActiveEditor(ed);
             }
         }));
         ctx.subscriptions.push(vscode.commands.registerCommand("java.select.editor.projects", () => revealActiveEditor()));
 
         // attempt to reveal NOW:
-        revealActiveEditor();
+        if (netbeansConfig.get("revealActiveInProjects")) {
+            revealActiveEditor();
+        }
     }
 
     async function showHtmlPage(params : HtmlPageParams): Promise<string> {

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -888,7 +888,9 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
             commands.executeCommand('setContext', 'nbJavaLSReady', true);
         
             // create project explorer:
-            c.findTreeViewService().createView('foundProjects', 'Projects', { canSelectMany : false });
+            //c.findTreeViewService().createView('foundProjects', 'Projects', { canSelectMany : false });
+            createProjectView(context, c);
+
             createDatabaseView(c);
             c.findTreeViewService().createView('cloud.resources', undefined, { canSelectMany : false });
         }).catch(setClient[1]);
@@ -944,6 +946,33 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                 customizable.addItemDecorator(new Decorator(customizable, c))
         });
         
+    }
+
+    async function createProjectView(ctx : ExtensionContext, client : NbLanguageClient) {
+        const ts : TreeViewService = client.findTreeViewService();
+        let tv : vscode.TreeView<Visualizer> = await ts.createView('foundProjects', 'Projects', { canSelectMany : false });
+
+        async function revealActiveEditor(ed? : vscode.TextEditor) {
+            if (!window.activeTextEditor?.document?.uri) {
+                return;
+            }
+            let vis : Visualizer | undefined = await ts.findPath(tv, window.activeTextEditor?.document?.uri?.toString());
+            if (!vis) {
+                return;
+            }
+            tv.reveal(vis, { select : true, focus : false, expand : false });
+        }
+
+        ctx.subscriptions.push(window.onDidChangeActiveTextEditor(ed => {
+            const netbeansConfig = workspace.getConfiguration('netbeans');
+            if (netbeansConfig.get("revealActiveInProjects", true)) {
+                revealActiveEditor(ed);
+            }
+        }));
+        ctx.subscriptions.push(vscode.commands.registerCommand("java.select.editor.projects", () => revealActiveEditor()));
+
+        // attempt to reveal NOW:
+        revealActiveEditor();
     }
 
     async function showHtmlPage(params : HtmlPageParams): Promise<string> {

--- a/java/java.lsp.server/vscode/src/protocol.ts
+++ b/java/java.lsp.server/vscode/src/protocol.ts
@@ -187,6 +187,12 @@ export interface ResourceData {
     contentSize : number;
 }
 
+export interface FindPathParams {
+    rootNodeId : number;
+    uri? : vscode.Uri;
+    selectData? : any;
+}
+
 export namespace NodeInfoNotification {
     export const type = new ProtocolNotificationType<NodeChangedParams, void>('nodes/nodeChanged');
 }
@@ -198,6 +204,7 @@ export namespace NodeInfoRequest {
     export const destroy = new ProtocolRequestType<NodeOperationParams, boolean, never, void, void>('nodes/delete');
     export const collapsed = new ProtocolNotificationType<NodeOperationParams, void>('nodes/collapsed');
     export const getresource = new ProtocolRequestType<GetResourceParams, ResourceData, never, void, void>('nodes/getresource');
+    export const findparams = new ProtocolRequestType<FindPathParams, number[], never, void, void>('nodes/findpath');
     
     export interface IconDescriptor {
         baseUri : vscode.Uri;


### PR DESCRIPTION
This PR adds a new message client > NBLS to the TreeView LSP protocol: find path from a certain root to some data => tuple of node ids. It is now only implemented for Projects view, which delegates to `PathFinder`s of the individual projects to do the searching job.

The vscode client uses this message to find a path in its Projects tree view in order to **reveal** the position of the current editor. This PR adds automatic synchronization (default: on), a setting to manage it (`netbeans.revealActiveInProjects`) true / false and an explicit command `java.select.editor.projects` to reveal the position manually - can be bound to some keyboard shortcut.

