### PR TITLE
Allow to find precise output folder for each language.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -381,11 +381,7 @@ class NbProjectInfoBuilder {
                                             }
                                         }
                                     }
-                                    if (candidate != null) {
-                                        outDir = candidate.toFile();
-                                    } else {
-                                        outDir = new File("");
-                                    }
+                                    outDir = candidate != null ? candidate.toFile() : new File("");
                                 }
                                 
                                 model.getInfo().put(propBase + lang + "_output_classes", outDir);

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
@@ -45,7 +45,7 @@ import org.netbeans.modules.gradle.spi.GradleFiles;
 public final class ProjectInfoDiskCache extends AbstractDiskCache<GradleFiles, QualifiedProjectInfo> {
 
     // Increase this number if new info is gathered from the projects.
-    private static final int COMPATIBLE_CACHE_VERSION = 22;
+    private static final int COMPATIBLE_CACHE_VERSION = 23;
     private static final String INFO_CACHE_FILE_NAME = "project-info.ser"; //NOI18N
     private static final Map<GradleFiles, ProjectInfoDiskCache> DISK_CACHES = Collections.synchronizedMap(new WeakHashMap<>());
 

--- a/java/gradle.java/apichanges.xml
+++ b/java/gradle.java/apichanges.xml
@@ -83,6 +83,19 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="sourceset-lang-output">
+            <api name="gradle.java.api"/>
+            <summary>Support for per-language output directories</summary>
+            <version major="1" minor="19"/>
+            <date day="28" month="6" year="2022"/>
+            <author login="sdedic"/>
+            <compatibility semantic="compatible" addition="yes" deprecation="no"/>
+            <description>
+                Each language plugin typically generates output to a specific directory. The mapping
+                allows more precise output-to-source mapping.
+            </description>
+            <class package="org.netbeans.modules.gradle.java.api" name="GradleJavaSourceSet"/>
+        </change>
         <change id="nested-class-locations">
             <api name="gradle.java.api"/>
             <summary>Location can represent nested classes</summary>

--- a/java/gradle.java/manifest.mf
+++ b/java/gradle.java/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gradle.java
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/java/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/java/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.18
+OpenIDE-Module-Specification-Version: 1.19

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaProjectBuilder.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaProjectBuilder.java
@@ -99,6 +99,11 @@ final class GradleJavaProjectBuilder implements ProjectInfoExtractor.Result {
                     if (compArgs != null) {
                         compilerArgs.put(lang, Collections.unmodifiableList(compArgs));
                     }
+                    // if detected, note the output dirs for individual language(s).
+                    File f = (File)info.get("sourceset_" + name + "_" + lang.name() + "_output_classes");
+                    if (f != null) {
+                        sourceSet.outputs.put(lang, f);
+                    }
                 }
                 sourceSet.sourcesCompatibility = Collections.unmodifiableMap(sourceComp);
                 sourceSet.targetCompatibility = Collections.unmodifiableMap(targetComp);

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
@@ -78,6 +78,7 @@ public final class GradleJavaSourceSet implements Serializable {
     private static final String DEFAULT_SOURCE_COMPATIBILITY = "1.5"; //NOI18N
 
     Map<SourceType, Set<File>> sources = new EnumMap<>(SourceType.class);
+    Map<SourceType, File> outputs = new EnumMap<>(SourceType.class);
     String name;
     String runtimeConfigurationName;
     String compileConfigurationName;
@@ -364,6 +365,33 @@ public final class GradleJavaSourceSet implements Serializable {
 
     public Set<File> getOutputClassDirs() {
         return outputClassDirs != null ? outputClassDirs : Collections.<File>emptySet();
+    }
+    
+    /**
+     * Represents an unknown value. This is different from a value that is not present,
+     * i.e. an output directory for a language that is not used in the project.
+     * @since 1.19
+     */
+    public static final File UNKNOWN = new File("");
+    
+    /**
+     * Returns output directories for the given source type in the sourceset. Returns
+     * null, if the source type has no output directories. Returns UNKNOWN, if the 
+     * output location is not known.
+     * 
+     * @param srcType language type
+     * @return location or {@code null}.
+     * @since 1.19
+     */
+    public File getOutputClassDir(SourceType srcType) {
+        File f = outputs.get(srcType);
+        if (f == null) {
+            return null;
+        } else if (UNKNOWN.equals(f)) {
+            // make the value canonical, so == can be used.
+            return UNKNOWN;
+        }
+        return f;
     }
 
     /**

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
@@ -385,9 +385,7 @@ public final class GradleJavaSourceSet implements Serializable {
      */
     public File getOutputClassDir(SourceType srcType) {
         File f = outputs.get(srcType);
-        if (f == null) {
-            return null;
-        } else if (UNKNOWN.equals(f)) {
+        if (UNKNOWN.equals(f)) {
             // make the value canonical, so == can be used.
             return UNKNOWN;
         }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceForBinary.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceForBinary.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -53,12 +54,48 @@ import org.openide.util.WeakListeners;
  * @author Laszlo Kishalmi
  */
 public class GradleSourceForBinary implements SourceForBinaryQueryImplementation2 {
+    
+    private static Map<SourceType, String> sourceMimeTypes = new EnumMap<>(SourceType.class);
+    
+    static {
+        sourceMimeTypes.put(JAVA, "text/x-java");
+        sourceMimeTypes.put(GROOVY, "text/x-groovy");
+        sourceMimeTypes.put(SCALA, "text/x-scala");
+        sourceMimeTypes.put(KOTLIN, "text/x-kotlin");
+    }
 
     private final Project project;
     private final Map<URL, Res> cache = new HashMap<>();
-
+    
     public GradleSourceForBinary(Project project) {
         this.project = project;
+    }
+    
+    private static final EnumSet<SourceType> ALL_LANGUAGES;
+    
+    static {
+        EnumSet<SourceType> s = EnumSet.allOf(SourceType.class);
+        s.remove(SourceType.RESOURCES);
+        s.remove(SourceType.GENERATED);
+        
+        ALL_LANGUAGES = s;
+    }
+    
+    private Result languageSourceForOutput(GradleJavaSourceSet ss, File outputDir) {
+        
+        for (SourceType st : ALL_LANGUAGES) {
+            File f = ss.getOutputClassDir(st);
+            if (outputDir.equals(f)) {
+                // special case for java here; Java replaces its classpath entries by corresponding cache entries with
+                // indexed sources (.sig files) so that it tracks not compiled source changes. Other languages do not generate
+                // the expected files.
+                // The proper solution will be to change java implementation to use output folder as a fallback if nothing
+                // is found in the cache; then this special case may be removed.
+                boolean canPreferSource = st == SourceType.JAVA;
+                return new Res(project, ss.getName(), EnumSet.of(RESOURCES), canPreferSource);
+            }
+        }
+        return new Res(project, ss.getName(), ALL_LANGUAGES, false);
     }
 
     @Override
@@ -76,8 +113,7 @@ public class GradleSourceForBinary implements SourceForBinaryQueryImplementation
                                 File outputDir = ss.getCompilerArgs(JAVA).contains("--module-source-path") ? //NOI18N
                                         root.getParentFile() : root;
                                 if (ss.getOutputClassDirs().contains(outputDir)) {
-                                    ret = new Res(project, ss.getName(), EnumSet.of(JAVA, GROOVY, SCALA, KOTLIN, GENERATED));
-                                    break;
+                                    return languageSourceForOutput(ss, outputDir);
                                 }
                                 if ((ret == null) && root.equals(ss.getOutputResources())) {
                                     ret = new Res(project, ss.getName(), EnumSet.of(RESOURCES));
@@ -122,11 +158,17 @@ public class GradleSourceForBinary implements SourceForBinaryQueryImplementation
         private final Set<SourceType> sourceTypes;
         private final PropertyChangeListener listener;
         private final ChangeSupport support = new ChangeSupport(this);
-
+        private final boolean preferSources;
+        
         public Res(Project project, String sourceSet, Set<SourceType> sourceTypes) {
+            this(project, sourceSet, sourceTypes, true);
+        }
+
+        public Res(Project project, String sourceSet, Set<SourceType> sourceTypes, boolean preferSources) {
             this.project = project;
             this.sourceSet = sourceSet;
             this.sourceTypes = sourceTypes;
+            this.preferSources = preferSources;
             listener = (PropertyChangeEvent evt) -> {
                 if (NbGradleProject.PROP_PROJECT_INFO.equals(evt.getPropertyName())) {
                     support.fireChange();
@@ -137,7 +179,7 @@ public class GradleSourceForBinary implements SourceForBinaryQueryImplementation
 
         @Override
         public boolean preferSources() {
-            return true;
+            return preferSources;
         }
 
         @Override


### PR DESCRIPTION
In a mixed-language project, such as `micronaut-core/http`, each language produces the output typically to a separate folder, although the output is in form of .class files.

Currently Gradle project knows the set of output folders, but does not know what language produces output in which particular one, so backwards mapping in `SourceForBinaryQuery` provides **all source folders**, which is not correct.

In addition, the result of SFBQ query in Gradle/java says that sources should be always preferred. This is fine in theory, but java uses (exclusively) its cached indexed folders instead of the real output folders - so it is able to react on editing changes even before they are compiled. But other languages behave differently.

These two things in effect lead to spurious "undersolved symbol" when Java code references some Groovy or Kotlin class:
- the `build/groovy/main/classes`, or `build/kotlin/main/classes` is on the `classpath/compile` ClassPath; that's right
- since `preferSources` is true, java support attempts of SFBQ to find sources. It gets a result. 
- And to avoid **parsing**, it replaces the source folder with cache folder, under assumption that the sources are indexed into .sig files Java can process.

The last thing is not true for groovy / kotlin, at least now. This could be improved in Java support if it did not entirely replace the output folder with the source, but used the output folder as a cache for the case the SFBQ result folder and its cache does not contain the desired type.


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

