### PR TITLE
Register @ActionsProvider.Registrations as annotation processed by DebuggerProcessor

### DIFF
--- a/ide/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
+++ b/ide/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
@@ -66,6 +66,7 @@ public class DebuggerProcessor extends LayerGeneratingProcessor {
     public @Override Set<String> getSupportedAnnotationTypes() {
         return new HashSet<String>(Arrays.asList(
             ActionsProvider.Registration.class.getCanonicalName(),
+            ActionsProvider.Registrations.class.getCanonicalName(),
             DebuggerEngineProvider.Registration.class.getCanonicalName(),
             SessionProvider.Registration.class.getCanonicalName(),
             LazyActionsManagerListener.Registration.class.getCanonicalName(),

--- a/ide/api.debugger/src/org/netbeans/spi/debugger/ActionsProviderSupport.java
+++ b/ide/api.debugger/src/org/netbeans/spi/debugger/ActionsProviderSupport.java
@@ -64,7 +64,7 @@ public abstract class ActionsProviderSupport extends ActionsProvider {
      * @param enabled the new state
      */
     protected final void setEnabled (Object action, boolean enabled) {
-        boolean fire = false;
+        boolean fire;
         if (enabled)
             fire = this.enabled.add (action);
         else


### PR DESCRIPTION
Small bugfix for the debugger annotation processor. There was a bug in `DebuggerProcessor`. If one used only `@ActionsProvider.Registrations` and no other annotations, the processor wasn't triggered. Extracted from #4196 as this is a non-controversial bugfix.