### PR TITLE
Fix Gradle Source4Binary always returns with resources location.

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceForBinary.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceForBinary.java
@@ -92,7 +92,7 @@ public class GradleSourceForBinary implements SourceForBinaryQueryImplementation
                 // The proper solution will be to change java implementation to use output folder as a fallback if nothing
                 // is found in the cache; then this special case may be removed.
                 boolean canPreferSource = st == SourceType.JAVA;
-                return new Res(project, ss.getName(), EnumSet.of(RESOURCES), canPreferSource);
+                return new Res(project, ss.getName(), EnumSet.of(st), canPreferSource);
             }
         }
         return new Res(project, ss.getName(), ALL_LANGUAGES, false);


### PR DESCRIPTION

This one is a fix for #4418.
