### PR TITLE
maven project wizard should set groupId #4343.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/newproject/idenative/IDENativeMavenWizardIterator.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/idenative/IDENativeMavenWizardIterator.java
@@ -94,6 +94,8 @@ public abstract class IDENativeMavenWizardIterator implements WizardDescriptor.I
         return new FileBuilder(w.getTemplate().getPrimaryFile(), w.getTargetFolder().getPrimaryFile().getParent()).
             param(TemplateUtils.PARAM_PACKAGE, (String) wiz.getProperty("package")).
             param(TemplateUtils.PARAM_PACKAGING, (String) this.packaging).
+            param(TemplateUtils.PARAM_GROUP_ID, (String) wiz.getProperty("groupId")).
+            param(TemplateUtils.PARAM_ARTIFACT_ID, (String) wiz.getProperty("artifactId")).
             param(TemplateUtils.PARAM_VERSION, (String) wiz.getProperty("version")).
             defaultMode(FileBuilder.Mode.COPY).
             name(w.getTargetName()).


### PR DESCRIPTION
fixes #4343

 - the groupId text field was ignored so far
 - this fixes a bug which breaks the project if no package is provided
   (since the package is used as fallback to generate a groupId which hid the issue)

(artifactId is only set for completes sake)