### PR TITLE
Improve performance of JS implementation of AlternativeLocationImpl

### DIFF
--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/navigation/DeclarationFinderImpl.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/navigation/DeclarationFinderImpl.java
@@ -398,6 +398,7 @@ public class DeclarationFinderImpl implements DeclarationFinder {
         private final int offset;
         private final DeclarationLocation location;
         private final IndexedElement element;
+        private String stringLocation;
 
         public AlternativeLocationImpl(IndexResult iResult) {
             this.iResult = iResult;
@@ -412,7 +413,10 @@ public class DeclarationFinderImpl implements DeclarationFinder {
             return element;
         }
 
-        private  String getStringLocation() {
+        private String getStringLocation() {
+            if(stringLocation != null) {
+                return stringLocation;
+            }
             int lineNumber = 0;
             int count = 0;
             List<String> asLines;
@@ -435,6 +439,7 @@ public class DeclarationFinderImpl implements DeclarationFinder {
             if (lineNumber > 0) {
                 result = result + " : " + lineNumber; //NOI18N
             }
+            stringLocation = result;
             return result;
         }
 
@@ -452,7 +457,13 @@ public class DeclarationFinderImpl implements DeclarationFinder {
         @Override
         public int compareTo(AlternativeLocation o) {
             AlternativeLocationImpl ali = (AlternativeLocationImpl)o;
-            return getStringLocation().compareTo(ali.getStringLocation());
+            String relPath1 = iResult.getRelativePath();
+            String relPath2 = ali.iResult.getRelativePath();
+            int comparison = relPath1.compareTo(relPath2);
+            if(comparison != 0) {
+                return comparison;
+            }
+            return offset - ali.offset;
         }
 
     }


### PR DESCRIPTION
#getStringLocation reads the original file, but is called from the EDT,
so invocations must be kept to a minimum. What is more the method is
used by #compareTo and thus is potentially called often.

Two optimisations are applied:

- the result of #getStringLocation is cached and only calculated once
- #compareTo was rewritten to use the relative path and offset directly.
  Before relative path and the line number was used to create an
  ordering, as offset and line number are related, switching for
  ordering shoud have no outside result
