### PR TITLE
LSP: Do not autoimport nested classes when not necessary.

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionCollector.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionCollector.java
@@ -276,7 +276,7 @@ public class JavadocCompletionCollector implements CompletionCollector {
             }
             if (handle != null) {
                 builder.documentation(JavaCompletionCollector.getDocumentation(doc, offset, handle));
-                builder.additionalTextEdits(JavaCompletionCollector.addImport(doc, handle));
+                builder.additionalTextEdits(JavaCompletionCollector.addImport(doc, offset, handle));
             }
             if (isDeprecated) {
                 builder.addTag(Completion.Tag.Deprecated);


### PR DESCRIPTION
LSP code completion should not autoimport nested classes when not necessary.