### PR TITLE
fix NPE on git checkout error, print msg to output instead.

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/ui/checkout/AbstractCheckoutAction.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/checkout/AbstractCheckoutAction.java
@@ -99,8 +99,7 @@ public abstract class AbstractCheckoutAction extends SingleRepositoryAction {
                         revision = newBranchName;
                         LOG.log(Level.FINE, "Creating branch: {0}:{1}", new Object[] { revision, revisionToCheckout }); //NOI18N
                         GitBranch branch = client.createBranch(revision, revisionToCheckout, getProgressMonitor());
-                        log(revisionToCheckout, branch);
-
+                        logBranchCreation(revisionToCheckout, branch);
                     }
                     client.addNotificationListener(new FileListener() {
                         @Override
@@ -170,9 +169,13 @@ public abstract class AbstractCheckoutAction extends SingleRepositoryAction {
                 return b != null && b.getName() != GitBranch.NO_BRANCH;
             }
 
-            private void log (String revision, GitBranch branch) {
+            private void logBranchCreation (String revision, GitBranch branch) {
                 OutputLogger logger = getLogger();
-                logger.outputLine(NbBundle.getMessage(CheckoutRevisionAction.class, "MSG_CheckoutRevisionAction.branchCreated", new Object[] { branch.getName(), revision, branch.getId() })); //NOI18N
+                if (branch != null) {
+                    logger.outputLine(NbBundle.getMessage(CheckoutRevisionAction.class, "MSG_CheckoutRevisionAction.branchCreated", new Object[] { branch.getName(), revision, branch.getId() })); //NOI18N
+                } else {
+                    logger.outputLine(NbBundle.getMessage(CheckoutRevisionAction.class, "MSG_CheckoutRevisionAction.noBranchCreated", new Object[] { revision })); //NOI18N
+                }
             }
 
             private boolean resolveConflicts (File[] conflicts, boolean mergeAllowed) throws GitException {

--- a/ide/git/src/org/netbeans/modules/git/ui/checkout/Bundle.properties
+++ b/ide/git/src/org/netbeans/modules/git/ui/checkout/Bundle.properties
@@ -48,6 +48,7 @@ MSG_CheckoutRevisionAction.branchCreated = Branch created\n\
 Name: {0}\n\
 From: {1}\n\
 Id  : {2}
+MSG_CheckoutRevisionAction.noBranchCreated = Branch with revision {0}, could not be created
 MSG_CheckoutRevisionAction.checkoutConflicts = You have local modification in working copy that would result in a checkout conflict.\n\
 You can try to merge, revert them or review them in the Versioning view.
 LBL_CheckoutRevisionAction.checkoutConflicts = Checkout conflicts


### PR DESCRIPTION
fixes #4148

following the reproduction steps as described in the issue, trying to check out a branch on windows from a repo which contains invalid files/paths will result in this output:
```
==[IDE]== 31.05.2022, 21:28:02 Cloning finished.
==[IDE]== 31.05.2022, 21:33:00 Checkout...
git branch --track main2 origin/main
Branch with revision origin/main, could not be created
git show conflicts
git checkout main2
==[IDE]== 31.05.2022, 21:33:03 Checkout... finished.
```
additional to the git error popup stating the error:
```
Commit e476c05de56775cd9074f307562cc947f7f5072b cannot be checked out because an invalid file name in one of the files.
Please remove the file from repository with an external tool and try again.

Invalid path: japanese/prn
```
the NPE is no longer thrown.