### PR TITLE
Using record construct on JDK-11 yields an error in the editor

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/base/SourceLevelUtils.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/base/SourceLevelUtils.java
@@ -32,6 +32,8 @@ public class SourceLevelUtils {
     public static final Source JDK1_7 = Source.lookup("7");
     public static final Source JDK1_8 = Source.lookup("8");
     public static final Source JDK1_9 = Source.lookup("9");
+    public static final Source JDK14 = Source.lookup("14");
+    public static final Source JDK15 = Source.lookup("15");
 
     public static boolean allowDefaultMethods(Source in) {
         return in.compareTo(JDK1_8) >= 0;

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -1190,6 +1190,13 @@ public class JavacParser extends Parser {
                                new Object[]{srcClassPath, sourceLevel, moduleBoot}); //NOI18N
                     return SourceLevelUtils.JDK1_8;
                 }
+                if (source.compareTo(SourceLevelUtils.JDK15) >= 0 &&
+                    !hasResource("java/lang/Record", new ClassPath[] {moduleBoot}, new ClassPath[] {moduleCompile, moduleAllUnnamed}, new ClassPath[] {srcClassPath})) { //NOI18N
+                    LOGGER.log(warnLevel,
+                               "Even though the source level of {0} is set to: {1}, java.lang.Record cannot be found on the system module path: {2}\n", //NOI18N
+                               new Object[]{srcClassPath, sourceLevel, moduleBoot}); //NOI18N
+                    return SourceLevelUtils.JDK14;
+                }
                 return source;
             }
         }


### PR DESCRIPTION
I have a project that is using `record` heavily, but still compiles to old JDKs. When I run NetBeans on JDK-8 everything is OK, but when I run them on JDK-11 I get an error:

![image](https://user-images.githubusercontent.com/1842422/180386137-aa7d2b66-b254-4b05-9ce5-e5a66af90746.png)

My project consists of a `pom.xml` file requesting `source` `18`:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>org.netbeans.test</groupId>
    <artifactId>userecords</artifactId>
    <packaging>jar</packaging>
    <version>1.0-SNAPSHOT</version>
    <build>
        <plugins>
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
                <version>3.8.1</version>
                <dependencies>
                    <dependency>
                        <groupId>org.frgaal</groupId>
                        <artifactId>compiler-maven-plugin</artifactId>
                        <version>19.0.0-RC1</version>
                    </dependency>
                </dependencies>
                <configuration>
                    <compilerId>frgaal</compilerId>
                    <source>18</source>
                    <target>8</target>
                    <compilerArgs>
                        <arg>-Xlint:deprecation</arg>
                        <arg>--enable-preview</arg>
                    </compilerArgs>
                </configuration>
            </plugin>
        </plugins>
    </build>
</project>
```
and a `Main.java` class using the `record`:

```java
package test;

record Main(Object data) {

    public static void main(String... args) {
        Main m = new Main("Hello");
        String reply = findReply(m);
        System.err.println(m.data() + ": " + reply);
        
        m = new Main(10);
        reply = findReply(m);
        System.err.println(m.data() + ": " + reply);
    }

    private static String findReply(Object o) {
        return switch (o) {
            case Main m -> " world";
            case Object x -> " any";
        };
    }

}
```
turns out we just need to expand the check in `JavacParser` to verify that source level >= 15 also has access to `java.lang.Record` class. 

I'd like to get this fix into NetBeans 15 - I am using this project setup a lot and I always have to restart NetBeans on JDK8 to avoid the error.