### PR TITLE
Enable direct loading of native library for junixsocket instead of loading from temp

### DIFF
--- a/ide/libs.c.kohlschutter.junixsocket/nbproject/project.properties
+++ b/ide/libs.c.kohlschutter.junixsocket/nbproject/project.properties
@@ -17,4 +17,17 @@
 
 release.external/junixsocket-common-2.4.0.jar=modules/ext/junixsocket-common-2.4.0.jar
 release.external/junixsocket-native-common-2.4.0.jar=modules/ext/junixsocket-native-common-2.4.0.jar
+release.external/junixsocket-native-common-2.4.0.jar!/lib/x86_64-MacOSX-clang/jni/libjunixsocket-native-2.4.0.dylib=modules/lib/x86_64/libjunixsocket-native-2.4.0.dylib
+release.external/junixsocket-native-common-2.4.0.jar!/lib/aarch64-MacOSX-clang/jni/libjunixsocket-native-2.4.0.dylib=modules/lib/aarch64/libjunixsocket-native-2.4.0.dylib
+release.external/junixsocket-native-common-2.4.0.jar!/lib/amd64-Linux-clang/jni/libjunixsocket-native-2.4.0.so=modules/lib/amd64/linux/libjunixsocket-native-2.4.0.so
+release.external/junixsocket-native-common-2.4.0.jar!/lib/aarch64-Linux-clang/jni/libjunixsocket-native-2.4.0.so=modules/lib/aarch64/linux/libjunixsocket-native-2.4.0.so
+release.external/junixsocket-native-common-2.4.0.jar!/lib/riscv64-Linux-clang/jni/libjunixsocket-native-2.4.0.so=modules/lib/riscv64/linux/libjunixsocket-native-2.4.0.so
+release.external/junixsocket-native-common-2.4.0.jar!/lib/amd64-Windows10-clang/jni/junixsocket-native-2.4.0.dll=modules/lib/amd64/junixsocket-native-2.4.0.dll
+jnlp.verify.excludes=\
+    modules/lib/x86_64/libjunixsocket-native-2.4.0.dylib,\
+    modules/lib/aarch64/libjunixsocket-native-2.4.0.dylib,\
+    modules/lib/amd64/linux/libjunixsocket-native-2.4.0.so,\
+    modules/lib/aarch64/linux/libjunixsocket-native-2.4.0.so,\
+    modules/lib/riscv64/linux/libjunixsocket-native-2.4.0.so,\
+    modules/lib/amd64/junixsocket-native-2.4.0.dll
 is.autoload=true


### PR DESCRIPTION
junixsocket loads by default the native library using System#loadLibrary
so the native libraries only need to be placed in the

modules/lib/\<arch>/\<os>

folders, so that they can be loaded directly with the requirement to
expand them and load them from java.io.tmpdir.

Closes: #4393
