### PR TITLE
Fix 'node id XXX already exists' error in vscode.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/LspTreeViewServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/LspTreeViewServiceImpl.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
@@ -48,6 +50,8 @@ import org.openide.util.Lookup;
  */
 @JsonSegment("nodes")
 public class LspTreeViewServiceImpl implements TreeViewService, LanguageClientAware {
+    private static final Logger LOG = Logger.getLogger(LspTreeViewServiceImpl.class.getName());
+    
     private final Lookup sessionLookup;
     /**
      * The delegate tree service.
@@ -62,6 +66,7 @@ public class LspTreeViewServiceImpl implements TreeViewService, LanguageClientAw
             @Override
             protected void notifyItemChanged(NodeChangedParams itemId) {
                 if (langClient != null) {
+                    LOG.log(Level.FINER, "Firing item {0} changed", itemId);
                     langClient.notifyNodeChange(itemId);
                 }
             }
@@ -127,6 +132,7 @@ public class LspTreeViewServiceImpl implements TreeViewService, LanguageClientAw
     // export const info = new ProtocolRequestType<NodeOperationParams, Data, never,void, void>('nodes/info');
     public CompletableFuture<TreeItem> info(NodeOperationParams params) {
         int nodeId = params.getNodeId();
+        LOG.log(Level.FINER, "> info({0})", nodeId);
         TreeViewProvider tvp = treeService.providerOf(nodeId);
         return tvp.getTreeItem(nodeId).toCompletableFuture();
     }
@@ -141,6 +147,7 @@ public class LspTreeViewServiceImpl implements TreeViewService, LanguageClientAw
     @Override
     public CompletableFuture<int[]> getChildren(NodeOperationParams params) {
         int id = params.getNodeId();
+        LOG.log(Level.FINER, "> children({0})", id);
         TreeViewProvider tvp = treeService.providerOf(id);
         return tvp.getChildren(id).toCompletableFuture();
     }
@@ -154,6 +161,7 @@ public class LspTreeViewServiceImpl implements TreeViewService, LanguageClientAw
     @Override
     public CompletableFuture<Boolean> delete(NodeOperationParams params) {
         int id = params.getNodeId();
+        LOG.log(Level.FINER, "> delete({0})", id);
         TreeViewProvider tvp = treeService.providerOf(id);
         if (tvp != null) {
             Node n = tvp.findNode(id);
@@ -186,6 +194,7 @@ public class LspTreeViewServiceImpl implements TreeViewService, LanguageClientAw
     @Override
     public CompletableFuture<int[]> findPath(FindPathParams params) {
         Object toSelect = params.getSelectData();
+        LOG.log(Level.FINER, "> findPath(fromId = {0}, select = {1})", new Object[] { params.getRootNodeId(), toSelect });
         TreeViewProvider tvp = treeService.providerOf(params.getRootNodeId());
         if (tvp == null) {
             return null;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
@@ -109,4 +109,11 @@ public class TreeItem {
             this.resourceUri = URLMapper.findURL(fo, URLMapper.EXTERNAL).toString();
         }
     }
+    
+    public String toString() {
+        return String.format(
+            "TreeItem[%s, id = %d, resource = %s, context = %s",
+            name, id, resourceUri, contextValue
+        );
+    }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
@@ -34,14 +34,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.logging.Level;
@@ -137,46 +135,56 @@ public abstract class TreeViewProvider {
     private SortedMap<Integer, NodeHolder> holdChildren = new TreeMap<>();
     
     /**
-     * Node > identity map.
+     * Node > identity map. Note that FilterNodes equals compare the original node, so
+     * IdentityHashMap-style map must be used.
      */
     // @GuardedBy(this)
-    private Map<Node, Integer> idMap = new WeakHashMap<>();
+    private WeakIdentityMap<Node, Integer> idMap = WeakIdentityMap.newHashMap();
     
     protected TreeViewProvider(String treeId, ExplorerManager manager, TreeNodeRegistry registry, Lookup context) {
         this.treeId = treeId;
         this.context = context;
         this.manager = manager;
+        
+        Node n;
         this.nodeRegistry = registry;
         
         this.nodeListener = new NodeListener() {
             @Override
             public void childrenAdded(NodeMemberEvent ev) {
+                LOG.log(Level.FINER, "tree {0} children of node {2} added: {1}", new Object[] { treeId, ev, ev.getNode() });
                 notifyChange(ev.getNode());
             }
 
             @Override
             public void childrenRemoved(NodeMemberEvent ev) {
+                LOG.log(Level.FINER, "tree {0} children of node {2} removed: {1}", new Object[] { treeId, ev, ev.getNode() });
                 notifyChange(ev.getNode());
             }
 
             @Override
             public void childrenReordered(NodeReorderEvent ev) {
+                LOG.log(Level.FINER, "tree {0} children of node {2} reordered: {1}", new Object[] { treeId, ev, ev.getNode() });
                 notifyChange(ev.getNode());
             }
 
             @Override
             public void nodeDestroyed(NodeEvent ev) {
+                LOG.log(Level.FINER, "tree {0} children of node {2} destroyed: {1}", new Object[] { treeId, ev, ev.getNode() });
                 removeNode(ev.getNode());
                 notifyChange(ev.getNode());
             }
 
             @Override
             public void propertyChange(PropertyChangeEvent ev) {
+                LOG.log(Level.FINER, "tree {0} property of node {2} changed: {1}", new Object[] { treeId, ev, ev.getSource()});
                 notifyChange((Node) ev.getSource());
             }
 
             private void notifyChange(Node src) {
-                onDidChangeTreeData(src, findId(src));
+                int id = findId(src);
+                LOG.log(Level.FINER, "tree {0} tree item changed: {1}", new Object[] { treeId, id});
+                onDidChangeTreeData(src, id);
             }
         };
         factories = context.lookupResult(TreeDataProvider.Factory.class);
@@ -368,6 +376,7 @@ public abstract class TreeViewProvider {
      * @return a TreeItem suitable for LSP transmit
      */
     public TreeItem findTreeItem(Node n) {
+        LOG.log(Level.FINER, "Finding tree item for node {0}", n);
         TreeDataProvider[] pa = this.providers;
         String v;
         boolean expanded;
@@ -411,7 +420,7 @@ public abstract class TreeViewProvider {
         if (data.getResourceURI() != null) {
             ti.resourceUri = data.getResourceURI().toString();
         }
-        
+        LOG.log(Level.FINER, "Finding tree item for node {0} => {1} ", new Object[] { n, ti });
         return ti;
     }
     
@@ -444,7 +453,7 @@ public abstract class TreeViewProvider {
             nh.id2Child = newId2Node;
         }
         if (LOG.isLoggable(Level.FINER)) {
-            LOG.log(Level.FINER, "Children of id {0}: {1}", new Object[] { parentId, Arrays.asList(ids) });
+            LOG.log(Level.FINER, "Children of id {0}: {1}", new Object[] { parentId, Arrays.toString(ids) });
         }
         if (obsolete != null) {
             synchronized (this) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/WeakIdentityMap.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/WeakIdentityMap.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.explorer;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implements a combination of {@link java.util.WeakHashMap} and {@link java.util.IdentityHashMap}.
+ * Useful for caches that need to key off of a {@code ==} comparison instead of a {@code .equals}.
+ *
+ * The code was originally part of Apache Lucene
+ */
+public final class WeakIdentityMap<K, V> {
+  private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+  private final Map<IdentityWeakReference, V> backingStore;
+  private final boolean reapOnRead;
+
+  /**
+   * Creates a new {@code WeakIdentityMap} based on a non-synchronized {@link HashMap}. The map <a
+   * href="#reapInfo">cleans up the reference queue on every read operation</a>.
+   */
+  public static <K, V> WeakIdentityMap<K, V> newHashMap() {
+    return newHashMap(true);
+  }
+
+  /**
+   * Creates a new {@code WeakIdentityMap} based on a non-synchronized {@link HashMap}.
+   *
+   * @param reapOnRead controls if the map <a href="#reapInfo">cleans up the reference queue on
+   *     every read operation</a>.
+   */
+  public static <K, V> WeakIdentityMap<K, V> newHashMap(boolean reapOnRead) {
+    return new WeakIdentityMap<>(new HashMap<IdentityWeakReference, V>(), reapOnRead);
+  }
+
+  /**
+   * Creates a new {@code WeakIdentityMap} based on a {@link ConcurrentHashMap}. The map <a
+   * href="#reapInfo">cleans up the reference queue on every read operation</a>.
+   */
+  public static <K, V> WeakIdentityMap<K, V> newConcurrentHashMap() {
+    return newConcurrentHashMap(true);
+  }
+
+  /**
+   * Creates a new {@code WeakIdentityMap} based on a {@link ConcurrentHashMap}.
+   *
+   * @param reapOnRead controls if the map <a href="#reapInfo">cleans up the reference queue on
+   *     every read operation</a>.
+   */
+  public static <K, V> WeakIdentityMap<K, V> newConcurrentHashMap(boolean reapOnRead) {
+    return new WeakIdentityMap<>(new ConcurrentHashMap<IdentityWeakReference, V>(), reapOnRead);
+  }
+
+  /** Private only constructor, to create use the static factory methods. */
+  private WeakIdentityMap(Map<IdentityWeakReference, V> backingStore, boolean reapOnRead) {
+    this.backingStore = backingStore;
+    this.reapOnRead = reapOnRead;
+  }
+
+  /** Removes all of the mappings from this map. */
+  public void clear() {
+    backingStore.clear();
+    reap();
+  }
+
+  /** Returns {@code true} if this map contains a mapping for the specified key. */
+  public boolean containsKey(Object key) {
+    if (reapOnRead) reap();
+    return backingStore.containsKey(new IdentityWeakReference(key, null));
+  }
+
+  /** Returns the value to which the specified key is mapped. */
+  public V get(Object key) {
+    if (reapOnRead) reap();
+    return backingStore.get(new IdentityWeakReference(key, null));
+  }
+
+  /**
+   * Associates the specified value with the specified key in this map. If the map previously
+   * contained a mapping for this key, the old value is replaced.
+   */
+  public V put(K key, V value) {
+    reap();
+    return backingStore.put(new IdentityWeakReference(key, queue), value);
+  }
+
+  /** Returns {@code true} if this map contains no key-value mappings. */
+  public boolean isEmpty() {
+    return size() == 0;
+  }
+
+  /**
+   * Removes the mapping for a key from this weak hash map if it is present. Returns the value to
+   * which this map previously associated the key, or {@code null} if the map contained no mapping
+   * for the key. A return value of {@code null} does not necessarily indicate that the map
+   * contained.
+   */
+  public V remove(Object key) {
+    reap();
+    return backingStore.remove(new IdentityWeakReference(key, null));
+  }
+
+  /**
+   * Returns the number of key-value mappings in this map. This result is a snapshot, and may not
+   * reflect unprocessed entries that will be removed before next attempted access because they are
+   * no longer referenced.
+   */
+  public int size() {
+    if (backingStore.isEmpty()) return 0;
+    if (reapOnRead) reap();
+    return backingStore.size();
+  }
+
+  /**
+   * Returns an iterator over all weak keys of this map. Keys already garbage collected will not be
+   * returned. This Iterator does not support removals.
+   */
+  public Iterator<K> keyIterator() {
+    reap();
+    final Iterator<IdentityWeakReference> iterator = backingStore.keySet().iterator();
+    // IMPORTANT: Don't use oal.util.FilterIterator here:
+    // We need *strong* reference to current key after setNext()!!!
+    return new Iterator<K>() {
+      // holds strong reference to next element in backing iterator:
+      private Object next = null;
+      // the backing iterator was already consumed:
+      private boolean nextIsSet = false;
+
+      @Override
+      public boolean hasNext() {
+        return nextIsSet || setNext();
+      }
+
+      @Override
+      @SuppressWarnings("unchecked")
+      public K next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        assert nextIsSet;
+        try {
+          return (K) next;
+        } finally {
+          // release strong reference and invalidate current value:
+          nextIsSet = false;
+          next = null;
+        }
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException();
+      }
+
+      private boolean setNext() {
+        assert !nextIsSet;
+        while (iterator.hasNext()) {
+          next = iterator.next().get();
+          if (next == null) {
+            // the key was already GCed, we can remove it from backing map:
+            iterator.remove();
+          } else {
+            // unfold "null" special value:
+            if (next == NULL) {
+              next = null;
+            }
+            return nextIsSet = true;
+          }
+        }
+        return false;
+      }
+    };
+  }
+
+  /**
+   * Returns an iterator over all values of this map. This iterator may return values whose key is
+   * already garbage collected while iterator is consumed, especially if {@code reapOnRead} is
+   * {@code false}.
+   */
+  public Iterator<V> valueIterator() {
+    if (reapOnRead) reap();
+    return backingStore.values().iterator();
+  }
+
+  /**
+   * This method manually cleans up the reference queue to remove all garbage collected key/value
+   * pairs from the map. Calling this method is not needed if {@code reapOnRead = true}. Otherwise
+   * it might be a good idea to call this method when there is spare time (e.g. from a background
+   * thread).
+   *
+   * @see <a href="#reapInfo">Information about the <code>reapOnRead</code> setting</a>
+   */
+  public void reap() {
+    Reference<?> zombie;
+    while ((zombie = queue.poll()) != null) {
+      backingStore.remove(zombie);
+    }
+  }
+
+  // we keep a hard reference to our NULL key, so map supports null keys that never get GCed:
+  static final Object NULL = new Object();
+
+  private static final class IdentityWeakReference extends WeakReference<Object> {
+    private final int hash;
+
+    IdentityWeakReference(Object obj, ReferenceQueue<Object> queue) {
+      super(obj == null ? NULL : obj, queue);
+      hash = System.identityHashCode(obj);
+    }
+
+    @Override
+    public int hashCode() {
+      return hash;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o instanceof IdentityWeakReference) {
+        final IdentityWeakReference ref = (IdentityWeakReference) o;
+        if (this.get() == ref.get()) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+}

--- a/platform/openide.nodes/src/org/openide/nodes/Children.java
+++ b/platform/openide.nodes/src/org/openide/nodes/Children.java
@@ -1679,7 +1679,8 @@ public abstract class Children extends Object {
     * added to the collection and if the same object is added
     * more than once it is indexed by a number.
     */
-    private abstract static class Dupl<T> implements Cloneable, Entry {
+    // package-private for tests only!
+    abstract static class Dupl<T> implements Cloneable, Entry {
         /** the key either real value or Dupl (Dupl (Dupl (... value ...)))*/
         protected Object key;
 


### PR DESCRIPTION
The bug manifests in several places. Most notably in vscode DB Explorer where a `Refresh` action causes vscode-nbls communication to fail with `Node xxx is already present`. This is caused by creation of a new node - a new identity, which is equal() to the previously created node, which is still in the map (since the client may still ask for its details).

And that node is created (since keys - underlying DB data) did not actually even change is done because of some of DB children use `ChildFactory` SPI from Nodes - this is the other fix. It turned out that `add` method of the `j.u.List` passed to `ChildFactory.createKeys()` is tweaked so it detects actual addition beyond the original content - and causes interim keys refresh, which, in turn, causes Node removal for whose keys are not (yet) present, since the `ChildFactory` did not add them.
Note that this fix is not a complete fix - if a (really) new node is inserted among existing, the nodes will be destroyed + recreated. I think it is probably impossible to fix without breaking Children and its event semantics. But the fix corrects situation when the content actually does not change or is only added to.

This second fix also fixes an issue in Gradle project view in NetBeans IDE; appears on root projects only.
- open a Gradle project, expand its `Build scrips` node. Suppose there are global `gradle.properties`, project's `gradle.properties`, `build.gradle` and `settings.gradle` (or make it so)
- open `build.gradle` in the editor
- modify the buildscript, save
- :open_mouth: the `build.gradle` node disappears !

@jhorvath please decide whether the fix should go to `master` or it is critical for DB explorer (where it mainly appears, but I've encountered it elsewhere as well) so `vscode` extension could benefit from inclusion in NB14.

adding @lkishalmi since it affects Gradle projects.