### PR TITLE
Recursively print type parameter's type parameters.

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyVirtualSourceProvider.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyVirtualSourceProvider.java
@@ -699,7 +699,12 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
             if (genericsType.isPlaceholder()) {
                 out.print(genericsType.getName());
             } else {
-                printTypeName(genericsType.getType(), out);
+                // Note: Groovy's GenericsType.toString() uses Set<String> to avoid
+                // recursion through placeholders; but the algorithm here differs, bcs
+                // placeholders bypass this recursive invocation at all. 
+                // If this simplified printing produces some errors, the algo should be
+                // tuned to be like the GenericsType.toString one.
+                printType(genericsType.getType(), out);
                 ClassNode[] upperBounds = genericsType.getUpperBounds();
                 ClassNode lowerBound = genericsType.getLowerBound();
                 if (upperBounds != null) {


### PR DESCRIPTION
This error can be reproduced i.e. on `micronaut-core/http` project; the project mixes Groovy + Java sources. Java references Groovy classes, so our `GroovyVirtualSourceProvider` generates a java stub source during indexing, so Java indexer is happy and can resolve the class' symbols.

But it seems that the stub generator stops at 1st level of type parameters and does not print potential type parameters of the actual type parameter(s). So instead of `Map<String, Map<String, ClassNode>>` it prints just `Map<String, Map>`. Javac will then complain about usage of such (incompatible) type in the java source which expects the correct one.

The fix is simple: recursively print the complete type incl. parameters and bounds.