### PR TITLE
Preventing to create hints more times.

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
@@ -164,7 +164,9 @@ public class GroovyParser extends Parser {
 
             @Override
             public void error(Error error) {
-                errors.add(error);
+                if (!errors.contains(error)) {
+                    errors.add(error);
+                }
             }
         };
         long t1 = System.currentTimeMillis();

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/error/GroovyError.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/error/GroovyError.java
@@ -180,6 +180,7 @@ public class GroovyError implements Badging {
         hash = (11 * hash) + this.id.hashCode();
         hash = (11 * hash) + this.key.hashCode();
         hash = (11 * hash) + this.severity.hashCode();
+
         return hash;
     }
     

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/error/GroovyError.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/error/GroovyError.java
@@ -137,7 +137,9 @@ public class GroovyError implements Badging {
             return false;
         }
         
-        if (!this.description.equals(test.description)) {
+        if ((this.description == null && test.description != null) || 
+                (this.description != null && test.description == null)
+                || !this.description.equals(test.description)) {
             return false;
         }
         
@@ -145,7 +147,9 @@ public class GroovyError implements Badging {
             return false;
         }
         
-        if (!this.file.equals(test.file)) {
+        if ((this.file == null && test.file != null) || 
+                (this.file != null && test.file == null)
+                || !this.file.equals(test.file)) {
             return false;
         }
         
@@ -170,9 +174,9 @@ public class GroovyError implements Badging {
 
         hash = (11 * hash) + this.start;
         hash = (11 * hash) + this.end;
-        hash = (11 * hash) + this.description.hashCode();
+        hash = (11 * hash) + (this.description != null ? this.description.hashCode() : 0);
         hash = (11 * hash) + this.displayName.hashCode();
-        hash = (11 * hash) + this.file.hashCode();
+        hash = (11 * hash) + (this.file != null ? this.file.hashCode() : 0);
         hash = (11 * hash) + this.id.hashCode();
         hash = (11 * hash) + this.key.hashCode();
         hash = (11 * hash) + this.severity.hashCode();

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/error/GroovyError.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/error/GroovyError.java
@@ -117,4 +117,66 @@ public class GroovyError implements Badging {
     public boolean showExplorerBadge() {
         return false;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj.getClass() != GroovyError.class) {
+            return false;
+        }
+
+        final GroovyError test = (GroovyError)obj;
+
+        if (this.start != test.start) {
+            return false;
+        }
+
+        if (this.end != test.end) {
+            return false;
+        }
+        
+        if (!this.description.equals(test.description)) {
+            return false;
+        }
+        
+        if (!this.displayName.equals(test.displayName)) {
+            return false;
+        }
+        
+        if (!this.file.equals(test.file)) {
+            return false;
+        }
+        
+        if (this.id != test.id) {
+            return false;
+        }
+        
+        if (!this.key.equals(test.key)) {
+            return false;
+        }
+        
+        if (this.severity != test.severity) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+
+        hash = (11 * hash) + this.start;
+        hash = (11 * hash) + this.end;
+        hash = (11 * hash) + this.description.hashCode();
+        hash = (11 * hash) + this.displayName.hashCode();
+        hash = (11 * hash) + this.file.hashCode();
+        hash = (11 * hash) + this.id.hashCode();
+        hash = (11 * hash) + this.key.hashCode();
+        hash = (11 * hash) + this.severity.hashCode();
+        return hash;
+    }
+    
 }


### PR DESCRIPTION
Sometimes the same error is reported from Groovy parser more times. This prevents processing such duplicated errors by our infrastructure. 