### PR TITLE
[NETBEANS-4044] Fixing patching of modular libraries

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/PatchModuleFileManager.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/PatchModuleFileManager.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.source.parsing;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -29,6 +30,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -43,6 +45,7 @@ import javax.tools.StandardLocation;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.java.queries.BinaryForSourceQuery;
 import org.netbeans.modules.java.source.indexing.JavaIndex;
 import org.netbeans.modules.java.source.util.Iterators;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
@@ -64,6 +67,7 @@ final class PatchModuleFileManager implements JavaFileManager {
     private final Map<String,List<URL>> patches;
     private final Map<URL, String> roots;
     private Set<PatchLocation> moduleLocations;
+    private String overrideModuleName;
 
     PatchModuleFileManager(
             @NonNull final JavaFileManager binDelegate,
@@ -162,7 +166,8 @@ final class PatchModuleFileManager implements JavaFileManager {
                 return true;
             }
         } else if (head.startsWith(JavacParser.NB_X_MODULE)) {
-            addModulePatches(head.substring(JavacParser.NB_X_MODULE.length()),
+            overrideModuleName = head.substring(JavacParser.NB_X_MODULE.length());
+            addModulePatches(overrideModuleName,
                              src.entries().stream().map(e -> e.getURL()).collect(Collectors.toList()));
             return true;
         }
@@ -214,6 +219,8 @@ final class PatchModuleFileManager implements JavaFileManager {
 
     @Override
     public Iterable<JavaFileObject> list(Location location, String packageName, Set<JavaFileObject.Kind> kinds, boolean recurse) throws IOException {
+        location = fixLocation(location);
+
         if (PatchLocation.isInstance(location)) {
             final PatchLocation pl = PatchLocation.cast(location);
             final ModuleLocation bin = pl.getBin();
@@ -249,6 +256,8 @@ final class PatchModuleFileManager implements JavaFileManager {
 
     @Override
     public JavaFileObject getJavaFileForInput(Location location, String className, JavaFileObject.Kind kind) throws IOException {
+        location = fixLocation(location);
+
         if (PatchLocation.isInstance(location)) {
             final PatchLocation pl = PatchLocation.cast(location);
             final ModuleLocation bin = pl.getBin();
@@ -285,6 +294,14 @@ final class PatchModuleFileManager implements JavaFileManager {
     }
     //</editor-fold>
 
+    private Location fixLocation(Location input) throws IOException {
+        if (input == StandardLocation.CLASS_OUTPUT && overrideModuleName != null) {
+            return this.moduleLocations.stream().filter(pl -> overrideModuleName.equals(pl.getModuleName())).map(pl -> (Location) pl).findAny().orElse(input);
+        } else {
+            return input;
+        }
+    }
+
     private Set<PatchLocation> moduleLocations(final Location baseLocation) throws IOException {
         if (baseLocation != StandardLocation.PATCH_MODULE_PATH) {
             throw new IllegalStateException(baseLocation.toString());
@@ -292,7 +309,7 @@ final class PatchModuleFileManager implements JavaFileManager {
         if (moduleLocations == null) {
             Set<PatchLocation> res = new HashSet<>();
             for (Map.Entry<String,List<URL>> patch : patches.entrySet()) {
-                res.add(createPatchLocation(patch.getKey(), patch.getValue()));
+                res.add(createPatchLocation(patch.getKey(), patch.getValue(), patch.getKey().equals(overrideModuleName)));
             }
             moduleLocations = Collections.unmodifiableSet(res);
         }
@@ -302,7 +319,8 @@ final class PatchModuleFileManager implements JavaFileManager {
     @NonNull
     private static PatchLocation createPatchLocation(
             @NonNull final String modName,
-            @NonNull final List<? extends URL> roots) throws IOException {
+            @NonNull final List<? extends URL> roots,
+                     final boolean sourceOverride) throws IOException {
         Collection<URL> bin = new ArrayList<>(roots.size());
         Collection<URL> src = new ArrayList<>(roots.size());
         for (URL root : roots) {
@@ -310,7 +328,11 @@ final class PatchModuleFileManager implements JavaFileManager {
                 src.add(root);
                 bin.add(FileUtil.urlForArchiveOrDir(JavaIndex.getClassFolder(root)));
             } else {
-                bin.add(root);
+                if (sourceOverride) {
+                    bin.addAll(Arrays.asList(BinaryForSourceQuery.findBinaryRoots(root).getRoots()));
+                } else {
+                    bin.add(root);
+                }
             }
         }
         return new PatchLocation(

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PatchModuleTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PatchModuleTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.java.source.parsing;
+
+import com.sun.tools.javac.Main;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import javax.swing.event.ChangeListener;
+import static junit.framework.TestCase.assertEquals;
+import org.netbeans.api.java.queries.BinaryForSourceQuery;
+import org.netbeans.api.java.source.CompilationController;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.JavaSource.Phase;
+import org.netbeans.api.java.source.SourceUtilsTestUtil;
+import org.netbeans.api.java.source.Task;
+import org.netbeans.api.java.source.TestUtilities;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.java.source.tasklist.CompilerSettings;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.netbeans.spi.java.queries.BinaryForSourceQueryImplementation;
+
+public class PatchModuleTest extends NbTestCase {
+
+    public PatchModuleTest(String name) {
+        super(name);
+    }
+
+    private FileObject sourceRoot;
+    private FileObject classRoot;
+    private FileObject cp;
+
+    protected void setUp() throws Exception {
+        SourceUtilsTestUtil.prepareTest(new String[0], new Object[] {settings, binaryForSource});
+        clearWorkDir();
+        prepareTest();
+    }
+
+    public void testNETBEANS_4044() throws Exception {
+        settings.commandLine = "-Xnb-Xmodule:patch";
+        binaryForSource.result = new BinaryForSourceQuery.Result() {
+            @Override
+            public URL[] getRoots() {
+                return new URL[] {classRoot.toURL()};
+            }
+            @Override
+            public void addChangeListener(ChangeListener l) {}
+            @Override
+            public void removeChangeListener(ChangeListener l) {}
+        };
+        FileObject sourceModule = createFile("module-info.java", "module patch {}"); SourceUtilsTestUtil.setSourceLevel(sourceModule, "11");
+        FileObject source1 = createFile("patch/Patch.java", "package patch; class Patch { Dep dep; }"); SourceUtilsTestUtil.setSourceLevel(source1, "11");
+        FileObject source2 = createFile("patch/Dep.java", "package patch; class Dep { }"); SourceUtilsTestUtil.setSourceLevel(source2, "11");
+        File classDir = FileUtil.toFile(classRoot);
+        List<String> options = new ArrayList<>();
+        options.add("-d");
+        options.add(classDir.getAbsolutePath());
+        Enumeration<? extends FileObject> en = sourceRoot.getChildren(true);
+        while (en.hasMoreElements()) {
+            FileObject f = en.nextElement();
+            if (f.isData()) {
+                options.add(FileUtil.toFile(f).getAbsolutePath());
+            }
+        }
+        assertEquals(0, Main.compile(options.toArray(new String[0])));
+        JavaSource js = JavaSource.forFileObject(source1);
+
+        js.runUserActionTask(new Task<CompilationController>() {
+            public void run(CompilationController parameter) throws Exception {
+                assertTrue(Phase.RESOLVED.compareTo(parameter.toPhase(Phase.RESOLVED)) <= 0);
+                assertEquals(parameter.getDiagnostics().toString(), 0, parameter.getDiagnostics().size());
+            }
+        }, true);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        settings.commandLine = null;
+        binaryForSource.result = null;
+    }
+
+    private FileObject createFile(String path, String content) throws Exception {
+        FileObject file = FileUtil.createData(sourceRoot, path);
+        TestUtilities.copyStringToFile(file, content);
+
+        return file;
+    }
+
+    private void prepareTest() throws Exception {
+        File work = getWorkDir();
+        FileObject workFO = FileUtil.toFileObject(work);
+
+        assertNotNull(workFO);
+
+        sourceRoot = workFO.createFolder("src");
+        classRoot = workFO.createFolder("class");
+
+        FileObject buildRoot  = workFO.createFolder("build");
+        FileObject cache = workFO.createFolder("cache");
+
+        SourceUtilsTestUtil.prepareTest(sourceRoot, buildRoot, cache, new FileObject[] {cp});
+    }
+
+    private static final CompilerSettingsImpl settings = new CompilerSettingsImpl();
+
+    private static final class CompilerSettingsImpl extends CompilerSettings {
+        private String commandLine;
+        @Override
+        protected String buildCommandLine(FileObject file) {
+            return commandLine;
+        }
+
+    }
+
+    private static final BinaryForSourceQueryImpl binaryForSource = new BinaryForSourceQueryImpl();
+
+    private static final class BinaryForSourceQueryImpl implements BinaryForSourceQueryImplementation {
+
+        private BinaryForSourceQuery.Result result;
+
+        @Override
+        public BinaryForSourceQuery.Result findBinaryRoots(URL sourceRoot) {
+            return result;
+        }
+
+    }
+}


### PR DESCRIPTION
Consider a binary library with an attached source. When opening a source file for the library, if the library is non-modular, the binary will be on the classpath, and the source will be able to refer to it. When the library is modular, javac will not look at the classpath anymore, but will try to lookup module-info and other dependencies on source and output path. So, we need to make sure the output path contains the binary library, so that the lookups work. This is what this patch is trying to achieve.


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

