### PR TITLE
Enable inline hints by default

### DIFF
--- a/ide/editor.actions/src/org/netbeans/modules/editor/actions/ShowInlineHintsAction.java
+++ b/ide/editor.actions/src/org/netbeans/modules/editor/actions/ShowInlineHintsAction.java
@@ -29,7 +29,7 @@ import org.netbeans.api.editor.EditorActionRegistration;
                           preferencesDefault=ShowInlineHintsAction.DEF_LINES)
 public class ShowInlineHintsAction extends AbstractAction {
     public static final String KEY_LINES = "enable.inline.hints";
-    public static final boolean DEF_LINES = false;
+    public static final boolean DEF_LINES = true;
     @Override
     public void actionPerformed(ActionEvent e) {
     }

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
@@ -924,7 +924,7 @@ public final class DocumentViewOp
         float lineHeightCorrectionOrig = rowHeightCorrection;
         rowHeightCorrection = prefs.getFloat(SimpleValueNames.LINE_HEIGHT_CORRECTION, 1.0f);
         boolean inlineHintsEnableOrig = inlineHintsEnable;
-        inlineHintsEnable = Boolean.TRUE.equals(prefs.getBoolean("enable.inline.hints", false)); // NOI18N
+        inlineHintsEnable = Boolean.TRUE.equals(prefs.getBoolean("enable.inline.hints", true)); // NOI18N
         boolean updateMetrics = (rowHeightCorrection != lineHeightCorrectionOrig);
         boolean releaseChildren = nonInitialUpdate && 
                 ((nonPrintableCharactersVisible != nonPrintableCharactersVisibleOrig) ||


### PR DESCRIPTION
Whenever I see people using other IDEs, they have _inline hints_ enabled and find it quite useful. Thanks to @jlahoda work NetBeans also supports _inline hins_ and I am using them without any major problems for last few releases. However the feature is turned off by default and I am afraid many users of NetBeans IDE do not even know it exists. This PR proposes to turn the feature on by default.

![image](https://user-images.githubusercontent.com/1842422/178132241-39bd2f14-3ff2-450d-99c5-68795efff62e.png)
