### PR TITLE
Fix possible NPE at RunUtils.getCompatibleGradleDistribution

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
@@ -259,6 +259,7 @@ public final class RunUtils {
     public static GradleDistribution getCompatibleGradleDistribution(Project prj) {
         GradleDistributionProvider pvd = prj.getLookup().lookup(GradleDistributionProvider.class);
         GradleDistribution ret = pvd != null ? pvd.getGradleDistribution() : GradleDistributionManager.get().defaultDistribution();
+        ret = ret != null ? ret : GradleDistributionManager.get().defaultDistribution();
         ret = ret.isCompatibleWithSystemJava() ? ret : GradleDistributionManager.get().defaultDistribution();
         return ret;
 


### PR DESCRIPTION

Trivial fix for NPE. The NPE can happen if the IDE is set to not prefer Gradle Wrapper, but a specific version.
