### PR TITLE
#4113: pretend that folders have no URI, so their icon can be customi…

### DIFF
--- a/java/java.lsp.server/vscode/CHANGELOG.md
+++ b/java/java.lsp.server/vscode/CHANGELOG.md
@@ -20,6 +20,11 @@
     under the License.
 
 -->
+## Version 14.0
+* Workaround for VSCode 1.67 error which breaks Projects explorer icon
+* Remove HTML tags from project problem messages
+* Fixes for Gradle projects and LSP
+
 ## Version 13.0.301
 * Added base code completion for Spock test framework
   * Spock Block Names are offered inside methods if the class extends Spock Specification


### PR DESCRIPTION
vscode version 1.67 released in April breaks icon display for `TreeItems`: if an item reports `resourceUri` that corresponds to a folder, system-default folder icon (by default: none) is displayed, regardless of the `TreeItem`'s configured `iconPath`. 

This was discovered by Friday's team testing. The fix affects just **Apache NetBeans Language Server** vscode extension release, not the NetBeans release. If included in NB14, this patch should have no effect on the main release (the code is not distributed with NetBeans IDE).

