### PR TITLE
Analyze Stack Trace window improvements.

### DIFF
--- a/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyserCellRenderer.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyserCellRenderer.java
@@ -82,7 +82,7 @@ class AnalyserCellRenderer extends DefaultListCellRenderer {
         Link link = StackLineAnalyser.analyse (line);
 
         if (isSelected) {
-            setBackground (bg == null ? list.getSelectionBackground () : bg);
+            setBackground(bg == null ? list.getSelectionBackground() : bg);
             setForeground(fg == null ? list.getSelectionForeground() : fg);
         } else {
             setBackground (list.getBackground ());
@@ -95,17 +95,23 @@ class AnalyserCellRenderer extends DefaultListCellRenderer {
         if (link != null) {
             StringBuilder sb = new StringBuilder ();
             sb.append ("<html>");
-            if (isSelected)
-                sb.append("<style> a.val {text-decoration: underline; color: " + toRgbText(getForeground().getRGB()) + "} </style><body>");
-            sb.append (line.substring (0, link.getStartOffset ()));
+            if (isSelected) {
+                sb.append("<style> a.val {text-decoration: underline; color: "+toRgbText(getForeground())+"} </style><body>");
+            }
+            String prefix = line.substring (0, link.getStartOffset ());
+            if (prefix.startsWith("at ")) {
+                prefix = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + prefix;
+            }
+            sb.append (prefix);
             sb.append ("<a class=\"val\" href=\"\">");
             sb.append (line.substring (link.getStartOffset (), link.getEndOffset ()));
             sb.append ("</a>");
             sb.append (line.substring (link.getEndOffset ()));
             sb.append ("</body></html>");
             setText (sb.toString ());
-        } else
+        } else {
             setText (line.trim ());
+        }
 
         setEnabled (list.isEnabled ());
 
@@ -136,13 +142,8 @@ class AnalyserCellRenderer extends DefaultListCellRenderer {
 //        return cp.findResource (resource) != null;
 //    }
 
-    private static String toRgbText(int rgb) {
-        if (rgb > 0xFFFFFF)
-            rgb = 0xFFFFFF;
-        if (rgb < 0)
-            rgb = 0;
-        String str = "000000" + Integer.toHexString(rgb); //NOI18N
-        return "#" + str.substring(str.length() - 6); //NOI18N
+    private String toRgbText(Color c) {
+        return String.format("#%02x%02x%02x", c.getRed(), c.getGreen(), c.getBlue());
     }
 }
 

--- a/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyzeStackTopComponent.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyzeStackTopComponent.java
@@ -37,6 +37,7 @@ import java.io.Serializable;
 import java.util.logging.Logger;
 import javax.swing.AbstractAction;
 import javax.swing.DefaultListModel;
+import javax.swing.UIManager;
 import javax.swing.text.DefaultEditorKit;
 
 import org.netbeans.modules.java.stackanalyzer.StackLineAnalyser.Link;
@@ -65,6 +66,7 @@ final class AnalyzeStackTopComponent extends TopComponent {
         getActionMap ().put (DefaultEditorKit.pasteAction, new PasteAction ());
         insertButton.getActionMap ().put (DefaultEditorKit.pasteAction, new PasteAction ());
         scrollPane.getActionMap ().put (DefaultEditorKit.pasteAction, new PasteAction ());
+        list.setBackground(UIManager.getColor("Tree.background"));
         list.getActionMap ().put (DefaultEditorKit.pasteAction, new PasteAction ());
         list.setCellRenderer (new AnalyserCellRenderer ());
         list.addKeyListener (new KeyAdapter () {
@@ -232,9 +234,7 @@ final class AnalyzeStackTopComponent extends TopComponent {
             Reader reader = DataFlavor.stringFlavor.getReaderForText (transferable);
             BufferedReader r = new BufferedReader (reader);
             fill(r);
-        } catch (UnsupportedFlavorException ex) {
-            Exceptions.printStackTrace (ex);
-        } catch (IOException ex) {
+        } catch (UnsupportedFlavorException | IOException ex) {
             Exceptions.printStackTrace (ex);
         }
     }//GEN-LAST:event_insertButtonActionPerformed


### PR DESCRIPTION
 - added indentation for more familiar stack trace formatting
 - fixed hyperlink text color when selected
 - fixed TopComponent background color to be consistent with other  windows

![indent_traces](https://user-images.githubusercontent.com/114367/178100840-3f1cf7f8-c5d0-4257-9912-26ccc7fe5fad.png)

The top component was a little bit too bright with dark theme (looked like the old color of the NB 14 dark theme and didn't fit to the rest)
Projects tab is: `#3C3F41`, Analyze Stack window was: `#46494B`, so i set it to `UIManager.getColor("Tree.background")` which is the same as the other top components (e.g projects tab).