### PR TITLE
Update FlatLaf from 2.3 to 2.4

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-D7A77B74A49FC9705199426FFA73BD67ACF06306 com.formdev:flatlaf:2.3
+691E1F12C78F42E0DFD9FC37BC599042A1EBDD0D com.formdev:flatlaf:2.4

--- a/platform/libs.flatlaf/external/flatlaf-2.4-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-2.4-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 2.3
-Files: flatlaf-2.3.jar
+Version: 2.4
+Files: flatlaf-2.4.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-2.3.jar=modules/ext/flatlaf-2.3.jar
+release.external/flatlaf-2.4.jar=modules/ext/flatlaf-2.4.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-2.3.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-2.3.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-2.4.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-2.4.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Update FlatLaf to v2.4.

Changes: https://github.com/JFormDesigner/FlatLaf/releases/tag/2.4

This version fixes issue #4231 (Netbeans 14 freezes spuriously when r-clicking at Design View)

It brings also some usability improvements to the window title bar (on Windows 10/11):
- There are now additional areas at top of embedded menu bar to resize the window. This makes it easier to resize small frames with lot of menus. (see red rectangles in below screenshot)
- The window title now has a minimum width, which avoids that it is completely hidden. The window title is important because it is needed to move the window. (green rectangle)

![image](https://user-images.githubusercontent.com/5604048/178956839-49b83495-cc41-42ed-a765-22edb0cf886b.png)
