### PR TITLE
ElementUtilities performance optimization.

### DIFF
--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -3234,7 +3234,12 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<List<QuickPickItem>> showQuickPick(ShowQuickPickParams params) {
-                return CompletableFuture.completedFuture(params.getItems().size() > 2 ? params.getItems().subList(0, 2) : params.getItems());
+                List<QuickPickItem> selection = params.getItems().stream()
+                        .filter((i) -> i.getLabel().equals("f1.chars(): IntStream") || i.getLabel().equals("f1.codePoints(): IntStream"))
+                        .sorted((i1, i2) -> i1.getLabel().compareTo(i2.getLabel()))
+                        .collect(Collectors.toList());
+                assertEquals(2, selection.size());
+                return CompletableFuture.completedFuture(selection);
             }
 
             @Override


### PR DESCRIPTION
fixes #4140

`ElementUtilities.getMembers()`, `getLocalMembersAndVars()`, `getLocalVars()` and `getGlobalTypes()` performance optimization.
 - optimization was contributed by @notzed, see NETBEANS-6504 or #4140
 - only minor changes were made from the proposed patch

This significantly improves auto completion performance on types with thousands of fields. 
example: https://github.com/apache/netbeans/issues/4140#issuecomment-1134414691 completion takes several seconds to show up before patch, after patch it shows up instantly.

Since `ElementUtilites` has many usages across NetBeans, this could potentially improve performance in other places too.

First commit is the interesting one, other is cleanup. I added tests and made sure they were green before and after patch. Its already squashed in the first commit.


baseline before optimization:
![completion_baseline](https://user-images.githubusercontent.com/114367/169800031-916ac8d9-6b96-42ae-96c8-ba685cef62b2.png)

lets see if tests are green

https://user-images.githubusercontent.com/114367/176787320-6026f789-7721-4c6e-bb5a-1f18dc1ff9a8.mp4


