### PR TITLE
Sampler module has a lot of obsolete dependencies

### DIFF
--- a/platform/sampler/nbproject/project.properties
+++ b/platform/sampler/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 is.autoload=true
 javac.source=1.8
-javac.compilerargs=-Xlint -Xlint:-serial
+javac.compilerargs=-Xlint -Xlint:-serial -Werror
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/sampler/nbproject/project.xml
+++ b/platform/sampler/nbproject/project.xml
@@ -44,14 +44,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.api.progress.nb</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>1.40</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.openide.awt</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/platform/sampler/nbproject/project.xml
+++ b/platform/sampler/nbproject/project.xml
@@ -52,14 +52,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.openide.dialogs</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>7.24</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.openide.filesystems</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -68,35 +60,11 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.openide.loaders</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>7.61</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.openide.modules</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>7.28</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.openide.nodes</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>7.26</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.openide.util.ui</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>9.3</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/sampler/src/org/netbeans/modules/sampler/InternalSampler.java
+++ b/platform/sampler/src/org/netbeans/modules/sampler/InternalSampler.java
@@ -30,7 +30,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.actions.Openable;
 import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.progress.ProgressHandleFactory;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.filesystems.FileObject;
@@ -173,7 +172,7 @@ final class InternalSampler extends Sampler {
             // log warnining
             return;
         }
-        progress = ProgressHandleFactory.createHandle(Save_Progress());
+        progress = ProgressHandle.createHandle(Save_Progress());
         progress.start(steps);
     }
 

--- a/platform/sampler/src/org/netbeans/modules/sampler/InternalSampler.java
+++ b/platform/sampler/src/org/netbeans/modules/sampler/InternalSampler.java
@@ -30,11 +30,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.actions.Openable;
 import org.netbeans.api.progress.ProgressHandle;
-import org.openide.DialogDisplayer;
-import org.openide.NotifyDescriptor;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
-import org.openide.loaders.DataObject;
 import org.openide.modules.Places;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle.Messages;
@@ -47,7 +44,6 @@ import static org.netbeans.modules.sampler.Bundle.*;
 final class InternalSampler extends Sampler {
     private static final String SAMPLER_NAME = "selfsampler";  // NOI18N
     private static final String FILE_NAME = SAMPLER_NAME+SamplesOutputStream.FILE_EXT;
-    private static final String UNKNOWN_MIME_TYPE = "content/unknown"; // NOI18N
     private static final String X_DEBUG_ARG = "-Xdebug"; // NOI18N
     private static final String JDWP_DEBUG_ARG = "-agentlib:jdwp"; // NOI18N
     private static final String JDWP_DEBUG_ARG_PREFIX = "-agentlib:jdwp="; // NOI18N
@@ -121,7 +117,10 @@ final class InternalSampler extends Sampler {
     }
 
     @Override
-    @Messages("SelfSamplerAction_SavedFile=Snapshot was saved to {0}")
+    @Messages({
+        "# {0} - the file",
+        "SelfSamplerAction_SavedFile=Snapshot was saved to {0}"
+    })
     protected void saveSnapshot(byte[] arr) throws IOException { // save snapshot
         File outFile = File.createTempFile(SAMPLER_NAME, SamplesOutputStream.FILE_EXT);
         File userDir = Places.getUserDirectory();
@@ -141,12 +140,15 @@ final class InternalSampler extends Sampler {
         // open snapshot
         FileObject fo = fs.findResource(FILE_NAME);
         // test for DefaultDataObject
-        if (UNKNOWN_MIME_TYPE.equals(fo.getMIMEType())) {
-            String msg = SelfSamplerAction_SavedFile(outFile.getAbsolutePath());
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(msg));
+        Openable open = fo.getLookup().lookup(Openable.class);
+        if (open != null) {
+            open.open();
         } else {
-            DataObject dobj = DataObject.find(fo);
-            dobj.getLookup().lookup(Openable.class).open();
+            IOException ex = new IOException("Cannot open " + fo + " with MIME type: " + fo.getMIMEType());
+            String msg = SelfSamplerAction_SavedFile(outFile.getAbsolutePath());
+            Exceptions.attachSeverity(ex, Level.WARNING);
+            Exceptions.attachLocalizedMessage(ex, msg);
+            Exceptions.printStackTrace(ex);
         }
     }
 

--- a/platform/sampler/src/org/netbeans/modules/sampler/SamplesOutputStream.java
+++ b/platform/sampler/src/org/netbeans/modules/sampler/SamplesOutputStream.java
@@ -36,8 +36,6 @@ import java.util.zip.GZIPOutputStream;
 
 import javax.management.StandardMBean;
 
-import org.openide.util.Exceptions;
-
 /**
  *
  * @author Tomas Hurka
@@ -267,7 +265,6 @@ class SamplesOutputStream {
                                                              true);
                 return (Object[]) getterBean.getAttribute("Threads");
             } catch (Exception ex) {
-                Exceptions.printStackTrace(ex);
                 return new Object[0];
             }
         }

--- a/platform/sampler/src/org/netbeans/modules/sampler/SelfSampleVFS.java
+++ b/platform/sampler/src/org/netbeans/modules/sampler/SelfSampleVFS.java
@@ -25,10 +25,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import org.openide.filesystems.AbstractFileSystem;
-import org.openide.util.Enumerations;
 
 /** Filesystem that allows to virtually move some files next to each other.
  *
@@ -143,7 +143,7 @@ implements AbstractFileSystem.List, AbstractFileSystem.Info, AbstractFileSystem.
 
     @Override
     public Enumeration<String> attributes(String name) {
-        return Enumerations.empty();
+        return Collections.emptyEnumeration();
     }
 
     @Override


### PR DESCRIPTION
We are trying to use [sampler module in our application](https://github.com/enso-org/enso/pull/3389), but we realized it has a lot of unnecessary dependencies. Ideally we just use the `org-netbeans-modules-sampler.jar` on its own - should in most cases work until one calls into `InternalSampler` - we don't.

However even if one uses `InternalSampler` there are some obsoleted dependencies that make the module [too heavyweight](http://wiki.apidesign.org/wiki/HeavyWeight). This PR clears them:
- using just simpler progress API
- using `FileObject.getLookup()`
- avoiding dialogs in favor of "exception like" report

