### PR TITLE
Add Athena/Redshift to Add Connection wizard

### DIFF
--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/NewConnectionPanel.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/NewConnectionPanel.java
@@ -590,7 +590,13 @@ public class NewConnectionPanel extends ConnectionDialog.FocusablePanel {
                 setUpFields();
             }
 
-            updateUrlFromFields();
+            if (wd.getDatabaseUrl() == null && jdbcurl.getSampleUrl() != null) {
+                // Show the appropriate sample URL if the user switches the JDBC URL type.
+                urlField.setText(jdbcurl.getSampleUrl());
+                updateFieldsFromUrl();
+            } else {
+                updateUrlFromFields();
+            }
             fireChange();
         }
     }//GEN-LAST:event_templateComboBoxItemStateChanged

--- a/ide/db/src/org/netbeans/modules/db/util/Bundle.properties
+++ b/ide/db/src/org/netbeans/modules/db/util/Bundle.properties
@@ -24,6 +24,10 @@ TYPE_ForSQLServer=Microsoft SQL Server
 TYPE_ForSybase=Sybase ASE
 TYPE_IDS=Informix Dynamic Server (IDS)
 TYPE_Cloudscape=Cloudscape Server
+TYPE_Standard=Standard
+TYPE_Endpoint=Endpoint
+TYPE_UserName=User Name
+TYPE_IAM=IAM
 
 ERR_InvalidURL=Invalid URL, should be of the form \n{0}
 
@@ -37,6 +41,8 @@ DRIVERNAME_OracleOCI=Oracle OCI
 DRIVERNAME_JTDS=jTDS
 DRIVERNAME_DB2JCC=IBM DB2 Universal Driver
 DRIVERNAME_MSSQL=Microsoft SQL Server
+DRIVERNAME_Athena=Amazon Athena
+DRIVERNAME_Redshift=Amazon Redshift
 
 # Map JDBC URL token identifiers to human-readable strings
 <HOST>=Host

--- a/ide/db/src/org/netbeans/modules/db/util/DriverListUtil.java
+++ b/ide/db/src/org/netbeans/modules/db/util/DriverListUtil.java
@@ -237,6 +237,46 @@ public class DriverListUtil {
         url.setSampleUser("root");
         url.setSamplePassword("");
 
+        /* Use the class com.simba.athena.jdbc.Driver instead of
+        com.simba.athena.jdbc42.Driver, per the documentation: "The connector supports the following
+        fully-qualified class names (FQCNs) that are independent of the JDBC version:
+        com.simba.athena.jdbc.Driver". */
+        url = add(NbBundle.getMessage(DriverListUtil.class, "DRIVERNAME_Athena"),
+                NbBundle.getMessage(DriverListUtil.class, "TYPE_Standard"),
+                "com.simba.athena.jdbc.Driver",
+                "jdbc:awsathena://[<ADDITIONAL>]", true); // NOI18N
+        url.setSampleUser("");
+        url.setSamplePassword("");
+        url.setSampleUrl("jdbc:awsathena://AwsRegion=us-west-1;S3OutputLocation=s3://working/dir");
+
+        url = add(NbBundle.getMessage(DriverListUtil.class, "DRIVERNAME_Athena"),
+                NbBundle.getMessage(DriverListUtil.class, "TYPE_Endpoint"),
+                "com.simba.athena.jdbc.Driver",
+                "jdbc:awsathena://<HOST>[:<PORT>][;<ADDITIONAL>]", true); // NOI18N
+        url.setSampleUser("");
+        url.setSamplePassword("");
+        url.setSampleUrl("jdbc:awsathena://athena.us-east-1.amazonaws.com:443;S3OutputLocation=s3://working/dir"); // Make sure the default port gets set.
+
+        /* Use the class com.amazon.redshift.jdbc.Driver instead of
+        com.amazon.redshift.jdbc42.Driver, per the documentation: "The connector supports the
+        following fully-qualified class names (FQCNs) that are independent of the JDBC version:
+        com.amazon.redshift.jdbc.Driver". */
+        url = add(NbBundle.getMessage(DriverListUtil.class, "DRIVERNAME_Redshift"),
+                NbBundle.getMessage(DriverListUtil.class, "TYPE_UserName"),
+                "com.amazon.redshift.jdbc.Driver",
+                "jdbc:redshift://[<HOST>[:<PORT>]][/<DB>][;<ADDITIONAL>]", true); // NOI18N
+        url.setSampleUser("");
+        url.setSamplePassword("");
+        url.setSampleUrl("jdbc:redshift://examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com:5439/dev"); // Make sure the default port gets set.
+
+        url = add(NbBundle.getMessage(DriverListUtil.class, "DRIVERNAME_Redshift"),
+                NbBundle.getMessage(DriverListUtil.class, "TYPE_IAM"),
+                "com.amazon.redshift.jdbc.Driver",
+                "jdbc:redshift:iam://[<HOST>[:<PORT>]][/<DB>][;<ADDITIONAL>]", true); // NOI18N
+        url.setSampleUser("");
+        url.setSamplePassword("");
+        url.setSampleUrl("jdbc:redshift:iam://examplecluster.abc123xyz789.us-west-2.redshift.amazonaws.com:5439/dev"); // Make sure the default port gets set.
+
         add("MySQL (MM.MySQL driver)",
         "org.gjt.mm.mysql.Driver",
         "jdbc:mysql://<HOST>[:<PORT>]/<DB>");

--- a/ide/db/src/org/netbeans/modules/db/util/JdbcUrl.java
+++ b/ide/db/src/org/netbeans/modules/db/util/JdbcUrl.java
@@ -172,7 +172,7 @@ public class JdbcUrl extends HashMap<String, String> {
             return nameAndType;
         }
     }
-    
+
     public boolean supportsToken(String token) {
         return supportedTokens.contains(token);
     }
@@ -737,7 +737,8 @@ public class JdbcUrl extends HashMap<String, String> {
                 "',className='" + className + // NOI18N
                 "',type='" + type + // NOI18N
                 "',urlTemplate='" + urlTemplate + // NOI18N
-                "'parseUrl,=" + parseUrl + "]"; // NOI18N
+                "',parseUrl,=" + parseUrl + // NOI18N
+                "',sampleUrl,=" + sampleUrl + "]"; // NOI18N
     }
 
     public String getSampleUser() {

--- a/ide/db/test/unit/src/org/netbeans/modules/db/util/DriverListUtilTest.java
+++ b/ide/db/test/unit/src/org/netbeans/modules/db/util/DriverListUtilTest.java
@@ -226,6 +226,86 @@ public class DriverListUtilTest extends TestCase {
         propValues.remove(JdbcUrl.TOKEN_HOST);
         testUrlString(url, propValues, "jdbc:mariadb:///" + DB);
     }
+
+    public void testAmazonAthenaStandard() throws Exception {
+        ArrayList<String> supportedProps = new ArrayList<>();
+        supportedProps.add(JdbcUrl.TOKEN_ADDITIONAL);
+        ArrayList<String> requiredProps = new ArrayList<String>();
+
+        JdbcUrl url = checkUrl(getDriverName("DRIVERNAME_Athena"), getType("TYPE_Standard"), "com.simba.athena.jdbc.Driver",
+                "jdbc:awsathena://[<ADDITIONAL>]",
+                supportedProps, requiredProps);
+
+        HashMap<String, String> propValues = buildPropValues(supportedProps);
+
+        testUrlString(url, propValues, "jdbc:awsathena://" + ADDITIONAL);
+
+        propValues.remove(JdbcUrl.TOKEN_ADDITIONAL);
+        testUrlString(url, propValues, "jdbc:awsathena://");
+    }
+
+    public void testAmazonAthenaEndpoint() throws Exception {
+        ArrayList<String> supportedProps = new ArrayList<>();
+        supportedProps.add(JdbcUrl.TOKEN_HOST);
+        supportedProps.add(JdbcUrl.TOKEN_PORT);
+        supportedProps.add(JdbcUrl.TOKEN_ADDITIONAL);
+        ArrayList<String> requiredProps = new ArrayList<String>();
+        requiredProps.add(JdbcUrl.TOKEN_HOST);
+
+        JdbcUrl url = checkUrl(getDriverName("DRIVERNAME_Athena"), getType("TYPE_Endpoint"), "com.simba.athena.jdbc.Driver",
+                "jdbc:awsathena://<HOST>[:<PORT>][;<ADDITIONAL>]",
+                supportedProps, requiredProps);
+
+        HashMap<String, String> propValues = buildPropValues(supportedProps);
+
+        testUrlString(url, propValues, "jdbc:awsathena://" + HOST + ":" + PORT + ";" + ADDITIONAL);
+
+        propValues.remove(JdbcUrl.TOKEN_ADDITIONAL);
+        testUrlString(url, propValues, "jdbc:awsathena://" + HOST + ":" + PORT);
+
+        propValues.remove(JdbcUrl.TOKEN_PORT);
+        testUrlString(url, propValues, "jdbc:awsathena://" + HOST);
+    }
+
+    public void testAmazonRedshiftUserName() throws Exception {
+        ArrayList<String> requiredProps = new ArrayList<String>();
+        JdbcUrl url = checkUrl(getDriverName("DRIVERNAME_Redshift"), getType("TYPE_UserName"), "com.amazon.redshift.jdbc.Driver",
+                "jdbc:redshift://[<HOST>[:<PORT>]][/<DB>][;<ADDITIONAL>]",
+                STD_SUPPORTED_PROPS, requiredProps);
+
+        HashMap<String, String> propValues = buildPropValues(STD_SUPPORTED_PROPS);
+
+        testUrlString(url, propValues, "jdbc:redshift://" + HOST + ":" + PORT + "/" + DB + ";" + ADDITIONAL);
+
+        propValues.remove(JdbcUrl.TOKEN_ADDITIONAL);
+        testUrlString(url, propValues, "jdbc:redshift://" + HOST + ":" + PORT + "/" + DB);
+
+        propValues.remove(JdbcUrl.TOKEN_PORT);
+        testUrlString(url, propValues, "jdbc:redshift://" + HOST + "/" + DB);
+
+        propValues.remove(JdbcUrl.TOKEN_HOST);
+        testUrlString(url, propValues, "jdbc:redshift:///" + DB);
+    }
+
+    public void testAmazonRedshiftIAM() throws Exception {
+        ArrayList<String> requiredProps = new ArrayList<String>();
+        JdbcUrl url = checkUrl(getDriverName("DRIVERNAME_Redshift"), getType("TYPE_IAM"), "com.amazon.redshift.jdbc.Driver",
+                "jdbc:redshift:iam://[<HOST>[:<PORT>]][/<DB>][;<ADDITIONAL>]",
+                STD_SUPPORTED_PROPS, requiredProps);
+
+        HashMap<String, String> propValues = buildPropValues(STD_SUPPORTED_PROPS);
+
+        testUrlString(url, propValues, "jdbc:redshift:iam://" + HOST + ":" + PORT + "/" + DB + ";" + ADDITIONAL);
+
+        propValues.remove(JdbcUrl.TOKEN_ADDITIONAL);
+        testUrlString(url, propValues, "jdbc:redshift:iam://" + HOST + ":" + PORT + "/" + DB);
+
+        propValues.remove(JdbcUrl.TOKEN_PORT);
+        testUrlString(url, propValues, "jdbc:redshift:iam://" + HOST + "/" + DB);
+
+        propValues.remove(JdbcUrl.TOKEN_HOST);
+        testUrlString(url, propValues, "jdbc:redshift:iam:///" + DB);
+    }
     
     enum DB2Types { DB2, IDS, CLOUDSCAPE };
     


### PR DESCRIPTION
Add support for Amazon Athena and Amazon Redshift connections in the IDE's database connection wizard.

Also ensure that the sample JDBC URL is properly shown when the user changes the URL type from the dropdown.
