### PR TITLE
After file external change fire reloaded event

### DIFF
--- a/platform/openide.text/apichanges.xml
+++ b/platform/openide.text/apichanges.xml
@@ -25,21 +25,42 @@
 <apidef name="text">Text API</apidef>
 </apidefs>
 <changes>
-      <change id="ask.on.document.reload">
-          <api name="text"/>
-          <summary>Rebrand defaults for Reload Editor Dialog</summary>
-          <version major="6" minor="80"/>
-          <date day="22" month="1" year="2021"/>
-          <author login="dbalek"/>
-          <compatibility addition="yes" binary="compatible" source="compatible"
-                         semantic="incompatible" deletion="no"
-                         modification="no"/>
-          <description>
-              A branding API to disable showing reload externally modified document dialog
-              - <a href="architecture-summary.html#group-branding">ASK_OnReload</a>.
-          </description>
-          <class package="org.openide.text" name="CloneableEditorSupport"/>
-      </change>
+    <change id="EditorCookie.Observable.PROP_RELOADING">
+        <api name="text"/>
+        <summary>Added EditorCookie.Observable.PROP_RELOADING and associated begin/end events</summary>
+        <version major="6" minor="86"/>
+        <date day="22" month="6" year="2022"/>
+        <author login="errael"/>
+        <compatibility addition="yes" binary="compatible" source="compatible"
+                       semantic="compatible" deletion="no"
+                       modification="no"/>
+        <description>
+            Added EditorCookie.Observable.PROP_RELOADING and associated
+            begin/end events so that editor modules can handle external file change.
+            These events are fired on the EDT by the document's CloneableEditorSupport;
+            evt.getNewValue() is a Boolean, true signals the start of reload
+            and false the end.
+            An editor kit might adjust multiple carets to keep the same
+            line/column before and after reload of an externally modified file.
+        </description>
+        <class package="org.openide.text" name="CloneableEditorSupport"/>
+        <class package="org.openide.cookies" name="EditorCookie"/>
+    </change>
+    <change id="ask.on.document.reload">
+        <api name="text"/>
+        <summary>Rebrand defaults for Reload Editor Dialog</summary>
+        <version major="6" minor="80"/>
+        <date day="22" month="1" year="2021"/>
+        <author login="dbalek"/>
+        <compatibility addition="yes" binary="compatible" source="compatible"
+                       semantic="incompatible" deletion="no"
+                       modification="no"/>
+        <description>
+            A branding API to disable showing reload externally modified document dialog
+            - <a href="architecture-summary.html#group-branding">ASK_OnReload</a>.
+        </description>
+        <class package="org.openide.text" name="CloneableEditorSupport"/>
+    </change>
     <change id="PositionRef.Position">
         <api name="text"/>
         <summary>Implement Position interface for compatibility</summary>

--- a/platform/openide.text/manifest.mf
+++ b/platform/openide.text/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.openide.text
 OpenIDE-Module-Localizing-Bundle: org/openide/text/Bundle.properties
 AutoUpdate-Essential-Module: true
-OpenIDE-Module-Specification-Version: 6.85
+OpenIDE-Module-Specification-Version: 6.86
 

--- a/platform/openide.text/src/org/openide/cookies/EditorCookie.java
+++ b/platform/openide.text/src/org/openide/cookies/EditorCookie.java
@@ -144,6 +144,12 @@ public interface EditorCookie extends LineCookie {
          */
         public static final String PROP_OPENED_PANES = "openedPanes";
 
+        /** This property is fired on the EDT when the reloading state of the
+         * document has changed; reloading is due to an external file change.
+         * @since 6.86
+         */
+        public static final String PROP_RELOADING = "reloading";
+
         /** Add a PropertyChangeListener to the listener list.
          * @param l  the PropertyChangeListener to be added
          */

--- a/platform/openide.text/src/org/openide/text/DocumentOpenClose.java
+++ b/platform/openide.text/src/org/openide/text/DocumentOpenClose.java
@@ -25,12 +25,15 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.swing.JEditorPane;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.EditorKit;
 import javax.swing.text.Position;
 import javax.swing.text.StyledDocument;
+
 import org.openide.awt.UndoRedo;
+import org.openide.cookies.EditorCookie;
 import org.openide.util.Mutex;
 import org.openide.util.RequestProcessor;
 import org.openide.util.Task;
@@ -692,6 +695,10 @@ final class DocumentOpenClose {
                                     ", loadSuccess=" + loadSuccess + "\n"); // NOI18N
                         }
                     }
+                    if(reload) {
+                        Mutex.EVENT.postReadRequest(() -> 
+                                ces.firePropertyChange(EditorCookie.Observable.PROP_RELOADING, true, false));
+                    }
                 }
             }
         }
@@ -816,6 +823,7 @@ final class DocumentOpenClose {
                     }
                 });
 
+                ces.firePropertyChange(EditorCookie.Observable.PROP_RELOADING, false, true);
                 // Next portion will run as Task in RP
                 activeReloadTask = RP.create(this);
                 activeReloadTask.schedule(0);


### PR DESCRIPTION
This PR adds, `PROP_RELOADING`, to signal begin/end of document reloading due to an external change.

This change is about handling fixup after a document is reloaded. Currently, `openide.text` adjusts any document positions such that after the reload the `PositionRef`s have the same line number and column offset. However, the **caret positions** in any editors are set to have the same offset as before; and so the caret often seems to jump around after the reload. Maintaining line/col seems preferable. This was discussed in the dev mailing list thread:
```
    Detecting file changed externally, 2022, Jun 7
    https://lists.apache.org/thread/tb1mkx1koctt74y48gbyqhqsbtrq56ys
```

The editors now support multiple carets and there may be other fixups after a document reload in addition to caret position; for example, repositioning the viewport.

With the `PROP_RELOADING` events things can be handled as needed where needed; an editor kit might use this for caret position fixup.

Using these events, a caret's line/col can be preserved after reload like this:
1. `PROP_RELOADING: evt.getNewValue() == true`
Save `PositionRef` for each caret
2. `PROP_RELOADING: evt.getNewValue() == false`
Restore caret position from `PositionRef` saved in 1.

The `PROP_RELOADING` event is fired on the EDT. This is probably the right choice in general for these events; in this situation it is required to insure that the end event comes after `DocumentOpenClose` adjusts the carets and after it gets the `CloneableEditorSupport` ready for prime time.

Upated June 21 to reflect change to two events with PROP_RELOADING, instead of starting with fileChange and ending with PROP_RELOADED.
