### PR TITLE
Do not include jdk.jshell in test mod list by default.

### DIFF
--- a/nbbuild/default.xml
+++ b/nbbuild/default.xml
@@ -246,6 +246,7 @@
           </filterchain>
       </loadfile>
       <property name="metabuild.jms-flags" value="${jms-base.flags}${jms-desktop.flags}${jms-compiler.flags}${jms-tools.flags}"/>
-      <property name="metabuild.jms-flags.jvm" value="${jms-base.flags.jvm}${jms-desktop.flags.jvm}${jms-compiler.flags.jvm}${jms-tools.flags.jvm}"/>
+      <!-- Excluding jms-tools.flags, as nbjavac usually overlaps with tools dependencies -->
+      <property name="metabuild.jms-flags.jvm" value="${jms-base.flags.jvm}${jms-desktop.flags.jvm}${jms-compiler.flags.jvm}"/>
   </target>
 </project>

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -289,7 +289,8 @@
     </target>
     <target name="test-lib-init" depends="-init-bootclasspath-prepend,init,-build-libs.junit4">
         <path id="test.unit.lib.cp"/>
-        <property name="test.run.args" value="-ea -Xmx700m ${metabuild.jms-flags.jvm} -XX:+IgnoreUnrecognizedVMOptions"/>
+        <property name="test.jms.flags" value=""/>
+        <property name="test.run.args" value="-ea -Xmx700m ${metabuild.jms-flags.jvm} ${test.jms.flags} -XX:+IgnoreUnrecognizedVMOptions"/>
         <property name="extra.test.libs.dir" location="${test.dist.dir}/extralibs"/>
         <macrodef name="test-init-nborg">
             <attribute name="test.type"/>


### PR DESCRIPTION
After PR #3974, the [Apache NBLS distribution is unbuildable](https://ci-builds.apache.org/job/Netbeans/job/netbeans-vscode/1037/):
- the IDE build now requires JDK11 (which might be OK, but was not communicated on mailing list in advance, so it is a sort of bad surprise since the build started to fail between vote start and vote end)
- when the build switched to JDK11, it [turned out that it still fails](https://ci-builds.apache.org/job/Netbeans/job/netbeans-vscode/1049/) 

The failure is because of:
```
 [junit] Test org.netbeans.modules.java.mx.project.SdkSuiteTest FAILED (crashed)
    [junit] Error occurred during initialization of boot layer
    [junit] java.lang.module.FindException: Module jdk.internal.opt not found, required by jdk.jshell
```
in `java/java.mx.project`, but essentially in **all modules that require nb-javac** for propert functionality (`requires.nb.javac` in their `project.properties`)

The reason why `master` builds OK is just that those tests for all those modules (i.e. `java/java.editor`) are not, and were never run on JDK11. We are now in a peculiar situation, when JDK "x" is required to build the product, but most part of the product is not only not tested on JDK "x", but if the test would execute on JDK "x", they would 100%  fail :)

This PR changes the default commandline for junit test so that it **excludes** `jms-config/tools.flags` (currently just the jdk.jshell); modules that need tool modules during test may use `test.jms.flags` property to add them.

This is because `--limit-modules` is used to exclude most of JDK contents, but specifically `jdk.compiler` that overlaps with nb-javac classes. As most tests do not run module system (because it's a way slower and more complicated) the classpath-located nbjavac would not be used if `jdk.compiler` was observable and loaded by JDK 9+.  And if `jdk.compiler` is not observable, `--add-module jdk.jshell` causes the VM failure during boot layer init.
