### PR TITLE
Fix WeakListener usage in Gradle modules

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectConnection.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectConnection.java
@@ -121,7 +121,7 @@ public final class GradleProjectConnection implements ProjectConnection {
             GradleConnector gconn = GradleConnector.newConnector();
             GradleDistributionProvider pvd = project.getLookup().lookup(GradleDistributionProvider.class);
             if (pvd != null) {
-                pvd.addChangeListener(WeakListeners.change(listener, null));
+                pvd.addChangeListener(WeakListeners.change(listener, pvd));
                 GradleDistribution dist = pvd.getGradleDistribution();
                 if (dist != null) {
                     conn = createConnection(dist, projectDir);

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/ProjectActionMappingProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/ProjectActionMappingProviderImpl.java
@@ -78,7 +78,7 @@ public class ProjectActionMappingProviderImpl implements ProjectActionMappingPro
                 }
             }
         };
-        NbGradleProject.addPropertyChangeListener(project, WeakListeners.propertyChange(pcl, null));
+        NbGradleProject.addPropertyChangeListener(project, WeakListeners.propertyChange(pcl, NbGradleProject.get(project)));
         File projectDir = FileUtil.toFile(project.getProjectDirectory());
         projectMappingFile = new File(projectDir, GradleFiles.GRADLE_PROPERTIES_NAME);
         loadProjectCustomMappings();

--- a/extide/gradle/src/org/netbeans/modules/gradle/nodes/SubProjectsNode.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/nodes/SubProjectsNode.java
@@ -53,6 +53,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.PreferenceChangeListener;
+import java.util.prefs.Preferences;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.spi.GradleSettings;
@@ -124,14 +125,15 @@ public class SubProjectsNode extends AbstractNode {
                     refresh(false);
                 }
             };
-            NbGradleProject.addPropertyChangeListener(project, WeakListeners.propertyChange(propListener, proj));
+            NbGradleProject.addPropertyChangeListener(project, WeakListeners.propertyChange(propListener, NbGradleProject.get(project)));
 
             prefListener = (evt) -> {
                 if (GradleSettings.PROP_DISPLAY_DESCRIPTION.equals(evt.getKey())) {
                     refresh(false);
                 }
             };
-            GradleSettings.getDefault().getPreferences().addPreferenceChangeListener(WeakListeners.create(PreferenceChangeListener.class, prefListener, null));
+            Preferences prefs = GradleSettings.getDefault().getPreferences();
+            prefs.addPreferenceChangeListener(WeakListeners.create(PreferenceChangeListener.class, prefListener, prefs));
         }
 
         @Override

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/AbstractGradleClassPathImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/AbstractGradleClassPathImpl.java
@@ -76,7 +76,7 @@ abstract class AbstractGradleClassPathImpl implements FlaggedClassPathImplementa
             }
             support.firePropertyChange(FlaggedClassPathImplementation.PROP_FLAGS, null, null);
         };
-        watcher.addPropertyChangeListener(WeakListeners.propertyChange(listener, null));
+        watcher.addPropertyChangeListener(WeakListeners.propertyChange(listener, watcher));
     }
 
     @Override

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
@@ -90,13 +90,13 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
                 updateResources(uri);
             }
         };
-        this.wPcl = WeakListeners.propertyChange(pcl, null, project);
         // by some miracle, the project might have been loaded!
         NbGradleProject gp = NbGradleProject.get(project);
+        this.wPcl = WeakListeners.propertyChange(pcl, null, gp);
         if (gp.isGradleProjectLoaded()) {
             updateGroups();
         }
-        NbGradleProject.addPropertyChangeListener(project, wPcl);
+        gp.addPropertyChangeListener(wPcl);
     }
     
     private void updateResources(URI uri) {

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/nodes/BootCPNodeFactory.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/nodes/BootCPNodeFactory.java
@@ -384,7 +384,7 @@ public class BootCPNodeFactory implements NodeFactory {
             Preferences prefs = NbGradleProject.getPreferences(project, false);
             prefs.addPreferenceChangeListener(
                     WeakListeners.create(PreferenceChangeListener.class, this, prefs));
-            NbGradleProject.addPropertyChangeListener(project, WeakListeners.propertyChange(this,project));
+            NbGradleProject.addPropertyChangeListener(project, WeakListeners.propertyChange(this, NbGradleProject.get(project)));
             
             if (this.boot != null) {
                 this.boot.addPropertyChangeListener(WeakListeners.propertyChange(this, this.boot));

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleCompilerOptionsQuery.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleCompilerOptionsQuery.java
@@ -49,9 +49,8 @@ public final class GradleCompilerOptionsQuery implements CompilerOptionsQueryImp
 
     public GradleCompilerOptionsQuery(Project project) {
         this.project = project;
-        final NbGradleProject watcher = NbGradleProject.get(project);
         listener = (evt) -> {
-            if (watcher.isUnloadable()) return;
+            if (NbGradleProject.get(project).isUnloadable()) return;
             if (NbGradleProject.PROP_PROJECT_INFO.equals(evt.getPropertyName())) {
                 //TODO: How shall we handle source set removal?
                 synchronized(GradleCompilerOptionsQuery.this) {
@@ -61,7 +60,7 @@ public final class GradleCompilerOptionsQuery implements CompilerOptionsQueryImp
                 }
             }
         };
-        watcher.addPropertyChangeListener(WeakListeners.propertyChange(listener, project));
+        NbGradleProject.addPropertyChangeListener(project, WeakListeners.propertyChange(listener, NbGradleProject.get(project)));
     }
 
     @Override

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceForBinary.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceForBinary.java
@@ -132,7 +132,7 @@ public class GradleSourceForBinary implements SourceForBinaryQueryImplementation
                     support.fireChange();
                 }
             };
-            NbGradleProject.get(project).addPropertyChangeListener(WeakListeners.propertyChange(listener, project));
+            NbGradleProject.addPropertyChangeListener(project, WeakListeners.propertyChange(listener, NbGradleProject.get(project)));
         }
 
         @Override

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceLevelImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceLevelImpl.java
@@ -78,7 +78,7 @@ public class GradleSourceLevelImpl implements SourceLevelQueryImplementation2 {
 
         private final FileObject javaFile;
         private final ChangeSupport cs = new ChangeSupport(this);
-        private final PropertyChangeListener pcl = WeakListeners.propertyChange(this, project.getLookup().lookup(NbGradleProject.class));
+        private final PropertyChangeListener pcl = WeakListeners.propertyChange(this, NbGradleProject.get(project));
         private String cachedLevel = null;
         private SourceLevelQuery.Profile cachedProfile;
         private final Object CACHE_LOCK = new Object();


### PR DESCRIPTION
As I saw some WeakListener detachment warnings in the IDE log coming from the Gradle modules, I've decided to have a look on them.

There were to types of issues:
  1. No source object were given, so the detachment of the listener would not happen. That kind of Ok.
  2. The NbGradleProjectImpl was passed as source instead of its NbGradlePorject so the removal could not happened.

The changes here should be trivial.