### PR TITLE
Use the copy constructor when that is all one needs.

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ExamineManifest.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ExamineManifest.java
@@ -51,7 +51,7 @@ public class ExamineManifest  {
     private String locBundle;
     private boolean publicPackages;
     private boolean populateDependencies = false;
-    private List<String> dependencyTokens = Collections.<String>emptyList();
+    private List<String> dependencyTokens = Collections.emptyList();
    
     
     public void checkFile() throws MojoExecutionException {

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/ProgressEventSupport.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/ProgressEventSupport.java
@@ -100,7 +100,7 @@ public class ProgressEventSupport {
 	Vector<ProgressListener> targets = null;
 	synchronized (this) {
 	    if (listeners != null) {
-	        targets = (Vector<ProgressListener>)listeners.clone();
+	        targets = new Vector<>(listeners);
 	    }
 	}
 

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/ProgressEventSupport.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/ProgressEventSupport.java
@@ -100,7 +100,7 @@ public class ProgressEventSupport {
 	Vector<ProgressListener> targets = null;
 	synchronized (this) {
 	    if (listeners != null) {
-	        targets = (Vector) listeners.clone();
+	        targets = new Vector<>(listeners);
 	    }
 	}
 

--- a/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
@@ -704,7 +704,7 @@ public final class DebuggerManager implements ContextProvider {
                 throw new IllegalArgumentException("Permutation of length "+permutation.length+", but have "+watches.size()+" watches.");
             }
             checkPermutation(permutation);
-            Vector<Watch> v = (Vector<Watch>)watches.clone();
+            Vector<Watch> v = new Vector<>(watches);
             for (int i = 0; i < v.size(); i++) {
                 watches.set(permutation[i], v.get(i));
             }

--- a/ide/api.debugger/src/org/netbeans/spi/debugger/ActionsProviderSupport.java
+++ b/ide/api.debugger/src/org/netbeans/spi/debugger/ActionsProviderSupport.java
@@ -80,7 +80,7 @@ public abstract class ActionsProviderSupport extends ActionsProvider {
      * @param enabled the new state
      */
     protected void fireActionStateChanged (Object action, boolean enabled) {
-        Vector<ActionsProviderListener> v = (Vector<ActionsProviderListener>)listeners.clone();
+        Vector<ActionsProviderListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             v.elementAt (i).actionStateChange (

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/RepositoryImpl.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/RepositoryImpl.java
@@ -426,7 +426,7 @@ public final class RepositoryImpl<R, Q, I> {
     public Collection<IssueImpl> getUnsubmittedIssues () {
         Collection<I> issues = issueStatusProvider != null ? issueStatusProvider.getUnsubmittedIssues(r) : null;
         if (issues == null || issues.isEmpty()) {
-            return Collections.<IssueImpl>emptyList();
+            return Collections.emptyList();
         }
         List<IssueImpl> ret = new ArrayList<>(issues.size());
         for (I i : issues) {

--- a/ide/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/StorageImpl.java
+++ b/ide/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/StorageImpl.java
@@ -441,7 +441,7 @@ public final class StorageImpl <K extends Object, V extends Object> {
                 }
                 
                 Filters filtersForId = filters.get(storageDescriptionId);
-                return filtersForId == null ? Collections.<StorageFilter>emptyList() : filtersForId.filtersForId;
+                return filtersForId == null ? Collections.emptyList() : filtersForId.filtersForId;
             }
         }
 

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
@@ -457,7 +457,7 @@ public class DebuggerManagerListener extends DebuggerManagerAdapter {
                         }
                     }
                 }
-                final List<ComponentInfo> windowsToClose = new ArrayList<ComponentInfo>(openedWindows);
+                final List<ComponentInfo> windowsToClose = new ArrayList<>(openedWindows);
                 //windowsToClose.removeAll(retainOpened);
                 try {
                     SwingUtilities.invokeLater(new Runnable() {
@@ -482,7 +482,7 @@ public class DebuggerManagerListener extends DebuggerManagerAdapter {
                                     }
                                 }
                             }
-                            List<ComponentInfo> windowsToCloseCopy = (ArrayList<ComponentInfo>) ((ArrayList) windowsToClose).clone();
+                            List<ComponentInfo> windowsToCloseCopy = new ArrayList<>(windowsToClose);
                             for (ComponentInfo ci : windowsToCloseCopy) {
                                 Component c = ci.getComponent();
                                 if (retainOpenedComponents.contains(c)) {

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/CallStackModel.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/CallStackModel.java
@@ -356,7 +356,7 @@ NodeActionsProvider, TableModel {
     // other mothods ...........................................................
 
     void fireChanges () {
-        Vector<ModelListener> v = (Vector<ModelListener>)listeners.clone();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             v.get (i).modelChanged(new ModelEvent.TreeChanged(this));

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/VariablesModel.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/VariablesModel.java
@@ -264,7 +264,7 @@ public class VariablesModel implements TreeModel, NodeModel, TableModel {
     // other mothods ...........................................................
 
     void fireChanges () {
-        Vector<ModelListener> v = (Vector<ModelListener>)listeners.clone();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             v.get(i).modelChanged(new ModelEvent.TreeChanged(this));

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/WatchesModel.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/WatchesModel.java
@@ -212,7 +212,7 @@ public class WatchesModel implements NodeModelFilter, TableModel {
     // other mothods ...........................................................
 
     void fireChanges () {
-        Vector<ModelListener> v = (Vector<ModelListener>)listeners.clone();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             v.get(i).modelChanged(new ModelEvent.TreeChanged(this));

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointModel.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointModel.java
@@ -138,7 +138,7 @@ public class BreakpointModel implements NodeModel {
         
      
     public void fireChanges () {
-        Vector<ModelListener> v = (Vector<ModelListener>)listeners.clone();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             v.get(i).modelChanged(new ModelEvent.TreeChanged(this));

--- a/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/SourcePathProviderImpl.java
+++ b/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/SourcePathProviderImpl.java
@@ -409,7 +409,7 @@ public class SourcePathProviderImpl extends SourcePathProvider {
         Properties sourcesProperties = Properties.getDefault ().getProperties ("debugger").getProperties ("sources");
         List<String> additionalSourceRoots = (List<String>) sourcesProperties.
                 getProperties("additional_source_roots").
-                getCollection("src_roots", Collections.<String>emptyList());
+                getCollection("src_roots", Collections.emptyList());
         if (additionalSourceRoots == null || additionalSourceRoots.isEmpty()) {
             return null;
         }
@@ -472,7 +472,7 @@ public class SourcePathProviderImpl extends SourcePathProvider {
     private Set<String> getRemoteDisabledSourceRoots() {
         Properties sourcesProperties = Properties.getDefault ().getProperties ("debugger").getProperties ("sources");
         return (Set<String>) sourcesProperties.getProperties("source_roots").
-            getCollection("remote_disabled", Collections.<String>emptySet());
+            getCollection("remote_disabled", Collections.emptySet());
     }
 
     private void storeDisabledSourceRoots(Set<String> disabledSourceRoots) {
@@ -516,7 +516,7 @@ public class SourcePathProviderImpl extends SourcePathProvider {
     public static Map<String, Integer> getRemoteSourceRootsOrder() {
         Properties sourcesProperties = Properties.getDefault ().getProperties ("debugger").getProperties ("sources");
         return (Map<String, Integer>) sourcesProperties.getProperties("source_roots").
-            getMap("remote_order", Collections.<String, Integer>emptyMap());
+            getMap("remote_order", Collections.emptyMap());
     }
 
     private static void storeSourceRootsOrder(File baseDir, String[] roots, int[] permutation) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
@@ -60,8 +60,8 @@ public final class NbLaunchRequestHandler {
         activeLaunchHandler = noDebug ? new NbLaunchWithoutDebuggingDelegate(terminateHandle)
                 : new NbLaunchWithDebuggingDelegate(terminateHandle);
         // validation
-        List<String> modulePaths = (List<String>) launchArguments.getOrDefault("modulePaths", Collections.<String>emptyList());
-        List<String> classPaths = (List<String>) launchArguments.getOrDefault("classPaths", Collections.<String>emptyList());
+        List<String> modulePaths = (List<String>) launchArguments.getOrDefault("modulePaths", Collections.emptyList());
+        List<String> classPaths = (List<String>) launchArguments.getOrDefault("classPaths", Collections.emptyList());
 
         // "file" key is provided by DAP client infrastructure, sometimes in an unsuitable manner, e.g. some cryptic ID for Output window etc. 
         // the "projectFile" allows to override the infrastructure from client logic.

--- a/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/BeanModelBuilder.java
+++ b/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/BeanModelBuilder.java
@@ -92,11 +92,11 @@ public final class BeanModelBuilder {
     /**
      * Names of factory methods usable to create the bean instance
      */
-    private Map<String, TypeMirrorHandle> factoryMethods = Collections.<String, TypeMirrorHandle>emptyMap();
+    private Map<String, TypeMirrorHandle> factoryMethods = Collections.emptyMap();
     
     private FxBean  resultInfo;
     
-    private Set<String> constants = Collections.<String>emptySet();
+    private Set<String> constants = Collections.emptySet();
     
     /**
      * Type element for the class.
@@ -741,7 +741,7 @@ public final class BeanModelBuilder {
         events.put(ei.getName(), ei);
     }
     
-    private Map<String, FxEvent>    events = Collections.<String, FxEvent>emptyMap();
+    private Map<String, FxEvent>    events = Collections.emptyMap();
     
     private FxBeanCache beanCache;
     

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/ModeParser.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/ModeParser.java
@@ -80,7 +80,7 @@ class ModeParser {
     private InternalConfig internalConfig;
     
     /** Map of TCRefParser instances. Used for fast access. */
-    private Map<String, TCRefParser> tcRefParserMap = new HashMap<String, TCRefParser>(19);
+    private Map<String, TCRefParser> tcRefParserMap = new HashMap<>(19);
     
     /** map of names of tcRefs to their index or null */
     private Map<String,Integer> tcRefOrder;
@@ -730,7 +730,7 @@ class ModeParser {
 
             // Update order
             List<TCRefParser> localList = new ArrayList<TCRefParser>(10);
-            Map<String,TCRefParser> localMap = (Map) ((HashMap) tcRefParserMap).clone();
+            Map<String, TCRefParser> localMap = new HashMap<>(tcRefParserMap);
 
             if( null == tcRefOrder ) {
                 //#232307

--- a/platform/openide.explorer/src/org/openide/explorer/DefaultEMLookup.java
+++ b/platform/openide.explorer/src/org/openide/explorer/DefaultEMLookup.java
@@ -82,7 +82,7 @@ final class DefaultEMLookup extends ProxyLookup implements LookupListener, Prope
 
         synchronized (this) {
             if (attachedTo == null) {
-                copy = Collections.<Lookup, Lookup.Result>emptyMap();
+                copy = Collections.emptyMap();
             } else {
                 copy = new HashMap<>(attachedTo);
             }

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/RadioInplaceEditor.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/RadioInplaceEditor.java
@@ -383,7 +383,7 @@ class RadioInplaceEditor extends JPanel implements InplaceEditor, ActionListener
                 return;
             }
 
-            list = (List<ActionListener>) ((ArrayList) actionListenerList).clone();
+            list = new ArrayList<>(actionListenerList);
         }
 
         final List<ActionListener> theList = list;

--- a/platform/openide.util/src/org/openide/util/Task.java
+++ b/platform/openide.util/src/org/openide/util/Task.java
@@ -20,6 +20,7 @@ package org.openide.util;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -68,7 +69,7 @@ public class Task extends Object implements Runnable {
     private boolean finished;
 
     /** listeners for the finish of task (TaskListener) */
-    private HashSet<TaskListener> list;
+    private Set<TaskListener> list;
 
     /** Create a new task.
     * The runnable should provide its own error-handling, as
@@ -207,7 +208,7 @@ public class Task extends Object implements Runnable {
                 return;
             }
 
-            it = ((HashSet<TaskListener>) list.clone()).iterator();
+            it = (new HashSet<>(list)).iterator();
         }
 
         while (it.hasNext()) {
@@ -246,7 +247,7 @@ public class Task extends Object implements Runnable {
         boolean callNow;
         synchronized (this) {
             if (list == null) {
-                list = new HashSet<TaskListener>();
+                list = new HashSet<>();
             }
             list.add(l);
             

--- a/webcommon/javascript2.source.query/src/org/netbeans/modules/javascript2/source/query/SourceElementsQueryImpl.java
+++ b/webcommon/javascript2.source.query/src/org/netbeans/modules/javascript2/source/query/SourceElementsQueryImpl.java
@@ -44,7 +44,7 @@ public class SourceElementsQueryImpl implements SourceElementsQuery {
 
     @Override
     public Collection<Var> getVarsAt(Source source, int offset) {
-        final Collection[] vars = new Collection[] { Collections.<Var>emptyList()};
+        final Collection<Var>[] vars = new Collection[] { Collections.emptyList()};
         try {
             ParserManager.parse(Collections.singleton(source), new UserTask() {
                 public @Override


### PR DESCRIPTION
Use the copy constructor when that is all one needs. Avoid using reflection and creating a clone as it can be expensive.

Warnings like this are cleaned up..

```
   [repeat] /home/bwalker/src/netbeans/platform/openide.nodes/src/org/openide/nodes/Children.java:1783: warning: [rawtypes] found raw type: Dupl
   [repeat]                 Dupl d = (Dupl) this.clone();
   [repeat]                 ^
   [repeat]   missing type arguments for generic class Dupl<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in class Dupl
```

Also, cleanup some improper usage of emptyList() and it's friends.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

