### PR TITLE
Gradle project reports unresolved configurations.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
@@ -267,16 +267,18 @@ public final class GradleBaseProject implements Serializable, ModuleSearchSuppor
     }
 
     /**
-     * Returns {@code true} if all configurations are resolved.
-     * @return true - if all configurations are resolved.
+     * Returns {@code true} if all resolvable configurations are resolved.
+     * @return true - if all resolvable configurations are resolved.
      */
     public boolean isResolved() {
         if (resolved == null) {
             boolean b = true;
             for (GradleConfiguration value : configurations.values()) {
-                b &= value.isResolved();
-                if (!b) {
-                    break;
+                if (value.isCanBeResolved()) {
+                    b &= value.isResolved();
+                    if (!b) {
+                        break;
+                    }
                 }
             }
             resolved = b;


### PR DESCRIPTION

Well, this is a bit oversight with the recent changes around how we handle configurations in Gradle. We started to include non-resolvable configurations in the IDE around NetBeans 14. That would give better information available, however no matter what the Configurations node would display a warning badge about there are some configurations left to be unresolved.

It turned out that we forgot to filter the non-resolvable configurations out of the configurations when we are checking whether a configuration is resolved or not.

Would be a nice trivial fix for NB15, However I hope there would be no more RC-s there.