### PR TITLE
Cleanup warnings related to raw type List

### DIFF
--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsConfigUtilities.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsConfigUtilities.java
@@ -138,7 +138,7 @@ public class StrutsConfigUtilities {
             mappings = sConfig.getActionMappings();
         }
         if (mappings==null) return;
-        Action [] actions = mappings.getAction();
+        Action[] actions = mappings.getAction();
         for (int j = 0; j < actions.length; j++)
             list.add(actions[j]);
     }

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/wsdlmodel/WsdlPort.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/wsdlmodel/WsdlPort.java
@@ -19,11 +19,13 @@
 
 package org.netbeans.modules.websvc.api.jaxws.wsdlmodel;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.sun.tools.ws.processor.model.Operation;
 import com.sun.tools.ws.processor.model.Port;
 import com.sun.tools.ws.wsdl.document.soap.SOAPStyle;
-import java.util.ArrayList;
-import java.util.List;
+
 import org.netbeans.modules.websvc.jaxwsmodelapi.WSPort;
 
 /**

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/wsdlmodel/WsdlService.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/wsdlmodel/WsdlService.java
@@ -19,9 +19,11 @@
 
 package org.netbeans.modules.websvc.api.jaxws.wsdlmodel;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.sun.tools.ws.processor.model.Port;
 import com.sun.tools.ws.processor.model.Service;
-import java.util.*;
 import org.netbeans.modules.websvc.jaxwsmodelapi.WSService;
 
 /**

--- a/ide/editor/src/org/netbeans/modules/editor/NbEditorKit.java
+++ b/ide/editor/src/org/netbeans/modules/editor/NbEditorKit.java
@@ -400,7 +400,7 @@ public class NbEditorKit extends ExtKit implements Callable {
                 String actionNames = prefs.get(settingName, null);
 
                 if (actionNames != null) {
-                    l = new ArrayList();
+                    l = new ArrayList<>();
                     for(StringTokenizer t = new StringTokenizer(actionNames, ","); t.hasMoreTokens(); ) { //NOI18N
                         String action = t.nextToken().trim();
                         l.add(action);

--- a/ide/versioning.util/src/org/netbeans/modules/turbo/TurboProvider.java
+++ b/ide/versioning.util/src/org/netbeans/modules/turbo/TurboProvider.java
@@ -83,7 +83,7 @@ public interface TurboProvider {
 
         private final boolean enabled;
 
-        private final List<Object> speculative;
+        private final List<Object[]> speculative;
 
         private final Memory memory;
 

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/FixedWatchesManager.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/FixedWatchesManager.java
@@ -265,7 +265,7 @@ NodeActionsProviderFilter, ExtendedNodeModelFilter, TableModelFilter {
     @Override
     public Action[] getActions (NodeActionsProvider original, Object node) 
     throws UnknownTypeException {
-        Action [] actions = original.getActions (node);
+        Action[] actions = original.getActions (node);
         List<Action> myActions = new ArrayList<>();
 
         if (fixedWatches.containsKey (new KeyWrapper(node))) {

--- a/platform/openide.execution.compat8/src/org/openide/execution/NbClassPathCompat.java
+++ b/platform/openide.execution.compat8/src/org/openide/execution/NbClassPathCompat.java
@@ -66,13 +66,13 @@ public class NbClassPathCompat {
     @Deprecated
     public static NbClassPath createRepositoryPath (FileSystemCapability cap) {
         Thread.dumpStack();
-        final List res = new LinkedList<>();
+        final List<Object> res = new LinkedList<>();
 
 
         final class Env extends FileSystem$Environment {
             /* method of interface Environment */
             public void addClassPath(String element) {
-                res.add (element);
+                res.add(element);
             }
         }
 


### PR DESCRIPTION
Cleanup warnings related to unchecked call to add as a member of raw type List..

Here is an example.

   [repeat] /home/bwalker/src/netbeans/ide/editor/src/org/netbeans/modules/editor/NbEditorKit.java:628: warning: [unchecked] unchecked call to add(E) as a member of the raw type List
   [repeat]                     objects.add(null);
   [repeat]                                ^
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in interface List

There are some remaining warnings. They are in generated code and therefore difficult to fix.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

