### PR TITLE
change default integration test goal action mapping to failsafe

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/defaultActionMappings.xml
+++ b/java/maven/src/org/netbeans/modules/maven/execute/defaultActionMappings.xml
@@ -98,7 +98,8 @@
             <packaging>*</packaging>
         </packagings>
         <goals>
-            <goal>integration-test</goal>
+            <goal>pre-integration-test</goal>
+            <goal>failsafe:integration-test</goal>
         </goals>
         <properties>
             <test>DummyToSkipUnitTests</test>
@@ -202,7 +203,8 @@
             <packaging>*</packaging>
         </packagings>
         <goals>
-            <goal>integration-test</goal>
+            <goal>pre-integration-test</goal>
+            <goal>failsafe:integration-test</goal>
         </goals>
         <properties>
             <test>DummyToSkipUnitTests</test>


### PR DESCRIPTION
This can be a fix for #4089 with the option to change de default action mapping for integration test.