### PR TITLE
use java.home as "default jdk" if jdk.home leads to symlinks.

### DIFF
--- a/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/Bundle.properties
+++ b/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/Bundle.properties
@@ -22,9 +22,7 @@ OpenIDE-Module-Short-Description=JPDA Debugger API
 OpenIDE-Module-Long-Description=JPDA Debugger API
 OpenIDE-Module-Package-Dependency-Message=\
     <b>The JDK is missing and is required to run some NetBeans modules</b><br> \
-    Please use the --jdkhome command line option to specify a JDK<br>\
-    installation or see <a href="http://wiki.netbeans.org/FaqRunningOnJre">http://wiki.netbeans.org/FaqRunningOnJre</a> for<br> \
-    more information.
+    Please use the --jdkhome command line option or set netbeans_jdkhome in your netbeans.conf to specify a JDK.
 MSG_NO_DEBUGGER=No debugger engine available.
 
 ClassBrkp_Type=Class Load/Unload

--- a/java/form/src/org/netbeans/modules/form/Bundle2.properties
+++ b/java/form/src/org/netbeans/modules/form/Bundle2.properties
@@ -22,6 +22,4 @@ OpenIDE-Module-Long-Description=The Form Editor module enables you to visually d
 OpenIDE-Module-Display-Category=Java
 OpenIDE-Module-Package-Dependency-Message=\
     <b>The JDK is missing and is required to run some NetBeans modules</b><br> \
-    Please use the --jdkhome command line option to specify a JDK<br>\
-    installation or see <a href="http://wiki.netbeans.org/FaqRunningOnJre">http://wiki.netbeans.org/FaqRunningOnJre</a> for<br> \
-    more information.
+    Please use the --jdkhome command line option or set netbeans_jdkhome in your netbeans.conf to specify a JDK.

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/DefaultPlatformImpl.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/DefaultPlatformImpl.java
@@ -23,13 +23,13 @@ import java.io.*;
 import java.net.URL;
 import java.util.*;
 import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.openide.util.Exceptions;
-
 import org.openide.util.NbBundle;
 import org.openide.util.Utilities;
 import org.openide.filesystems.FileUtil;
 import org.netbeans.api.java.platform.*;
-import org.netbeans.api.java.classpath.*;
 
 /**
  * Implementation of the "Default" platform. The information here is extracted
@@ -42,8 +42,6 @@ public class DefaultPlatformImpl extends J2SEPlatformImpl {
 
     public static final String DEFAULT_PLATFORM_ANT_NAME = "default_platform";           //NOI18N
 
-    private ClassPath standardLibs;
-
     @SuppressWarnings("unchecked")  //Properties cast to Map<String,String>
     static JavaPlatform create(Map<String,String> properties, List<URL> sources, List<URL> javadoc) {
         if (properties == null) {
@@ -53,9 +51,9 @@ public class DefaultPlatformImpl extends J2SEPlatformImpl {
         synchronized (p) {
             p = new HashMap<>(p);
         }
-        String  jdkHome = System.getProperty("jdk.home"); // NOI18N
+        String jdkHome = System.getProperty("jdk.home"); // NOI18N
         File javaHome;
-        if (jdkHome == null) {
+        if (jdkHome == null || Files.isSymbolicLink(Paths.get(jdkHome, "bin", "java"))) {
             if (Util.getSpecificationVersion((String) p.get("java.specification.version")).compareTo(Util.JDK9) < 0) {
                 javaHome = FileUtil.normalizeFile(new File(System.getProperty("java.home")).getParentFile()); // NOI18N
             } else {
@@ -64,6 +62,7 @@ public class DefaultPlatformImpl extends J2SEPlatformImpl {
         } else {
             javaHome = FileUtil.normalizeFile(new File(jdkHome));
         }
+
         List<URL> installFolders = new ArrayList<> ();
         try {
             installFolders.add (Utilities.toURI(javaHome).toURL());


### PR DESCRIPTION
   - /usr shouldn't be a valid path for the default JDK
   - use java.home if jdk.home/bin/java is a symlink
   - updated some related warning messages
   - fixes #4365

NB can't actually be started on a "JRE" (whatever a JRE is these days since it isn't well defined anymore). However, the "default jdk" path could be invalid still which will cause trouble at runtime. (looking at you, installer)

e.g trying to run NB on a "JRE" fails early so we don't have to worry about this scenario (at least not for the IDE):
```
./netbeans 
Error occurred during initialization of boot layer
java.lang.module.FindException: Module jdk.jshell not found
```