### PR TITLE
#4366: Handle references to other compilation units.

### DIFF
--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/Call.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/Call.java
@@ -216,10 +216,7 @@ final class Call implements CallDescriptor {
         }
 
         if(selectionElm.getKind() != ElementKind.INSTANCE_INIT && selectionElm.getKind() != ElementKind.STATIC_INIT) {
-            TreePath declarationPath = javac.getTrees().getPath(selectionElm);
-            if (declarationPath != null) {
-                c.declaration = TreePathHandle.create(declarationPath, javac);
-            }
+            c.declaration = TreePathHandle.create(selectionElm, javac);
         }
 
         if (c.identity != null) {


### PR DESCRIPTION
For description, see #4366 

It **was** actually a one-liner ... The problem was that Trees.getPath() won't work outside of compilation units processed by the parser - but TreePathHandle.create/from() can process any element, so I've used that as a fallback.