### PR TITLE
Fix NPE when there is no build.gradle for the root project

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProject.java
@@ -121,7 +121,7 @@ public final class GradleProject implements Serializable, Lookup.Provider {
 
     public final GradleProject invalidate(String... reason) {
         GradleFiles gf = new GradleFiles(baseProject.getProjectDir(), true);
-        Path scriptPath = gf.getBuildScript().toPath();
+        Path scriptPath = gf.getBuildScript() != null ? gf.getBuildScript().toPath() : null;
         List<GradleReport> reports = new ArrayList<>();
         for (String s : reason) {
             reports.add(GradleReport.simple(scriptPath, s));

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleReport.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleReport.java
@@ -51,7 +51,7 @@ public final class GradleReport {
     }
     
     public static GradleReport simple(Path script, String message) {
-        return new GradleReport(null, script.toString(), -1, message, null);
+        return new GradleReport(null, script != null ? script.toString() : null, -1, message, null);
     }
 
     public GradleReport(Path scriptLocation, String message, GradleReport causedBy) {


### PR DESCRIPTION
It's getting somewhat usual to have project without root build.gradle (or build.gradle.kts) script, only a settings.gradle in the root.
That setup is completely valid, though it could cause NPE-s. This trivial patch fixes that.
