### PR TITLE
Added support for properties backed up by functional interfaces

### DIFF
--- a/platform/openide.nodes/apichanges.xml
+++ b/platform/openide.nodes/apichanges.xml
@@ -25,6 +25,30 @@
 <apidef name="nodes">Nodes API</apidef>
 </apidefs>
 <changes>
+    <change id="PropertySupport.FunctionalProperty">
+        <api name="nodes"/>
+        <summary>Adding static methods to PropertySupport to allow easy creation
+            of properties using functional interfaces.
+        </summary>
+        <version major="7" minor="62"/>
+        <date day="26" month="5" year="2022"/>
+        <author login="lkishalmi"/>
+        <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible"/>
+        <description>
+            <a href="@TOP@/org/openide/nodes/PropertySupport.html">PropertySupport</a>
+            received a bunch of static methods (<code>readWrite</code>, <code>readOnly</code>, and
+            <code>writeOnly</code> to allow easy property creation with <code>Supplier</code> and
+            <code>Provider</code> functional interfaces.
+            <pre>
+                Sheet.Set set = ...
+                SomeObject obj = getLookup().lookup(SomeObject.class);
+
+                set.put(PropertySupport.readWrite("name", String.class, obj::getName, obj::setName));
+                set.put(PropertySupport.readOnly("size", Long.class, obj::getSize));
+            </pre>
+        </description>
+        <class package="org.openide.nodes" name="DestroyableNodesFactory"/>
+    </change>
     <change id="ChildFactory.DestroyableNodes">
         <api name="nodes"/>
         <summary>Adding ChildFactory.Detachable to allow ChildFactory implementations to


### PR DESCRIPTION

I was working on Gradle configuration nodes to expose more information on them, while I bumped into PropertySupport and realized how old school that could be, especially if the represented value needs to be converted/formatted as well.

So I put some new age in the code. I hope you do not mind that I've removed some compile warnings alongside my additions.

Also, I'm open for feedback, method name changes etc.