### PR TITLE
upgrade nb-javac to 18.0.1.

### DIFF
--- a/java/libs.javacapi/external/binaries-list
+++ b/java/libs.javacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-2449F4A630A5493F55CC013CF452632AE93007CA com.dukescript.nbjavac:nb-javac:jdk-18+36:api
-DC722E7A5691677C02F315A7E669BE20C47E70B1 com.dukescript.nbjavac:nb-javac:jdk-18+36
+ECA15E615777CE6E7550F71EF312B8CEEBCBE0BD com.dukescript.nbjavac:nb-javac:jdk-18.0.1+10:api
+3AD512FBC8830D89AC70D0CA59397C4868789DCC com.dukescript.nbjavac:nb-javac:jdk-18.0.1+10

--- a/java/libs.javacapi/external/nb-javac-jdk-18.0.1+10-license.txt
+++ b/java/libs.javacapi/external/nb-javac-jdk-18.0.1+10-license.txt
@@ -1,7 +1,7 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: jdk-18+36
-Files: nb-javac-jdk-18+36-api.jar nb-javac-jdk-18+36.jar
+Version: 18.0.1+10
+Files: nb-javac-jdk-18.0.1+10-api.jar nb-javac-jdk-18.0.1+10.jar
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk18)
 Source: https://github.com/openjdk/jdk18

--- a/java/libs.javacapi/nbproject/project.xml
+++ b/java/libs.javacapi/nbproject/project.xml
@@ -40,11 +40,11 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-18+36-api.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-18.0.1+10-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-18+36.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-18.0.1+10.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.nbjavacapi/external/binaries-list
+++ b/java/libs.nbjavacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-2449F4A630A5493F55CC013CF452632AE93007CA com.dukescript.nbjavac:nb-javac:jdk-18+36:api
-DC722E7A5691677C02F315A7E669BE20C47E70B1 com.dukescript.nbjavac:nb-javac:jdk-18+36
+ECA15E615777CE6E7550F71EF312B8CEEBCBE0BD com.dukescript.nbjavac:nb-javac:jdk-18.0.1+10:api
+3AD512FBC8830D89AC70D0CA59397C4868789DCC com.dukescript.nbjavac:nb-javac:jdk-18.0.1+10

--- a/java/libs.nbjavacapi/external/nb-javac-jdk-18.0.1+10-license.txt
+++ b/java/libs.nbjavacapi/external/nb-javac-jdk-18.0.1+10-license.txt
@@ -1,7 +1,7 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Files: nb-javac-jdk-18+36-api.jar nb-javac-jdk-18+36.jar
-Version: jdk-18+36
+Files: nb-javac-jdk-18.0.1+10-api.jar nb-javac-jdk-18.0.1+10.jar
+Version: jdk-18.0.1+10
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk18)
 Source: https://github.com/openjdk/jdk18

--- a/java/libs.nbjavacapi/nbproject/project.properties
+++ b/java/libs.nbjavacapi/nbproject/project.properties
@@ -18,5 +18,5 @@
 javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial
 license.file.override=${nb_all}/nbbuild/licenses/GPL-2-CP
-release.external/nb-javac-jdk-18+36-api.jar=modules/ext/nb-javac-jdk-18-api.jar
-release.external/nb-javac-jdk-18+36.jar=modules/ext/nb-javac-jdk-18.jar
+release.external/nb-javac-jdk-18.0.1+10-api.jar=modules/ext/nb-javac-jdk-18-api.jar
+release.external/nb-javac-jdk-18.0.1+10.jar=modules/ext/nb-javac-jdk-18.jar

--- a/java/libs.nbjavacapi/nbproject/project.xml
+++ b/java/libs.nbjavacapi/nbproject/project.xml
@@ -37,11 +37,11 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>ext/nb-javac-jdk-18-api.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-18+36-api.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-18.0.1+10-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/nb-javac-jdk-18.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-18+36.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-18.0.1+10.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -39,10 +39,6 @@ nbbuild/external/langtools-9.zip nbbuild/external/langtools-9.zip
 # Used to parse data during build, but need to as a lib for ide cluster
 nbbuild/external/json-simple-1.1.1.jar ide/libs.json_simple/external/json-simple-1.1.1.jar
 
-# Compile only nb-javac
-java/libs.nbjavacapi/external/nb-javac-jdk-18+36-api.jar nbbuild/external/nb-javac-jdk-17+36-api.jar
-java/libs.nbjavacapi/external/nb-javac-jdk-18+36.jar nbbuild/external/nb-javac-jdk-17+36.jar
-
 # JFlex is used by multiple modules.
 webcommon/javascript2.jade/external/jflex-1.4.3.jar webcommon/javascript2.lexer/external/jflex-1.4.3.jar
 
@@ -121,8 +117,8 @@ webcommon/javascript2.jsdoc/external/testfiles-jsdoc-1.zip webcommon/javascript2
 harness/apisupport.harness/external/launcher-12.5-distribution.zip platform/o.n.bootstrap/external/launcher-12.5-distribution.zip
 
 # only one is part of the product:
-java/libs.javacapi/external/nb-javac-jdk-18+36-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-18+36-api.jar
-java/libs.javacapi/external/nb-javac-jdk-18+36.jar java/libs.nbjavacapi/external/nb-javac-jdk-18+36.jar
+java/libs.javacapi/external/nb-javac-jdk-18.0.1+10-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-18.0.1+10-api.jar
+java/libs.javacapi/external/nb-javac-jdk-18.0.1+10.jar java/libs.nbjavacapi/external/nb-javac-jdk-18.0.1+10.jar
 
 # Maven and Gradle are self-contained distributions - ignoring overlaps
 platform/o.apache.commons.lang3/external/commons-lang3-3.8.1.jar java/maven.embedder/external/apache-maven-3.8.5-bin.zip


### PR DESCRIPTION
nb-javac got updated https://github.com/JaroslavTulach/nb-javac/pull/7

this PR bumps the nb-javac version from GA to the update release. I did **NOT** bump any module versions since master is already at 18.1 (https://github.com/apache/netbeans/pull/4045/files). Someone would have to tell me what to increment :)

18.0.1 fixes three javac related bugs:
https://bugs.openjdk.java.net/browse/JDK-8278373
https://bugs.openjdk.java.net/browse/JDK-8278834
https://bugs.openjdk.java.net/browse/JDK-8278930

delta is likely fairly small since not much happened language wise in Java 18.

we are super late in the RC cycle though, the fact that travis isn't running doesn't help the situation.

this is based on delivery