### PR TITLE
LSPClient: Don't assume URL -> FileObject mapping exists

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LanguageClientImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LanguageClientImpl.java
@@ -158,10 +158,11 @@ public class LanguageClientImpl implements LanguageClient, Endpoint {
     public void publishDiagnostics(PublishDiagnosticsParams pdp) {
         try {
             FileObject file = URLMapper.findFileObject(new URI(pdp.getUri()).toURL());
-            EditorCookie ec = file.getLookup().lookup(EditorCookie.class);
+            EditorCookie ec = file != null ? file.getLookup().lookup(EditorCookie.class) : null;
             Document doc = ec != null ? ec.getDocument() : null;
-            if (doc == null)
+            if (doc == null) {
                 return ; //ignore...
+            }
             List<ErrorDescription> diags = pdp.getDiagnostics().stream().map(d -> {
                 LazyFixList fixList = allowCodeActions ? new DiagnosticFixList(pdp.getUri(), d) : ErrorDescriptionFactory.lazyListForFixes(Collections.emptyList());
                 return ErrorDescriptionFactory.createErrorDescription(severityMap.get(d.getSeverity()), d.getMessage(), fixList, file, Utils.getOffset(doc, d.getRange().getStart()), Utils.getOffset(doc, d.getRange().getEnd()));


### PR DESCRIPTION
While working with a typescript project, I multiple times copied files,
renamed, edited and closed them. I noticed, that I got a
NullPointerException from the LanguageClientImpl:

```
java.lang.NullPointerException: Cannot invoke "org.openide.filesystems.FileObject.getLookup()" because "file" is null
            at org.netbeans.modules.lsp.client.bindings.LanguageClientImpl.publishDiagnostics(LanguageClientImpl.java:161)
Caused: java.lang.reflect.InvocationTargetException
            at jdk.internal.reflect.GeneratedMethodAccessor159.invoke(Unknown Source)
            at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.base/java.lang.reflect.Method.invoke(Method.java:568)
            at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$null$0(GenericEndpoint.java:65)
Caused: java.lang.RuntimeException
            at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$null$0(GenericEndpoint.java:67)
            at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.notify(GenericEndpoint.java:152)
```

This looks like a race condition between the LSP server reporting
diagnostics and the URLMapper being updated or the LSP server reporting
diagnostics after the file was already closed.

LanguageClientImpl#publishDiagnostics already guards against missing
EditorCookies and Documents, so this change just expands this to the
FileObject itself.

