### PR TITLE
Exception reporter improvments

### DIFF
--- a/nb/ide.branding/o.n.core/src/org/netbeans/core/Bundle_nb.properties
+++ b/nb/ide.branding/o.n.core/src/org/netbeans/core/Bundle_nb.properties
@@ -18,9 +18,10 @@
 # {0} - class name of exception
 # {1} - path to system folder
 NTF_ExceptionalException=\
-        A {0} exception has occurred.\n\
-	Please report this at https://netbeans.apache.org/nb/report-issue,\n\
-	including a copy of your messages.log file as an attachment.\n\
-	The messages.log file is located in your {1} folder.
+    A <code>{0}</code> has occurred.<br/><br/>\
+	If you are running the <a href="https://netbeans.apache.org/download">latest</a> version of NetBeans you can \
+    <a href="https://netbeans.apache.org/nb/report-issue">report this</a>, \
+	including a copy of your messages.log file as an attachment.<br/><br/>\
+	The messages.log file is located in <a href="{1}">this folder</a>.
 
-NTF_ExceptionalExceptionReport=Show and Report Problem to NetBeans Team
+NTF_ExceptionalExceptionReport=Show Details

--- a/platform/o.n.core/src/org/netbeans/core/Bundle.properties
+++ b/platform/o.n.core/src/org/netbeans/core/Bundle.properties
@@ -28,13 +28,13 @@ OpenIDE-Module-Long-Description=\
 # {0} - class name of exception
 # {1} - path to system folder
 NTF_ExceptionalException=\
-        A {0} exception has occurred.\n\
-\tClick Show Details or see the messages.log file located in your {1} folder.
+        A {0} exception has occurred.<br/><br/>\
+        Click Show Details or see the messages.log file located in your {1} folder.
 NTF_ExceptionalExceptionTitle=Unexpected Exception
 # {0} - class name of exception
 NTF_ExceptionWarning=\
-        A {0} exception has occurred.\n\
-        However, the system should continue working without further problems.\n\
+        A {0} exception has occurred.<br/><br/>\
+        However, the system should continue working without further problems.<br/><br/>\
         Click Show Details for the stack trace.
 NTF_ExceptionWarningTitle=Warning
 

--- a/platform/openide.dialogs/src/org/openide/NotifyDescriptor.java
+++ b/platform/openide.dialogs/src/org/openide/NotifyDescriptor.java
@@ -43,6 +43,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JRadioButton;
+import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.JToggleButton;
@@ -183,10 +184,10 @@ public class NotifyDescriptor extends Object {
     private static final int MAXIMUM_TEXT_WIDTH = 100;
 
     /** preferred width of text area */
-    private static final int SIZE_PREFERRED_WIDTH = 300;
+    private static final int SIZE_PREFERRED_WIDTH = 350;
 
     /** preferred height of text area */
-    private static final int SIZE_PREFERRED_HEIGHT = 100;
+    private static final int SIZE_PREFERRED_HEIGHT = 150;
     private Object message;
 
     /** The message type. */
@@ -342,7 +343,6 @@ public class NotifyDescriptor extends Object {
         if (newMessage instanceof String) {
             // bugfix #25457, use JTextArea for word-wrapping
             JTextArea area = new JTextArea((String) newMessage);
-            area.setPreferredSize(new Dimension(SIZE_PREFERRED_WIDTH, SIZE_PREFERRED_HEIGHT));
             area.setBackground(UIManager.getColor("Label.background")); // NOI18N
             area.setBorder(BorderFactory.createEmptyBorder());
             area.setLineWrap(true);
@@ -351,7 +351,10 @@ public class NotifyDescriptor extends Object {
             area.setFocusable(true);
             area.getAccessibleContext().setAccessibleName(NbBundle.getMessage(NotifyDescriptor.class, "ACN_NotifyDescriptor_MessageJTextArea")); // NOI18N
             area.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(NotifyDescriptor.class, "ACD_NotifyDescriptor_MessageJTextArea")); // NOI18N
-            newMessage = area;
+            JScrollPane sp = new JScrollPane(area);
+            sp.setBorder(BorderFactory.createEmptyBorder());
+            sp.setPreferredSize(new Dimension(SIZE_PREFERRED_WIDTH, SIZE_PREFERRED_HEIGHT));
+            newMessage = sp;
         }
 
         message = newMessage;


### PR DESCRIPTION
We see users periodically reporting issues for old NB versions (e.g #4477 + discussion). So I wanted to see if the messaging could be a little bit improved.
It turned out that the exception reporter was a little bit broken, the message didn't fit into the window and it had no scrollbars, so the user would only see part of it.

related update to website:
 - https://github.com/apache/netbeans-website/pull/603

this PR:
 - improved the messages
   * emphasized latest release requirement
   * switched text to html
   * added hyperlinks which open the issue page/log folder (having long URIs in wrapping/scrolling text is annoying)
 - wrapped TextArea of NotifyDescriptor into a ScrollPane
 - switched stack trace pane (show details) to TextArea and disabled line wrap
 - slightly larger dimensions for everything

![exception-report_improved](https://user-images.githubusercontent.com/114367/183682460-7eb7127a-45f4-492b-b379-f9fa9ba7c39f.png)

