### PR TITLE
Debugger Line Breakpoint Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -358,7 +358,7 @@ matrix:
             - hide-logs.sh ant $OPTS -f java/debugger.jpda.projects test
             - hide-logs.sh ant $OPTS -f java/debugger.jpda.projectsui test
             #- ant $OPTS -f java/debugger.jpda.truffle test
-            #- ant $OPTS -f java/debugger.jpda.ui test
+            - hide-logs.sh ant $OPTS -f java/debugger.jpda.ui test-unit
             - travis_wait hide-logs.sh ant $OPTS -f java/editor.htmlui test
             #- travis_wait 30 hide-logs.sh  ant $OPTS -f java/form test
             - ant $OPTS -f java/hudson.maven test

--- a/ide/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
+++ b/ide/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
@@ -66,6 +66,7 @@ public class DebuggerProcessor extends LayerGeneratingProcessor {
     public @Override Set<String> getSupportedAnnotationTypes() {
         return new HashSet<String>(Arrays.asList(
             ActionsProvider.Registration.class.getCanonicalName(),
+            ActionsProvider.Registrations.class.getCanonicalName(),
             DebuggerEngineProvider.Registration.class.getCanonicalName(),
             SessionProvider.Registration.class.getCanonicalName(),
             LazyActionsManagerListener.Registration.class.getCanonicalName(),

--- a/ide/api.debugger/src/org/netbeans/spi/debugger/ActionsProviderSupport.java
+++ b/ide/api.debugger/src/org/netbeans/spi/debugger/ActionsProviderSupport.java
@@ -64,7 +64,7 @@ public abstract class ActionsProviderSupport extends ActionsProvider {
      * @param enabled the new state
      */
     protected final void setEnabled (Object action, boolean enabled) {
-        boolean fire = false;
+        boolean fire;
         if (enabled)
             fire = this.enabled.add (action);
         else

--- a/java/debugger.jpda.ui/manifest.mf
+++ b/java/debugger.jpda.ui/manifest.mf
@@ -3,7 +3,7 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.debugger.jpda.ui/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/debugger/jpda/ui/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/debugger/jpda/resources/mf-layer.xml
-OpenIDE-Module-Specification-Version: 1.71
+OpenIDE-Module-Specification-Version: 1.72
 OpenIDE-Module-Requires: org.netbeans.api.debugger.jpda.JPDADebuggerEngineImpl,
   org.netbeans.spi.debugger.ui
 OpenIDE-Module-Provides: org.netbeans.modules.debugger.jpda.ui

--- a/java/debugger.jpda.ui/nbproject/project.xml
+++ b/java/debugger.jpda.ui/nbproject/project.xml
@@ -343,6 +343,13 @@
                         <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
                     </test-dependency>
                 </test-type>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                </test-type>
             </test-dependencies>
             <friend-packages>
                 <friend>org.netbeans.modules.debugger.jpda.truffle</friend>

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/Bundle.properties
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/Bundle.properties
@@ -317,3 +317,5 @@ ACSN_LineBreakpoint=Line Breakpoint properties
 ACSN_FieldBreakpoint=Field Breakpoint properties
 ACSN_ExceptionBreakpoint=Exception Breakpoint properties
 TTT_ExceptionClassName=The class name representing the exception.
+TTT_TF_Class_Name=Optional class name to stop at with * wildcard before and after
+MSG_ClassPatternWrong=Class name pattern can only contains single * at beginning or end

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/LineBreakpointPanel.form
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/LineBreakpointPanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 
@@ -113,7 +113,7 @@
           </AccessibilityProperties>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="0" gridY="3" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
+              <GridBagConstraints gridX="0" gridY="4" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -131,7 +131,35 @@
           </AccessibilityProperties>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="1" gridY="3" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="10" weightX="1.0" weightY="0.0"/>
+              <GridBagConstraints gridX="1" gridY="4" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="10" weightX="1.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel2">
+          <Properties>
+            <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+              <ComponentRef name="tfClassName"/>
+            </Property>
+            <Property name="text" type="java.lang.String" value="Class name:"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="17" weightX="0.0" weightY="0.0"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JTextField" name="tfClassName">
+          <Properties>
+            <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="org/netbeans/modules/debugger/jpda/ui/breakpoints/Bundle.properties" key="TTT_TF_Class_Name" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+            </Property>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="tfClassNameActionPerformed"/>
+          </Events>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+              <GridBagConstraints gridX="1" gridY="2" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="10" weightX="0.0" weightY="0.0"/>
             </Constraint>
           </Constraints>
         </Component>

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/LineBreakpointPanel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/LineBreakpointPanel.java
@@ -103,6 +103,7 @@ public class LineBreakpointPanel extends JPanel implements ControllerProvider, o
         if (createBreakpoint) {
             tfFileName.setEditable(true);
         }
+        tfClassName.setText(b.getPreferredClassName());
 
         String urlStr = b.getURL();
         logger.fine("LineBreakpointPanel("+urlStr+")");
@@ -142,6 +143,7 @@ public class LineBreakpointPanel extends JPanel implements ControllerProvider, o
         pActions.add (actionsPanel, "Center");  // NOI18N
 
         tfFileName.getDocument().addDocumentListener(validityDocumentListener);
+        tfClassName.getDocument().addDocumentListener(validityDocumentListener);
         tfLineNumber.getDocument().addDocumentListener(validityDocumentListener);
         SwingUtilities.invokeLater(new Runnable() {
             public void run() {
@@ -192,6 +194,8 @@ public class LineBreakpointPanel extends JPanel implements ControllerProvider, o
         tfFileName = new javax.swing.JTextField();
         jLabel1 = new javax.swing.JLabel();
         tfLineNumber = new javax.swing.JTextField();
+        jLabel2 = new javax.swing.JLabel();
+        tfClassName = new javax.swing.JTextField();
         cPanel = new javax.swing.JPanel();
         pActions = new javax.swing.JPanel();
         jPanel1 = new javax.swing.JPanel();
@@ -229,7 +233,7 @@ public class LineBreakpointPanel extends JPanel implements ControllerProvider, o
         org.openide.awt.Mnemonics.setLocalizedText(jLabel1, bundle.getString("L_Line_Breakpoint_Line_Number")); // NOI18N
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridy = 4;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(3, 3, 3, 3);
@@ -239,7 +243,7 @@ public class LineBreakpointPanel extends JPanel implements ControllerProvider, o
         tfLineNumber.setToolTipText(bundle.getString("TTT_TF_Line_Breakpoint_Line_Number")); // NOI18N
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridy = 4;
         gridBagConstraints.gridwidth = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.weightx = 1.0;
@@ -247,6 +251,30 @@ public class LineBreakpointPanel extends JPanel implements ControllerProvider, o
         pSettings.add(tfLineNumber, gridBagConstraints);
         tfLineNumber.getAccessibleContext().setAccessibleName("Line number");
         tfLineNumber.getAccessibleContext().setAccessibleDescription(bundle.getString("ACSD_TF_Line_Breakpoint_Line_Number")); // NOI18N
+
+        jLabel2.setLabelFor(tfClassName);
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel2, "Class name:");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(3, 3, 3, 3);
+        pSettings.add(jLabel2, gridBagConstraints);
+
+        tfClassName.setToolTipText(org.openide.util.NbBundle.getMessage(LineBreakpointPanel.class, "TTT_TF_Class_Name")); // NOI18N
+        tfClassName.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                tfClassNameActionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.insets = new java.awt.Insets(3, 3, 3, 3);
+        pSettings.add(tfClassName, gridBagConstraints);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
@@ -278,6 +306,9 @@ public class LineBreakpointPanel extends JPanel implements ControllerProvider, o
         getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(LineBreakpointPanel.class, "ACSN_LineBreakpoint")); // NOI18N
     }// </editor-fold>//GEN-END:initComponents
 
+    private void tfClassNameActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_tfClassNameActionPerformed
+    }//GEN-LAST:event_tfClassNameActionPerformed
+
     
     // Controller implementation ...............................................
     
@@ -285,14 +316,39 @@ public class LineBreakpointPanel extends JPanel implements ControllerProvider, o
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel cPanel;
     private javax.swing.JLabel jLabel1;
+    private javax.swing.JLabel jLabel2;
     private javax.swing.JLabel jLabel3;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel pActions;
     private javax.swing.JPanel pSettings;
+    private javax.swing.JTextField tfClassName;
     private javax.swing.JTextField tfFileName;
     private javax.swing.JTextField tfLineNumber;
     // End of variables declaration//GEN-END:variables
 
+    static boolean isClassNamePatternValid(String pn) {
+        if (pn != null) {
+            if (pn.equals("*")) {
+                return false;
+            }
+            boolean starts = pn.startsWith("*");
+            boolean ends = pn.endsWith("*");
+            if (starts && ends) {
+                return false;
+            }
+            if (starts) {
+                pn = pn.substring(1);
+            }
+            if (ends) {
+                pn = pn.substring(0, pn.length() - 1);
+            }
+            if (pn.contains("*")) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
     public Controller getController() {
         return controller;
     }
@@ -322,10 +378,18 @@ public class LineBreakpointPanel extends JPanel implements ControllerProvider, o
             breakpoint.setCondition (conditionsPanel.getCondition());
             breakpoint.setHitCountFilter(conditionsPanel.getHitCount(),
                     conditionsPanel.getHitCountFilteringStyle());
-
+            breakpoint.setPreferredClassName(findPreferredClassName());
             if (createBreakpoint)
                 DebuggerManager.getDebuggerManager ().addBreakpoint (breakpoint);
             return true;
+        }
+
+        private String findPreferredClassName() {
+            final String text = tfClassName.getText();
+            if (text != null && text.trim().length() == 0) {
+                return null;
+            }
+            return text;
         }
 
         /**
@@ -357,9 +421,16 @@ public class LineBreakpointPanel extends JPanel implements ControllerProvider, o
                 setValid(false);
                 return ;
             } else if (!"text/x-java".equals(fo.getMIMEType())) {
-                setErrorMessage(NbBundle.getMessage(LineBreakpointPanel.class, "MSG_NonJava_File_Spec"));
+                if (findPreferredClassName() == null) {
+                    setErrorMessage(NbBundle.getMessage(LineBreakpointPanel.class, "MSG_NonJava_File_Spec"));
+                    setValid(false);
+                    return ;
+                }
+            }
+            if (!isClassNamePatternValid(findPreferredClassName())) {
+                setErrorMessage(NbBundle.getMessage(LineBreakpointPanel.class, "MSG_ClassPatternWrong"));
                 setValid(false);
-                return ;
+                return;
             }
             int line;
             try {

--- a/java/debugger.jpda.ui/test/unit/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/LineBreakpointPanelTest.java
+++ b/java/debugger.jpda.ui/test/unit/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/LineBreakpointPanelTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.debugger.jpda.ui.breakpoints;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class LineBreakpointPanelTest {
+
+    @Test
+    public void testClassNameIsValid() {
+        boolean result = LineBreakpointPanel.isClassNamePatternValid("java.lang.Integer");
+        assertEquals(true, result);
+    }
+
+    @Test
+    public void testSimpleClassNamePrefixedWithStar() {
+        boolean result = LineBreakpointPanel.isClassNamePatternValid("*.Integer");
+        assertEquals(true, result);
+    }
+
+    @Test
+    public void testClassNameWithPostfix() {
+        boolean result = LineBreakpointPanel.isClassNamePatternValid("java.lang.Integer*");
+        assertEquals(true, result);
+    }
+
+    @Test
+    public void starInMiddleIsntValid() {
+        boolean result = LineBreakpointPanel.isClassNamePatternValid("java.*.Integer*");
+        assertEquals(false, result);
+    }
+
+    @Test
+    public void bothPrefixAndSuffixStarIsInvalid() {
+        boolean result = LineBreakpointPanel.isClassNamePatternValid("*.Integer*");
+        assertEquals(false, result);
+    }
+
+    @Test
+    public void justStarIsInvalid() {
+        boolean result = LineBreakpointPanel.isClassNamePatternValid("*");
+        assertEquals(false, result);
+    }
+
+
+}


### PR DESCRIPTION
While debugging mixed [Java/Scala application](http://enso.org) I realized there is `LineBreakpoint.preferredClassName` and found it quite useful. This PR exposes its value to users. By default the field is empty, but it can be used like on the following screenshot:

![image](https://user-images.githubusercontent.com/1842422/171984579-f7237589-9ecd-4760-91ba-bbf25e190ca2.png)

There was a bug in `DebuggerProcessor`. If one used only `@ActionsProvider.Registrations` and no other annotations, the processor wasn't triggered.
