### PR TITLE
Show source levels of Java platform in Ant APISupport UI.

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerSources.form
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerSources.form
@@ -21,9 +21,13 @@
 
 -->
 
-<Form version="1.0" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+<Form version="1.2" maxVersion="1.2" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <AuxValues>
+    <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+    <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerSources.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerSources.java
@@ -22,10 +22,14 @@ package org.netbeans.modules.apisupport.project.ui.customizer;
 import java.awt.EventQueue;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.modules.apisupport.project.ui.ApisupportAntUIUtils;
 import org.netbeans.spi.project.ui.support.ProjectCustomizer;
 import org.openide.NotifyDescriptor;
 import org.openide.modules.SpecificationVersion;
+import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 
 /**
@@ -87,8 +91,9 @@ final class CustomizerSources extends NbPropertyPanel.Single {
         srcLevelValueBeingUpdated = true;
         try {
             srcLevelValue.removeAllItems();
-            for (int i = 0; i < SingleModuleProperties.SOURCE_LEVELS.length; i++) {
-                srcLevelValue.addItem(SingleModuleProperties.SOURCE_LEVELS[i]);
+            String[] levels = sourceLevels(getProperties().getActiveJavaPlatform());
+            for (String level : levels) {
+                srcLevelValue.addItem(level);
             }
             srcLevelValue.setSelectedItem(getProperty(SingleModuleProperties.JAVAC_SOURCE));
         } finally {
@@ -204,4 +209,23 @@ final class CustomizerSources extends NbPropertyPanel.Single {
         prjFolderValue.getAccessibleContext().setAccessibleDescription(getMessage("ACS_PrjFolderValue"));
     }
     
+    private String[] sourceLevels(JavaPlatform platform) {
+        List<String> levels = new ArrayList<>();
+        levels.add("1.4");
+        levels.add("1.5");
+        levels.add("1.6");
+        levels.add("1.7");
+        levels.add("1.8");
+        try {
+            String platformVersion = platform.getSpecification().getVersion().toString();
+            int maxLevel = Integer.parseInt(platformVersion.split("\\.")[0]);
+            for (int level = 9; level <= maxLevel; level++) {
+                levels.add(Integer.toString(level));
+            }
+        } catch (Exception ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        return levels.toArray(new String[0]);
+    }
+
 }

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SingleModuleProperties.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SingleModuleProperties.java
@@ -118,7 +118,6 @@ public final class SingleModuleProperties extends ModuleProperties {
     public static final String SPEC_VERSION_BASE = "spec.version.base"; // NOI18N
     /** @see "#66278" */
     public static final String JAVAC_COMPILERARGS = "javac.compilerargs"; // NOI18N
-    static final String[] SOURCE_LEVELS = {"1.4", "1.5", "1.6", "1.7", "1.8", "9", "10", "11", "12", "13", "14"}; // NOI18N
     private static final Map<String, String> DEFAULTS;
 
     private static final Logger LOG = Logger.getLogger(SingleModuleProperties.class.getName());


### PR DESCRIPTION
The Ant APISupport UI only showed a hard-coded list of possible Java source levels for platform modules. This was a complaint raised by someone on users@. This is a quick fix to show levels up to that of the selected Java platform. (I couldn't see an API to get the supported levels directly? Would be useful).