### PR TITLE
Moving UIContext out of public package.

### DIFF
--- a/java/java.lsp.server/manifest.mf
+++ b/java/java.lsp.server/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: true
-OpenIDE-Module: org.netbeans.modules.java.lsp.server
+OpenIDE-Module: org.netbeans.modules.java.lsp.server/2
 OpenIDE-Module-Implementation-Version: 1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/lsp/server/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/java/lsp/server/layer.xml

--- a/java/java.lsp.server/nbcode/integration/nbproject/project.xml
+++ b/java/java.lsp.server/nbcode/integration/nbproject/project.xml
@@ -81,7 +81,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.19</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/nbproject/org-netbeans-modules-java-lsp-server.sig
+++ b/java/java.lsp.server/nbproject/org-netbeans-modules-java-lsp-server.sig
@@ -123,24 +123,6 @@ supr java.lang.Object
 hfds lastCtx
 hcls StdErrContext
 
-CLSS public abstract org.netbeans.modules.java.lsp.server.ui.UIContext
-cons public init()
-meth protected abstract boolean isValid()
-meth protected abstract java.util.concurrent.CompletableFuture<org.eclipse.lsp4j.MessageActionItem> showMessageRequest(org.eclipse.lsp4j.ShowMessageRequestParams)
-meth protected abstract org.openide.awt.StatusDisplayer$Message showStatusMessage(org.netbeans.modules.java.lsp.server.protocol.ShowStatusMessageParams)
-meth protected abstract void logMessage(org.eclipse.lsp4j.MessageParams)
-meth protected abstract void showMessage(org.eclipse.lsp4j.MessageParams)
-meth protected java.util.concurrent.CompletableFuture<java.lang.String> showHtmlPage(org.netbeans.modules.java.lsp.server.protocol.HtmlPageParams)
-meth protected java.util.concurrent.CompletableFuture<java.lang.String> showInputBox(org.netbeans.modules.java.lsp.server.protocol.ShowInputBoxParams)
-meth protected java.util.concurrent.CompletableFuture<java.util.List<org.netbeans.modules.java.lsp.server.protocol.QuickPickItem>> showQuickPick(org.netbeans.modules.java.lsp.server.protocol.ShowQuickPickParams)
-meth public static org.netbeans.modules.java.lsp.server.ui.UIContext find()
- anno 0 org.netbeans.api.annotations.common.NonNull()
-meth public static org.netbeans.modules.java.lsp.server.ui.UIContext find(org.openide.util.Lookup)
- anno 0 org.netbeans.api.annotations.common.NonNull()
-supr java.lang.Object
-hfds lastCtx
-hcls LogImpl
-
 CLSS public abstract interface org.netbeans.modules.progress.spi.ProgressEnvironment
 meth public abstract org.netbeans.api.progress.ProgressHandle createHandle(java.lang.String,org.openide.util.Cancellable,boolean)
 meth public abstract org.netbeans.modules.progress.spi.Controller getController()

--- a/java/java.lsp.server/nbproject/project.properties
+++ b/java/java.lsp.server/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=2.0
+spec.version.base=2.0.0
 javadoc.arch=${basedir}/arch.xml
 requires.nb.javac=true
 lsp.build.dir=vscode/nbcode

--- a/java/java.lsp.server/nbproject/project.properties
+++ b/java/java.lsp.server/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=1.21.0
+spec.version.base=2.0
 javadoc.arch=${basedir}/arch.xml
 requires.nb.javac=true
 lsp.build.dir=vscode/nbcode

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientCapabilities.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientCapabilities.java
@@ -22,7 +22,6 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.InitializeParams;
-import org.netbeans.modules.java.lsp.server.ui.UIContext;
 
 /**
  * Encapsulates all nbcode-specific client capabilities. Need to be passed in

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/UIContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/UIContext.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.modules.java.lsp.server.ui;
+package org.netbeans.modules.java.lsp.server.protocol;
 
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
@@ -30,12 +30,10 @@ import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.netbeans.api.annotations.common.NonNull;
-import org.netbeans.modules.java.lsp.server.protocol.HtmlPageParams;
 import org.netbeans.modules.java.lsp.server.input.QuickPickItem;
 import org.netbeans.modules.java.lsp.server.input.ShowInputBoxParams;
 import org.netbeans.modules.java.lsp.server.input.ShowMutliStepInputParams;
 import org.netbeans.modules.java.lsp.server.input.ShowQuickPickParams;
-import org.netbeans.modules.java.lsp.server.protocol.ShowStatusMessageParams;
 import org.openide.awt.StatusDisplayer.Message;
 import org.openide.util.Lookup;
 
@@ -84,15 +82,15 @@ public abstract class UIContext {
         return find(Lookup.getDefault());
     }
 
-    protected abstract boolean isValid();
-    protected abstract void showMessage(MessageParams msg);
-    protected CompletableFuture<String> showHtmlPage(HtmlPageParams msg) {
+    public abstract boolean isValid();
+    public abstract void showMessage(MessageParams msg);
+    public CompletableFuture<String> showHtmlPage(HtmlPageParams msg) {
         showMessage(new MessageParams(MessageType.Log, msg.getUri()));
         return CompletableFuture.completedFuture(null);
     }
-    protected abstract CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams msg);
-    protected abstract void logMessage(MessageParams msg);
-    protected abstract Message showStatusMessage(ShowStatusMessageParams msg);
+    public abstract CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams msg);
+    public abstract void logMessage(MessageParams msg);
+    public abstract Message showStatusMessage(ShowStatusMessageParams msg);
     
     /**
      * Shows an input box to ask the user for a text input.
@@ -101,15 +99,15 @@ public abstract class UIContext {
      * @return future that yields the entered value
      * @since 1.18
      */
-    protected CompletableFuture<String> showInputBox(ShowInputBoxParams params) {
+    public CompletableFuture<String> showInputBox(ShowInputBoxParams params) {
         throw new AbstractMethodError();
     }
 
-    protected CompletableFuture<List<QuickPickItem>> showQuickPick(ShowQuickPickParams params) {
+    public CompletableFuture<List<QuickPickItem>> showQuickPick(ShowQuickPickParams params) {
         throw new AbstractMethodError();
     }
 
-    protected CompletableFuture<Map<String, Either<List<QuickPickItem>, String>>> showMultiStepInput(ShowMutliStepInputParams params) {
+    public CompletableFuture<Map<String, Either<List<QuickPickItem>, String>>> showMultiStepInput(ShowMutliStepInputParams params) {
         throw new AbstractMethodError();
     }
 
@@ -120,48 +118,48 @@ public abstract class UIContext {
         }
 
         @Override
-        protected CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams msg) {
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams msg) {
             System.err.println(msg.getType() + ": " + msg.getMessage());
             CompletableFuture<MessageActionItem> ai = CompletableFuture.completedFuture(null);
             return ai;
         }
 
         @Override
-        protected void showMessage(MessageParams msg) {
+        public void showMessage(MessageParams msg) {
             System.err.println(msg.getType() + ": " + msg.getMessage());
         }
 
         @Override
-        protected void logMessage(MessageParams msg) {
+        public void logMessage(MessageParams msg) {
             System.err.println(msg.getType() + ": " + msg.getMessage());
         }
 
         @Override
-        protected Message showStatusMessage(ShowStatusMessageParams msg) {
+        public Message showStatusMessage(ShowStatusMessageParams msg) {
             System.out.println(msg.getType() + ": " + msg.getMessage());
             return (int timeInMillis) -> {};
         }
 
         @Override
-        protected boolean isValid() {
+        public boolean isValid() {
             return true;
         }
 
         @Override
-        protected CompletableFuture<String> showHtmlPage(HtmlPageParams msg) {
+        public CompletableFuture<String> showHtmlPage(HtmlPageParams msg) {
             System.out.println("Open in browser: " + msg.getUri());
             return CompletableFuture.completedFuture(null);
         }
 
         @Override
-        protected CompletableFuture<String> showInputBox(ShowInputBoxParams params) {
+        public CompletableFuture<String> showInputBox(ShowInputBoxParams params) {
             System.err.println("input: " + params.getPrompt());
             CompletableFuture<String> ai = CompletableFuture.completedFuture(null);
             return ai;
         }
 
         @Override
-        protected CompletableFuture<List<QuickPickItem>> showQuickPick(ShowQuickPickParams params) {
+        public CompletableFuture<List<QuickPickItem>> showQuickPick(ShowQuickPickParams params) {
             System.err.println("quickPick: " + params.getPlaceHolder());
             return CompletableFuture.completedFuture(Collections.emptyList());
         }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceUIContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceUIContext.java
@@ -29,7 +29,6 @@ import org.netbeans.modules.java.lsp.server.input.QuickPickItem;
 import org.netbeans.modules.java.lsp.server.input.ShowQuickPickParams;
 import org.netbeans.modules.java.lsp.server.input.ShowInputBoxParams;
 import org.netbeans.modules.java.lsp.server.input.ShowMutliStepInputParams;
-import org.netbeans.modules.java.lsp.server.ui.UIContext;
 import org.openide.awt.StatusDisplayer;
 
 /**
@@ -44,22 +43,22 @@ class WorkspaceUIContext extends UIContext {
     }
 
     @Override
-    protected boolean isValid() {
+    public boolean isValid() {
         return true;
     }
 
     @Override
-    protected CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams msg) {
+    public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams msg) {
         return client.showMessageRequest(msg);
     }
 
     @Override
-    protected void showMessage(MessageParams msg) {
+    public void showMessage(MessageParams msg) {
         client.showMessage(msg);
     }
 
     @Override
-    protected CompletableFuture<String> showInputBox(ShowInputBoxParams params) {
+    public CompletableFuture<String> showInputBox(ShowInputBoxParams params) {
         return client.showInputBox(params);
     }
 
@@ -74,12 +73,12 @@ class WorkspaceUIContext extends UIContext {
     }
 
     @Override
-    protected void logMessage(MessageParams msg) {
+    public void logMessage(MessageParams msg) {
         client.logMessage(msg);
     }
 
     @Override
-    protected StatusDisplayer.Message showStatusMessage(ShowStatusMessageParams msg) {
+    public StatusDisplayer.Message showStatusMessage(ShowStatusMessageParams msg) {
         if (client.getNbCodeCapabilities().hasStatusBarMessageSupport()) {
             client.showStatusBarMessage(msg);
         } else {
@@ -89,7 +88,7 @@ class WorkspaceUIContext extends UIContext {
     }
 
     @Override
-    protected CompletableFuture<String> showHtmlPage(HtmlPageParams msg) {
+    public CompletableFuture<String> showHtmlPage(HtmlPageParams msg) {
         return client.showHtmlPage(msg);
     }
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayer.java
@@ -22,6 +22,7 @@ import java.awt.Dialog;
 import java.awt.HeadlessException;
 import java.util.concurrent.CompletableFuture;
 import org.netbeans.modules.java.lsp.server.LspServerUtils;
+import org.netbeans.modules.java.lsp.server.protocol.UIContext;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractLspHtmlViewer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractLspHtmlViewer.java
@@ -29,6 +29,7 @@ import static org.netbeans.modules.java.lsp.server.htmlui.Buttons.buttonName0;
 import static org.netbeans.modules.java.lsp.server.htmlui.Buttons.buttonText0;
 import org.netbeans.modules.java.lsp.server.protocol.HtmlPageParams;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeClientCapabilities;
+import org.netbeans.modules.java.lsp.server.protocol.UIContext;
 import org.openide.util.Exceptions;
 import org.netbeans.spi.htmlui.HTMLViewerSpi;
 import org.openide.util.NbBundle;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractLspStatusDisplayer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractLspStatusDisplayer.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.lsp.server.ui;
 import javax.swing.event.ChangeListener;
 import org.eclipse.lsp4j.MessageType;
 import org.netbeans.modules.java.lsp.server.protocol.ShowStatusMessageParams;
+import org.netbeans.modules.java.lsp.server.protocol.UIContext;
 import org.openide.awt.StatusDisplayer;
 
 public abstract class AbstractLspStatusDisplayer extends StatusDisplayer {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
@@ -53,6 +53,7 @@ import org.netbeans.modules.java.lsp.server.input.QuickPickStep;
 import org.netbeans.modules.java.lsp.server.input.ShowInputBoxParams;
 import org.netbeans.modules.java.lsp.server.input.ShowMutliStepInputParams;
 import org.netbeans.modules.java.lsp.server.input.ShowQuickPickParams;
+import org.netbeans.modules.java.lsp.server.protocol.UIContext;
 import org.openide.NotificationLineSupport;
 import org.openide.NotifyDescriptor;
 import org.openide.awt.Actions;

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayerTest.java
@@ -43,6 +43,7 @@ import org.netbeans.modules.java.lsp.server.input.ShowInputBoxParams;
 import org.netbeans.modules.java.lsp.server.input.ShowMutliStepInputParams;
 import org.netbeans.modules.java.lsp.server.input.ShowQuickPickParams;
 import org.netbeans.modules.java.lsp.server.protocol.ShowStatusMessageParams;
+import org.netbeans.modules.java.lsp.server.protocol.UIContext;
 import org.openide.NotifyDescriptor;
 import org.openide.awt.StatusDisplayer;
 import org.openide.util.RequestProcessor;
@@ -59,40 +60,40 @@ public class AbstractDialogDisplayerTest extends NbTestCase {
     
     private static class MockUIContext extends UIContext {
         @Override
-        protected boolean isValid() {
+        public boolean isValid() {
             return true;
         }
 
         @Override
-        protected void showMessage(MessageParams msg) {
+        public void showMessage(MessageParams msg) {
         }
 
         @Override
-        protected CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams msg) {
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams msg) {
             return CompletableFuture.completedFuture(null);
         }
 
         @Override
-        protected CompletableFuture<String> showInputBox(ShowInputBoxParams params) {
+        public CompletableFuture<String> showInputBox(ShowInputBoxParams params) {
             return CompletableFuture.completedFuture(null);
         }
 
         @Override
-        protected CompletableFuture<List<QuickPickItem>> showQuickPick(ShowQuickPickParams params) {
+        public CompletableFuture<List<QuickPickItem>> showQuickPick(ShowQuickPickParams params) {
             return CompletableFuture.completedFuture(Collections.emptyList());
         }
 
         @Override
-        protected CompletableFuture<Map<String, Either<List<QuickPickItem>, String>>> showMultiStepInput(ShowMutliStepInputParams params) {
+        public CompletableFuture<Map<String, Either<List<QuickPickItem>, String>>> showMultiStepInput(ShowMutliStepInputParams params) {
             return CompletableFuture.completedFuture(Collections.emptyMap());
         }
 
         @Override
-        protected void logMessage(MessageParams msg) {
+        public void logMessage(MessageParams msg) {
         }
 
         @Override
-        protected StatusDisplayer.Message showStatusMessage(ShowStatusMessageParams msg) {
+        public StatusDisplayer.Message showStatusMessage(ShowStatusMessageParams msg) {
             return null;
         }
     }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ui/MockHtmlViewer.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ui/MockHtmlViewer.java
@@ -33,6 +33,7 @@ import org.netbeans.html.json.spi.FunctionBinding;
 import org.netbeans.html.json.spi.PropertyBinding;
 import org.netbeans.html.json.spi.Technology;
 import org.netbeans.modules.java.lsp.server.protocol.HtmlPageParams;
+import org.netbeans.modules.java.lsp.server.protocol.UIContext;
 import org.openide.util.lookup.ServiceProvider;
 import org.netbeans.spi.htmlui.HTMLViewerSpi;
 


### PR DESCRIPTION
Moving abstract class `UIContext` out of public package. It contains methods that use non API classes as parameter types (strange that `sigtest` did not complained), so it cannot be subclassed/implemented outside of the `java.lsp.module` anyway.
This is an attempt to fix problems mentioned in #4189