### PR TITLE
Cleanup warnings related to raw type List..

### DIFF
--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/CmpFieldsNode.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/CmpFieldsNode.java
@@ -88,11 +88,11 @@ public class CmpFieldsNode extends EjbSectionNode {
                 return this;
             }
         } else if (element instanceof CmpField[]) {
-            final List list1 = Arrays.asList(cmpFields.getCmpFields());
-            final List list2 = new LinkedList<>(Arrays.asList((CmpField[]) element));
+            final List<CmpField> list1 = Arrays.asList(cmpFields.getCmpFields());
+            final List<CmpField> list2 = new LinkedList<>(Arrays.asList((CmpField[]) element));
             if (list1.size() == list2.size()) {
                 list2.removeAll(list1);
-                if (list2.size() == 0) {
+                if (list2.isEmpty()) {
                     return this;
                 }
             }

--- a/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/ErrorAnnotationImpl.java
+++ b/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/ErrorAnnotationImpl.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.StyledDocument;
@@ -75,8 +76,8 @@ public class ErrorAnnotationImpl implements ErrorAnnotation {
      */
     @Override
     public void annotate(ErrorInfo[] errors){
-        List added, removed, unchanged;
-        Collection newAnnotations;
+        List<LineSetAnnotation> added, removed, unchanged;
+        Collection<LineSetAnnotation> newAnnotations;
         
         // obtain data object
         DataObject doJsp;
@@ -126,18 +127,14 @@ public class ErrorAnnotationImpl implements ErrorAnnotation {
 
         // are there new annotations?
         if (!added.isEmpty()) {
-            final List finalAdded = added;
+            final List<LineSetAnnotation>  finalAdded = added;
             final DataObject doJsp2 = doJsp;
-            Runnable docRenderer = new Runnable() {
-                @Override
-                public void run() {
-                    LineCookie cookie = (LineCookie)doJsp2.getCookie(LineCookie.class);
-                    Line.Set lines = cookie.getLineSet();
-
-                    for (Iterator i=finalAdded.iterator();i.hasNext();) {
-                        LineSetAnnotation ann=(LineSetAnnotation)i.next();
-                        ann.attachToLineSet(lines);
-                    }
+            Runnable docRenderer = () -> {
+                LineCookie cookie = (LineCookie)doJsp2.getCookie(LineCookie.class);
+                Line.Set lines = cookie.getLineSet();
+                                
+                for (LineSetAnnotation ann : finalAdded) {
+                    ann.attachToLineSet(lines);
                 }
             };
 
@@ -151,9 +148,9 @@ public class ErrorAnnotationImpl implements ErrorAnnotation {
     
     /** Transforms ErrosInfo to Annotation
      */
-    private Collection getAnnotations(ErrorInfo[] errors, StyledDocument document) {
+    private Collection<LineSetAnnotation> getAnnotations(ErrorInfo[] errors, StyledDocument document) {
         BaseDocument doc = (BaseDocument) document;
-        HashMap map = new HashMap(errors.length);
+        Map<Integer, LineSetAnnotation> map = new HashMap<>(errors.length);
         for (int i = 0; i < errors.length; i ++) {
             ErrorInfo err = errors[i];
             int line = err.getLine();

--- a/enterprise/web.core/src/org/netbeans/modules/web/taglib/TaglibCatalog.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/taglib/TaglibCatalog.java
@@ -19,6 +19,9 @@
 
 package org.netbeans.modules.web.taglib;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.netbeans.modules.xml.catalog.spi.CatalogDescriptor;
 import org.netbeans.modules.xml.catalog.spi.CatalogListener;
 import org.netbeans.modules.xml.catalog.spi.CatalogReader;
@@ -62,7 +65,7 @@ public class TaglibCatalog implements CatalogReader, CatalogDescriptor, org.xml.
      * @return null if cannot proceed, try later.
      */
     public java.util.Iterator getPublicIDs() {
-        java.util.List list = new java.util.ArrayList();
+        List<String> list = new ArrayList<>();
         list.add(TAGLIB_1_1);
         list.add(TAGLIB_1_2);
         list.add(TAGLIB_2_0_ID);

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsConfigUtilities.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsConfigUtilities.java
@@ -132,7 +132,7 @@ public class StrutsConfigUtilities {
         return list;
     }
 
-    private static void addActions(List list, StrutsConfig sConfig) {
+    private static void addActions(List<Action> list, StrutsConfig sConfig) {
         ActionMappings mappings = null;
         if (sConfig != null) {
             mappings = sConfig.getActionMappings();
@@ -143,7 +143,7 @@ public class StrutsConfigUtilities {
             list.add(actions[j]);
     }
     
-    private static void addFormBeans(List list, StrutsConfig sConfig) {
+    private static void addFormBeans(List<FormBean> list, StrutsConfig sConfig) {
         FormBeans formBeans = sConfig.getFormBeans();
         if (formBeans==null) return;
         FormBean [] beans = formBeans.getFormBean();
@@ -151,7 +151,7 @@ public class StrutsConfigUtilities {
             list.add(beans[j]);
     }
     
-    private static void addMessageResource(List list, StrutsConfig sConfig) {
+    private static void addMessageResource(List<MessageResources> list, StrutsConfig sConfig) {
         MessageResources[] rosources = sConfig.getMessageResources();
         for (int j = 0; j < rosources.length; j++)
             list.add(rosources[j]);
@@ -304,7 +304,7 @@ public class StrutsConfigUtilities {
             Servlet servlet = getActionServlet(dd);
             if (servlet!=null) {
                 InitParam[] params = servlet.getInitParam();
-                List list = new ArrayList();
+                List<String> list = new ArrayList<>();
                 for (int i=0;i<params.length;i++) {
                     String paramName=params[i].getParamName();
                     if (paramName!=null) {
@@ -336,7 +336,7 @@ public class StrutsConfigUtilities {
             Servlet servlet = getActionServlet(dd);
             if (servlet!=null) {
                 InitParam[] params = servlet.getInitParam();
-                List list = new ArrayList();
+                List<FileObject> list = new ArrayList<>();
                 FileObject file;
                 for (int i=0;i<params.length;i++) {
                     String paramName=params[i].getParamName();

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsFrameworkProvider.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsFrameworkProvider.java
@@ -111,9 +111,9 @@ public class StrutsFrameworkProvider extends WebFrameworkProvider {
         return sb.toString();
     }
 
-    public java.io.File[] getConfigurationFiles(org.netbeans.modules.web.api.webmodule.WebModule wm) {
+    public File[] getConfigurationFiles(org.netbeans.modules.web.api.webmodule.WebModule wm) {
         FileObject webinf = wm.getWebInf();
-        List files = new ArrayList();
+        List<File> files = new ArrayList<>();
         // The JavaEE 5 introduce web modules without deployment descriptor. 
         // In such wm can not be struts used. 
         FileObject dd = wm.getDeploymentDescriptor();

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/wsdlmodel/WsdlPort.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/wsdlmodel/WsdlPort.java
@@ -45,7 +45,7 @@ public class WsdlPort implements WSPort {
     }
     
     public List<WsdlOperation> getOperations() {
-        List wsdlOperations = new ArrayList();
+        List<WsdlOperation> wsdlOperations = new ArrayList<>();
         if (port==null) return wsdlOperations;
         List<Operation> operations = port.getOperations();
         for (Operation op:operations)

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/wsdlmodel/WsdlService.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/wsdlmodel/WsdlService.java
@@ -49,7 +49,7 @@ public class WsdlService implements WSService {
     }
     
     public List<WsdlPort> getPorts() {
-        List wsdlPorts = new ArrayList();
+        List<WsdlPort> wsdlPorts = new ArrayList<>();
         if (service==null) return wsdlPorts;
         List<Port> ports = service.getPorts();
         for (Port p:ports)

--- a/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
@@ -158,7 +158,7 @@ public final class DebuggerManager implements ContextProvider {
     private static DebuggerManager            debuggerManager;
     private Session                           currentSession;
     private DebuggerEngine                    currentEngine;
-    private final List                        sessions = new ArrayList();
+    private final List<Session>               sessions = new ArrayList<>();
     private final Set                         engines = new HashSet ();
     private final Vector<Breakpoint>          breakpoints = new Vector<>();
     private boolean                           breakpointsInitializing = false;
@@ -265,8 +265,8 @@ public final class DebuggerManager implements ContextProvider {
         //S ystem.out.println("@StartDebugging info: " + info);
         
         // init sessions
-        List sessionProviders = new ArrayList();
-        List<DebuggerEngine> engines = new ArrayList<DebuggerEngine>();
+        List sessionProviders = new ArrayList<>();
+        List<DebuggerEngine> engines = new ArrayList<>();
         Lookup l = info.getLookup ();
         Lookup l2 = info.getLookup ();
         synchronized (l) {
@@ -315,7 +315,7 @@ public final class DebuggerManager implements ContextProvider {
             }
             
             // init DebuggerEngines
-            ArrayList engineProviders = new ArrayList ();
+            List<Object> engineProviders = new ArrayList<>();
             synchronized (l2) {
                 engineProviders.addAll (
                     l2.lookup (null, DebuggerEngineProvider.class)
@@ -1699,52 +1699,5 @@ public final class DebuggerManager implements ContextProvider {
             }
         }
     }
-    
-    /*
-    private class ModuleUnloadListeners {
-        
-        private Map<ClassLoader, ModuleChangeListener> moduleChangeListeners
-                = new HashMap<ClassLoader, ModuleChangeListener>();
-        
-        public void listenOn(ClassLoader cl) {
-            /*
-            org.openide.util.Lookup.Result<ModuleInfo> moduleLookupResult =
-                    org.openide.util.Lookup.getDefault ().lookup(
-                        new org.openide.util.Lookup.Template<ModuleInfo>(ModuleInfo.class));
-            synchronized(moduleChangeListeners) {
-                if (!moduleChangeListeners.containsKey(cl)) {
-                    for (ModuleInfo mi : moduleLookupResult.allInstances()) {
-                        if (mi.isEnabled() && mi.getClassLoader() == cl) {
-                            ModuleChangeListener l = new ModuleChangeListener(cl);
-                            mi.addPropertyChangeListener(WeakListeners.propertyChange(l, mi));
-                            moduleChangeListeners.put(cl, l);
-                        }
-                    }
-                }
-            }
-             *//*
-        }
-        
-        private final class ModuleChangeListener implements PropertyChangeListener {
-            
-            private ClassLoader cl;
-
-            public ModuleChangeListener(ClassLoader cl) {
-                this.cl = cl;
-            }
-
-            public void propertyChange(PropertyChangeEvent evt) {
-                ModuleInfo mi = (ModuleInfo) evt.getSource();
-                if (!mi.isEnabled()) {
-                    synchronized (moduleChangeListeners) {
-                        moduleChangeListeners.remove(cl);
-                    }
-                    moduleUnloaded(cl);
-                }
-            }
-
-        }
-    }
-                */
 }
 

--- a/ide/api.debugger/src/org/netbeans/api/debugger/GestureSubmitter.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/GestureSubmitter.java
@@ -21,7 +21,6 @@ package org.netbeans.api.debugger;
 
 import org.openide.util.NbBundle;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -44,11 +43,11 @@ class GestureSubmitter {
         record.setResourceBundle(NbBundle.getBundle(GestureSubmitter.class));
         record.setResourceBundleName(GestureSubmitter.class.getPackage().getName() + ".Bundle"); // NOI18N
         record.setLoggerName(USG_LOGGER.getName());
-        List params = new ArrayList();
+        List<String> params = new ArrayList<>();
         params.add(s.getName());
         params.add(s.getLocationName());
         params.add(s.getCurrentLanguage());
-        record.setParameters(params.toArray(new Object[params.size()]));
+        record.setParameters(params.toArray());
         USG_LOGGER.log(record);
     }
 }

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/CondNode.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/CondNode.java
@@ -206,28 +206,29 @@ public class CondNode extends AbstractNode
     public class ColumnPropertyEditor1 extends PropertyEditorSupport {
 
         public String[] getTags() {
-            List columnNames ;
+            List<String> columnNames ;
             try {
                 columnNames = _queryBuilder.getColumnNames(_table1);
             } catch(SQLException sqle) {
                 return new String[0] ;
             }
-            return (String[])columnNames.toArray(new String[columnNames.size()]);
+            return columnNames.toArray(new String[0]);
             // return new String[] {"PERSONID", "NAME" };
         }
     }
 
     public class ColumnPropertyEditor2 extends PropertyEditorSupport {
 
+        @Override
         public String[] getTags() {
 
-           List columnNames ;
+           List<String> columnNames ;
             try {
                 columnNames = _queryBuilder.getColumnNames(_table2);
             } catch (SQLException sqle) {
                 return new String[0] ;
             }
-            return (String[])columnNames.toArray(new String[columnNames.size()]);
+            return columnNames.toArray(new String[0]);
         }
     }
 }

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilder.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilder.java
@@ -1053,7 +1053,7 @@ public class QueryBuilder extends TopComponent
 
     // Wrappers for schema methods that are used by other classes in the query builder
 
-    List getColumnNames(String fullTableName) throws SQLException {
+    List<String> getColumnNames(String fullTableName) throws SQLException {
 	return qbMetaData.getColumnNames( fullTableName );
     }
 

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderMetaData.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderMetaData.java
@@ -24,18 +24,19 @@ import org.netbeans.modules.db.sql.visualeditor.querymodel.Column;
 import org.netbeans.modules.db.sql.visualeditor.api.VisualSQLEditorMetaData;
 import org.netbeans.modules.db.sql.visualeditor.Log;
 
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Iterator;
 import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import java.sql.SQLException;
 
 public class QueryBuilderMetaData {
 
     // Metadata managed by the QueryEditor
-    private Hashtable 		importKcTable = new Hashtable();
-    private Hashtable 		allColumnNames = null;
+    private Map<String, List<String>>   importKcTable = new Hashtable<>();
+    private Map<String, String>         allColumnNames = null;
 
     // Metadata object
     // This will contain *either* a metadata object provided by the client,
@@ -99,7 +100,7 @@ public class QueryBuilderMetaData {
     // Implemented by fetching all columns for all known tables
     // ToDo: Decide how to avoid re-fetching all the information
     void getAllColumnNames() throws SQLException {
-        allColumnNames = new Hashtable(500);
+        allColumnNames = new Hashtable<>(500);
         List<List<String>> tables = getTables();
         for (List<String> table : tables) {
             List<String> columns = getColumns(table.get(0), table.get(1));
@@ -609,14 +610,14 @@ public class QueryBuilderMetaData {
      * This was formerly included in SqlStatementMetaDataCache, now implemented
      * in the QueryEditor
      */
-    List getImportedKeyColumns(String fullTableName) throws SQLException {
-        List keys = (List) importKcTable.get(fullTableName);
+    List<String> getImportedKeyColumns(String fullTableName) throws SQLException {
+        List<String> keys = importKcTable.get(fullTableName);
         if (keys != null) {
             return keys;
         }
         String[] tb = parseTableName(fullTableName);
         List<List<String>> importedKeys = getImportedKeys(tb[0], tb[1]);
-        keys = new ArrayList();
+        keys = new ArrayList<>();
         for (List<String> key : importedKeys) {
             keys.add(key.get(1));
         }
@@ -682,7 +683,7 @@ public class QueryBuilderMetaData {
         keys.addAll(getExportedKeys(tableSpec[0], tableSpec[1]));
 
         // Convert to a List(String[]), for compatibility with the rest of the QueryEditor
-        List result = new ArrayList();
+        List<Object> result = new ArrayList<>();
         for (List<String> key : keys) {
             result.add(key.toArray());
         }
@@ -804,7 +805,7 @@ public class QueryBuilderMetaData {
         }
     }
 
-    public List getColumnNames(String fullTableName) throws SQLException {
+    public List<String> getColumnNames(String fullTableName) throws SQLException {
 
         // Log.getLogger().entering("QueryBuilderMetaData", "getColumnNames", fullTableName ); // NOI18N
         String[] tb = parseTableName(fullTableName);

--- a/ide/db/src/org/netbeans/api/db/explorer/node/ChildNodeFactory.java
+++ b/ide/db/src/org/netbeans/api/db/explorer/node/ChildNodeFactory.java
@@ -78,7 +78,7 @@ public class ChildNodeFactory extends ChildFactory<Lookup> {
     }
 
     @Override
-    protected boolean createKeys(List toPopulate) {
+    protected boolean createKeys(List<Lookup> toPopulate) {
         
         // the node registry is in the data lookup
         NodeRegistry registry = dataLookup.lookup(NodeRegistry.class);

--- a/ide/editor.structure/src/org/netbeans/modules/editor/structure/formatting/TagBasedLexerFormatter.java
+++ b/ide/editor.structure/src/org/netbeans/modules/editor/structure/formatting/TagBasedLexerFormatter.java
@@ -163,9 +163,9 @@ public abstract class TagBasedLexerFormatter {
 
         public void run() {
             try {
-                TokenHierarchy tokenHierarchy = TokenHierarchy.get(doc);
+                TokenHierarchy<BaseDocument> tokenHierarchy = TokenHierarchy.get(doc);
 
-                TokenSequence[] tokenSequences = (TokenSequence[]) tokenHierarchy.tokenSequenceList(supportedLanguagePath(), 0, Integer.MAX_VALUE).toArray(new TokenSequence[0]);
+                TokenSequence[] tokenSequences = tokenHierarchy.tokenSequenceList(supportedLanguagePath(), 0, Integer.MAX_VALUE).toArray(new TokenSequence[0]);
                 TextBounds[] tokenSequenceBounds = new TextBounds[tokenSequences.length];
 
                 for (int i = 0; i < tokenSequenceBounds.length; i++) {
@@ -511,8 +511,8 @@ public abstract class TagBasedLexerFormatter {
                         newIndent = getExistingIndent(doc, lineNumber - 1);
                     }
                     
-                    TokenHierarchy tokenHierarchy = TokenHierarchy.get(doc);
-                    TokenSequence[] tokenSequences = (TokenSequence[]) tokenHierarchy.tokenSequenceList(supportedLanguagePath(), 0, Integer.MAX_VALUE).toArray(new TokenSequence[0]);
+                    TokenHierarchy<BaseDocument> tokenHierarchy = TokenHierarchy.get(doc);
+                    TokenSequence[] tokenSequences = tokenHierarchy.tokenSequenceList(supportedLanguagePath(), 0, Integer.MAX_VALUE).toArray(new TokenSequence[0]);
                     TextBounds[] tokenSequenceBounds = new TextBounds[tokenSequences.length];
                     
                     for (int i = 0; i < tokenSequenceBounds.length; i++) {
@@ -544,8 +544,8 @@ public abstract class TagBasedLexerFormatter {
     }
     
     private boolean indexWithinCurrentLanguage(BaseDocument doc, int index) throws BadLocationException{
-        TokenHierarchy tokenHierarchy = TokenHierarchy.get(doc);
-        TokenSequence[] tokenSequences = (TokenSequence[]) tokenHierarchy.tokenSequenceList(supportedLanguagePath(), 0, Integer.MAX_VALUE).toArray(new TokenSequence[0]);
+        TokenHierarchy<BaseDocument> tokenHierarchy = TokenHierarchy.get(doc);
+        TokenSequence[] tokenSequences = tokenHierarchy.tokenSequenceList(supportedLanguagePath(), 0, Integer.MAX_VALUE).toArray(new TokenSequence[0]);
         
         for (TokenSequence tokenSequence: tokenSequences){
             TextBounds languageBounds = findTokenSequenceBounds(doc, tokenSequence);
@@ -591,8 +591,8 @@ public abstract class TagBasedLexerFormatter {
     
     public boolean isSmartEnter(BaseDocument doc, int dotPos) {
         
-        TokenHierarchy tokenHierarchy = TokenHierarchy.get(doc);
-        TokenSequence[] tokenSequences = (TokenSequence[]) tokenHierarchy.tokenSequenceList(supportedLanguagePath(), 0, Integer.MAX_VALUE).toArray(new TokenSequence[0]);
+        TokenHierarchy<BaseDocument> tokenHierarchy = TokenHierarchy.get(doc);
+        TokenSequence[] tokenSequences = tokenHierarchy.tokenSequenceList(supportedLanguagePath(), 0, Integer.MAX_VALUE).toArray(new TokenSequence[0]);
         TextBounds[] tokenSequenceBounds = new TextBounds[tokenSequences.length];
         try {
 
@@ -659,7 +659,7 @@ public abstract class TagBasedLexerFormatter {
             BaseDocument doc = (BaseDocument) context.document();
             LinkedList<TagIndentationData> unprocessedOpeningTags = new LinkedList<TagIndentationData>();
             List<TagIndentationData> matchedOpeningTags = new ArrayList<TagIndentationData>();
-            TokenHierarchy tokenHierarchy = TokenHierarchy.get(doc);
+            TokenHierarchy<BaseDocument> tokenHierarchy = TokenHierarchy.get(doc);
 
             if (tokenHierarchy == null) {
                 logger.severe("Could not retrieve TokenHierarchy for document " + doc);
@@ -689,7 +689,7 @@ public abstract class TagBasedLexerFormatter {
             Arrays.fill(embeddingType, EmbeddingType.OUTER);
             int[] indentsWithinTags = new int[transferData.getNumberOfLines()];
 
-            TokenSequence[] tokenSequences = (TokenSequence[]) tokenHierarchy.tokenSequenceList(
+            TokenSequence[] tokenSequences = tokenHierarchy.tokenSequenceList(
                     supportedLanguagePath(), 0, Integer.MAX_VALUE).toArray(new TokenSequence[0]);
             
             TextBounds[] tokenSequenceBounds = new TextBounds[tokenSequences.length];

--- a/ide/editor/src/org/netbeans/modules/editor/NbEditorKit.java
+++ b/ide/editor/src/org/netbeans/modules/editor/NbEditorKit.java
@@ -47,6 +47,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.Action;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JEditorPane;
+import javax.swing.JSeparator;
 import javax.swing.KeyStroke;
 import javax.swing.UIDefaults;
 import javax.swing.UIManager;
@@ -392,7 +393,7 @@ public class NbEditorKit extends ExtKit implements Callable {
         }
 
         public void run() {
-            List l = PopupMenuActionsProvider.getPopupMenuItems(mimeType);
+            List<String> l = PopupMenuActionsProvider.getPopupMenuItems(mimeType);
 
             if (l.isEmpty()){
                 Preferences prefs = MimeLookup.getLookup(mimeType).lookup(Preferences.class);
@@ -407,7 +408,7 @@ public class NbEditorKit extends ExtKit implements Callable {
                 }
             }
             
-            initedObjects = new ArrayList<Object>(l.size());
+            initedObjects = new ArrayList<>(l.size());
             instructions = new int[l.size()];
 
             for (Iterator i = l.iterator(); i.hasNext(); ) {
@@ -588,7 +589,7 @@ public class NbEditorKit extends ExtKit implements Callable {
         private final NbEditorKit editorKit;
         private final String localizedName;
         
-        List    objects;
+        List<Object>    objects;
         int[]   instructions;
         int     index;
         
@@ -618,13 +619,13 @@ public class NbEditorKit extends ExtKit implements Callable {
             this.localizedName = getLocalizedName(folder);
             
             List items = ActionsList.convert(sort(folder.getChildren()), false);
-            objects = new ArrayList(items.size());
+            objects = new ArrayList<>(items.size());
             instructions = new int[items.size()];
             
             for (Iterator i = items.iterator(); i.hasNext(); ) {
                 Object obj = i.next();
                 
-                if (obj == null || obj instanceof javax.swing.JSeparator) {
+                if (obj == null || obj instanceof JSeparator) {
                     objects.add(null);
                     instructions[index++] = ACTION_SEPARATOR;
                 } else if (obj instanceof String) {

--- a/ide/languages/src/org/netbeans/modules/languages/FeatureList.java
+++ b/ide/languages/src/org/netbeans/modules/languages/FeatureList.java
@@ -87,7 +87,7 @@ public class FeatureList {
         return features.get (0);
     }
     
-    private void collectFeatures(List result, String featureName) {
+    private void collectFeatures(List<Feature> result, String featureName) {
         if (features != null) {
             List<Feature> list = features.get(featureName);
             if (list != null) {

--- a/ide/languages/src/org/netbeans/modules/languages/NBSLanguageReader.java
+++ b/ide/languages/src/org/netbeans/modules/languages/NBSLanguageReader.java
@@ -492,7 +492,7 @@ public class NBSLanguageReader {
         String              nt, 
         int                 id, 
         GRNode              grNode, 
-        List                right, 
+        List<String>        right, 
         List<Rule>          rules,
         Language            language
     ) throws ParseException {

--- a/ide/languages/src/org/netbeans/modules/languages/features/CodeCommentAction.java
+++ b/ide/languages/src/org/netbeans/modules/languages/features/CodeCommentAction.java
@@ -71,7 +71,7 @@ public class CodeCommentAction extends CommentAction {
                                 int end = (endPos > 0 && Utilities.getRowStart(doc, endPos) == endPos) ?
                                     endPos-1 : endPos;
                                 int lineCnt = Utilities.getRowCount(doc, startPos, end);
-                                List mimeTypes = new ArrayList(lineCnt);
+                                List<String> mimeTypes = new ArrayList<>(lineCnt);
                                 int pos = startPos;
                                 for (int x = lineCnt ; x > 0; x--) {
                                     mimeTypes.add(getRealMimeType(ts, pos));

--- a/ide/languages/src/org/netbeans/modules/languages/features/CodeUncommentAction.java
+++ b/ide/languages/src/org/netbeans/modules/languages/features/CodeUncommentAction.java
@@ -71,7 +71,7 @@ public class CodeUncommentAction extends UncommentAction {
                                 int end = (endPos > 0 && Utilities.getRowStart(doc, endPos) == endPos) ?
                                     endPos - 1 : endPos;
                                 int lineCnt = Utilities.getRowCount(doc, startPos, end);
-                                List mimeTypes = new ArrayList(lineCnt);
+                                List<String> mimeTypes = new ArrayList<>(lineCnt);
                                 int pos = startPos;
                                 for (int x = lineCnt ; x > 0; x--) {
                                     mimeTypes.add(getRealMimeType(ts, pos));

--- a/ide/languages/src/org/netbeans/modules/languages/features/EditorTokenInput.java
+++ b/ide/languages/src/org/netbeans/modules/languages/features/EditorTokenInput.java
@@ -44,7 +44,7 @@ public class EditorTokenInput extends TokenInput {
 
     private TokenSequence   tokenSequence;
     private Language        language;
-    private List            tokens = new ArrayList ();
+    private List<ASTToken>  tokens = new ArrayList<>();
     private int             index = 0;
     private Set<Integer>    filter;
     private StyledDocument  doc;

--- a/ide/languages/src/org/netbeans/modules/languages/features/ToggleCommentAction.java
+++ b/ide/languages/src/org/netbeans/modules/languages/features/ToggleCommentAction.java
@@ -72,7 +72,7 @@ public class ToggleCommentAction extends ExtKit.ToggleCommentAction {
                                 endPos--;
                             }
                             int lineCnt = Utilities.getRowCount(doc, startPos, endPos);
-                            List mimeTypes = new ArrayList(lineCnt);
+                            List<String> mimeTypes = new ArrayList<>(lineCnt);
                             int pos = startPos;
                             boolean commented = isCommented;
                             for (int x = lineCnt ; x > 0; x--) {

--- a/ide/languages/src/org/netbeans/modules/languages/parser/AnalyserAnalyser.java
+++ b/ide/languages/src/org/netbeans/modules/languages/parser/AnalyserAnalyser.java
@@ -45,23 +45,23 @@ public class AnalyserAnalyser {
             System.out.println ("Rules:");
         else 
             writer.println ("Rules:");
-        List<String> l = new ArrayList<String> ();
-        Map<String,List> m = new HashMap<String,List> ();
-        Map<String,List> mm = new HashMap<String,List> ();
+        List<String> l = new ArrayList<> ();
+        Map<String, List<Rule>> m = new HashMap<> ();
+        Map<String, List<Integer>> mm = new HashMap<> ();
         int i = 0;
         Iterator<Rule> it = rules.iterator ();
         while (it.hasNext ()) {
             Rule r = it.next ();
-            if (!m.containsKey (r.getNT ()))
+            if (!m.containsKey (r.getNT()))
                 l.add (r.getNT ());
-            List ll = m.get (r.getNT ());
+            List<Rule> ll = m.get(r.getNT());
             if (ll == null) {
-                ll = new ArrayList ();
-                m.put (r.getNT (), ll);
-                mm.put (r.getNT (), new ArrayList ());
+                ll = new ArrayList<>();
+                m.put(r.getNT(), ll);
+                mm.put(r.getNT(), new ArrayList<>());
             }
-            ll.add (r);
-            mm.get (r.getNT ()).add (new Integer (i++));
+            ll.add(r);
+            mm.get(r.getNT ()).add (i++);
         }
         Collections.sort (l);
         Iterator<String> it2 = l.iterator ();
@@ -70,11 +70,12 @@ public class AnalyserAnalyser {
             List ll = m.get (nt);
             Iterator it3 = ll.iterator ();
             Iterator it4 = mm.get (nt).iterator ();
-            while (it3.hasNext ())
+            while (it3.hasNext ()) {
                 if (writer == null)
                     System.out.println ("  " + it3.next () + " (" + it4.next () + ")");
                 else
                     writer.println ("  " + it3.next () + " (" + it4.next () + ")");
+            }
         }
         if (writer == null)
             System.out.println ("");

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/spi/OptionsFilter.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/spi/OptionsFilter.java
@@ -226,15 +226,15 @@ public final class OptionsFilter {
                 return ;
             }
 
-            List<Integer> childIndices = new LinkedList<Integer>();
-            List<Object> children = new LinkedList<Object>();
+            List<Integer> childIndices = new LinkedList<>();
+            List<Object> children = new LinkedList<>();
 
             Object[] ch = e.getChildren();
             
             // special case for root node: include all children
             if (ch == null) {
-                List l = Collections.list(((TreeNode)e.getTreePath().getLastPathComponent()).children());
-                ch = l.toArray(new Object[l.size()]);
+                List<? extends TreeNode> l = Collections.list(((TreeNode)e.getTreePath().getLastPathComponent()).children());
+                ch = l.toArray(new Object[0]);
             }
             for (Object c : ch) {
                 int i = getIndexOfChild(e.getTreePath().getLastPathComponent(), e.getTreePath().getLastPathComponent());

--- a/ide/versioning.util/src/org/netbeans/modules/turbo/Turbo.java
+++ b/ide/versioning.util/src/org/netbeans/modules/turbo/Turbo.java
@@ -66,7 +66,7 @@ import org.netbeans.modules.versioning.util.Utils;
 public final class Turbo {
 
     /** Default providers registry. */
-    private static Lookup.Result providers;
+    private static Lookup.Result<TurboProvider> providers;
 
     /** Custom providers 'registry'. */
     private final CustomProviders customProviders;
@@ -182,7 +182,7 @@ public final class Turbo {
     private Iterator providers() {
         if (customProviders == null) {
             Collection plugins = providers.allInstances();
-            List all = new ArrayList(plugins.size() +1);
+            List<TurboProvider> all = new ArrayList<>(plugins.size() + 1);
             all.addAll(plugins);
             all.add(DefaultTurboProvider.getDefault());
             return all.iterator();

--- a/ide/versioning.util/src/org/netbeans/modules/turbo/TurboProvider.java
+++ b/ide/versioning.util/src/org/netbeans/modules/turbo/TurboProvider.java
@@ -83,7 +83,7 @@ public interface TurboProvider {
 
         private final boolean enabled;
 
-        private final List speculative;
+        private final List<Object> speculative;
 
         private final Memory memory;
 

--- a/ide/versioning.util/src/org/netbeans/modules/versioning/history/SummaryCellRenderer.java
+++ b/ide/versioning.util/src/org/netbeans/modules/versioning/history/SummaryCellRenderer.java
@@ -162,14 +162,14 @@ class SummaryCellRenderer implements ListCellRenderer {
             ListCellRenderer ren = getRenderer(value);
             if (ren == null) {
                 ren = new RevisionRenderer();
-                renderers.put(value, new SoftReference<ListCellRenderer>(ren));
+                renderers.put(value, new SoftReference<>(ren));
             }
             return ren.getListCellRendererComponent(list, value, index, selected, hasFocus);
         } else if (value instanceof AbstractSummaryView.EventItem) {
             ListCellRenderer ren = getRenderer(value);
             if (ren == null) {
                 ren = new EventRenderer();
-                renderers.put(value, new SoftReference<ListCellRenderer>(ren));
+                renderers.put(value, new SoftReference<>(ren));
             }
             return ren.getListCellRendererComponent(list, value, index, selected, hasFocus);
         } else if (value instanceof AbstractSummaryView.LoadingEventsItem) {

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/SectionNode.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/SectionNode.java
@@ -55,6 +55,7 @@ public class SectionNode extends AbstractNode {
     /**
      * Create a new section node with a given child set.
      *
+     * @param sectionNodeView
      * @param children the children for this node.
      * @param key the key by which this node is identified
      * @param title the title for the node
@@ -115,7 +116,7 @@ public class SectionNode extends AbstractNode {
      * @param boxPanel the panel to be populated
      */
     public void populateBoxPanel(BoxPanel boxPanel) {
-        List nodeList = new LinkedList<>();
+        List<Component> nodeList = new LinkedList<>();
         SectionInnerPanel nodeInnerPanel = createNodeInnerPanel();
         if (nodeInnerPanel != null) {
             nodeList.add(nodeInnerPanel);
@@ -124,7 +125,7 @@ public class SectionNode extends AbstractNode {
         for (int i = 0; i < nodes.length; i++) {
             nodeList.add(((SectionNode) nodes[i]).getSectionNodePanel());
         }
-        boxPanel.setComponents((Component[]) nodeList.toArray(new Component[0]));
+        boxPanel.setComponents(nodeList.toArray(new Component[0]));
     }
 
 

--- a/ide/xml/src/org/netbeans/modules/xml/actions/CollectSystemAction.java
+++ b/ide/xml/src/org/netbeans/modules/xml/actions/CollectSystemAction.java
@@ -44,7 +44,7 @@ public abstract class CollectSystemAction extends SystemAction implements Presen
     /** empty array of menu items */
     static JMenuItem[] NONE = new JMenuItem[] {};
 
-    protected final List registeredAction = new ArrayList<>();
+    protected final List<Object> registeredAction = new ArrayList<>();
 
     /** Which Class should be used for Lookup? */
     protected abstract Class getActionLookClass ();

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -328,7 +328,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
         return result;
     }
     
-    private List checkReferences(List tables, DDLBridge bridge, String schema) throws SQLException {
+    private List checkReferences(List<String> tables, DDLBridge bridge, String schema) throws SQLException {
         ResultSet rs;
         String pkSchema;
         String fkSchema;

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/FixedWatchesManager.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/FixedWatchesManager.java
@@ -266,7 +266,8 @@ NodeActionsProviderFilter, ExtendedNodeModelFilter, TableModelFilter {
     public Action[] getActions (NodeActionsProvider original, Object node) 
     throws UnknownTypeException {
         Action [] actions = original.getActions (node);
-        List myActions = new ArrayList();
+        List<Action> myActions = new ArrayList<>();
+
         if (fixedWatches.containsKey (new KeyWrapper(node))) {
             KeyStroke deleteKey = KeyStroke.getKeyStroke ("DELETE");
             int deleteIndex = -1;

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/SourcePath.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/SourcePath.java
@@ -609,10 +609,10 @@ public class SourcePath {
     private static List annotateOperations(JPDADebugger debugger, String url,
                                            Operation currentOperation, List lastOperations,
                                            int locLineNumber) {
-        List annotations = null;
+        List<Object> annotations = null;
         int currentOperationLine = -1;
         if (currentOperation != null) {
-            annotations = new ArrayList();
+            annotations = new ArrayList<>();
             Object ann = createAnnotation(debugger, url, currentOperation,
                                           EditorContext.CURRENT_LINE_ANNOTATION_TYPE,
                                           true);

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsTreeModelFilter.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsTreeModelFilter.java
@@ -90,7 +90,7 @@ public class BreakpointsTreeModelFilter implements TreeModelFilter {
             return new Object[0];
         }
         Object[] ch = original.getChildren (parent, from, to);
-        List l = new ArrayList ();
+        List<Object> l = new ArrayList<>();
         int i, k = ch.length, n = to - from;
         Map maxLines = new HashMap();
         for (i = 0; i < k; i++) {

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTreeModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTreeModel.java
@@ -25,7 +25,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -64,7 +63,6 @@ import org.netbeans.spi.viewmodel.TreeModel;
 import org.netbeans.spi.viewmodel.UnknownTypeException;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
-import org.openide.util.NbPreferences;
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
 
@@ -293,8 +291,9 @@ public class DebuggingTreeModel extends CachedChildrenTreeModel {
     }
 
     private Object[] getTopLevelThreadsAndGroups() {
-        List result = new LinkedList();
-        Set groups = new HashSet();
+        List<Object> result = new LinkedList<>();
+        Set<JPDADVThreadGroup> groups = new HashSet<>();
+
         for (JPDAThread thread : debugger.getThreadsCollector().getAllThreads()) {
             JPDAThreadGroup group = thread.getParentThreadGroup();
             if (group == null) {
@@ -494,7 +493,7 @@ public class DebuggingTreeModel extends CachedChildrenTreeModel {
             } else {
                 return ;
             }
-            List nodes = new ArrayList();
+            List<Object> nodes = new ArrayList<>();
             DebuggingTreeModel tm = getModel();
             if (tg == null || !showThreadGroups) {
                 nodes.add(ROOT);
@@ -512,7 +511,7 @@ public class DebuggingTreeModel extends CachedChildrenTreeModel {
                     task = createTask();
                 }
                 if (nodesToRefresh == null) {
-                    nodesToRefresh = new LinkedHashSet<Object>();
+                    nodesToRefresh = new LinkedHashSet<>();
                 }
                 nodesToRefresh.addAll(nodes);
                 task.schedule(100);

--- a/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GestureSubmitter.java
+++ b/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GestureSubmitter.java
@@ -52,7 +52,7 @@ class GestureSubmitter {
         record.setResourceBundle(NbBundle.getBundle(GestureSubmitter.class));
         record.setResourceBundleName(GestureSubmitter.class.getPackage().getName() + ".Bundle"); // NOI18N
         record.setLoggerName(USG_LOGGER.getName());
-        List params = new ArrayList();
+        List<String> params = new ArrayList<>();
         params.add(language);
         record.setParameters(params.toArray(new Object[params.size()]));
         USG_LOGGER.log(record);

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorVisitor.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorVisitor.java
@@ -4519,7 +4519,7 @@ public class EvaluatorVisitor extends ErrorAwareTreePathScanner<Mirror, Evaluati
             com.sun.jdi.Method forName = clazz.concreteMethodByName("forName", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;");
             StackFrame frame = evaluationContext.getFrame();
             ClassLoaderReference executingClassloader = frame.location().declaringType().classLoader();
-            List args = new ArrayList();
+            List<Value> args = new ArrayList<>();
             StringReference className = createStringMirrorWithDisabledCollection(name, vm, evaluationContext);
             args.add(className);
             args.add(vm.mirrorOf(true));
@@ -5512,7 +5512,7 @@ public class EvaluatorVisitor extends ErrorAwareTreePathScanner<Mirror, Evaluati
 
         @Override
         public Map<Field, Value> getValues(List<? extends Field> list) {
-            List[] listByTypes = new List[types.length];
+            List<Field>[] listByTypes = new List[types.length];
             for (int i = 0; i < types.length; i++) {
                 listByTypes[i] = new ArrayList();
                 ReferenceType t = types[i];
@@ -5532,7 +5532,7 @@ public class EvaluatorVisitor extends ErrorAwareTreePathScanner<Mirror, Evaluati
                         singleMap = tmap;
                     } else {
                         if (map == null) {
-                            map = new HashMap<Field, Value>(list.size());
+                            map = new HashMap<>(list.size());
                             map.putAll(singleMap);
                         }
                         map.putAll(tmap);

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEjbGenerator.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEjbGenerator.java
@@ -316,7 +316,7 @@ public class DbSchemaEjbGenerator {
         String roleBCmr = EntityMember.makeRelationshipFieldName(roleAClassName, colectionType, true);
         
         roleACmr = uniqueAlgorithm(getFieldNames(roleAHelper), roleACmr, null);
-        List roleBFieldNames = getFieldNames(roleBHelper);
+        List<String> roleBFieldNames = getFieldNames(roleBHelper);
         if (tableAName.equals(tableBName)) {
             // Handle the special case when both parts of the join table reference
             // the same table -- in that case both roleACmr and roleBCmr

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/analysis/AnalyzerImpl.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/analysis/AnalyzerImpl.java
@@ -102,7 +102,7 @@ public class AnalyzerImpl implements Analyzer {
         todo.addAll(ctx.getScope().getFiles());
 
         BatchResult candidates = BatchSearch.findOccurrences(hints, Scopes.specifiedFoldersScope(Folder.convert(todo)), w, settings);
-        List<MessageImpl> problems = new LinkedList<MessageImpl>(candidates.problems);
+        List<MessageImpl> problems = new LinkedList<>(candidates.problems);
         
         BatchSearch.getVerifiedSpans(candidates, w, new BatchSearch.VerifiedSpansCallBack() {
             public void groupStarted() {}

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/OperationWizardModel.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/OperationWizardModel.java
@@ -431,7 +431,7 @@ public abstract class OperationWizardModel {
         final Object[] arr;
         final Object[] closingArr = new Object[] { c };
         if (!Arrays.asList(opts).contains(c)) {
-            List newOpts = new ArrayList<>(Arrays.asList(opts));
+            List<Object> newOpts = new ArrayList<>(Arrays.asList(opts));
             Object o = wd.getProperty("OperationWizardModel_disabledCancel");
             // replace previously disabled cancel
             int n = o == null ? -1 : newOpts.indexOf(o);

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/DefaultTabDataModel.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/DefaultTabDataModel.java
@@ -365,7 +365,7 @@ public class DefaultTabDataModel implements TabDataModel {
      */
     @Override
     public void removeTabs(int start, int end) {
-        java.util.List affected = new ArrayList(list.subList(start, end));
+        List<TabData> affected = new ArrayList<>(list.subList(start, end));
         if (start == end) {
             list.remove(start);
         } else {
@@ -374,13 +374,13 @@ public class DefaultTabDataModel implements TabDataModel {
         ComplexListDataEvent lde = new ComplexListDataEvent(this,
                                                             ListDataEvent.INTERVAL_REMOVED,
                                                             start, end);
-        lde.setAffectedItems((TabData[]) affected.toArray(new TabData[0]));
+        lde.setAffectedItems(affected.toArray(new TabData[0]));
         fireIntervalRemoved(lde);
     }
 
     @Override
     public void addTabs(int[] indices, TabData[] data) {
-        Map<Integer,TabData> m = new HashMap<Integer,TabData>(data.length);
+        Map<Integer,TabData> m = new HashMap<>(data.length);
         for (int i = 0; i < data.length; i++) {
             m.put(new Integer(indices[i]), data[i]);
         }

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/TableSorter.java
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/TableSorter.java
@@ -121,7 +121,7 @@ public class TableSorter extends AbstractTableModel {
     private MouseListener mouseListener;
     private TableModelListener tableModelListener;
     private Map columnComparators = new HashMap();
-    private List sortingColumns = new ArrayList();
+    private List<Directive> sortingColumns = new ArrayList<>();
 
     public TableSorter() {
         this.mouseListener = new MouseHandler();


### PR DESCRIPTION
This pull request attempts to cleanup a lot of the warnings related to raw type list..

   [repeat] /home/bwalker/src/netbeans/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/DefaultTabDataModel.java:377: warning: [unchecked] unchecked call to <T>toArray(T[]) as a member of the raw type List
   [repeat]         lde.setAffectedItems((TabData[]) affected.toArray(new TabData[0]));
   [repeat]                                                          ^
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in method <T>toArray(T[])

I was able to reduce the warnings in half. Of the remaining ones, the majority are related to a generated file. The few remaining ones are going to require some real work. Which is beyond the scope of what I'm trying to do.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

