### PR TITLE
Improve stability of gradle build info extraction

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
@@ -19,19 +19,21 @@
 
 package org.netbeans.modules.gradle.tooling;
 
-import java.util.ArrayList;
 import static java.util.Arrays.asList;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.logging.LogLevel;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.process.CommandLineArgumentProvider;
-
 /**
  *
  * @author Laszlo Kishalmi
  */
 class NetBeansRunSinglePlugin implements Plugin<Project> {
+    private static final Logger LOG = Logging.getLogger(NetBeansRunSinglePlugin.class);
 
     private static final String RUN_SINGLE_TASK = "runSingle";
     private static final String RUN_SINGLE_MAIN = "runClassName";
@@ -59,7 +61,15 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
                         }
                     });
                 }
-                je.setStandardInput(System.in);
+                try {
+                    je.setStandardInput(System.in);
+                } catch (RuntimeException ex) {
+                    if(LOG.isEnabled(LogLevel.DEBUG)) {
+                        LOG.debug("Failed to set STDIN for Plugin: " + je.toString(), ex);
+                    } else {
+                        LOG.info("Failed to set STDIN for Plugin: " + je.toString());
+                    }
+                }
                 if (project.hasProperty(RUN_SINGLE_CWD)) {
                     je.setWorkingDir(project.property(RUN_SINGLE_CWD).toString());
                 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleReport.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleReport.java
@@ -46,7 +46,7 @@ public final class GradleReport {
         this.errorClass = errorClass;
         this.location = location;
         this.line = line;
-        this.message = message;
+        this.message = message == null ? "" : message;
         this.causedBy = causedBy;
     }
     


### PR DESCRIPTION
While trying to work with the gradle projects from liferay-portal it
was observed, that loading failed with an exception. There are two
problems:

1. The liferay build provides incomplete implementation of JavaExec,
   which do not support setting the standard input

2. The generated UnsupportedOperation exception carries a null message,
   rendering the @NonNull annotation in GradleReport invalid and
   causing NullPointerExceptions in use sites.

Fixes:

1. Setting stdin is changed to be a best-effort operation. It is
   assumed that, if the setter fails, the access to stdin is not
   expected and thus does not need to be wired.

2. If a null message is passed into GradleReport, it is replaced with
   an empty string.