### PR TITLE
Fix #4411 - ensure moduleLocations is initialized.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/PatchModuleFileManager.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/PatchModuleFileManager.java
@@ -296,7 +296,8 @@ final class PatchModuleFileManager implements JavaFileManager {
 
     private Location fixLocation(Location input) throws IOException {
         if (input == StandardLocation.CLASS_OUTPUT && overrideModuleName != null) {
-            return this.moduleLocations.stream().filter(pl -> overrideModuleName.equals(pl.getModuleName())).map(pl -> (Location) pl).findAny().orElse(input);
+            return moduleLocations(StandardLocation.PATCH_MODULE_PATH)
+                    .stream().filter(pl -> overrideModuleName.equals(pl.getModuleName())).map(pl -> (Location) pl).findAny().orElse(input);
         } else {
             return input;
         }


### PR DESCRIPTION
Fix #4411 - protect against NPE by ensuring moduleLocations is initialized in PatchModuleFileManager::fixLocation.

I think this is the right approach rather than bailing on null.  At least, every other use in that class is via the initializing method.