### PR TITLE
Update FlatLaf from 2.1 to 2.3

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-D425A89164BB82E1967F84B6FD3EFF5FF9F60ECD com.formdev:flatlaf:2.1
+D7A77B74A49FC9705199426FFA73BD67ACF06306 com.formdev:flatlaf:2.3

--- a/platform/libs.flatlaf/external/flatlaf-2.3-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-2.3-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 2.1
-Files: flatlaf-2.1.jar
+Version: 2.3
+Files: flatlaf-2.3.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-2.1.jar=modules/ext/flatlaf-2.1.jar
+release.external/flatlaf-2.3.jar=modules/ext/flatlaf-2.3.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-2.1.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-2.1.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-2.3.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-2.3.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -28,6 +28,8 @@ controlShadow=$Component.borderColor
 # hide grip in divider
 SplitPaneDivider.style = plain
 
+TabbedPane.inactiveUnderlineColor = $EditorTab.inactiveUnderlineColor
+
 
 #---- TabbedContainer ----
 


### PR DESCRIPTION
Update FlatLaf to v2.3.

Changes:
- https://github.com/JFormDesigner/FlatLaf/releases/tag/2.2
- https://github.com/JFormDesigner/FlatLaf/releases/tag/2.3

### JTabbedPane

Selected tab underline color now changes depending on whether the focus is within the tab content
(left is focused, right is not focused):

![image](https://user-images.githubusercontent.com/5604048/176488094-e63ca3fc-961f-494f-a032-879438e732e7.png)

The new color can be changed by setting UI value `TabbedPane.inactiveUnderlineColor`.
`This PR changes it to the same color used for editor and view tabs.

### File chooser shortcuts panel 

This release adds a shortcuts panel to the left side of all file choosers (class `JFileChooser`):

![image](https://user-images.githubusercontent.com/5604048/165567283-cfc30f8a-c4e6-4724-bc8d-e822472e1f53.png)

On Windows, the content of the shortcuts panel is the same as in the Java Windows L&F.
On macOS and Linux the shortcuts panel is empty and hidden.