### PR TITLE
Implemnted --direct-disable module option.

### DIFF
--- a/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/Bundle.properties
+++ b/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/Bundle.properties
@@ -49,4 +49,4 @@ MSG_ListModules=Prints the list of all modules, their versions and enablement st
 MSG_InstallModules=Installs provided JAR files as modules
 MSG_DisableModules=Disable modules for specified codebase names
 MSG_EnableModules=Enable modules for specified codebase names
-
+MSG_DirectDisableModule=Disable module immediately

--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -1982,6 +1982,15 @@ public final class ModuleManager extends Modules {
     FIND_AUTOLOADS:
         while (it.hasNext()) {
             Module m = it.next();
+            String host = m.getFragmentHostCodeName();
+            if (host != null) {
+                Module theHost = modulesByName.get(host);
+                if (theHost != null && theHost.isEnabled()) {
+                    // will not disable fragment module, as it is merged to an
+                    // enabled host.
+                    continue;
+                }
+            }
             if (m.isAutoload()) {
                 for (Module other: stillEnabled) {
                     Dependency[] dependencies = other.getDependenciesArray();


### PR DESCRIPTION
The module system offers several options for module management. `--enable` option seems to work well, as it directly calls `ModuleManager.enable` and enables the requested modules (+ dependencies) on the fly. But `--disable` was implemented for some reason through delayed-disable, but **unlike** plugin UI, it will not generate the next-startup information files and does not request a restart: it seems broken. I filed [NETBEANS-6516](https://issues.apache.org/jira/browse/NETBEANS-6516) to track this,

Option that would **disable modules on the fly** is missing completely. This was removed from the UI, perhaps because **removing** code from the memory is hard: there may be half-linked dangling listeners etc. But the option processing happens during startup before the UI even appears, so it seems a lot safe.

I have implemented `--direct-disable` option that allows to disable one or more modules; the state will be persisted in the user directory config area. It will error out and abort the execution in case of any error, such as another not disabled module that depends on the one that should be disabled.
