### PR TITLE
Maven / dependency query fixes.

### DIFF
--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ArtifactSpec.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ArtifactSpec.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.project.dependency;
 import java.util.Objects;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
+import org.openide.filesystems.FileObject;
 
 /**
  * Represents an artifact. Each artifact is identified by
@@ -62,9 +63,10 @@ public final class ArtifactSpec<T> {
     private final String versionSpec;
     private final String classifier;
     private final boolean optional;
+    private final FileObject localFile;
     final T data;
 
-    ArtifactSpec(VersionKind kind, String groupId, String artifactId, String versionSpec, String type, String classifier, boolean optional, T impl) {
+    ArtifactSpec(VersionKind kind, String groupId, String artifactId, String versionSpec, String type, String classifier, boolean optional, FileObject localFile, T impl) {
         this.kind = kind;
         this.groupId = groupId;
         this.artifactId = artifactId;
@@ -73,6 +75,15 @@ public final class ArtifactSpec<T> {
         this.optional = optional;
         this.data = impl;
         this.type = type;
+        this.localFile = localFile;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public FileObject getLocalFile() {
+        return localFile;
     }
 
     public VersionKind getKind() {
@@ -174,15 +185,15 @@ public final class ArtifactSpec<T> {
     public static <V> ArtifactSpec<V> createVersionSpec(
             @NonNull String groupId, @NonNull String artifactId, 
             @NullAllowed String type, @NullAllowed String classifier, 
-            @NonNull String versionSpec, boolean optional, @NonNull V data) {
-        return new ArtifactSpec<V>(VersionKind.REGULAR, groupId, artifactId, versionSpec, type, classifier, optional, data);
+            @NonNull String versionSpec, boolean optional, @NullAllowed FileObject localFile, @NonNull V data) {
+        return new ArtifactSpec<V>(VersionKind.REGULAR, groupId, artifactId, versionSpec, type, classifier, optional, localFile, data);
     }
 
     public static <V> ArtifactSpec<V> createSnapshotSpec(
             @NonNull String groupId, @NonNull String artifactId, 
             @NullAllowed String type, @NullAllowed String classifier, 
-            @NonNull String versionSpec, boolean optional, @NonNull V data) {
-        return new ArtifactSpec<V>(VersionKind.SNAPSHOT, groupId, artifactId, versionSpec, type, classifier, false, data);
+            @NonNull String versionSpec, boolean optional, @NullAllowed FileObject localFile, @NonNull V data) {
+        return new ArtifactSpec<V>(VersionKind.SNAPSHOT, groupId, artifactId, versionSpec, type, classifier, optional, localFile, data);
     }
 
 }

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/DependencyResult.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/DependencyResult.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.project.dependency;
 
 import java.io.IOException;
+import java.util.Collection;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.project.Project;
 import org.openide.util.Lookup;
@@ -45,7 +46,17 @@ public interface DependencyResult extends Lookup.Provider {
      */
     public Dependency getRoot();
     
+    /**
+     * Checks if the data is still valid
+     * @return true, if the data is valid
+     */
     public boolean isValid();
+    
+    /**
+     * Returns artifacts that may be unavailable or erroneous.
+     * @return problem artifacts
+     */
+    public Collection<ArtifactSpec> getProblemArtifacts();
     
     /**
      * Registers a Listener to be notified when validity changes.

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectDependencies.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectDependencies.java
@@ -20,11 +20,10 @@ package org.netbeans.modules.project.dependency;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import org.netbeans.api.project.Project;
-import org.openide.util.Lookup;
-import org.openide.util.lookup.Lookups;
 import org.netbeans.modules.project.dependency.spi.ProjectDependenciesImplementation;
-import org.openide.filesystems.FileObject;
 
 /**
  * Project Query that collects dependencies using project-specific services.
@@ -40,14 +39,119 @@ public class ProjectDependencies {
         return pds.getProjectArtifact();
     }
     
-    public static DependencyResult findDependencies(Project target, Dependency.Filter filterOrNull, Scope... scopes) throws ProjectOperationException {
+    /**
+     * Finds project dependencies.
+     * 
+     * @param target the project to query
+     * @param query the query
+     * @return the dependency tree, result of the query.
+     * @throws ProjectOperationException 
+     */
+    public static DependencyResult findDependencies(Project target, DependencyQuery query) throws ProjectOperationException {
         ProjectDependenciesImplementation pds = target.getLookup().lookup(ProjectDependenciesImplementation.class);
         if (pds == null) {
             return null;
         } else {
-            return pds.findDependencies(
-                    scopes == null ? Collections.singletonList(Scopes.COMPILE) : Arrays.asList(scopes), 
-                    filterOrNull != null ? filterOrNull : (s, a) -> true);
+            return pds.findDependencies(query);
+        }
+    }
+    
+    /**
+     * Creates the dependency query builder
+     * @return the builder instance.
+     */
+    public static DependencyQueryBuilder newBuilder() {
+        return new DependencyQueryBuilder();
+    }
+    
+    /**
+     * Creates a simple query. The query runs offline and uses available caches. Different
+     * behaviour can be configured by using {@link DependencyQueryBuilder}
+     * @param scopes scope(s) to query
+     * @return the query instance
+     */
+    public static DependencyQuery newQuery(Scope... scopes) {
+        return newBuilder().scope(scopes).build();
+    }
+    
+    /**
+     * Builder that can create {@link DependencyQuery} instance.
+     */
+    public static final class DependencyQueryBuilder {
+        private Set<Scope> scopes;
+        private Dependency.Filter filter;
+        private boolean offline = true;
+        private boolean flush;
+        
+        private DependencyQueryBuilder() {
+        }
+        
+        public DependencyQuery build() {
+            if (scopes == null) {
+                scope(Scopes.COMPILE);
+            }
+            return new DependencyQuery(scopes, filter, offline, flush);
+        }
+        
+        public DependencyQueryBuilder filter(Dependency.Filter f) {
+            this.filter = f;
+            return this;
+        }
+        
+        public DependencyQueryBuilder scope(Scope... s) {
+            if (s == null || s.length == 0) {
+                return this;
+            }
+            if (scopes == null) {
+                scopes = new LinkedHashSet<>();
+            }
+            scopes.addAll(Arrays.asList(s));
+            return this;
+        }
+        
+        public DependencyQueryBuilder online() {
+            this.offline = false;
+            return this;
+        }
+        
+        public DependencyQueryBuilder offline() {
+            this.offline = true;
+            return this;
+        }
+        
+        public DependencyQueryBuilder withoutCaches() {
+            flush = true;
+            return this;
+        }
+    }
+    
+    public static final class DependencyQuery {
+        private final Set<Scope> scopes;
+        private final Dependency.Filter filter;
+        private final boolean offline;
+        private final boolean flushChaches;
+
+        private DependencyQuery(Set<Scope> scopes, Dependency.Filter filter, boolean offline, boolean flushCaches) {
+            this.scopes = scopes == null ? Collections.emptySet() : Collections.unmodifiableSet(new LinkedHashSet<>(scopes));
+            this.filter = filter;
+            this.offline = offline;
+            this.flushChaches = flushCaches;
+        }
+
+        public Set<Scope> getScopes() {
+            return scopes;
+        }
+
+        public Dependency.Filter getFilter() {
+            return filter;
+        }
+
+        public boolean isOffline() {
+            return offline;
+        }
+
+        public boolean isFlushChaches() {
+            return flushChaches;
         }
     }
 }

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectOperationException.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectOperationException.java
@@ -31,6 +31,11 @@ import org.netbeans.api.project.Project;
 public final class ProjectOperationException extends IllegalStateException {
     public enum State {
         /**
+         * Unexpected project system error, see the exception cause for details.
+         */
+        ERROR,
+        
+        /**
          * The project has not been yet fully initialized. The query can not
          * produce sane results.
          */
@@ -48,9 +53,9 @@ public final class ProjectOperationException extends IllegalStateException {
         OFFLINE,
         
         /**
-         * The project is OK
+         * The project is OK. The project operation threw an exception.
          */
-        OK,
+        OK
     }
     
     private final Project project;

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/Scope.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/Scope.java
@@ -56,6 +56,15 @@ public abstract class Scope {
     public abstract boolean exports(Scope s);
     
     /**
+     * Determines if artifacts in this scope apply to the other one. This is the reverse of {@link includes} and
+     * allows injection to existing scopes.
+     * 
+     * @param s the scope to test.
+     * @return true, if the scope 's' is implied (includes) this one.
+     */
+    public abstract boolean implies(Scope s);
+    
+    /**
      * @return name / identifier for the scope. Not subject to L10N.
      */
     public String name() {

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/Scopes.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/Scopes.java
@@ -18,7 +18,9 @@
  */
 package org.netbeans.modules.project.dependency;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -37,11 +39,6 @@ public final class Scopes {
     public static final Scope EXTERNAL = new DefaultScope("external", Collections.emptySet(), Collections.emptySet());
     
     /**
-     * Test dependencies.
-     */
-    public static final Scope TEST = new DefaultScope("test", Collections.emptySet(), Collections.emptySet());
-    
-    /**
      * Compile dependencies. Resources used by build tools to build the application. Includes 
      * {@link #PROCESS} but does not export it further.
      */
@@ -54,6 +51,24 @@ public final class Scopes {
     public static final Scope RUNTIME = new DefaultScope("runtime", Collections.singleton(COMPILE), Collections.emptySet());
     
     /**
+     * Test compile dependencies.
+     */
+    public static final Scope TEST_COMPILE = new DefaultScope("testCompile", 
+            new HashSet<>(Arrays.asList(PROCESS, COMPILE)), Collections.emptySet());
+    
+    /**
+     * Test compile dependencies.
+     */
+    public static final Scope TEST_RUNTIME = new DefaultScope("testRuntime", 
+            new HashSet<>(Arrays.asList(TEST_COMPILE)), Collections.emptySet());
+    
+    /**
+     * Test dependencies.
+     */
+    public static final Scope TEST = new DefaultScope("test", 
+            new HashSet<>(Arrays.asList(PROCESS, COMPILE, RUNTIME)), Collections.emptySet()).imply(TEST_RUNTIME, TEST_COMPILE);
+    
+    /**
      * Included resources.
     public static final Scope INCLUDED = new DefaultScope("included", Collections.emptySet(), Collections.emptySet());
      */
@@ -61,6 +76,7 @@ public final class Scopes {
     static final class DefaultScope extends Scope {
         private final Set<Scope> includes;
         private final Set<Scope> stops;
+        private Set<Scope> implies;
 
         public DefaultScope(String name, Set<Scope> includes, Set<Scope> stops) {
             super(name);
@@ -81,6 +97,16 @@ public final class Scopes {
         @Override
         public String toString() {
             return name();
+        }
+
+        @Override
+        public boolean implies(Scope s) {
+            return implies != null && implies.contains(s);
+        }
+        
+        public DefaultScope imply(Scope... scopes) {
+            this.implies = new HashSet<>(Arrays.asList(scopes));
+            return this;
         }
     }
 }

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/spi/ProjectDependenciesImplementation.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/spi/ProjectDependenciesImplementation.java
@@ -18,14 +18,11 @@
  */
 package org.netbeans.modules.project.dependency.spi;
 
-import java.util.Collection;
 import org.netbeans.api.annotations.common.NonNull;
-import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.modules.project.dependency.ArtifactSpec;
-import org.netbeans.modules.project.dependency.Dependency;
 import org.netbeans.modules.project.dependency.DependencyResult;
+import org.netbeans.modules.project.dependency.ProjectDependencies;
 import org.netbeans.modules.project.dependency.ProjectOperationException;
-import org.netbeans.modules.project.dependency.Scope;
 
 /**
  *
@@ -36,11 +33,6 @@ public interface ProjectDependenciesImplementation {
     public ArtifactSpec getProjectArtifact();
     
     @NonNull
-    public DependencyResult findDependencies(
-            @NullAllowed Collection<Scope> scopes, @NullAllowed Dependency.Filter filter)
+    public DependencyResult findDependencies(@NonNull ProjectDependencies.DependencyQuery query)
             throws ProjectOperationException;
-    /*
-    @CheckForNull
-    public Dependency mergeDependencies(@NonNull Dependency one, @NonNull Dependency two);
-    */
 }

--- a/java/maven.embedder/apichanges.xml
+++ b/java/maven.embedder/apichanges.xml
@@ -83,26 +83,21 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
-        
-        <!--change id="ProjectsRootNode-badging">
-           <api name="general"/>
-           <summary>Project root nodes automatically badged</summary>
-           <version major="1" minor="31"/>
-           <date day="9" month="6" year="2008"/>
-           <author login="jglick"/>
-           <compatibility modification="yes" semantic="compatible"/>
-           <description>
-               <p>
-                   Project root nodes will now automatically be badged
-                   according to VCS status of contained files.
-               </p>
-           </description>
-           <class package="org.netbeans.spi.project.ui" name="LogicalViewProvider"/>
-           <issue number="135399"/>
-        </change-->
-
-    
-        
+        <change id="dependency-multiple-scopes">
+            <api name="general"/>
+            <summary>Multiple scopes allowed for dependency tree query</summary>
+            <version major="2" minor="71"/>
+            <date day="1" month="6" year="2022"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes" modification="yes" semantic="compatible" deprecation="yes"/>
+            <description>
+                Multiple scopes can be specified when building dependency tree. Exceptions thrown from the
+                maven operations can be checked if the operation failed because of offline mode was selected.
+                See <a href="@TOP@/org/netbeans/modules/maven/embeddder/EmbedderFactory.html#isOfflineException-java.lang.Throwable-">EmbedderFactory.isOfflineException()</a>.
+            </description>
+            <class package="org.netbeans.modules.maven.embedder" name="EmbedderFactory"/>
+            <class package="org.netbeans.modules.maven.embedder" name="DependencyTreeFactory"/>
+        </change>
     </changes>
 
     <!-- Now the surrounding HTML text and document structure: -->

--- a/java/maven.embedder/manifest.mf
+++ b/java/maven.embedder/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven.embedder/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/embedder/Bundle.properties
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Specification-Version: 2.70
+OpenIDE-Module-Specification-Version: 2.71

--- a/java/maven.embedder/src/org/netbeans/modules/maven/embedder/EmbedderFactory.java
+++ b/java/maven.embedder/src/org/netbeans/modules/maven/embedder/EmbedderFactory.java
@@ -44,6 +44,7 @@ import org.netbeans.api.project.ui.ProjectGroup;
 import org.netbeans.api.project.ui.ProjectGroupChangeEvent;
 import org.netbeans.api.project.ui.ProjectGroupChangeListener;
 import org.netbeans.modules.maven.embedder.impl.ExtensionModule;
+import org.netbeans.modules.maven.embedder.impl.OfflineOperationError;
 import org.openide.filesystems.FileUtil;
 import org.openide.modules.InstalledFileLocator;
 import org.openide.util.NbPreferences;
@@ -513,5 +514,18 @@ public final class EmbedderFactory {
             properties.setProperty("env." + key, entry.getValue());
         }
         return properties;
+    }
+
+    /**
+     * Checks if the throwable is actually a report that operation failed because of
+     * offline mode. The errors are thrown if an operation attempts to go online despite
+     * that the maven session was configured for offline mode.
+     * 
+     * @param t throwable to check
+     * @return true, if the throwable 
+     * @since 2.71
+     */
+    public static boolean isOfflineException(Throwable t) {
+        return t instanceof OfflineOperationError;
     }
 }

--- a/java/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/OfflineConnector.java
+++ b/java/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/OfflineConnector.java
@@ -40,9 +40,9 @@ public final class OfflineConnector implements RepositoryConnectorFactory {
         // (No apparent way to suppress WRCF from the Plexus container; using "wagon" as the role hint does not work.)
         // Could also return a no-op RepositoryConnector which would perform no downloads.
         // But we anyway want to ensure that related code is consistently setting the offline flag on all Maven structures that require it.
-        throw new AssertionError();
+        throw new OfflineOperationError();
     }
-
+    
     @Override
     public float getPriority() {
         return Float.MAX_VALUE;

--- a/java/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/OfflineOperationError.java
+++ b/java/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/OfflineOperationError.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.embedder.impl;
+
+/**
+ * Marks abortion because of offline operation mode. The error is thrown internally
+ * by Maven embedder, when an online operation is attempted despite the session was
+ * marked as read-only
+ * @author sdedic
+ * @since 2.71
+ */
+public final class OfflineOperationError extends AssertionError {
+}

--- a/java/maven/.gitignore
+++ b/java/maven/.gitignore
@@ -1,1 +1,2 @@
 test/unit/data/parent-projects/**/target/
+test/unit/data/projects/**/target/

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -219,7 +219,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.54</specification-version>
+                        <specification-version>2.71</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven/test/unit/data/projects/dependencies/golden/testCompileDependencies
+++ b/java/maven/test/unit/data/projects/dependencies/golden/testCompileDependencies
@@ -1,5 +1,6 @@
 [ ] nbtest.grp:test-app:12.6[jar] / compilation
  +-- [ ] nbtest.grp:annotation:12.6[jar] / compilation
  +-- [ ] nbtest.grp:test-lib:12.6[jar] / compilation
+ |    +-- [ ] nbtest.grp:annotation:12.6[jar] / compilation
  |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
  |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation

--- a/java/maven/test/unit/data/projects/dependencies/golden/testRuntimeDependencies
+++ b/java/maven/test/unit/data/projects/dependencies/golden/testRuntimeDependencies
@@ -1,7 +1,9 @@
 [ ] nbtest.grp:test-app:12.6[jar] / compilation
  +-- [ ] nbtest.grp:annotation:12.6[jar] / compilation
  +-- [ ] nbtest.grp:test-lib:12.6[jar] / compilation
+ |    +-- [ ] nbtest.grp:annotation:12.6[jar] / compilation
  |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
  |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
  +-- [ ] nbtest.grp:test-lib4:12.6[jar] / runtime
  +-- [ ] org.slf4j:slf4j-jdk14:1.7.36[jar] / runtime
+ |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / runtime

--- a/java/maven/test/unit/data/projects/dependencies/repo/grp/test-lib/12.6/_remote.repositories
+++ b/java/maven/test/unit/data/projects/dependencies/repo/grp/test-lib/12.6/_remote.repositories
@@ -1,4 +1,4 @@
 #NOTE: This is a Maven Resolver internal implementation file, its format can be changed without prior notice.
-#Tue May 24 16:10:16 CEST 2022
+#Wed Jun 01 16:58:08 CEST 2022
 test-lib-12.6.jar>=
 test-lib-12.6.pom>=

--- a/java/maven/test/unit/data/projects/dependencies/repo/grp/test-lib/12.6/test-lib-12.6.jardir/META-INF/maven/nbtest.grp/test-lib/pom.xml
+++ b/java/maven/test/unit/data/projects/dependencies/repo/grp/test-lib/12.6/test-lib-12.6.jardir/META-INF/maven/nbtest.grp/test-lib/pom.xml
@@ -39,7 +39,7 @@
             <groupId>nbtest.grp</groupId>
             <artifactId>test-lib3</artifactId>
             <version>12.6</version>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/java/maven/test/unit/data/projects/dependencies/repo/grp/test-lib/12.6/test-lib-12.6.pom
+++ b/java/maven/test/unit/data/projects/dependencies/repo/grp/test-lib/12.6/test-lib-12.6.pom
@@ -39,7 +39,7 @@
             <groupId>nbtest.grp</groupId>
             <artifactId>test-lib3</artifactId>
             <version>12.6</version>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/java/maven/test/unit/data/projects/dependencies/src/test-lib/pom.xml
+++ b/java/maven/test/unit/data/projects/dependencies/src/test-lib/pom.xml
@@ -39,7 +39,7 @@
             <groupId>nbtest.grp</groupId>
             <artifactId>test-lib3</artifactId>
             <version>12.6</version>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenDependenciesImplementationTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenDependenciesImplementationTest.java
@@ -140,7 +140,7 @@ public class MavenDependenciesImplementationTest extends NbTestCase {
         
         primeProject(p);
         
-        DependencyResult dr = ProjectDependencies.findDependencies(p, null, Scopes.COMPILE);
+        DependencyResult dr = ProjectDependencies.findDependencies(p, ProjectDependencies.newQuery(Scopes.COMPILE));
         Dependency root = dr.getRoot();
         assertContents(printDependencyTree(root), getName());
     }
@@ -157,7 +157,7 @@ public class MavenDependenciesImplementationTest extends NbTestCase {
         
         primeProject(p);
         
-        DependencyResult dr = ProjectDependencies.findDependencies(p, null, Scopes.RUNTIME);
+        DependencyResult dr = ProjectDependencies.findDependencies(p, ProjectDependencies.newQuery(Scopes.RUNTIME));
         Dependency root = dr.getRoot();
         assertContents(printDependencyTree(root), getName());
     }
@@ -174,7 +174,7 @@ public class MavenDependenciesImplementationTest extends NbTestCase {
  
         primeProject(p);
 
-        DependencyResult dr = ProjectDependencies.findDependencies(p, null, Scopes.RUNTIME);
+        DependencyResult dr = ProjectDependencies.findDependencies(p, ProjectDependencies.newQuery(Scopes.RUNTIME));
         
         Dependency dep = dr.getRoot().getChildren().stream().filter(d -> d.getArtifact().getArtifactId().equals("test-lib")).findAny().get();
         SourceLocation srcLoc = dr.getDeclarationRange(dep);
@@ -202,7 +202,7 @@ public class MavenDependenciesImplementationTest extends NbTestCase {
 
         primeProject(p);
 
-        DependencyResult dr = ProjectDependencies.findDependencies(p, null, Scopes.RUNTIME);
+        DependencyResult dr = ProjectDependencies.findDependencies(p, ProjectDependencies.newQuery(Scopes.RUNTIME));
         
         Dependency libDep = dr.getRoot().getChildren().stream().filter(d -> d.getArtifact().getArtifactId().equals("test-lib")).findAny().get();
         Dependency annoDep = libDep.getChildren().stream().filter(d -> d.getArtifact().getArtifactId().equals("javax.annotation-api")).findAny().get();


### PR DESCRIPTION
During testing (and usage), it turned out that the newer `DependencyGraphBuilder` does not give out as much information as the older `DependencyTreeBuilder`. Namely duplicated artifacts are omitted from the dependency report and in case of a version clash, the clashing artifact is **removed at all** from the report.

So this PR mainly rewrites the maven implementation back to the older API so that more info can be pulled out from maven.

I've realized that the client may need to allow artifact fetching (online / offline mode) as well as order to flush caches before running the query. I changed the private API so that `DependencyQuery` object is now used as a parameter (+ added a `Builder` for it). Further extensions should be API-compatible.

Strangely enough, our infrastructure (?) sometimes fails to configure the session properly (?) or maybe Maven does not propagate the offline flag everywhere, so our `RepositoryConnector` pulls on an emergency brake and throws `AssertionError` to abort the unexpected and disallowed online operation. I've added a test method to see whether the throwable is an 'offline' exception.

I've extended `DependencyTreeFactory` API to allow multiple scopes to be specified; and also wraps maven internal errors into `MavenExecutionException` instead of just returning `null` (which can't be inspected for what happened). The older method variant remains compatible (catches, logs, returns `null`).

Note: I've **removed** a method from `DependencyTreeFactory` that has been accidentally added by previous commit (ea62da49). This version was not released yet.