### PR TITLE
Treat Gradle disk cache at least as evaluated.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
@@ -43,9 +43,13 @@ public class DiskCacheProjectLoader extends AbstractProjectLoader {
         if (cache.isCompatible()) {
             GradleProject prev = createGradleProject(ctx.project.getGradleFiles(), cache.loadData());
             LOG.log(Level.FINER, "Loaded from cache: {0}, valid: {1}", new Object[] { prev, cache.isValid() });
-            if (cache.isValid() && GradleArtifactStore.getDefault().sanityCheckCachedProject(prev)) {
-                updateSubDirectoryCache(prev);
-                return prev;
+            if (GradleArtifactStore.getDefault().sanityCheckCachedProject(prev)) {
+                if (cache.isValid()) {
+                    updateSubDirectoryCache(prev);
+                    return prev;
+                } else {
+                    return prev.invalidate("Disk cache data is invalid.");
+                }
             }
         }
         return null;

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
@@ -88,7 +88,8 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
                     ret = loader.load();
                     LOGGER.log(Level.FINER, "Loaded with loader {0} -> {1}", new Object[] { loader, ret });
                 }
-                if (ret != null) {
+                if ((ret != null) && ret.getQuality().atLeast(aim)) {
+                    // We have the quality we are looking for, let's be happy with that
                     break;
                 }
             } else {


### PR DESCRIPTION
This patch treats the on-dosk Gradle cache data as EVALUATED even if invalid. Usually there is a good chance that the information there is still better, than we can get from the heuristics.

This one would make ```ClassPathProviderImplTest.testCompilePreTrusted``` happy.

I hope this is not too late for NB15. Please review!
