### PR TITLE
Prevent Type.Unknown to be cast to ClassType in VanilaCompileWorker

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
@@ -690,6 +690,11 @@ final class VanillaCompileWorker extends CompileWorker {
                     //likely a duplicate of another class, don't touch:
                     return null;
                 }
+                if (isOtherClass(csym)) {
+                    // Something went somewhere the csym.type is Type.Unknown,
+                    // do not go any further
+                    return null;
+                }
                 currentClass = csym;
                 Type.ClassType ct = (Type.ClassType) csym.type;
                 if (csym == syms.objectType.tsym) {
@@ -1049,8 +1054,13 @@ final class VanillaCompileWorker extends CompileWorker {
         }
         return isErroneousClass(((JCClassDecl) tree).sym);
     }
+
     private boolean isErroneousClass(Element el) {
         return el instanceof ClassSymbol && (((ClassSymbol) el).asType() == null || ((ClassSymbol) el).asType().getKind() == TypeKind.ERROR);
+    }
+
+    private boolean isOtherClass(Element el) {
+        return el instanceof ClassSymbol && (((ClassSymbol) el).asType() == null || ((ClassSymbol) el).asType().getKind() == TypeKind.OTHER);
     }
 
     public static Function<Diagnostic<?>, String> DIAGNOSTIC_TO_TEXT = d -> d.getMessage(null);


### PR DESCRIPTION

Bumped into the following, while the IDE tried to index the Gradle project:
```
java.lang.ClassCastException: class com.sun.tools.javac.code.Type$UnknownType cannot be cast to class com.sun.tools.javac.code.Type$ClassType (com.sun.tools.javac.code.Type$UnknownType and com.sun.tools.javac.code.Type$ClassType are in unnamed module of loader org.netbeans.StandardModule$OneModuleClassLoader @29bfa8a1)
	at org.netbeans.modules.java.source.indexing.VanillaCompileWorker$3.visitClass(VanillaCompileWorker.java:694)
	at org.netbeans.modules.java.source.indexing.VanillaCompileWorker$3.visitClass(VanillaCompileWorker.java:535)
	at com.sun.tools.javac.tree.JCTree$JCClassDecl.accept(JCTree.java:860)
	at com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:86)
	at org.netbeans.modules.java.source.indexing.VanillaCompileWorker$3.scan(VanillaCompileWorker.java:886)
	at org.netbeans.modules.java.source.indexing.VanillaCompileWorker$3.scan(VanillaCompileWorker.java:535)
	at com.sun.source.util.TreeScanner.scanAndReduce(TreeScanner.java:96)
```

This one is just something blind, prevent the ClassCastException to happen in this case.