### PR TITLE
[3921] Correctly handling opens directive in package rename.

### DIFF
--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveTransformer.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveTransformer.java
@@ -449,16 +449,26 @@ public class MoveTransformer extends RefactoringVisitor {
 
     @Override
     public Tree visitExports(ExportsTree node, Element p) {
-        if (!workingCopy.getTreeUtilities().isSynthetic(getCurrentPath())) {
-            final Element el = workingCopy.getTrees().getElement(new TreePath(getCurrentPath(), node.getPackageName()));
-            if (el != null && el.getKind() == ElementKind.PACKAGE && isThisPackageMoving((PackageElement)el)) {
-                Tree nju = make.Identifier(getTargetPackageName(el));
-                rewrite(node.getPackageName(), nju);                 
-            }
-        }
+        renamePackage(node.getPackageName());
         return super.visitExports(node, p);
     }
-    
+
+    @Override
+    public Tree visitOpens(OpensTree node, Element p) {
+        renamePackage(node.getPackageName());
+        return super.visitOpens(node, p);
+    }
+
+    private void renamePackage(ExpressionTree packageName) {
+        if (!workingCopy.getTreeUtilities().isSynthetic(getCurrentPath())) {
+            final Element el = workingCopy.getTrees().getElement(new TreePath(getCurrentPath(), packageName));
+            if (el != null && el.getKind() == ElementKind.PACKAGE && isThisPackageMoving((PackageElement)el)) {
+                Tree nju = make.Identifier(getTargetPackageName(el));
+                rewrite(packageName, nju);
+            }
+        }
+    }
+
     private boolean containsAnyOf(Element el, EnumSet<Modifier> neededMods) {
         for (Modifier mod : neededMods) {
             if(el.getModifiers().contains(mod)) {

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RenamePackageTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RenamePackageTest.java
@@ -20,8 +20,10 @@
 package org.netbeans.modules.refactoring.java.test;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import org.netbeans.modules.java.source.parsing.JavacParser;
 import org.netbeans.modules.refactoring.api.Problem;
 import org.netbeans.modules.refactoring.api.RefactoringSession;
@@ -37,8 +39,10 @@ import org.openide.util.lookup.Lookups;
  */
 public class RenamePackageTest extends RefactoringTestBase {
 
+    private static final Set<String> MODULAR_TESTS = new HashSet<>(Arrays.asList("testModuleOpens"));
+
     public RenamePackageTest(String name) {
-        super(name, "1.8");
+        super(name, MODULAR_TESTS.contains(name) ? "9" : "1.8");
     }
     
     static {
@@ -129,6 +133,26 @@ public class RenamePackageTest extends RefactoringTestBase {
                 + "}"));
     }
     
+    public void testModuleOpens() throws Exception {
+        writeFilesAndWaitForScan(src,
+                new File("module-info.java", "module m {\n"
+                + "exports t;\n"
+                + "opens t;\n"
+                + "}"),
+                new File("t/A.java", "package t;\n"
+                + "public class A {\n"
+                + "}"));
+        performRenameFolder(src.getFileObject("t"), "u", false);
+        verifyContent(src,
+                new File("module-info.java", "module m {\n"
+                + "exports u;\n"
+                + "opens u;\n"
+                + "}"),
+                new File("u/A.java", "package u;\n"
+                + "public class A {\n"
+                + "}"));
+    }
+
         
     private void performRenameFolder(FileObject source, final String newname, boolean searchInComments, Problem... expectedProblems) throws Exception {
         final RenameRefactoring[] r = new RenameRefactoring[1];


### PR DESCRIPTION
When a package is renamed, reference to it in the `opens` directive is not renamed - fixed. See:
https://github.com/apache/netbeans/issues/3921
