### PR TITLE
improve php test performance

### DIFF
--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -189,6 +189,11 @@ import static org.openide.util.test.MockLookup.setLookup;
  */
 public abstract class CslTestBase extends NbTestCase {
 
+    static {
+        // testing performance: set scanner update delay to 0
+        System.setProperty(PathRegistry.class.getName()+".FIRER_EVT_COLLAPSE_WINDOW", "0");
+    }
+
     public CslTestBase(String testName) {
         super(testName);
     }

--- a/ide/ide.kit/nbproject/project.properties
+++ b/ide/ide.kit/nbproject/project.properties
@@ -42,7 +42,7 @@ test.config.versioning.includes=\
 test.timeout=900000
 requires.nb.javac=true
 
-test.run.args=-ea -Xmx700m -XX:+IgnoreUnrecognizedVMOptions \
+test.jms.flags=\
  --add-opens=java.base/java.net=ALL-UNNAMED \
  --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED \
  --add-opens=java.desktop/javax.swing=ALL-UNNAMED \
@@ -50,4 +50,4 @@ test.run.args=-ea -Xmx700m -XX:+IgnoreUnrecognizedVMOptions \
  --add-opens=java.desktop/javax.swing.text=ALL-UNNAMED \
  --add-opens=java.desktop/sun.awt=ALL-UNNAMED \
  --add-modules=jdk.jdwp.agent,jdk.attach,jdk.jdi,jdk.jshell,java.compiler,jdk.compiler,jdk.management,jdk.unsupported,jdk.internal.le,jdk.internal.ed,jdk.internal.opt,jdk.internal.jvmstat \
- --add-exports=jdk.jdi/com.sun.jdi=ALL-UNNAMED \
+ --add-exports=jdk.jdi/com.sun.jdi=ALL-UNNAMED

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRegistry.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRegistry.java
@@ -68,7 +68,9 @@ import org.openide.util.WeakListeners;
 public final class PathRegistry implements Runnable {
 
     private static final boolean FIRE_UNKNOWN_ALWAYS = false;
-    /*test*/ static final int FIRER_EVT_COLLAPSE_WINDOW = 500;
+
+    // property set/field used in tests
+    static final int FIRER_EVT_COLLAPSE_WINDOW = Integer.getInteger(PathRegistry.class.getName()+".FIRER_EVT_COLLAPSE_WINDOW", 500);
 
     private static PathRegistry instance;
     private static final RequestProcessor firer = new RequestProcessor ("Path Registry Request Processor"); //NOI18N

--- a/java/java.hints/nbproject/project.properties
+++ b/java/java.hints/nbproject/project.properties
@@ -115,8 +115,8 @@ test.config.batch2-vanilla-javac.includes=\
 test.config.batch2-vanilla-javac.excludes=\
     ${vanilla-javac.excludes}
 
-test.run.args=-ea -Xmx700m -XX:+IgnoreUnrecognizedVMOptions \
+test.jms.flags=\
  --add-opens=java.base/java.net=ALL-UNNAMED \
  --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED \
  --add-opens=java.desktop/javax.swing.text=ALL-UNNAMED \
- --add-opens=java.desktop/sun.awt=ALL-UNNAMED \
+ --add-opens=java.desktop/sun.awt=ALL-UNNAMED

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -290,7 +290,7 @@
     <target name="test-lib-init" depends="-init-bootclasspath-prepend,init,-build-libs.junit4">
         <path id="test.unit.lib.cp"/>
         <property name="test.jms.flags" value=""/>
-        <property name="test.run.args" value="-ea -Xmx700m ${metabuild.jms-flags.jvm} ${test.jms.flags} -XX:+IgnoreUnrecognizedVMOptions"/>
+        <property name="test.run.args" value="-ea -Xms1200m -Xmx1200m -XX:+UseParallelGC ${metabuild.jms-flags.jvm} ${test.jms.flags} -XX:+IgnoreUnrecognizedVMOptions"/>
         <property name="extra.test.libs.dir" location="${test.dist.dir}/extralibs"/>
         <macrodef name="test-init-nborg">
             <attribute name="test.type"/>


### PR DESCRIPTION
lets see if this has any side effects, I didn't do a full test run yet, only checked few specific tests - CI will tell for sure.

edit:
holy bytecode batman! The **total** went down from >2h to <1h

before:
`PHP on ubuntu-20.04/JDK 8 succeeded in 2h 4m 24s `
after: 
`PHP on ubuntu-20.04/JDK 8 succeeded in 41m 53s`

GC tweaks result in small improvements too, observable when comparing travis time totals, see https://github.com/apache/netbeans/pull/4284#discussion_r907747129

commit msg:

 - set event delay to 0
 - tweak JVM settings a bit (little bit more heap, use throughput GC)

the event delay caused some tests to lose >1s per test method with CPU mostly
idling. Tests with a lot of cases were observed to complete 4-5x faster after
this tweak.

e.g: OccurrencesFinderImplTest: ~10 mins -> ~2 mins