### PR TITLE
#4447 - Fix missing code folding blocks in java editor for conditions, loops and try/catch

### DIFF
--- a/java/java.editor.lib/src/org/netbeans/editor/ext/java/JavaFoldManager.java
+++ b/java/java.editor.lib/src/org/netbeans/editor/ext/java/JavaFoldManager.java
@@ -42,7 +42,9 @@ public abstract class JavaFoldManager implements FoldManager {
     
     public static final FoldType JAVADOC_FOLD_TYPE = JavaElementFoldManager.JAVADOC_FOLD_TYPE;
 
-    public static final FoldType CODE_BLOCK_FOLD_TYPE = JavaElementFoldManager.CODE_BLOCK_FOLD_TYPE;
+    public static final FoldType CODE_BLOCK_FOLD_TYPE = JavaElementFoldManager.METHOD_BLOCK_FOLD_TYPE;
+
+    public static final FoldType METHOD_BLOCK_FOLD_TYPE = JavaElementFoldManager.METHOD_BLOCK_FOLD_TYPE;
     
     public static final FoldType INNERCLASS_TYPE = JavaElementFoldManager.INNERCLASS_TYPE;
     
@@ -68,7 +70,11 @@ public abstract class JavaFoldManager implements FoldManager {
 
     @Deprecated
     public static final FoldTemplate CODE_BLOCK_FOLD_TEMPLATE
-        = new FoldTemplate(CODE_BLOCK_FOLD_TYPE, CODE_BLOCK_FOLD_DESCRIPTION, 1, 1);
+            = new FoldTemplate(CODE_BLOCK_FOLD_TYPE, CODE_BLOCK_FOLD_DESCRIPTION, 1, 1);
+
+    @Deprecated
+    public static final FoldTemplate METHOD_BLOCK_FOLD_TEMPLATE
+            = new FoldTemplate(METHOD_BLOCK_FOLD_TYPE, CODE_BLOCK_FOLD_DESCRIPTION, 1, 1);
 
     @Deprecated
     public static final FoldTemplate INNER_CLASS_FOLD_TEMPLATE

--- a/java/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManager.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManager.java
@@ -76,7 +76,11 @@ public class JavaElementFoldManager implements FoldManager {
 	     new org.netbeans.api.editor.fold.FoldTemplate(3, 2, "/**...*/")); // NOI18N
 
     @NbBundle.Messages("FoldType_Methods=Methods")
-    public static final FoldType CODE_BLOCK_FOLD_TYPE = FoldType.MEMBER.derive("method", Bundle.FoldType_Methods(), 
+    public static final FoldType METHOD_BLOCK_FOLD_TYPE = FoldType.MEMBER.derive("method", Bundle.FoldType_Methods(), 
+            new org.netbeans.api.editor.fold.FoldTemplate(1, 1, "{...}")); // NOI18N
+
+    @NbBundle.Messages("FoldType_CodeBlocks=Code Blocks")
+    public static final FoldType CODE_BLOCK_FOLD_TYPE = FoldType.CODE_BLOCK.derive("code-block", Bundle.FoldType_CodeBlocks(), 
 	     new org.netbeans.api.editor.fold.FoldTemplate(1, 1, "{...}")); // NOI18N
     
     @NbBundle.Messages("FoldType_InnerClasses=Inner Classes")
@@ -271,6 +275,11 @@ public class JavaElementFoldManager implements FoldManager {
                 @Override
                 public FoldInfo createInnerClassFold(int start, int end) {
                     return FoldInfo.range(start, end, INNERCLASS_TYPE);
+                }
+
+                @Override
+                public FoldInfo createMethodFold(int start, int end) {
+                    return FoldInfo.range(start, end, METHOD_BLOCK_FOLD_TYPE);
                 }
 
                 @Override

--- a/java/java.editor/src/org/netbeans/modules/java/editor/fold/JavaFoldTypeProvider.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/fold/JavaFoldTypeProvider.java
@@ -37,6 +37,7 @@ public class JavaFoldTypeProvider implements FoldTypeProvider {
     public JavaFoldTypeProvider() {
         types.add(JavaElementFoldManager.CODE_BLOCK_FOLD_TYPE);
         types.add(JavaElementFoldManager.INNERCLASS_TYPE);
+        types.add(JavaElementFoldManager.METHOD_BLOCK_FOLD_TYPE);
         types.add(JavaElementFoldManager.IMPORTS_FOLD_TYPE);
         types.add(JavaElementFoldManager.JAVADOC_FOLD_TYPE);
         types.add(JavaElementFoldManager.INITIAL_COMMENT_FOLD_TYPE);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1496,9 +1496,14 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                     public FoldingRange createInnerClassFold(int start, int end) {
                         return createFold(start, end, FoldingRangeKind.Region);
                     }
-
+                    
                     @Override
                     public FoldingRange createCodeBlockFold(int start, int end) {
+                        return createFold(start, end, FoldingRangeKind.Region);
+                    }
+                    
+                    @Override
+                    public FoldingRange createMethodFold(int start, int end) {
                         return createFold(start, end, FoldingRangeKind.Region);
                     }
 


### PR DESCRIPTION
The motivation about this was to implement those missing folding blocks in java editor. This was just implemented for imports, classes, inner classes, methods but not for stuff inside methods like if/else if/else, try/catch and loops because all of them are treated like as code blocks.


Please bare with me and my knowledge of the stuff. Unfortunately I dunno why the if statement was implemented, that I removed from JavaElementFoldVisitor but this prevents it from adding folding rectangle to those blocks. This is the only line that I need to change in general but, now I changed the method code block to general code-blocks because now it is not only for methods anymore.

Before:

<img width="686" alt="image" src="https://user-images.githubusercontent.com/795658/181634976-87444df2-b598-417b-8b2a-99858e48fb4c.png">


After:

<img width="720" alt="image" src="https://user-images.githubusercontent.com/795658/181635432-5d2c7d91-59bd-47e3-828b-ea46999c17a5.png">

It works for the mentioned blocks, but switch is still missing.