### PR TITLE
improved tests for MapFormat

### DIFF
--- a/platform/openide.util/test/unit/src/org/openide/util/MapFormatTest.java
+++ b/platform/openide.util/test/unit/src/org/openide/util/MapFormatTest.java
@@ -18,68 +18,281 @@
  */
 package org.openide.util;
 
+import java.text.ParsePosition;
+import static java.util.Collections.emptyMap;
+import java.util.Date;
 import java.util.HashMap;
-import junit.framework.*;
-import org.openide.util.MapFormat;
+import java.util.Map;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+import static org.openide.util.MapFormat.format;
 
 /**
  *
- * @author Jaroslav Tulach
+ * @author Jaroslav Tulach, Lukasz Bownik
  */
-public class MapFormatTest extends TestCase {
+public class MapFormatTest {
 
-    public MapFormatTest(String testName) {
-        super(testName);
+    private final Map<String, Object> johnDoe = new HashMap<>();
+    private final Map<String, Object> dateNumberAndClass = new HashMap<>();
+
+    //--------------------------------------------------------------------------
+    @Before
+    public void setUp() {
+
+        this.johnDoe.put("first", "John");
+        this.johnDoe.put("last", "Doe");
+        this.johnDoe.put("prefix", "Mr");
+
+        this.dateNumberAndClass.put("date", new Date(1234, 7, 6, 12, 23, 51));
+        this.dateNumberAndClass.put("number", 999);
+        this.dateNumberAndClass.put("class", Void.class);
     }
 
-    protected void setUp() throws Exception {
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_throwsNullPointer_whenGivenNullArgument() {
+
+        try {
+            format(null, emptyMap());
+            fail();
+        } catch (final NullPointerException e) {
+            //good
+        }
+        try {
+            format("{name}", null);
+            fail();
+        } catch (final NullPointerException e) {
+            //good
+        }
     }
 
-    protected void tearDown() throws Exception {
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_returnEmptyString_whenGivenEmptyFormatString() {
+
+        assertEquals("", format("", this.johnDoe));
     }
-    public void testFormatIssue67238() {
 
-        HashMap args = new HashMap();
-        args.put("NAME", "Jaroslav");
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_returnsFormatStringUnchanged_whenGivenNoArgumentMap() {
 
-        MapFormat f = new MapFormat(args);
-        f.setLeftBrace("__");
-        f.setRightBrace("__");
-        f.setExactMatch(false);
-        String result = f.format("/*_____________________*/\n/*__NAME__*/");
+        assertEquals("{name}", format("{name}", emptyMap()));
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_throwsIllegalArgument_whenKeyIsNotFound_andThrowExceptionFlagIsTrue() {
+
+        MapFormat mf = new MapFormat(emptyMap());
         
-        assertEquals("Should be ok: " + result, "/*_____________________*/\n/*Jaroslav*/", result);
+        assertFalse(mf.willThrowExceptionIfKeyWasNotFound());
+        
+        mf.setThrowExceptionIfKeyWasNotFound(true);
+        
+        assertTrue(mf.willThrowExceptionIfKeyWasNotFound());
+
+        try {
+            mf.format("{name}");
+        } catch (final IllegalArgumentException e) {
+            //good
+        }
     }
-    
-    public void testExectLineWithTheProblemFromFormatIssue67238 () {
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_returnsFormatedString_whenFivenProperParameters() {
+
+        assertEquals("My name is John Doe.", format("My name is {first} {last}.", this.johnDoe));
+        assertEquals("Hello Mr Doe.", format("Hello {prefix} {last}.", this.johnDoe));
+        assertEquals("Hello {prefix Doe.", format("Hello {prefix {last}.", this.johnDoe));
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_preservesUnknownTagsAndEmptyBraces() {
+
+        assertEquals("My {strange} name {} is John {{{{{}}}}}{Doe.",
+                format("My {strange} name {} is {first} {{{{{}}}}}{{last}.", this.johnDoe));
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_throwsIllegalArgument_whenGivenTagsWithMissingRightBraces() {
+
+        try {
+            format("Hello {prefix} {last.", this.johnDoe);
+            fail();
+        } catch (IllegalArgumentException e) {
+            //good
+        }
+        try {
+            format("Hello {prefix {last.", this.johnDoe);
+            fail();
+        } catch (IllegalArgumentException e) {
+            //good
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_preservesTagsWithMissingLefttBraces() {
+
+        assertEquals("Hello prefix} Doe.", format("Hello prefix} {last}.", this.johnDoe));
+        assertEquals("Hello Mr last}.", format("Hello {prefix} last}.", this.johnDoe));
+        assertEquals("Hello prefix} last}.", format("Hello prefix} last}.", this.johnDoe));
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_propertlyRecognizes_CustomBraces() {
+
+        MapFormat mf = new MapFormat(this.johnDoe);
+        
+        assertEquals("{", mf.getLeftBrace());
+        assertEquals("}", mf.getRightBrace());
+        
+        mf.setLeftBrace("$1$");
+        mf.setRightBrace("*");
+        
+        assertEquals("$1$", mf.getLeftBrace());
+        assertEquals("*", mf.getRightBrace());
+
+        assertEquals("Hello Mr Doe.", mf.format("Hello $1$prefix* $1$last*."));
+
+        assertEquals("Hello prefix* Doe.", mf.format("Hello prefix* $1$last*."));
+
+        assertEquals("Hello $1$prefix Doe.", mf.format("Hello $1$prefix $1$last*."));
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_throwsIllegalArgument_whenGivenTagsWithMissingCustomRightBraces() {
+
+        MapFormat mf = new MapFormat(this.johnDoe);
+        mf.setLeftBrace("$1$");
+        mf.setRightBrace("*");
+
+        try {
+            mf.format("Hello $1$prefix* $1$last.");
+            fail();
+        } catch (IllegalArgumentException e) {
+            //good
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_ignoresEmptySequanceOfMultipleBraces() {
+
+        MapFormat mf = new MapFormat(this.johnDoe);
+        mf.setLeftBrace("__");
+        mf.setRightBrace("__");
+        mf.setExactMatch(false);
+
         String s = "/*___________________________________________________________________________*/";
-        
-        HashMap args = new HashMap();
-        args.put("NAME", "Jaroslav");
+        assertEquals(s, mf.format(s));
 
-        MapFormat f = new MapFormat(args);
-        f.setLeftBrace("__");
-        f.setRightBrace("__");
-        f.setExactMatch(false);
-        String result = f.format(s);
-        
-        assertEquals("Should be ok: " + result, s, result);
-        
+        assertEquals("/*_____________________*/\n/*John*/",
+                mf.format("/*_____________________*/\n/*__first__*/"));
     }
-    
-    public void testIssue67238() {
-        final String s = "/*___________________________________________________________________________*/";
-        HashMap args = new HashMap();
-        args.put("NAME", "Jaroslav");
-        MapFormat f = new MapFormat(args) {
-            protected Object processKey(String key) {
-                fail("There is no key in \"" + s + "\", processKey() should not be called with key:" + key);
-                return "not defined";
-            }
-        };
-        f.setLeftBrace("__");
-        f.setRightBrace("__");
-        f.setExactMatch(false);
-        f.format(s);
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_acceptsFormatStringWithMissingRightBraces_ifExactMatchIsFalse() {
+
+        MapFormat mf = new MapFormat(this.johnDoe);
+        
+        assertTrue(mf.isExactMatch());
+        
+        mf.setExactMatch(false);
+        
+        assertFalse(mf.isExactMatch());
+        
+        assertEquals("Hello {prefix Doe.", mf.format("Hello {prefix {last}."));
+        assertEquals("Hello Mr {last.", mf.format("Hello {prefix} {last."));
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void format_worksWithDatesAndNumbersAsArgumentsAndOther() {
+
+        String result = format("{date} {number}.", this.dateNumberAndClass);
+        // Since exact format depends on default locale we need to verify this 
+        // the result indirectly.
+        System.out.println(result);
+        assertTrue(result.contains("34"));
+        assertTrue(result.contains("8"));
+        assertTrue(result.contains("6"));
+        assertTrue(result.contains("12"));
+        assertTrue(result.contains("23"));
+        assertTrue(result.contains("999"));
+
+        assertEquals("class java.lang.Void", format("{class}", this.dateNumberAndClass));
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void parseObject_throwsNullPointer_whenGivenNullArgument() {
+
+        MapFormat mf = new MapFormat(this.johnDoe);
+
+        try {
+            mf.parseObject(null, new ParsePosition(0));
+            fail();
+        } catch (final NullPointerException e) {
+            //good
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void parseObject_returnsEmptyString_whenGivenEmptyString() {
+
+        MapFormat mf = new MapFormat(this.johnDoe);
+
+        assertEquals("", mf.parseObject("", new ParsePosition(0)));
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void parseObject_returnsPatternString_whenProperMessageString() {
+
+        MapFormat mf = new MapFormat(this.johnDoe);
+
+        assertEquals("Hello {first}.", mf.parseObject("Hello John.", new ParsePosition(0)));
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void parseObject_returnsItsArgument_whenNoTagsCanBeResolved() {
+
+        MapFormat mf = new MapFormat(this.johnDoe);
+
+        assertEquals("Hello Adam.", mf.parseObject("Hello Adam.", new ParsePosition(0)));
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void getMap_returnsMapPassedThroughConstructor() {
+
+        MapFormat mf = new MapFormat(this.johnDoe);
+
+        assertEquals(this.johnDoe, mf.getMap());
+    }
+
+    //--------------------------------------------------------------------------
+    @Test
+    public void setMap_properlyAssignsNewMapToFormatter() {
+
+        MapFormat mf = new MapFormat(this.johnDoe);
+        mf.setMap(this.dateNumberAndClass);
+
+        assertEquals(this.dateNumberAndClass, mf.getMap());
     }
 }


### PR DESCRIPTION
improved tests for MapFormat
refactored MapFormat.format, works 2x faster and generated about 50x less garbage
removed public method MapFormat.processPattern - it was not used and considering it's functionality must have been made public by mistake






