### PR TITLE
updated col.toArray() java editor template ("2ar").

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultAbbrevs.xml
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultAbbrevs.xml
@@ -334,7 +334,7 @@ ${selection}${cursor}
     <!-- Arrays and List conversion and sorting -->
     <codetemplate abbreviation="2ar">
          <code>
- <![CDATA[${clazz}[] ${var newVarName default="arr"} = ${typeCast cast default="" editable=false} ${coll instanceof="java.util.Collection"}.toArray(new ${clazz}[${coll}.size()]);
+ <![CDATA[${clazz}[] ${var newVarName default="arr"} = ${typeCast cast default="" editable=false} ${coll instanceof="java.util.Collection"}.toArray(new ${clazz}[0]);
  ]]>
          </code>
      </codetemplate>

--- a/java/java.editor/test/qa-functional/data/goldenfiles/org/netbeans/test/java/editor/codetemplates/CodeTemplatesTest/testDumpTemplates.pass
+++ b/java/java.editor/test/qa-functional/data/goldenfiles/org/netbeans/test/java/editor/codetemplates/CodeTemplatesTest/testDumpTemplates.pass
@@ -7,7 +7,7 @@ ${baseType type="java.util.List" default="List" editable="false"} <${type defaul
 null
 -----------------------
 2ar
-${clazz}[] ${var newVarName default="arr"} = ${typeCast cast default="" editable=false} ${coll instanceof="java.util.Collection"}.toArray(new ${clazz}[${coll}.size()]);
+${clazz}[] ${var newVarName default="arr"} = ${typeCast cast default="" editable=false} ${coll instanceof="java.util.Collection"}.toArray(new ${clazz}[0]);
  
 null
 -----------------------


### PR DESCRIPTION
old: 
```java
.toArray(new ${clazz}[${coll}.size()]);
```
new: 
```java
.toArray(new ${clazz}[0]);
```

see #3166 for details

would have been nice if the template would be able to conditionally generate the more modern version:
```java
 .toArray(${clazz}[]::new);
```