### PR TITLE
Regex checker UI improvements

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/Bundle.properties
@@ -111,15 +111,17 @@ DESC_AnnoProcessor_ObsoleteSupportedSource=If the project's source level is grea
     another useless warning during compilation. <p/>\
     It is recommended to return at least the current project's source level. \
     For future compatibility, consider to return <b>SourceVersion.latest()</b>; most Processors are not affected by future language changes.
-CheckRegexTopComponent.regexLabel.text=Re&gular Expression:
-CheckRegexTopComponent.exampleLabel.text=E&xample:
-CheckRegexTopComponent.strictCheckBox.text=Str&ict Check
 
 #{0}: PatternSyntaxException.getDescription()
 #{1}: PatternSyntaxException.getMessage()
 #{2}: PatternSyntaxException.getPattern()
 #{3}: PatternSyntaxException.getIndex()
 DN_RegExp=Invalid regular expression: {0}
+
+CheckRegexTopComponent.regexLabel.text=Re&gular Expression:
+CheckRegexTopComponent.exampleLabel.text=E&xample:
+CheckRegexTopComponent.strictCheckBox.text=Str&ict Check
+CheckRegexTopComponent.strictCheckBox.toolTipText=Always match full String.
 CheckRegexTopComponent.flagsButton.text=Regex Flags
 CheckRegexTopComponent.dotAllMenuItem.text=DOTALL
 CheckRegexTopComponent.caseInsensitiveMenuItem.text=CASE_INSENSITIVE
@@ -140,10 +142,8 @@ CheckRegexTopComponent.canonEqMenuItem.text=CANON_EQ
 CheckRegexTopComponent.unixLinesMenuItem.toolTipText=Only the '\\n' line terminator is recognized in the behavior of ., ^, and $
 CheckRegexTopComponent.canonEqMenuItem.toolTipText=Enables canonical equivalence=
 CheckRegexTopComponent.examplesButton.text=Generate Examples
-CheckRegexTopComponent.regexLabel1.text=Re&gular Expression:
-RegexExampleVisualPanel1.regExLabel.text=Regular Expression:
-RegexExampleVisualPanel1.numberField.text=10
-RegexExampleVisualPanel1.NoLabel.text=No.:
-RegexExampleVisualPanel1.regenerateButton.text=Regenerate
-RegexExampleVisualPanel1.REGEX_EXAMPLES=Regex Examples
-RegexExampleVisualPanel1.exampleTextArea.invalidText=Input valid number
+RegexExampleGeneratorPanel.REGEX_EXAMPLES=Regex Examples
+RegexExampleGeneratorPanel.regExLabel.text=Regular Expression:
+RegexExampleGeneratorPanel.regenerateButton.text=Regenerate
+RegexExampleGeneratorPanel.NoLabel.text=No.:
+RegexExampleGeneratorPanel.numberField.text=10

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/CheckRegexTopComponent.form
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/CheckRegexTopComponent.form
@@ -148,64 +148,6 @@
         </MenuItem>
       </SubComponents>
     </Container>
-    <Container class="javax.swing.JFrame" name="examplesFrame">
-      <Properties>
-        <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
-          <Color id="Default Cursor"/>
-        </Property>
-        <Property name="locationByPlatform" type="boolean" value="true"/>
-      </Properties>
-
-      <Layout>
-        <DimensionLayout dim="0">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="jScrollPane1" min="-2" pref="306" max="-2" attributes="0"/>
-                      <Component id="regexLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <EmptySpace max="32767" attributes="0"/>
-              </Group>
-          </Group>
-        </DimensionLayout>
-        <DimensionLayout dim="1">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="1" attributes="0">
-                  <EmptySpace pref="15" max="32767" attributes="0"/>
-                  <Component id="regexLabel1" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="jScrollPane1" min="-2" pref="235" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-              </Group>
-          </Group>
-        </DimensionLayout>
-      </Layout>
-      <SubComponents>
-        <Container class="javax.swing.JScrollPane" name="jScrollPane1">
-          <AuxValues>
-            <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
-          </AuxValues>
-
-          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
-          <SubComponents>
-            <Component class="javax.swing.JTextArea" name="jTextArea1">
-              <Properties>
-                <Property name="columns" type="int" value="20"/>
-                <Property name="rows" type="int" value="5"/>
-              </Properties>
-            </Component>
-          </SubComponents>
-        </Container>
-        <Component class="javax.swing.JLabel" name="regexLabel1">
-          <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="CheckRegexTopComponent.regexLabel1.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-            </Property>
-          </Properties>
-        </Component>
-      </SubComponents>
-    </Container>
   </NonVisualComponents>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="1"/>
@@ -222,174 +164,39 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" attributes="0">
+          <Group type="102" alignment="1" attributes="0">
+              <EmptySpace min="-2" pref="7" max="-2" attributes="0"/>
+              <Component id="flagsButton" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="regexLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                  <Component id="exampleLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="regexScrollPane" min="-2" pref="320" max="-2" attributes="0"/>
-                      <EmptySpace min="-2" pref="62" max="-2" attributes="0"/>
-                      <Component id="errorLabel" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <Component id="exampleLayeredPane" alignment="0" min="-2" max="-2" attributes="0"/>
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="-2" pref="1" max="-2" attributes="0"/>
-                      <Component id="flagsButton" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="examplesButton" min="-2" max="-2" attributes="0"/>
-                  </Group>
-              </Group>
-              <EmptySpace min="-2" pref="266" max="-2" attributes="0"/>
+              <Component id="examplesButton" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
+              <Component id="strictCheckBox" min="-2" max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="6" max="-2" attributes="0"/>
+          </Group>
+          <Group type="102" alignment="0" attributes="0">
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="verticalSplitPane" pref="453" max="32767" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="1" attributes="0">
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Component id="regexLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="regexScrollPane" min="-2" pref="42" max="-2" attributes="0"/>
-                  <Component id="errorLabel" min="-2" max="-2" attributes="0"/>
-              </Group>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
-              <Component id="exampleLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Component id="exampleLayeredPane" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="verticalSplitPane" pref="186" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="flagsButton" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="examplesButton" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="strictCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
   </Layout>
   <SubComponents>
-    <Component class="javax.swing.JLabel" name="regexLabel">
-      <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="CheckRegexTopComponent.regexLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-      </Properties>
-    </Component>
-    <Container class="javax.swing.JScrollPane" name="regexScrollPane">
-      <Properties>
-        <Property name="verticalScrollBarPolicy" type="int" value="21"/>
-        <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[164, 74]"/>
-        </Property>
-      </Properties>
-      <AuxValues>
-        <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
-      </AuxValues>
-
-      <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
-      <SubComponents>
-        <Component class="javax.swing.JTextArea" name="regexTextArea">
-          <Properties>
-            <Property name="columns" type="int" value="20"/>
-            <Property name="rows" type="int" value="5"/>
-            <Property name="focusAccelerator" type="char" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-              <Connection code="&apos;g&apos;" type="code"/>
-            </Property>
-          </Properties>
-          <Events>
-            <EventHandler event="keyReleased" listener="java.awt.event.KeyListener" parameters="java.awt.event.KeyEvent" handler="regexTextAreaKeyReleased"/>
-          </Events>
-        </Component>
-      </SubComponents>
-    </Container>
-    <Component class="javax.swing.JLabel" name="exampleLabel">
-      <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="CheckRegexTopComponent.exampleLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-      </Properties>
-    </Component>
-    <Container class="javax.swing.JLayeredPane" name="exampleLayeredPane">
-
-      <Layout>
-        <DimensionLayout dim="0">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="1" attributes="0">
-                  <EmptySpace pref="297" max="32767" attributes="0"/>
-                  <Component id="iconLabel" min="-2" pref="17" max="-2" attributes="0"/>
-                  <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
-                  <Component id="strictCheckBox" min="-2" max="-2" attributes="0"/>
-              </Group>
-              <Group type="103" rootIndex="1" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="exampleScrollPane" min="-2" pref="320" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="15" max="32767" attributes="0"/>
-                  </Group>
-              </Group>
-          </Group>
-        </DimensionLayout>
-        <DimensionLayout dim="1">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="0" attributes="0">
-                  <EmptySpace min="-2" pref="21" max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="strictCheckBox" min="-2" max="-2" attributes="0"/>
-                      <Component id="iconLabel" min="-2" pref="18" max="-2" attributes="0"/>
-                  </Group>
-                  <EmptySpace pref="9" max="32767" attributes="0"/>
-              </Group>
-              <Group type="103" rootIndex="1" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="exampleScrollPane" min="-2" pref="44" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="6" max="32767" attributes="0"/>
-                  </Group>
-              </Group>
-          </Group>
-        </DimensionLayout>
-      </Layout>
-      <SubComponents>
-        <Component class="javax.swing.JLabel" name="iconLabel">
-        </Component>
-        <Container class="javax.swing.JScrollPane" name="exampleScrollPane">
-          <Properties>
-            <Property name="verticalScrollBarPolicy" type="int" value="21"/>
-            <Property name="opaque" type="boolean" value="false"/>
-          </Properties>
-          <AuxValues>
-            <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
-          </AuxValues>
-
-          <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
-          <SubComponents>
-            <Component class="javax.swing.JTextArea" name="exampleTextArea">
-              <Properties>
-                <Property name="columns" type="int" value="20"/>
-                <Property name="rows" type="int" value="5"/>
-                <Property name="focusAccelerator" type="char" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                  <Connection code="&apos;x&apos;" type="code"/>
-                </Property>
-              </Properties>
-              <Events>
-                <EventHandler event="keyReleased" listener="java.awt.event.KeyListener" parameters="java.awt.event.KeyEvent" handler="exampleTextAreaKeyReleased"/>
-              </Events>
-            </Component>
-          </SubComponents>
-        </Container>
-        <Component class="javax.swing.JCheckBox" name="strictCheckBox">
-          <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="CheckRegexTopComponent.strictCheckBox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-            </Property>
-          </Properties>
-          <Events>
-            <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="strictCheckBoxItemStateChanged"/>
-          </Events>
-        </Component>
-      </SubComponents>
-    </Container>
-    <Component class="javax.swing.JLabel" name="errorLabel">
-    </Component>
     <Component class="javax.swing.JButton" name="flagsButton">
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
@@ -409,6 +216,247 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="examplesButtonActionPerformed"/>
       </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+      </AuxValues>
     </Component>
+    <Component class="javax.swing.JCheckBox" name="strictCheckBox">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="CheckRegexTopComponent.strictCheckBox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+        <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="CheckRegexTopComponent.strictCheckBox.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="strictCheckBoxItemStateChanged"/>
+      </Events>
+    </Component>
+    <Container class="javax.swing.JSplitPane" name="verticalSplitPane">
+      <Properties>
+        <Property name="dividerLocation" type="int" value="80"/>
+        <Property name="orientation" type="int" value="0"/>
+      </Properties>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>
+      <SubComponents>
+        <Container class="javax.swing.JPanel" name="regexPanel">
+          <Properties>
+            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[517, 80]"/>
+            </Property>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout$JSplitPaneConstraintsDescription">
+              <JSplitPaneConstraints position="top"/>
+            </Constraint>
+          </Constraints>
+
+          <Layout>
+            <DimensionLayout dim="0">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" attributes="0">
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="regexScrollPane" pref="441" max="32767" attributes="0"/>
+                          <Group type="102" attributes="0">
+                              <Component id="regexLabel" min="-2" max="-2" attributes="0"/>
+                              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                          </Group>
+                          <Component id="errorLabel" max="32767" attributes="0"/>
+                      </Group>
+                      <EmptySpace max="-2" attributes="0"/>
+                  </Group>
+              </Group>
+            </DimensionLayout>
+            <DimensionLayout dim="1">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" alignment="0" attributes="0">
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="regexLabel" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="regexScrollPane" pref="30" max="32767" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="errorLabel" min="-2" max="-2" attributes="0"/>
+                  </Group>
+              </Group>
+            </DimensionLayout>
+          </Layout>
+          <SubComponents>
+            <Component class="javax.swing.JLabel" name="regexLabel">
+              <Properties>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="CheckRegexTopComponent.regexLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+              </AuxValues>
+            </Component>
+            <Container class="javax.swing.JScrollPane" name="regexScrollPane">
+              <Properties>
+                <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                  <Dimension value="[6, 30]"/>
+                </Property>
+                <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                  <Dimension value="[164, 74]"/>
+                </Property>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
+              </AuxValues>
+
+              <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+              <SubComponents>
+                <Component class="javax.swing.JTextArea" name="regexTextArea">
+                  <Properties>
+                    <Property name="columns" type="int" value="20"/>
+                    <Property name="rows" type="int" value="5"/>
+                    <Property name="focusAccelerator" type="char" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                      <Connection code="&apos;g&apos;" type="code"/>
+                    </Property>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="keyReleased" listener="java.awt.event.KeyListener" parameters="java.awt.event.KeyEvent" handler="regexTextAreaKeyReleased"/>
+                  </Events>
+                </Component>
+              </SubComponents>
+            </Container>
+            <Component class="javax.swing.JLabel" name="errorLabel">
+              <Properties>
+                <Property name="foreground" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                  <Color blue="0" green="0" red="ff" type="rgb"/>
+                </Property>
+                <Property name="text" type="java.lang.String" value="dummy error message" noResource="true"/>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+              </AuxValues>
+            </Component>
+          </SubComponents>
+        </Container>
+        <Container class="javax.swing.JPanel" name="examplePanel">
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+          </AuxValues>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout$JSplitPaneConstraintsDescription">
+              <JSplitPaneConstraints position="right"/>
+            </Constraint>
+          </Constraints>
+
+          <Layout>
+            <DimensionLayout dim="0">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" alignment="0" attributes="0">
+                      <EmptySpace min="-2" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="exampleLayeredPane" max="32767" attributes="0"/>
+                          <Group type="102" attributes="0">
+                              <Component id="exampleLabel" min="-2" max="-2" attributes="0"/>
+                              <EmptySpace min="0" pref="386" max="32767" attributes="0"/>
+                          </Group>
+                      </Group>
+                      <EmptySpace max="-2" attributes="0"/>
+                  </Group>
+              </Group>
+            </DimensionLayout>
+            <DimensionLayout dim="1">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" alignment="0" attributes="0">
+                      <EmptySpace min="-2" max="-2" attributes="0"/>
+                      <Component id="exampleLabel" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="exampleLayeredPane" max="32767" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                  </Group>
+              </Group>
+            </DimensionLayout>
+          </Layout>
+          <SubComponents>
+            <Component class="javax.swing.JLabel" name="exampleLabel">
+              <Properties>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="CheckRegexTopComponent.exampleLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+              </AuxValues>
+            </Component>
+            <Container class="javax.swing.JLayeredPane" name="exampleLayeredPane">
+              <Properties>
+                <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+                  <Dimension value="[0, 40]"/>
+                </Property>
+              </Properties>
+
+              <Layout>
+                <DimensionLayout dim="0">
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" alignment="1" attributes="0">
+                          <EmptySpace max="32767" attributes="0"/>
+                          <Component id="iconLabel" min="-2" pref="17" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                      </Group>
+                      <Group type="103" rootIndex="1" groupAlignment="0" attributes="0">
+                          <Component id="exampleScrollPane" alignment="0" pref="278" max="32767" attributes="0"/>
+                      </Group>
+                  </Group>
+                </DimensionLayout>
+                <DimensionLayout dim="1">
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="iconLabel" min="-2" pref="18" max="-2" attributes="0"/>
+                          <EmptySpace pref="42" max="32767" attributes="0"/>
+                      </Group>
+                      <Group type="103" rootIndex="1" groupAlignment="0" attributes="0">
+                          <Group type="102" alignment="0" attributes="0">
+                              <Component id="exampleScrollPane" pref="86" max="32767" attributes="0"/>
+                              <EmptySpace max="-2" attributes="0"/>
+                          </Group>
+                      </Group>
+                  </Group>
+                </DimensionLayout>
+              </Layout>
+              <SubComponents>
+                <Component class="javax.swing.JLabel" name="iconLabel">
+                </Component>
+                <Container class="javax.swing.JScrollPane" name="exampleScrollPane">
+                  <Properties>
+                    <Property name="opaque" type="boolean" value="false"/>
+                  </Properties>
+                  <AuxValues>
+                    <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
+                  </AuxValues>
+
+                  <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+                  <SubComponents>
+                    <Component class="javax.swing.JTextArea" name="exampleTextArea">
+                      <Properties>
+                        <Property name="columns" type="int" value="20"/>
+                        <Property name="rows" type="int" value="5"/>
+                        <Property name="focusAccelerator" type="char" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                          <Connection code="&apos;x&apos;" type="code"/>
+                        </Property>
+                      </Properties>
+                      <Events>
+                        <EventHandler event="keyReleased" listener="java.awt.event.KeyListener" parameters="java.awt.event.KeyEvent" handler="exampleTextAreaKeyReleased"/>
+                      </Events>
+                    </Component>
+                  </SubComponents>
+                </Container>
+              </SubComponents>
+            </Container>
+          </SubComponents>
+        </Container>
+      </SubComponents>
+    </Container>
   </SubComponents>
 </Form>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/CheckRegexTopComponent.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/CheckRegexTopComponent.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.java.hints.jdk;
 
 import java.awt.Color;
-import java.util.ArrayList;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -39,7 +38,7 @@ import org.openide.windows.Mode;
 import org.openide.windows.WindowManager;
 
 /**
- * Top component which displays something.
+ * Top component for inspecting regular expressions.
  */
 @ConvertAsProperties(
         dtd = "-//org.netbeans.modules.java.hints.jdk//CheckRegex//EN",
@@ -72,6 +71,7 @@ public final class CheckRegexTopComponent extends TopComponent {
     
     public CheckRegexTopComponent() {
         initComponents();
+        errorLabel.setVisible(false);
         setName(Bundle.CTL_CheckRegexTopComponent());
         setToolTipText(Bundle.HINT_CheckRegexTopComponent());
         isStrictMatch = false;
@@ -95,22 +95,21 @@ public final class CheckRegexTopComponent extends TopComponent {
         canonEqMenuItem = new javax.swing.JCheckBoxMenuItem();
         unicodeCaseMenuItem = new javax.swing.JCheckBoxMenuItem();
         unicodeCharacterClassMenuItem = new javax.swing.JCheckBoxMenuItem();
-        examplesFrame = new javax.swing.JFrame();
-        jScrollPane1 = new javax.swing.JScrollPane();
-        jTextArea1 = new javax.swing.JTextArea();
-        regexLabel1 = new javax.swing.JLabel();
-        regexLabel = new javax.swing.JLabel();
+        flagsButton = new javax.swing.JButton();
+        javax.swing.JButton examplesButton = new javax.swing.JButton();
+        strictCheckBox = new javax.swing.JCheckBox();
+        verticalSplitPane = new javax.swing.JSplitPane();
+        regexPanel = new javax.swing.JPanel();
+        javax.swing.JLabel regexLabel = new javax.swing.JLabel();
         regexScrollPane = new javax.swing.JScrollPane();
         regexTextArea = new javax.swing.JTextArea();
-        exampleLabel = new javax.swing.JLabel();
+        errorLabel = new javax.swing.JLabel();
+        javax.swing.JPanel examplePanel = new javax.swing.JPanel();
+        javax.swing.JLabel exampleLabel = new javax.swing.JLabel();
         exampleLayeredPane = new javax.swing.JLayeredPane();
         iconLabel = new javax.swing.JLabel();
         exampleScrollPane = new javax.swing.JScrollPane();
         exampleTextArea = new javax.swing.JTextArea();
-        strictCheckBox = new javax.swing.JCheckBox();
-        errorLabel = new javax.swing.JLabel();
-        flagsButton = new javax.swing.JButton();
-        examplesButton = new javax.swing.JButton();
 
         org.openide.awt.Mnemonics.setLocalizedText(multilineMenuItem, org.openide.util.NbBundle.getMessage(CheckRegexTopComponent.class, "CheckRegexTopComponent.multilineMenuItem.text")); // NOI18N
         multilineMenuItem.setToolTipText(org.openide.util.NbBundle.getMessage(CheckRegexTopComponent.class, "CheckRegexTopComponent.multilineMenuItem.toolTipText")); // NOI18N
@@ -193,105 +192,6 @@ public final class CheckRegexTopComponent extends TopComponent {
         });
         flagsPopupMenu.add(unicodeCharacterClassMenuItem);
 
-        examplesFrame.setCursor(new java.awt.Cursor(java.awt.Cursor.DEFAULT_CURSOR));
-        examplesFrame.setLocationByPlatform(true);
-
-        jTextArea1.setColumns(20);
-        jTextArea1.setRows(5);
-        jScrollPane1.setViewportView(jTextArea1);
-
-        org.openide.awt.Mnemonics.setLocalizedText(regexLabel1, org.openide.util.NbBundle.getMessage(CheckRegexTopComponent.class, "CheckRegexTopComponent.regexLabel1.text")); // NOI18N
-
-        javax.swing.GroupLayout examplesFrameLayout = new javax.swing.GroupLayout(examplesFrame.getContentPane());
-        examplesFrame.getContentPane().setLayout(examplesFrameLayout);
-        examplesFrameLayout.setHorizontalGroup(
-            examplesFrameLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(examplesFrameLayout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(examplesFrameLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 306, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(regexLabel1))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-        );
-        examplesFrameLayout.setVerticalGroup(
-            examplesFrameLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, examplesFrameLayout.createSequentialGroup()
-                .addContainerGap(15, Short.MAX_VALUE)
-                .addComponent(regexLabel1)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 235, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap())
-        );
-
-        org.openide.awt.Mnemonics.setLocalizedText(regexLabel, org.openide.util.NbBundle.getMessage(CheckRegexTopComponent.class, "CheckRegexTopComponent.regexLabel.text")); // NOI18N
-
-        regexScrollPane.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER);
-        regexScrollPane.setPreferredSize(new java.awt.Dimension(164, 74));
-
-        regexTextArea.setColumns(20);
-        regexTextArea.setRows(5);
-        regexTextArea.setFocusAccelerator('g');
-        regexTextArea.addKeyListener(new java.awt.event.KeyAdapter() {
-            public void keyReleased(java.awt.event.KeyEvent evt) {
-                regexTextAreaKeyReleased(evt);
-            }
-        });
-        regexScrollPane.setViewportView(regexTextArea);
-
-        org.openide.awt.Mnemonics.setLocalizedText(exampleLabel, org.openide.util.NbBundle.getMessage(CheckRegexTopComponent.class, "CheckRegexTopComponent.exampleLabel.text")); // NOI18N
-
-        exampleScrollPane.setVerticalScrollBarPolicy(javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER);
-        exampleScrollPane.setOpaque(false);
-
-        exampleTextArea.setColumns(20);
-        exampleTextArea.setRows(5);
-        exampleTextArea.setFocusAccelerator('x');
-        exampleTextArea.addKeyListener(new java.awt.event.KeyAdapter() {
-            public void keyReleased(java.awt.event.KeyEvent evt) {
-                exampleTextAreaKeyReleased(evt);
-            }
-        });
-        exampleScrollPane.setViewportView(exampleTextArea);
-
-        org.openide.awt.Mnemonics.setLocalizedText(strictCheckBox, org.openide.util.NbBundle.getMessage(CheckRegexTopComponent.class, "CheckRegexTopComponent.strictCheckBox.text")); // NOI18N
-        strictCheckBox.addItemListener(new java.awt.event.ItemListener() {
-            public void itemStateChanged(java.awt.event.ItemEvent evt) {
-                strictCheckBoxItemStateChanged(evt);
-            }
-        });
-
-        exampleLayeredPane.setLayer(iconLabel, javax.swing.JLayeredPane.DEFAULT_LAYER);
-        exampleLayeredPane.setLayer(exampleScrollPane, javax.swing.JLayeredPane.DEFAULT_LAYER);
-        exampleLayeredPane.setLayer(strictCheckBox, javax.swing.JLayeredPane.DEFAULT_LAYER);
-
-        javax.swing.GroupLayout exampleLayeredPaneLayout = new javax.swing.GroupLayout(exampleLayeredPane);
-        exampleLayeredPane.setLayout(exampleLayeredPaneLayout);
-        exampleLayeredPaneLayout.setHorizontalGroup(
-            exampleLayeredPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, exampleLayeredPaneLayout.createSequentialGroup()
-                .addContainerGap(297, Short.MAX_VALUE)
-                .addComponent(iconLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 17, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(12, 12, 12)
-                .addComponent(strictCheckBox))
-            .addGroup(exampleLayeredPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addGroup(exampleLayeredPaneLayout.createSequentialGroup()
-                    .addComponent(exampleScrollPane, javax.swing.GroupLayout.PREFERRED_SIZE, 320, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addGap(0, 15, Short.MAX_VALUE)))
-        );
-        exampleLayeredPaneLayout.setVerticalGroup(
-            exampleLayeredPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(exampleLayeredPaneLayout.createSequentialGroup()
-                .addGap(21, 21, 21)
-                .addGroup(exampleLayeredPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(strictCheckBox)
-                    .addComponent(iconLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 18, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-            .addGroup(exampleLayeredPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addGroup(exampleLayeredPaneLayout.createSequentialGroup()
-                    .addComponent(exampleScrollPane, javax.swing.GroupLayout.PREFERRED_SIZE, 44, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addGap(0, 6, Short.MAX_VALUE)))
-        );
-
         org.openide.awt.Mnemonics.setLocalizedText(flagsButton, org.openide.util.NbBundle.getMessage(CheckRegexTopComponent.class, "CheckRegexTopComponent.flagsButton.text")); // NOI18N
         flagsButton.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -306,45 +206,159 @@ public final class CheckRegexTopComponent extends TopComponent {
             }
         });
 
+        org.openide.awt.Mnemonics.setLocalizedText(strictCheckBox, org.openide.util.NbBundle.getMessage(CheckRegexTopComponent.class, "CheckRegexTopComponent.strictCheckBox.text")); // NOI18N
+        strictCheckBox.setToolTipText(org.openide.util.NbBundle.getMessage(CheckRegexTopComponent.class, "CheckRegexTopComponent.strictCheckBox.toolTipText")); // NOI18N
+        strictCheckBox.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                strictCheckBoxItemStateChanged(evt);
+            }
+        });
+
+        verticalSplitPane.setDividerLocation(80);
+        verticalSplitPane.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
+
+        regexPanel.setPreferredSize(new java.awt.Dimension(517, 80));
+
+        org.openide.awt.Mnemonics.setLocalizedText(regexLabel, org.openide.util.NbBundle.getMessage(CheckRegexTopComponent.class, "CheckRegexTopComponent.regexLabel.text")); // NOI18N
+
+        regexScrollPane.setMinimumSize(new java.awt.Dimension(6, 30));
+        regexScrollPane.setPreferredSize(new java.awt.Dimension(164, 74));
+
+        regexTextArea.setColumns(20);
+        regexTextArea.setRows(5);
+        regexTextArea.setFocusAccelerator('g');
+        regexTextArea.addKeyListener(new java.awt.event.KeyAdapter() {
+            public void keyReleased(java.awt.event.KeyEvent evt) {
+                regexTextAreaKeyReleased(evt);
+            }
+        });
+        regexScrollPane.setViewportView(regexTextArea);
+
+        errorLabel.setForeground(new java.awt.Color(255, 0, 0));
+        org.openide.awt.Mnemonics.setLocalizedText(errorLabel, "dummy error message"); // NOI18N
+
+        javax.swing.GroupLayout regexPanelLayout = new javax.swing.GroupLayout(regexPanel);
+        regexPanel.setLayout(regexPanelLayout);
+        regexPanelLayout.setHorizontalGroup(
+            regexPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(regexPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(regexPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(regexScrollPane, javax.swing.GroupLayout.DEFAULT_SIZE, 441, Short.MAX_VALUE)
+                    .addGroup(regexPanelLayout.createSequentialGroup()
+                        .addComponent(regexLabel)
+                        .addGap(0, 0, Short.MAX_VALUE))
+                    .addComponent(errorLabel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addContainerGap())
+        );
+        regexPanelLayout.setVerticalGroup(
+            regexPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(regexPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(regexLabel)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(regexScrollPane, javax.swing.GroupLayout.DEFAULT_SIZE, 30, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(errorLabel))
+        );
+
+        verticalSplitPane.setTopComponent(regexPanel);
+
+        org.openide.awt.Mnemonics.setLocalizedText(exampleLabel, org.openide.util.NbBundle.getMessage(CheckRegexTopComponent.class, "CheckRegexTopComponent.exampleLabel.text")); // NOI18N
+
+        exampleLayeredPane.setMinimumSize(new java.awt.Dimension(0, 40));
+
+        exampleScrollPane.setOpaque(false);
+
+        exampleTextArea.setColumns(20);
+        exampleTextArea.setRows(5);
+        exampleTextArea.setFocusAccelerator('x');
+        exampleTextArea.addKeyListener(new java.awt.event.KeyAdapter() {
+            public void keyReleased(java.awt.event.KeyEvent evt) {
+                exampleTextAreaKeyReleased(evt);
+            }
+        });
+        exampleScrollPane.setViewportView(exampleTextArea);
+
+        exampleLayeredPane.setLayer(iconLabel, javax.swing.JLayeredPane.DEFAULT_LAYER);
+        exampleLayeredPane.setLayer(exampleScrollPane, javax.swing.JLayeredPane.DEFAULT_LAYER);
+
+        javax.swing.GroupLayout exampleLayeredPaneLayout = new javax.swing.GroupLayout(exampleLayeredPane);
+        exampleLayeredPane.setLayout(exampleLayeredPaneLayout);
+        exampleLayeredPaneLayout.setHorizontalGroup(
+            exampleLayeredPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, exampleLayeredPaneLayout.createSequentialGroup()
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addComponent(iconLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 17, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap())
+            .addGroup(exampleLayeredPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                .addComponent(exampleScrollPane, javax.swing.GroupLayout.DEFAULT_SIZE, 278, Short.MAX_VALUE))
+        );
+        exampleLayeredPaneLayout.setVerticalGroup(
+            exampleLayeredPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(exampleLayeredPaneLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(iconLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 18, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap(42, Short.MAX_VALUE))
+            .addGroup(exampleLayeredPaneLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                .addGroup(exampleLayeredPaneLayout.createSequentialGroup()
+                    .addComponent(exampleScrollPane, javax.swing.GroupLayout.DEFAULT_SIZE, 86, Short.MAX_VALUE)
+                    .addContainerGap()))
+        );
+
+        javax.swing.GroupLayout examplePanelLayout = new javax.swing.GroupLayout(examplePanel);
+        examplePanel.setLayout(examplePanelLayout);
+        examplePanelLayout.setHorizontalGroup(
+            examplePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(examplePanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(examplePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(exampleLayeredPane, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addGroup(examplePanelLayout.createSequentialGroup()
+                        .addComponent(exampleLabel)
+                        .addGap(0, 386, Short.MAX_VALUE)))
+                .addContainerGap())
+        );
+        examplePanelLayout.setVerticalGroup(
+            examplePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(examplePanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(exampleLabel)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(exampleLayeredPane, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addContainerGap())
+        );
+
+        verticalSplitPane.setRightComponent(examplePanel);
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                .addGap(7, 7, 7)
+                .addComponent(flagsButton)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(examplesButton)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addComponent(strictCheckBox)
+                .addGap(6, 6, 6))
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(regexLabel)
-                    .addComponent(exampleLabel)
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(regexScrollPane, javax.swing.GroupLayout.PREFERRED_SIZE, 320, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addGap(62, 62, 62)
-                        .addComponent(errorLabel))
-                    .addComponent(exampleLayeredPane, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addGroup(layout.createSequentialGroup()
-                        .addGap(1, 1, 1)
-                        .addComponent(flagsButton)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(examplesButton)))
-                .addGap(266, 266, 266))
+                .addComponent(verticalSplitPane, javax.swing.GroupLayout.DEFAULT_SIZE, 453, Short.MAX_VALUE)
+                .addContainerGap())
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(regexLabel)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(regexScrollPane, javax.swing.GroupLayout.PREFERRED_SIZE, 42, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(errorLabel))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addComponent(exampleLabel)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(exampleLayeredPane, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(verticalSplitPane, javax.swing.GroupLayout.DEFAULT_SIZE, 186, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(flagsButton)
-                    .addComponent(examplesButton))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .addComponent(examplesButton)
+                    .addComponent(strictCheckBox))
+                .addContainerGap())
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -463,9 +477,8 @@ public final class CheckRegexTopComponent extends TopComponent {
 
     private void examplesButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_examplesButtonActionPerformed
         
-        Pattern p;
         try {
-            p = Pattern.compile(regexTextArea.getText());
+            Pattern.compile(regexTextArea.getText());
         } catch (PatternSyntaxException pse) {
             errorLabel.setText(Bundle.CheckRegexTopComponent_label_error(pse.getDescription()));
             return;
@@ -480,27 +493,22 @@ public final class CheckRegexTopComponent extends TopComponent {
     private javax.swing.JCheckBoxMenuItem commentsMenuItem;
     private javax.swing.JCheckBoxMenuItem dotAllMenuItem;
     private javax.swing.JLabel errorLabel;
-    private javax.swing.JLabel exampleLabel;
     private javax.swing.JLayeredPane exampleLayeredPane;
     private javax.swing.JScrollPane exampleScrollPane;
     private javax.swing.JTextArea exampleTextArea;
-    private javax.swing.JButton examplesButton;
-    private javax.swing.JFrame examplesFrame;
     private javax.swing.JButton flagsButton;
     private javax.swing.JPopupMenu flagsPopupMenu;
     private javax.swing.JLabel iconLabel;
-    private javax.swing.JScrollPane jScrollPane1;
-    private javax.swing.JTextArea jTextArea1;
     private javax.swing.JCheckBoxMenuItem literalMenuItem;
     private javax.swing.JCheckBoxMenuItem multilineMenuItem;
-    private javax.swing.JLabel regexLabel;
-    private javax.swing.JLabel regexLabel1;
+    private javax.swing.JPanel regexPanel;
     private javax.swing.JScrollPane regexScrollPane;
     private javax.swing.JTextArea regexTextArea;
     private javax.swing.JCheckBox strictCheckBox;
     private javax.swing.JCheckBoxMenuItem unicodeCaseMenuItem;
     private javax.swing.JCheckBoxMenuItem unicodeCharacterClassMenuItem;
     private javax.swing.JCheckBoxMenuItem unixLinesMenuItem;
+    private javax.swing.JSplitPane verticalSplitPane;
     // End of variables declaration//GEN-END:variables
     @Override
     public void componentOpened() {
@@ -570,17 +578,21 @@ public final class CheckRegexTopComponent extends TopComponent {
         Highlighter highlighter = exampleTextArea.getHighlighter();
         highlighter.removeAllHighlights();
 
-        errorLabel.setText("");
         iconLabel.setIcon(null);
 
-        if (regexTextArea.getText().length() == 0 || exampleTextArea.getText().length() == 0) {
+        if (regexTextArea.getText().isEmpty() || exampleTextArea.getText().isEmpty()) {
             return;
         }
         Pattern p;
         try {
             p = Pattern.compile(regexTextArea.getText(), Flags);
+            errorLabel.setVisible(false);
         } catch (PatternSyntaxException pse) {
             errorLabel.setText(Bundle.CheckRegexTopComponent_label_error(pse.getDescription()));
+            errorLabel.setVisible(true);
+            if (regexPanel.getHeight() < regexPanel.getPreferredSize().height) {
+                verticalSplitPane.resetToPreferredSizes();
+            }
             return;
         }
         Matcher m = p.matcher(exampleTextArea.getText());

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/RegexExampleGeneratorPanel.form
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/RegexExampleGeneratorPanel.form
@@ -62,18 +62,18 @@
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="regExLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="expressionLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="numberField" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="NoLabel" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="exampleScrollPane" min="-2" pref="207" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <Component id="exampleScrollPane" pref="203" max="32767" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Component id="regenerateButton" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -82,12 +82,18 @@
     <Component class="javax.swing.JLabel" name="regExLabel">
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="RegexExampleVisualPanel1.regExLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="RegexExampleGeneratorPanel.regExLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+      </AuxValues>
     </Component>
     <Container class="javax.swing.JScrollPane" name="exampleScrollPane">
       <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
         <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
       </AuxValues>
 
@@ -106,21 +112,25 @@
     <Component class="javax.swing.JTextField" name="numberField">
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="RegexExampleVisualPanel1.numberField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="RegexExampleGeneratorPanel.numberField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>
     <Component class="javax.swing.JLabel" name="NoLabel">
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="RegexExampleVisualPanel1.NoLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="RegexExampleGeneratorPanel.NoLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+      </AuxValues>
     </Component>
     <Component class="javax.swing.JButton" name="regenerateButton">
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="RegexExampleVisualPanel1.regenerateButton.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+          <ResourceString bundle="org/netbeans/modules/java/hints/jdk/Bundle.properties" key="RegexExampleGeneratorPanel.regenerateButton.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
       <Events>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/RegexExampleGeneratorPanel.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/RegexExampleGeneratorPanel.java
@@ -29,13 +29,13 @@ import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
 import org.openide.util.NbBundle;
 
-public final class RegexExampleVisualPanel1 extends JPanel {
+public final class RegexExampleGeneratorPanel extends JPanel {
     
     private final String expression;
     /**
      * Creates new form RegexExampleVisualPanel1
      */
-    public RegexExampleVisualPanel1() {
+    public RegexExampleGeneratorPanel() {
         initComponents();
         this.expression = CheckRegexTopComponent.findInstance().getExpression();
         expressionLabel.setText(expression);
@@ -44,7 +44,7 @@ public final class RegexExampleVisualPanel1 extends JPanel {
 
     @Override
     public String getName() {
-        return NbBundle.getMessage(RegexExampleVisualPanel1.class, "RegexExampleVisualPanel1.REGEX_EXAMPLES");
+        return NbBundle.getMessage(RegexExampleGeneratorPanel.class, "RegexExampleGeneratorPanel.REGEX_EXAMPLES");
     }
 
     /**
@@ -55,25 +55,25 @@ public final class RegexExampleVisualPanel1 extends JPanel {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
-        regExLabel = new javax.swing.JLabel();
-        exampleScrollPane = new javax.swing.JScrollPane();
+        javax.swing.JLabel regExLabel = new javax.swing.JLabel();
+        javax.swing.JScrollPane exampleScrollPane = new javax.swing.JScrollPane();
         exampleTextArea = new javax.swing.JTextArea();
         expressionLabel = new javax.swing.JLabel();
         numberField = new javax.swing.JTextField();
-        NoLabel = new javax.swing.JLabel();
+        javax.swing.JLabel NoLabel = new javax.swing.JLabel();
         regenerateButton = new javax.swing.JButton();
 
-        org.openide.awt.Mnemonics.setLocalizedText(regExLabel, org.openide.util.NbBundle.getMessage(RegexExampleVisualPanel1.class, "RegexExampleVisualPanel1.regExLabel.text")); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(regExLabel, org.openide.util.NbBundle.getMessage(RegexExampleGeneratorPanel.class, "RegexExampleGeneratorPanel.regExLabel.text")); // NOI18N
 
         exampleTextArea.setColumns(20);
         exampleTextArea.setRows(5);
         exampleScrollPane.setViewportView(exampleTextArea);
 
-        numberField.setText(org.openide.util.NbBundle.getMessage(RegexExampleVisualPanel1.class, "RegexExampleVisualPanel1.numberField.text")); // NOI18N
+        numberField.setText(org.openide.util.NbBundle.getMessage(RegexExampleGeneratorPanel.class, "RegexExampleGeneratorPanel.numberField.text")); // NOI18N
 
-        org.openide.awt.Mnemonics.setLocalizedText(NoLabel, org.openide.util.NbBundle.getMessage(RegexExampleVisualPanel1.class, "RegexExampleVisualPanel1.NoLabel.text")); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(NoLabel, org.openide.util.NbBundle.getMessage(RegexExampleGeneratorPanel.class, "RegexExampleGeneratorPanel.NoLabel.text")); // NOI18N
 
-        org.openide.awt.Mnemonics.setLocalizedText(regenerateButton, org.openide.util.NbBundle.getMessage(RegexExampleVisualPanel1.class, "RegexExampleVisualPanel1.regenerateButton.text")); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(regenerateButton, org.openide.util.NbBundle.getMessage(RegexExampleGeneratorPanel.class, "RegexExampleGeneratorPanel.regenerateButton.text")); // NOI18N
         regenerateButton.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 regenerateButtonActionPerformed(evt);
@@ -111,7 +111,7 @@ public final class RegexExampleVisualPanel1 extends JPanel {
                     .addComponent(numberField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(NoLabel))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(exampleScrollPane, javax.swing.GroupLayout.PREFERRED_SIZE, 207, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(exampleScrollPane, javax.swing.GroupLayout.DEFAULT_SIZE, 203, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(regenerateButton)
                 .addContainerGap())
@@ -123,12 +123,9 @@ public final class RegexExampleVisualPanel1 extends JPanel {
     }//GEN-LAST:event_regenerateButtonActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    private javax.swing.JLabel NoLabel;
-    private javax.swing.JScrollPane exampleScrollPane;
     private javax.swing.JTextArea exampleTextArea;
     private javax.swing.JLabel expressionLabel;
     private javax.swing.JTextField numberField;
-    private javax.swing.JLabel regExLabel;
     private javax.swing.JButton regenerateButton;
     // End of variables declaration//GEN-END:variables
 
@@ -136,17 +133,17 @@ public final class RegexExampleVisualPanel1 extends JPanel {
         RegExParser r = new RegExParser(expression);        
         RegEx p = r.parse();        
         ExampleGenerator eg = new ExampleGenerator(p);
-        int noFieldVal = 0;
+        int noFieldVal;
         try{
-         noFieldVal = Integer.parseInt(numberField.getText());    
+            noFieldVal = Integer.parseInt(numberField.getText());
         }catch(NumberFormatException e){
-            return NbBundle.getMessage(RegexExampleVisualPanel1.class, "RegexExampleVisualPanel1.exampleTextArea.invalidText");
+            return NbBundle.getMessage(RegexExampleGeneratorPanel.class, "RegexExampleGeneratorPanel.exampleTextArea.invalidText");
         }    
         ArrayList<String> generate = eg.generate(noFieldVal); 
-        StringBuilder sb = new StringBuilder();        
+        StringBuilder sb = new StringBuilder();
         generate.forEach(example -> {
-            sb.append(example + "\n");
-        });        
+            sb.append(example).append("\n");
+        });
         return sb.toString();
     }
 }
@@ -155,7 +152,7 @@ final class RegexExampleAction implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        DialogDescriptor dd = new DialogDescriptor(new RegexExampleVisualPanel1(), NbBundle.getMessage(RegexExampleVisualPanel1.class, "RegexExampleVisualPanel1.REGEX_EXAMPLES"));        
+        DialogDescriptor dd = new DialogDescriptor(new RegexExampleGeneratorPanel(), NbBundle.getMessage(RegexExampleGeneratorPanel.class, "RegexExampleGeneratorPanel.REGEX_EXAMPLES"));
         dd.setOptions(new Object[0]);
         DialogDisplayer.getDefault().notify(dd);
     }


### PR DESCRIPTION
wanted to check out the new regex checker with a fairly long regex (output window exception matcher from #4180), but noticed that the text fields had all fixed sizes despite it being a top component.

So I tried to fix this first ;)
 - everything resizes now properly (the example generator window too)
 - added vertical splitter as bonus
 - moved the error msg label a little bit around (try invalid regex)
 - noticed that the form had a unused JFrame stored, removed that (might have been the first version of the RegexExampleGeneratorPanel)

before.
![regex-checker-baseline](https://user-images.githubusercontent.com/114367/172075577-59f19f2c-4220-4b44-b853-c10be74a2fee.png)

after:
![regex-checker-layout](https://user-images.githubusercontent.com/114367/172075583-169cf40f-c2f1-4f74-8124-1c0b33e27e1d.png)

@mishrasandeep what do you think?