### PR TITLE
Present project view files as tree leaves.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/DefaultDecorationsImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/DefaultDecorationsImpl.java
@@ -45,7 +45,6 @@ import org.openide.loaders.DataObjectNotFoundException;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
-import org.openide.util.Exceptions;
 import org.openide.util.lookup.ServiceProvider;
 
 /**

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
@@ -44,6 +44,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.netbeans.modules.java.lsp.server.explorer.TreeItem.CollapsibleState;
 import org.netbeans.modules.java.lsp.server.explorer.TreeItem.IconDescriptor;
 import org.openide.explorer.ExplorerManager;
 import org.openide.nodes.AbstractNode;
@@ -399,6 +400,9 @@ public abstract class TreeViewProvider {
         v = data.getContextValues() == null ? "" : String.join(" ", data.getContextValues()); // NOI18N
 
         TreeItem ti = new TreeItem(id, n, expanded, v);
+        if (data.isLeaf()) {
+            ti.collapsibleState = CollapsibleState.None;
+        }
         
         if (data.getIconImage() != null && data.getIconImage() != DUMMY_NODE.getIcon(BeanInfo.ICON_COLOR_16x16)) {
             TreeNodeRegistry.ImageDataOrIndex idoi = nodeRegistry.imageOrIndex(data.getIconImage());

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/TreeItemData.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/TreeItemData.java
@@ -39,6 +39,7 @@ public final class TreeItemData {
     private String[] contextValues;
     private String command;
     private URI resourceURI;
+    private boolean leaf;
     
     static {
         try {
@@ -50,6 +51,16 @@ public final class TreeItemData {
 
     public TreeItemData() {
     }
+
+    public boolean isLeaf() {
+        return leaf;
+    }
+
+    public TreeItemData makeLeaf() {
+        this.leaf = true;
+        return this;
+    }
+    
 
     public URI getResourceURI() {
         return resourceURI;
@@ -122,6 +133,7 @@ public final class TreeItemData {
         if (data.getIconImage() != null) {
             setIconImage(data.getIconImage());
         }
+        leaf |= data.isLeaf();
         return this;
     }
 }


### PR DESCRIPTION
The current `foundProjects` tree view exported from LSP presents certain files as expandable, although they are not - most notably XML files. This is different from NB IDE environment - in NB IDE, the XML file is handled by `org.netbeans.modules.xml` and its XMLDataObject, which behaves fine. But in the reduced NBLS environment, XML files are handled by `openide.loaders` module and its base XMLDataObject that attempts to delegate its node to several implementations. This delegation breaks `isLeaf()` detection in `Node` interface - the loader's XML node may eventually get some children, when it rebounds to a node with children, so it is not a leaf according to NetBeans APIs.

There are other nodes, like Bundle.properties that also show subnodes in the Projects view, this time in NetBeans IDE as well. But for the LSP project navigation I believe that exposing internal structure right in the Project tree is not good.

I've added a decorator to the project view, that will force `CollapsibleState = None` for `TreeItems` that correspond to a file.