### PR TITLE
ci xserver for commit validation matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,6 +102,12 @@ jobs:
       - name: Extract
         run: tar --zstd -xf build.tar.zst
 
+      - name: Setup Xvfb
+        if: ${{ matrix.java != '19-ea' }}  # see #4299
+        run: |
+          echo "DISPLAY=:99.0" >> $GITHUB_ENV
+          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+
       - name: Commit Validation tests
         run: ant -Dcluster.config=release commit-validation
 
@@ -252,7 +258,7 @@ jobs:
           extensions: xdebug
           ini-values: xdebug.mode=debug
 
-      - name: Launch Xvfb
+      - name: Setup Xvfb
         if: contains(matrix.os, 'ubuntu')
         run: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
       # - - -
@@ -307,7 +313,7 @@ jobs:
       - name: Test PHP Composer
         run: ant $OPTS -f php/php.composer test
 
-      # needs X fails on fails on Windows
+      # needs X fails on Windows
       - name: Test PHP Debugger
         if: contains(matrix.os, 'ubuntu')
         run: ant $OPTS -f php/php.dbgp test
@@ -369,10 +375,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-          submodules: recursive
+          submodules: true
 
-      - uses: ./.github/actions/delete-artifact/
-        name: Delete build Artifact
+      - name: Delete build Artifact
+        uses: ./.github/actions/delete-artifact/
         with:
           name: build
           failOnError: true

--- a/ide/ide.kit/nbproject/project.properties
+++ b/ide/ide.kit/nbproject/project.properties
@@ -44,6 +44,7 @@ requires.nb.javac=true
 
 test.jms.flags=\
  --add-opens=java.base/java.net=ALL-UNNAMED \
+ --add-opens=java.base/java.security=ALL-UNNAMED \
  --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED \
  --add-opens=java.desktop/javax.swing=ALL-UNNAMED \
  --add-opens=java.desktop/javax.swing.plaf.synth=ALL-UNNAMED \

--- a/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/ui/CssStylesPanelProviderImpl.java
+++ b/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/ui/CssStylesPanelProviderImpl.java
@@ -34,6 +34,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.LayoutStyle;
 import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.css.lib.api.CssParserResult;
@@ -54,7 +55,6 @@ import org.netbeans.modules.web.common.api.WebUtils;
 import org.netbeans.modules.web.inspect.PageInspectorImpl;
 import org.netbeans.modules.web.inspect.PageModel;
 import org.netbeans.spi.project.ActionProvider;
-import org.openide.explorer.view.BeanTreeView;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
 import org.openide.loaders.DataObjectNotFoundException;
@@ -139,7 +139,7 @@ public abstract class CssStylesPanelProviderImpl extends JPanel implements CssSt
         noStylesLabel.setHorizontalAlignment(SwingConstants.CENTER);
         noStylesLabel.setVerticalAlignment(SwingConstants.CENTER);
         noStylesLabel.setEnabled(false);
-        noStylesLabel.setBackground(new BeanTreeView().getViewport().getView().getBackground());
+        noStylesLabel.setBackground(UIManager.getColor("Tree.background"));
         noStylesLabel.setOpaque(true);
     }
 

--- a/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/ui/DomPanel.java
+++ b/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/ui/DomPanel.java
@@ -265,7 +265,7 @@ public class DomPanel extends JPanel implements ExplorerManager.Provider {
         noDomLabel.setHorizontalAlignment(SwingConstants.CENTER);
         noDomLabel.setVerticalAlignment(SwingConstants.CENTER);
         noDomLabel.setEnabled(false);
-        noDomLabel.setBackground(treeView.getViewport().getView().getBackground());
+        noDomLabel.setBackground(UIManager.getColor("Tree.background"));
         noDomLabel.setOpaque(true);
     }
 

--- a/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/webkit/knockout/unused/UnusedBindingsPanel.form
+++ b/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/webkit/knockout/unused/UnusedBindingsPanel.form
@@ -26,7 +26,7 @@
     <Container class="javax.swing.JPanel" name="findPanel">
       <Properties>
         <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="treeView.getViewport().getView().getBackground()" type="code"/>
+          <Connection code="UIManager.getColor(&quot;Tree.background&quot;)" type="code"/>
         </Property>
       </Properties>
 
@@ -124,7 +124,7 @@
     <Component class="javax.swing.JLabel" name="messageLabel">
       <Properties>
         <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="treeView.getViewport().getView().getBackground()" type="code"/>
+          <Connection code="UIManager.getColor(&quot;Tree.background&quot;)" type="code"/>
         </Property>
         <Property name="horizontalAlignment" type="int" value="0"/>
         <Property name="enabled" type="boolean" value="false"/>

--- a/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/webkit/knockout/unused/UnusedBindingsPanel.java
+++ b/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/webkit/knockout/unused/UnusedBindingsPanel.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JComponent;
+import javax.swing.UIManager;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -326,7 +327,7 @@ public class UnusedBindingsPanel extends javax.swing.JPanel implements ExplorerM
         refreshButton = new javax.swing.JButton();
         messageLabel = new javax.swing.JLabel();
 
-        findPanel.setBackground(treeView.getViewport().getView().getBackground());
+        findPanel.setBackground(UIManager.getColor("Tree.background"));
 
         org.openide.awt.Mnemonics.setLocalizedText(findButton, org.openide.util.NbBundle.getMessage(UnusedBindingsPanel.class, "UnusedBindingsPanel.findButton.text")); // NOI18N
         findButton.addActionListener(new java.awt.event.ActionListener() {
@@ -386,7 +387,7 @@ public class UnusedBindingsPanel extends javax.swing.JPanel implements ExplorerM
 
         dataPanel.add(refreshPanel, java.awt.BorderLayout.PAGE_END);
 
-        messageLabel.setBackground(treeView.getViewport().getView().getBackground());
+        messageLabel.setBackground(UIManager.getColor("Tree.background"));
         messageLabel.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
         messageLabel.setEnabled(false);
         messageLabel.setOpaque(true);


### PR DESCRIPTION
enable the xserver for the commit validation matrix.

 - 19ea fails unfortunately, ~~so we switch it to 18 for now~~ don't enable the xserver there, issue filed: #4299
 - fixed some NPEs in UI code which appear during CV test runs:
```
cat out.log | grep -A5 "because the return value of"
[junit] java.lang.NullPointerException: Cannot invoke "java.awt.Component.getBackground()" because the return value of "javax.swing.JViewport.getView()" is null
    [junit] 	at org.netbeans.modules.web.inspect.ui.DomPanel.initNoDOMLabel(DomPanel.java:268)
    [junit] 	at org.netbeans.modules.web.inspect.ui.DomPanel.<init>(DomPanel.java:96)
    [junit] 	at org.netbeans.modules.web.inspect.ui.DomTC.update(DomTC.java:85)
    [junit] 	at org.netbeans.modules.web.inspect.ui.DomTC.<init>(DomTC.java:75)
    [junit] 	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:67)
--
    [junit] java.lang.NullPointerException: Cannot invoke "java.awt.Component.getBackground()" because the return value of "javax.swing.JViewport.getView()" is null
    [junit] 	at org.netbeans.modules.web.inspect.ui.CssStylesPanelProviderImpl.initNoStylesLabel(CssStylesPanelProviderImpl.java:142)
    [junit] 	at org.netbeans.modules.web.inspect.ui.CssStylesPanelProviderImpl.<init>(CssStylesPanelProviderImpl.java:122)
    [junit] 	at org.netbeans.modules.web.inspect.ui.CssStylesPanelProviderImpl$SelectionView.<init>(CssStylesPanelProviderImpl.java:398)
    [junit] 	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:67)
    [junit] 	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
--
    [junit] java.lang.NullPointerException: Cannot invoke "java.awt.Component.getBackground()" because the return value of "javax.swing.JViewport.getView()" is null
    [junit] 	at org.netbeans.modules.web.inspect.webkit.knockout.unused.UnusedBindingsPanel.initComponents(UnusedBindingsPanel.java:329)
    [junit] 	at org.netbeans.modules.web.inspect.webkit.knockout.unused.UnusedBindingsPanel.<init>(UnusedBindingsPanel.java:66)
    [junit] 	at org.netbeans.modules.web.inspect.webkit.knockout.KnockoutPanel.<init>(KnockoutPanel.java:86)
    [junit] 	at org.netbeans.modules.web.inspect.webkit.knockout.KnockoutTC.update(KnockoutTC.java:96)
    [junit] 	at org.netbeans.modules.web.inspect.webkit.knockout.KnockoutTC.<init>(KnockoutTC.java:79)
```
