### PR TITLE
Change output encoding fallback behavior to account for JEP400

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
@@ -202,7 +202,7 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
         private boolean skipLF = false;
 
         public Output(InputStream instream) {
-            str = new BufferedReader(new InputStreamReader(instream, getNativeCharset()));
+            str = new BufferedReader(new InputStreamReader(instream, getPreferredCharset()));
         }
 
         private String readLine() throws IOException {
@@ -701,7 +701,7 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
 
         public @Override void run() {
             Reader in = inputOutput.getIn();
-            try (Writer out = new OutputStreamWriter(str, getNativeCharset())) {
+            try (Writer out = new OutputStreamWriter(str, getPreferredCharset())) {
                 while (true) {
                     int read = in.read();
                     if (read != -1) {
@@ -827,30 +827,45 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
         }
         
     }    
-
-    private static Charset getNativeCharset() {
+    
+    /**
+     * Returns the preferred Charset that is obtained by checking the following system properties:
+     * stdout.encoding, sun.stdout.encoding, native.encoding, Charset.defaultCharset()
+     * @see org.netbeans.api.extexecution.base.BaseExecutionService#getInputOutputEncoding
+     * @return Charset
+     */
+    private static Charset getPreferredCharset() {
         // The CommandLineOutputHandler used the default charset to convert
         // output from command line invocations to strings. That encoding is
         // derived from the system file.encoding. From JDK 18 onwards its
         // default value changed to UTF-8.
-        // JDK 18+ exposes the native encoding as the new system property
+        // JDK 17+ exposes the native encoding as the new system property
         // native.encoding, prior versions don't have that property and will
         // report NULL for it.
-        // The algorithm is simple: If native.encoding is set, it will be used
-        // else the old default will be queried via Charset#defaultCharset.
-        String nativeEncoding = System.getProperty("native.encoding");
-        Charset nativeCharset = null;
-        if (nativeEncoding != null) {
-            try {
-                nativeCharset = Charset.forName(nativeEncoding);
-            } catch (Exception ex) {
-                LOG.log(java.util.logging.Level.WARNING, "Failed to get charset for native.encoding value : '" + nativeEncoding + "'", ex);
+        // To account for the behavior of JEP400 the following order is used to determine the encoding:
+        // stdout.encoding, sun.stdout.encoding, native.encoding, Charset.defaultCharset()
+        String[] encodingSystemProperties = new String[]{"stdout.encoding", "sun.stdout.encoding", "native.encoding"};
+
+        Charset preferredCharset = null;
+        for (String encodingProperty : encodingSystemProperties) {
+            String encodingPropertyValue = System.getProperty(encodingProperty);
+            if (encodingPropertyValue == null) {
+                continue;
             }
+
+            try {
+                preferredCharset = Charset.forName(encodingPropertyValue);
+            } catch (IllegalArgumentException ex) {
+                LOG.log(java.util.logging.Level.WARNING, "Failed to get charset for '" + encodingProperty + "' value : '" + encodingPropertyValue + "'", ex);
+            }
+
+            if (preferredCharset != null) {
+                return preferredCharset;
+            }
+
         }
-        if (nativeCharset == null) {
-            nativeCharset = Charset.defaultCharset();
-        }
-        return nativeCharset;
+
+        return Charset.defaultCharset();
     }
 }
 


### PR DESCRIPTION
Since JEP400/JDK18 `Console.charset()`/`stdout.encoding`/`sun.stdout.encoding` is used by default for the console's encoding. Prior to this it was `Charset.defaultEncoding()`/`file.encoding`.

This PR changes the order the encoding is inferred by to accomodate for this behavior.

This should fix #3824 as well as #4261.

As `stdout.encoding`/`sun.stdout.encoding` is settable, in the rare case that the default value should not match the desired Output encoding it can be changed via the corresponding commandline argument.

Please see [this comment](https://github.com/apache/netbeans/issues/4261#issuecomment-1185669743) by @neilcsmith-net for further details

[Requested via](https://lists.apache.org/thread/pzv6899dn4w2syo6dk400qc3n9wr6slf)