### PR TITLE
Unbalanced hint should work for fields initialized in constructor

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unbalanced.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unbalanced.java
@@ -103,14 +103,6 @@ public class Unbalanced {
 
     @Hint(displayName = "#DN_org.netbeans.modules.java.hints.bugs.Unbalanced.Array", description = "#DESC_org.netbeans.modules.java.hints.bugs.Unbalanced.Array", category="bugs", options=Options.QUERY, suppressWarnings="MismatchedReadAndWriteOfArray")
     public static final class Array {
-        private static final Set<Kind> ARRAY_WRITE = EnumSet.of(
-            Kind.AND_ASSIGNMENT, Kind.ASSIGNMENT, Kind.CONDITIONAL_AND, Kind.CONDITIONAL_OR,
-            Kind.DIVIDE_ASSIGNMENT, Kind.LEFT_SHIFT_ASSIGNMENT, Kind.MINUS_ASSIGNMENT,
-            Kind.MULTIPLY_ASSIGNMENT, Kind.OR_ASSIGNMENT, Kind.PLUS_ASSIGNMENT,
-            Kind.POSTFIX_DECREMENT, Kind.POSTFIX_INCREMENT, Kind.PREFIX_DECREMENT,
-            Kind.PREFIX_INCREMENT, Kind.REMAINDER_ASSIGNMENT, Kind.RIGHT_SHIFT_ASSIGNMENT,
-            Kind.UNSIGNED_RIGHT_SHIFT_ASSIGNMENT, Kind.XOR_ASSIGNMENT
-        );
 
         private static VariableElement testElement(HintContext ctx) {
             Element el = ctx.getInfo().getTrees().getElement(ctx.getPath());
@@ -160,7 +152,7 @@ public class Unbalanced {
                 if (secondAccess != null) {
                     record(ctx.getInfo(), var, secondAccess);
                 }
-            } else {
+            } else if (!var.getModifiers().contains(Modifier.FINAL)) {
                 record(ctx.getInfo(), var, State.WRITE, State.READ);
             }
 
@@ -204,8 +196,11 @@ public class Unbalanced {
 
     @Hint(displayName = "#DN_org.netbeans.modules.java.hints.bugs.Unbalanced.Collection", description = "#DESC_org.netbeans.modules.java.hints.bugs.Unbalanced.Collection", category="bugs", options=Options.QUERY, suppressWarnings="MismatchedQueryAndUpdateOfCollection")
     public static final class Collection {
-        private static final Set<String> READ_METHODS = new HashSet<String>(Arrays.asList("get", "contains", "remove", "containsAll", "removeAll", "retain", "retainAll", "containsKey", "containsValue", "iterator", "isEmpty", "size", "toArray", "listIterator", "indexOf", "lastIndexOf"));
-        private static final Set<String> WRITE_METHODS = new HashSet<String>(Arrays.asList("add", "addAll", "set"));
+        private static final Set<String> READ_METHODS = new HashSet<>(Arrays.asList(
+                "get", "getOrDefault", "contains", "remove", "containsAll", "removeAll", "removeIf", "retain", "retainAll", "containsKey",
+                "containsValue", "iterator", "listIterator", "isEmpty", "size", "toArray", "entrySet", "keySet", "values", "indexOf", "lastIndexOf",
+                "stream", "parallelStream", "spliterator", "forEach"));
+        private static final Set<String> WRITE_METHODS = new HashSet<>(Arrays.asList("add", "addAll", "set", "put", "putAll", "putIfAbsent"));
 
         private static boolean testType(CompilationInfo info, TypeMirror actualType, String superClass) {
             TypeElement juCollection = info.getElements().getTypeElement(superClass);
@@ -259,7 +254,9 @@ public class Unbalanced {
                 }
             }
 
-            record(ctx.getInfo(), var, State.WRITE, State.READ);
+            if (!var.getModifiers().contains(Modifier.FINAL)) {
+                record(ctx.getInfo(), var, State.WRITE, State.READ);
+            }
 
             return null;
         }

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnbalancedTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnbalancedTest.java
@@ -68,6 +68,19 @@ public class UnbalancedTest extends NbTestCase {
                 .assertContainsWarnings("2:19-2:22:verifier:ERR_UnbalancedArrayREAD arr");
     }
 
+    public void testArrayReadOnly3() throws Exception {
+        HintTest
+                .create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    private final byte[] arr;\n" +
+                       "    private Test() { arr = new byte[0]; }\n" +
+                       "    private void t() { System.err.println(arr[0]); }\n" +
+                       "}\n")
+                .run(Unbalanced.Array.class)
+                .assertContainsWarnings("2:25-2:28:verifier:ERR_UnbalancedArrayREAD arr");
+    }
+
     public void testArrayNeg1() throws Exception {
         HintTest
                 .create()
@@ -310,6 +323,19 @@ com.sun.tools.javac.tree.JCTree$JCCompilationUnit@40d0726d
                        "}\n")
                 .run(Unbalanced.Collection.class)
                 .assertContainsWarnings("2:35-2:39:verifier:ERR_UnbalancedCollectionREAD coll");
+    }
+
+    public void testCollectionReadOnly4() throws Exception {
+        HintTest
+                .create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    private final java.util.List<String> coll;\n" +
+                       "    private Test () { coll = new java.util.ArrayList<String>(1); }\n" +
+                       "    private java.util.stream.Stream t() { return coll.stream(); }\n" +
+                       "}\n")
+                .run(Unbalanced.Collection.class)
+                .assertContainsWarnings("2:41-2:45:verifier:ERR_UnbalancedCollectionREAD coll");
     }
 
     public void testMapReadOnly1() throws Exception {


### PR DESCRIPTION
 - we can make this work for final fields, non-final fields would
   be more complicated [explained here](https://github.com/apache/netbeans/issues/4402#issuecomment-1192312559)
 - added missing methods to READ_METHODS set

fixes #4402 