### PR TITLE
Improve vertical centering of FlatLAF buttons on Windows

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
@@ -21,14 +21,23 @@ package org.netbeans.swing.laf.flatlaf;
 
 import com.formdev.flatlaf.util.UIScale;
 import java.awt.Color;
+import java.awt.Font;
+import java.awt.Insets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.swing.BorderFactory;
 import javax.swing.InputMap;
 import javax.swing.KeyStroke;
 import javax.swing.UIDefaults;
 import javax.swing.UIDefaults.LazyValue;
 import javax.swing.UIManager;
+import javax.swing.border.CompoundBorder;
+import javax.swing.plaf.InsetsUIResource;
 import org.netbeans.swing.laf.flatlaf.ui.FlatTabControlIcon;
 import org.netbeans.swing.plaf.LFCustoms;
 import org.netbeans.swing.tabcontrol.plaf.TabControlButton;
+import org.openide.util.Utilities;
 
 /**
  * LFCustoms for FlatLaf based LAFs (light, dark, etc).
@@ -54,7 +63,7 @@ public class FlatLFCustoms extends LFCustoms {
             "ctrl PAGE_DOWN", null // NOI18N
         };
 
-        return new Object[] {
+        Object[] constants = new Object[] {
             // unified background
             "nb.options.categories.tabPanelBackground", unifiedBackground,
             "nb.quicksearch.background", quicksearchBackground,
@@ -120,6 +129,29 @@ public class FlatLFCustoms extends LFCustoms {
             "Table.ancestorInputMap.RightToLeft", new LazyModifyInputMap( "Table.ancestorInputMap.RightToLeft", removeCtrlPageUpDownKeyBindings ), // NOI18N
             "Tree.focusInputMap", new LazyModifyInputMap( "Tree.focusInputMap", removeCtrlPageUpDownKeyBindings ), // NOI18N
         };
+        List<Object> result = new ArrayList<>();
+        result.addAll(Arrays.asList(constants));
+        if (Utilities.isWindows()) {
+            /* Make sure button labels appear vertically centered on Windows. On the standard
+            Windows LAF, WindowsButtonUI/WindowsRadioButtonUI/WindowsToggleButtonUI.getPreferredSize
+            add one pixel to the button's height to ensure that it is odd-numbered. This makes the
+            text centered with either Tahoma 11 (the default Swing Windows LAF font) or Segoe UI 12
+            (the default font on modern Windows versions, and on FlatLAF on Windows). */
+            for (String key : new String[] { "Button", "RadioButton", "ToggleButton" }) {
+                UIDefaults defaults = UIManager.getDefaults();
+                Font font = defaults.getFont(key + ".font");
+                Insets bm = defaults.getInsets(key + ".margin");
+                if (font != null && bm instanceof InsetsUIResource &&
+                        font.getFamily().equals("Segoe UI") && font.getSize() == 12 &&
+                        bm.top == bm.bottom) {
+                    result.add(key + ".margin");
+                    /* Create an InsetsUIResource rather than an Insets, as FlatLAF treats them
+                    differently. Not doing this caused buttons in the main toolbar to become very wide. */
+                    result.add(new InsetsUIResource(bm.top, bm.left, bm.bottom + 1, bm.right));
+                }
+            }
+        }
+        return result.toArray();
     }
 
     static void updateUnifiedBackground() {


### PR DESCRIPTION
On FlatLAF on Windows, improve vertical centering of labels in buttons. The solution was to make the buttons one pixel taller, as was done in the standard Swing Windows LAF.

See before/after screenshots below.

![Centering](https://user-images.githubusercontent.com/886243/163715807-aa85cf7d-a007-4351-b02f-d44d15cf89f0.png)

