### PR TITLE
NEON - added FlatLaf Dark specific colors to improve legibility

### DIFF
--- a/php/languages.neon/src/org/netbeans/modules/languages/neon/resources/FontAndColors-FlatLafDark.xml
+++ b/php/languages.neon/src/org/netbeans/modules/languages/neon/resources/FontAndColors-FlatLafDark.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
+<fontscolors>
+    <fontcolor name="valuedblock" default="separator" foreColor="F6F683" />
+    <fontcolor name="number" default="number" foreColor="FFC800" />
+    <fontcolor name="reference" default="identifier" foreColor="92CDF9" />
+</fontscolors>

--- a/php/languages.neon/src/org/netbeans/modules/languages/neon/resources/layer.xml
+++ b/php/languages.neon/src/org/netbeans/modules/languages/neon/resources/layer.xml
@@ -125,6 +125,13 @@
                             </file>
                         </folder>
                     </folder>
+                    <folder name="FlatLafDark">
+                        <folder name="Defaults">
+                            <file name="FontAndColors-FlatLafDark.xml" url="FontAndColors-FlatLafDark.xml">
+                                <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.languages.neon.resources.Bundle"/>
+                            </file>
+                        </folder>
+                    </folder>
                 </folder>
             </folder>
         </folder>


### PR DESCRIPTION
Changed colors of valued block, reference and number to improve legibility when using FlatLaf Dark color profile.

Before:
![before](https://user-images.githubusercontent.com/4249184/179422100-c9531198-2e86-47be-8eac-4a7ea541eef7.png)

After:
![after](https://user-images.githubusercontent.com/4249184/179422103-01eafcf2-87bb-40b8-bbbf-c547433f234e.png)

