### PR TITLE
ci test reports via gh job summaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,15 @@ jobs:
       - name: Commit Validation tests
         run: ant -Dcluster.config=release commit-validation
 
-      - name: Upload Build
+      - name: Create Test Summary
+        uses: test-summary/action@v1
+        if: failure()
+        with:
+          paths: "./nbbuild/build/test/commit-validation/results/*.xml"
+
+# the test-summary action above is currently only looking for failures and ignores errors,
+# this step can be removed as soon this is fixed upstream
+      - name: Upload Test Results
         if: failure()
         uses: actions/upload-artifact@v3
         with:
@@ -223,6 +231,12 @@ jobs:
 
       - name: Commit Validation tests
         run: ant -Dcluster.config=release commit-validation
+
+      - name: Create Test Summary
+        uses: test-summary/action@v1
+        if: failure()
+        with:
+          paths: "./*/*/build/test/*/results/*.xml"
 
   php:
     needs: base-build
@@ -359,6 +373,12 @@ jobs:
 
       - name: Test PHP Spellchecker Bindings
         run: ant $OPTS -f php/spellchecker.bindings.php test
+
+      - name: Create Test Summary
+        uses: test-summary/action@v1
+        if: failure()
+        with:
+          paths: "./*/*/build/test/*/results/*.xml"
  
 
 # last job depends on everything so that it is forced to run last even if a long job fails early


### PR DESCRIPTION
The new and more secure [job summaries](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) feature might be our way out of #4116

- [x] [test-summary](https://github.com/test-summary/action) action likely not whitelisted and might require the submodule trick too (done, see [INFRA-23445](https://issues.apache.org/jira/browse/INFRA-23445))
- [x] will have to test how aggregation works (done, it aggregates automatically)

confirmed:
```
Error: .github#L1
test-summary/action@v1 is not allowed to be used in apache/netbeans. Actions in this workflow must be: within a repository owned by apache, created by GitHub, verified in the GitHub Marketplace, or matching the following: */*@[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]+, AdoptOpenJDK/install-jdk@*, JamesIves/github-pages-deploy-action@5dc1d5a192aeb5ab5b7d5a77b7d36aea4a7f5c92, TobKed/label-when-approved-action@*, actions-cool/issues-helper@*, actions-rs/*, al-cheb/configure-pagefile-action@*, amannn/action-semantic-pull-request@*, apache/*, burrunan/gradle-cache-action@*, bytedeco/javacpp-presets/.github/actions/*, chromaui/action@*, codecov/codecov-action@*, conda-incubator/setup-miniconda@*, container-tools/kind-action@*, container-tools/microshift-action@*, dawidd6/action-download-artifact@*, delaguardo/setup-graalvm@*, docker://jekyll/jekyll:*, docker://pandoc/core:2.9, eps1lon/actions-label-merge-conflict@*, gaurav-nelson/github-action-markdown-link-check@*, golangc...
```
-> ~use via git submodule~ commit removed, infra added it to the list

result looks promising, example run:
https://github.com/apache/netbeans/actions/runs/2607773744
![junit-report](https://user-images.githubusercontent.com/114367/177262163-b0586cc9-2c30-4439-aa54-14851288ee7b.png)



other observations:
 - the summary doesn't list errors ("Forked Java VM exited abnormally"), only failures (filed: https://github.com/test-summary/action/issues/9)
 - commit validation tests are broken, but that is off topic, see dev list