### PR TITLE
Try to generate maven project skeleton from our dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,9 +158,6 @@ jobs:
       - name: Extract
         run: tar --zstd -xf build.tar.zst
 
-      - name: Get maven coordinates
-        run: ant getallmavencoordinates
-
       - name: Build nbms
         run: ant build-nbms
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/MavenSkeletonProject.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/MavenSkeletonProject.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.nbbuild.extlibs;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Task;
+
+/**
+ * Task to check that external libraries have legitimate licenses, etc.
+ */
+public class MavenSkeletonProject extends Task {
+
+    private File nball;
+
+    public void setNball(File nball) {
+        this.nball = nball;
+    }
+
+    private File mavenfolderFile;
+
+    /**
+     * JUnit-format XML result file to generate, rather than halting the build.
+     */
+    public void setMavenFolder(File report) {
+        this.mavenfolderFile = report;
+    }
+
+    private Set<String> modules;
+
+    public @Override
+    void execute() throws BuildException {
+        try { // XXX workaround for http://issues.apache.org/bugzilla/show_bug.cgi?id=43398
+            if (getProject().getProperty("allmodules") != null) {
+                modules = new TreeSet<>(Arrays.asList(getProject().getProperty("allmodules").split("[, ]+")));
+                modules.add("nbbuild");
+            } else {
+                Path nbAllPath = nball.toPath();
+                modules = new TreeSet<>(
+                        Files.walk(nbAllPath)
+                                .filter(p -> Files.exists(p.resolve("external/binaries-list")))
+                                .map(p -> nbAllPath.relativize(p))
+                                .map(p -> p.toString())
+                                .collect(Collectors.toSet())
+                );
+            }
+            try {
+                buildLibPomForMaven();
+            } catch (IOException x) {
+                throw new BuildException(x, getLocation());
+            }
+
+        } catch (NullPointerException | IOException x) {
+            x.printStackTrace();
+            throw new BuildException(x);
+        }
+    }
+
+    private void buildLibPomForMaven() throws IOException {
+        Path pseudoMaven = mavenfolderFile.toPath();
+        if (Files.exists(pseudoMaven)) {
+            Files.walk(pseudoMaven).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+        }
+        Path pseudoMavendirectory = Files.createDirectory(pseudoMaven);
+        Path parentPom = Files.createFile(pseudoMavendirectory.resolve("pom.xml"));
+        Files.write(parentPom, ("<project>"
+                + "\n  <modelVersion>4.0.0</modelVersion>"
+                + "\n  <groupId>com.mycompany.app</groupId>"
+                + "\n  <artifactId>my-app</artifactId>"
+                + "\n  <version>1</version>"
+                + "\n  <packaging>pom</packaging>"
+                + "<distributionManagement>\n"
+                + "    <site><id>dummy</id><url>https://netbeans.apache.org/dummy</url><name>dummy</name></site>\n"
+                + "  </distributionManagement>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        Files.write(parentPom, "\n  <modules>".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        for (String module : modules) {
+            File d = new File(new File(nball, module), "external");
+            if (d.exists() && d.isDirectory()) {
+                String moduleName = module.replace("/", "").replace(".", "");
+                Files.write(parentPom, ("\n    <module>" + moduleName + "</module>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                Path modulesPathFolder = Files.createDirectory(pseudoMavendirectory.resolve(moduleName));
+                Path moduleparentPom = Files.createFile(modulesPathFolder.resolve("pom.xml"));
+                Files.write(moduleparentPom, ("<project>"
+                        + "\n  <modelVersion>4.0.0</modelVersion>"
+                        + "\n  <parent><groupId>com.mycompany.app</groupId><artifactId>my-app</artifactId><version>1</version></parent>"
+                        + "\n  <groupId>com.mycompany.app</groupId>"
+                        + "\n  <artifactId>" + moduleName + "</artifactId>"
+                        + "\n  <version>1</version>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+                Files.write(moduleparentPom, "\n  <dependencies>".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+
+                File list = new File(d, "binaries-list");
+                if (list.isFile()) {
+
+                    try ( Reader r = new FileReader(list)) {
+                        BufferedReader br = new BufferedReader(r);
+                        String line;
+                        while ((line = br.readLine()) != null) {
+                            if (line.startsWith("#")) {
+                                continue;
+                            }
+                            if (line.trim().length() == 0) {
+                                continue;
+                            }
+                            String[] hashAndFile = line.split(" ", 2);
+                            if (hashAndFile.length < 2) {
+                                throw new BuildException("Bad line '" + line + "' in " + list);
+                            }
+                            if (MavenCoordinate.isMavenFile(hashAndFile[1])) {
+                                MavenCoordinate coordinate = MavenCoordinate.fromGradleFormat(hashAndFile[1]);
+                                Files.write(moduleparentPom, ("\n    <dependency>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                                Files.write(moduleparentPom, ("\n    <groupId>" + coordinate.getGroupId() + "</groupId>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                                Files.write(moduleparentPom, ("\n    <artifactId>" + coordinate.getArtifactId() + "</artifactId>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                                Files.write(moduleparentPom, ("\n    <version>" + coordinate.getVersion() + "</version>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                                Files.write(moduleparentPom, ("\n    <type>" + coordinate.getExtension() + "</type>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+
+                                if (coordinate.hasClassifier()) {
+                                    Files.write(moduleparentPom, ("\n    <classifier>" + coordinate.getClassifier() + "</classifier>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                                }
+                                Files.write(moduleparentPom, ("\n    </dependency>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                            }
+                        }
+                    }
+                }
+                Files.write(moduleparentPom, "\n  </dependencies>".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                Files.write(moduleparentPom, "</project>".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+
+            }
+        }
+        Files.write(parentPom, "\n  </modules>".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        Files.write(parentPom, ("\n  <build>\n"
+                + "        <pluginManagement>\n"
+                + "            <plugins>\n"
+                + "                <plugin>\n"
+                + "                    <artifactId>maven-site-plugin</artifactId>\n"
+                + "                    <version>4.0.0-M1</version>\n"
+                + "                </plugin>\n"
+                + "            </plugins>\n"
+                + "        </pluginManagement>\n"
+                + "  </build>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+
+        Files.write(parentPom, ("\n  <reporting>\n"
+                + "    <plugins>\n"
+                + "      <plugin>\n"
+                + "        <groupId>org.owasp</groupId>\n"
+                + "        <artifactId>dependency-check-maven</artifactId>\n"
+                + "        <version>7.1.0</version>\n"
+                + "        <configuration>\n"
+                + "          <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>\n"
+                + "          <failOnError>false</failOnError>\n"
+                + "        </configuration>\n"
+                + "        <reportSets>\n"
+                + "          <reportSet>\n"
+                + "            <reports>\n"
+                + "              <report>aggregate</report>\n"
+                + "            </reports>\n"
+                + "          </reportSet>\n"
+                + "        </reportSets>\n"
+                + "      </plugin>\n"
+                + "      \n"
+                + "      <plugin>\n"
+                + "        <groupId>org.codehaus.mojo</groupId>\n"
+                + "        <artifactId>versions-maven-plugin</artifactId>\n"
+                + "        <version>2.11.0</version>\n"
+                + "        <reportSets>\n"
+                + "          <reportSet>\n"
+                + "            <reports>\n"
+                + "              <report>dependency-updates-report</report>\n"
+                + "            </reports>\n"
+                + "          </reportSet>\n"
+                + "        </reportSets>\n"
+                + "      </plugin>\n"
+                + "    </plugins>\n"
+                + "  </reporting>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        Files.write(parentPom, "</project>".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+
+    }
+
+}

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/MavenSkeletonProject.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/MavenSkeletonProject.java
@@ -67,7 +67,6 @@ public class MavenSkeletonProject extends Task {
                 modules.add("nbbuild");
             } else {
                 Path nbAllPath = nball.toPath();
-                modules = new TreeSet<>();
                 try ( Stream<Path> walk = Files.walk(nbAllPath)) {
                     modules = new TreeSet<>(
                             walk.filter(p -> Files.exists(p.resolve("external/binaries-list")))

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
@@ -95,15 +95,14 @@ public class VerifyLibsAndLicenses extends Task {
             modules.add("nbbuild");
         } else {
             Path nbAllPath = nball.toPath();
-            modules = new TreeSet<>();
-                try ( Stream<Path> walk = Files.walk(nbAllPath)) {
-                    modules = new TreeSet<>(
-                            walk.filter(p -> Files.exists(p.resolve("external/binaries-list")))
-                                    .map(p -> nbAllPath.relativize(p))
-                                    .map(p -> p.toString())
-                                    .collect(Collectors.toSet())
-                    );
-                }
+            try ( Stream<Path> walk = Files.walk(nbAllPath)) {
+                modules = new TreeSet<>(
+                        walk.filter(p -> Files.exists(p.resolve("external/binaries-list")))
+                                .map(p -> nbAllPath.relativize(p))
+                                .map(p -> p.toString())
+                                .collect(Collectors.toSet())
+                );
+            }
         }
         try {
             testNoStrayThirdPartyBinaries();
@@ -429,7 +428,7 @@ public class VerifyLibsAndLicenses extends Task {
 
     private void testLicenseinfo() throws IOException {
         Path nballPath = nball.toPath();
-        List<File> licenseinfofiles = new ArrayList<>();
+        List<File> licenseinfofiles;
         try ( Stream<Path> walk = Files.walk(nballPath)) {
             licenseinfofiles = walk
                     .filter(p -> p.endsWith("licenseinfo.xml"))

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/VerifyLibsAndLicenses.java
@@ -32,14 +32,11 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -79,12 +76,6 @@ public class VerifyLibsAndLicenses extends Task {
     public void setReport(File report) {
         this.reportFile = report;
     }
-    
-    private File mavenfolderFile;
-    /** JUnit-format XML result file to generate, rather than halting the build. */
-    public void setMavenFolder(File report) {
-        this.mavenfolderFile = report;
-    }
 
     private boolean haltonfailure;
     /** JUnit-format XML result file to generate, rather than halting the build. */
@@ -117,7 +108,6 @@ public class VerifyLibsAndLicenses extends Task {
             testLicenses();
             testBinaryUniqueness();
             testLicenseinfo();
-            buildLibPomForMaven();
         } catch (IOException x) {
             throw new BuildException(x, getLocation());
         }
@@ -130,125 +120,6 @@ public class VerifyLibsAndLicenses extends Task {
         } catch (NullPointerException | IOException x) {x.printStackTrace(); throw new BuildException(x);}
     }
 
-    private void buildLibPomForMaven() throws IOException {
-        Path pseudoMaven = mavenfolderFile.toPath();
-        if (Files.exists(pseudoMaven)) {
-            Files.walk(pseudoMaven).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-        }
-        Path pseudoMavendirectory = Files.createDirectory(pseudoMaven);
-        Path parentPom = Files.createFile(pseudoMavendirectory.resolve("pom.xml"));
-        Files.write(parentPom,("<project>"
-                + "\n  <modelVersion>4.0.0</modelVersion>"
-                + "\n  <groupId>com.mycompany.app</groupId>"
-                + "\n  <artifactId>my-app</artifactId>"
-                + "\n  <version>1</version>"
-                + "\n  <packaging>pom</packaging>"+
-                "<distributionManagement>\n" +
-"    <site><id>dummy</id><url>https://netbeans.apache.org/dummy</url><name>dummy</name></site>\n" +
-"  </distributionManagement>").getBytes(StandardCharsets.UTF_8),StandardOpenOption.CREATE,StandardOpenOption.APPEND);
-        Files.write(parentPom,"\n  <modules>".getBytes(StandardCharsets.UTF_8),StandardOpenOption.APPEND);
-        for (String module : modules) {
-            File d = new File(new File(nball, module), "external");
-            if (d.exists() && d.isDirectory()) {
-                String moduleName = module.replace("/", "").replace(".", "");
-                Files.write(parentPom, ("\n    <module>" + moduleName + "</module>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
-                Path modulesPathFolder = Files.createDirectory(pseudoMavendirectory.resolve(moduleName));
-                Path moduleparentPom = Files.createFile(modulesPathFolder.resolve("pom.xml"));
-                Files.write(moduleparentPom, ("<project>"
-                        + "\n  <modelVersion>4.0.0</modelVersion>"
-                        + "\n  <parent><groupId>com.mycompany.app</groupId><artifactId>my-app</artifactId><version>1</version></parent>"
-                        + "\n  <groupId>com.mycompany.app</groupId>"
-                        + "\n  <artifactId>" + moduleName + "</artifactId>"
-                        + "\n  <version>1</version>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
-                Files.write(moduleparentPom, "\n  <dependencies>".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
-
-                File list = new File(d, "binaries-list");
-                if (list.isFile()) {
-                    
-                    try ( Reader r = new FileReader(list)) {
-                        BufferedReader br = new BufferedReader(r);
-                        String line;
-                        while ((line = br.readLine()) != null) {
-                            if (line.startsWith("#")) {
-                                continue;
-                            }
-                            if (line.trim().length() == 0) {
-                                continue;
-                            }
-                            String[] hashAndFile = line.split(" ", 2);
-                            if (hashAndFile.length < 2) {
-                                throw new BuildException("Bad line '" + line + "' in " + list);
-                            }
-                            if (MavenCoordinate.isMavenFile(hashAndFile[1])) {
-                                MavenCoordinate coordinate = MavenCoordinate.fromGradleFormat(hashAndFile[1]);
-                                Files.write(moduleparentPom,("\n    <dependency>").getBytes(StandardCharsets.UTF_8),StandardOpenOption.APPEND);
-                                Files.write(moduleparentPom,("\n    <groupId>"+coordinate.getGroupId()+"</groupId>").getBytes(StandardCharsets.UTF_8),StandardOpenOption.APPEND);
-                                Files.write(moduleparentPom,("\n    <artifactId>"+coordinate.getArtifactId()+"</artifactId>").getBytes(StandardCharsets.UTF_8),StandardOpenOption.APPEND);
-                                Files.write(moduleparentPom,("\n    <version>"+coordinate.getVersion()+"</version>").getBytes(StandardCharsets.UTF_8),StandardOpenOption.APPEND);
-                                Files.write(moduleparentPom,("\n    <type>"+coordinate.getExtension()+"</type>").getBytes(StandardCharsets.UTF_8),StandardOpenOption.APPEND);
-                                
-                                if (coordinate.hasClassifier()) {
-                                   Files.write(moduleparentPom,("\n    <classifier>"+coordinate.getClassifier()+"</classifier>").getBytes(StandardCharsets.UTF_8),StandardOpenOption.APPEND);
-                                }
-                                Files.write(moduleparentPom,("\n    </dependency>").getBytes(StandardCharsets.UTF_8),StandardOpenOption.APPEND);                                                   
-                            } 
-                        }
-                    }
-                }
-                Files.write(moduleparentPom,"\n  </dependencies>".getBytes(StandardCharsets.UTF_8),StandardOpenOption.APPEND);
-                Files.write(moduleparentPom,"</project>".getBytes(StandardCharsets.UTF_8),StandardOpenOption.APPEND);
-        
-            }
-        }
-        Files.write(parentPom, "\n  </modules>".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
-        Files.write(parentPom, ("\n  <build>\n"
-                + "        <pluginManagement>\n"
-                + "            <plugins>\n"
-                + "                <plugin>\n"
-                + "                    <artifactId>maven-site-plugin</artifactId>\n"
-                + "                    <version>4.0.0-M1</version>\n"
-                + "                </plugin>\n"
-                + "            </plugins>\n"
-                + "        </pluginManagement>\n"
-                + "  </build>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
-
-        Files.write(parentPom, ("\n  <reporting>\n"
-                + "    <plugins>\n"
-                + "      <plugin>\n"
-                + "        <groupId>org.owasp</groupId>\n"
-                + "        <artifactId>dependency-check-maven</artifactId>\n"
-                + "        <version>7.1.0</version>\n"
-                + "        <configuration>\n"
-                + "          <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>\n"
-                + "          <failOnError>false</failOnError>\n"
-                + "        </configuration>\n"
-                + "        <reportSets>\n"
-                + "          <reportSet>\n"
-                + "            <reports>\n"
-                + "              <report>aggregate</report>\n"
-                + "            </reports>\n"
-                + "          </reportSet>\n"
-                + "        </reportSets>\n"
-                + "      </plugin>\n"
-                + "      \n"
-                + "      <plugin>\n"
-                + "        <groupId>org.codehaus.mojo</groupId>\n"
-                + "        <artifactId>versions-maven-plugin</artifactId>\n"
-                + "        <version>2.11.0</version>\n"
-                + "        <reportSets>\n"
-                + "          <reportSet>\n"
-                + "            <reports>\n"
-                + "              <report>dependency-updates-report</report>\n"
-                + "            </reports>\n"
-                + "          </reportSet>\n"
-                + "        </reportSets>\n"
-                + "      </plugin>\n"
-                + "    </plugins>\n"
-                + "  </reporting>").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
-        Files.write(parentPom,"</project>".getBytes(StandardCharsets.UTF_8),StandardOpenOption.APPEND);
-        
-    }
-    
     private void testBinaryUniqueness() throws IOException {
         List<String> ignoredPatterns = loadPatterns("ignored-overlaps");
         StringBuffer msg = new StringBuffer();
@@ -552,20 +423,20 @@ public class VerifyLibsAndLicenses extends Task {
         }
         pseudoTests.put("testLicenses", msg.length() > 0 ? "Some license files have incorrect headers" + msg : null);
     }
-    
+
     private void testLicenseinfo() throws IOException {
         Path nballPath = nball.toPath();
         List<File> licenseinfofiles = Files.walk(nballPath)
                 .filter(p -> p.endsWith("licenseinfo.xml"))
                 .map(p -> p.toFile())
                 .collect(Collectors.toList());
-        
+
         File licenses = new File(new File(nball, "nbbuild"), "licenses");
         StringBuilder msg = new StringBuilder();
-        
+
         for (File licenseInfoFile: licenseinfofiles) {
             String path = nballPath.relativize(licenseInfoFile.toPath()).toString();
-            
+
             Licenseinfo li;
             try {
                 li = Licenseinfo.parse(licenseInfoFile);
@@ -576,7 +447,7 @@ public class VerifyLibsAndLicenses extends Task {
                 msg.append(ex.getMessage());
                 continue;
             }
-            
+
             for(Fileset fs: li.getFilesets()) {
                 for(File f: fs.getFiles()) {
                     if(! f.exists()) {
@@ -604,10 +475,10 @@ public class VerifyLibsAndLicenses extends Task {
                 }
             }
         }
- 
+
         pseudoTests.put("testLicenseinfo", msg.length() > 0 ? "Some licenseinfo.xml files failed verification:" + msg : null);
     }
-    
+
     private static String templateMatch(String actual, String expected, boolean left) {
         String reason = null;
         boolean expectReason = false;

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -1591,13 +1591,17 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
     <target name="verify-all-libs-and-licenses" depends="bootstrap,download-all-extbins" description="Verify the contents of third-party libraries and licenses.">
         <taskdef name="verifylibsandlicenses" classname="org.netbeans.nbbuild.extlibs.VerifyLibsAndLicenses" classpath="${nbantext.jar}"/>
         <property name="verify-libs-and-licenses.haltonfailure" value="false" />
-        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" mavenfolder="${nb.build.dir}/mavenpoms" nball=".." haltonfailure="${verify-libs-and-licenses.haltonfailure}" />
+        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" nball=".." haltonfailure="${verify-libs-and-licenses.haltonfailure}" />
+        <taskdef name="mavenskeletonbuild" classname="org.netbeans.nbbuild.extlibs.MavenSkeletonProject" classpath="${nbantext.jar}"/>
+        <mavenskeletonbuild mavenfolder="${nb.build.dir}/mavenpoms" nball=".." />        
     </target>
 
     <target name="verify-libs-and-licenses" depends="bootstrap,download-selected-extbins" description="Verify the contents of third-party libraries and licenses in the selected configuration.">
         <taskdef name="verifylibsandlicenses" classname="org.netbeans.nbbuild.extlibs.VerifyLibsAndLicenses" classpath="${nbantext.jar}"/>
         <property name="verify-libs-and-licenses.haltonfailure" value="false" />
-        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" mavenfolder="${nb.build.dir}/mavenpoms" nball=".." haltonfailure="${verify-libs-and-licenses.haltonfailure}" />
+        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" nball=".." haltonfailure="${verify-libs-and-licenses.haltonfailure}" />
+        <taskdef name="mavenskeletonbuild" classname="org.netbeans.nbbuild.extlibs.MavenSkeletonProject" classpath="${nbantext.jar}"/>
+        <mavenskeletonbuild mavenfolder="${nb.build.dir}/mavenpoms" nball=".." />        
     </target>
 
     <target name="create-mandatory-files-for-binary" depends="bootstrap,download-selected-extbins" description="Create a summary of the licenses used by libraries in the build.">

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -244,26 +244,6 @@ metabuild.hash=${metabuild.hash}</echo>
   </target>
 
   <!-- create list of all maven coordinate -->
-  <target name="getallmavencoordinates">
-      <concat destfile="${nb_all}/nbbuild/build/external.info">
-          <fileset dir="${nb_all}" includes="**/external/binaries-list" />
-          <fileset dir="${nb_all}" includes="**/external/binariesembedded-list" />
-          <filterchain>
-              <!-- remove comment inline not inline -->
-              <tokenfilter>
-                  <replaceregex pattern="#(.*)$" replace="" flags="gim" />
-              </tokenfilter>
-              <!-- : is sparator for maven coordinate -->
-              <linecontains>
-                  <contains value=":"/>
-              </linecontains>
-              <!--  needed as separator -->
-              <tokenfilter>
-                  <replacestring from=" " to=";"/>
-              </tokenfilter>
-          </filterchain>
-      </concat>
-  </target>
   <target name="download-selected-extbins" unless="ext.binaries.downloaded" depends="init-module-list">
     <echo>Downloading external binaries (*/external/ directories) for cluster.config=${cluster.config}...</echo>
     <pathconvert property="modules.binaries-list" pathsep=",">
@@ -1611,13 +1591,13 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
     <target name="verify-all-libs-and-licenses" depends="bootstrap,download-all-extbins" description="Verify the contents of third-party libraries and licenses.">
         <taskdef name="verifylibsandlicenses" classname="org.netbeans.nbbuild.extlibs.VerifyLibsAndLicenses" classpath="${nbantext.jar}"/>
         <property name="verify-libs-and-licenses.haltonfailure" value="false" />
-        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" nball=".." haltonfailure="${verify-libs-and-licenses.haltonfailure}" />
+        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" mavenfolder="${nb.build.dir}/mavenpoms" nball=".." haltonfailure="${verify-libs-and-licenses.haltonfailure}" />
     </target>
 
     <target name="verify-libs-and-licenses" depends="bootstrap,download-selected-extbins" description="Verify the contents of third-party libraries and licenses in the selected configuration.">
         <taskdef name="verifylibsandlicenses" classname="org.netbeans.nbbuild.extlibs.VerifyLibsAndLicenses" classpath="${nbantext.jar}"/>
         <property name="verify-libs-and-licenses.haltonfailure" value="false" />
-        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" nball=".." haltonfailure="${verify-libs-and-licenses.haltonfailure}" />
+        <verifylibsandlicenses report="${nb.build.dir}/verifylibsandlicenses.xml" mavenfolder="${nb.build.dir}/mavenpoms" nball=".." haltonfailure="${verify-libs-and-licenses.haltonfailure}" />
     </target>
 
     <target name="create-mandatory-files-for-binary" depends="bootstrap,download-selected-extbins" description="Create a summary of the licenses used by libraries in the build.">


### PR DESCRIPTION
Try to generate a maven multimodule pom from externals libraries located in nbbuild/build/mavenpoms.

remove getmavencoordinate I introduced a year ago to debug nb-repository

On this generated folder I tried
 mvn org.owasp:dependency-check-maven:7.1.0:check it could works (api rate limitation) some blocker due to too old dep.

 was thinking to push the pseudo maven project to https://github.com/apache/netbeans-temp and put a dependatbot on it.
