### PR TITLE
Let ClassSource check for null elements in constructor.

### DIFF
--- a/java/form/src/org/netbeans/modules/form/project/ClassSource.java
+++ b/java/form/src/org/netbeans/modules/form/project/ClassSource.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
 
 /**
@@ -50,6 +49,9 @@ public final class ClassSource {
         this(className, entries, null);
     }
     public ClassSource(String className, Collection<? extends Entry> entries, String typeParameters) {
+        if (entries.contains(null)) {
+            throw new IllegalArgumentException("entries contains null entry: "+entries);
+        }
         this.className = className;
         this.entries = entries;
         this.typeParameters = typeParameters;
@@ -73,7 +75,7 @@ public final class ClassSource {
 
     /** Union of {@link ClassSource.Entry#getClasspath}. */
     public List<URL> getClasspath() {
-        List<URL> cp = new ArrayList<URL>();
+        List<URL> cp = new ArrayList<>();
         for (Entry entry : entries) {
             cp.addAll(entry.getClasspath());
         }


### PR DESCRIPTION
addToProjectClassPath() would fail later with a less useful stacktrace as observed in #4365.

(this doesn't really fix a bug, defensive checks make finding bugs a bit easier)