### PR TITLE
Fix GradleReport Notification and potential NPE on Gradle earlier, than 6.8

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -445,9 +445,14 @@ class NbProjectInfoBuilder {
                                 // do not bother with components that only select a variant, which is itself a component
                                 // TODO: represent as a special component type so the IDE shows it, but the IDE knows it is an abstract
                                 // intermediate with no artifact(s).
-                                if (rdr.getResolvedVariant() == null ||
-                                    !rdr.getResolvedVariant().getExternalVariant().isPresent()) {
+                                if (rdr.getResolvedVariant() == null) {
                                     componentIds.add(rdr.getSelected().getId().toString());
+                                } else {
+                                    sinceGradle("6.8", () -> {
+                                        if (!rdr.getResolvedVariant().getExternalVariant().isPresent()) {
+                                            componentIds.add(rdr.getSelected().getId().toString());
+                                        }
+                                    });
                                 }
                             }
                         }

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleReport.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleReport.java
@@ -107,6 +107,11 @@ public final class GradleReport {
         return Objects.equals(this.location, other.location);
     }
 
+    @Override
+    public String toString() {
+        return formatReportForHintOrProblem(true, null);
+    }
+
     @NbBundle.Messages({
         "# {0} - previous part",
         "# {1} - appended part",
@@ -119,6 +124,7 @@ public final class GradleReport {
         "# {1} - the file",
         "FMT_MessageWithLocationNoLine={0} ({1})"
     })
+
     /**
      * Formats the report for simple viewing. The function concatenates report messages, starting from
      * outer Report. If `includeLocation` is true, script name + line is printed at the end. 

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
@@ -175,7 +175,7 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
                 errors.openNotification(
                         TIT_LOAD_ISSUES(base.getProjectDir().getName()),
                         TIT_LOAD_ISSUES(base.getProjectDir().getName()),
-                        GradleProjectErrorNotifications.bulletedList(info.getProblems()));                
+                        GradleProjectErrorNotifications.bulletedList(info.getProblems()));
             }
             if (!info.hasException()) {
                 if (!info.getProblems().isEmpty() || !info.getReports().isEmpty()) {
@@ -373,9 +373,11 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
         
         if (e.getClass().getName().endsWith("LocationAwareException")) { // NOI18N
             String rawLoc = getLocation(e);
-            Matcher m = FILE_PATH_FROM_LOCATION.matcher(rawLoc);
-            loc = m.matches() ? m.group(1) : rawLoc;
-            line = getLineNumber(e);
+            if (rawLoc != null) {
+                Matcher m = FILE_PATH_FROM_LOCATION.matcher(rawLoc);
+                loc = m.matches() ? m.group(1) : rawLoc;
+                line = getLineNumber(e);
+            }
             reported = e.getCause();
         } else {
             reported = e;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1381701/163730370-07939117-cd65-411e-a04f-fff17af1d53d.png)

My intention was to fix this notification, by adding an appropriate toString() method to GradleReport. Though it seems the project where I've got this was generating an NPE in LegacyProjectLoader. Which root cause was that, the recently introduced method call of getExternalVariant() was added only Gradle 6.8