### PR TITLE
Allow tests to access JPDA. Pass mx path to the testsuite.

### DIFF
--- a/java/java.mx.project/nbproject/project.properties
+++ b/java/java.mx.project/nbproject/project.properties
@@ -19,3 +19,6 @@
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial -Werror -Xlint:-processing
 requires.nb.javac=true
+
+# For testing we need path to the MX executable. The executable is checked out by the buildscript.
+test.run.args=-Dorg.netbeans.modules.java.mx.project.test.mxpath=${basedir}/test/unit/data/mx/mx

--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
@@ -48,6 +48,7 @@ import org.openide.windows.OutputEvent;
 import org.openide.windows.OutputListener;
 
 final class SuiteActionProvider implements ActionProvider {
+    private static final String TEST_MX_PATH = System.getProperty("org.netbeans.modules.java.mx.project.test.mxpath"); // NOI18N
     private static final RequestProcessor ASYNC = new RequestProcessor("Mx Async", 10);
     private static final List<String> SUPPORTED_ACTIONS = Arrays.asList(
         ActionProvider.COMMAND_CLEAN,
@@ -240,7 +241,9 @@ final class SuiteActionProvider implements ActionProvider {
                 });
         ProcessBuilder processBuilder = ProcessBuilder.getLocal();
         processBuilder.setWorkingDirectory(suiteDir.getPath());
-        processBuilder.setExecutable("mx"); // NOI18N
+        
+        String executable = TEST_MX_PATH != null ? TEST_MX_PATH : "mx"; // NOI18N
+        processBuilder.setExecutable(executable); // NOI18N
         processBuilder.setArguments(Arrays.asList(args));
         ExecutionService service = ExecutionService.newService(processBuilder, descriptor, taskName);
         Future<Integer> task = service.run();

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -123,7 +123,7 @@
         </condition>
     </target>
     <target name="-init-bootclasspath-prepend-run9" depends="-init-bootclasspath-prepend-compile" if="have-jdk-1.9">
-        <condition property="test.bootclasspath.prepend.args" value="--limit-modules=java.base,java.logging,java.xml,java.prefs,java.desktop,java.management,java.instrument,jdk.zipfs,java.scripting,java.naming">
+        <condition property="test.bootclasspath.prepend.args" value="--limit-modules=java.base,java.logging,java.xml,java.prefs,java.desktop,java.management,java.instrument,jdk.zipfs,java.scripting,java.naming,jdk.jdi">
             <and>
                 <istrue value="${requires.nb.javac}"/>
                 <not>


### PR DESCRIPTION
Yet another fixes to fix `java.mx.project` testsuite on JDK11. Potentially other testsuites, too
- tests that access JPDA API should be now failing on JDK11, as `--limit-modules` does not allow them to see JPDA classes. This should be less controversial :) as we definitely want to access debugger support in platform from java cluster at least.
- `java.mx.project` testsuite needs `mx` binary on PATH (or know full path to it); the buildscript `git clone`s one, but it's not on path. Moreover the copy made into `build/test/unit/data` directory omits executable attribute, so the git clone sources must be used directly

Note that passing the `mx` location in system properties should also fix tests on JDK8 -- see for example [Test Java modules with nb-javac on Java 8](https://api.travis-ci.com/v3/job/568921174/log.txt):
```
    [junit] java.io.IOException: error=2, No such file or directory
    [junit] 	at java.lang.UNIXProcess.forkAndExec(Native Method)
    [junit] 	at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
    [junit] 	at java.lang.ProcessImpl.start(ProcessImpl.java:134)
    [junit] 	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
    [junit] Caused: java.io.IOException: Cannot run program "mx" (in directory "/home/travis/build/apache/netbeans/java/java.mx.project/build/test/unit/data/graal/sdk"): error=2, No such file or directory
    [junit] 	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
    [junit] 	at org.netbeans.modules.extexecution.base.ExternalProcessBuilder.call(ExternalProcessBuilder.java:272)
    [junit] 	at org.netbeans.api.extexecution.base.ProcessBuilder$LocalProcessBuilder.createProcess(ProcessBuilder.java:301)
    [junit] 	at org.netbeans.api.extexecution.base.ProcessBuilder.call(ProcessBuilder.java:252)
    [junit] 	at org.netbeans.api.extexecution.base.ProcessBuilder.call(ProcessBuilder.java:71)
```
(but the test still completes successfully; strage ... will fix in a subsequent PR)