### PR TITLE
3967: Avoid NPEs, assure compilation phase.

### DIFF
--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/LspElementUtils.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/LspElementUtils.java
@@ -77,11 +77,13 @@ public class LspElementUtils {
 
         StructureProvider.Builder builder = StructureProvider.newBuilder(createName(info, el), ElementHeaders.javaKind2Structure(el));
         builder.detail(createDetail(info, el));
-        FileObject f;
-        FileObject owner;
+        FileObject f = null;
+        FileObject owner = null;
         if (!bypassOpen) {
             Object[] oi = setOffsets(info, el, builder);
-            owner = f = (FileObject)oi[0]; 
+            if (oi != null) {
+                owner = f = (FileObject)oi[0]; 
+            }
         } else {
             f = null;
             owner = parentFile;
@@ -294,6 +296,9 @@ public class LspElementUtils {
     }
     
     private static StructureProvider.Builder processOffsetInfo(Object[] info, StructureProvider.Builder builder) {
+        if (info == null) {
+            return builder;
+        }
         int selStart = (int)info[3];
         if (selStart < 0) {
             selStart = (int)info[1];

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTasks.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTasks.java
@@ -486,7 +486,11 @@ final class CallHierarchyTasks {
         
         @Override
         protected void runTask() throws Exception {
-            JavaSource js = JavaSource.forFileObject(elmDesc.getSourceToQuery().getFileObject());
+            TreePathHandle tph = elmDesc.getSourceToQuery();
+            if (tph == null || tph.getFileObject() == null) {
+                return;
+            }
+            JavaSource js = JavaSource.forFileObject(tph.getFileObject());
             if (js != null) {
                 Future<Void> control = ScanUtils.postUserActionTask(js, this);
                 control.get();


### PR DESCRIPTION
This PR adds necessary checks to avoid NPE. Also CompilationController phase is advanced so the level required by later queries. There's one [functional change](https://github.com/apache/netbeans/pull/3979/files#diff-aedca9ee0932ddf7ad79f4c605251d11739cc4feb43a6fac994cfbefb1515ef4R294) - the hierarchy must be build with `true` for incoming (CALLER) and false for outgoing (CALLEE) hierearchies.

Fixes #3967.