### PR TITLE
Additional fixes for Gradle reports

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleReport.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleReport.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.gradle;
 
 import java.io.File;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
@@ -150,8 +151,13 @@ public final class GradleReport {
         if (relativeTo != null) {
             // try convert the location to a FileObject:
             File dir = FileUtil.toFile(relativeTo);
-            Path scriptPath = Paths.get(getLocation());
-            locString = dir.toPath().relativize(scriptPath).toString();
+            try {
+                Path scriptPath = Paths.get(getLocation());
+                locString = dir.toPath().relativize(scriptPath).toString();
+            } catch (FileSystemNotFoundException | IllegalArgumentException ex) {
+                // perhaps the location is not a filename
+                locString = getLocation();
+            }
         } else {
             locString = getLocation();
         }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
@@ -353,7 +353,7 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
      * LocationAwareException uses ScriptSource.getDisplayName() in its location; so the filename is prepended by 'build file', usually
      * capitalized. Who knows what other labels the resources gradle uses can have ? Add newly discovered ones to the regexp.
      */
-    private static final Pattern FILE_PATH_FROM_LOCATION = Pattern.compile("build file '(.*)'(?: line:.*)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern FILE_PATH_FROM_LOCATION = Pattern.compile("(?:build|settings) file '(.*)'(?: line:.*)$", Pattern.CASE_INSENSITIVE);
 
     /**
      * Converts exception hierarchy into chain of {@link GradleReports}. Each LocationAwareException's data


### PR DESCRIPTION
During testing of #4041, I've encountered issues that possibly affect NB14 - fixes are simple enough. 
* If `location' does not contain a proper path (it is a description, or e.g. a remote), Paths.get() or Path.relativize() may throw an exception
* setting file locations are interpreted