### PR TITLE
Add necessary dependencies for com.jcraft.jsch

### DIFF
--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -30,7 +30,6 @@ cluster.path=\
 disabled.modules=\
     bcpg,\
     com.googlecode.javaewah.JavaEWAH,\
-    libs.c.kohlschutter.junixsocket,\
     org.apache.commons.lang,\
     org.apache.ws.commons.util,\
     org.apache.xmlrpc,\


### PR DESCRIPTION
On startup, NBLS logs the following exception:
```
rg.osgi.framework.BundleException: The bundle "com.jcraft.jsch_0.1.72 [161]" could not be resolved. Reason: Missing Constraint: Require-Bundle: libs.c.kohlschutter.junixsocket; bundle-version="0.0.0"org.osgi.framework.BundleException: The bundle "com.jcraft.jsch_0.1.72 [161]" could not be resolved. Reason: Missing Constraint: Require-Bundle: libs.c.kohlschutter.junixsocket; bundle-version="0.0.0" at org.eclipse.osgi.framework.internal.core.AbstractBundle.getResolverError(AbstractBundle.java:1332) at org.eclipse.osgi.framework.internal.core.AbstractBundle.getResolutionFailureException(AbstractBundle.java:1316) at org.eclipse.osgi.framework.internal.core.BundleHost.startWorker(BundleHost.java:323) at org.eclipse.osgi.framework.internal.core.AbstractBundle.resume(AbstractBundle.java:390) at org.eclipse.osgi.framework.internal.core.Framework.resumeBundle(Framework.java:1184) at org.eclipse.osgi.framework.internal.core.StartLevelManager.resumeBundles(StartLevelManager.java:559) at org.eclipse.osgi.framework.internal.core.StartLevelManager.resumeBundles(StartLevelManager.java:544) at org.eclipse.osgi.framework.internal.core.StartLevelManager.incFWSL(StartLevelManager.java:457) at org.eclipse.osgi.framework.internal.core.StartLevelManager.doSetStartLevel(StartLevelManager.java:243) at org.eclipse.osgi.framework.internal.core.EquinoxLauncher.internalStart(EquinoxLauncher.java:271) at org.eclipse.osgi.framework.internal.core.EquinoxLauncher$2.run(EquinoxLauncher.java:246) at 
...

`com.jcraft.jsch` library is needed by `cpplite.debugger` and 'dlight.nativeexecution' that we need for their functionality in NBLS; need to add the `junixsocket` library so that jsch module loads.