### PR TITLE
Let iterate() initialize the indexer first.

### DIFF
--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
@@ -1275,10 +1275,10 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
     private ResultImplementation<NBVersionInfo> findBySHA1(final String sha1, final ResultImpl<NBVersionInfo> result, List<RepositoryInfo> repos, final boolean skipUnIndexed) {
         final List<NBVersionInfo> infos = new ArrayList<>(result.getResults());
         final SkippedAction skipAction = new SkippedAction(result);
-        BooleanQuery bq = new BooleanQuery.Builder()
-                .add(new BooleanClause((setBooleanRewrite(constructQuery(MAVEN.SHA1, sha1))), BooleanClause.Occur.SHOULD))
-                .build();
         iterate(repos, (RepositoryInfo repo, IndexingContext context) -> {
+            BooleanQuery bq = new BooleanQuery.Builder()
+                    .add(new BooleanClause((setBooleanRewrite(constructQuery(MAVEN.SHA1, sha1))), BooleanClause.Occur.SHOULD))
+                    .build();
             IteratorSearchResponse response = repeatedPagedSearch(bq, Collections.singletonList(context), MAX_RESULT_COUNT);
             if (response != null) {
                 try {


### PR DESCRIPTION
The following exception appears in the log when one tries to `Attach Sources` and uses `Download`:

```
java.lang.NullPointerExceptionjava.lang.NullPointerException 
at org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl.constructQuery(NexusRepositoryIndexerImpl.java:1154)
at org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl.findBySHA1(NexusRepositoryIndexerImpl.java:1279)
at org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl.findBySHA1(NexusRepositoryIndexerImpl.java:1272)
at org.netbeans.modules.maven.indexer.api.RepositoryQueries.lambda$findBySHA1$6(RepositoryQueries.java:357)
at org.netbeans.modules.maven.indexer.api.RepositoryQueries.getQueryResult(RepositoryQueries.java:217)
at org.netbeans.modules.maven.indexer.api.RepositoryQueries.findBySHA1(RepositoryQueries.java:354)
at org.netbeans.modules.maven.indexer.api.RepositoryQueries.findBySHA1Result(RepositoryQueries.java:346)
at org.netbeans.modules.maven.queries.MavenSourceJavadocAttacher.attach(MavenSourceJavadocAttacher.java:87)
[catch] 
at org.netbeans.modules.maven.queries.MavenSourceJavadocAttacher.getSources(MavenSourceJavadocAttacher.java:204)
at org.netbeans.modules.java.j2seplatform.queries.SourceJavadocAttacherUtil$Downloader.run(SourceJavadocAttacherUtil.java:140)
at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)
```

The reason si that in 656e520  the `constructQuery` was [moved outside of the `iterate()` invocation](https://github.com/apache/netbeans/commit/656e5209812854905d7c2f164cf4f648430a2797#diff-388a78e69b7729d3486a578826691d1606ea56f099d2f1c0eb7c484deba12948R1376) which lazy-initializes the whole class (instantiates maven services).
