### PR TITLE
Support JUnit5 nested test classes

### DIFF
--- a/ide/api.java.classpath/src/org/netbeans/api/java/classpath/ClassPath.java
+++ b/ide/api.java.classpath/src/org/netbeans/api/java/classpath/ClassPath.java
@@ -1204,8 +1204,9 @@ public final class ClassPath {
         final StringBuilder relativePathBuilder = new StringBuilder();
         FileObject child;
         String separator = "";    //NOI18N
-        for (int i = 0; i < nameParts.length && parent != null; i += 2, parent = child) {            
-            child = parent.getFileObject(nameParts[i], nameParts[i + 1]);
+        for (int i = 0; i < nameParts.length && parent != null; i += 2, parent = child) {
+            String classDefinedInFile = nameParts[i].split("\\$")[0];
+            child = parent.getFileObject(classDefinedInFile, nameParts[i + 1]);
             if (child != null) {
                 relativePathBuilder.append(separator).append(child.getNameExt());
             }

--- a/ide/projectapi/src/org/netbeans/spi/project/SingleMethod.java
+++ b/ide/projectapi/src/org/netbeans/spi/project/SingleMethod.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.spi.project;
 
+import java.util.Objects;
 import org.openide.filesystems.FileObject;
 
 /**
@@ -31,6 +32,7 @@ public final class SingleMethod {
 
     private FileObject file;
     private String methodName;
+    private String enclosingType = null;
 
     /**
      * Creates a new instance holding the specified identification
@@ -54,6 +56,19 @@ public final class SingleMethod {
         this.methodName = methodName;
     }
 
+    public SingleMethod(FileObject file, String methodName, String enclosingType) {
+        super();
+        if (file == null) {
+            throw new IllegalArgumentException("file is <null>");
+        }
+        if (methodName == null) {
+            throw new IllegalArgumentException("methodName is <null>");
+        }
+        this.file = file;
+        this.methodName = methodName;
+        this.enclosingType = enclosingType;
+    }
+
     /**
      * Returns the file identification.
      *
@@ -72,6 +87,10 @@ public final class SingleMethod {
      */
     public String getMethodName() {
         return methodName;
+    }
+
+    public String getEnclosingType() {
+        return enclosingType;
     }
 
     /**
@@ -94,14 +113,16 @@ public final class SingleMethod {
             return false;
         }
         SingleMethod other = (SingleMethod) obj;
-        return other.file.equals(file) && other.methodName.equals(methodName);
+        return other.file.equals(file) && other.methodName.equals(methodName)
+            && Objects.equals(this.enclosingType, other.enclosingType);
     }
 
     @Override
     public int hashCode() {
         int hash = 7;
-        hash = 29 * hash + this.file.hashCode();
-        hash = 29 * hash + this.methodName.hashCode();
+        hash = 29 * hash + Objects.hashCode(this.file);
+        hash = 29 * hash + Objects.hashCode(this.methodName);
+        hash = 29 * hash + Objects.hashCode(this.enclosingType);
         return hash;
     }
 }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
@@ -99,9 +99,23 @@ public class GradleJavaTokenProvider implements ReplaceTokenProvider {
         if ((fo != null) && fo.isData()) {
             GradleJavaProject gjp = GradleJavaProject.get(project);
             String className = evaluateClassName(gjp, fo);
-            String selectedMethod = method != null ? className + '.' + method.getMethodName() : className;
+            String selectedMethod = fullyQualifiedMethodName(className, method);
             map.put(SELECTED_METHOD, selectedMethod);
         }
+    }
+
+    private String fullyQualifiedMethodName(String className, SingleMethod singleMethod) {
+        if(singleMethod == null) {
+            return className;
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append(className);
+        if(singleMethod.getEnclosingType() != null) {
+            sb.append(singleMethod.getEnclosingType());
+        }
+        sb.append('.');
+        sb.append(singleMethod.getMethodName());
+        return sb.toString();
     }
 
     private void processSourceSets(final Map<String, String> map, Lookup context) {

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestClassInfoTask.java
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestClassInfoTask.java
@@ -25,7 +25,6 @@ import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.Trees;
-import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,7 +56,6 @@ import org.netbeans.modules.java.testrunner.ui.spi.ComputeTestMethods;
 import org.netbeans.modules.java.testrunner.ui.spi.ComputeTestMethods.Factory;
 import org.netbeans.modules.parsing.spi.Parser;
 import org.netbeans.spi.project.SingleMethod;
-import org.openide.ErrorManager;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
 import org.openide.util.lookup.ServiceProvider;
@@ -150,12 +148,13 @@ public final class TestClassInfoTask implements Task<CompilationController> {
                     int end = (int) sp.getEndPosition(tp.getCompilationUnit(), tp.getLeaf());
                     Document doc = info.getSnapshot().getSource().getDocument(false);
                     try {
+                        String enclosingType = getEnclosingType(elements.getBinaryName(typeElement).toString(), info.getFileObject().getName());
                         result.add(new TestMethod(elements.getBinaryName(typeElement).toString(),
-                                doc != null ? doc.createPosition(clazzPreferred) : new SimplePosition(clazzPreferred),
-                                new SingleMethod(info.getFileObject(), mn),
-                                doc != null ? doc.createPosition(start) : new SimplePosition(start),
-                                doc != null ? doc.createPosition(preferred) : new SimplePosition(preferred),
-                                doc != null ? doc.createPosition(end) : new SimplePosition(end)));
+                            doc != null ? doc.createPosition(clazzPreferred) : new SimplePosition(clazzPreferred),
+                            new SingleMethod(info.getFileObject(), mn, enclosingType),
+                            doc != null ? doc.createPosition(start) : new SimplePosition(start),
+                            doc != null ? doc.createPosition(preferred) : new SimplePosition(preferred),
+                            doc != null ? doc.createPosition(end) : new SimplePosition(end)));
                     } catch (BadLocationException ex) {
                         //ignore
                     }
@@ -176,6 +175,15 @@ public final class TestClassInfoTask implements Task<CompilationController> {
                 }
             });
         }
+    }
+
+    private static String getEnclosingType(String fqClassName, String fileName) {
+        // drop the package name
+        String classOnly = fqClassName.substring(fqClassName.lastIndexOf('.') + 1);
+        if (classOnly.startsWith(fileName) && classOnly.length() > fileName.length()) {
+            return classOnly.substring(fileName.length());
+        }
+        return null;
     }
 
     private static boolean isTestSource(FileObject fo) {

--- a/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitNodeOpener.java
+++ b/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitNodeOpener.java
@@ -114,11 +114,16 @@ public final class MavenJUnitNodeOpener extends NodeOpener {
                             compilationController.toPhase(Phase.ELEMENTS_RESOLVED);
                             Trees trees = compilationController.getTrees();
                             CompilationUnitTree compilationUnitTree = compilationController.getCompilationUnit();
+                            String desiredClassName = extractDeepestClass(node.getTestcase().getClassName());
                             List<? extends Tree> typeDecls = compilationUnitTree.getTypeDecls();
                             for (Tree tree : typeDecls) {
                                 Element element = trees.getElement(trees.getPath(compilationUnitTree, tree));
-                                if (element != null && element.getKind() == ElementKind.CLASS && element.getSimpleName().contentEquals(fo2open[0].getName())) {
-                                    List<? extends ExecutableElement> methodElements = ElementFilter.methodsIn(element.getEnclosedElements());
+                                Element classElement = getClassElement(element, desiredClassName);
+                                if (classElement == null) {
+                                    classElement = getClassElement(element, fo2open[0].getName());
+                                }
+                                if (classElement != null) {
+                                    List<? extends ExecutableElement> methodElements = ElementFilter.methodsIn(classElement.getEnclosedElements());
                                     for (Element child : methodElements) {
                                         String name = node.getTestcase().getName(); // package.name.method.name
                                         if (child.getSimpleName().contentEquals(name.substring(name.lastIndexOf(".") + 1))) {
@@ -143,6 +148,36 @@ public final class MavenJUnitNodeOpener extends NodeOpener {
             }
             UIJavaUtils.openFile(fo2open[0], (int) line[0]);
         }
+    }
+
+    private String extractDeepestClass(String testNodeClassName) {
+        String classNamesOnly = testNodeClassName;
+        // strip package names
+        int lastDot = testNodeClassName.lastIndexOf(".");
+        if (lastDot >= 0) {
+            classNamesOnly = classNamesOnly.substring(lastDot + 1);
+        }
+
+        // split embedded classes
+        String[] classes = classNamesOnly.split("\\$");
+        return classes[classes.length - 1];
+    }
+
+    private Element getClassElement(Element element, String className) {
+        if (element == null || element.getKind() != ElementKind.CLASS) {
+            return null;
+        }
+
+        if (element.getSimpleName().contentEquals(className)) {
+            return element;
+        }
+        for (Element enclosedElement : element.getEnclosedElements()) {
+            Element enclosedClass = getClassElement(enclosedElement, className);
+            if (enclosedClass != null) {
+                return enclosedClass;
+            }
+        }
+        return null;
     }
 
     public void openCallstackFrame(Node node, @NonNull String frameInfo) {

--- a/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
+++ b/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
@@ -681,6 +681,13 @@ public class JUnitOutputListenerProvider implements OutputProcessor {
                     }
                 }
 
+                String classname = testcase.getAttributeValue("classname");
+                // keep the embedded class in classnames and add to display name
+                int suiteNameLength = suite.getName().length();
+                if (classname.length() > suiteNameLength && classname.startsWith(suite.getName())) {
+                    displayName = classname.substring(suiteNameLength) + "." + methodName;
+                }
+
                 Testcase test = new JUnitTestcase(methodName, displayName, testType, session);
                 Element stdout = testcase.getChild("system-out"); //NOI18N
                 // If *-output.txt file exists do not log standard output here to avoid logging it twice.
@@ -714,7 +721,6 @@ public class JUnitOutputListenerProvider implements OutputProcessor {
                     float fl = NumberFormat.getNumberInstance(Locale.ENGLISH).parse(time).floatValue();
                     test.setTimeMillis((long)(fl * 1000));
                 }
-                String classname = testcase.getAttributeValue("classname");
                 if (classname != null) {
                     //#204480
                     if (classname.endsWith(nameSuffix)) {

--- a/java/maven/src/org/netbeans/modules/maven/TestChecker.java
+++ b/java/maven/src/org/netbeans/modules/maven/TestChecker.java
@@ -54,9 +54,17 @@ public class TestChecker implements PrerequisitesChecker {
         { //NOI18N - profile-tests is not really nice but well.
                 String test = config.getProperties().get("test");
                 String method = config.getProperties().get(DefaultReplaceTokenProvider.METHOD_NAME);
-                if (test != null && method != null) {
+                String enclosingType = config.getProperties().get(DefaultReplaceTokenProvider.ENCLOSING_TYPE_NAME);
+                if (test != null) {
                     config.setProperty(DefaultReplaceTokenProvider.METHOD_NAME, null);
-                    config.setProperty("test", test + '#' + method);
+                    config.setProperty(DefaultReplaceTokenProvider.ENCLOSING_TYPE_NAME, null);
+                    // ensure that maven executes all the methods in embedded classes too.
+                    String methodConstraint = method == null ? "," + test + "$*" : "#" + method;
+                    if (enclosingType != null) {
+                        config.setProperty("test", test + enclosingType + methodConstraint);
+                    } else {
+                        config.setProperty("test", test + methodConstraint);
+                    }
                 }
         }
         if (ActionProviderImpl.COMMAND_INTEGRATION_TEST_SINGLE.equals(action) ||
@@ -65,9 +73,16 @@ public class TestChecker implements PrerequisitesChecker {
         {
                 String test = config.getProperties().get("it.test"); //NOI18N
                 String method = config.getProperties().get(DefaultReplaceTokenProvider.METHOD_NAME);
-                if (test != null && method != null) {
+                String enclosingType = config.getProperties().get(DefaultReplaceTokenProvider.ENCLOSING_TYPE_NAME);
+                if (test != null) {
                     config.setProperty(DefaultReplaceTokenProvider.METHOD_NAME, null);
-                    config.setProperty("it.test", test + '#' + method); //NOI18N
+                    config.setProperty(DefaultReplaceTokenProvider.ENCLOSING_TYPE_NAME, null);
+                    String methodConstraint = method == null ? "," + test + "$*" : "#" + method;
+                    if (enclosingType != null) {
+                        config.setProperty("it.test", test + enclosingType + methodConstraint);
+                    } else {
+                        config.setProperty("it.test", test + methodConstraint);
+                    }
                 }
         }
         if (MavenSettings.getDefault().isSkipTests()) {

--- a/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
@@ -29,7 +29,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.swing.ActionMap;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.java.project.JavaProjectConstants;
 import org.netbeans.api.java.queries.UnitTestForSourceQuery;
@@ -44,7 +43,6 @@ import org.netbeans.modules.maven.NbMavenProjectImpl;
 import org.netbeans.modules.maven.api.NbMavenProject;
 import org.netbeans.modules.maven.classpath.MavenSourcesImpl;
 import org.netbeans.modules.maven.configurations.M2ConfigProvider;
-import org.netbeans.modules.maven.runjar.MavenExecuteUtils;
 import org.netbeans.modules.maven.spi.actions.ActionConvertor;
 import org.netbeans.modules.maven.spi.actions.ReplaceTokenProvider;
 import org.netbeans.spi.project.ActionProvider;
@@ -74,6 +72,7 @@ public class DefaultReplaceTokenProvider implements ReplaceTokenProvider, Action
     static final String PACK_CLASSNAME = "packageClassName";//NOI18N
     static final String ABSOLUTE_PATH = "absolutePathName";
     public static final String METHOD_NAME = "nb.single.run.methodName"; //NOI18N
+    public static final String ENCLOSING_TYPE_NAME = "nb.single.run.enclosingType"; //NOI18N
     private static final String VARIABLE_PREFIX = "var."; //NOI18N
     // as defined in org.netbeans.modules.project.ant.VariablesModel
     public static String[] fileBasedProperties = new String[] {
@@ -234,6 +233,7 @@ public class DefaultReplaceTokenProvider implements ReplaceTokenProvider, Action
             //sort of hack to push the method name through the current apis..
             SingleMethod method = methods.iterator().next();
             replaceMap.put(METHOD_NAME, method.getMethodName());
+            replaceMap.put(ENCLOSING_TYPE_NAME, method.getEnclosingType());
         }
 
         if (group != null &&

--- a/java/maven/src/org/netbeans/modules/maven/spi/actions/AbstractMavenActionsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/spi/actions/AbstractMavenActionsProvider.java
@@ -264,6 +264,7 @@ public abstract class AbstractMavenActionsProvider implements MavenActionsProvid
                 if (replaceMap.containsKey(DefaultReplaceTokenProvider.METHOD_NAME)) {
                     //sort of hack to push the method name through the current apis..
                     mrc.setProperty(DefaultReplaceTokenProvider.METHOD_NAME, replaceMap.get(DefaultReplaceTokenProvider.METHOD_NAME));
+                    mrc.setProperty(DefaultReplaceTokenProvider.ENCLOSING_TYPE_NAME, replaceMap.get(DefaultReplaceTokenProvider.ENCLOSING_TYPE_NAME));
                 }
                 return mrc;
             }


### PR DESCRIPTION
Adds support for nested Junit5 test classes  (`@Nested`) for the following operations:

1. [MAVEN] Navigate from the Test results to a method inside a nested class - for Gradle this has already been fixed in the past.
2. [MAVEN | GRADLE] Execute a single test method from a nested test class
3. [MAVEN] Distinguish method names inside embedded classes with their enclosing type
4. [MAVEN] Test file action now executes all test methods, including those in the embedded classes

Implements most of https://github.com/apache/netbeans/issues/3975.

IMO, the outstanding item is GRADLE Test Results showing all the test methods in the UI.


