### PR TITLE
JS: Don't generate hint for missing semicolon in generated constructor node

### DIFF
--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/hints/JsConventionRule.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/hints/JsConventionRule.java
@@ -31,11 +31,14 @@ import com.oracle.js.parser.ir.ReturnNode;
 import com.oracle.js.parser.ir.ThrowNode;
 import com.oracle.js.parser.ir.VarNode;
 import com.oracle.js.parser.ir.WhileNode;
+
 import static com.oracle.js.parser.TokenType.EQ;
 import static com.oracle.js.parser.TokenType.NE;
+
 import com.oracle.js.parser.ir.ClassNode;
 import com.oracle.js.parser.ir.ExpressionStatement;
 import com.oracle.js.parser.ir.IdentNode;
+import com.oracle.js.parser.ir.PropertyNode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -593,6 +596,29 @@ public class JsConventionRule extends JsAstRule {
         public boolean enterBinaryNode(BinaryNode binaryNode) {
             checkCondition(binaryNode);
             return super.enterBinaryNode(binaryNode);
+        }
+
+        @Override
+        public boolean enterPropertyNode(PropertyNode propertyNode) {
+            ClassNode enclosingClass = classDefinitionHierarchie.isEmpty() ? null : classDefinitionHierarchie.get(classDefinitionHierarchie.size() - 1);
+            if(enclosingClass != null && propertyNode.getToken() == enclosingClass.getToken()) {
+                return false;
+            }
+            return super.enterPropertyNode(propertyNode);
+        }
+
+        private List<ClassNode> classDefinitionHierarchie = new ArrayList<>();
+
+        @Override
+        public boolean enterClassNode(ClassNode classNode) {
+            classDefinitionHierarchie.add(classNode);
+            return super.enterClassNode(classNode);
+        }
+
+        @Override
+        public Node leaveClassNode(ClassNode classNode) {
+            classDefinitionHierarchie.remove(classDefinitionHierarchie.size() - 1);
+            return super.leaveClassNode(classNode);
         }
     }
 }

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/hints/semicolonWarningGeneratedConstructor.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/hints/semicolonWarningGeneratedConstructor.js
@@ -1,0 +1,8 @@
+class A {
+}
+
+/**
+ * This class definition should not generate a "missing semicolon" hint
+ */
+class B extends A {
+}

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/hints/semicolonWarningRealConstructor.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/hints/semicolonWarningRealConstructor.js
@@ -1,0 +1,13 @@
+class A {
+}
+
+/**
+ * This class definition should generate a "missing semicolon" hint, as the
+ * explicit constructor really has not semicolon
+ */
+class B extends A {
+    constructor() {
+        super()
+    }
+}
+

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/hints/semicolonWarningRealConstructor.js.testSemicolonWarningRealConstructor.hints
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/hints/semicolonWarningRealConstructor.js.testSemicolonWarningRealConstructor.hints
@@ -1,0 +1,3 @@
+        super()
+              -
+HINT:Expected semicolon ; after ")".

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/hint/JsConventionHintTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/hint/JsConventionHintTest.java
@@ -211,5 +211,13 @@ public class JsConventionHintTest extends HintTestBase {
     
     public void testIssue269659_04() throws Exception {
         checkHints(this, createDuplicatePropertyHint(), "testfiles/hints/issue269659_04.js", null);
-    } 
+    }
+
+    public void testSemicolonWarningGeneratedConstructor() throws Exception {
+        checkHints(this, createSemicolonHint(), "testfiles/hints/semicolonWarningGeneratedConstructor.js", null);
+    }
+
+    public void testSemicolonWarningRealConstructor() throws Exception {
+        checkHints(this, createSemicolonHint(), "testfiles/hints/semicolonWarningRealConstructor.js", null);
+    }
 }


### PR DESCRIPTION
For this construct:

class A {
}
class B extends A {
}

the graaljs parser generates the default constructor:

constructor(...args) {
  super(...args);
}

This irritates the semicolon hint, as the token for the semicolon can't
be found and thus the hint is generated.

Closes: #4214
