### PR TITLE
Taking caret offset from SourceModificationEvent.

### DIFF
--- a/ide/csl.api/src/org/netbeans/modules/csl/spi/GsfUtilities.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/spi/GsfUtilities.java
@@ -49,6 +49,7 @@ import org.netbeans.modules.editor.indent.api.IndentUtils;
 import org.netbeans.modules.parsing.api.Snapshot;
 import org.netbeans.modules.parsing.api.Source;
 import org.netbeans.modules.parsing.spi.CursorMovedSchedulerEvent;
+import org.netbeans.modules.parsing.spi.SourceModificationEvent;
 import org.openide.ErrorManager;
 import org.openide.cookies.EditorCookie;
 import org.openide.cookies.LineCookie;
@@ -694,6 +695,10 @@ public final class GsfUtilities {
             return enforcedCaretOffset;
         }
 
+        if (event instanceof SourceModificationEvent) {
+            return ((SourceModificationEvent)event).getAffectedEndOffset();
+        }
+        
         return -1;
     }
 


### PR DESCRIPTION
Usually the GSF Languages use `sanitizing` source code to get some reasonable output from parsers. This means that the source is parsed and if there is not usable result, then the edited code is somehow change and parsed again. When the second attempt doesn't returns anything useful, then is used different sanitization and again parsed. 

A sanitization needs to know, where the last change was made, which is usually taken from caret position. In NetBeans this position is taken form opened JTextComponent. In the VSCode case, the components are not opened and caret position is set to -1. Then the edited source is not sanitized correctly. 

This fix is trying to take the possition from SourceModificationEvent. 



