### PR TITLE
[NETBEANS-5599] PHP 8.1 Support: Enumerations

### DIFF
--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -20,7 +20,7 @@ build.compiler=extJavac
 nbjavac.ignore.missing.enclosing=**/CUP$ASTPHP5Parser$actions.class
 javac.compilerargs=-J-Xmx512m
 nbm.needs.restart=true
-spec.version.base=2.13.0
+spec.version.base=2.14.0
 release.external/predefined_vars-1.0.zip=docs/predefined_vars.zip
 sigtest.gen.fail.on.error=false
 

--- a/php/php.editor/src/org/netbeans/modules/php/editor/api/ElementQuery.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/api/ElementQuery.java
@@ -143,6 +143,8 @@ public interface ElementQuery {
 
         Set<InterfaceElement> getInterfaces(NameKind query, Set<AliasedName> aliases, AliasedElement.Trait trait);
 
+        Set<EnumElement> getEnums(NameKind query, Set<AliasedName> aliases, AliasedElement.Trait trait);
+
         Set<TraitElement> getTraits(final NameKind query);
 
         Set<EnumElement> getEnums(final NameKind query);

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -146,6 +146,8 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
         PHP_KEYWORDS.put("use", KeywordCompletionType.SIMPLE); //NOI18N
         PHP_KEYWORDS.put("namespace", KeywordCompletionType.SIMPLE); //NOI18N
         PHP_KEYWORDS.put("class", KeywordCompletionType.ENDS_WITH_SPACE); //NOI18N
+        PHP_KEYWORDS.put("trait", KeywordCompletionType.ENDS_WITH_SPACE); //NOI18N
+        PHP_KEYWORDS.put("enum", KeywordCompletionType.ENDS_WITH_SPACE); //NOI18N
         PHP_KEYWORDS.put("const", KeywordCompletionType.ENDS_WITH_SPACE); //NOI18N
         PHP_KEYWORDS.put("continue", KeywordCompletionType.ENDS_WITH_SEMICOLON); //NOI18N
         PHP_KEYWORDS.put("function", KeywordCompletionType.ENDS_WITH_SPACE); //NOI18N

--- a/php/php.editor/src/org/netbeans/modules/php/editor/elements/IndexQueryImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/elements/IndexQueryImpl.java
@@ -223,7 +223,7 @@ public final class IndexQueryImpl implements ElementQuery.Index {
         return Collections.unmodifiableSet(traits);
     }
 
-    private Set<EnumElement> getEnumImpl(final NameKind query) {
+    private Set<EnumElement> getEnumsImpl(final NameKind query) {
         final long start = (LOG.isLoggable(Level.FINE)) ? System.currentTimeMillis() : 0;
         final Set<EnumElement> enums = new HashSet<>();
         final Collection<? extends IndexResult> result = results(EnumElementImpl.IDX_FIELD, query);
@@ -271,7 +271,7 @@ public final class IndexQueryImpl implements ElementQuery.Index {
         types.addAll(getClassesImpl(query));
         types.addAll(getInterfacesImpl(query));
         types.addAll(getTraitsImpl(query));
-        types.addAll(getEnumImpl(query));
+        types.addAll(getEnumsImpl(query));
         return types;
     }
 
@@ -564,7 +564,7 @@ public final class IndexQueryImpl implements ElementQuery.Index {
                 for (final IndexResult indexResult : enumResults) {
                     for (final TypeElement enumElement : EnumElementImpl.fromSignature(typeQuery, this, indexResult)) {
                         members.addAll(MethodElementImpl.fromSignature(enumElement, memberQuery, this, indexResult));
-                        members.addAll(MethodElementImpl.fromSignature(enumElement, memberQuery, this, indexResult));
+                        members.addAll(CaseElementImpl.fromSignature(enumElement, memberQuery, this, indexResult));
                         members.addAll(TypeConstantElementImpl.fromSignature(enumElement, memberQuery, this, indexResult));
                     }
                 }
@@ -1514,7 +1514,7 @@ public final class IndexQueryImpl implements ElementQuery.Index {
         types.addAll(getClassesImpl(typeQuery));
         types.addAll(getInterfacesImpl(typeQuery));
         types.addAll(getTraitsImpl(typeQuery));
-        types.addAll(getEnumImpl(typeQuery));
+        types.addAll(getEnumsImpl(typeQuery));
         for (TypeElement typeElement : types) {
             retval.addAll(ElementFilter.forName(methodQuery).filter(getAllMethods(typeElement)));
         }
@@ -1537,7 +1537,7 @@ public final class IndexQueryImpl implements ElementQuery.Index {
         Set<TypeElement> types = new HashSet<>();
         types.addAll(getClassesImpl(typeQuery));
         types.addAll(getInterfacesImpl(typeQuery));
-        types.addAll(getEnumImpl(typeQuery));
+        types.addAll(getEnumsImpl(typeQuery));
         for (TypeElement typeElement : types) {
             retval.addAll(ElementFilter.forName(constantQuery).filter(getAllTypeConstants(typeElement)));
         }
@@ -1548,7 +1548,7 @@ public final class IndexQueryImpl implements ElementQuery.Index {
     public Set<EnumCaseElement> getAllEnumCases(Exact typeQuery, NameKind enumCaseQuery) {
         Set<EnumCaseElement> retval = new HashSet<>();
         Set<TypeElement> types = new HashSet<>();
-        types.addAll(getEnumImpl(typeQuery));
+        types.addAll(getEnumsImpl(typeQuery));
         for (TypeElement typeElement : types) {
             retval.addAll(ElementFilter.forName(enumCaseQuery).filter(getAllEnumCases(typeElement)));
         }
@@ -2025,6 +2025,24 @@ public final class IndexQueryImpl implements ElementQuery.Index {
     }
 
     @Override
+    public Set<EnumElement> getEnums(final NameKind query, final Set<AliasedName> aliasedNames, final Trait trait) {
+        final Set<EnumElement> retval = new HashSet<>();
+        for (final AliasedName aliasedName : aliasedNames) {
+            for (final NameKind nextQuery : queriesForAlias(query, aliasedName, PhpElementKind.ENUM)) {
+                for (final EnumElement nextClass : getEnumsImpl(nextQuery)) {
+                    final AliasedEnum aliasedClass = new AliasedEnum(aliasedName, nextClass);
+                    if (trait != null) {
+                        aliasedClass.setTrait(trait);
+                    }
+                    retval.add(aliasedClass);
+                }
+            }
+        }
+        retval.addAll(getEnumsImpl(query));
+        return retval;
+    }
+
+    @Override
     public Set<NamespaceElement> getNamespaces(final NameKind query, final Set<AliasedName> aliasedNames, final Trait trait) {
         final Set<NamespaceElement> retval = new HashSet<>();
         for (final AliasedName aliasedName : aliasedNames) {
@@ -2166,7 +2184,7 @@ public final class IndexQueryImpl implements ElementQuery.Index {
     @Override
     public Set<EnumElement> getEnums(NameKind query) {
         final Set<EnumElement> retval = new HashSet<>();
-        retval.addAll(getEnumImpl(query));
+        retval.addAll(getEnumsImpl(query));
         return retval;
     }
 

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/EnumScopeImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/EnumScopeImpl.java
@@ -31,7 +31,6 @@ import org.netbeans.modules.php.api.util.StringUtils;
 import org.netbeans.modules.php.editor.api.ElementQuery;
 import org.netbeans.modules.php.editor.api.PhpElementKind;
 import org.netbeans.modules.php.editor.api.QualifiedName;
-import org.netbeans.modules.php.editor.api.elements.ClassElement;
 import org.netbeans.modules.php.editor.api.elements.EnumElement;
 import org.netbeans.modules.php.editor.api.elements.InterfaceElement;
 import org.netbeans.modules.php.editor.api.elements.MethodElement;
@@ -300,9 +299,9 @@ class EnumScopeImpl extends TypeScopeImpl implements EnumScope, VariableNameFact
 
     @Override
     public QualifiedName getNamespaceName() {
-        if (indexedElement instanceof ClassElement) {
-            ClassElement indexedClass = (ClassElement) indexedElement;
-            return indexedClass.getNamespaceName();
+        if (indexedElement instanceof EnumElement) {
+            EnumElement indexedEnum = (EnumElement) indexedElement;
+            return indexedEnum.getNamespaceName();
         }
         return super.getNamespaceName();
     }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/IndexScopeImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/IndexScopeImpl.java
@@ -230,6 +230,8 @@ class IndexScopeImpl extends ScopeImpl implements IndexScope {
                         retval.add(new InterfaceScopeImpl(this, (InterfaceElement) typeElement));
                     } else if (typeElement instanceof TraitElement) {
                         retval.add(new TraitScopeImpl(this, (TraitElement) typeElement));
+                    } else if (typeElement instanceof EnumElement) {
+                        retval.add(new EnumScopeImpl(this, (EnumElement) typeElement));
                     } else {
                         assert false : typeElement.getClass();
                     }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/ScopeImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/ScopeImpl.java
@@ -85,6 +85,7 @@ abstract class ScopeImpl extends ModelElementImpl implements Scope {
             case USE_STATEMENT:
             case GROUP_USE_STATEMENT:
             case TRAIT:
+            case ENUM:
                 result = true;
                 break;
             default:

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/Type.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/Type.java
@@ -97,7 +97,7 @@ public final class Type {
     private static final List<String> TYPES_FOR_PHP_DOC = Arrays.asList(STRING, INTEGER, INT, BOOLEAN, BOOL, FLOAT, DOUBLE, OBJECT, MIXED, ARRAY,
             RESOURCE, VOID, NULL, CALLBACK, CALLABLE, ITERABLE, FALSE, TRUE, SELF);
     private static final List<String> MIXED_TYPE = Arrays.asList(ARRAY, BOOL, CALLABLE, INT, FLOAT, NULL, OBJECT, /*RESOURCE, */STRING);
-
+    private static final List<String> TYPES_FOR_BACKING_TYPE = Arrays.asList(INT, STRING);
 
     public static boolean isPrimitive(String typeName) {
         boolean retval = false;
@@ -176,6 +176,15 @@ public final class Type {
 
     public static List<String> getTypesForPhpDoc() {
         return TYPES_FOR_PHP_DOC;
+    }
+
+    /**
+     * Get valid types for the backing type. "int" and "string" are available.
+     *
+     * @return valid types for the backing type
+     */
+    public static List<String> getTypesForBackingType() {
+        return TYPES_FOR_BACKING_TYPE;
     }
 
     /**

--- a/php/php.editor/src/org/netbeans/modules/php/editor/resources/code-templates.xml
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/resources/code-templates.xml
@@ -49,6 +49,27 @@
 }]]>
         </code>
     </codetemplate>
+    <codetemplate uuid="org.netbeans.modules.php.editor.codetemplate.en" abbreviation="en" contexts="php-code">
+        <code>
+<![CDATA[enum ${EnumName} {
+    case ${CaseName};${cursor}
+}]]>
+        </code>
+    </codetemplate>
+    <codetemplate uuid="org.netbeans.modules.php.editor.codetemplate.eni" abbreviation="eni" contexts="php-code">
+        <code>
+<![CDATA[enum ${EnumName}: int {
+    case ${CaseName} = ${value};${cursor}
+}]]>
+        </code>
+    </codetemplate>
+    <codetemplate uuid="org.netbeans.modules.php.editor.codetemplate.ens" abbreviation="ens" contexts="php-code">
+        <code>
+<![CDATA[enum ${EnumName}: string {
+    case ${CaseName} = ${value};${cursor}
+}]]>
+        </code>
+    </codetemplate>
     <codetemplate uuid="org.netbeans.modules.php.editor.codetemplate.cln" abbreviation="cln" contexts="php-code">
         <code>
 <![CDATA[$$${NEW_VAR newVarName default="newObj"} = clone ${VARIABLE variableFromPreviousAssignment default="$variable"};

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/IncorrectEnumHintError.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/IncorrectEnumHintError.java
@@ -18,16 +18,25 @@
  */
 package org.netbeans.modules.php.editor.verification;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.netbeans.modules.csl.api.Hint;
 import org.netbeans.modules.csl.api.HintFix;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.csl.spi.support.CancelSupport;
 import org.netbeans.modules.php.editor.CodeUtils;
+import org.netbeans.modules.php.editor.model.EnumScope;
+import org.netbeans.modules.php.editor.model.FieldElement;
 import org.netbeans.modules.php.editor.model.FileScope;
+import org.netbeans.modules.php.editor.model.MethodScope;
+import org.netbeans.modules.php.editor.model.ModelElement;
+import org.netbeans.modules.php.editor.model.ModelUtils;
+import org.netbeans.modules.php.editor.model.TraitScope;
 import org.netbeans.modules.php.editor.model.impl.Type;
 import org.netbeans.modules.php.editor.parser.PHPParseResult;
 import org.netbeans.modules.php.editor.parser.astnodes.ASTNode;
@@ -37,6 +46,7 @@ import org.netbeans.modules.php.editor.parser.astnodes.EnumDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.Expression;
 import org.netbeans.modules.php.editor.parser.astnodes.FieldsDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.Statement;
+import org.netbeans.modules.php.editor.parser.astnodes.UseTraitStatement;
 import org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultVisitor;
 import org.openide.filesystems.FileObject;
 import org.openide.util.NbBundle;
@@ -58,7 +68,10 @@ public class IncorrectEnumHintError extends HintErrorRule {
     @NbBundle.Messages({
         "IncorrectEnumHintError.incorrectEnumCases=\"case\" can only be in enums",
         "IncorrectEnumHintError.incorrectEnumBackingTypes=Backing type must be \"string\" or \"int\"",
-        "IncorrectEnumHintError.incorrectEnumProperties=Enums cannot have properties",
+        "IncorrectEnumHintError.incorrectEnumProperties=Enum cannot have properties",
+        "# {0} - the trait name",
+        "IncorrectEnumHintError.incorrectEnumPropertiesWithTrait=Enum cannot have properties, but \"{0}\" has properties",
+        "IncorrectEnumHintError.incorrectEnumConstructor=Enum cannot have a constructor",
     })
     public void invoke(PHPRuleContext context, List<Hint> hints) {
         PHPParseResult phpParseResult = (PHPParseResult) context.parserResult;
@@ -91,6 +104,51 @@ public class IncorrectEnumHintError extends HintErrorRule {
                 }
                 addHint(incorrectEnumProperty, Bundle.IncorrectEnumHintError_incorrectEnumProperties(), hints);
             }
+
+            // incorrect property with trait
+            Collection<? extends EnumScope> declaredEnums = ModelUtils.getDeclaredEnums(fileScope);
+            for (EnumScope declaredEnum : declaredEnums) {
+                if (CancelSupport.getDefault().isCancelled()) {
+                    return;
+                }
+                checkTraits(declaredEnum.getTraits(), declaredEnum, hints, checkVisitor.getUseTraits());
+                checkConstructor(declaredEnum.getDeclaredMethods(), hints);
+            }
+        }
+    }
+
+    private void checkTraits(Collection<? extends TraitScope> traits, EnumScope enumScope, List<Hint> hints, Map<EnumDeclaration, UseTraitStatement> useTraits) {
+        for (TraitScope trait : traits) {
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            checkTraits(trait.getTraits(), enumScope, hints, useTraits);
+            Collection<? extends FieldElement> declaredFields = trait.getDeclaredFields();
+            if (!declaredFields.isEmpty()) {
+                UseTraitStatement useTraitStatement = null;
+                for (Map.Entry<EnumDeclaration, UseTraitStatement> entry : useTraits.entrySet()) {
+                    if (CancelSupport.getDefault().isCancelled()) {
+                        return;
+                    }
+                    if (entry.getKey().getName().getStartOffset() == enumScope.getNameRange().getStart()) {
+                        useTraitStatement = entry.getValue();
+                        break;
+                    }
+
+                }
+                addHint(useTraitStatement, Bundle.IncorrectEnumHintError_incorrectEnumPropertiesWithTrait(trait.getName()), hints);
+            }
+        }
+    }
+
+    private void checkConstructor(Collection<? extends MethodScope> methods, List<Hint> hints) {
+        for (MethodScope method : methods) {
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            if (method.isConstructor()) {
+                addHint(method, Bundle.IncorrectEnumHintError_incorrectEnumConstructor(), hints);
+            }
         }
     }
 
@@ -109,12 +167,28 @@ public class IncorrectEnumHintError extends HintErrorRule {
         ));
     }
 
+    private void addHint(ModelElement element, String description, List<Hint> hints) {
+        addHint(element, description, hints, Collections.emptyList());
+    }
+
+    private void addHint(ModelElement element, String description, List<Hint> hints, List<HintFix> fixes) {
+        hints.add(new Hint(
+                this,
+                description,
+                fileObject,
+                element.getNameRange(),
+                fixes,
+                500
+        ));
+    }
+
     //~ Inner classes
     private static final class CheckVisitor extends DefaultVisitor {
 
         private final Set<CaseDeclaration> incorrectEnumCases = new HashSet<>();
         private final Set<Expression> incorrectBackingTypes = new HashSet<>();
         private final Set<FieldsDeclaration> incorrectEnumProperties = new HashSet<>();
+        private final Map<EnumDeclaration, UseTraitStatement> useTraits = new HashMap<>();
 
         @Override
         public void visit(ClassDeclaration node) {
@@ -157,16 +231,18 @@ public class IncorrectEnumHintError extends HintErrorRule {
                 }
             }
             scan(node.getBackingType());
-            checkFields(node.getBody().getStatements());
+            checkStatements(node.getBody().getStatements(), node);
         }
 
-        private void checkFields(List<Statement> statements) {
+        private void checkStatements(List<Statement> statements, EnumDeclaration node) {
             for (Statement statement : statements) {
                 if (CancelSupport.getDefault().isCancelled()) {
                     return;
                 }
                 if (statement instanceof FieldsDeclaration) {
                     incorrectEnumProperties.add((FieldsDeclaration) statement);
+                } else if (statement instanceof UseTraitStatement) {
+                    useTraits.put(node, (UseTraitStatement) statement);
                 }
                 scan(statement);
             }
@@ -182,6 +258,10 @@ public class IncorrectEnumHintError extends HintErrorRule {
 
         public Set<FieldsDeclaration> getIncorrectEnumProperties() {
             return Collections.unmodifiableSet(incorrectEnumProperties);
+        }
+
+        public Map<EnumDeclaration, UseTraitStatement> getUseTraits() {
+            return Collections.unmodifiableMap(useTraits);
         }
 
     }

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue153707.php.testIssue153707_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue153707.php.testIssue153707_01.completion
@@ -180,6 +180,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -214,6 +215,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue153867.php.testIssue153867.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue153867.php.testIssue153867.completion
@@ -171,6 +171,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -205,6 +206,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInTrait_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInTrait_01.completion
@@ -60,6 +60,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -94,6 +95,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefix_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefix_01.completion
@@ -86,6 +86,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -120,6 +121,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/netbeans68version/paramdecltypes/paramdecltypes.php.testParamDeclTypes.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/netbeans68version/paramdecltypes/paramdecltypes.php.testParamDeclTypes.completion
@@ -48,6 +48,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -82,6 +83,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass02.php.testAnonymousClass02a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass02.php.testAnonymousClass02a.completion
@@ -117,6 +117,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -151,6 +152,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass02.php.testAnonymousClass02d.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass02.php.testAnonymousClass02d.completion
@@ -117,6 +117,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -151,6 +152,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass02.php.testAnonymousClass02e.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass02.php.testAnonymousClass02e.completion
@@ -117,6 +117,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -151,6 +152,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testMultiCatch/fullyQualifiedName.php.testMultiCatch_FullyQualifiedName05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testMultiCatch/fullyQualifiedName.php.testMultiCatch_FullyQualifiedName05.completion
@@ -48,6 +48,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -82,6 +83,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testMultiCatch/fullyQualifiedNameWithoutWS.php.testMultiCatch_FullyQualifiedNameWithoutWS05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testMultiCatch/fullyQualifiedNameWithoutWS.php.testMultiCatch_FullyQualifiedNameWithoutWS05.completion
@@ -48,6 +48,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -82,6 +83,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testMultiCatch/unqualifiedName.php.testMultiCatch_UnqualifiedName03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testMultiCatch/unqualifiedName.php.testMultiCatch_UnqualifiedName03.completion
@@ -48,6 +48,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -82,6 +83,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testMultiCatch/unqualifiedNameWithoutWS.php.testMultiCatch_UnqualifiedNameWithoutWS03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testMultiCatch/unqualifiedNameWithoutWS.php.testMultiCatch_UnqualifiedNameWithoutWS03.completion
@@ -48,6 +48,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -82,6 +83,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_02.completion
@@ -45,6 +45,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -79,6 +80,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_05b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_05b.completion
@@ -49,6 +49,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -83,6 +84,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_08.completion
@@ -49,6 +49,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -83,6 +84,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_15a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_15a.completion
@@ -49,6 +49,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -83,6 +84,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_17d.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_17d.completion
@@ -51,6 +51,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -85,6 +86,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_18c.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_18c.completion
@@ -51,6 +51,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -85,6 +86,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_21b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_21b.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_24b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_24b.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInFunction/arrowFunctionsInFunction.php.testArrowFunctionsInFunction_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInFunction/arrowFunctionsInFunction.php.testArrowFunctionsInFunction_01a.completion
@@ -47,6 +47,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -81,6 +82,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInFunctionWithError/arrowFunctionsInFunctionWithError.php.testArrowFunctionsInFunctionWithError_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInFunctionWithError/arrowFunctionsInFunctionWithError.php.testArrowFunctionsInFunctionWithError_01a.completion
@@ -48,6 +48,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -82,6 +83,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInFunctionWithError/arrowFunctionsInFunctionWithError.php.testArrowFunctionsInFunctionWithError_02a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInFunctionWithError/arrowFunctionsInFunctionWithError.php.testArrowFunctionsInFunctionWithError_02a.completion
@@ -49,6 +49,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -83,6 +84,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInFunctionWithError/arrowFunctionsInFunctionWithError.php.testArrowFunctionsInFunctionWithError_03a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInFunctionWithError/arrowFunctionsInFunctionWithError.php.testArrowFunctionsInFunctionWithError_03a.completion
@@ -48,6 +48,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -82,6 +83,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethod/arrowFunctionsInMethod.php.testArrowFunctionsInMethod_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethod/arrowFunctionsInMethod.php.testArrowFunctionsInMethod_01a.completion
@@ -51,6 +51,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -85,6 +86,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethodWithError/arrowFunctionsInMethodWithError.php.testArrowFunctionsInMethodWithError_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethodWithError/arrowFunctionsInMethodWithError.php.testArrowFunctionsInMethodWithError_01a.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethodWithError/arrowFunctionsInMethodWithError.php.testArrowFunctionsInMethodWithError_02a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethodWithError/arrowFunctionsInMethodWithError.php.testArrowFunctionsInMethodWithError_02a.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsNested/arrowFunctionsNested.php.testArrowFunctionsNested_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsNested/arrowFunctionsNested.php.testArrowFunctionsNested_01.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsWithError01/arrowFunctionsWithError01.php.testArrowFunctionsWithError01_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsWithError01/arrowFunctionsWithError01.php.testArrowFunctionsWithError01_01a.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsWithError01/arrowFunctionsWithError01.php.testArrowFunctionsWithError01_01b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsWithError01/arrowFunctionsWithError01.php.testArrowFunctionsWithError01_01b.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsWithError02/arrowFunctionsWithError02.php.testArrowFunctionsWithError02_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsWithError02/arrowFunctionsWithError02.php.testArrowFunctionsWithError02_01a.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsWithError02/arrowFunctionsWithError02.php.testArrowFunctionsWithError02_01b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsWithError02/arrowFunctionsWithError02.php.testArrowFunctionsWithError02_01b.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsWithError02/arrowFunctionsWithError02.php.testArrowFunctionsWithError02_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsWithError02/arrowFunctionsWithError02.php.testArrowFunctionsWithError02_03.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02.completion
@@ -59,6 +59,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -93,6 +94,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02a.completion
@@ -60,6 +60,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -94,6 +95,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_03.completion
@@ -61,6 +61,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -95,6 +96,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_04.completion
@@ -61,6 +61,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -95,6 +96,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunction01/namedArgumentsFunction01.php.testNamedArgumentsFunction01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunction01/namedArgumentsFunction01.php.testNamedArgumentsFunction01.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunction03/namedArgumentsFunction03.php.testNamedArgumentsFunction03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunction03/namedArgumentsFunction03.php.testNamedArgumentsFunction03.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunction05/namedArgumentsFunction05.php.testNamedArgumentsFunction05_a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunction05/namedArgumentsFunction05.php.testNamedArgumentsFunction05_a.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunction05/namedArgumentsFunction05.php.testNamedArgumentsFunction05_b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunction05/namedArgumentsFunction05.php.testNamedArgumentsFunction05_b.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunction06/namedArgumentsFunction06.php.testNamedArgumentsFunction06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunction06/namedArgumentsFunction06.php.testNamedArgumentsFunction06.completion
@@ -45,6 +45,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -79,6 +80,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunctionNested01/namedArgumentsFunctionNested01.php.testNamedArgumentsFunctionNested01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunctionNested01/namedArgumentsFunctionNested01.php.testNamedArgumentsFunctionNested01.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunctionNested03/namedArgumentsFunctionNested03.php.testNamedArgumentsFunctionNested03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsFunctionNested03/namedArgumentsFunctionNested03.php.testNamedArgumentsFunctionNested03.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod01/namedArgumentsMethod01.php.testNamedArgumentsMethod01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod01/namedArgumentsMethod01.php.testNamedArgumentsMethod01.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod02/namedArgumentsMethod02.php.testNamedArgumentsMethod02_b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod02/namedArgumentsMethod02.php.testNamedArgumentsMethod02_b.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod03/namedArgumentsMethod03.php.testNamedArgumentsMethod03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod03/namedArgumentsMethod03.php.testNamedArgumentsMethod03.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod05/namedArgumentsMethod05.php.testNamedArgumentsMethod05_a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod05/namedArgumentsMethod05.php.testNamedArgumentsMethod05_a.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod05/namedArgumentsMethod05.php.testNamedArgumentsMethod05_b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod05/namedArgumentsMethod05.php.testNamedArgumentsMethod05_b.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod06/namedArgumentsMethod06.php.testNamedArgumentsMethod06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsMethod06/namedArgumentsMethod06.php.testNamedArgumentsMethod06.completion
@@ -54,6 +54,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -88,6 +89,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod01/namedArgumentsStaticMethod01.php.testNamedArgumentsStaticMethod01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod01/namedArgumentsStaticMethod01.php.testNamedArgumentsStaticMethod01.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod02/namedArgumentsStaticMethod02.php.testNamedArgumentsStaticMethod02_b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod02/namedArgumentsStaticMethod02.php.testNamedArgumentsStaticMethod02_b.completion
@@ -45,6 +45,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -79,6 +80,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod03/namedArgumentsStaticMethod03.php.testNamedArgumentsStaticMethod03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod03/namedArgumentsStaticMethod03.php.testNamedArgumentsStaticMethod03.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod05/namedArgumentsStaticMethod05.php.testNamedArgumentsStaticMethod05_a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod05/namedArgumentsStaticMethod05.php.testNamedArgumentsStaticMethod05_a.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod05/namedArgumentsStaticMethod05.php.testNamedArgumentsStaticMethod05_b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod05/namedArgumentsStaticMethod05.php.testNamedArgumentsStaticMethod05_b.completion
@@ -52,6 +52,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -86,6 +87,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod06/namedArgumentsStaticMethod06.php.testNamedArgumentsStaticMethod06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testNamedArgumentsStaticMethod06/namedArgumentsStaticMethod06.php.testNamedArgumentsStaticMethod06.completion
@@ -54,6 +54,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -88,6 +89,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum1;
+enum Simple {
+
+    use TestTrait;
+
+    case CASE1;
+    case CASE2;
+    public const PUBLIC_CONST = "public";
+    private const PRIVATE_CONST = "private";
+    protected const PROTECTED_CONST = "protected";
+    const CONSTANT1 = "CONSTANT1";
+    const CONSTANT2 = self::CASE2;
+
+    public function publicEnumMethod(): void {
+        echo "publicEnumMethod()" . PHP_EOL;
+    }
+
+    private function privateEnumMethod(): void {
+        echo "privateEnumMethod()" . PHP_EOL;
+    }
+
+    protected function protectedEnumMethod(): void {
+        echo "protectedEnumMethod()" . PHP_EOL;
+    }
+
+    public static function publicStaticEnumMethod(): void {
+        echo "publicStaticEnumMethod()" . PHP_EOL;
+    }
+
+    private static function privateStaticEnumMethod(): void {
+        echo "privateStaticEnumMethod()" . PHP_EOL;
+    }
+
+    protected static function protectedStaticEnumMethod(): void {
+        echo "protectedStaticEnumMethod()" . PHP_EOL;
+    }
+
+    public function testEnum(): string {
+        return match ($this) {
+            static::CASE1 => 'Case1',
+            static::CASE2 => 'Case2',
+        };
+    }
+
+    public static function testStaticEnum(): void {
+        Simple::CASE2;
+        Simple::PRIVATE_CONST;
+        Simple::protectedStaticEnumMethod();
+        Simple::CASE1->publicEnumMethod();
+        Simple::CASE1::publicStaticEnumMethod();
+        self::CASE1;
+        self::privateStaticEnumMethod();
+        self::CASE1->privateEnumMethod();
+        self::CASE1::protectedStaticEnumMethod();
+        static::privateStaticEnumMethod();
+        static::CASE1->publicEnumMethod();
+        static::CASE1::publicEnumMethod();
+    }
+}
+
+trait TestTrait {
+    public function publicTraitMethod(): void {
+    }
+    private function privateTraitMethod(): void {
+    }
+    protected function protectedTraitMethod(): void {
+    }
+    public static function publicStaticTraitMethod(): void {
+    }
+    private static function privateStaticTraitMethod(): void {
+    }
+    protected static function protectedStaticTraitMethod(): void {
+    }
+}
+
+namespace Enum2;
+
+use Enum1\Simple;
+
+Simple::CASE1::CONSTANT1;
+Simple::CASE2->publicEnumMethod();
+Simple::publicStaticEnumMethod();
+$i = Simple::CASE2;
+$i::CASE1;
+$i->publicEnumMethod();

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_01.completion
@@ -1,0 +1,18 @@
+Code completion result for source line:
+const CONSTANT2 = self::|CASE2;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateStaticEnumMethod()       [PRIVATE,  \Enum1\Simple
+METHOD     privateStaticTraitMethod()      [PRIVATE,  \Enum1\TestTrait
+METHOD     protectedStaticEnumMethod()     [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticTraitMethod()    [PROTECTE  \Enum1\TestTrait
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     testStaticEnum()                [STATIC]   \Enum1\Simple
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT1 "CONSTANT1"           [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Enum1\Simple
+CONSTANT   PRIVATE_CONST "private"         [PRIVATE]  \Enum1\Simple
+CONSTANT   PROTECTED_CONST "protected"     [PROTECTE  \Enum1\Simple
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple
+CONSTANT   class \Enum1\Simple             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_02.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+const CONSTANT2 = self::CASE|2;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_03.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+static::CAS|E1 => 'Case1',
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_04.completion
@@ -1,0 +1,18 @@
+Code completion result for source line:
+Simple::|CASE2;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateStaticEnumMethod()       [PRIVATE,  \Enum1\Simple
+METHOD     privateStaticTraitMethod()      [PRIVATE,  \Enum1\TestTrait
+METHOD     protectedStaticEnumMethod()     [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticTraitMethod()    [PROTECTE  \Enum1\TestTrait
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     testStaticEnum()                [STATIC]   \Enum1\Simple
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT1 "CONSTANT1"           [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Enum1\Simple
+CONSTANT   PRIVATE_CONST "private"         [PRIVATE]  \Enum1\Simple
+CONSTANT   PROTECTED_CONST "protected"     [PROTECTE  \Enum1\Simple
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple
+CONSTANT   class \Enum1\Simple             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_05.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+Simple::C|ASE2;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT1 "CONSTANT1"           [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Enum1\Simple
+CONSTANT   class \Enum1\Simple             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_06.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+Simple::PRIV|ATE_CONST;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateStaticEnumMethod()       [PRIVATE,  \Enum1\Simple
+METHOD     privateStaticTraitMethod()      [PRIVATE,  \Enum1\TestTrait
+CONSTANT   PRIVATE_CONST "private"         [PRIVATE]  \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_07.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+Simple::protected|StaticEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     protectedStaticEnumMethod()     [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticTraitMethod()    [PROTECTE  \Enum1\TestTrait
+CONSTANT   PROTECTED_CONST "protected"     [PROTECTE  \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_08.completion
@@ -1,0 +1,17 @@
+Code completion result for source line:
+Simple::CASE1->|publicEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateEnumMethod()             [PRIVATE]  \Enum1\Simple
+METHOD     privateStaticEnumMethod()       [PRIVATE,  \Enum1\Simple
+METHOD     privateStaticTraitMethod()      [PRIVATE,  \Enum1\TestTrait
+METHOD     privateTraitMethod()            [PRIVATE]  \Enum1\TestTrait
+METHOD     protectedEnumMethod()           [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticEnumMethod()     [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticTraitMethod()    [PROTECTE  \Enum1\TestTrait
+METHOD     protectedTraitMethod()          [PROTECTE  \Enum1\TestTrait
+METHOD     publicEnumMethod()              [PUBLIC]   \Enum1\Simple
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     publicTraitMethod()             [PUBLIC]   \Enum1\TestTrait
+METHOD     testEnum()                      [PUBLIC]   \Enum1\Simple
+METHOD     testStaticEnum()                [STATIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_09.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+Simple::CASE1->publicEnum|Method();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicEnumMethod()              [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_10.completion
@@ -1,0 +1,18 @@
+Code completion result for source line:
+Simple::CASE1::|publicStaticEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateStaticEnumMethod()       [PRIVATE,  \Enum1\Simple
+METHOD     privateStaticTraitMethod()      [PRIVATE,  \Enum1\TestTrait
+METHOD     protectedStaticEnumMethod()     [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticTraitMethod()    [PROTECTE  \Enum1\TestTrait
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     testStaticEnum()                [STATIC]   \Enum1\Simple
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT1 "CONSTANT1"           [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Enum1\Simple
+CONSTANT   PRIVATE_CONST "private"         [PRIVATE]  \Enum1\Simple
+CONSTANT   PROTECTED_CONST "protected"     [PROTECTE  \Enum1\Simple
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple
+CONSTANT   class \Enum1\Simple             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_11.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+Simple::CASE1::publicStatic|EnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_12.completion
@@ -1,0 +1,18 @@
+Code completion result for source line:
+self::|CASE1;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateStaticEnumMethod()       [PRIVATE,  \Enum1\Simple
+METHOD     privateStaticTraitMethod()      [PRIVATE,  \Enum1\TestTrait
+METHOD     protectedStaticEnumMethod()     [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticTraitMethod()    [PROTECTE  \Enum1\TestTrait
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     testStaticEnum()                [STATIC]   \Enum1\Simple
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT1 "CONSTANT1"           [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Enum1\Simple
+CONSTANT   PRIVATE_CONST "private"         [PRIVATE]  \Enum1\Simple
+CONSTANT   PROTECTED_CONST "protected"     [PROTECTE  \Enum1\Simple
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple
+CONSTANT   class \Enum1\Simple             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_13.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_13.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+self::CASE|1;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_14.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_14.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+self::privateStatic|EnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateStaticEnumMethod()       [PRIVATE,  \Enum1\Simple
+METHOD     privateStaticTraitMethod()      [PRIVATE,  \Enum1\TestTrait

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_15.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_15.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+self::CASE|1->privateEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_16.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_16.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+self::CASE1->priv|ateEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateEnumMethod()             [PRIVATE]  \Enum1\Simple
+METHOD     privateStaticEnumMethod()       [PRIVATE,  \Enum1\Simple
+METHOD     privateStaticTraitMethod()      [PRIVATE,  \Enum1\TestTrait
+METHOD     privateTraitMethod()            [PRIVATE]  \Enum1\TestTrait

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_17.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_17.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+self::CASE1|::protectedStaticEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_18.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_18.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+self::CASE1::protectedStatic|EnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     protectedStaticEnumMethod()     [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticTraitMethod()    [PROTECTE  \Enum1\TestTrait

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_19.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_19.completion
@@ -1,0 +1,12 @@
+Code completion result for source line:
+static::p|rivateStaticEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateStaticEnumMethod()       [PRIVATE,  \Enum1\Simple
+METHOD     privateStaticTraitMethod()      [PRIVATE,  \Enum1\TestTrait
+METHOD     protectedStaticEnumMethod()     [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticTraitMethod()    [PROTECTE  \Enum1\TestTrait
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+CONSTANT   PRIVATE_CONST "private"         [PRIVATE]  \Enum1\Simple
+CONSTANT   PROTECTED_CONST "protected"     [PROTECTE  \Enum1\Simple
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_20.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_20.completion
@@ -1,0 +1,15 @@
+Code completion result for source line:
+static::CASE1->p|ublicEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateEnumMethod()             [PRIVATE]  \Enum1\Simple
+METHOD     privateStaticEnumMethod()       [PRIVATE,  \Enum1\Simple
+METHOD     privateStaticTraitMethod()      [PRIVATE,  \Enum1\TestTrait
+METHOD     privateTraitMethod()            [PRIVATE]  \Enum1\TestTrait
+METHOD     protectedEnumMethod()           [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticEnumMethod()     [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticTraitMethod()    [PROTECTE  \Enum1\TestTrait
+METHOD     protectedTraitMethod()          [PROTECTE  \Enum1\TestTrait
+METHOD     publicEnumMethod()              [PUBLIC]   \Enum1\Simple
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     publicTraitMethod()             [PUBLIC]   \Enum1\TestTrait

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_21.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_21.completion
@@ -1,0 +1,12 @@
+Code completion result for source line:
+static::CASE1::p|ublicEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateStaticEnumMethod()       [PRIVATE,  \Enum1\Simple
+METHOD     privateStaticTraitMethod()      [PRIVATE,  \Enum1\TestTrait
+METHOD     protectedStaticEnumMethod()     [PROTECTE  \Enum1\Simple
+METHOD     protectedStaticTraitMethod()    [PROTECTE  \Enum1\TestTrait
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+CONSTANT   PRIVATE_CONST "private"         [PRIVATE]  \Enum1\Simple
+CONSTANT   PROTECTED_CONST "protected"     [PROTECTE  \Enum1\Simple
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_22.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_22.completion
@@ -1,0 +1,12 @@
+Code completion result for source line:
+Simple::CASE1::|CONSTANT1;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     testStaticEnum()                [STATIC]   \Enum1\Simple
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT1 "CONSTANT1"           [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Enum1\Simple
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple
+CONSTANT   class \Enum1\Simple             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_23.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_23.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+Simple::CASE1::CON|STANT1;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   CONSTANT1 "CONSTANT1"           [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_24.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_24.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+Simple::CASE2->|publicEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicEnumMethod()              [PUBLIC]   \Enum1\Simple
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     publicTraitMethod()             [PUBLIC]   \Enum1\TestTrait
+METHOD     testEnum()                      [PUBLIC]   \Enum1\Simple
+METHOD     testStaticEnum()                [STATIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_25.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_25.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+Simple::CASE2->public|EnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicEnumMethod()              [PUBLIC]   \Enum1\Simple
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     publicTraitMethod()             [PUBLIC]   \Enum1\TestTrait

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_26.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_26.completion
@@ -1,0 +1,12 @@
+Code completion result for source line:
+Simple::|publicStaticEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     testStaticEnum()                [STATIC]   \Enum1\Simple
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT1 "CONSTANT1"           [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Enum1\Simple
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple
+CONSTANT   class \Enum1\Simple             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_27.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_27.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+Simple::publicStatic|EnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_28.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_28.completion
@@ -1,0 +1,12 @@
+Code completion result for source line:
+$i::|CASE1;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     testStaticEnum()                [STATIC]   \Enum1\Simple
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT1 "CONSTANT1"           [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Enum1\Simple
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple
+CONSTANT   class \Enum1\Simple             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_29.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_29.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+$i::CASE|1;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_30.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_30.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+$i->|publicEnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicEnumMethod()              [PUBLIC]   \Enum1\Simple
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     publicTraitMethod()             [PUBLIC]   \Enum1\TestTrait
+METHOD     testEnum()                      [PUBLIC]   \Enum1\Simple
+METHOD     testStaticEnum()                [STATIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_31.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnums/enums.php.testEnums_31.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+$i->public|EnumMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicEnumMethod()              [PUBLIC]   \Enum1\Simple
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     publicTraitMethod()             [PUBLIC]   \Enum1\TestTrait

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_01.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace2;
+
+use EnumTestNamespace1\EnumInterface1;
+use EnumTestNamespace1\EnumInterface2;
+use EnumTestNamespace1\EnumIClass;
+use EnumTestNamespace1\Enum1;
+enum EnumTest: 
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_01.php.testEnumsBackingTypesTyping_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_01.php.testEnumsBackingTypesTyping_01.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+enum EnumTest: |
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+KEYWORD    int                                        null
+KEYWORD    string                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_02.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace2;
+
+use EnumTestNamespace1\EnumInterface1;
+use EnumTestNamespace1\EnumInterface2;
+use EnumTestNamespace1\EnumIClass;
+use EnumTestNamespace1\Enum1;
+enum EnumTest: in
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_02.php.testEnumsBackingTypesTyping_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_02.php.testEnumsBackingTypesTyping_02.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+enum EnumTest: in|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_03.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_03.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace2;
+
+use EnumTestNamespace1\EnumInterface1;
+use EnumTestNamespace1\EnumInterface2;
+use EnumTestNamespace1\EnumIClass;
+use EnumTestNamespace1\Enum1;
+enum EnumTest: int i
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_03.php.testEnumsBackingTypesTyping_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsBackingTypesTyping/enumsBackingTypesTyping_03.php.testEnumsBackingTypesTyping_03.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+enum EnumTest: int i|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+KEYWORD    implements                                 null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace1;
+
+use EnumTestNamespace2\Enum1;
+use EnumTestNamespace2\Enum2;
+use EnumTestNamespace2\Class1;
+use EnumTestNamespace2\Interface1;
+
+class FieldTypeTest {
+    private Enum1 $field;
+    public static Enum1 $staticField;
+}
+
+namespace EnumTestNamespace2;
+enum Enum1 {
+    case CASE1;
+}
+
+enum Enum2 {
+    case CASE1;
+}
+
+class Class1 {}
+
+interface Interface1 {}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_01a.completion
@@ -1,0 +1,33 @@
+Code completion result for source line:
+private |Enum1 $field;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Class1                          [PUBLIC]   EnumTestNamespace2
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      FieldTypeTest                   [PUBLIC]   EnumTestNamespace1
+CLASS      Interface1                      [PUBLIC]   EnumTestNamespace2
+------------------------------------
+KEYWORD    abstract                                   null
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    const                                      null
+KEYWORD    false                                      null
+KEYWORD    final                                      null
+KEYWORD    float                                      null
+KEYWORD    function                                   null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    parent                                     null
+KEYWORD    private                                    null
+KEYWORD    protected                                  null
+KEYWORD    public                                     null
+KEYWORD    readonly                                   null
+KEYWORD    self                                       null
+KEYWORD    static                                     null
+KEYWORD    string                                     null
+KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_01b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_01b.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+private En|um1 $field;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_02a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_02a.completion
@@ -1,0 +1,33 @@
+Code completion result for source line:
+public static |Enum1 $staticField;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Class1                          [PUBLIC]   EnumTestNamespace2
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      FieldTypeTest                   [PUBLIC]   EnumTestNamespace1
+CLASS      Interface1                      [PUBLIC]   EnumTestNamespace2
+------------------------------------
+KEYWORD    abstract                                   null
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    const                                      null
+KEYWORD    false                                      null
+KEYWORD    final                                      null
+KEYWORD    float                                      null
+KEYWORD    function                                   null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    parent                                     null
+KEYWORD    private                                    null
+KEYWORD    protected                                  null
+KEYWORD    public                                     null
+KEYWORD    readonly                                   null
+KEYWORD    self                                       null
+KEYWORD    static                                     null
+KEYWORD    string                                     null
+KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_02b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_02b.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+public static Enum|1 $staticField;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping01/enumsFieldTypeTyping01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping01/enumsFieldTypeTyping01.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace1;
+
+use EnumTestNamespace2\Enum1;
+use EnumTestNamespace2\Enum2;
+use EnumTestNamespace2\Class1;
+use EnumTestNamespace2\Interface1;
+
+class FieldTypeTest {
+    private 
+}
+
+namespace EnumTestNamespace2;
+enum Enum1 {
+    case CASE1;
+}
+
+enum Enum2 {
+    case CASE1;
+}
+
+class Class1 {}
+
+interface Interface1 {}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping01/enumsFieldTypeTyping01.php.testEnumsFieldTypeTyping01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping01/enumsFieldTypeTyping01.php.testEnumsFieldTypeTyping01.completion
@@ -1,0 +1,33 @@
+Code completion result for source line:
+private |
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Class1                          [PUBLIC]   EnumTestNamespace2
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      FieldTypeTest                   [PUBLIC]   EnumTestNamespace1
+CLASS      Interface1                      [PUBLIC]   EnumTestNamespace2
+------------------------------------
+KEYWORD    abstract                                   null
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    const                                      null
+KEYWORD    false                                      null
+KEYWORD    final                                      null
+KEYWORD    float                                      null
+KEYWORD    function                                   null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    parent                                     null
+KEYWORD    private                                    null
+KEYWORD    protected                                  null
+KEYWORD    public                                     null
+KEYWORD    readonly                                   null
+KEYWORD    self                                       null
+KEYWORD    static                                     null
+KEYWORD    string                                     null
+KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping02/enumsFieldTypeTyping02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping02/enumsFieldTypeTyping02.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace1;
+
+use EnumTestNamespace\Enum1;
+use EnumTestNamespace\Enum2;
+use EnumTestNamespace\Class1;
+use EnumTestNamespace\Interface1;
+
+class FieldTypeTest {
+    private En
+}
+
+namespace EnumTestNamespace2;
+enum Enum1 {
+    case CASE1;
+}
+
+enum Enum2 {
+    case CASE1;
+}
+
+class Class1 {}
+
+interface Interface1 {}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping02/enumsFieldTypeTyping02.php.testEnumsFieldTypeTyping02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping02/enumsFieldTypeTyping02.php.testEnumsFieldTypeTyping02.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+private En|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping03/enumsFieldTypeTyping03.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping03/enumsFieldTypeTyping03.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace1;
+
+use EnumTestNamespace2\Enum1;
+use EnumTestNamespace2\Enum2;
+use EnumTestNamespace2\Class1;
+use EnumTestNamespace2\Interface1;
+
+class FieldTypeTest {
+    private static 
+}
+
+namespace EnumTestNamespace2;
+enum Enum1 {
+    case CASE1;
+}
+
+enum Enum2 {
+    case CASE1;
+}
+
+class Class1 {}
+
+interface Interface1 {}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping03/enumsFieldTypeTyping03.php.testEnumsFieldTypeTyping03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping03/enumsFieldTypeTyping03.php.testEnumsFieldTypeTyping03.completion
@@ -1,0 +1,24 @@
+Code completion result for source line:
+private static |
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Class1                          [PUBLIC]   EnumTestNamespace2
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      FieldTypeTest                   [PUBLIC]   EnumTestNamespace1
+CLASS      Interface1                      [PUBLIC]   EnumTestNamespace2
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    false                                      null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    parent                                     null
+KEYWORD    readonly                                   null
+KEYWORD    self                                       null
+KEYWORD    string                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping04/enumsFieldTypeTyping04.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping04/enumsFieldTypeTyping04.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace1;
+
+use EnumTestNamespace2\Enum1;
+use EnumTestNamespace2\Enum2;
+use EnumTestNamespace2\Class1;
+use EnumTestNamespace2\Interface1;
+
+class FieldTypeTest {
+    private static Enum
+}
+
+namespace EnumTestNamespace2;
+enum Enum1 {
+    case CASE1;
+}
+
+enum Enum2 {
+    case CASE1;
+}
+
+class Class1 {}
+
+interface Interface1 {}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping04/enumsFieldTypeTyping04.php.testEnumsFieldTypeTyping04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping04/enumsFieldTypeTyping04.php.testEnumsFieldTypeTyping04.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+private static Enum|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypes.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypes.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace;
+
+interface EnumInterface1 {}
+interface EnumInterface2 {}
+class EnumClass {}
+enum Enum1 {
+    case CASE1;
+}
+
+enum EnumTest implements EnumInterface1 {
+
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_01.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace2;
+
+use EnumTestNamespace1\EnumInterface1;
+use EnumTestNamespace1\EnumInterface2;
+use EnumTestNamespace1\EnumIClass;
+use EnumTestNamespace1\Enum1;
+enum EnumTest implements  {
+
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_01.php.testEnumsImplementTypesTyping_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_01.php.testEnumsImplementTypesTyping_01.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+enum EnumTest implements | {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+------------------------------------
+CLASS      EnumInterface1                  [PUBLIC]   EnumTestNamespace
+CLASS      EnumInterface2                  [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_01b.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_01b.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace2;
+
+use EnumTestNamespace1\EnumInterface1;
+use EnumTestNamespace1\EnumInterface2;
+use EnumTestNamespace1\EnumIClass;
+use EnumTestNamespace1\Enum1;
+enum EnumTest:int implements  {
+
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_01b.php.testEnumsImplementTypesTyping_01b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_01b.php.testEnumsImplementTypesTyping_01b.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+enum EnumTest:int implements | {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+------------------------------------
+CLASS      EnumInterface1                  [PUBLIC]   EnumTestNamespace
+CLASS      EnumInterface2                  [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_02.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace2;
+
+use EnumTestNamespace1\EnumInterface1;
+use EnumTestNamespace1\EnumInterface2;
+use EnumTestNamespace1\EnumIClass;
+use EnumTestNamespace1\Enum1;
+enum EnumTest implements EnumInter {
+
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_02.php.testEnumsImplementTypesTyping_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_02.php.testEnumsImplementTypesTyping_02.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+enum EnumTest implements EnumInter| {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      EnumInterface1                  [PUBLIC]   EnumTestNamespace
+CLASS      EnumInterface2                  [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_02b.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_02b.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace2;
+
+use EnumTestNamespace1\EnumInterface1;
+use EnumTestNamespace1\EnumInterface2;
+use EnumTestNamespace1\EnumIClass;
+use EnumTestNamespace1\Enum1;
+enum EnumTest:int implements EnumInter {
+
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_02b.php.testEnumsImplementTypesTyping_02b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_02b.php.testEnumsImplementTypesTyping_02b.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+enum EnumTest:int implements EnumInter| {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      EnumInterface1                  [PUBLIC]   EnumTestNamespace
+CLASS      EnumInterface2                  [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_03.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_03.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace2;
+
+use EnumTestNamespace1\EnumInterface1;
+use EnumTestNamespace1\EnumInterface2;
+use EnumTestNamespace1\EnumIClass;
+use EnumTestNamespace1\Enum1;
+enum EnumTest implements EnumInterface1, EnumIn {
+
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_03.php.testEnumsImplementTypesTyping_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_03.php.testEnumsImplementTypesTyping_03.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+enum EnumTest implements EnumInterface1, EnumIn| {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      EnumInterface1                  [PUBLIC]   EnumTestNamespace
+CLASS      EnumInterface2                  [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_03b.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_03b.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace2;
+
+use EnumTestNamespace1\EnumInterface1;
+use EnumTestNamespace1\EnumInterface2;
+use EnumTestNamespace1\EnumIClass;
+use EnumTestNamespace1\Enum1;
+enum EnumTest:int implements EnumInterface1, EnumIn {
+
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_03b.php.testEnumsImplementTypesTyping_03b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsImplementTypesTyping/enumsImplementTypesTyping_03b.php.testEnumsImplementTypesTyping_03b.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+enum EnumTest:int implements EnumInterface1, EnumIn| {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      EnumInterface1                  [PUBLIC]   EnumTestNamespace
+CLASS      EnumInterface2                  [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsInConstExpr01/enumsInConstExpr01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsInConstExpr01/enumsInConstExpr01.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace;
+enum EnumTest {
+    public const PUBLIC_CONST = ;
+
+}
+enum Enum1 {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsInConstExpr01/enumsInConstExpr01.php.testEnumsInConstExpr01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsInConstExpr01/enumsInConstExpr01.php.testEnumsInConstExpr01.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+public const PUBLIC_CONST = |;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace
+KEYWORD    parent::                                   null
+KEYWORD    self::                                     null
+------------------------------------
+KEYWORD    array                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsInConstExpr02/enumsInConstExpr02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsInConstExpr02/enumsInConstExpr02.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace;
+enum EnumTest {
+    public const PUBLIC_CONST = Enum;
+
+}
+enum Enum1 {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsInConstExpr02/enumsInConstExpr02.php.testEnumsInConstExpr02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsInConstExpr02/enumsInConstExpr02.php.testEnumsInConstExpr02.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public const PUBLIC_CONST = Enum|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace1;
+
+use EnumTestNamespace2\Enum1;
+use EnumTestNamespace2\Enum2;
+
+function paramType(EnumTest $param): void {
+}
+
+enum EnumTest {
+    public function publicMethod1(Enum1 $enum1, Enum2 $enum2): void {
+    }
+    public static function publicMethod2(Enum1|Enum2 $enum1): void {
+    }
+    public function publicMethod3(Enum1&Enum2 $enum1, Enum1&Enum2 $enum2): void {
+    }
+    public function publicMethod4(?Enum1 $enum1): void {
+    }
+}
+
+namespace EnumTestNamespace2;
+enum Enum1 {
+    case CASE1;
+}
+
+enum Enum2 {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_01.completion
@@ -1,0 +1,20 @@
+Code completion result for source line:
+function paramType(|EnumTest $param): void {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace1
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    callable                                   null
+KEYWORD    false                                      null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    string                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_02.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+function paramType(Enum|Test $param): void {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_03.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+public function publicMethod1(En|um1 $enum1, Enum2 $enum2): void {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_04.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+public function publicMethod1(Enum1 $enum1, Enum2| $enum2): void {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_05.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+public static function publicMethod2(Enu|m1|Enum2 $enum1): void {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_06.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+public static function publicMethod2(Enum1|Enum|2 $enum1): void {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_07.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+public function publicMethod3(Enum1&Enum2 $enum1, En|um1&Enum2 $enum2): void {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_08.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+public function publicMethod3(Enum1&Enum2 $enum1, Enum1&|Enum2 $enum2): void {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_09.completion
@@ -1,0 +1,20 @@
+Code completion result for source line:
+public function publicMethod4(?|Enum1 $enum1): void {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace1
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    callable                                   null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    object                                     null
+KEYWORD    parent                                     null
+KEYWORD    self                                       null
+KEYWORD    string                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_10.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+public function publicMethod4(?Enum|1 $enum1): void {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace1              [PUBLIC]   null
+PACKAGE    EnumTestNamespace2              [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace2
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace2
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace EnumTestNamespace;
+function returnType(): Enum1 {
+}
+
+enum EnumTest {
+    public function publicMethod1(): Enum1 {
+    }
+    public function publicMethod2(): Enum1|Enum2 {
+    }
+    public static function publicMethod3(): Enum1&Enum2 {
+    }
+    public function publicMethod4(): ?Enum1 {
+    }
+
+}
+enum Enum1 {
+    case CASE1;
+}
+
+enum Enum2 {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_01.completion
@@ -1,0 +1,21 @@
+Code completion result for source line:
+function returnType(): |Enum1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    callable                                   null
+KEYWORD    false                                      null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    never                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    string                                     null
+KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_02.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+function returnType(): Enum|1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_03.completion
@@ -1,0 +1,24 @@
+Code completion result for source line:
+public function publicMethod1(): |Enum1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    callable                                   null
+KEYWORD    false                                      null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    never                                      null
+KEYWORD    null                                       null
+KEYWORD    object                                     null
+KEYWORD    parent                                     null
+KEYWORD    self                                       null
+KEYWORD    static                                     null
+KEYWORD    string                                     null
+KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_04.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+public function publicMethod1(): Enu|m1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_05.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+public function publicMethod2(): Enum1|Enum|2 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_06.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+public static function publicMethod3(): Enu|m1&Enum2 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_07.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+public static function publicMethod3(): Enum1&Enum2| {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_08.completion
@@ -1,0 +1,20 @@
+Code completion result for source line:
+public function publicMethod4(): ?|Enum1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace
+------------------------------------
+KEYWORD    array                                      null
+KEYWORD    bool                                       null
+KEYWORD    callable                                   null
+KEYWORD    float                                      null
+KEYWORD    int                                        null
+KEYWORD    iterable                                   null
+KEYWORD    mixed                                      null
+KEYWORD    object                                     null
+KEYWORD    parent                                     null
+KEYWORD    self                                       null
+KEYWORD    static                                     null
+KEYWORD    string                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_09.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+public function publicMethod4(): ?Enum|1 {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+PACKAGE    EnumTestNamespace               [PUBLIC]   null
+CLASS      Enum1                           [PUBLIC]   EnumTestNamespace
+CLASS      Enum2                           [PUBLIC]   EnumTestNamespace
+CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum1;
+enum Simple {
+
+    use TestTrait;
+
+    case CASE1;
+    case CASE2;
+    public const PUBLIC_CONST = "public";
+    private const PRIVATE_CONST = "private";
+    protected const PROTECTED_CONST = "protected";
+    const CONSTANT1 = "CONSTANT1";
+    const CONSTANT2 = self::CASE2;
+
+    public function publicEnumMethod(): void {
+        echo "publicEnumMethod()" . PHP_EOL;
+    }
+
+    private function privateEnumMethod(): void {
+        echo "privateEnumMethod()" . PHP_EOL;
+    }
+
+    protected function protectedEnumMethod(): void {
+        echo "protectedEnumMethod()" . PHP_EOL;
+    }
+
+    public static function publicStaticEnumMethod(): void {
+        echo "publicStaticEnumMethod()" . PHP_EOL;
+    }
+
+    private static function privateStaticEnumMethod(): void {
+        echo "privateStaticEnumMethod()" . PHP_EOL;
+    }
+
+    protected static function protectedStaticEnumMethod(): void {
+        echo "protectedStaticEnumMethod()" . PHP_EOL;
+    }
+
+}
+
+trait TestTrait {
+    public function publicTraitMethod(): void {
+    }
+    private function privateTraitMethod(): void {
+    }
+    protected function protectedTraitMethod(): void {
+    }
+    public static function publicStaticTraitMethod(): void {
+    }
+    private static function privateStaticTraitMethod(): void {
+    }
+    protected static function protectedStaticTraitMethod(): void {
+    }
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_01.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum2;
+
+use Enum1\Simple;
+
+/*test */ Si

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_01.php.testEnumsTyping_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_01.php.testEnumsTyping_01.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+/*test */ Si|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      Simple                          [PUBLIC]   Enum1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_02.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum2;
+
+use Enum1\Simple;
+
+/*test */ Simple::

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_02.php.testEnumsTyping_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_02.php.testEnumsTyping_02.completion
@@ -1,0 +1,12 @@
+Code completion result for source line:
+/*test */ Simple::|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT1 "CONSTANT1"           [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Enum1\Simple
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple
+CONSTANT   class \Enum1\Simple             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_03.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_03.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum2;
+
+use Enum1\Simple;
+
+/*test */ Simple::CA

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_03.php.testEnumsTyping_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_03.php.testEnumsTyping_03.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+/*test */ Simple::CA|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_04.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_04.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum2;
+
+use Enum1\Simple;
+
+/*test */ Simple::CASE1::

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_04.php.testEnumsTyping_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_04.php.testEnumsTyping_04.completion
@@ -1,0 +1,12 @@
+Code completion result for source line:
+/*test */ Simple::CASE1::|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+CONSTANT   CASE1 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CASE2 ?                         [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT1 "CONSTANT1"           [PUBLIC]   \Enum1\Simple
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Enum1\Simple
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple
+CONSTANT   class \Enum1\Simple             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_05.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_05.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum2;
+
+use Enum1\Simple;
+
+/*test */ Simple::CASE1::pub

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_05.php.testEnumsTyping_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_05.php.testEnumsTyping_05.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+/*test */ Simple::CASE1::pub|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+CONSTANT   PUBLIC_CONST "public"           [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_06.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_06.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum2;
+
+use Enum1\Simple;
+
+/*test */ Simple::CASE1->

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_06.php.testEnumsTyping_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_06.php.testEnumsTyping_06.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+/*test */ Simple::CASE1->|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     publicEnumMethod()              [PUBLIC]   \Enum1\Simple
+METHOD     publicStaticEnumMethod()        [STATIC]   \Enum1\Simple
+METHOD     publicStaticTraitMethod()       [STATIC]   \Enum1\TestTrait
+METHOD     publicTraitMethod()             [PUBLIC]   \Enum1\TestTrait

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_07.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_07.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum2;
+
+use Enum1\Simple;
+
+/*test */ Simple::CASE1->publicE

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_07.php.testEnumsTyping_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_07.php.testEnumsTyping_07.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+/*test */ Simple::CASE1->publicE|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     publicEnumMethod()              [PUBLIC]   \Enum1\Simple

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_fqn_01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_fqn_01.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum2;
+
+\Enum1\

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_fqn_01.php.testEnumsTyping_fqn_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_fqn_01.php.testEnumsTyping_fqn_01.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+\Enum1\|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      Simple                          [PUBLIC]   Enum1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_fqn_02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_fqn_02.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum2;
+
+\Enum1\Sim

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_fqn_02.php.testEnumsTyping_fqn_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_fqn_02.php.testEnumsTyping_fqn_02.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+\Enum1\Sim|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      Simple                          [PUBLIC]   Enum1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_use_01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_use_01.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum2;
+
+use Enum1\

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_use_01.php.testEnumsTyping_use_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_use_01.php.testEnumsTyping_use_01.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+use Enum1\|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      Simple                          [PUBLIC]   Enum1
+CLASS      TestTrait                       [PUBLIC]   Enum1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_use_02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_use_02.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum2;
+
+use Enum1\Sim

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_use_02.php.testEnumsTyping_use_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsTyping/enumsTyping_use_02.php.testEnumsTyping_use_02.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+use Enum1\Sim|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      Simple                          [PUBLIC]   Enum1

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNewInInitializersAttributeTyping01/newInInitializersAttributeTyping01.php.testNewInInitializersAttributeTyping01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNewInInitializersAttributeTyping01/newInInitializersAttributeTyping01.php.testNewInInitializersAttributeTyping01.completion
@@ -47,6 +47,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -81,6 +82,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNewInInitializersConstantTyping01/newInInitializersConstantTyping01.php.testNewInInitializersConstantTyping01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNewInInitializersConstantTyping01/newInInitializersConstantTyping01.php.testNewInInitializersConstantTyping01.completion
@@ -42,6 +42,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -76,6 +77,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNewInInitializersStaticVariableTyping01/newInInitializersStaticVariableTyping01.php.testNewInInitializersStaticVariableTyping01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNewInInitializersStaticVariableTyping01/newInInitializersStaticVariableTyping01.php.testNewInInitializersStaticVariableTyping01.completion
@@ -42,6 +42,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -76,6 +77,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/test207188/test207188.php.testUseCase2.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/test207188/test207188.php.testUseCase2.completion
@@ -44,6 +44,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -78,6 +79,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/test233938/issue233938.php.testUseCase1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/test233938/issue233938.php.testUseCase1.completion
@@ -42,6 +42,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -76,6 +77,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests235450/issue235450.php.testLowercase_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests235450/issue235450.php.testLowercase_01.completion
@@ -47,6 +47,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -81,6 +82,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests247082/issue247082.php.testForKeywords.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests247082/issue247082.php.testForKeywords.completion
@@ -70,6 +70,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -104,6 +105,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests257088/issue257088.php.testClassKeywords.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests257088/issue257088.php.testClassKeywords.completion
@@ -46,6 +46,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -80,6 +81,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests268332/issue268332.php.testAnonymousFunction.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests268332/issue268332.php.testAnonymousFunction.completion
@@ -44,6 +44,7 @@ KEYWORD    endforeach                                 null
 KEYWORD    endif                                      null
 KEYWORD    endswitch                                  null
 KEYWORD    endwhile                                   null
+KEYWORD    enum                                       null
 KEYWORD    eval()                                     Language Construct
 KEYWORD    exit()                                     Language Construct
 KEYWORD    extends                                    null
@@ -78,6 +79,7 @@ KEYWORD    return ;                                   Language Construct
 KEYWORD    static                                     null
 KEYWORD    switch                                     null
 KEYWORD    throw                                      null
+KEYWORD    trait                                      null
 KEYWORD    try                                        null
 KEYWORD    unset()                                    Language Construct
 KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/verification/IncorrectEnumHintError/testIncorrectEnums.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/IncorrectEnumHintError/testIncorrectEnums.php
@@ -24,10 +24,20 @@ enum IncorrectProperties {
     case CASE_NAME;
 }
 
+enum IncorrectPropertiesWithTrait {
+    use TestTrait1;
+    case CASE_NAME;
+}
+
 enum IncorrectBackingType: Foo {
     public int $property = 1;
     public static string $staticProperty = "error";
     case CASE_NAME;
+}
+
+enum IncorrectConstructor {
+    public function __construct() {
+    }
 }
 
 enum CorrectBackingTypeString: string {
@@ -45,9 +55,15 @@ class IncorrectEnumCase {
     public static string $property = "correct";
 }
 
-trait TestTrait {
+trait TestTrait1 {
+    use TestTrait2;
     public int $property = 1;
     public static string $property = "correct";
+}
+
+trait TestTrait2 {
+    public int $property2 = 1;
+    public static string $property2 = "correct";
 }
 
 interface TestInterface {

--- a/php/php.editor/test/unit/data/testfiles/verification/IncorrectEnumHintError/testIncorrectEnums.php.testIncorrectEnums.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/IncorrectEnumHintError/testIncorrectEnums.php.testIncorrectEnums.hints
@@ -1,18 +1,25 @@
     public int $property;
     ---------------------
-HINT:Enums cannot have properties
+HINT:Enum cannot have properties
     public static string $staticProperty = "error";
     -----------------------------------------------
-HINT:Enums cannot have properties
+HINT:Enum cannot have properties
+    use TestTrait1;
+    ---------------
+HINT:Enum cannot have properties, but "TestTrait1" has properties
+HINT:Enum cannot have properties, but "TestTrait2" has properties
 enum IncorrectBackingType: Foo {
                            ---
 HINT:Backing type must be "string" or "int"
     public int $property = 1;
     -------------------------
-HINT:Enums cannot have properties
+HINT:Enum cannot have properties
     public static string $staticProperty = "error";
     -----------------------------------------------
-HINT:Enums cannot have properties
+HINT:Enum cannot have properties
+    public function __construct() {
+                    -----------
+HINT:Enum cannot have a constructor
     case C;
     -------
 HINT:"case" can only be in enums

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP81CodeCompletionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP81CodeCompletionTest.java
@@ -767,4 +767,325 @@ public class PHP81CodeCompletionTest extends PHPCodeCompletionTestBase {
         checkCompletionCustomTemplateResult(getTestPath("testIntersectionTypesOverrideMethod03"), "    test^",
                 new DefaultFilter(PhpVersion.PHP_81, "test"), true);
     }
+
+    public void testEnums_01() throws Exception {
+        checkCompletion("enums", "const CONSTANT2 = self::^CASE2;");
+    }
+
+    public void testEnums_02() throws Exception {
+        checkCompletion("enums", "const CONSTANT2 = self::CASE^2;");
+    }
+
+    public void testEnums_03() throws Exception {
+        checkCompletion("enums", "static::CAS^E1 => 'Case1',");
+    }
+
+    public void testEnums_04() throws Exception {
+        checkCompletion("enums", "        Simple::^CASE2;");
+    }
+
+    public void testEnums_05() throws Exception {
+        checkCompletion("enums", "        Simple::C^ASE2;");
+    }
+
+    public void testEnums_06() throws Exception {
+        checkCompletion("enums", "        Simple::PRIV^ATE_CONST;");
+    }
+
+    public void testEnums_07() throws Exception {
+        checkCompletion("enums", "        Simple::protected^StaticEnumMethod();");
+    }
+
+    public void testEnums_08() throws Exception {
+        checkCompletion("enums", "        Simple::CASE1->^publicEnumMethod();");
+    }
+
+    public void testEnums_09() throws Exception {
+        checkCompletion("enums", "        Simple::CASE1->publicEnum^Method();");
+    }
+
+    public void testEnums_10() throws Exception {
+        checkCompletion("enums", "Simple::CASE1::^publicStaticEnumMethod();");
+    }
+
+    public void testEnums_11() throws Exception {
+        checkCompletion("enums", "Simple::CASE1::publicStatic^EnumMethod();");
+    }
+
+    public void testEnums_12() throws Exception {
+        checkCompletion("enums", "        self::^CASE1;");
+    }
+
+    public void testEnums_13() throws Exception {
+        checkCompletion("enums", "        self::CASE^1;");
+    }
+
+    public void testEnums_14() throws Exception {
+        checkCompletion("enums", "        self::privateStatic^EnumMethod();");
+    }
+
+    public void testEnums_15() throws Exception {
+        checkCompletion("enums", "        self::CASE^1->privateEnumMethod();");
+    }
+
+    public void testEnums_16() throws Exception {
+        checkCompletion("enums", "        self::CASE1->priv^ateEnumMethod();");
+    }
+
+    public void testEnums_17() throws Exception {
+        checkCompletion("enums", "        self::CASE1^::protectedStaticEnumMethod();");
+    }
+
+    public void testEnums_18() throws Exception {
+        checkCompletion("enums", "        self::CASE1::protectedStatic^EnumMethod();");
+    }
+
+    public void testEnums_19() throws Exception {
+        checkCompletion("enums", "        static::p^rivateStaticEnumMethod();");
+    }
+
+    public void testEnums_20() throws Exception {
+        checkCompletion("enums", "        static::CASE1->p^ublicEnumMethod();");
+    }
+
+    public void testEnums_21() throws Exception {
+        checkCompletion("enums", "        static::CASE1::p^ublicEnumMethod();");
+    }
+
+    public void testEnums_22() throws Exception {
+        checkCompletion("enums", "Simple::CASE1::^CONSTANT1;");
+    }
+
+    public void testEnums_23() throws Exception {
+        checkCompletion("enums", "Simple::CASE1::CON^STANT1;");
+    }
+
+    public void testEnums_24() throws Exception {
+        checkCompletion("enums", "Simple::CASE2->^publicEnumMethod();");
+    }
+
+    public void testEnums_25() throws Exception {
+        checkCompletion("enums", "Simple::CASE2->public^EnumMethod();");
+    }
+
+    public void testEnums_26() throws Exception {
+        checkCompletion("enums", "Simple::^publicStaticEnumMethod();");
+    }
+
+    public void testEnums_27() throws Exception {
+        checkCompletion("enums", "Simple::publicStatic^EnumMethod();");
+    }
+
+    public void testEnums_28() throws Exception {
+        checkCompletion("enums", "$i::^CASE1;");
+    }
+
+    public void testEnums_29() throws Exception {
+        checkCompletion("enums", "$i::CASE^1;");
+    }
+
+    public void testEnums_30() throws Exception {
+        checkCompletion("enums", "$i->^publicEnumMethod();");
+    }
+
+    public void testEnums_31() throws Exception {
+        checkCompletion("enums", "$i->public^EnumMethod();");
+    }
+
+    public void testEnumsTyping_01() throws Exception {
+        checkCompletion("enumsTyping_01", "/*test */ Si^");
+    }
+
+    public void testEnumsTyping_02() throws Exception {
+        checkCompletion("enumsTyping_02", "/*test */ Simple::^");
+    }
+
+    public void testEnumsTyping_03() throws Exception {
+        checkCompletion("enumsTyping_03", "/*test */ Simple::CA^");
+    }
+
+    public void testEnumsTyping_04() throws Exception {
+        checkCompletion("enumsTyping_04", "/*test */ Simple::CASE1::^");
+    }
+
+    public void testEnumsTyping_05() throws Exception {
+        checkCompletion("enumsTyping_05", "/*test */ Simple::CASE1::pub^");
+    }
+
+    public void testEnumsTyping_06() throws Exception {
+        checkCompletion("enumsTyping_06", "/*test */ Simple::CASE1->^");
+    }
+
+    public void testEnumsTyping_07() throws Exception {
+        checkCompletion("enumsTyping_07", "/*test */ Simple::CASE1->publicE^");
+    }
+
+    public void testEnumsTyping_use_01() throws Exception {
+        checkCompletion("enumsTyping_use_01", "use Enum1\\^");
+    }
+
+    public void testEnumsTyping_use_02() throws Exception {
+        checkCompletion("enumsTyping_use_02", "use Enum1\\Sim^");
+    }
+
+    public void testEnumsTyping_fqn_01() throws Exception {
+        checkCompletion("enumsTyping_fqn_01", "\\Enum1\\^");
+    }
+
+    public void testEnumsTyping_fqn_02() throws Exception {
+        checkCompletion("enumsTyping_fqn_02", "\\Enum1\\Sim^");
+    }
+
+    public void testEnumsInConstExpr01() throws Exception {
+        checkCompletion("enumsInConstExpr01", "    public const PUBLIC_CONST = ^;");
+    }
+
+    public void testEnumsInConstExpr02() throws Exception {
+        checkCompletion("enumsInConstExpr02", "    public const PUBLIC_CONST = Enum^;");
+    }
+
+    public void testEnumsReturnType_01() throws Exception {
+        checkCompletion("enumsReturnType", "function returnType(): ^Enum1 {");
+    }
+
+    public void testEnumsReturnType_02() throws Exception {
+        checkCompletion("enumsReturnType", "function returnType(): Enum^1 {");
+    }
+
+    public void testEnumsReturnType_03() throws Exception {
+        checkCompletion("enumsReturnType", "    public function publicMethod1(): ^Enum1 {");
+    }
+
+    public void testEnumsReturnType_04() throws Exception {
+        checkCompletion("enumsReturnType", "    public function publicMethod1(): Enu^m1 {");
+    }
+
+    public void testEnumsReturnType_05() throws Exception {
+        checkCompletion("enumsReturnType", "    public function publicMethod2(): Enum1|Enum^2 {");
+    }
+
+    public void testEnumsReturnType_06() throws Exception {
+        checkCompletion("enumsReturnType", "    public static function publicMethod3(): Enu^m1&Enum2 {");
+    }
+
+    public void testEnumsReturnType_07() throws Exception {
+        checkCompletion("enumsReturnType", "    public static function publicMethod3(): Enum1&Enum2^ {");
+    }
+
+    public void testEnumsReturnType_08() throws Exception {
+        checkCompletion("enumsReturnType", "    public function publicMethod4(): ?^Enum1 {");
+    }
+
+    public void testEnumsReturnType_09() throws Exception {
+        checkCompletion("enumsReturnType", "    public function publicMethod4(): ?Enum^1 {");
+    }
+
+    public void testEnumsParamType_01() throws Exception {
+        checkCompletion("enumsParamType", "function paramType(^EnumTest $param): void {");
+    }
+
+    public void testEnumsParamType_02() throws Exception {
+        checkCompletion("enumsParamType", "function paramType(Enum^Test $param): void {");
+    }
+
+    public void testEnumsParamType_03() throws Exception {
+        checkCompletion("enumsParamType", "    public function publicMethod1(En^um1 $enum1, Enum2 $enum2): void {");
+    }
+
+    public void testEnumsParamType_04() throws Exception {
+        checkCompletion("enumsParamType", "    public function publicMethod1(Enum1 $enum1, Enum2^ $enum2): void {");
+    }
+
+    public void testEnumsParamType_05() throws Exception {
+        checkCompletion("enumsParamType", "    public static function publicMethod2(Enu^m1|Enum2 $enum1): void {");
+    }
+
+    public void testEnumsParamType_06() throws Exception {
+        checkCompletion("enumsParamType", "    public static function publicMethod2(Enum1|Enum^2 $enum1): void {");
+    }
+
+    public void testEnumsParamType_07() throws Exception {
+        checkCompletion("enumsParamType", "    public function publicMethod3(Enum1&Enum2 $enum1, En^um1&Enum2 $enum2): void {");
+    }
+
+    public void testEnumsParamType_08() throws Exception {
+        checkCompletion("enumsParamType", "    public function publicMethod3(Enum1&Enum2 $enum1, Enum1&^Enum2 $enum2): void {");
+    }
+
+    public void testEnumsParamType_09() throws Exception {
+        checkCompletion("enumsParamType", "    public function publicMethod4(?^Enum1 $enum1): void {");
+    }
+
+    public void testEnumsParamType_10() throws Exception {
+        checkCompletion("enumsParamType", "    public function publicMethod4(?Enum^1 $enum1): void {");
+    }
+
+    public void testEnumsFieldType_01a() throws Exception {
+        checkCompletion("enumsFieldType", "    private ^Enum1 $field;");
+    }
+
+    public void testEnumsFieldType_01b() throws Exception {
+        checkCompletion("enumsFieldType", "    private En^um1 $field;");
+    }
+
+    public void testEnumsFieldType_02a() throws Exception {
+        checkCompletion("enumsFieldType", "    public static ^Enum1 $staticField;");
+    }
+
+    public void testEnumsFieldType_02b() throws Exception {
+        checkCompletion("enumsFieldType", "    public static Enum^1 $staticField;");
+    }
+
+    public void testEnumsImplementTypesTyping_01() throws Exception {
+        checkCompletion("enumsImplementTypesTyping_01", "enum EnumTest implements ^ {");
+    }
+
+    public void testEnumsImplementTypesTyping_02() throws Exception {
+        checkCompletion("enumsImplementTypesTyping_02", "enum EnumTest implements EnumInter^ {");
+    }
+
+    public void testEnumsImplementTypesTyping_03() throws Exception {
+        checkCompletion("enumsImplementTypesTyping_03", "enum EnumTest implements EnumInterface1, EnumIn^ {");
+    }
+
+    public void testEnumsImplementTypesTyping_01b() throws Exception {
+        checkCompletion("enumsImplementTypesTyping_01b", "enum EnumTest:int implements ^ {");
+    }
+
+    public void testEnumsImplementTypesTyping_02b() throws Exception {
+        checkCompletion("enumsImplementTypesTyping_02b", "enum EnumTest:int implements EnumInter^ {");
+    }
+
+    public void testEnumsImplementTypesTyping_03b() throws Exception {
+        checkCompletion("enumsImplementTypesTyping_03b", "enum EnumTest:int implements EnumInterface1, EnumIn^ {");
+    }
+
+    public void testEnumsBackingTypesTyping_01() throws Exception {
+        checkCompletion("enumsBackingTypesTyping_01", "enum EnumTest: ^");
+    }
+
+    public void testEnumsBackingTypesTyping_02() throws Exception {
+        checkCompletion("enumsBackingTypesTyping_02", "enum EnumTest: in^");
+    }
+
+    public void testEnumsBackingTypesTyping_03() throws Exception {
+        checkCompletion("enumsBackingTypesTyping_03", "enum EnumTest: int i^");
+    }
+
+    public void testEnumsFieldTypeTyping01() throws Exception {
+        checkCompletion("enumsFieldTypeTyping01", "    private ^");
+    }
+
+    public void testEnumsFieldTypeTyping02() throws Exception {
+        checkCompletion("enumsFieldTypeTyping02", "    private En^");
+    }
+
+    public void testEnumsFieldTypeTyping03() throws Exception {
+        checkCompletion("enumsFieldTypeTyping03", "    private static ^");
+    }
+
+    public void testEnumsFieldTypeTyping04() throws Exception {
+        checkCompletion("enumsFieldTypeTyping04", "    private static Enum^");
+    }
+
 }


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/NETBEANS-5599
- https://wiki.php.net/rfc/enumerations

### Part 12

- Fix the code completion feature
- Add code templates for enums

### Part 13

- Add `enum` and `trait` keywords for CC
- Fix unit tests

### Part 14

- Improve the `IncorrectEnumHintError`
- Show an error if the enum has __construct()
- Show an error if the enum uses traits that have properties
- Fix unit tests

![nb-php81-enumerations-incorrect-construct-and-use-traits](https://user-images.githubusercontent.com/738383/163795290-56aaff49-4ee4-41d5-95c8-a2037c4e2b8b.png)

