### PR TITLE
new nb module project wizard improvements.

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardPanelVisual.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardPanelVisual.java
@@ -22,22 +22,17 @@ package org.netbeans.modules.maven.apisupport;
 import java.awt.EventQueue;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.SwingUtilities;
-import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
-import org.apache.maven.artifact.resolver.ArtifactResolutionException;
-import org.netbeans.api.progress.aggregate.AggregateProgressFactory;
 import org.netbeans.api.progress.aggregate.AggregateProgressHandle;
-import org.netbeans.api.progress.aggregate.ProgressContributor;
 import org.netbeans.modules.maven.api.MavenValidators;
 import org.netbeans.modules.maven.api.archetype.Archetype;
-import static org.netbeans.modules.maven.apisupport.Bundle.ADD_Module_Name;
-import static org.netbeans.modules.maven.apisupport.Bundle.Handle_Download;
-import static org.netbeans.modules.maven.apisupport.Bundle.NbmWizardPanelVisual_wait;
-import org.netbeans.modules.maven.embedder.exec.ProgressTransferListener;
 import org.netbeans.modules.maven.indexer.api.NBVersionInfo;
 import org.netbeans.modules.maven.indexer.api.RepositoryInfo;
 import org.netbeans.modules.maven.indexer.api.RepositoryPreferences;
@@ -51,10 +46,12 @@ import org.netbeans.validation.api.builtin.stringvalidation.StringValidators;
 import org.netbeans.validation.api.ui.ValidationGroup;
 import org.netbeans.validation.api.ui.swing.SwingValidationGroup;
 import org.openide.WizardDescriptor;
-import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.RequestProcessor;
+
+import static org.netbeans.modules.maven.apisupport.Bundle.ADD_Module_Name;
+import static org.netbeans.modules.maven.apisupport.Bundle.NbmWizardPanelVisual_wait;
 
 /**
  *
@@ -66,6 +63,10 @@ public class NbmWizardPanelVisual extends javax.swing.JPanel {
 
     @Messages("NbmWizardPanelVisual.wait=Searching...")
     private static final String SEARCHING = NbmWizardPanelVisual_wait();
+    private static final String RELEASE_PREFIX = "RELEASE";
+    private static final int MINIMUM_VERSION = 111;
+    private static final Set<String> IGNORE_RELEASES = new HashSet<>(Arrays.asList("RELEASE120"));
+
     private final NbmWizardPanel panel;
     private ValidationGroup vg = ValidationGroup.create();
     private ValidationGroup vgEnabled = ValidationGroup.create();
@@ -73,7 +74,6 @@ public class NbmWizardPanelVisual extends javax.swing.JPanel {
     private boolean isLoaded = false;
     private AggregateProgressHandle handle;
     private final Object HANDLE_LOCK = new Object();
-    
 
     @SuppressWarnings("unchecked") // SIMPLEVALIDATION-48
     @Messages({"ADD_Module_Name=NetBeans Module ArtifactId", 
@@ -113,70 +113,20 @@ public class NbmWizardPanelVisual extends javax.swing.JPanel {
                     }
                 }
                 if (info != null) {
-                    final List<String> versions = new ArrayList<String>();
                     final Result<NBVersionInfo> result = RepositoryQueries.getVersionsResult("org.netbeans.cluster", "platform", Collections.unmodifiableList(info));
-                    for (NBVersionInfo version : result.getResults()) { // NOI18N
-                        versions.add(version.getVersion());
-                    }
-                    versions.add(NbmWizardIterator.SNAPSHOT_VERSION); // NOI18N
-                    if (result.isPartial() || versions.size() == 1) {
-                        RP.post(new Runnable() {
-                            //download archetype to figure the default value of the netbeansVersion parameter.
-                            @Override
-                            public void run() {
-                                AggregateProgressHandle hndl = AggregateProgressFactory.createHandle(Handle_Download(),
-                                        new ProgressContributor[]{
-                                            AggregateProgressFactory.createProgressContributor("zaloha")}, //NOI18N
-                                        ProgressTransferListener.cancellable(), null);
-                                synchronized (HANDLE_LOCK) {
-                                    handle = hndl;
-                                }
+                    List<String> versions = filterVersions(result);
 
-                                try {
-                                    arch.resolveArtifacts(hndl);
-                                    Map<String, String> props = arch.loadRequiredProperties();
-                                    String def = props.get("netbeansVersion");
-                                    final List<String> versions3 = new ArrayList<String>();
-                                    if (def != null) {
-                                        versions3.add(def);
-                                    }
-                                    versions3.add(NbmWizardIterator.SNAPSHOT_VERSION);
-                                    if (result.isPartial()) {
-                                        versions3.add(SEARCHING);
-                                    }
-                                    EventQueue.invokeLater(new Runnable() {
-                                        public @Override
-                                        void run() {
-                                            versionCombo.setModel(new DefaultComboBoxModel(versions3.toArray()));
-                                            versionComboActionPerformed(null);
-                                        }
-                                    });
-                                } catch (ArtifactResolutionException ex) {
-                                    Exceptions.printStackTrace(ex);
-                                } catch (ArtifactNotFoundException ex) {
-                                    Exceptions.printStackTrace(ex);
-                                } finally {
-                                }
-                            }
-                        });
-                    }
                     if (result.isPartial()) {
                         versions.add(SEARCHING);
                         //we return the values we have and schedule retrieval of the rest.
                         RP.post(new Runnable() {
                             @Override
                             public void run() {
-                                final List<String> versions2 = new ArrayList<String>();
                                 result.waitForSkipped();
-                                RepositoryPreferences.getInstance().removeTransientRepositories(key);
-                                for (NBVersionInfo version : result.getResults()) { // NOI18N
-                                    versions2.add(version.getVersion());
-                                }
-                                versions2.add(NbmWizardIterator.SNAPSHOT_VERSION); // NOI18N
-
+                                List<String> allVersions = filterVersions(result);
                                 EventQueue.invokeLater(new Runnable()  {
                                             public @Override void run() {
-                                                versionCombo.setModel(new DefaultComboBoxModel(versions2.toArray()));
+                                                versionCombo.setModel(new DefaultComboBoxModel(allVersions.toArray()));
                                                 versionComboActionPerformed(null);
                                             }
                                         });
@@ -196,6 +146,27 @@ public class NbmWizardPanelVisual extends javax.swing.JPanel {
             }
         });
         
+    }
+
+    private static List<String> filterVersions(Result<NBVersionInfo> result) {
+        List<String> versions = result.getResults().stream()
+                .map(NBVersionInfo::getVersion)
+                .filter((v) -> v.startsWith(RELEASE_PREFIX) && v.length() > RELEASE_PREFIX.length())
+                .filter((v) -> versionOf(v) >= MINIMUM_VERSION)
+                .filter((v) -> !IGNORE_RELEASES.contains(v))
+                .sorted((v1, v2) -> v2.compareTo(v1))
+                .collect(Collectors.toCollection(ArrayList::new)); // must be mutable
+        versions.add(NbmWizardIterator.SNAPSHOT_VERSION);
+        return versions;
+    }
+
+    private static int versionOf(String release) {
+        int end;
+        for (end = RELEASE_PREFIX.length(); end < release.length(); end++) {
+            if (!Character.isDigit(release.charAt(end)))
+                break;
+        }
+        return Integer.parseInt(release.substring(RELEASE_PREFIX.length(), end));
     }
 
     private void initValidators() {
@@ -313,15 +284,14 @@ public class NbmWizardPanelVisual extends javax.swing.JPanel {
 }//GEN-LAST:event_cbAddModuleActionPerformed
 
     private void versionComboActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_versionComboActionPerformed
-        String version = (String) versionCombo.getSelectedItem();
-        NBVersionInfo nbvi = new NBVersionInfo("x", "x", "x", version, null, null, null, null, null);
-        if (version != null && (version.equals(NbmWizardIterator.SNAPSHOT_VERSION) || nbvi.compareTo(new NBVersionInfo("x", "x", "x", "RELEASE69-BETA", null, null, null, null, null)) <= 0)) {
-            cbOsgiDeps.setEnabled(true);
-            //cbOsgiDeps.setSelected(version.equals("SNAPSHOT") || nbvi.compareTo(new NBVersionInfo("x", "x", "x", "RELEASE71", null, null, null, null, null)) <= 0);
-        } else {
-            cbOsgiDeps.setEnabled(false);
-            cbOsgiDeps.setSelected(false);
-        }
+        cbOsgiDeps.setVisible(false); // none of the apache releases support osgi
+//        String version = (String) versionCombo.getSelectedItem();
+//        if (RELEASE90_VERSION.equals(version)) {
+//            cbOsgiDeps.setEnabled(true);
+//        } else {
+//            cbOsgiDeps.setEnabled(false);
+//            cbOsgiDeps.setSelected(false);
+//        }
         vgEnabled.performValidation();
     }//GEN-LAST:event_versionComboActionPerformed
 


### PR DESCRIPTION
 - use dev snapshot as fallback instead of RELEASE90
 - sort the version list properly, newest first
 - filter out non-apache releases

second commit is the usual language lvl cleanup, first commit has the fixes.