### PR TITLE
Update graaljs parser to handle optional chaining (?.) for indexing and function calls

### DIFF
--- a/webcommon/javascript2.doc/manifest.mf
+++ b/webcommon/javascript2.doc/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.javascript2.doc/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/javascript2/doc/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.16
+OpenIDE-Module-Specification-Version: 1.17
 

--- a/webcommon/javascript2.doc/nbproject/project.xml
+++ b/webcommon/javascript2.doc/nbproject/project.xml
@@ -40,7 +40,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.0</specification-version>
+                        <specification-version>2.2</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript2.editor/manifest.mf
+++ b/webcommon/javascript2.editor/manifest.mf
@@ -3,5 +3,5 @@ OpenIDE-Module: org.netbeans.modules.javascript2.editor/1
 OpenIDE-Module-Install: org/netbeans/modules/javascript2/editor/ModuleInstaller.class
 OpenIDE-Module-Layer: org/netbeans/modules/javascript2/editor/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/javascript2/editor/Bundle.properties
-OpenIDE-Module-Specification-Version: 0.91
+OpenIDE-Module-Specification-Version: 0.92
 OpenIDE-Module-Recommends: cnb.org.netbeans.modules.html.editor

--- a/webcommon/javascript2.editor/nbproject/project.xml
+++ b/webcommon/javascript2.editor/nbproject/project.xml
@@ -66,7 +66,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.0</specification-version>
+                        <specification-version>2.2</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript2.model/manifest.mf
+++ b/webcommon/javascript2.model/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.javascript2.model/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/javascript2/model/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.21
+OpenIDE-Module-Specification-Version: 1.22
 

--- a/webcommon/javascript2.model/nbproject/project.xml
+++ b/webcommon/javascript2.model/nbproject/project.xml
@@ -48,7 +48,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.0</specification-version>
+                        <specification-version>2.2</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/libs.nashorn/external/binaries-list
+++ b/webcommon/libs.nashorn/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-29C85B2008846727388E491BA336ADB81AE8B471 eu.doppel-helix.netbeans.lib:graaljs-parser:1.0
+E7865ABC417BD5973D5F8B10BC34FB870F6E2919 eu.doppel-helix.netbeans.lib:graaljs-parser:1.1

--- a/webcommon/libs.nashorn/external/graaljs-parser-1.1-license.txt
+++ b/webcommon/libs.nashorn/external/graaljs-parser-1.1-license.txt
@@ -1,5 +1,5 @@
 Name: Graal.js Parser
-Version: 1.0
+Version: 1.1
 Description: An ECMAScript 13 (ECMAScript 2022) compatible parser for JavaScript source code. Based on the parser of Graal.js (https://github.com/graalvm/graaljs).
 License: UPL
 Origin: https://github.com/matthiasblaesing/graaljs-nb

--- a/webcommon/libs.nashorn/manifest.mf
+++ b/webcommon/libs.nashorn/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.libs.nashorn/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/nashorn/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.1
+OpenIDE-Module-Specification-Version: 2.2

--- a/webcommon/libs.nashorn/nbproject/project.properties
+++ b/webcommon/libs.nashorn/nbproject/project.properties
@@ -19,4 +19,4 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/graaljs-parser-1.0.jar=modules/ext/graaljs-parser-1.0.jar
+release.external/graaljs-parser-1.1.jar=modules/ext/graaljs-parser-1.1.jar

--- a/webcommon/libs.nashorn/nbproject/project.xml
+++ b/webcommon/libs.nashorn/nbproject/project.xml
@@ -29,8 +29,8 @@
                 <subpackages>com.oracle.js.parser</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/graaljs-parser-1.0.jar</runtime-relative-path>
-                <binary-origin>external/graaljs-parser-1.0.jar</binary-origin>
+                <runtime-relative-path>ext/graaljs-parser-1.1.jar</runtime-relative-path>
+                <binary-origin>external/graaljs-parser-1.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Optional function calls: base?.(arg1, arg2)
Optional indexing calls: base?.[idx]
