### PR TITLE
Set --enable-preview for jtreg tests.

### DIFF
--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImpl.java
@@ -58,137 +58,130 @@ public class ClassPathProviderImpl implements ClassPathProvider {
 
     @Override
     public ClassPath findClassPath(FileObject file, String type) {
-        FileObject search = file.getParent();
-        FileObject testProperties = null;
+        TestRootDescription rootDesc = TestRootDescription.findRootDescriptionFor(file);
 
-        while (search != null) {
-            if (testProperties == null) {
-                testProperties =  BuildUtils.getFileObject(search, "TEST.properties");
+        if (rootDesc == null) {
+            return null;
+        }
+
+        FileObject testProperties = rootDesc.testProperties;
+        FileObject testRoot = rootDesc.testRoot;
+        FileObject testRootFile = rootDesc.testRootFile;
+
+        boolean javac = (Utilities.isLangtoolsRepository(testRoot.getParent()) || testRoot.getNameExt().equals("langtools")) &&
+                        ShortcutUtils.getDefault().shouldUseCustomTest("langtools", FileUtil.getRelativePath(testRoot.getParent(), file));
+        FileObject keyRoot = javac ? testRoot.getNameExt().equals("langtools") ? Utilities.getLangtoolsKeyRoot(testRoot.getParent().getParent()) : Utilities.getLangtoolsKeyRoot(testRoot.getParent()) : null;
+        //XXX: hack to make things work for langtools:
+        switch (type) {
+            case ClassPath.COMPILE:
+                if (javac) {
+                    ClassPath langtoolsCP = ClassPath.getClassPath(keyRoot, ClassPath.COMPILE);
+                    Library testngLib = LibraryManager.getDefault().getLibrary("testng");
+
+                    if (testngLib != null) {
+                        return ClassPathSupport.createProxyClassPath(ClassPathSupport.createClassPath(testngLib.getContent("classpath").toArray(new URL[0])),
+                                                                     langtoolsCP);
+                    }
+
+                    if (langtoolsCP == null)
+                        return ClassPath.EMPTY;
+                    else
+                        return langtoolsCP;
+                }
+                else return null;
+            case ClassPath.BOOT:
+                if (javac) {
+                    try {
+                        ClassPath langtoolsBCP = ClassPath.getClassPath(keyRoot, ClassPath.BOOT);
+                        List<URL> roots = new ArrayList<>();
+                        for (String rootPaths : new String[] {"build/classes/",
+                                                              "build/java.compiler/classes/",
+                                                              "build/jdk.compiler/classes/",
+                                                              "build/jdk.javadoc/classes/",
+                                                              "build/jdk.dev/classes/"}) {
+                            roots.add(testRoot.getParent().toURI().resolve(rootPaths).toURL());
+                        }
+                        return ClassPathSupport.createProxyClassPath(ClassPathSupport.createClassPath(roots.toArray(new URL[roots.size()])), langtoolsBCP);
+                    } catch (MalformedURLException ex) {
+                        Exceptions.printStackTrace(ex);
+                    }
+                }
+                return null;
+            case ClassPath.SOURCE:
+                break;
+            default:
+                return null;
+        }
+
+        Set<FileObject> roots = new LinkedHashSet<>();
+
+        if (testProperties != null) {
+            roots.add(testProperties.getParent());
+
+            try (InputStream in = testProperties.getInputStream()) {
+                Properties p = new Properties();
+                p.load(in);
+                String libDirsText = p.getProperty("lib.dirs");
+                FileObject libDirsRoot = libDirsText != null ? resolve(testProperties, testRoot, libDirsText) : null;
+
+                if (libDirsRoot != null) roots.add(libDirsRoot);
+            } catch (IOException ex) {
+                Exceptions.printStackTrace(ex);
             }
+        } else {
+            if (file.isFolder()) return null;
 
-            FileObject testRoot = BuildUtils.getFileObject(search, "TEST.ROOT");
+            roots.add(file.getParent());
+            try (Reader r = new InputStreamReader(file.getInputStream(), FileEncodingQuery.getEncoding(file))) {
+                StringBuilder content = new StringBuilder();
+                int read;
 
-            if (testRoot != null) {
-                boolean javac = (Utilities.isLangtoolsRepository(search.getParent()) || search.getNameExt().equals("langtools")) &&
-                                ShortcutUtils.getDefault().shouldUseCustomTest("langtools", FileUtil.getRelativePath(search.getParent(), file));
-                FileObject keyRoot = javac ? search.getNameExt().equals("langtools") ? Utilities.getLangtoolsKeyRoot(search.getParent().getParent()) : Utilities.getLangtoolsKeyRoot(search.getParent()) : null;
-                //XXX: hack to make things work for langtools:
-                switch (type) {
-                    case ClassPath.COMPILE:
-                        if (javac) {
-                            ClassPath langtoolsCP = ClassPath.getClassPath(keyRoot, ClassPath.COMPILE);
-                            Library testngLib = LibraryManager.getDefault().getLibrary("testng");
-
-                            if (testngLib != null) {
-                                return ClassPathSupport.createProxyClassPath(ClassPathSupport.createClassPath(testngLib.getContent("classpath").toArray(new URL[0])),
-                                                                             langtoolsCP);
-                            }
-
-                            if (langtoolsCP == null)
-                                return ClassPath.EMPTY;
-                            else
-                                return langtoolsCP;
-                        }
-                        else return null;
-                    case ClassPath.BOOT:
-                        if (javac) {
-                            try {
-                                ClassPath langtoolsBCP = ClassPath.getClassPath(keyRoot, ClassPath.BOOT);
-                                List<URL> roots = new ArrayList<>();
-                                for (String rootPaths : new String[] {"build/classes/",
-                                                                      "build/java.compiler/classes/",
-                                                                      "build/jdk.compiler/classes/",
-                                                                      "build/jdk.javadoc/classes/",
-                                                                      "build/jdk.dev/classes/"}) {
-                                    roots.add(search.getParent().toURI().resolve(rootPaths).toURL());
-                                }
-                                return ClassPathSupport.createProxyClassPath(ClassPathSupport.createClassPath(roots.toArray(new URL[roots.size()])), langtoolsBCP);
-                            } catch (MalformedURLException ex) {
-                                Exceptions.printStackTrace(ex);
-                            }
-                        }
-                        return null;
-                    case ClassPath.SOURCE:
-                        break;
-                    default:
-                        return null;
+                while ((read = r.read()) != (-1)) {
+                    content.append((char) read);
                 }
 
-                Set<FileObject> roots = new LinkedHashSet<>();
+                Pattern library = Pattern.compile("@library (.*)\n");
+                Matcher m = library.matcher(content.toString());
 
-                if (testProperties != null) {
-                    roots.add(testProperties.getParent());
-
-                    try (InputStream in = testProperties.getInputStream()) {
+                if (m.find()) {
+                    List<FileObject> libDirs = new ArrayList<>();
+                    try (InputStream in = testRootFile.getInputStream()) {
                         Properties p = new Properties();
                         p.load(in);
-                        String libDirsText = p.getProperty("lib.dirs");
-                        FileObject libDirsRoot = libDirsText != null ? resolve(testProperties, search, libDirsText) : null;
+                        String externalLibRoots = p.getProperty("external.lib.roots");
+                        if (externalLibRoots != null) {
+                            for (String extLib : externalLibRoots.split("\\s+")) {
+                                FileObject libDir = BuildUtils.getFileObject(testRoot, extLib);
 
-                        if (libDirsRoot != null) roots.add(libDirsRoot);
-                    } catch (IOException ex) {
-                        Exceptions.printStackTrace(ex);
-                    }
-                } else {
-                    if (file.isFolder()) return null;
-                    
-                    roots.add(file.getParent());
-                    try (Reader r = new InputStreamReader(file.getInputStream(), FileEncodingQuery.getEncoding(file))) {
-                        StringBuilder content = new StringBuilder();
-                        int read;
-                        
-                        while ((read = r.read()) != (-1)) {
-                            content.append((char) read);
-                        }
-                        
-                        Pattern library = Pattern.compile("@library (.*)\n");
-                        Matcher m = library.matcher(content.toString());
-
-                        if (m.find()) {
-                            List<FileObject> libDirs = new ArrayList<>();
-                            try (InputStream in = testRoot.getInputStream()) {
-                                Properties p = new Properties();
-                                p.load(in);
-                                String externalLibRoots = p.getProperty("external.lib.roots");
-                                if (externalLibRoots != null) {
-                                    for (String extLib : externalLibRoots.split("\\s+")) {
-                                        FileObject libDir = BuildUtils.getFileObject(search, extLib);
-
-                                        if (libDir != null) {
-                                            libDirs.add(libDir);
-                                        }
-                                    }
-                                }
-                            }
-                            libDirs.add(search);
-                            String libraryPaths = m.group(1).trim();
-                            for (String libraryPath : libraryPaths.split(" ")) {
-                                for (FileObject libDir : libDirs) {
-                                    FileObject libFO = resolve(file, libDir, libraryPath);
-
-                                    if (libFO != null) {
-                                        roots.add(libFO);
-                                    }
+                                if (libDir != null) {
+                                    libDirs.add(libDir);
                                 }
                             }
                         }
-                    } catch (IOException ex) {
-                        Exceptions.printStackTrace(ex);
+                    }
+                    libDirs.add(testRoot);
+                    String libraryPaths = m.group(1).trim();
+                    for (String libraryPath : libraryPaths.split(" ")) {
+                        for (FileObject libDir : libDirs) {
+                            FileObject libFO = resolve(file, libDir, libraryPath);
+
+                            if (libFO != null) {
+                                roots.add(libFO);
+                            }
+                        }
                     }
                 }
-
-                //XXX:
-                for (FileObject root : roots) {
-                    initializeUsagesQuery(root);
-                }
-
-                return ClassPathSupport.createClassPath(roots.toArray(new FileObject[0]));
+            } catch (IOException ex) {
+                Exceptions.printStackTrace(ex);
             }
-
-            search = search.getParent();
         }
-        
-        return null;
+
+        //XXX:
+        for (FileObject root : roots) {
+            initializeUsagesQuery(root);
+        }
+
+        return ClassPathSupport.createClassPath(roots.toArray(new FileObject[0]));
     }
 
     private FileObject resolve(FileObject file, FileObject root, String spec) {

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/CompilerOptionsQueryImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/CompilerOptionsQueryImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.openjdk.jtreg;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.event.ChangeListener;
+import org.netbeans.spi.java.queries.CompilerOptionsQueryImplementation;
+import org.openide.filesystems.FileObject;
+import org.openide.util.lookup.ServiceProvider;
+
+@ServiceProvider(service=CompilerOptionsQueryImplementation.class, position=9999)
+public class CompilerOptionsQueryImpl implements CompilerOptionsQueryImplementation {
+
+    @Override
+    public Result getOptions(FileObject file) {
+        TestRootDescription rootDesc = TestRootDescription.findRootDescriptionFor(file);
+
+        if (rootDesc == null) {
+            return null;
+        }
+
+        //enable preview in tests:
+        return ENABLE_PREVIEW;
+    }
+
+    private static final Result ENABLE_PREVIEW = new EnablePreviewResult();
+
+    private static final class EnablePreviewResult extends Result {
+
+        private static final List<String> ENABLE_PREVIEW_ARGS =
+                Collections.unmodifiableList(Arrays.asList("--enable-preview"));
+
+        @Override
+        public List<? extends String> getArguments() {
+            return ENABLE_PREVIEW_ARGS;
+        }
+
+        @Override
+        public void addChangeListener(ChangeListener listener) {}
+
+        @Override
+        public void removeChangeListener(ChangeListener listener) {}
+
+    }
+}

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/TestRootDescription.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/TestRootDescription.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.openjdk.jtreg;
+
+import org.netbeans.modules.java.openjdk.common.BuildUtils;
+import org.openide.filesystems.FileObject;
+
+public class TestRootDescription {
+    public final FileObject testProperties;
+    public final FileObject testRoot;
+    public final FileObject testRootFile;
+
+    private TestRootDescription(FileObject testProperties, FileObject testRoot, FileObject testRootFile) {
+        this.testProperties = testProperties;
+        this.testRoot = testRoot;
+        this.testRootFile = testRootFile;
+    }
+
+    public static TestRootDescription findRootDescriptionFor(FileObject file) {
+        FileObject search = file.getParent();
+        FileObject testProperties = null;
+
+        while (search != null) {
+            if (testProperties == null) {
+                testProperties =  BuildUtils.getFileObject(search, "TEST.properties");
+            }
+
+            FileObject testRoot = BuildUtils.getFileObject(search, "TEST.ROOT");
+
+            if (testRoot != null) {
+                return new TestRootDescription(testProperties, search, testRoot);
+            }
+            search = search.getParent();
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
I would like to add `--enable-preview` to the javac parameters used internally by the IDE to parse jtreg (OpenJDK) tests.
