### PR TITLE
[GITHUB-3913] Disable Micronaut HyperlinkProviders to prevent deadlock

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/hyperlink/MicronautConfigHyperlinkProvider.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/hyperlink/MicronautConfigHyperlinkProvider.java
@@ -51,17 +51,19 @@ import org.springframework.boot.configurationmetadata.ConfigurationMetadataPrope
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataSource;
 
 /**
+ * CURRENTLY NOT ACTIVE - @MimeRegistration DISABLED to work around 
+ * <a href="https://github.com/apache/netbeans/issues/3913">GITHUB-3913</a>
  *
  * @author Dusan Balek
  */
 public class MicronautConfigHyperlinkProvider implements HyperlinkProviderExt {
 
-    @MimeRegistration(mimeType = "text/x-yaml", service = HyperlinkProviderExt.class, position = 1250)
+    //@MimeRegistration(mimeType = "text/x-yaml", service = HyperlinkProviderExt.class, position = 1250)
     public static MicronautConfigHyperlinkProvider createYamlProvider() {
         return new MicronautConfigHyperlinkProvider();
     }
 
-    @MimeRegistration(mimeType = "text/x-properties", service = HyperlinkProviderExt.class, position = 1250)
+    //@MimeRegistration(mimeType = "text/x-properties", service = HyperlinkProviderExt.class, position = 1250)
     public static MicronautConfigHyperlinkProvider createPropertiesProvider() {
         return new MicronautConfigHyperlinkProvider();
     }
@@ -169,12 +171,12 @@ public class MicronautConfigHyperlinkProvider implements HyperlinkProviderExt {
 
     public static class LocationProvider implements HyperlinkLocationProvider {
 
-        @MimeRegistration(mimeType = "text/x-yaml", service = HyperlinkLocationProvider.class)
+        //@MimeRegistration(mimeType = "text/x-yaml", service = HyperlinkLocationProvider.class)
         public static LocationProvider createYamlProvider() {
             return new LocationProvider();
         }
 
-        @MimeRegistration(mimeType = "text/x-properties", service = HyperlinkLocationProvider.class)
+        //@MimeRegistration(mimeType = "text/x-properties", service = HyperlinkLocationProvider.class)
         public static LocationProvider createPropertiesProvider() {
             return new LocationProvider();
         }

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/hyperlink/MicronautJavaHyperlinkProvider.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/hyperlink/MicronautJavaHyperlinkProvider.java
@@ -61,10 +61,12 @@ import org.openide.util.Exceptions;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
 
 /**
+ * CURRENTLY NOT ACTIVE - @MimeRegistration DISABLED to work around
+ * <a href="https://github.com/apache/netbeans/issues/3913">GITHUB-3913</a>
  *
  * @author Dusan Balek
  */
-@MimeRegistration(mimeType = "text/x-java", service = HyperlinkProviderExt.class, position = 1250)
+//@MimeRegistration(mimeType = "text/x-java", service = HyperlinkProviderExt.class, position = 1250)
 public class MicronautJavaHyperlinkProvider implements HyperlinkProviderExt {
 
     private static final Pattern INJECT = Pattern.compile("\\$\\{(\\S+)(:\\S*)?}");


### PR DESCRIPTION
The relevant stacktraces for the affected threads are saved below.

As there is also a warning logged with a clear indication:

>  WARNING [org.netbeans.modules.parsing.impl.TaskProcessor]: ParserManager.parse called in AWT event thread by:
  org.netbeans.modules.micronaut.hyperlink.MicronautJavaHyperlinkProvider.getPropertyName(MicronautJavaHyperlinkProvider.java:151)

Stacktraces:

```
"AWT-EventQueue-0" #24 prio=6 os_prio=0 cpu=69156.33ms elapsed=76496.39s tid=0x00007feca4122b90 nid=0x106e2a waiting on condition  [0x00007fec9756e000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@17.0.3/Native Method)
	- parking to wait for  <0x00000006d7905fd0> (a java.util.concurrent.locks.ReentrantLock$FairSync)
	at java.util.concurrent.locks.LockSupport.park(java.base@17.0.3/LockSupport.java:211)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.3/AbstractQueuedSynchronizer.java:715)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.3/AbstractQueuedSynchronizer.java:938)
	at java.util.concurrent.locks.ReentrantLock$Sync.lock(java.base@17.0.3/ReentrantLock.java:153)
	at java.util.concurrent.locks.ReentrantLock.lock(java.base@17.0.3/ReentrantLock.java:322)
	at org.netbeans.modules.parsing.impl.TaskProcessor.runUserTask(TaskProcessor.java:170)
	at org.netbeans.modules.parsing.api.ParserManager.parse(ParserManager.java:83)
	at org.netbeans.api.java.source.JavaSource.runUserActionTaskImpl(JavaSource.java:454)
	at org.netbeans.api.java.source.JavaSource.runUserActionTask(JavaSource.java:425)
	at org.netbeans.modules.micronaut.hyperlink.MicronautJavaHyperlinkProvider.getPropertyName(MicronautJavaHyperlinkProvider.java:151)
	at org.netbeans.modules.micronaut.hyperlink.MicronautJavaHyperlinkProvider.resolve(MicronautJavaHyperlinkProvider.java:122)
	at org.netbeans.modules.micronaut.hyperlink.MicronautJavaHyperlinkProvider.getHyperlinkSpan(MicronautJavaHyperlinkProvider.java:85)


"Editor Parsing Loop (14-c4f2d87113e1a2d2d4e21e8952e1f99612d5b3fd)" #28 daemon prio=1 os_prio=0 cpu=65769.71ms elapsed=76494.46s tid=0x00007feca4401250 nid=0x106e35 in Object.wait()  [0x00007fec957fe000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(java.base@17.0.3/Native Method)
	- waiting on <no object reference available>
	at java.lang.Object.wait(java.base@17.0.3/Object.java:338)
	at org.netbeans.modules.parsing.impl.TaskProcessor$CurrentRequestReference.setCurrentTask(TaskProcessor.java:1128)
	- locked <0x00000006d75591d8> (a org.netbeans.modules.parsing.impl.TaskProcessor$CurrentRequestReference$CRRLock)
	at org.netbeans.modules.parsing.impl.TaskProcessor$RequestPerformer.run(TaskProcessor.java:842)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:279)
	at org.netbeans.modules.parsing.impl.TaskProcessor$RequestPerformer.execute(TaskProcessor.java:702)
	at org.netbeans.modules.parsing.impl.TaskProcessor$CompilationJob.run(TaskProcessor.java:663)

"Module-Actions" #163 daemon prio=1 os_prio=0 cpu=2546.95ms elapsed=253.00s tid=0x00007fec806c9c90 nid=0x1abee2 in Object.wait()  [0x00007fec951fa000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(java.base@17.0.3/Native Method)
	- waiting on <no object reference available>
	at java.lang.Object.wait(java.base@17.0.3/Object.java:338)
	at javax.swing.text.AbstractDocument.writeLock(java.desktop@17.0.3/AbstractDocument.java:1378)
	- locked <0x0000000718f28200> (a org.netbeans.modules.editor.NbEditorDocument)
	at org.netbeans.editor.BaseDocument.extWriteLock(BaseDocument.java:1696)
	at org.netbeans.editor.BaseDocument.atomicLockImpl(BaseDocument.java:1744)
	- locked <0x0000000718f28200> (a org.netbeans.modules.editor.NbEditorDocument)
	- locked <0x0000000718f28200> (a org.netbeans.modules.editor.NbEditorDocument)
	at org.netbeans.editor.GuardedDocument.runAtomicAsUser(GuardedDocument.java:329)
	at org.netbeans.modules.editor.lib.BeforeSaveTasks$TaskRunnable.run(BeforeSaveTasks.java:131)
	at org.netbeans.modules.editor.lib.TrailingWhitespaceRemove.runLocked(TrailingWhitespaceRemove.java:77)
```