### PR TITLE
Add property sheet for Gradle Configuration nodes

### DIFF
--- a/extide/gradle/nbproject/project.xml
+++ b/extide/gradle/nbproject/project.xml
@@ -314,7 +314,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.38.1</specification-version>
+                        <specification-version>7.62</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +54,8 @@ import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.initialization.IncludedBuild;
@@ -417,8 +420,16 @@ class NbProjectInfoBuilder {
             String propBase = "configuration_" + it.getName() + "_";
             model.getInfo().put(propBase + "non_resolving", !resolvable(it));
             model.getInfo().put(propBase + "transitive",  it.isTransitive());
+            model.getInfo().put(propBase + "canBeConsumed", it.isCanBeConsumed());
             model.getInfo().put(propBase + "extendsFrom",  it.getExtendsFrom().stream().map(c -> c.getName()).collect(Collectors.toCollection(HashSet::new)));
             model.getInfo().put(propBase + "description",  it.getDescription());
+
+            Map<String, String> attributes = new LinkedHashMap<>();
+            AttributeContainer attrs = it.getAttributes();
+            for (Attribute<?> attr : attrs.keySet()) {
+                attributes.put(attr.getName(), String.valueOf(attrs.getAttribute(attr)));
+            }
+            model.getInfo().put(propBase + "attributes", attributes);
         });
         //visibleConfigurations = visibleConfigurations.findAll() { resolvable(it) }
         visibleConfigurations.forEach(it -> {

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
@@ -284,6 +284,11 @@ class GradleBaseProjectBuilder implements ProjectInfoExtractor.Result {
                 Boolean transitive = (Boolean) info.get("configuration_" + name + "_transitive");
                 conf.transitive = transitive == null ? true : transitive;
 
+                Boolean canBeConsumed = (Boolean) info.get("configuration_" + name + "_canBeConsumed");
+                conf.canBeConsumed = canBeConsumed == null ? false : canBeConsumed;
+
+                conf.attributes = (Map<String, String>) info.get("configuration_" + name + "_attributes");
+
                 conf.description = (String) info.get("configuration_" + name + "_description");
             }
             for (String name : configurationNames) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleConfiguration.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleConfiguration.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.gradle.api;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import org.netbeans.modules.gradle.GradleModuleFileCache21;
 
@@ -41,6 +42,8 @@ public final class GradleConfiguration implements Serializable, ModuleSearchSupp
     GradleDependency.FileCollectionDependency files;
     boolean transitive;
     boolean canBeResolved = true;
+    boolean canBeConsumed;
+    Map<String, String> attributes;
 
     GradleConfiguration(String name) {
         this.name = name;
@@ -117,6 +120,29 @@ public final class GradleConfiguration implements Serializable, ModuleSearchSupp
 
     public boolean isCanBeResolved() {
         return canBeResolved;
+    }
+
+    /**
+     * Returns {@code true} if this configuration is to be consumed.
+     * 
+     * @return {@code true} if this configuration is consumable.
+     * @since 2.24
+     */
+    public boolean isCanBeConsumed() {
+        return canBeConsumed;
+    }
+
+    /**
+     * Returns the attributes of this configuration. The returned map is a
+     * simplified version of the Gradle configuration
+     * {@link https://docs.gradle.org/current/javadoc/org/gradle/api/attributes/AttributeContainer.html AttributeContainer},
+     * where the attribute names are the keys and the attribute string values are the values.
+     *
+     * @return the attributes of this configuration
+     * @since 2.24
+     */
+    public Map<String, String> getAttributes() {
+        return attributes != null ? attributes : Collections.emptyMap();
     }
 
     public boolean isEmpty() {

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
@@ -45,7 +45,7 @@ import org.netbeans.modules.gradle.spi.GradleFiles;
 public final class ProjectInfoDiskCache extends AbstractDiskCache<GradleFiles, QualifiedProjectInfo> {
 
     // Increase this number if new info is gathered from the projects.
-    private static final int COMPATIBLE_CACHE_VERSION = 21;
+    private static final int COMPATIBLE_CACHE_VERSION = 22;
     private static final String INFO_CACHE_FILE_NAME = "project-info.ser"; //NOI18N
     private static final Map<GradleFiles, ProjectInfoDiskCache> DISK_CACHES = Collections.synchronizedMap(new WeakHashMap<>());
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1381701/171725362-5643bec6-5058-48fe-91ee-197bbc4db39e.png)

Added more information on configuration both to the UI and to the API. The API supports reading simplified configuration attributes which can be useful debugging variant matching.  Planning to support published artifacts and capabilities in upcoming PR-s.