### PR TITLE
Add markup tag completion hints for inline snippets

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionTask.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionTask.java
@@ -1244,6 +1244,8 @@ public class JavadocCompletionTask<T> extends UserTask {
                 add("highlight");
                 add("replace");
                 add("link");
+                add("start");
+                add("end");
             }};
             for(String str: inlineAttr) {
                 items.add(factory.createNameItem(str, this.caretOffset));
@@ -1259,10 +1261,23 @@ public class JavadocCompletionTask<T> extends UserTask {
     private void completeInlineMarkupTag(String str, List<String> attr) {
         String value = " = \"<value>\"";
         switch(str) {
-            case "@highlight": attr.add("type"); break;
-            case "@replace":attr.add("replacement");break;
-            case "@link":attr.add("target"); attr.add("type"); break;
-            default: break;
+            case "@highlight":
+                attr.add("type");
+                break;
+            case "@replace":
+                attr.add("replacement");
+                break;
+            case "@link":
+                attr.add("target");
+                attr.add("type");
+                break;
+            case "@start":
+            case "@end":
+                attr.clear();
+                attr.add("region");
+                break;
+            default:
+                break;
         }
         if(attr.size()>3) {
             for(String entry:attr) {

--- a/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionTask.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionTask.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -1258,9 +1259,9 @@ public class JavadocCompletionTask<T> extends UserTask {
                 }
             } else {
                 String[] tags = {"@highlight", "@replace", "@link", "@start", "@end"};
-                String str = (subStr.substring(subStr.lastIndexOf("@"))).strip();
-                if (Arrays.asList(tags).contains(str)) {
-                    completeInlineMarkupTag(str, new ArrayList() {
+                Matcher match = Pattern.compile("@\\b\\w{1,}\\b\\s+(?!.*@\\b\\w{1,}\\b\\s+)").matcher(subStr);
+                if (match.find() && Arrays.asList(tags).contains(match.group(0).trim())) {
+                    completeInlineMarkupTag(match.group(0).trim(), new ArrayList() {
                         {
                             add("substring");
                             add("regex");

--- a/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/javadoc/JavaDocCompletionTaskTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/javadoc/JavaDocCompletionTaskTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.editor.javadoc;
+
+import java.util.List;
+import java.util.ArrayList;
+import org.netbeans.modules.java.editor.base.javadoc.JavadocTestSupport;
+
+/**
+ *
+ * @author mjayan
+ */
+public class JavaDocCompletionTaskTest extends JavadocTestSupport{
+    public JavaDocCompletionTaskTest(String name) {
+        super(name);
+    }
+
+    public void testMarkupTagHint() throws Exception {
+        String code =
+                "public static void main(String... args) {\n" +
+                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
+                " *           if (!arg.isBlank()) {\n" +
+                " *               System.out.println(arg); //@";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        task.insideInlineSnippet(code);
+        List<JavadocCompletionItem> list = task.getResults();
+        assertNotNull(list);
+        List<String> listStr = new ArrayList<>();
+        for(JavadocCompletionItem item : list) {
+            listStr.add(item.getSortText().toString());
+        }
+        List<String> inlineAttr =new ArrayList() {{
+            add("highlight");
+            add("replace");
+            add("link");
+            add("start");
+            add("end");
+        }};
+        assertEquals(listStr,inlineAttr);
+    }
+
+    public void testMarkupTagHintNoMatch() throws Exception {
+        String code =
+                "public static void main(String... args) {\n" +
+                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
+                " *           if (!arg.isBlank()) {\n" +
+                " *               System.out.println(arg); //@qwerty";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        task.insideInlineSnippet(code);
+        List<JavadocCompletionItem> list = task.getResults();
+        assertNotNull(list);
+        List<String> listStr = new ArrayList<>();
+        assertEquals(list,listStr);
+    }
+
+    public void testHighlightTagHint() throws Exception {
+        String code =
+                "public static void main(String... args) {\n" +
+                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
+                " *           if (!arg.isBlank()) {\n" +
+                " *               System.out.println(arg); //@highlight";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        task.insideInlineSnippet(code);
+        List<JavadocCompletionItem> list = task.getResults();
+        assertNotNull(list);
+        List<String> listStr = new ArrayList<>();
+        for(JavadocCompletionItem item : list) {
+            listStr.add(item.getSortText().toString());
+        }
+        String value = " = \"<value>\"";
+        List<String> inlineAttr =new ArrayList() {{
+            add("substring" + value);
+            add("regex"+value);
+            add("region"+value);
+            add("type"+value);
+        }};
+        assertEquals(listStr,inlineAttr);
+    }
+
+    public void testReplaceTagHint() throws Exception {
+        String code =
+                "public static void main(String... args) {\n" +
+                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
+                " *           if (!arg.isBlank()) {\n" +
+                " *               System.out.println(arg); //@replace";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        task.insideInlineSnippet(code);
+        List<JavadocCompletionItem> list = task.getResults();
+        assertNotNull(list);
+        List<String> listStr = new ArrayList<>();
+        for(JavadocCompletionItem item : list) {
+            listStr.add(item.getSortText().toString());
+        }
+        String value = " = \"<value>\"";
+        List<String> inlineAttr =new ArrayList() {{
+            add("substring" + value);
+            add("regex"+value);
+            add("region"+value);
+            add("replacement"+value);
+        }};
+        assertEquals(listStr,inlineAttr);
+    }
+
+    public void testLinkTagHint() throws Exception {
+        String code =
+                "public static void main(String... args) {\n" +
+                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
+                " *           if (!arg.isBlank()) {\n" +
+                " *               System.out.println(arg); //@link";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        task.insideInlineSnippet(code);
+        List<JavadocCompletionItem> list = task.getResults();
+        assertNotNull(list);
+        List<String> listStr = new ArrayList<>();
+        for(JavadocCompletionItem item : list) {
+            listStr.add(item.getSortText().toString());
+        }
+        String value = " = \"<value>\"";
+        List<String> inlineAttr =new ArrayList() {{
+            add("substring" + value);
+            add("regex"+value);
+            add("region"+value);
+            add("target"+value);
+            add("type"+value);
+        }};
+        assertEquals(listStr,inlineAttr);
+    }
+
+    public void testStartTagHint() throws Exception {
+        String code =
+                "public static void main(String... args) {\n" +
+                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
+                " *           if (!arg.isBlank()) {\n" +
+                " *               System.out.println(arg); //@start";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        task.insideInlineSnippet(code);
+        List<JavadocCompletionItem> list = task.getResults();
+        assertNotNull(list);
+        List<String> listStr = new ArrayList<>();
+        for(JavadocCompletionItem item : list) {
+            listStr.add(item.getSortText().toString());
+        }
+        String value = " = \"<value>\"";
+        List<String> inlineAttr =new ArrayList() {{
+            add("region"+value);
+        }};
+        assertEquals(listStr,inlineAttr);
+    }
+
+    public void testEndTagHint() throws Exception {
+        String code =
+                "public static void main(String... args) {\n" +
+                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
+                " *           if (!arg.isBlank()) {\n" +
+                " *               System.out.println(arg); //@end";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        task.insideInlineSnippet(code);
+        List<JavadocCompletionItem> list = task.getResults();
+        assertNotNull(list);
+        List<String> listStr = new ArrayList<>();
+        for(JavadocCompletionItem item : list) {
+            listStr.add(item.getSortText().toString());
+        }
+        String value = " = \"<value>\"";
+        List<String> inlineAttr =new ArrayList() {{
+            add("region"+value);
+        }};
+        assertEquals(listStr,inlineAttr);
+    }
+}

--- a/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/javadoc/JavaDocCompletionTaskTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/javadoc/JavaDocCompletionTaskTest.java
@@ -26,161 +26,190 @@ import org.netbeans.modules.java.editor.base.javadoc.JavadocTestSupport;
  *
  * @author mjayan
  */
-public class JavaDocCompletionTaskTest extends JavadocTestSupport{
+public class JavaDocCompletionTaskTest extends JavadocTestSupport {
+
     public JavaDocCompletionTaskTest(String name) {
         super(name);
     }
 
     public void testMarkupTagHint() throws Exception {
-        String code =
-                "public static void main(String... args) {\n" +
-                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
-                " *           if (!arg.isBlank()) {\n" +
-                " *               System.out.println(arg); //@";
-        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        String code = "System.out.println(arg); //@";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0, new JavadocCompletionItem.Factory(), false, null);
         task.insideInlineSnippet(code);
         List<JavadocCompletionItem> list = task.getResults();
         assertNotNull(list);
         List<String> listStr = new ArrayList<>();
-        for(JavadocCompletionItem item : list) {
+        for (JavadocCompletionItem item : list) {
             listStr.add(item.getSortText().toString());
         }
-        List<String> inlineAttr =new ArrayList() {{
-            add("highlight");
-            add("replace");
-            add("link");
-            add("start");
-            add("end");
-        }};
-        assertEquals(listStr,inlineAttr);
+        List<String> inlineAttr = new ArrayList() {
+            {
+                add("highlight");
+                add("replace");
+                add("link");
+                add("start");
+                add("end");
+            }
+        };
+        assertEquals(listStr, inlineAttr);
     }
 
     public void testMarkupTagHintNoMatch() throws Exception {
-        String code =
-                "public static void main(String... args) {\n" +
-                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
-                " *           if (!arg.isBlank()) {\n" +
-                " *               System.out.println(arg); //@qwerty";
-        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        String code = "System.out.println(arg); //@qwerty ";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0, new JavadocCompletionItem.Factory(), false, null);
         task.insideInlineSnippet(code);
         List<JavadocCompletionItem> list = task.getResults();
         assertNotNull(list);
         List<String> listStr = new ArrayList<>();
-        assertEquals(list,listStr);
+        assertEquals(list, listStr);
     }
 
     public void testHighlightTagHint() throws Exception {
-        String code =
-                "public static void main(String... args) {\n" +
-                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
-                " *           if (!arg.isBlank()) {\n" +
-                " *               System.out.println(arg); //@highlight";
-        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        String code = "System.out.println(arg); //@highlight ";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0, new JavadocCompletionItem.Factory(), false, null);
         task.insideInlineSnippet(code);
         List<JavadocCompletionItem> list = task.getResults();
         assertNotNull(list);
         List<String> listStr = new ArrayList<>();
-        for(JavadocCompletionItem item : list) {
+        for (JavadocCompletionItem item : list) {
             listStr.add(item.getSortText().toString());
         }
         String value = " = \"<value>\"";
-        List<String> inlineAttr =new ArrayList() {{
-            add("substring" + value);
-            add("regex"+value);
-            add("region"+value);
-            add("type"+value);
-        }};
-        assertEquals(listStr,inlineAttr);
+        List<String> inlineAttr = new ArrayList() {
+            {
+                add("substring" + value);
+                add("regex" + value);
+                add("region" + value);
+                add("type" + value);
+            }
+        };
+        assertEquals(listStr, inlineAttr);
     }
 
     public void testReplaceTagHint() throws Exception {
-        String code =
-                "public static void main(String... args) {\n" +
-                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
-                " *           if (!arg.isBlank()) {\n" +
-                " *               System.out.println(arg); //@replace";
-        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        String code = "System.out.println(arg); //@replace ";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0, new JavadocCompletionItem.Factory(), false, null);
         task.insideInlineSnippet(code);
         List<JavadocCompletionItem> list = task.getResults();
         assertNotNull(list);
         List<String> listStr = new ArrayList<>();
-        for(JavadocCompletionItem item : list) {
+        for (JavadocCompletionItem item : list) {
             listStr.add(item.getSortText().toString());
         }
         String value = " = \"<value>\"";
-        List<String> inlineAttr =new ArrayList() {{
-            add("substring" + value);
-            add("regex"+value);
-            add("region"+value);
-            add("replacement"+value);
-        }};
-        assertEquals(listStr,inlineAttr);
+        List<String> inlineAttr = new ArrayList() {
+            {
+                add("substring" + value);
+                add("regex" + value);
+                add("region" + value);
+                add("replacement" + value);
+            }
+        };
+        assertEquals(listStr, inlineAttr);
     }
 
     public void testLinkTagHint() throws Exception {
-        String code =
-                "public static void main(String... args) {\n" +
-                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
-                " *           if (!arg.isBlank()) {\n" +
-                " *               System.out.println(arg); //@link";
-        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        String code = "System.out.println(arg); //@link ";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0, new JavadocCompletionItem.Factory(), false, null);
         task.insideInlineSnippet(code);
         List<JavadocCompletionItem> list = task.getResults();
         assertNotNull(list);
         List<String> listStr = new ArrayList<>();
-        for(JavadocCompletionItem item : list) {
+        for (JavadocCompletionItem item : list) {
             listStr.add(item.getSortText().toString());
         }
         String value = " = \"<value>\"";
-        List<String> inlineAttr =new ArrayList() {{
-            add("substring" + value);
-            add("regex"+value);
-            add("region"+value);
-            add("target"+value);
-            add("type"+value);
-        }};
-        assertEquals(listStr,inlineAttr);
+        List<String> inlineAttr = new ArrayList() {
+            {
+                add("substring" + value);
+                add("regex" + value);
+                add("region" + value);
+                add("target" + value);
+                add("type" + value);
+            }
+        };
+        assertEquals(listStr, inlineAttr);
     }
 
     public void testStartTagHint() throws Exception {
-        String code =
-                "public static void main(String... args) {\n" +
-                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
-                " *           if (!arg.isBlank()) {\n" +
-                " *               System.out.println(arg); //@start";
-        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        String code = "System.out.println(arg); //@start ";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0, new JavadocCompletionItem.Factory(), false, null);
         task.insideInlineSnippet(code);
         List<JavadocCompletionItem> list = task.getResults();
         assertNotNull(list);
         List<String> listStr = new ArrayList<>();
-        for(JavadocCompletionItem item : list) {
+        for (JavadocCompletionItem item : list) {
             listStr.add(item.getSortText().toString());
         }
         String value = " = \"<value>\"";
-        List<String> inlineAttr =new ArrayList() {{
-            add("region"+value);
-        }};
-        assertEquals(listStr,inlineAttr);
+        List<String> inlineAttr = new ArrayList() {
+            {
+                add("region" + value);
+            }
+        };
+        assertEquals(listStr, inlineAttr);
     }
 
     public void testEndTagHint() throws Exception {
-        String code =
-                "public static void main(String... args) {\n" +
-                " *       for (var arg : args) {      // @highlight region regex = \"\\barg\\b\"\n" +
-                " *           if (!arg.isBlank()) {\n" +
-                " *               System.out.println(arg); //@end";
-        JavadocCompletionTask task = JavadocCompletionTask.create(0,new JavadocCompletionItem.Factory(),false,null);
+        String code = "System.out.println(arg); //@end ";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0, new JavadocCompletionItem.Factory(), false, null);
         task.insideInlineSnippet(code);
         List<JavadocCompletionItem> list = task.getResults();
         assertNotNull(list);
         List<String> listStr = new ArrayList<>();
-        for(JavadocCompletionItem item : list) {
+        for (JavadocCompletionItem item : list) {
             listStr.add(item.getSortText().toString());
         }
         String value = " = \"<value>\"";
-        List<String> inlineAttr =new ArrayList() {{
-            add("region"+value);
-        }};
-        assertEquals(listStr,inlineAttr);
+        List<String> inlineAttr = new ArrayList() {
+            {
+                add("region" + value);
+            }
+        };
+        assertEquals(listStr, inlineAttr);
+    }
+
+    public void testMultipleTags() throws Exception {
+        String code = "System.out.println(arg); //@highlight region @";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0, new JavadocCompletionItem.Factory(), false, null);
+        task.insideInlineSnippet(code);
+        List<JavadocCompletionItem> list = task.getResults();
+        assertNotNull(list);
+        List<String> listStr = new ArrayList<>();
+        for (JavadocCompletionItem item : list) {
+            listStr.add(item.getSortText().toString());
+        }
+        List<String> inlineAttr = new ArrayList() {
+            {
+                add("highlight");
+                add("replace");
+                add("link");
+                add("start");
+                add("end");
+            }
+        };
+        assertEquals(listStr, inlineAttr);
+    }
+
+    public void testMultipleAttr() throws Exception {
+        String code = "System.out.println(arg); //@highlight region=\"<value>\" ";
+        JavadocCompletionTask task = JavadocCompletionTask.create(0, new JavadocCompletionItem.Factory(), false, null);
+        task.insideInlineSnippet(code);
+        List<JavadocCompletionItem> list = task.getResults();
+        assertNotNull(list);
+        List<String> listStr = new ArrayList<>();
+        for (JavadocCompletionItem item : list) {
+            listStr.add(item.getSortText().toString());
+        }
+        String value = " = \"<value>\"";
+        List<String> inlineAttr = new ArrayList() {
+            {
+                add("substring" + value);
+                add("regex" + value);
+                add("region" + value);
+                add("type" + value);
+            }
+        };
+        assertEquals(listStr, inlineAttr);
     }
 }


### PR DESCRIPTION
Provide hints for markup tags in inline snippets. Below is the screenshot for the feature
![markupHint](https://user-images.githubusercontent.com/100354762/168003733-efa7161c-b1e2-47ab-97be-510679d213c3.gif)

![multipleMarkupTag](https://user-images.githubusercontent.com/100354762/174064459-7a6151e3-9d0f-43c4-afaa-2bace8b70338.gif)

