### PR TITLE
API to trigger LSP diagnostic collection.

### DIFF
--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -51,6 +51,23 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="diagnosticReporter">
+        <api name="LSP_API"/>
+        <summary>Added DiagnosticReporter to trigger diagnostic collection</summary>
+        <version major="1" minor="11"/>
+        <date day="30" month="5" year="2022"/>
+        <author login="sdedic"/>
+        <compatibility binary="compatible" source="compatible" addition="yes" deletion="no"/>
+        <description>
+            <a href="@TOP@/org/netbeans/spi/lsp/DiagnosticReporter.html">DiagnosticReporter</a> SPI should be implemented to allow
+            alerting the LSP server core that diagnostics for certain file(s) may have changed. The core implementation should then poll 
+            <a href="@TOP@/org/netbeans/spi/lsp/ErrorProvider.html">ErrorProviders</a> to collect the diagnostics.
+            API clients should call <a href="@TOP@/org/netbeans/api/lsp/Diagnostic.html#findReporterControl-org.openide.util.Lookup-org.openide.filesystems.FileObject-">Diagnostic.findReporterControl</a>
+            to obtain an accessor which can fire the alert.
+        </description>
+        <class package="org.netbeans.api.lsp" name="Diagnostic"/>
+        <class package="org.netbeans.spi.lsp" name="DiagnosticReporter"/>
+    </change>
     <change id="CallHierarchyProvider">
         <api name="LSP_API"/>
         <summary>Added CallHierarchyProvider and relevant elements</summary>

--- a/ide/api.lsp/manifest.mf
+++ b/ide/api.lsp/manifest.mf
@@ -1,6 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.lsp/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/lsp/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.10
+OpenIDE-Module-Specification-Version: 1.11
 AutoUpdate-Show-In-Client: false
-

--- a/ide/api.lsp/src/org/netbeans/api/lsp/Diagnostic.java
+++ b/ide/api.lsp/src/org/netbeans/api/lsp/Diagnostic.java
@@ -18,8 +18,13 @@
  */
 package org.netbeans.api.lsp;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
+import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.modules.lsp.DiagnosticUtils;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Lookup;
 
 /**
  * A diagnostic for LSP. Use a {@link Diagnostic.Builder} to create an instance.
@@ -186,4 +191,36 @@ public class Diagnostic {
          */
         public List<CodeAction> computeCodeActions(Consumer<Exception> errorReporter);
     }
+    
+   /**
+    * Allows to trigger diagnostics collection. The implementation will
+    * coordinate potential push of the diagnostic information to the LSP client.
+    */
+   public interface ReporterControl {
+       /**
+        * Notifies that the diagnostics for {@code file} may have changed. The 
+        * implementation should coordinate collection of {@link Diagnostic} information
+        * for the affected files.
+        * @param files files whose diagnostics may have changed.
+        * @param mimeType optional; mimetype selector for changed files.
+        */
+       public void diagnosticChanged(Collection<FileObject> files, String mimeType);
+   }  
+   
+    /**
+     * Returns a Control object appropriate for the context and the file. The returned 
+     * object can be used to fire changes to LSP client(s). It is important to call
+     * the method while the context is in effect, i.e. during the client's request. May
+     * return {@code null} if no suitable LSP can be found.
+     * 
+     * @param context the Optional. Context used to identify the LSP client. If {@code null},
+     * the default Lookup will be used.
+     * @param file Optional. The file or folder whose diagnostic will be reported.
+     * @return the control object.
+     * @since 1.11
+     */
+   public static ReporterControl findReporterControl(@NullAllowed Lookup context, @NullAllowed FileObject file) {
+       return DiagnosticUtils.findReporterControl(context, file);
+   }
+
 }

--- a/ide/api.lsp/src/org/netbeans/modules/lsp/DiagnosticUtils.java
+++ b/ide/api.lsp/src/org/netbeans/modules/lsp/DiagnosticUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.lsp;
+
+import java.util.Collection;
+import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.api.lsp.Diagnostic;
+import org.netbeans.spi.lsp.DiagnosticReporter;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Lookup;
+
+/**
+ *
+ * @author sdedic
+ */
+public class DiagnosticUtils {
+    private static final Diagnostic.ReporterControl DUMMY = new Diagnostic.ReporterControl() {
+        @Override
+        public void diagnosticChanged(Collection<FileObject> files, String mimeType) {
+        }
+    };
+    
+    public static Diagnostic.ReporterControl findReporterControl(@NullAllowed Lookup context, @NullAllowed FileObject file) {
+        if (context == null) {
+            context = Lookup.getDefault();
+        }
+        for (DiagnosticReporter rc : Lookup.getDefault().lookupAll(DiagnosticReporter.class)) {
+            Diagnostic.ReporterControl ctrl = rc.findDiagnosticControl(context, file);
+            if (ctrl != null) {
+                return ctrl;
+            }
+        }
+        return DUMMY;
+    }
+}

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/DiagnosticReporter.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/DiagnosticReporter.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.spi.lsp;
+
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NullAllowed;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Lookup;
+import org.netbeans.api.lsp.Diagnostic.ReporterControl;
+
+/**
+ * Allows to control diagnostics push to the LSP client on behalf of the
+ * LSP server background processes. The {@code pushDiagnostics} is a server-initiated
+ * message. Traditionally the diagnostics are collected and pushed whenever a
+ * file is operated on, but there may be different events (for example a background
+ * analytical process finishes) that may change the diagnostic information for a file.
+ * <p>
+ * 
+ * 
+ * @author sdedic
+ */
+public interface DiagnosticReporter {
+    /**
+     * Returns a Control object appropriate for the context and the file. The returned 
+     * object can be used to fire changes to LSP client(s). It is important to call
+     * the method while the context is in effect, i.e. during the client's request. May
+     * return {@code null} if no suitable LSP can be found.
+     * 
+     * @param context the Optional. Context used to identify the LSP client. If {@code null},
+     * the default Lookup will be used.
+     * @param file Optional. The file or folder whose diagnostic will be reported.
+     * @return the control object.
+     */
+    @CheckForNull
+    public ReporterControl findDiagnosticControl(@NullAllowed Lookup context, @NullAllowed FileObject file);
+}

--- a/java/java.lsp.server/nbcode/integration/nbproject/project.xml
+++ b/java/java.lsp.server/nbcode/integration/nbproject/project.xml
@@ -162,6 +162,15 @@
                         <specification-version>1.0</specification-version>
                     </run-dependency>
                 </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.api.lsp</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.11</specification-version>
+                    </run-dependency>
+                </dependency>
             </module-dependencies>
             <test-dependencies>
                 <test-type>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspDiagnosticReporter.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspDiagnosticReporter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.nbcode.integration;
+
+import org.netbeans.modules.java.lsp.server.ui.AbstractDiagnosticReporter;
+import org.openide.util.lookup.ServiceProvider;
+import org.netbeans.spi.lsp.DiagnosticReporter;
+/**
+ *
+ * @author sdedic
+ */
+@ServiceProvider(service = DiagnosticReporter.class)
+public class LspDiagnosticReporter extends AbstractDiagnosticReporter {
+    
+}

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -128,7 +128,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.9</specification-version>
+                        <specification-version>1.11</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -45,6 +45,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import com.google.gson.InstanceCreator;
 import com.google.gson.JsonObject;
+import java.util.LinkedHashSet;
 import org.eclipse.lsp4j.CallHierarchyRegistrationOptions;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionOptions;
@@ -668,7 +669,7 @@ public final class Server {
         @Override
         public OpenedDocuments getOpenedDocuments() {
             return openedDocuments;
-        }
+        } 
 
         private JavaSource showIndexingCompleted(Project[] opened) {
             try {
@@ -720,7 +721,7 @@ public final class Server {
                 CallHierarchyRegistrationOptions chOpts = new CallHierarchyRegistrationOptions();
                 chOpts.setWorkDoneProgress(true);
                 capabilities.setCallHierarchyProvider(chOpts);
-                List<String> commands = new ArrayList<>(Arrays.asList(GRAALVM_PAUSE_SCRIPT,
+                Set<String> commands = new LinkedHashSet<>(Arrays.asList(GRAALVM_PAUSE_SCRIPT,
                         JAVA_BUILD_WORKSPACE,
                         JAVA_CLEAN_WORKSPACE,
                         JAVA_RUN_PROJECT_ACTION,
@@ -742,7 +743,7 @@ public final class Server {
                 for (CodeActionsProvider codeActionsProvider : Lookup.getDefault().lookupAll(CodeActionsProvider.class)) {
                     commands.addAll(codeActionsProvider.getCommands());
                 }
-                capabilities.setExecuteCommandProvider(new ExecuteCommandOptions(commands));
+                capabilities.setExecuteCommandProvider(new ExecuteCommandOptions(new ArrayList<>(commands)));
                 capabilities.setWorkspaceSymbolProvider(true);
                 capabilities.setCodeLensProvider(new CodeLensOptions(false));
                 RenameOptions renOpt = new RenameOptions();

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractDiagnosticReporter.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractDiagnosticReporter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.ui;
+
+import org.netbeans.api.lsp.Diagnostic;
+import org.netbeans.modules.java.lsp.server.LspServerState;
+import org.netbeans.modules.java.lsp.server.protocol.TextDocumentServiceImpl;
+import org.netbeans.spi.lsp.DiagnosticReporter;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Lookup;
+
+/**
+ *
+ * @author sdedic
+ */
+public class AbstractDiagnosticReporter implements DiagnosticReporter {
+
+    @Override
+    public Diagnostic.ReporterControl findDiagnosticControl(Lookup context, FileObject file) {
+        LspServerState state = context.lookup(LspServerState.class);
+        if (state == null) {
+            return null;
+        }
+        return ((TextDocumentServiceImpl)state.getTextDocumentService()).createReporterControl();
+    }
+}


### PR DESCRIPTION
Simple API that can be used by LSP-aware code  to trigger error re-collection from `ErrorProvider`s & publish to the client.
