### PR TITLE
Better messages from Janitor on abandoned cache dirs.

### DIFF
--- a/platform/janitor/src/org/netbeans/modules/janitor/JanitorPanel.form
+++ b/platform/janitor/src/org/netbeans/modules/janitor/JanitorPanel.form
@@ -65,7 +65,7 @@
   <SubComponents>
     <Component class="javax.swing.JLabel" name="jLabel1">
       <Properties>
-        <Property name="verticalAlignment" type="int" value="1"/>
+        <Property name="horizontalAlignment" type="int" value="0"/>
       </Properties>
     </Component>
     <Component class="javax.swing.JCheckBox" name="cbEnabled">

--- a/platform/janitor/src/org/netbeans/modules/janitor/JanitorPanel.java
+++ b/platform/janitor/src/org/netbeans/modules/janitor/JanitorPanel.java
@@ -49,7 +49,7 @@ public class JanitorPanel extends javax.swing.JPanel {
         jLabel1 = new javax.swing.JLabel();
         cbEnabled = new javax.swing.JCheckBox();
 
-        jLabel1.setVerticalAlignment(javax.swing.SwingConstants.TOP);
+        jLabel1.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
 
         org.openide.awt.Mnemonics.setLocalizedText(cbEnabled, org.openide.util.NbBundle.getMessage(JanitorPanel.class, "JanitorPanel.cbEnabled.text")); // NOI18N
 


### PR DESCRIPTION
Small patch makes the Janitor messages on removing 'NetBeans version 64' a bit more descriptive.
