### PR TITLE
Fixing ElementJavadoc for files without package clause.

### DIFF
--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -309,7 +309,6 @@ public class ServerTest extends NbTestCase {
         }
     }
 
-    @org.junit.Ignore
     public void testMain() throws Exception {
         File src = new File(getWorkDir(), "Test.java");
         src.getParentFile().mkdirs();
@@ -1282,7 +1281,6 @@ public class ServerTest extends NbTestCase {
                          "<none>:1:26-1:29", "<none>:2:12-2:15", "<none>:3:17-3:20");
     }
 
-    @org.junit.Ignore
     public void testHover() throws Exception {
         File src = new File(getWorkDir(), "Test.java");
         src.getParentFile().mkdirs();

--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
@@ -394,7 +394,8 @@ public class ElementJavadoc {
         this.fileObject = compilationInfo.getFileObject();
         this.handle = element == null ? null : ElementHandle.create(element);
         this.cancel = cancel;
-        this.packageName = compilationInfo.getCompilationUnit().getPackageName().toString();
+        this.packageName = compilationInfo.getCompilationUnit().getPackageName() != null ? compilationInfo.getCompilationUnit().getPackageName().toString()
+                                                                                         : "";
         this.imports = compilationInfo.getCompilationUnit().getImports();
         this.className = compilationInfo.getCompilationUnit().getSourceFile().getName().replaceFirst("[.][^.]+$", "");
 


### PR DESCRIPTION
Attempting to fix javadoc computation when there's not package clause. Should fix the `java.lsp.server`'s `ServerTest`.
