### PR TITLE
Fixing potential NPE.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -445,7 +445,8 @@ class NbProjectInfoBuilder {
                                 // do not bother with components that only select a variant, which is itself a component
                                 // TODO: represent as a special component type so the IDE shows it, but the IDE knows it is an abstract
                                 // intermediate with no artifact(s).
-                                if (!rdr.getResolvedVariant().getExternalVariant().isPresent()) {
+                                if (rdr.getResolvedVariant() == null ||
+                                    !rdr.getResolvedVariant().getExternalVariant().isPresent()) {
                                     componentIds.add(rdr.getSelected().getId().toString());
                                 }
                             }


### PR DESCRIPTION
It seems that `getResolvedVariant()` can be sometimes null in the case of resolved component - need to check for null here. Gradle sources (serializer) assume that getExternalVariant() is never null (as it is Optional).
The fix is conservative = if no resolved variant -> cannot check for externality -> pass on as a dependency.