### PR TITLE
PHPStan - fixes typo in config panel and updates config file name

### DIFF
--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/options/Bundle.properties
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/options/Bundle.properties
@@ -62,4 +62,4 @@ PHPStanOptionsPanel.phpStanNoteLabel.text=<html><i>Note:</i></html>
 PHPStanOptionsPanel.phpStanMinVersionInfoLabel.text=PHPStan 0.10.3 or newer is supported.
 PHPStanOptionsPanel.phpStanLearnMoreLabel.text=<html><a href="#">Learn more about PHPStan</a></html>
 PHPStanOptionsPanel.phpStanMemoryLimitLabel.text=&Memory Limit:
-PHPStanOptionsPanel.phpStanConfigurationInfoLabel.text=Full configuration file path(typically, phpstan.neon or phpstan.neon.dist)
+PHPStanOptionsPanel.phpStanConfigurationInfoLabel.text=Full configuration file path (typically, phpstan.neon or phpstan.dist.neon)


### PR DESCRIPTION
Use configuration file "phpstan.dist.neon" instead of "phpstan.neon.dist" because the former is opened as NEON file in NetBeans.
Both configuration files are supported by PHPStan. See https://phpstan.org/config-reference#config-file

Fixes #4426
