### PR TITLE
Make VSIX settings Remote SSH aware

### DIFF
--- a/java/java.lsp.server/vscode/CHANGELOG.md
+++ b/java/java.lsp.server/vscode/CHANGELOG.md
@@ -20,6 +20,9 @@
     under the License.
 
 -->
+
+## Version 14.0
+* netbeans.jdkhome setting is Remote SSH aware
 ## Version 13.0.301
 * Added base code completion for Spock test framework
   * Spock Block Names are offered inside methods if the class extends Spock Specification

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -94,7 +94,8 @@
 						"null"
 					],
 					"default": null,
-					"description": "Specifies JDK for the Apache NetBeans Language Server"
+					"description": "Specifies JDK for the Apache NetBeans Language Server",
+					"scope": "machine"
 				},
 				"netbeans.verbose": {
 					"type": "boolean",


### PR DESCRIPTION
Property `netbeans.jdkhome` is going to be stored in settings.json on remote host when used with Remote SSH extension for remote dev. It will prevent _global user settings.json_ from getting wrong path to JDK used to run VSNetBeans.