### PR TITLE
Proxy selector fixes

### DIFF
--- a/ide/libs.truffleapi/nbproject/project.xml
+++ b/ide/libs.truffleapi/nbproject/project.xml
@@ -38,6 +38,7 @@
                 <package>com.oracle.truffle.api</package>
                 <package>com.oracle.truffle.api.debug</package>
                 <package>com.oracle.truffle.api.dsl</package>
+                <package>com.oracle.truffle.api.exception</package>
                 <package>com.oracle.truffle.api.frame</package>
                 <package>com.oracle.truffle.api.instrumentation</package>
                 <package>com.oracle.truffle.api.interop</package>

--- a/platform/core.network/src/org/netbeans/core/network/proxy/NbProxySelector.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/NbProxySelector.java
@@ -55,7 +55,7 @@ public final class NbProxySelector extends ProxySelector {
         original = ProxySelector.getDefault();
         LOG.log(Level.FINE, "java.net.useSystemProxies has been set to {0}", useSystemProxies());
         if (original == null || original.getClass().getName().equals(DEFAULT_PROXY_SELECTOR_CLASS_NAME)) {
-            NetworkProxyReloader.reloadNetworkProxy();
+            RP.post(() -> NetworkProxyReloader.reloadNetworkProxy());
         }
         ProxySettings.addPreferenceChangeListener(new ProxySettingsListener());
         copySettingsToSystem();


### PR DESCRIPTION
It seems we missed some API changes in truffle and are not exporting a required API package. Because of that, when NB starts on JDK11 _and_ in an environment that provides `http://wpad/wpad.dat`, the following exception is printed at startup:
```
WARNING [org.netbeans.core.network.proxy.ProxyAutoConfig]: There was a catastrophic error with the PAC script downloaded from http://wpad/wpad.dat. Will use dummy instead. Error was : 
org.graalvm.polyglot.PolyglotException: java.lang.NoClassDefFoundError: com/oracle/truffle/api/exception/AbstractTruffleException while loading com.oracle.truffle.regex.RegexSyntaxException; see http://wiki.netbeans.org/DevFaqTroubleshootClassNotFound
        at org.netbeans.ProxyClassLoader.selfLoadClass(ProxyClassLoader.java:250)
        at org.netbeans.ProxyClassLoader.doFindClass(ProxyClassLoader.java:174)
        at org.netbeans.ProxyClassLoader.loadClass(ProxyClassLoader.java:125)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
        at com.oracle.truffle.regex.RegexEngineBuilder.execute(RegexEngineBuilder.java:117)
        at com.oracle.truffle.regex.RegexEngineBuilderGen$InteropLibraryExports$Uncached.execute(RegexEngineBuilderGen.java:197)
        at com.oracle.truffle.api.interop.InteropLibrary$Asserts.execute(InteropLibrary.java:2279)
        at com.oracle.truffle.api.interop.InteropLibraryGen$UncachedDispatch.execute(InteropLibraryGen.java:4780)
        at com.oracle.truffle.js.runtime.JSContext.createTRegexEngine(JSContext.java:998)
        at com.oracle.truffle.js.runtime.JSContext.getRegexEngine(JSContext.java:978)
        at com.oracle.truffle.js.runtime.RegexCompilerInterface.validate(RegexCompilerInterface.java:77)
...
Caused by: java.lang.NoClassDefFoundError: com/oracle/truffle/api/exception/AbstractTruffleException
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
        at org.netbeans.JarClassLoader.doLoadClass(JarClassLoader.java:287)
        at org.netbeans.ProxyClassLoader.selfLoadClass(ProxyClassLoader.java:246)
        ... 69 more
Caused by: java.lang.ClassNotFoundException: com.oracle.truffle.api.exception.AbstractTruffleException starting from ModuleCL@26f7b4fd[org.netbeans.libs.graaljs] with possible defining loaders [ModuleCL@7cf167b8[org.netbeans.libs.truffleapi]] and declared parents [ModuleCL@7cf167b8[org.netbeans.libs.truffleapi], ModuleCL@a80f08c[org.netbeans.libs.graalsdk]]
        at org.netbeans.ProxyClassLoader.doFindClass(ProxyClassLoader.java:211)
        at org.netbeans.ProxyClassLoader.loadClass(ProxyClassLoader.java:125)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
        ... 73 more
Caused by: java.lang.ClassNotFoundException: com.oracle.truffle.api.exception.AbstractTruffleException
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
        at org.netbeans.ProxyClassLoader.doFindClass(ProxyClassLoader.java:209)
        ... 75 more
```

In addition, I've noticed that the PAC is evaluated **during startup** by the main thread - which means the whole IDE startup process will block until the JS engine initializes and evaluates PAC; this may take even seconds. This is fixed by reloading the network proxy in a request processor.