### PR TITLE
Fix potential NPE in GradleModuleFileCache21 

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleModuleFileCache21.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleModuleFileCache21.java
@@ -222,12 +222,16 @@ public final class GradleModuleFileCache21 {
     }
 
     public CachedArtifactVersion resolveCachedArtifactVersion(Path artifact) throws IllegalArgumentException {
-        return new CachedArtifactVersion(artifact.getParent().getParent());
+        return artifact == null
+                || artifact.getParent() == null
+                || artifact.getParent().getParent() == null
+                ?  null
+                :  new CachedArtifactVersion(artifact.getParent().getParent());
     }
 
     public CachedArtifactVersion.Entry resolveEntry(Path artifact) throws IllegalArgumentException {
         CachedArtifactVersion av = resolveCachedArtifactVersion(artifact);
-        return av.entries.get(artifact.getFileName().toString());
+        return av != null ? av.entries.get(artifact.getFileName().toString()) : null;
     }
 
     public CachedArtifactVersion resolveModule(String moduleId) throws IllegalArgumentException {


### PR DESCRIPTION
Fix potential NPE in GradleModuleFileCache21 when trying to resolve non-gradle artifacts.
This is a patch for #4208 
