### PR TITLE
Repair failing TrufleSuiteTest.testParseTruffleSourcesWithoutError().

### DIFF
--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/DumpStack.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/DumpStack.java
@@ -43,8 +43,8 @@ final class DumpStack extends TimerTask {
     }
     
     public static void start() {
-        final int threeMinutes = 1000 * 60 * 3;
+        final int tenMinutes = 1000 * 60 * 10;
         final int tenSeconds = 10000;
-        TIMER.schedule(new DumpStack(), threeMinutes, tenSeconds);
+        TIMER.schedule(new DumpStack(), tenMinutes, tenSeconds);
     }
 }

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SuiteActionProviderTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SuiteActionProviderTest.java
@@ -44,7 +44,7 @@ public class SuiteActionProviderTest extends SuiteCheck {
     }
     
     public void testActionsEnabledWithProgress() throws Exception {
-        File sdkSibling = findSuite("sdk");
+        File sdkSibling = findSuite("regex");
 
         FileObject fo = FileUtil.toFileObject(sdkSibling);
         assertNotNull("project directory found", fo);
@@ -86,11 +86,12 @@ public class SuiteActionProviderTest extends SuiteCheck {
         MockProgress progress = new MockProgress();
 
         Lookup ctx = Lookups.fixed(fo, p, progress);
-        assertTrue("Clean is supported", ap.isActionEnabled(ActionProvider.COMMAND_CLEAN, ctx));
-        ap.invokeAction(ActionProvider.COMMAND_CLEAN, ctx);
+        assertTrue("Build is supported", ap.isActionEnabled(ActionProvider.COMMAND_BUILD, ctx));
+        // Do not run clean action here as it breaks next tests.
+        ap.invokeAction(ActionProvider.COMMAND_BUILD, ctx);
 
         assertTrue("Progress started", progress.started);
-        progress.finished.await(10, TimeUnit.SECONDS);
+        progress.finished.await(45, TimeUnit.SECONDS);
         assertNotNull("Progress finished", progress.success);
     }
 

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/TrufleSuiteTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/TrufleSuiteTest.java
@@ -18,8 +18,6 @@
  */
 package org.netbeans.modules.java.mx.project;
 
-import org.netbeans.junit.RandomlyFails;
-
 public class TrufleSuiteTest extends SuiteCheck {
     public TrufleSuiteTest(String n) {
         super(n);
@@ -29,7 +27,6 @@ public class TrufleSuiteTest extends SuiteCheck {
         return SuiteCheck.suite(TrufleSuiteTest.class);
     }
 
-    @RandomlyFails
     public void testParseTruffleSourcesWithoutError() throws Exception {
         verifyNoErrorsInSuite("truffle");
     }


### PR DESCRIPTION
Test [org.netbeans.modules.java.mx.project.TrufleSuiteTest.testParseTruffleSourcesWithoutError](https://ci-builds.apache.org/job/Netbeans/job/netbeans-vscode/1067/testReport/org.netbeans.modules.java.mx.project/TrufleSuiteTest/testParseTruffleSourcesWithoutError/) is failing regularly. The cause was a clean action run by `SuiteActionProviderTest`, which deleted build artifacts that were necessary to assemble the class path.