### PR TITLE
Update FlatLaf from 2.0.1 to 2.1

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-5CD4AE96F6B538FB784549F2636E50122FDBB5D8 com.formdev:flatlaf:2.0.1
+D425A89164BB82E1967F84B6FD3EFF5FF9F60ECD com.formdev:flatlaf:2.1

--- a/platform/libs.flatlaf/external/flatlaf-2.1-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-2.1-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 2.0.1
-Files: flatlaf-2.0.1.jar
+Version: 2.1
+Files: flatlaf-2.1.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-2.0.1.jar=modules/ext/flatlaf-2.0.1.jar
+release.external/flatlaf-2.1.jar=modules/ext/flatlaf-2.1.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-2.0.1.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-2.0.1.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-2.1.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-2.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Update FlatLaf to v2.1: https://github.com/JFormDesigner/FlatLaf/releases/tag/2.1

This release significantly improves the usability of submenus. It makes it much easier to move the mouse into a submenu without the risk that the submenu is hidden.

![grafik](https://user-images.githubusercontent.com/5604048/155986219-f719fd6d-fdc2-4863-a748-e061690ebeb6.png)

Previously, you have to move the mouse on the **red** path, otherwise the submenu will be hidden.
Now, you can move the mouse on the **green** path, over other menu items.

