### PR TITLE
Correction of getOwningClass(), including a test.

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/ASTUtils.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/ASTUtils.java
@@ -528,7 +528,7 @@ public class ASTUtils {
     }
 
     public static ClassNode getOwningClass(AstPath path) {
-        Iterator<ASTNode> it = path.rootToLeaf();
+        Iterator<ASTNode> it = path.leafToRoot();
         while (it.hasNext()) {
             ASTNode node = it.next();
             if (node instanceof ClassNode) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/language/GroovyDeclarationFinder.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/language/GroovyDeclarationFinder.java
@@ -265,10 +265,7 @@ public class GroovyDeclarationFinder implements DeclarationFinder {
                 if (scope != null) {
                     ASTNode variable = ASTUtils.getVariable(scope, variableExpression.getName(), path, doc, lexOffset);
                     if (variable != null) {
-                        // I am using getRange and not getOffset, because getRange is adding 'def_' to offset of field
-                        int offset = ASTUtils.getRange(variable, doc).getStart();
-                        // FIXME parsing API
-                        return new DeclarationLocation(info.getSnapshot().getSource().getFileObject(), offset);
+                        return getVariableLocation(variable, doc, info);
                     }
                 }
             // find a field ?
@@ -289,9 +286,7 @@ public class GroovyDeclarationFinder implements DeclarationFinder {
                         }
                         ASTNode variable = ASTUtils.getVariable(scope, ((ConstantExpression) property).getText(), path, doc, lexOffset);
                         if (variable != null) {
-                            int offset = ASTUtils.getOffset(doc, variable.getLineNumber(), variable.getColumnNumber());
-                            // FIXME parsing API
-                            return new DeclarationLocation(info.getSnapshot().getSource().getFileObject(), offset);
+                            return getVariableLocation(variable, doc, info);
                         }
                     } else {
                         // find variable type
@@ -382,6 +377,13 @@ public class GroovyDeclarationFinder implements DeclarationFinder {
             Exceptions.printStackTrace(ble);
         }
         return DeclarationLocation.NONE;
+    }
+
+    private DeclarationLocation getVariableLocation(ASTNode variable, BaseDocument doc, ParserResult info) {
+        // I am using getRange and not getOffset, because getRange is adding 'def_' to offset of field
+        int offset = ASTUtils.getRange(variable, doc).getStart();
+        // FIXME parsing API
+        return new DeclarationLocation(info.getSnapshot().getSource().getFileObject(), offset);
     }
 
     private DeclarationLocation findType(String fqName, OffsetRange range,

--- a/groovy/groovy.editor/test/unit/data/testfiles/declarationfinder/ClassWithInner.groovy
+++ b/groovy/groovy.editor/test/unit/data/testfiles/declarationfinder/ClassWithInner.groovy
@@ -1,0 +1,23 @@
+class ClassWithInner {
+
+    String x = "A"
+    String y = "B"
+
+    class Inner {
+
+        Point x = new Point();
+
+        def method() {
+            this.x = null
+            y.isEmpty()
+        }
+    }
+
+    def method() {
+        this.x.isNumber()
+    }
+
+    class Point {
+        int x, y
+    }
+}

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/GroovyDeclarationFinderTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/GroovyDeclarationFinderTest.java
@@ -180,4 +180,19 @@ public class GroovyDeclarationFinderTest extends GroovyTestBase {
         checkDeclaration(TEST_BASE + "Annotations.groovy",
                 "    @Annot^ation public String method() {}", "Annotation.java", 30);
     }
+
+    public void testGroovyClassInner1() throws Exception {
+        checkDeclaration(TEST_BASE + "ClassWithInner.groovy",
+                "            this.^x = null", "ClassWithInner.groovy", 96);
+    }
+
+    public void testGroovyClassInner2() throws Exception {
+        checkDeclaration(TEST_BASE + "ClassWithInner.groovy",
+                "            ^y.isEmpty()", "ClassWithInner.groovy", 54);
+    }
+
+    public void testGroovyClassInner3() throws Exception {
+        checkDeclaration(TEST_BASE + "ClassWithInner.groovy",
+                "        this.^x.isNumber()", "ClassWithInner.groovy", 35);
+    }
 }


### PR DESCRIPTION
`ASTUtils.getOwningClass()` iterates paths in the wrong order.
A small correction is also applied to `GroovyDeclarationFinder`, where once `ASTUtils.getRange(...)` was called and once `ASTUtils.getOffset(...)`. I've extracted that to `getVariableLocation(...)` to assure that the logic is the same.
A test is included.