### PR TITLE
Add minimal support for Gradle default version catalog

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,22 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="gradlefiles-versioncatalog">
+            <api name="general"/>
+            <summary>GradleFiles.Kind.VERSION_CATALOG introduced</summary>
+            <version major="2" minor="25"/>
+            <date day="15" month="7" year="2022"/>
+            <author login="lkishalmi"/>
+            <compatibility semantic="compatible" addition="yes"/>
+            <description>
+                <a href="@TOP@/org/netbeans/modules/gradle/spi/GradleFiles.Kind.html#VERSION_CATALOG">GradleFiles.Kind.VERSION_CATALOG</a>
+                was addedd to represent <code>$rootDir/gradle.libs.versions.toml</code> file of the project.
+                <code>
+                    <a href="@TOP@/org-netbeans-modules-gradle/org/netbeans/modules/gradle/spi/GradleFiles.html#getFile-org.netbeans.modules.gradle.spi.GradleFiles.Kind-">GradleFiles.getKind(VERSION_CATALOG)</a>
+                </code> can be used to retrieve the represented file. (The file might not exists though.)
+            </description>
+            <class package="org.netbeans.modules.gradle.api" name="NbGradleProject"/>
+        </change>
         <change id="gradleproject-files">
             <api name="general"/>
             <summary>GradleFiles can be obtained from API</summary>

--- a/extide/gradle/manifest.mf
+++ b/extide/gradle/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gradle/2
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.24
+OpenIDE-Module-Specification-Version: 2.25

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleReport.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleReport.java
@@ -51,7 +51,7 @@ public final class GradleReport {
     }
     
     public static GradleReport simple(Path script, String message) {
-        return new GradleReport(null, script != null ? script.toString() : null, -1, message, null);
+        return new GradleReport(null, Objects.toString(script), -1, message, null);
     }
 
     public GradleReport(Path scriptLocation, String message, GradleReport causedBy) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/nodes/BuildScriptsNode.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/nodes/BuildScriptsNode.java
@@ -79,7 +79,7 @@ public final class BuildScriptsNode extends AnnotatedAbstractNode {
 
     // The order in this array determines the order of the nodes under Build Scripts
     private static final Kind[] SCRIPTS = new Kind[] {
-        BUILD_SRC, USER_PROPERTIES, SETTINGS_SCRIPT, ROOT_SCRIPT, ROOT_PROPERTIES, BUILD_SCRIPT, PROJECT_PROPERTIES
+        BUILD_SRC, VERSION_CATALOG, USER_PROPERTIES, SETTINGS_SCRIPT, ROOT_SCRIPT, ROOT_PROPERTIES, BUILD_SCRIPT, PROJECT_PROPERTIES
     };
 
     @Override
@@ -172,6 +172,7 @@ public final class BuildScriptsNode extends AnnotatedAbstractNode {
                 case USER_PROPERTIES:
                     return createBuildFileNode(fo, Bundle.LBL_UserSuffix());
                 case SETTINGS_SCRIPT:
+                case VERSION_CATALOG:
                     return createBuildFileNode(fo, null);
                 case BUILD_SRC:
                     return createSubProjectNode(fo);

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
@@ -58,11 +58,13 @@ public final class GradleFiles implements Serializable {
         PROJECT_PROPERTIES,
         ROOT_PROPERTIES,
         /** @since 2.4 */
-        BUILD_SRC;
+        BUILD_SRC,
+        /** @since 2.25 */
+        VERSION_CATALOG;
 
         public static final Set<Kind> SCRIPTS = EnumSet.of(ROOT_SCRIPT, BUILD_SCRIPT, SETTINGS_SCRIPT, BUILD_SRC);
         public static final Set<Kind> PROPERTIES = EnumSet.of(USER_PROPERTIES, PROJECT_PROPERTIES, ROOT_PROPERTIES);
-        public static final Set<Kind> PROJECT_FILES = EnumSet.of(ROOT_SCRIPT, BUILD_SCRIPT, SETTINGS_SCRIPT, PROJECT_PROPERTIES, ROOT_PROPERTIES);
+        public static final Set<Kind> PROJECT_FILES = EnumSet.of(ROOT_SCRIPT, BUILD_SCRIPT, SETTINGS_SCRIPT, VERSION_CATALOG, PROJECT_PROPERTIES, ROOT_PROPERTIES);
     }
 
     private static final Logger LOG = Logger.getLogger(GradleFiles.class.getName());
@@ -73,6 +75,8 @@ public final class GradleFiles implements Serializable {
     public static final String BUILD_FILE_NAME_KTS    = "build.gradle.kts"; //NOI18N
     public static final String GRADLE_PROPERTIES_NAME = "gradle.properties"; //NOI18N
     public static final String WRAPPER_PROPERTIES     = "gradle/wrapper/gradle-wrapper.properties"; //NOI18N
+    /** @since 2.25 */
+    public static final String VERSION_CATALOG        = "gradle/libs.versions.toml"; //NOI18N
 
     final File projectDir;
     final boolean knownProject;
@@ -300,10 +304,11 @@ public final class GradleFiles implements Serializable {
                     return new File(projectDir, GRADLE_PROPERTIES_NAME);
                 case ROOT_PROPERTIES:
                     return new File(rootDir, GRADLE_PROPERTIES_NAME);
-                case USER_PROPERTIES: {
+                case USER_PROPERTIES: 
                     File guh = GradleSettings.getDefault().getGradleUserHome();
                     return new File(guh, GRADLE_PROPERTIES_NAME);
-                }
+                case VERSION_CATALOG:
+                    return new File(rootDir, VERSION_CATALOG);
                 case BUILD_SRC:
                     return new File(rootDir, "buildSrc"); //NOI18N
                 default:


### PR DESCRIPTION
Implement minimal support for #4337. The libs.versions.toml file will be displayed under the build scripts node.
