### PR TITLE
Put .gradle directories on Global ignore list.

### DIFF
--- a/platform/core.ui/src/org/netbeans/core/ui/options/filetypes/IgnoredFilesPreferences.java
+++ b/platform/core.ui/src/org/netbeans/core/ui/options/filetypes/IgnoredFilesPreferences.java
@@ -42,7 +42,7 @@ final class IgnoredFilesPreferences {
     private static final String PROP_IGNORE_HIDDEN_FILES_IN_USER_HOME
             = "IgnoreHiddenFilesInUserHome";                           // NOI18N
     /** Default ignored files pattern. Pattern \.(cvsignore|svn|DS_Store) is covered by ^\..*$ **/
-    static final String DEFAULT_IGNORED_FILES = "^(CVS|SCCS|vssver.?\\.scc|#.*#|%.*%|_svn)$|~$|^\\.(git|hg|svn|cache|DS_Store)$|^Thumbs.db$"; //NOI18N
+    static final String DEFAULT_IGNORED_FILES = "^(CVS|SCCS|vssver.?\\.scc|#.*#|%.*%|_svn)$|~$|^\\.(git|hg|svn|cache|gradle|DS_Store)$|^Thumbs.db$"; //NOI18N
     private static String syntaxError;
 
     private IgnoredFilesPreferences() {

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/GlobalVisibilityQueryImpl.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/GlobalVisibilityQueryImpl.java
@@ -134,7 +134,7 @@ public class GlobalVisibilityQueryImpl implements VisibilityQueryImplementation2
 
     protected String getIgnoredFiles() {
         // \.(cvsignore|svn|DS_Store) is covered by ^\..*$
-        String retval = getPreferences().get(PROP_IGNORED_FILES, "^(CVS|SCCS|vssver.?\\.scc|#.*#|%.*%|_svn)$|~$|^\\.(git|hg|svn|cache|DS_Store)$|^Thumbs.db$");//NOI18N;
+        String retval = getPreferences().get(PROP_IGNORED_FILES, "^(CVS|SCCS|vssver.?\\.scc|#.*#|%.*%|_svn)$|~$|^\\.(git|hg|svn|cache|gradle|DS_Store)$|^Thumbs.db$");//NOI18N;
         PreferenceChangeListener listenerToAdd;
         synchronized (this) {
             if (preferencesListener == null) {


### PR DESCRIPTION
Trivial enhancement on the Global ignore list adding ```.gradle/``` directories.

In general Gradle plugin adds the ```.gradle/``` directories to the project ignore list, though this might be handy as well.