### PR TITLE
Fixes unhandled ExpressionArrayAccess in PHP Editor

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
@@ -43,6 +43,7 @@ import org.netbeans.modules.php.editor.parser.astnodes.ClassDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.ClassInstanceCreation;
 import org.netbeans.modules.php.editor.parser.astnodes.ClassName;
 import org.netbeans.modules.php.editor.parser.astnodes.Expression;
+import org.netbeans.modules.php.editor.parser.astnodes.ExpressionArrayAccess;
 import org.netbeans.modules.php.editor.parser.astnodes.FieldAccess;
 import org.netbeans.modules.php.editor.parser.astnodes.FormalParameter;
 import org.netbeans.modules.php.editor.parser.astnodes.FunctionDeclaration;
@@ -288,6 +289,8 @@ public final class CodeUtils {
         } else if (typeName instanceof NullableType) {
             NullableType nullableType = (NullableType) typeName;
             return NULLABLE_TYPE_PREFIX + extractQualifiedName(nullableType.getType());
+        } else if (typeName instanceof ExpressionArrayAccess) {
+            return extractQualifiedName(((ExpressionArrayAccess) typeName).getExpression());
         } else if (typeName instanceof UnionType) {
             UnionType unionType = (UnionType) typeName;
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Create following PHP class and open it in NetBeans (current master branch):

```php
class ConstantArrayAccess {

    private const NUMBER_TO_NAME_MAP = [3 => 'three'];

    public function getName($number) {
        $name = self::NUMBER_TO_NAME_MAP[$number];

        return $name;
    }

}
```

Following exception appears:
<details>
<summary>Exception stack trace</summary>
```
java.lang.AssertionError: class org.netbeans.modules.php.editor.parser.astnodes.ExpressionArrayAccess
        at org.netbeans.modules.php.editor.CodeUtils.extractQualifiedName(CodeUtils.java:312)
        at org.netbeans.modules.php.editor.model.impl.VariousUtils.extractVariableTypeFromVariableBase(VariousUtils.java:1153)
        at org.netbeans.modules.php.editor.model.impl.VariousUtils.extractTypeFroVariableBase(VariousUtils.java:208)
        at org.netbeans.modules.php.editor.model.impl.VariousUtils.extractTypeFroVariableBase(VariousUtils.java:199)
        at org.netbeans.modules.php.editor.model.impl.ModelVisitor.visit(ModelVisitor.java:294)
        at org.netbeans.modules.php.editor.parser.astnodes.ReturnStatement.accept(ReturnStatement.java:50)
        at org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultVisitor.scan(DefaultVisitor.java:142)
        at org.netbeans.modules.php.editor.model.impl.ModelVisitor.scan(ModelVisitor.java:196)
        at org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultVisitor.scan(DefaultVisitor.java:149)
        at org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultVisitor.visit(DefaultVisitor.java:211)
        at org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultTreePathVisitor.visit(DefaultTreePathVisitor.java:236)
        at org.netbeans.modules.php.editor.parser.astnodes.Block.accept(Block.java:70)
        at org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultVisitor.scan(DefaultVisitor.java:142)
        at org.netbeans.modules.php.editor.model.impl.ModelVisitor.scan(ModelVisitor.java:196)
        at org.netbeans.modules.php.editor.model.impl.ModelVisitor.visit(ModelVisitor.java:576)
        at org.netbeans.modules.php.editor.parser.astnodes.MethodDeclaration.accept(MethodDeclaration.java:73)
        at org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultVisitor.scan(DefaultVisitor.java:142)
        at org.netbeans.modules.php.editor.model.impl.ModelVisitor.scan(ModelVisitor.java:196)
        at org.netbeans.modules.php.editor.model.impl.ModelVisitor.scanNoLazy(ModelVisitor.java:1696)
        at org.netbeans.modules.php.editor.model.impl.MethodScopeImpl.scan(MethodScopeImpl.java:289)
        at org.netbeans.modules.php.editor.model.impl.ClassScopeImpl.addSelfToIndex(ClassScopeImpl.java:440)
        at org.netbeans.modules.php.editor.index.PHPIndexer.index(PHPIndexer.java:157)
        at org.netbeans.modules.parsing.spi.indexing.Indexable$MyAccessor$3.run(Indexable.java:225)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.runIndexer(RepositoryUpdater.java:274)
        at org.netbeans.modules.parsing.spi.indexing.Indexable$MyAccessor.index(Indexable.java:223)
[catch] at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Work$1T.run(RepositoryUpdater.java:3229)
        at org.netbeans.modules.parsing.impl.TaskProcessor.callUserTask(TaskProcessor.java:586)
        at org.netbeans.modules.parsing.api.ParserManager$MultiUserTaskAction.run(ParserManager.java:169)
        at org.netbeans.modules.parsing.api.ParserManager$MultiUserTaskAction.run(ParserManager.java:140)
        at org.netbeans.modules.parsing.impl.TaskProcessor$2.call(TaskProcessor.java:181)
        at org.netbeans.modules.parsing.impl.TaskProcessor$2.call(TaskProcessor.java:178)
        at org.netbeans.modules.masterfs.filebasedfs.utils.FileChangedManager.priorityIO(FileChangedManager.java:153)
        at org.netbeans.modules.masterfs.providers.ProvidedExtensions.priorityIO(ProvidedExtensions.java:335)
        at org.netbeans.modules.parsing.nb.DataObjectEnvFactory.runPriorityIO(DataObjectEnvFactory.java:118)
        at org.netbeans.modules.parsing.impl.Utilities.runPriorityIO(Utilities.java:67)
        at org.netbeans.modules.parsing.impl.TaskProcessor.runUserTask(TaskProcessor.java:178)
        at org.netbeans.modules.parsing.api.ParserManager.parse(ParserManager.java:85)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Work.indexEmbedding(RepositoryUpdater.java:3253)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Work.doIndex(RepositoryUpdater.java:2861)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Work.lambda$index$0(RepositoryUpdater.java:2626)
        at org.netbeans.modules.parsing.impl.indexing.errors.TaskCache.refreshTransaction(TaskCache.java:540)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Work.index(RepositoryUpdater.java:2625)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$AbstractRootsWork.lambda$scanSource$3(RepositoryUpdater.java:5719)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.lambda$runInContext$4(RepositoryUpdater.java:2119)
        at org.openide.util.lookup.Lookups.executeWith(Lookups.java:279)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.runInContext(RepositoryUpdater.java:2117)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.runInContext(RepositoryUpdater.java:2098)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.access$1400(RepositoryUpdater.java:135)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$AbstractRootsWork.scanSource(RepositoryUpdater.java:5754)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$AbstractRootsWork.scanSources(RepositoryUpdater.java:5427)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$RootsWork.getDone(RepositoryUpdater.java:5059)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Work.doTheWork(RepositoryUpdater.java:3436)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task._run(RepositoryUpdater.java:6181)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task.access$3400(RepositoryUpdater.java:5839)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task$2.lambda$call$0(RepositoryUpdater.java:6100)
        at org.openide.util.lookup.Lookups.executeWith(Lookups.java:279)
        at org.netbeans.modules.parsing.impl.RunWhenScanFinishedSupport.performScan(RunWhenScanFinishedSupport.java:83)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task$2.call(RepositoryUpdater.java:6100)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task$2.call(RepositoryUpdater.java:6096)
        at org.netbeans.modules.masterfs.filebasedfs.utils.FileChangedManager.priorityIO(FileChangedManager.java:153)
        at org.netbeans.modules.masterfs.providers.ProvidedExtensions.priorityIO(ProvidedExtensions.java:335)
        at org.netbeans.modules.parsing.nb.DataObjectEnvFactory.runPriorityIO(DataObjectEnvFactory.java:118)
        at org.netbeans.modules.parsing.impl.Utilities.runPriorityIO(Utilities.java:67)
        at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task.run(RepositoryUpdater.java:6096)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
        at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
        at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
        at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)
```
</details>
