### PR TITLE
ignore ISSUE_TEMPLATE for rat

### DIFF
--- a/nbbuild/rat-exclusions.txt
+++ b/nbbuild/rat-exclusions.txt
@@ -221,3 +221,7 @@ ide/xml.text/src/org/netbeans/modules/xml/text/resources/DTDExample
 ide/xml.text/src/org/netbeans/modules/xml/text/resources/XMLExample
 ide/xml.text/src/org/netbeans/modules/xml/text/resources/XMLExampleIndent
 ide/properties.syntax/src/org/netbeans/modules/properties/syntax/PropertiesExample
+
+
+###### GitHub Issue tooling
+.github/**


### PR DESCRIPTION
netbeans-license job show issue for  files in ISSUE_TEMPLATE folder
https://github.com/apache/netbeans/tree/master/.github/ISSUE_TEMPLATE

We can ignore by merging this PR. 