### PR TITLE
Cleanup references to the generic emptySet()..

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ExamineManifest.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ExamineManifest.java
@@ -51,7 +51,7 @@ public class ExamineManifest  {
     private String locBundle;
     private boolean publicPackages;
     private boolean populateDependencies = false;
-    private List dependencyTokens = Collections.emptyList();
+    private List<String> dependencyTokens = Collections.<String>emptyList();
    
     
     public void checkFile() throws MojoExecutionException {
@@ -278,7 +278,7 @@ public class ExamineManifest  {
         return dependencyTokens;
     }
 
-    public void setDependencyTokens(List dependencyTokens) {
+    public void setDependencyTokens(List<String> dependencyTokens) {
         this.dependencyTokens = dependencyTokens;
     }
     

--- a/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
@@ -134,7 +134,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
             attrDecls = new HashMap<>();
 
             // Commonly used variables
-            Set emptySet = new TreeSet();
+            Set<String> emptySet = new TreeSet<>();
             String spaceAtt = "xml:space";  // NOI18N
             Set<String> tmpSet;
 

--- a/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/SourcePathProviderImpl.java
+++ b/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/SourcePathProviderImpl.java
@@ -409,7 +409,7 @@ public class SourcePathProviderImpl extends SourcePathProvider {
         Properties sourcesProperties = Properties.getDefault ().getProperties ("debugger").getProperties ("sources");
         List<String> additionalSourceRoots = (List<String>) sourcesProperties.
                 getProperties("additional_source_roots").
-                getCollection("src_roots", Collections.emptyList());
+                getCollection("src_roots", Collections.<String>emptyList());
         if (additionalSourceRoots == null || additionalSourceRoots.isEmpty()) {
             return null;
         }
@@ -472,7 +472,7 @@ public class SourcePathProviderImpl extends SourcePathProvider {
     private Set<String> getRemoteDisabledSourceRoots() {
         Properties sourcesProperties = Properties.getDefault ().getProperties ("debugger").getProperties ("sources");
         return (Set<String>) sourcesProperties.getProperties("source_roots").
-            getCollection("remote_disabled", Collections.emptySet());
+            getCollection("remote_disabled", Collections.<String>emptySet());
     }
 
     private void storeDisabledSourceRoots(Set<String> disabledSourceRoots) {
@@ -516,7 +516,7 @@ public class SourcePathProviderImpl extends SourcePathProvider {
     public static Map<String, Integer> getRemoteSourceRootsOrder() {
         Properties sourcesProperties = Properties.getDefault ().getProperties ("debugger").getProperties ("sources");
         return (Map<String, Integer>) sourcesProperties.getProperties("source_roots").
-            getMap("remote_order", Collections.emptyMap());
+            getMap("remote_order", Collections.<String, Integer>emptyMap());
     }
 
     private static void storeSourceRootsOrder(File baseDir, String[] roots, int[] permutation) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
@@ -60,8 +60,8 @@ public final class NbLaunchRequestHandler {
         activeLaunchHandler = noDebug ? new NbLaunchWithoutDebuggingDelegate(terminateHandle)
                 : new NbLaunchWithDebuggingDelegate(terminateHandle);
         // validation
-        List<String> modulePaths = (List<String>) launchArguments.getOrDefault("modulePaths", Collections.emptyList());
-        List<String> classPaths = (List<String>) launchArguments.getOrDefault("classPaths", Collections.emptyList());
+        List<String> modulePaths = (List<String>) launchArguments.getOrDefault("modulePaths", Collections.<String>emptyList());
+        List<String> classPaths = (List<String>) launchArguments.getOrDefault("classPaths", Collections.<String>emptyList());
 
         // "file" key is provided by DAP client infrastructure, sometimes in an unsuitable manner, e.g. some cryptic ID for Output window etc. 
         // the "projectFile" allows to override the infrastructure from client logic.

--- a/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/BeanModelBuilder.java
+++ b/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/BeanModelBuilder.java
@@ -92,11 +92,11 @@ public final class BeanModelBuilder {
     /**
      * Names of factory methods usable to create the bean instance
      */
-    private Map<String, TypeMirrorHandle> factoryMethods = Collections.emptyMap();
+    private Map<String, TypeMirrorHandle> factoryMethods = Collections.<String, TypeMirrorHandle>emptyMap();
     
     private FxBean  resultInfo;
     
-    private Set<String> constants = Collections.emptySet();
+    private Set<String> constants = Collections.<String>emptySet();
     
     /**
      * Type element for the class.
@@ -619,7 +619,7 @@ public final class BeanModelBuilder {
         TypeMirrorHandle returnType = TypeMirrorHandle.create(m.getReturnType());
         
         if (factoryMethods.isEmpty()) {
-            factoryMethods = new HashMap<String, TypeMirrorHandle>();
+            factoryMethods = new HashMap<>();
         }
         factoryMethods.put(m.getSimpleName().toString(), returnType);
         consumed = true;
@@ -741,7 +741,7 @@ public final class BeanModelBuilder {
         events.put(ei.getName(), ei);
     }
     
-    private Map<String, FxEvent>    events = Collections.emptyMap();
+    private Map<String, FxEvent>    events = Collections.<String, FxEvent>emptyMap();
     
     private FxBeanCache beanCache;
     

--- a/platform/openide.explorer/src/org/openide/explorer/DefaultEMLookup.java
+++ b/platform/openide.explorer/src/org/openide/explorer/DefaultEMLookup.java
@@ -84,7 +84,7 @@ final class DefaultEMLookup extends ProxyLookup implements LookupListener, Prope
             if (attachedTo == null) {
                 copy = Collections.<Lookup, Lookup.Result>emptyMap();
             } else {
-                copy = new HashMap<Lookup, Lookup.Result>(attachedTo);
+                copy = new HashMap<>(attachedTo);
             }
         }
 

--- a/webcommon/javascript2.source.query/src/org/netbeans/modules/javascript2/source/query/SourceElementsQueryImpl.java
+++ b/webcommon/javascript2.source.query/src/org/netbeans/modules/javascript2/source/query/SourceElementsQueryImpl.java
@@ -44,7 +44,7 @@ public class SourceElementsQueryImpl implements SourceElementsQuery {
 
     @Override
     public Collection<Var> getVarsAt(Source source, int offset) {
-        final Collection[] vars = new Collection[] { Collections.emptyList()};
+        final Collection[] vars = new Collection[] { Collections.<Var>emptyList()};
         try {
             ParserManager.parse(Collections.singleton(source), new UserTask() {
                 public @Override


### PR DESCRIPTION
Cleanup references to the generic emptySet()..

   [repeat] /home/bwalker/src/netbeans/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigUtilities.java:250: warning: [rawtypes] found raw type: Set
   [repeat]         Set result = Collections.emptySet();
   [repeat]         ^
   [repeat]   missing type arguments for generic class Set<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in interface Set





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

