### PR TITLE
Support for project output artifacts

### DIFF
--- a/enterprise/micronaut/nbproject/project.xml
+++ b/enterprise/micronaut/nbproject/project.xml
@@ -69,6 +69,32 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.maven</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <specification-version>2.154</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.project.dependency</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <implementation-version/>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.maven.embedder</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <specification-version>2.72</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -382,6 +408,39 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.java.source.base</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.editor.mimelookup.impl</code-name-base>
+                        <recursive/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.openide.modules</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>ext/spring-boot-configuration-metadata-2.4.4.jar</runtime-relative-path>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/maven/BuildActions.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/maven/BuildActions.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.micronaut.maven;
+
+import java.util.Arrays;
+import javax.swing.Action;
+import org.netbeans.api.project.Project;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ui.support.ProjectActionPerformer;
+import org.netbeans.spi.project.ui.support.ProjectSensitiveActions;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
+
+/**
+ *
+ * @author sdedic
+ */
+public class BuildActions {
+    
+    @ActionID(id = "org.netbeans.modules.micronaut.maven.nativeBuild", category = "Project")
+    @ActionRegistration(displayName = "#LBL_NativeBuild", lazy=false)
+    @ActionReference(position = 520, path = "Projects/org-netbeans-modules-maven/Actions")
+    @NbBundle.Messages({
+        "LBL_NativeBuild=Build Native Executable"
+    })
+    public static Action    createNativeBuild() {
+        return ProjectSensitiveActions.projectSensitiveAction(new NativeBuildPerformer(), Bundle.LBL_NativeBuild(), null);
+    }
+    
+    private static class NativeBuildPerformer implements ProjectActionPerformer {
+        @Override
+        public boolean enable(Project project) {
+            ActionProvider ap = project.getLookup().lookup(ActionProvider.class);
+            return 
+                    ap != null &&
+                    Arrays.asList(ap.getSupportedActions()).contains(MicronautMavenConstants.ACTION_NATIVE_COMPILE) &&
+                    ap.isActionEnabled(MicronautMavenConstants.ACTION_NATIVE_COMPILE, Lookup.EMPTY);
+        }
+
+        @Override
+        public void perform(Project project) {
+            ActionProvider ap = project.getLookup().lookup(ActionProvider.class);
+            if (ap == null) {
+                return;
+            }
+            if (!Arrays.asList(ap.getSupportedActions()).contains(MicronautMavenConstants.ACTION_NATIVE_COMPILE) || 
+                !ap.isActionEnabled(MicronautMavenConstants.ACTION_NATIVE_COMPILE, Lookup.EMPTY)) {
+                return;
+            }
+            ap.invokeAction(MicronautMavenConstants.ACTION_NATIVE_COMPILE, Lookup.EMPTY);
+        }
+    }
+}

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/maven/MicronautMavenConstants.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/maven/MicronautMavenConstants.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.micronaut.maven;
+
+/**
+ *
+ * @author sdedic
+ */
+public final class MicronautMavenConstants {
+    
+    /**
+     * Plugin ID of the native-image plugin
+     */
+    public static final String NATIVE_BUILD_PLUGIN_ID = "native-maven-plugin"; // NOI18N
+
+    /**
+     * Group ID of the native-image plugin
+     */
+    public static final String NATIVE_BUILD_PLUGIN_GROUP = "org.graalvm.buildtools"; // NOI18N
+
+    /**
+     * Type of the native-executable artifact. Unofficial type, as the artifact is not installed
+     * by Maven and has no GAV.
+     */
+    public static final String TYPE_EXECUTABLE = "exe";
+    
+    /**
+     * Type of the dynamic library artifact. Unofficial type.
+     */
+    public static final String TYPE_DYNAMIC_LIBRARY = "dynlib";
+    
+    /**
+     * Classifier for the native-image artifact. Unofficial, as the install
+     * plugin will not install this artifact into local repository.
+     */
+    public static final String CLASSIFIER_NATIVE = "native-image";
+    
+    /**
+     * Native image plugin's goal to compile image without fork.
+     */
+    public static final String PLUGIN_GOAL_COMPILE_NOFORK = "build";
+
+    /**
+     * Native image plugin's goal to compile image from commandline
+     */
+    public static final String PLUGIN_GOAL_COMPILE = "compile";
+
+    /**
+     * Performs native compilation instead of the java one.
+     */
+    public static final String ACTION_NATIVE_COMPILE = "native-build";
+    
+    /**
+     * Packaging that will trigger the native-image compiler.
+     */
+    public static final String PACKAGING_NATIVE = "native-image";
+}

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/maven/MicronautPackagingArtifactsImpl.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/maven/MicronautPackagingArtifactsImpl.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.micronaut.maven;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectActionContext;
+import org.netbeans.modules.maven.api.NbMavenProject;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.netbeans.modules.project.dependency.ProjectArtifactsQuery;
+import org.netbeans.modules.project.dependency.spi.ProjectArtifactsImplementation;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.LookupProvider;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.*;
+import org.openide.util.lookup.Lookups;
+
+/**
+ *
+ * @author sdedic
+ */
+public class MicronautPackagingArtifactsImpl implements ProjectArtifactsImplementation<MicronautPackagingArtifactsImpl.R> {
+    // TBD: possibly configure the N-I plugin coordinates in the IDE settings.
+    
+    /**
+     * sharedLibrary plugin parameter. Will build a DLL or .so 
+     */
+    public static final String PLUGIN_PARAM_SHAREDLIBRARY = "sharedLibrary";
+    
+    private static final Set<String> SUPPORTED_ARTIFACT_TYPES = new HashSet<>(Arrays.asList(
+            MicronautMavenConstants.TYPE_DYNAMIC_LIBRARY, MicronautMavenConstants.TYPE_EXECUTABLE
+    ));
+    
+    /**
+     * imageName plugin parameter; defines the executable name.
+     */
+    public static final String PLUGIN_PARAM_IMAGENAME = "imageName";
+    
+    private final Project project;
+    private final NbMavenProject mavenProject;
+    
+    public MicronautPackagingArtifactsImpl(Project project) {
+        this.project = project;
+        mavenProject = project.getLookup().lookup(NbMavenProject.class);
+    }
+
+    @Override
+    public R evaluate(ProjectArtifactsQuery.Filter query) {
+        return new R(project, mavenProject, query);
+    }
+
+    @Override
+    public Project findProject(R r) {
+        return r.getProject();
+    }
+
+    @Override
+    public List<ArtifactSpec> findArtifacts(R r) {
+        return r.getArtifacts();
+    }
+
+    @Override
+    public Collection<ArtifactSpec> findExcludedArtifacts(R r) {
+        return r.getExcludedArtifacts();
+    }
+
+    @Override
+    public void handleChangeListener(R r, ChangeListener l, boolean add) {
+        if (add) {
+            r.addChangeListener(l);
+        } else {
+            r.removeChangeListener(l);
+        }
+    }
+
+    @Override
+    public boolean computeSupportsChanges(R r) {
+        return true;
+    }
+
+   static class R implements PropertyChangeListener {
+        private final Project project;
+        private final NbMavenProject mavenProject;
+        private final ProjectArtifactsQuery.Filter query;
+
+        // @GuardedBy(this)
+        private final List<ChangeListener> listeners = new ArrayList<>();
+        // @GuardedBy(this)
+        private List<ArtifactSpec> artifacts;
+        
+        private PropertyChangeListener projectL;
+
+        public R(Project project, NbMavenProject mavenProject, ProjectArtifactsQuery.Filter query) {
+            this.project = project;
+            this.mavenProject = mavenProject;
+            this.query = query;
+        }
+
+        public Project getProject() {
+            return project;
+        }
+        
+        public void addChangeListener(ChangeListener l) {
+            synchronized (this) {
+                if (projectL == null) {
+                    projectL = WeakListeners.propertyChange(this, project);
+                    mavenProject.addPropertyChangeListener(projectL);
+                }
+                listeners.add(l);
+            }
+        }
+        
+        public void removeChangeListener(ChangeListener l) {
+            synchronized (this) {
+                listeners.remove(l);
+            }
+        }
+
+        public List<ArtifactSpec> getArtifacts() {
+            synchronized (this) {
+                if (artifacts != null) {
+                    return artifacts;
+                }
+            }
+            List<ArtifactSpec> as = update();
+            synchronized (this) {
+                if (artifacts == null) {
+                    artifacts = as;
+                }
+            }
+            return as;
+        }
+
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            if (!NbMavenProject.PROP_PROJECT.equals(evt.getPropertyName())) {
+                return;
+            }
+            List<ArtifactSpec> old;
+            
+            synchronized (this) {
+                if (artifacts == null) {
+                    return;
+                }
+                old = artifacts;
+                artifacts = null;
+                if (listeners.isEmpty()) {
+                    return;
+                }
+            }
+            
+            List<ArtifactSpec> n = update();
+            ChangeListener[] ll;
+            
+            synchronized (this) {
+                if (artifacts == null) {
+                    this.artifacts = n;
+                }
+                if (old != null && n.equals(old)) {
+                    return;
+                }
+                ll = listeners.toArray(new ChangeListener[listeners.size()]);
+            }
+            ChangeEvent e = new ChangeEvent(this);
+            for (ChangeListener l : ll) {
+                l.stateChanged(e);
+            }
+        }
+
+        public Collection<ArtifactSpec> getExcludedArtifacts() {
+            return null;
+        }
+        
+        private List<ArtifactSpec> update() {
+            ProjectActionContext buildCtx;
+            
+            if (query.getBuildContext() != null) {
+                if (query.getBuildContext().getProjectAction() == null) {
+                    buildCtx = query.getBuildContext().newDerivedBuilder().forProjectAction(ActionProvider.COMMAND_BUILD).context();
+                } else {
+                    buildCtx = query.getBuildContext();
+                }
+            } else {
+                buildCtx = ProjectActionContext.newBuilder(project).forProjectAction(ActionProvider.COMMAND_BUILD).context();
+            }
+            if (query.getArtifactType() != null && 
+                !SUPPORTED_ARTIFACT_TYPES.contains(query.getArtifactType()) &&
+                !ProjectArtifactsQuery.Filter.TYPE_ALL.equals(query.getArtifactType())) {
+                return Collections.emptyList();
+            }
+            if (query.getClassifier()!= null && !ProjectArtifactsQuery.Filter.CLASSIFIER_ANY.equals(query.getClassifier())) {
+                return Collections.emptyList();
+            }
+            MavenProject model = mavenProject.getEvaluatedProject(buildCtx);
+            if (!MicronautMavenConstants.PACKAGING_NATIVE.equals(model.getPackaging())) {
+                return Collections.emptyList();
+            }
+            List<ArtifactSpec> nativeStuff = new ArrayList<>();
+            for (Plugin p : model.getBuild().getPlugins()) {
+                if (!(MicronautMavenConstants.NATIVE_BUILD_PLUGIN_GROUP.equals(p.getGroupId()) && MicronautMavenConstants.NATIVE_BUILD_PLUGIN_ID.equals(p.getArtifactId()))) {
+                    continue;
+                }
+                for (PluginExecution pe : p.getExecutions()) {
+                    if (pe.getGoals().contains(MicronautMavenConstants.PLUGIN_GOAL_COMPILE_NOFORK)) { // NOI18N
+                        Xpp3Dom dom = model.getGoalConfiguration(MicronautMavenConstants.NATIVE_BUILD_PLUGIN_GROUP, MicronautMavenConstants.NATIVE_BUILD_PLUGIN_ID, pe.getId(), MicronautMavenConstants.PLUGIN_GOAL_COMPILE_NOFORK); // NOI18N
+                        if (dom != null) {
+                            Xpp3Dom imageName = dom.getChild(PLUGIN_PARAM_IMAGENAME); // NOI18N
+                            Xpp3Dom sharedLib = dom.getChild(PLUGIN_PARAM_SHAREDLIBRARY); // NOI18N
+
+                            String name;
+                            if (imageName == null) {
+                                // project default, but should be injected / interpolated by Maven already.
+                                name = model.getArtifactId();
+                            } else {
+                                name = imageName.getValue();
+                            }
+                            
+                            Path full = Paths.get(model.getBuild().getDirectory()).resolve(name);
+                            nativeStuff.add(ArtifactSpec.builder(model.getGroupId(), model.getArtifactId(), model.getVersion(), pe)
+                                    .type(sharedLib != null && Boolean.parseBoolean(sharedLib.getValue()) ? MicronautMavenConstants.TYPE_DYNAMIC_LIBRARY : MicronautMavenConstants.TYPE_EXECUTABLE)
+                                    .location(full.toUri())
+                                    .forceLocalFile(FileUtil.toFileObject(full.toFile()))
+                                    .build()
+                            );
+                        }
+                    }
+                }
+            }
+            return nativeStuff;
+        }
+    }
+    
+    @NbBundle.Messages({
+        "DN_MicronautArtifacts=Micronaut artifact support"
+    })
+    public static LookupProvider projectLookup(Map<Object, Object> attrs) {
+        return new LookupProvider() {
+            @Override
+            public Lookup createAdditionalLookup(Lookup baseContext) {
+                Project p = baseContext.lookup(Project.class);
+                if (p == null) {
+                    return Lookup.EMPTY;
+                }
+                return Lookups.fixed(new MicronautPackagingArtifactsImpl(p));
+                /*
+                return Lookups.fixed(ProjectArtifactsImplementation.class, new InstanceContent.Convertor<Class<ProjectArtifactsImplementation>, ProjectArtifactsImplementation>() {
+                    @Override
+                    public ProjectArtifactsImplementation convert(Class<ProjectArtifactsImplementation> obj) {
+                        return new MicronautPackagingArtifactsImpl(p);
+                    }
+
+                    @Override
+                    public Class<? extends ProjectArtifactsImplementation> type(Class<ProjectArtifactsImplementation> obj) {
+                        return MicronautPackagingArtifactsImpl.class;
+                    }
+
+                    @Override
+                    public String id(Class<ProjectArtifactsImplementation> obj) {
+                        return obj.getName();
+                    }
+
+                    @Override
+                    public String displayName(Class<ProjectArtifactsImplementation> obj) {
+                        return Bundle.DN_MicronautArtifacts();
+                    }
+                });
+                */
+            }
+        };
+    }
+}

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/Bundle.properties
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/Bundle.properties
@@ -15,10 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
-javac.compilerargs=-Xlint -Xlint:-serial
-release.external/spring-boot-configuration-metadata-2.4.4.jar=modules/ext/spring-boot-configuration-metadata-2.4.4.jar
-release.external/android-json-0.0.20131108.vaadin1.jar=modules/ext/android-json-0.0.20131108.vaadin1.jar
-spec.version.base=1.7.0
-requires.nb.javac=true
-test-unit-sys-prop.test.netbeans.dest.dir=${netbeans.dest.dir}
+action.native-build=Build with Native Image

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
@@ -53,6 +53,10 @@
                         <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
                         <attr name="resource" stringvalue="nbres:/org/netbeans/modules/micronaut/resources/micronaut-actions.xml"/>
                     </file>
+                    <file name="native-image-artifacts.instance">
+                        <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                        <attr name="instanceCreate" methodvalue="org.netbeans.modules.micronaut.maven.MicronautPackagingArtifactsImpl.projectLookup"/>
+                    </file>
                 </folder>
             </folder>
         </folder>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/micronaut-actions.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/micronaut-actions.xml
@@ -17,6 +17,25 @@
 -->
 
 <actions>
+    <action>
+        <actionName>native-build</actionName>
+        <packagings>
+            <packaging>*</packaging>
+        </packagings>
+        <!--
+        <packagings>
+            <packaging>jar</packaging>
+            <packaging>native-image</packaging>
+        </packagings>
+        -->
+        <goals>
+            <goal>package</goal>
+        </goals>
+        <properties>
+            <packaging>native-image</packaging>
+        </properties>
+    </action>
+    
     <profiles>
         <profile>
             <id>micronaut-auto</id>

--- a/enterprise/micronaut/test/unit/data/maven/artifacts/native-default/pom.xml
+++ b/enterprise/micronaut/test/unit/data/maven/artifacts/native-default/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>single</artifactId>
+  <version>1.0</version>
+  <packaging>${packaging}</packaging>
+  
+  <parent>
+    <groupId>io.micronaut</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>3.5.3</version>
+  </parent>
+  
+  <properties>
+      <packaging>native-image</packaging>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.build</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/enterprise/micronaut/test/unit/data/maven/artifacts/native-optional/pom.xml
+++ b/enterprise/micronaut/test/unit/data/maven/artifacts/native-optional/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>single</artifactId>
+  <version>1.0</version>
+  <packaging>${packaging}</packaging>
+  
+  <parent>
+    <groupId>io.micronaut</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>3.5.3</version>
+  </parent>
+  
+  <properties>
+      <packaging>jar</packaging>
+  </properties>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.build</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/enterprise/micronaut/test/unit/data/maven/artifacts/simple/pom.xml
+++ b/enterprise/micronaut/test/unit/data/maven/artifacts/simple/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>single</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/maven/MicronautPackagingArtifactImplTest.java
+++ b/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/maven/MicronautPackagingArtifactImplTest.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.micronaut.maven;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Collection;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectActionContext;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.netbeans.modules.project.dependency.ProjectArtifactsQuery;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.modules.DummyInstalledFileLocator;
+import org.openide.windows.IOProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+public class MicronautPackagingArtifactImplTest extends NbTestCase {
+
+    public MicronautPackagingArtifactImplTest(String name) {
+        super(name);
+    }
+    
+    private static File getTestNBDestDir() throws Exception {
+        String destDir = System.getProperty("test.netbeans.dest.dir");
+        // set in project.properties as test-unit-sys-prop.test.netbeans.dest.dir
+        assertNotNull("test.netbeans.dest.dir property has to be set when running within binary distribution", destDir);
+        return new File(destDir);
+    }
+    
+    FileObject d;
+    FileObject dataFO;
+
+    protected @Override void setUp() throws Exception {
+        clearWorkDir();
+        
+        // This is needed, otherwose the core window's startup code will redirect
+        // System.out/err to the IOProvider, and its Trivial implementation will redirect
+        // it back to System.err - loop is formed. Initialize IOProvider first, it gets
+        // the real System.err/out references.
+        IOProvider p = IOProvider.getDefault();
+        d = FileUtil.toFileObject(getWorkDir());
+        System.setProperty("test.reload.sync", "true");
+        dataFO = FileUtil.toFileObject(getDataDir());
+        
+        // Configure the DummyFilesLocator with NB harness dir
+        File destDirF = getTestNBDestDir();
+        DummyInstalledFileLocator.registerDestDir(destDirF);
+    }
+    
+    @Override
+    protected void tearDown() throws Exception {
+    }
+    
+    /**
+     * Checks that native artifact provider does not obscure normal project's query
+     * @throws Exception 
+     */
+    public void testProjectArtifactWithNormalQuery() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        
+        FileObject testApp = dataFO.getFileObject("maven/artifacts/simple");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "simple");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, ProjectArtifactsQuery.newQuery(null));
+        
+        assertNotNull(ar);
+        assertEquals(1, ar.getArtifacts().size());
+        ArtifactSpec spec = ar.getArtifacts().get(0);
+        assertEquals("jar", spec.getType());
+    }
+    
+    /**
+     * The project has no native build, so the action should produce no artifact(s)
+     */
+    public void testProjectNoArtifactForNonExistingNativeBuild() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        
+        FileObject testApp = dataFO.getFileObject("maven/artifacts/simple");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "simple");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
+                ProjectArtifactsQuery.newQuery(null, null, 
+                        ProjectActionContext.newBuilder(p).forProjectAction("native-build").context())
+        );
+        
+        assertNotNull(ar);
+        assertEquals(0, ar.getArtifacts().size());
+    }
+    
+    /**
+     * If jar packaging is the default, then no-arg query should still produce the jar artifact.
+     */
+    public void testProjectArtifactOptionalNativePackaging() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        
+        FileObject testApp = dataFO.getFileObject("maven/artifacts/native-optional");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "native-optional");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, ProjectArtifactsQuery.newQuery(null));
+        
+        assertNotNull(ar);
+        assertEquals(1, ar.getArtifacts().size());
+        ArtifactSpec spec = ar.getArtifacts().get(0);
+        assertEquals("jar", spec.getType());
+    }
+    
+    /**
+     * If jar packaging is the default, then native stuff is not built at all, so it is not present in ALL artifact enum.
+     */
+    public void testAllArtifactOptionalNativePackaging() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        
+        FileObject testApp = dataFO.getFileObject("maven/artifacts/native-optional");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "native-optional");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, ProjectArtifactsQuery.newQuery(ProjectArtifactsQuery.Filter.TYPE_ALL));
+        
+        assertNotNull(ar);
+        assertEquals(1, ar.getArtifacts().size());
+        ArtifactSpec spec = ar.getArtifacts().get(0);
+        assertEquals("jar", spec.getType());
+    }
+    
+    /**
+     * But with native-build action, the response should be 'exe'
+     */
+    public void testProjectArtifactOptionalNativeAndAction() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        
+        FileObject testApp = dataFO.getFileObject("maven/artifacts/native-optional");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "native-optional");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
+                ProjectArtifactsQuery.newQuery(null, null, 
+                        ProjectActionContext.newBuilder(p).forProjectAction("native-build").context())
+        );
+        
+        assertNotNull(ar);
+        assertEquals(1, ar.getArtifacts().size());
+        ArtifactSpec spec = ar.getArtifacts().get(0);
+        assertEquals("exe", spec.getType());
+    }
+    
+   /**
+     * Checks that project with default native-image packaging will provide the excutable
+     * @throws Exception 
+     */
+    public void testProjectArtifactWithDefaultNativePackaging() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        
+        FileObject testApp = dataFO.getFileObject("maven/artifacts/native-default");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "native-default");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, ProjectArtifactsQuery.newQuery(null));
+        
+        assertNotNull(ar);
+        assertEquals("Default product is just the exe", 1, ar.getArtifacts().size());
+        ArtifactSpec spec = ar.getArtifacts().get(0);
+        assertEquals("Exe must be present", "exe", spec.getType());
+    }
+
+  /**
+     * Checks that project with default native-image packaging will provide the excutable
+     * @throws Exception 
+     */
+    public void testProjectNativePackagingSearchJar() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        
+        FileObject testApp = dataFO.getFileObject("maven/artifacts/native-default");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "native-default");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
+                ProjectArtifactsQuery.newQuery("jar"));
+        
+        assertNotNull(ar);
+        assertEquals("Single jar is produced", 1, ar.getArtifacts().size());
+        ArtifactSpec spec = ar.getArtifacts().get(0);
+        assertEquals("Just jar must be present", "jar", spec.getType());
+    }
+
+
+   /**
+     * Checks that project with default native-image packaging will provide the excutable
+     * @throws Exception 
+     */
+    public void testAllArtifactsWithNativePackaging() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        
+        FileObject testApp = dataFO.getFileObject("maven/artifacts/native-default");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "native-default");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, ProjectArtifactsQuery.newQuery(ProjectArtifactsQuery.Filter.TYPE_ALL));
+        Collection<ArtifactSpec> arts = ar.getArtifacts();
+        assertEquals("All query should produce BOTH jar and exe ", 2, arts.size());
+        
+        ArtifactSpec jar = null;
+        ArtifactSpec exe = null;
+        for (ArtifactSpec a : arts) {
+            if ("exe".equals(a.getType())) {
+                exe = a;
+            } else if ("jar".equals(a.getType())) {
+                jar = a;
+            }
+        }
+        assertNotNull("Jar should be present", jar);
+        assertNotNull("Exe should be present", jar);
+        assertFalse("Exe should not contain the version",exe.getLocation().toString().contains("0.1"));
+    }
+}

--- a/ide/project.dependency/nbproject/project.xml
+++ b/ide/project.dependency/nbproject/project.xml
@@ -40,7 +40,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.87</specification-version>
+                        <specification-version>1.89</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -49,6 +49,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>9.29</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.26</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ArtifactSpec.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ArtifactSpec.java
@@ -123,6 +123,7 @@ public final class ArtifactSpec<T> {
         hash = 79 * hash + Objects.hashCode(this.artifactId);
         hash = 79 * hash + Objects.hashCode(this.versionSpec);
         hash = 79 * hash + Objects.hashCode(this.classifier);
+        hash = 79 * hash + Objects.hashCode(this.location);
         return hash;
     }
 
@@ -151,6 +152,9 @@ public final class ArtifactSpec<T> {
             return false;
         }
         if (!Objects.equals(this.classifier, other.classifier)) {
+            return false;
+        }
+        if (!Objects.equals(this.location, other.location)) {
             return false;
         }
         return this.kind == other.kind;

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ArtifactSpec.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ArtifactSpec.java
@@ -18,10 +18,18 @@
  */
 package org.netbeans.modules.project.dependency;
 
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
 import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
 
 /**
  * Represents an artifact. Each artifact is identified by
@@ -41,6 +49,8 @@ import org.openide.filesystems.FileObject;
  * @author sdedic
  */
 public final class ArtifactSpec<T> {
+    static final Logger LOG = Logger.getLogger(ProjectDependencies.class.getName());
+    
     /**
      * Kind of the artifact version
      */
@@ -63,10 +73,11 @@ public final class ArtifactSpec<T> {
     private final String versionSpec;
     private final String classifier;
     private final boolean optional;
-    private final FileObject localFile;
+    private final URI location;
+    private FileObject localFile;
     final T data;
 
-    ArtifactSpec(VersionKind kind, String groupId, String artifactId, String versionSpec, String type, String classifier, boolean optional, FileObject localFile, T impl) {
+    ArtifactSpec(VersionKind kind, String groupId, String artifactId, String versionSpec, String type, String classifier, boolean optional, URI location, FileObject localFile, T impl) {
         this.kind = kind;
         this.groupId = groupId;
         this.artifactId = artifactId;
@@ -75,6 +86,7 @@ public final class ArtifactSpec<T> {
         this.optional = optional;
         this.data = impl;
         this.type = type;
+        this.location = location;
         this.localFile = localFile;
     }
 
@@ -82,10 +94,37 @@ public final class ArtifactSpec<T> {
         return data;
     }
 
+    /**
+     * Returns local file which the artifact represents. For library (dependencies) artifacts,
+     * the file is the library consumed, e.g. from a local repository. For outputs, the artifact
+     * represents the build output, usually in project's build directory. Note that FileObject for 
+     * a dependency and its corresponding Project may not be the same.
+     * 
+     * @return 
+     */
     public FileObject getLocalFile() {
-        return localFile;
+        // It's not locked well, but localFile will eventually become non-null, even though
+        // more lookups could be needed under contention.
+        FileObject f = localFile;
+        if (f == null) {
+            if (location != null) {
+                try {
+                    synchronized (this) {
+                        return this.localFile = URLMapper.findFileObject(location.toURL());
+                    }
+                } catch (MalformedURLException ex) {
+                    LOG.log(Level.WARNING, "Artifact location cannot be converted to URL: {0}", location);
+                }
+                f = localFile = FileUtil.getConfigRoot();
+            }
+        }
+        return f == FileUtil.getConfigRoot() ? null : f;
     }
 
+    public URI getLocation() {
+        return location;
+    }
+    
     public VersionKind getKind() {
         return kind;
     }
@@ -190,14 +229,97 @@ public final class ArtifactSpec<T> {
             @NullAllowed String groupId, @NonNull String artifactId, 
             @NullAllowed String type, @NullAllowed String classifier, 
             @NonNull String versionSpec, boolean optional, @NullAllowed FileObject localFile, @NonNull V data) {
-        return new ArtifactSpec<V>(VersionKind.REGULAR, groupId, artifactId, versionSpec, type, classifier, optional, localFile, data);
+        URL u = localFile == null ? null : URLMapper.findURL(localFile, URLMapper.EXTERNAL);
+        URI uri = null;
+        if (u != null) {
+            try {
+                uri = u.toURI();
+            } catch (URISyntaxException ex) {
+                // should not happen
+            }
+        }
+        return new ArtifactSpec<V>(VersionKind.REGULAR, groupId, artifactId, versionSpec, type, classifier, optional, uri, localFile, data);
     }
 
     public static <V> ArtifactSpec<V> createSnapshotSpec(
             @NonNull String groupId, @NonNull String artifactId, 
             @NullAllowed String type, @NullAllowed String classifier, 
             @NonNull String versionSpec, boolean optional, @NullAllowed FileObject localFile, @NonNull V data) {
-        return new ArtifactSpec<V>(VersionKind.SNAPSHOT, groupId, artifactId, versionSpec, type, classifier, optional, localFile, data);
+        URL u = URLMapper.findURL(localFile, URLMapper.EXTERNAL);
+        URI uri = null;
+        if (u != null) {
+            try {
+                uri = u.toURI();
+            } catch (URISyntaxException ex) {
+                // should not happen
+            }
+        }
+        return new ArtifactSpec<V>(VersionKind.SNAPSHOT, groupId, artifactId, versionSpec, type, classifier, optional, uri, localFile, data);
+    }
+    
+    public static final <T> Builder<T> builder(String group, String artifact, String version, T projectData) {
+        return new Builder(group, artifact, version, projectData);
     }
 
+    public final static class Builder<T> {
+        private final T data;
+        private final String groupId;
+        private final String artifactId;
+        private final String versionSpec;
+        private VersionKind kind = VersionKind.REGULAR;
+        private String type;
+        private String classifier;
+        private boolean optional;
+        private FileObject localFile;
+        private URI location;
+        
+        public Builder(String groupId, String artifactId, String versionSpec, T data) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+            this.versionSpec = versionSpec;
+            this.data = data;
+        }
+
+        public Builder type(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder classifier(String classifier) {
+            this.classifier = classifier;
+            return this;
+        }
+
+        public Builder optional(boolean optional) {
+            this.optional = optional;
+            return this;
+        }
+
+        public Builder localFile(FileObject localFile) {
+            this.localFile = localFile;
+            return this;
+        }
+
+        /**
+         * Forces the local file reference. Unlike {@link #localFile}, if {@code null} is
+         * passed, the {@link ArtifactSpec#getLocalFile()} will not attempt to resole the URI
+         * to a FileObject. Might be useful to indicate that no file was known <b>at the time 
+         * of the ArtifactSpec creation</b>
+         * @param localFile the local file, {@code null} to disallows URI to FileObject implicit conversion.
+         * @return builder instance.
+         */
+        public Builder forceLocalFile(FileObject localFile) {
+            this.localFile = localFile == null ?FileUtil.getConfigRoot() : localFile;
+            return this;
+        }
+
+        public Builder location(URI location) {
+            this.location = location;
+            return this;
+        }
+        
+        public ArtifactSpec build() {
+            return new ArtifactSpec(kind, groupId, artifactId, versionSpec, type, classifier, optional, location, localFile, data);
+        }
+    }
 }

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectArtifactsQuery.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectArtifactsQuery.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.project.dependency;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectActionContext;
+import org.netbeans.modules.project.dependency.spi.ProjectArtifactsImplementation;
+import org.openide.util.*;
+
+/**
+ *
+ * @author sdedic
+ */
+public final class ProjectArtifactsQuery {
+    
+    public static ArtifactsResult findArtifacts(Project project, Filter filter) {
+        Parameters.notNull("project", project);
+        Parameters.notNull("filter", filter);
+        List<ProjectArtifactsImplementation.Result> delegates = new ArrayList<>();
+        for (ProjectArtifactsImplementation impl : project.getLookup().lookupAll(ProjectArtifactsImplementation.class)) {
+            ProjectArtifactsImplementation.Result r = impl.findArtifacts(filter);
+            if (r != null) {
+                delegates.add(r);
+            }
+        }
+        
+        return new ArtifactsResult(delegates);
+    }
+    
+    public static final class ArtifactsResult {
+        private final List<ProjectArtifactsImplementation.Result> delegates;
+
+        // @GuardedBy(this)
+        private final List<ChangeListener> listeners = new ArrayList<>();
+        // @GuardedBy(this)
+        private ChangeListener delListener;
+        // @GuardedBy(this)
+        private List<ArtifactSpec> artifacts;
+        // @GuardedBy(this)
+        private Boolean supportsChanges;
+
+        ArtifactsResult(List<ProjectArtifactsImplementation.Result> delegates) {
+            this.delegates = delegates;
+        }
+        
+        public List<ArtifactSpec> getArtifacts() {
+            synchronized (this) {
+                if (artifacts != null) {
+                    return artifacts;
+                }
+            }
+            return updateResults();
+        }
+        
+        List<ArtifactSpec> updateResults() {
+            boolean changes = false;
+            Collection<ArtifactSpec> specs = new LinkedHashSet<>();
+            for (ProjectArtifactsImplementation.Result d : delegates) {
+                Collection<ArtifactSpec> ex = d.getExcludedArtifacts();
+                if (ex != null) {
+                    specs.removeAll(ex);
+                }
+                Collection<ArtifactSpec> add = d.getArtifacts();
+                if (add != null) {
+                    specs.addAll(add);
+                }
+                changes |= d.supportsChanges();
+            }
+            List<ArtifactSpec> copy = new ArrayList<>(specs);
+            ChangeListener[] ll;
+            
+            synchronized (this) {
+                if (null == supportsChanges) {
+                    this.supportsChanges = changes;
+                }
+                if (this.artifacts != null && this.artifacts.equals(specs)) {
+                    return copy;
+                }
+                this.artifacts = copy;
+                if (listeners.isEmpty()) {
+                    return copy;
+                }
+                ll = listeners.toArray(new ChangeListener[listeners.size()]);
+            }
+            ChangeEvent e = new ChangeEvent(this);
+            
+            for (ChangeListener l : ll) {
+                l.stateChanged(e);
+            }
+            return copy;
+        }
+        
+        public void addChangeListener(ChangeListener l) {
+            synchronized (this) {
+                if (supportsChanges == Boolean.FALSE) {
+                    return;
+                }
+                if (delListener == null) {
+                    delListener = WeakListeners.change((e) -> updateResults(), null);
+                    for (ProjectArtifactsImplementation.Result d : delegates) {
+                        d.addChangeListener(delListener);
+                    }
+                }
+                listeners.add(l);
+            }
+        }
+        
+        public void removeChangeListener(ChangeListener l) {
+            synchronized (this) {
+                listeners.remove(l);
+            }
+        }
+    }
+    
+    /**
+     * Specifies the artifact filter. By default, the default artifact type is returned,
+     * perhaps determined by the configured packaging with <b>no classifier</b>. It it possible
+     * to list artifacts of all types and/or artifacts with any classifier in one query.
+     */
+    public static class Filter {
+        /**
+         * Represents all types of artifacts. The query will return all build products
+         */
+        public static final String TYPE_ALL = "all"; // NOI18N
+        
+        /**
+         * Will return artifacts with any classifier.
+         */
+        public static final String CLASSIFIER_ANY = "any"; // NOI18N
+        
+        private final String classifier;
+        private final String artifactType;
+        private final ProjectActionContext  buildContext;
+        
+        Filter(String artifactType, String classifier, ProjectActionContext buildContext) {
+            this.classifier = classifier;
+            this.artifactType = artifactType;
+            this.buildContext = buildContext;
+        }
+
+        /**
+         * The desired artifact classifier. Only artifact with the specific classifier will be returned. The value
+         * {@link #CLASSIFIER_ANY} means that any classifier will match. {@code null} (the default) value means
+         * the default (none) classifier will match.
+         * 
+         * @return artifact classifier
+         */
+        @CheckForNull
+        public String getClassifier() {
+            return classifier;
+        }
+
+        /**
+         * The desired artifact type. Only artifacts with tha type will be returned. {@link #TYPE_ALL} means that artifacts
+         * of all types will be returned. {@code null} (the default) means the default type, i.e. defined by project packaging.
+         * @return artifact type
+         */
+        @CheckForNull
+        public String getArtifactType() {
+            return artifactType;
+        }
+
+        /**
+         * The {@link ProjectActionContext} that shall be used during evaluation.
+         * @return context instance of {@code null}  if none specified.
+         */
+        @CheckForNull
+        public ProjectActionContext getBuildContext() {
+            return buildContext;
+        }
+    }
+    
+    /**
+     * Creates a new simple Filter that returns artifacts of the specified type and
+     * no classifier.
+     * @param artifactType the desired type
+     * @return Filter instance.
+     */
+    @NonNull
+    public static Filter newQuery(@NullAllowed String artifactType) {
+        return new Filter(artifactType, null, null);
+    }
+    
+    /**
+     * Creates a Filter with the specified properties
+     * @param artifactType the desired type; use {@code null} for the default artifact type (i.e. defined by packaging)
+     * @param classifier the desired classifier; use {@code null} for no classifier
+     * @param buildContext the action context
+     * @return Filter instance.
+     */
+    @NonNull
+    public static Filter newQuery(@NullAllowed String artifactType, @NullAllowed String classifier, @NullAllowed ProjectActionContext buildContext) {
+        return new Filter(artifactType, classifier, buildContext);
+    }
+}

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectArtifactsQuery.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectArtifactsQuery.java
@@ -22,6 +22,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.annotations.common.CheckForNull;
@@ -33,27 +36,80 @@ import org.netbeans.modules.project.dependency.spi.ProjectArtifactsImplementatio
 import org.openide.util.*;
 
 /**
- *
+ * This project query provides access to artifacts produced or managed by a project. An artifact
+ * is essentially a file (may extend to a collection of files in the future) that is a product of a project build,
+ * or generally of a project or build system action. A project can have multiple artifacts produced by a build,
+ * or can have multiple sets of artifacts produced by specific project actions. 
+ * <p>
+ * By default the query will return artifacts produced by project's compilation (incl. packaging, in maven terminology) - 
+ * but the exact meaning depends on a build system used, and the project's settings and the active configuration.
+ * 
  * @author sdedic
  */
 public final class ProjectArtifactsQuery {
     
+    /**
+     * Computes artifacts produced by a project. The returned Result can enumerate artifacts
+     * from the project, along with their location(s) either actual or supposed. The Result can
+     * be listened of changes that may change the artifacts reported.
+     * 
+     * @param project the project to be queried
+     * @param filter artifact filter
+     * @return list of artifacts that can be listened on.
+     */
     public static ArtifactsResult findArtifacts(Project project, Filter filter) {
         Parameters.notNull("project", project);
         Parameters.notNull("filter", filter);
-        List<ProjectArtifactsImplementation.Result> delegates = new ArrayList<>();
-        for (ProjectArtifactsImplementation impl : project.getLookup().lookupAll(ProjectArtifactsImplementation.class)) {
-            ProjectArtifactsImplementation.Result r = impl.findArtifacts(filter);
+        
+        List<ProjectArtifactsImplementation> impls = new ArrayList<>(project.getLookup().lookupAll(ProjectArtifactsImplementation.class));
+        SortedMap<Integer, List<E<?>>> buckets = new TreeMap<>();
+        for (ProjectArtifactsImplementation impl : impls) {
+            Object r = impl.evaluate(filter);
             if (r != null) {
-                delegates.add(r);
+                buckets.computeIfAbsent(impl.getOrder(), i -> new ArrayList<>()).add(new E(r, impl));
             }
         }
-        
+        List<E<?>> delegates;
+        if (buckets.size() == 1) {
+            delegates = buckets.values().iterator().next();
+        } else {
+            delegates = buckets.values().stream().flatMap(l -> l.stream()).collect(Collectors.toList());
+        }
         return new ArtifactsResult(delegates);
     }
     
+    private static final class E<T> {
+        final T data;
+        final ProjectArtifactsImplementation<T> impl;
+
+        public E(T data, ProjectArtifactsImplementation<T> impl) {
+            this.data = data;
+            this.impl = impl;
+        }
+        
+        public Project findProject() {
+            return impl.findProject(data);
+        }
+
+        public List<ArtifactSpec> findArtifacts() {
+            return impl.findArtifacts(data);
+        }
+
+        public Collection<ArtifactSpec> findExcludedArtifacts() {
+            return impl.findExcludedArtifacts(data);
+        }
+
+        public void handleChangeListener(ChangeListener l, boolean add) {
+            impl.handleChangeListener(data, l, add);
+        }
+
+        public boolean computeSupportsChanges() {
+            return impl.computeSupportsChanges(data);
+        }
+    }
+    
     public static final class ArtifactsResult {
-        private final List<ProjectArtifactsImplementation.Result> delegates;
+        private final List<E<?>> delegates;
 
         // @GuardedBy(this)
         private final List<ChangeListener> listeners = new ArrayList<>();
@@ -64,10 +120,15 @@ public final class ProjectArtifactsQuery {
         // @GuardedBy(this)
         private Boolean supportsChanges;
 
-        ArtifactsResult(List<ProjectArtifactsImplementation.Result> delegates) {
+        ArtifactsResult(List<E<?>> delegates) {
             this.delegates = delegates;
         }
         
+        /**
+         * Returns project artifacts. The result may become invalida after the result fires
+         * an event to its {@link #addChangeListener(javax.swing.event.ChangeListener) ChangeListeners}.
+         * @return artifacts produced by the project. 
+         */
         public List<ArtifactSpec> getArtifacts() {
             synchronized (this) {
                 if (artifacts != null) {
@@ -80,16 +141,16 @@ public final class ProjectArtifactsQuery {
         List<ArtifactSpec> updateResults() {
             boolean changes = false;
             Collection<ArtifactSpec> specs = new LinkedHashSet<>();
-            for (ProjectArtifactsImplementation.Result d : delegates) {
-                Collection<ArtifactSpec> ex = d.getExcludedArtifacts();
+            for (E<?> e : delegates) {
+                Collection<ArtifactSpec> ex = e.findExcludedArtifacts();
                 if (ex != null) {
                     specs.removeAll(ex);
                 }
-                Collection<ArtifactSpec> add = d.getArtifacts();
+                Collection<ArtifactSpec> add = e.findArtifacts();
                 if (add != null) {
                     specs.addAll(add);
                 }
-                changes |= d.supportsChanges();
+                changes |= e.computeSupportsChanges();
             }
             List<ArtifactSpec> copy = new ArrayList<>(specs);
             ChangeListener[] ll;
@@ -115,21 +176,31 @@ public final class ProjectArtifactsQuery {
             return copy;
         }
         
+        /**
+         * Adds a listener that will be informed of changes. An event will fire if
+         * the project changes in a way that might affect the reported artifacts.
+         * 
+         * @param l the listener
+         */
         public void addChangeListener(ChangeListener l) {
             synchronized (this) {
-                if (supportsChanges == Boolean.FALSE) {
+                if (Boolean.FALSE.equals(supportsChanges)) {
                     return;
                 }
                 if (delListener == null) {
                     delListener = WeakListeners.change((e) -> updateResults(), null);
-                    for (ProjectArtifactsImplementation.Result d : delegates) {
-                        d.addChangeListener(delListener);
+                    for (E d : delegates) {
+                        d.handleChangeListener(delListener, true);
                     }
                 }
                 listeners.add(l);
             }
         }
         
+        /**
+         * Removes a previously registered Listener.
+         * @param l the listener to unregister
+         */
         public void removeChangeListener(ChangeListener l) {
             synchronized (this) {
                 listeners.remove(l);

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectDependencies.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectDependencies.java
@@ -30,15 +30,6 @@ import org.netbeans.modules.project.dependency.spi.ProjectDependenciesImplementa
  * @author sdedic
  */
 public class ProjectDependencies {
-    
-    public static ArtifactSpec getProjectArtifact(Project target) {
-        ProjectDependenciesImplementation pds = target.getLookup().lookup(ProjectDependenciesImplementation.class);
-        if (pds == null) {
-            return null;
-        }
-        return pds.getProjectArtifact();
-    }
-    
     /**
      * Finds project dependencies.
      * 

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/spi/ProjectArtifactsImplementation.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/spi/ProjectArtifactsImplementation.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.project.dependency.spi;
+
+import java.util.Collection;
+import java.util.List;
+import javax.swing.event.ChangeListener;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.netbeans.modules.project.dependency.ProjectArtifactsQuery;
+
+/**
+ *
+ * @author sdedic
+ */
+public interface ProjectArtifactsImplementation {
+    /**
+     * Finds project artifact(s) that match the query. 
+     * @param query the query to answer
+     * @param previous result of previous buildsteps
+     * @param all
+     * @return 
+     */
+    public Result findArtifacts(ProjectArtifactsQuery.Filter query);
+    
+    public interface Result {
+        public Project getProject();
+        
+        /**
+         * @return Reports project artifacts.
+         */
+        public List<ArtifactSpec> getArtifacts();
+
+        /**
+         * If not null, specifies artifacts to be excluded from the final result. For example
+         * a transformation plugin may rename the original artifact so that the original place
+         * is empty.
+         * @return excluded artifacts, or {@code null}.
+         */
+        public Collection<ArtifactSpec> getExcludedArtifacts();
+        
+        public default void addChangeListener(ChangeListener l) {}
+        
+        public default void removeChangeListener(ChangeListener l) {}
+        
+        public default boolean supportsChanges() {
+            return false;
+        }
+    }
+}

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/spi/ProjectArtifactsImplementation.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/spi/ProjectArtifactsImplementation.java
@@ -29,38 +29,42 @@ import org.netbeans.modules.project.dependency.ProjectArtifactsQuery;
  *
  * @author sdedic
  */
-public interface ProjectArtifactsImplementation {
+public interface ProjectArtifactsImplementation<Result> {
     /**
-     * Finds project artifact(s) that match the query. 
+     * Finds project artifact(s) that match the query. The implementation should
+     * compute data and store it into implementation-defined Result data structure,
+     * which will be used during subsequent calls.
+     * 
      * @param query the query to answer
-     * @param previous result of previous buildsteps
-     * @param all
+     * @return result structure.
+     */
+    public Result evaluate(ProjectArtifactsQuery.Filter query);
+
+    /**
+     * Returns evaluation order of this Implementation. If the Implementation needs to post-process
+     * 
      * @return 
      */
-    public Result findArtifacts(ProjectArtifactsQuery.Filter query);
-    
-    public interface Result {
-        public Project getProject();
-        
-        /**
-         * @return Reports project artifacts.
-         */
-        public List<ArtifactSpec> getArtifacts();
-
-        /**
-         * If not null, specifies artifacts to be excluded from the final result. For example
-         * a transformation plugin may rename the original artifact so that the original place
-         * is empty.
-         * @return excluded artifacts, or {@code null}.
-         */
-        public Collection<ArtifactSpec> getExcludedArtifacts();
-        
-        public default void addChangeListener(ChangeListener l) {}
-        
-        public default void removeChangeListener(ChangeListener l) {}
-        
-        public default boolean supportsChanges() {
-            return false;
-        }
+    public default int getOrder() {
+        return 10000;
     }
+    
+    public Project findProject(Result r);
+    
+    /**
+     * @return Reports project artifacts.
+     */
+    public List<ArtifactSpec> findArtifacts(Result r);
+    
+    /**
+     * If not null, specifies artifacts to be excluded from the final result. For example
+     * a transformation plugin may rename the original artifact so that the original place
+     * is empty.
+     * @return excluded artifacts, or {@code null}.
+     */
+    public Collection<ArtifactSpec> findExcludedArtifacts(Result r);
+    
+    public void handleChangeListener(Result r, ChangeListener l, boolean add);
+    
+    public boolean computeSupportsChanges(Result r);
 }

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/spi/ProjectDependenciesImplementation.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/spi/ProjectDependenciesImplementation.java
@@ -18,11 +18,8 @@
  */
 package org.netbeans.modules.project.dependency.spi;
 
-import java.util.List;
 
 import org.netbeans.api.annotations.common.NonNull;
-import org.netbeans.modules.project.dependency.ArtifactSpec;
-import org.netbeans.modules.project.dependency.Dependency;
 import org.netbeans.modules.project.dependency.DependencyResult;
 import org.netbeans.modules.project.dependency.ProjectDependencies;
 import org.netbeans.modules.project.dependency.ProjectOperationException;
@@ -32,16 +29,9 @@ import org.netbeans.modules.project.dependency.ProjectOperationException;
  * @author sdedic
  */
 public interface ProjectDependenciesImplementation {
-    @NonNull
-    public ArtifactSpec getProjectArtifact();
-    
     // TODO: change to CompletionStage<>, as the implementation is likely to use some dedicated
     // thread to evaluate the project.
     @NonNull
     public DependencyResult findDependencies(@NonNull ProjectDependencies.DependencyQuery query)
             throws ProjectOperationException;
-    
-    public interface DependencyChildren {
-        public List<Dependency> createChildren(Dependency parent);
-    }
 }

--- a/ide/projectapi/apichanges.xml
+++ b/ide/projectapi/apichanges.xml
@@ -83,6 +83,37 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="project-action-context">
+            <api name="general"/>
+            <summary>Added <code>ProjectActionContext</code> that can pass action-like environment to project queries</summary>
+            <version major="1" minor="89"/>
+            <date day="10" month="8" year="2022"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes"/>
+            <description>
+                <p>
+                    <code><a href="@TOP@/org/netbeans/api/project/ProjectActionContext.html">ProjectActionContext</a></code> can be used
+                    to inform various project queries about the intended action or environment for which the value is requested. This
+                    contract is optional for query implementors.
+                </p>
+            </description>
+            <class package="org.netbeans.api.project" name="ProjectActionContext"/>
+        </change>
+        <change id="active-configuration-getset">
+            <api name="general"/>
+            <summary>Added <code>ProjectUtils.get/setActiveConfiguration</code> convenience methods</summary>
+            <version major="1" minor="89"/>
+            <date day="10" month="8" year="2022"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes"/>
+            <description>
+                <p>
+                    Clients do not need to interact with Project's Lookup and <a href="@TOP@/org/netbeans/spi/project/ProjectConfigurationProvider.html">ProjectConfigurationProvider</a> directly,
+                    handling missing provider and mutex; they can use the convenience API method.
+                </p>
+            </description>
+            <class package="org.netbeans.api.project" name="ProjectUtils"/>
+        </change>
         <change id="project-priming-action">
             <api name="general"/>
             <summary>Added <code>ActionProvider.COMMAND_PRIME</code> that initializes the project for IDE use.</summary>

--- a/ide/projectapi/manifest.mf
+++ b/ide/projectapi/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.projectapi/1
-OpenIDE-Module-Specification-Version: 1.88
+OpenIDE-Module-Specification-Version: 1.89
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/projectapi/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/projectapi/layer.xml
 OpenIDE-Module-Needs: org.netbeans.spi.project.ProjectManagerImplementation

--- a/ide/projectapi/src/org/netbeans/api/project/ProjectActionContext.java
+++ b/ide/projectapi/src/org/netbeans/api/project/ProjectActionContext.java
@@ -1,0 +1,435 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.project;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.spi.project.ProjectConfiguration;
+import org.openide.util.BaseUtilities;
+import org.openide.util.Lookup;
+import org.openide.util.Parameters;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ProxyLookup;
+
+/**
+ * This represents context for a project model query. The context describe a project action
+ * for which the query should be evaluated, project configuration (if not the active one), 
+ * and possible custom overrides.
+ * {@link ProjectConfiguration} or the IDE-supported project action and the associated properties, profiles, or Lookup may
+ * affect behaviour of queries across the IDE.
+ * <p>
+ * Properties map to user-settable properties of the build system, such as system properties in Maven
+ * or project properties in Gradle.
+ * <p>
+ * Profiles map to profiles in Maven, but do not have any effect in Gradle at the moment; this might change.
+ * <p>
+ * Instances of {@link ProjectActionContext} may be passed to some queries as (part of the) parameters explicitly. In case
+ * the API does not support such flexibility directly, the implementation(s) may - the context may be published for the
+ * query computation using {@link #apply}; the implementation may then use {@link #find} to obtain a {@link ProjectActionContext}
+ * effective for that project.
+ * <p>
+ * <b>Important note:</b> Not all project queries support {@link ProjectActionContext}. Queries which do should mention that
+ * fact in their documentation, or expose it in their APIs.
+ * 
+ * @author sdedic
+ * @since 1.89
+ */
+public final class ProjectActionContext {
+    private final Project project;
+
+    ProjectActionContext(Project project) {
+        this.project = project;
+    }
+   
+    /**
+     * The project action.
+     */
+    private String projectAction;
+    
+    /**
+     * The desired project configuration.
+     */
+    private ProjectConfiguration configuration;
+    
+    /**
+     * Specific property values.
+     */
+    private Map<String, String> properties;
+    
+    /**
+     * Specific profiles to be included.
+     */
+    private Set<String> profiles;
+    
+    /**
+     * Specific Lookup contents that may modify the processing.
+     */
+    private Lookup lookup = Lookup.EMPTY;
+
+    /**
+     * Returns the project this context applies to. Having {@link Project} as a property allows multiple
+     * contexts, individually for each project, to be active.
+     * @return the target project.
+     */
+    public @NonNull Project getProject() {
+        return project;
+    }
+
+    /**
+     * Additional information for the underlying project implementation, similar to 
+     * context lookup in {@link org.netbeans.spi.project.ActionProvider#invokeAction}.
+     * Project service implementors may optimize, if the returned value is {@link Lookup#EMPTY}
+     * reference.
+     * 
+     * @return Lookup with additional information.
+     */
+    public Lookup getLookup() {
+        return lookup;
+    }
+
+    /**
+     * The project action in whose context the project queries are performed. May be
+     * left unspecified, so the implementation can choose an appropriate default behaviour.
+     * 
+     * @return project aciton or {@code null} for unspecified.
+     */
+    public @CheckForNull String getProjectAction() {
+        return projectAction;
+    }
+
+    /**
+     * The project configuration to use for the project query. Can be {@code null} to 
+     * indicate the project's default Configuration should be used.
+     * 
+     * @return the project's configuration or {@code null}.
+     */
+    public @CheckForNull ProjectConfiguration getConfiguration() {
+        return configuration;
+    }
+    
+    /**
+     * User-customized properties that should be effective during the computation. The same
+     * customization should be made during project action execution to obtain the same results as 
+     * evaluated by the query. If none specific properties are present, an empty map is returned.
+     * 
+     * @return user properties
+     */
+    public @NonNull Map<String, String> getProperties() {
+        return properties == null ? Collections.emptyMap() : Collections.unmodifiableMap(properties);
+    }
+
+    /**
+     * Profiles or some project system features/tags that should be applied for the evaluation. If no
+     * specific profiles are set an empty set is returned.
+     * @return applied additional profiles.
+     */
+    public @NonNull Set<String> getProfiles() {
+        return profiles == null ? Collections.emptySet() : Collections.unmodifiableSet(profiles);
+    }
+    
+    /**
+     * Creates a Builder to create a similar ProjectActionContext to this one. All
+     * settings are copied to the Builder, so just calling {@link Builder#context()} on
+     * the result will produce a copy of this {@link ProjectActionContext}.
+     * @return preconfigured {@link Builder} instance.
+     */
+    public @NonNull Builder newDerivedBuilder() {
+        return newBuilder(project)
+                .forProjectAction(projectAction)
+                .useConfiguration(configuration)
+                .withProfiles(profiles)
+                .withProperties(properties);
+    }
+    
+    /**
+     * Creates a new {@link ProjectActionContext} builder for the given project.
+     * @param p the project
+     * @return the builder instance
+     */
+    public static @NonNull Builder newBuilder(Project p) {
+        return new Builder(p);
+    }
+
+    /**
+     * Builder used to construct the {@link ProjectActionContext}.
+     */
+    public static final class Builder {
+        private ProjectActionContext ctx;
+        
+        Builder(Project p) {
+            ctx = new ProjectActionContext(p);
+        }
+        
+        
+        /**
+         * Specifies a Lookup to be included in the context. To remove 
+         * lookup customizations, pass in {@link Lookup#EMPTY} value.
+         * 
+         * @param lkp Lookup instance
+         * @return the builder
+         */
+        public Builder withLookup(Lookup lkp) {
+            Parameters.notNull("lkp", lkp);
+            if (ctx.lookup == lkp) {
+                return this;
+            }
+            ctx.lookup = lkp;
+            return this;
+        }
+        
+        // PENDING: if a pattern of ADDING lookups emerges, addLookup() could
+        // be added that uses ProxyLookup.Controller to merge the lookups.
+        // not done ATM.
+        
+        /**
+         * Specifies the intended project action. {@code null} (the default)
+         * means an unspecified action.
+         * 
+         * @param projectAction project action.
+         * @return the builder instance
+         */
+        public @NonNull Builder forProjectAction(String projectAction) {
+            ctx.projectAction = projectAction;
+            return this;
+        }
+
+        /**
+         * Binds to a specific {@link ProjectConfiguration}, which must resolve to an instance of
+         * {@link MavenConfiguration}.
+         * @param configuration
+         * @return builder instance
+         */
+        public @NonNull Builder useConfiguration(ProjectConfiguration configuration) {
+            ctx.configuration = configuration;
+            return this;
+        }
+
+        /**
+         * Uses specific user properties for the query computation.
+         * @param properties user properties.
+         * @return builder instance
+         */
+        public @NonNull Builder withProperties(Map<String, String> properties) {
+            if (properties == null) {
+                return this;
+            }
+            if (ctx.properties == null) {
+                ctx.properties = new HashMap<>();
+            }
+            ctx.properties.putAll(properties);
+            return this;
+        } 
+
+        /**
+         * Use specific build system profiles or tags for the query evaluation. 
+         * @param profiles applied profile(s).
+         * @return builder instance
+         */
+        public @NonNull Builder withProfiles(Collection<String> profiles) {
+            if (profiles == null) {
+                return this;
+            }
+            if (ctx.profiles == null) {
+                ctx.profiles = new HashSet<>();
+            }
+            ctx.profiles.addAll(profiles);
+            return this;
+        }
+
+        /**
+         * Uses specific property value for the query computation.
+         * @param n property name
+         * @param v property value
+         * @return builder instance
+         */
+        public @NonNull Builder withProperty(String n, String v) {
+            if (ctx.properties == null) {
+                ctx.properties = new HashMap<>();
+            }
+            ctx.properties.put(n, v);
+            return this;
+        }
+        
+        /**
+         * Use specific build system profiles or tags for the query evaluation. 
+         * @param profiles applied profile(s).
+         * @return builder instance
+         */
+        public @NonNull Builder withProfiles(String... profiles) {
+            return withProfiles(Arrays.asList(profiles));
+        }
+        
+        /**
+         * @return the configured {@link ProjectActionContext}
+         */
+        public @NonNull ProjectActionContext context() {
+            return ctx;
+        }
+    }
+    
+    /**
+     * Find the ProjectActionContext for the project. If no context was specified explicitly, 
+     * @param p the project in question
+     * @return the context
+     */
+    @NonNull
+    public static ProjectActionContext find(Project p) {
+        for (ProjectActionContext pac : Lookup.getDefault().lookupAll(ProjectActionContext.class)) {
+            if (p == pac.getProject()) {
+                return pac;
+            }
+        }
+        return new ProjectActionContext(p);
+    }
+    
+    /**
+     * Executes a query using this project context. Other contexts may be specified as well (optional).
+     * During the passed {@link Runnable}, or tasks initiated from the Runnable, the {@link #find} method
+     * will find the appropriate {@link ProjectActionContext} specified as parameter.
+     * 
+     * @param r the code to execute.
+     * @param otherProjectContexts optional instances for other projects
+     */
+    public void apply(Runnable r, ProjectActionContext... otherProjectContexts) {
+        Lookup add;
+        if (otherProjectContexts == null || otherProjectContexts.length == 0) {
+            add = Lookups.fixed(this);
+        } else {
+            ProjectActionContext[] all = Arrays.copyOf(otherProjectContexts, otherProjectContexts.length + 1);
+            all[all.length - 1] = this;
+            add = Lookups.fixed(all);
+        }
+        Lookup localDefLookup = new ProxyLookup(add, Lookup.getDefault());
+        Lookups.executeWith(localDefLookup, r);
+    }
+    
+    
+    private static <E extends Throwable> void sneakyThrow(Throwable e) throws E {
+        throw (E) e;
+    }
+    
+    /**
+     * Executes a query using this project context. Other contexts may be specified as well (optional).
+     * During the passed {@link Runnable}, or tasks initiated from the Runnable, the {@link #find} method
+     * will find the appropriate {@link ProjectActionContext} specified as parameter.
+     * 
+     * @param r the code to execute.
+     * @param <V> the return type
+     * @param <E> exception thrown from the executed code.
+     * @param otherProjectContexts optional instances for other projects
+     */
+    public <V, E extends Exception> V apply(ProjectCallback<V, E> r, ProjectActionContext... otherProjectContexts) throws E {
+        Lookup add;
+        if (otherProjectContexts == null || otherProjectContexts.length == 0) {
+            add = Lookups.fixed(this);
+        } else {
+            ProjectActionContext[] all = Arrays.copyOf(otherProjectContexts, otherProjectContexts.length + 1);
+            all[all.length - 1] = this;
+            add = Lookups.fixed(all);
+        }
+        Lookup localDefLookup = new ProxyLookup(add, Lookup.getDefault());
+        Object[] res = new Object[1];
+        Exception[] t = new Exception[1];
+        
+        Lookups.executeWith(localDefLookup, () -> {
+            try {
+                res[0] = r.call();
+            } catch (Error | RuntimeException td) {
+                throw td;
+            } catch (Exception ex) {
+                t[0] = ex;
+            }
+        });
+        if (t[0] != null) {
+            sneakyThrow(t[0]);
+            // never reached
+            return null;
+        } else {
+            return (V)res[0];
+        }
+    }
+    
+    /**
+     * Functional callback interface to be used with {@link #apply(org.netbeans.modules.project.dependency.ProjectActionContext.ProjectCallback, org.netbeans.modules.project.dependency.ProjectActionContext...) }
+     * @param <V> value produced by the callback
+     * @param <E> exception thrown by the callback
+     */
+    @FunctionalInterface
+    public interface ProjectCallback<V,E extends Exception> extends Callable<V> {
+        /**
+         * Performs the project operation, returning a value. The method may throw one
+         * checked exception.
+         * 
+         * @return the operation's result
+         * @throws E on failure.
+         */
+        public V call() throws E;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 59 * hash + Objects.hashCode(this.project);
+        hash = 59 * hash + Objects.hashCode(this.projectAction);
+        hash = 59 * hash + Objects.hashCode(this.configuration);
+        hash = 59 * hash + Objects.hashCode(this.properties);
+        hash = 59 * hash + Objects.hashCode(this.profiles);
+        hash = 59 * hash + Objects.hashCode(this.lookup);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ProjectActionContext other = (ProjectActionContext) obj;
+        if (!Objects.equals(this.projectAction, other.projectAction)) {
+            return false;
+        }
+        if (!Objects.equals(this.project, other.project)) {
+            return false;
+        }
+        if (!Objects.equals(this.configuration, other.configuration)) {
+            return false;
+        }
+        if (!Objects.equals(this.properties, other.properties)) {
+            return false;
+        }
+        if (!Objects.equals(this.lookup, other.lookup)) {
+            return false;
+        }
+        return Objects.equals(this.profiles, other.profiles);
+    }
+}

--- a/ide/projectapi/src/org/netbeans/api/project/ProjectUtils.java
+++ b/ide/projectapi/src/org/netbeans/api/project/ProjectUtils.java
@@ -36,6 +36,8 @@ import org.netbeans.spi.project.AuxiliaryProperties;
 import org.netbeans.spi.project.CacheDirectoryProvider;
 import org.netbeans.spi.project.DependencyProjectProvider;
 import org.netbeans.spi.project.ParentProjectProvider;
+import org.netbeans.spi.project.ProjectConfiguration;
+import org.netbeans.spi.project.ProjectConfigurationProvider;
 import org.netbeans.spi.project.ProjectContainerProvider;
 import org.netbeans.spi.project.ProjectInformationProvider;
 import org.netbeans.spi.project.RootProjectProvider;
@@ -45,6 +47,8 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
 import org.openide.util.Mutex;
+import org.openide.util.Mutex.ExceptionAction;
+import org.openide.util.MutexException;
 import org.openide.util.Parameters;
 
 /**
@@ -56,6 +60,65 @@ public class ProjectUtils {
     private ProjectUtils() {}
 
     private static final Logger LOG = Logger.getLogger(ProjectUtils.class.getName());
+    
+    /**
+     * Returns the active configuration for the given project. Returns {@code null},
+     * if the project does not support configurations at all.
+     * 
+     * @param p the project
+     * @return the active configuration, or {@code null} if configurations are not supported.
+     * @since 1.89
+     */
+    public ProjectConfiguration getActiveConfiguration(@NonNull Project p) {
+        ProjectConfigurationProvider pcp = p.getLookup().lookup(ProjectConfigurationProvider.class);
+        if (pcp == null) {
+            return null;
+        }
+        return ProjectManager.mutex().readAccess(() -> pcp.getActiveConfiguration());
+    }
+    
+    /**
+     * Sets the active configuration to a project. The configuration should have been previously obtained by 
+     * {@link #getActiveConfiguration(org.netbeans.api.project.Project)} from the same project. The method
+     * returns {@code false}, if the configuration could not be set: if the project does not support configurations
+     * at all, or the project failed to switch the configurations. Since the active configuration setting is persisted,
+     * the method throws {@link IOException} if the setting save fails.
+     * 
+     * @param <C> configuration type
+     * @param p the project
+     * @param cfg configuration or {@code null} for default configuration.
+     * @return true, if the configuration was successfully set.
+     * @throws IOException when the selected configuration cannot be persisted.
+     * @since 1.89
+     */
+    public <C extends ProjectConfiguration> boolean setActiveConfiguration(@NonNull Project p, @NonNull C cfg) throws IOException {
+        ProjectConfigurationProvider<C> pcp = p.getLookup().lookup(ProjectConfigurationProvider.class);
+        if (pcp == null) {
+            return false;
+        }
+        try {
+            try {
+                return (Boolean)ProjectManager.mutex().writeAccess(new ExceptionAction() {
+                    @Override
+                    public Object run() throws Exception {
+                        if (!pcp.getConfigurations().contains(cfg)) {
+                            return false;
+                        }
+                        pcp.setActiveConfiguration(cfg);
+                        return cfg == null || cfg.equals(pcp.getActiveConfiguration());
+                    }
+                });
+            } catch (MutexException ex) {
+                throw ex.getException();
+            }
+        } catch (IOException ex) {
+            throw ex;
+        } catch (RuntimeException | Error ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IOException(ex);
+        }
+    }
     
     /**
      * Get basic information about a project.

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementation.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementation.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
@@ -115,12 +116,6 @@ public class GradleDependenciesImplementation implements ProjectDependenciesImpl
         }
     }
 
-    // Interim, will vanish after PR#4495 merges
-    @Override
-    public ArtifactSpec getProjectArtifact() {
-        return null;
-    }
-    
     @NbBundle.Messages({
         "# {0} - project directory path",
         "ERR_NoProjectDirectory=Unable to find project directory: {0}"

--- a/java/java.lsp.server/nbcode/integration/nbproject/project.xml
+++ b/java/java.lsp.server/nbcode/integration/nbproject/project.xml
@@ -214,6 +214,14 @@
                         <specification-version>9.24</specification-version>
                     </run-dependency>
                 </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.project.dependency</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <implementation-version/>
+                    </run-dependency>
+                </dependency>
             </module-dependencies>
             <test-dependencies>
                 <test-type>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
@@ -80,30 +80,10 @@ public class ProjectAuditCommand extends CodeActionsProvider {
             throw new IllegalArgumentException("Expected 3 parameters: resource, compartment, knowledgebase");
         }
         
-        FileObject f = null;
-        String s = "";
-        if (arguments.get(0) instanceof JsonPrimitive) {
-            s = ((JsonPrimitive)arguments.get(0)).getAsString();
-            try {
-                URI uri = new URI(s);
-                f = URLMapper.findFileObject(uri.toURL());
-            } catch (URISyntaxException | MalformedURLException ex) {
-                f = FileUtil.toFileObject(new File(s));
-            }
-        } else {
-            // accept something that looks like vscode.Uri structure
-            JsonObject executeOn = gson.fromJson(gson.toJson(arguments.get(0)), JsonObject.class);
-            if (executeOn.has("fsPath")) {
-                s = executeOn.get("fsPath").getAsString();
-                f = FileUtil.toFileObject(new File(s));
-            }
-        }
-        if (f == null) {
-            throw new IllegalArgumentException("Invalid path specified: " + s);
-        }
+        FileObject f = Utils.extractFileObject(arguments.get(0), gson);
         Project p = FileOwnerQuery.getOwner(f);
         if (p == null) {
-            throw new IllegalArgumentException("Not part of a project " + s);
+            throw new IllegalArgumentException("Not part of a project " + f);
         }
         ProjectVulnerability v = p.getLookup().lookup(ProjectVulnerability.class);
         ProjectInformation pi = ProjectUtils.getInformation(p);

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectMetadataCommand.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectMetadataCommand.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.nbcode.integration.commands;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectActionContext;
+import org.netbeans.modules.java.lsp.server.protocol.CodeActionsProvider;
+import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
+import org.netbeans.modules.parsing.api.ResultIterator;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.netbeans.modules.project.dependency.ProjectArtifactsQuery;
+import org.netbeans.modules.project.dependency.ProjectArtifactsQuery.ArtifactsResult;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.RequestProcessor;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+@ServiceProvider(service = CodeActionsProvider.class)
+public class ProjectMetadataCommand extends CodeActionsProvider {
+    private static final String COMMAND_ARTIFACTS = "nbls.gcn.project.artifacts"; // NOI18N
+
+    private static final Set<String> COMMANDS = new HashSet<>(Arrays.asList(
+            COMMAND_ARTIFACTS
+    ));
+    private static final Set<String> ARTIFACT_BLOCK_FIELDS = new HashSet<>(Arrays.asList(
+        "data" // NOI18N
+    ));
+    
+    private static final RequestProcessor METADATA_PROCESSOR = new RequestProcessor(ProjectMetadataCommand.class);
+    
+    private final Gson gson;
+    
+    public ProjectMetadataCommand() {
+        gson = new GsonBuilder()
+             // block the opaque 'data' field 
+            .addSerializationExclusionStrategy(new ExclusionStrategy() {
+                    @Override
+                    public boolean shouldSkipField(FieldAttributes fa) {
+                        if (fa.getDeclaringClass() == ArtifactSpec.class) {
+                          return ARTIFACT_BLOCK_FIELDS.contains(fa.getName());
+                        }
+                        return false;
+                    }
+
+                    @Override
+                    public boolean shouldSkipClass(Class<?> type) {
+                        return false;
+                    }
+            })
+            // serialize FileObject as null|path
+            .registerTypeAdapterFactory(new TypeAdapterFactory() {
+                @Override
+                public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> tt) {
+                    if (tt.getRawType() != FileObject.class) {
+                        return null;
+                    }
+                    return new TypeAdapter<T>() {
+                        @Override
+                        public void write(JsonWriter writer, T t) throws IOException {
+                            FileObject f = (FileObject)t;
+                            writer.value(f == null ? null : f.getPath());
+                        }
+
+                        @Override
+                        public T read(JsonReader reader) throws IOException {
+                            if (reader.peek() == JsonToken.NULL) {
+                                reader.nextNull();
+                                return null;
+                            } else {
+                                String s = reader.nextString();
+                                if (s == null) {
+                                    return null;
+                                }
+                                FileObject fo = FileUtil.toFileObject(Paths.get(s).toFile());
+                                return (T)fo;
+                            }
+                        }
+                    };
+                }
+            })
+            .create();
+    }
+    
+    @Override
+    public List<CodeAction> getCodeActions(ResultIterator resultIterator, CodeActionParams params) throws Exception {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return COMMANDS;
+    }
+
+    @Override
+    public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
+        if (arguments.size() < 1) {
+            throw new IllegalArgumentException("Expected at least project URI/path");
+        }
+        FileObject f = Utils.extractFileObject(arguments.get(0), gson);
+        Project p = FileOwnerQuery.getOwner(f);
+        if (p == null || p.getProjectDirectory() != f) {
+            throw new IllegalArgumentException("Not a project " + f);
+        }
+        String artifactType = null;
+        ProjectActionContext ctx = null;
+        
+        if (arguments.size() > 1) {
+            // 2nd parameter is the project action
+            Object o = arguments.get(1);
+            if (!(o instanceof JsonPrimitive)) {
+                throw new IllegalArgumentException("String or null expected as parameter #3, got " + o);
+            }
+            ctx = ProjectActionContext.newBuilder(p).forProjectAction(((JsonPrimitive)o).getAsString()).context();
+        }
+        if (arguments.size() > 2) {
+            // 3rd parameter is the type of artifact
+            Object o = arguments.get(2);
+            if (!(o instanceof JsonPrimitive)) {
+                throw new IllegalArgumentException("String or null expected as parameter #2, got " + o);
+            }
+            artifactType = ((JsonPrimitive)o).getAsString();
+        }
+        ProjectArtifactsQuery.Filter filter = ProjectArtifactsQuery.newQuery(artifactType, null, ctx);
+        CompletableFuture result = new CompletableFuture();
+        METADATA_PROCESSOR.post(() -> {
+            try {
+                ArtifactsResult arts = ProjectArtifactsQuery.findArtifacts(p, filter);
+                // must serialize in advance, since we cannot configure gson instance in lsp4j
+                Object o = gson.toJsonTree(arts.getArtifacts());
+                result.complete(o);
+            } catch (Exception | Error ex) {
+                result.completeExceptionally(ex);
+            }
+        });
+        
+        return result;
+    }
+}

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/Utils.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/Utils.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.nbcode.integration.commands;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
+
+/**
+ *
+ * @author sdedic
+ */
+class Utils {
+    static FileObject extractFileObject(Object argument, Gson gson) {
+        FileObject f = null;
+        String s = "";
+        if (argument instanceof JsonPrimitive) {
+            s = ((JsonPrimitive)argument).getAsString();
+            try {
+                URI uri = new URI(s);
+                f = URLMapper.findFileObject(uri.toURL());
+            } catch (URISyntaxException | MalformedURLException ex) {
+                f = FileUtil.toFileObject(new File(s));
+            }
+        } else {
+            // accept something that looks like vscode.Uri structure
+            JsonObject executeOn = gson.fromJson(gson.toJson(argument), JsonObject.class);
+            if (executeOn.has("fsPath")) {
+                s = executeOn.get("fsPath").getAsString();
+                f = FileUtil.toFileObject(new File(s));
+            }
+        }
+        if (f == null) {
+            throw new IllegalArgumentException("Invalid path specified: " + s);
+        }
+        return f;
+    }
+}

--- a/java/maven.embedder/nbproject/project.xml
+++ b/java/maven.embedder/nbproject/project.xml
@@ -182,6 +182,7 @@
                 <friend>io.github.jeddict.runtime</friend>
                 <friend>io.github.jeddict.rest.generator</friend>
                 <!-- XXX <subpackages> not permitted by schema -->
+                <friend>org.netbeans.modules.micronaut</friend>
                 <package>javax.inject</package>
                 <package>com.google.inject</package>
                 <package>com.google.common.base</package>

--- a/java/maven/apichanges.xml
+++ b/java/maven/apichanges.xml
@@ -83,6 +83,20 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="evaluated-project">
+            <api name="general"/>
+            <summary>Project model can be customized for specific action or usage</summary>
+            <version major="2" minor="155"/>
+            <date day="10" month="8" year="2022"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes" semantic="compatible"/>
+            <description>
+                Project state can be inspected with respect to an intended action to be run or used, and possible
+                customized properties or profiles. This allows clients to more precisely follow customizations in 
+                the project file and/or action mapping that would be applied when actually using project actions.
+            </description>
+            <class package="org.netbeans.modules.maven.api" name="NbMavenProject"/>
+        </change>
         <change id="plugin.conf.paths">
             <api name="general"/>
             <summary>Added helper method to get artifact paths from build plugin configurations.</summary>

--- a/java/maven/nbproject/project.properties
+++ b/java/maven/nbproject/project.properties
@@ -22,7 +22,7 @@ javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 javahelp.hs=maven.hs
 extra.module.files=maven-nblib/
-spec.version.base: 2.154
+spec.version.base: 2.155
 
 # The CPExtender test fails in library processing (not randomly) since NetBeans 8.2; disabling.
 test.excludes=**/CPExtenderTest.class

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -653,6 +653,8 @@
                 <friend>org.netbeans.modules.maven.util</friend>
                 <!-- JShel support -->
                 <friend>org.netbeans.modules.jshell.support</friend>
+                <!-- sdedic@apache.org -->
+                <friend>org.netbeans.modules.micronaut</friend>
                 <package>org.netbeans.modules.maven.api</package>
                 <package>org.netbeans.modules.maven.api.archetype</package>
                 <package>org.netbeans.modules.maven.api.classpath</package>

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -316,7 +316,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.80</specification-version>
+                        <specification-version>1.89</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -69,12 +70,14 @@ import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.annotations.common.NullUnknown;
 import org.netbeans.api.java.project.classpath.ProjectClassPathModifier;
 import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectActionContext;
 import org.netbeans.api.queries.VisibilityQuery;
 import org.netbeans.modules.maven.api.Constants;
 import org.netbeans.modules.maven.api.FileUtilities;
 import org.netbeans.modules.maven.api.NbMavenProject;
 import org.netbeans.modules.maven.api.PluginPropertyUtils;
 import org.netbeans.modules.maven.api.execute.ActiveJ2SEPlatformProvider;
+import org.netbeans.modules.maven.api.execute.RunConfig;
 import org.netbeans.modules.maven.configurations.M2ConfigProvider;
 import org.netbeans.modules.maven.configurations.M2Configuration;
 import org.netbeans.modules.maven.configurations.ProjectProfileHandlerImpl;
@@ -82,6 +85,7 @@ import org.netbeans.modules.maven.cos.CopyResourcesOnSave;
 import org.netbeans.modules.maven.debug.MavenJPDAStart;
 import org.netbeans.modules.maven.embedder.EmbedderFactory;
 import org.netbeans.modules.maven.embedder.MavenEmbedder;
+import org.netbeans.modules.maven.execute.ActionToGoalUtils;
 import org.netbeans.modules.maven.modelcache.MavenProjectCache;
 import org.netbeans.modules.maven.options.MavenSettings;
 import org.netbeans.modules.maven.problems.ProblemReporterImpl;
@@ -139,6 +143,7 @@ public final class NbMavenProjectImpl implements Project {
                 if (hardReferencingMavenProject) {
                     hardRefProject = prj;
                 }
+                projectVariants.clear();
             }
             ACCESSOR.doFireReload(watcher);
         }
@@ -421,6 +426,48 @@ public final class NbMavenProjectImpl implements Project {
         // in case someone got already information from the NbMavenProject:
         ACCESSOR.doFireReload(watcher);
         return mp;
+    }
+    
+    /**
+     * Variants of the projects, possibly other than the ones with the
+     * <b>active configuration</b>
+     */
+    private Map<ProjectActionContext, Reference<MavenProject>> projectVariants = new WeakHashMap<>();
+    
+    public @NonNull MavenProject getEvaluatedProject(ProjectActionContext ctx) {
+        if (ctx == null) {
+            return getOriginalMavenProject();
+        }
+        ProjectActionContext stripped = 
+                ProjectActionContext.newBuilder(ctx.getProject())
+                    .withProfiles(ctx.getProfiles())
+                    .withProperties(ctx.getProperties())
+                    .context();
+        MavenProject result;
+        
+        synchronized (this) {
+            Reference<MavenProject> ref = projectVariants.get(stripped);
+            if (ref != null) {
+                result = ref.get();
+                if (result != null) {
+                    return result;
+                } else {
+                    projectVariants.remove(stripped);
+                }
+            }
+        }
+        RunConfig runConf = null;
+        if (ctx != null && ctx.getProjectAction() != null) {
+            runConf = ActionToGoalUtils.createRunConfig(ctx.getProjectAction(), this, ctx.getConfiguration(), Lookup.EMPTY);
+        }
+        MavenProject newproject = MavenProjectCache.loadMavenProject(this.getPOMFile(), ctx, runConf);
+        synchronized (this) {
+            Reference<MavenProject> ref = projectVariants.get(stripped);
+            if (ref == null || ref.get() == null) {
+                projectVariants.put(stripped, new SoftReference<>(newproject));
+            }
+        }
+        return newproject;
     }
     
     /**

--- a/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
@@ -44,6 +44,7 @@ import org.netbeans.api.progress.aggregate.AggregateProgressHandle;
 import org.netbeans.api.progress.aggregate.BasicAggregateProgressFactory;
 import org.netbeans.api.progress.aggregate.ProgressContributor;
 import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectActionContext;
 import org.netbeans.modules.maven.NbMavenProjectImpl;
 import static org.netbeans.modules.maven.api.Bundle.*;
 import org.netbeans.modules.maven.embedder.EmbedderFactory;
@@ -284,6 +285,22 @@ public final class NbMavenProject {
      */ 
     public @NonNull MavenProject getMavenProject() {
         return project.getOriginalMavenProject();
+    }
+    
+    /**
+     * Returns a project evaluated for a certain purpose. The while {@link #getMavenProject}
+     * works with the <b>active configuration</b> and does not apply any action-specific properties,
+     * this method tries to apply mappings, configurations, etc when loading the project model.
+     * <p>
+     * Note that loading an evaluated project may take significant time (comparable to loading
+     * the base project itself). The implementation might optimize if the passed context does not
+     * prescribe different profiles, properties etc than have been used for the default model.
+     * 
+     * @param context the loading context
+     * @return evaluated project
+     */
+    public @NonNull MavenProject getEvaluatedProject(ProjectActionContext context) {
+        return project.getEvaluatedProject(context);
     }
     
     /**

--- a/java/maven/src/org/netbeans/modules/maven/api/customizer/ModelHandle2.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/customizer/ModelHandle2.java
@@ -66,6 +66,8 @@ public class ModelHandle2 {
     private final POMModel model;
     private final List<ModelOperation<POMModel>> pomOperations = new ArrayList<ModelOperation<POMModel>>();
     private final Map<String, ActionToGoalMapping> mappings;
+    private final List<String> allActions;
+    
     private List<Configuration> configurations;
     private boolean modConfig = false;
     private Configuration active;
@@ -87,8 +89,9 @@ public class ModelHandle2 {
                                         Map<String, ActionToGoalMapping> mapp, 
                                         List<Configuration> configs,
                                         Configuration active,
+                                        List<String> allActions,
                                         MavenProjectPropsImpl auxProps) {
-            return new ModelHandle2(model, proj, mapp, configs, active, auxProps);
+            return new ModelHandle2(model, proj, mapp, configs, active, allActions, auxProps);
         }
         
          public void assign() {
@@ -96,6 +99,11 @@ public class ModelHandle2 {
                  CustomizerProviderImpl.ACCESSOR2 = this;
              }
          }
+
+        @Override
+        public List<String> getAllActions(ModelHandle2 handle) {
+            return handle.getAllActions();
+        }
 
         @Override
         public TreeMap<String, String> getModifiedAuxProps(ModelHandle2 handle, boolean shared) {
@@ -111,18 +119,16 @@ public class ModelHandle2 {
         public boolean isModified(ModelHandle2 handle, ActionToGoalMapping mapp) {
             return handle.modifiedMappings.contains(mapp);
         }
-
-    
     }    
 
-    private ModelHandle2(POMModel model, MavenProject proj, Map<String, ActionToGoalMapping> mapp, List<Configuration> configs, Configuration active, MavenProjectPropsImpl auxProps) {
+    private ModelHandle2(POMModel model, MavenProject proj, Map<String, ActionToGoalMapping> mapp, List<Configuration> configs, Configuration active, List<String> allActions, MavenProjectPropsImpl auxProps) {
         project = proj;
         this.mappings = mapp;
         configurations = configs;
         this.active = active;
         auxiliaryProps = auxProps;
         this.model = model;
-        
+        this.allActions = allActions;
     }
     
     /**
@@ -358,6 +364,10 @@ public class ModelHandle2 {
         CustomizerProviderImpl.writeNbActionsModel(project, mapping, M2Configuration.getFileNameExt(cfg.getId()));
     }    
     
+    List<String> getAllActions() {
+        return allActions;
+    }
+    
     
 /**
      * a javabean wrapper for configurations within the project customizer
@@ -480,7 +490,6 @@ public class ModelHandle2 {
         public String toString() {
             return getDisplayName();
         }
-        
         
     }    
     

--- a/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
@@ -780,7 +780,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
     })
     private void loadMappings() {
         DefaultListModel model = new DefaultListModel();
-
+        fixedActions = new HashSet<>();
         if (handle != null) {
             boolean isWar = NbMavenProject.TYPE_WAR.equalsIgnoreCase(project.getProjectWatcher().getPackagingType());
             addSingleAction(ActionProvider.COMMAND_BUILD, model);
@@ -808,6 +808,10 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
                 addSingleAction(ActionProvider.COMMAND_PROFILE_SINGLE + ".deploy", model); //NOI18N
             }
             addSingleAction("javadoc", model); //NOI18N
+            
+            for (String a : CustomizerProviderImpl.ACCESSOR2.getAllActions(handle)) {
+                addSingleAction(a, model, true); //NOI18N
+            }
         }
         for (NetbeansActionMapping elem : getActionMappings().getActions()) {
             if (elem.getActionName().startsWith(CUSTOM_ACTION_PREFIX)) {
@@ -819,7 +823,13 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
         lstMappings.setModel(model);
     }
     
+    private Set<String> fixedActions = new HashSet<>();
+    
     private void addSingleAction(String action, DefaultListModel model) {
+        addSingleAction(action, model, false);
+    }
+    
+    private void addSingleAction(String action, DefaultListModel model, boolean ignoreIfNotExist) {
         NetbeansActionMapping mapp = null;
         for (NetbeansActionMapping elem : getActionMappings().getActions()) {
             if (action.equals(elem.getActionName())) {
@@ -829,17 +839,24 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
         }
         boolean userDefined = true;
         if (mapp == null) {
+            if (fixedActions.contains(action)) {
+                return;
+            }
             mapp = ActionToGoalUtils.getDefaultMapping(action, project);
             userDefined = false;
         }
         MappingWrapper wr;
         if (mapp == null) {
+            if (ignoreIfNotExist) {
+                return;
+            }
             wr = new MappingWrapper(action);
         } else {
             wr = new MappingWrapper(mapp);
         }
         wr.setUserDefined(userDefined);
         model.addElement(wr);
+        fixedActions.add(action);
     }
     
     private String createSpaceSeparatedList(List<String> list) {

--- a/java/maven/src/org/netbeans/modules/maven/customizer/CustomizerProviderImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/CustomizerProviderImpl.java
@@ -25,6 +25,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.*;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +77,7 @@ import org.openide.util.HelpCtx;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.Lookups;
 import static org.netbeans.modules.maven.customizer.Bundle.*;
+import org.netbeans.spi.project.ActionProvider;
 import org.netbeans.spi.project.ui.CustomizerProvider2;
 import org.openide.util.Mutex;
 import org.openide.util.NbBundle.Messages;
@@ -250,12 +253,16 @@ public class CustomizerProviderImpl implements CustomizerProvider2 {
         if (active == null) { //#152706
             active = configs.get(0); //default if current not found..
         }
+        
+        ActionProvider ap = project.getLookup().lookup(ActionProvider.class);
+        List<String> actionNames = ap == null ? Collections.emptyList() : Arrays.asList(ap.getSupportedActions());
 
         handle = ACCESSOR.createHandle(model,
                 project.getLookup().lookup(NbMavenProject.class).getMavenProject(), mapps, configs, active,
                 project.getLookup().lookup(MavenProjectPropsImpl.class));
         handle2 = ACCESSOR2.createHandle(model,
-                project.getLookup().lookup(NbMavenProject.class).getMavenProject(), mapps, new ArrayList<ModelHandle2.Configuration>(configs), active, 
+                project.getLookup().lookup(NbMavenProject.class).getMavenProject(), mapps, new ArrayList<ModelHandle2.Configuration>(configs), active,
+                actionNames,
                 project.getLookup().lookup(MavenProjectPropsImpl.class));
         return model;
     }
@@ -292,13 +299,15 @@ public class CustomizerProviderImpl implements CustomizerProvider2 {
     public abstract static class ModelAccessor2 {
         
         public abstract ModelHandle2 createHandle(POMModel model, MavenProject proj, Map<String, ActionToGoalMapping> mapp,
-                List<ModelHandle2.Configuration> configs, ModelHandle2.Configuration active, MavenProjectPropsImpl auxProps);
+                List<ModelHandle2.Configuration> configs, ModelHandle2.Configuration active, List<String> allActions, MavenProjectPropsImpl auxProps);
         
         public abstract TreeMap<String, String> getModifiedAuxProps(ModelHandle2 handle, boolean shared);
         
         public abstract boolean isConfigurationModified(ModelHandle2 handle);
         
         public abstract boolean isModified(ModelHandle2 handle, ActionToGoalMapping mapp);
+        
+        public abstract List<String> getAllActions(ModelHandle2 handle);
         
         }
         

--- a/java/maven/src/org/netbeans/modules/maven/execute/ActionNameProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/ActionNameProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.execute;
+
+import java.util.ResourceBundle;
+
+/**
+ *
+ * @author sdedic
+ */
+public interface ActionNameProvider {
+    public ResourceBundle getTranslations();
+}

--- a/java/maven/src/org/netbeans/modules/maven/execute/Bundle.properties
+++ b/java/maven/src/org/netbeans/modules/maven/execute/Bundle.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+action.debug.fix=Fix & Continue Debugging
+

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenArtifactsImplementation.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenArtifactsImplementation.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.queries;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectActionContext;
+import org.netbeans.modules.maven.api.Constants;
+import org.netbeans.modules.maven.api.NbMavenProject;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.netbeans.modules.project.dependency.ProjectArtifactsQuery;
+import org.netbeans.modules.project.dependency.spi.ProjectArtifactsImplementation;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.RequestProcessor;
+import org.openide.util.WeakListeners;
+
+/**
+ *
+ * @author sdedic
+ */
+@ProjectServiceProvider(service = ProjectArtifactsImplementation.class, projectType = NbMavenProject.TYPE)
+public class MavenArtifactsImplementation implements ProjectArtifactsImplementation {
+    private static final Logger LOG = Logger.getLogger(ProjectArtifactsImplementation.class.getName());
+    
+    private final Project project;
+
+    public MavenArtifactsImplementation(Project project) {
+        this.project = project;
+    }
+    @Override
+    public Result findArtifacts(ProjectArtifactsQuery.Filter query) {
+        ProjectActionContext ctx = query.getBuildContext();
+        if (ctx != null) {
+            if (ctx.getProjectAction() != null) {
+                switch (ctx.getProjectAction()) {
+                    case ActionProvider.COMMAND_BUILD:
+                    case ActionProvider.COMMAND_REBUILD:
+                    case ActionProvider.COMMAND_RUN:
+                    case ActionProvider.COMMAND_DEBUG:
+                    case ActionProvider.COMMAND_RUN_SINGLE:
+                    case ActionProvider.COMMAND_DEBUG_SINGLE:
+                    case ActionProvider.COMMAND_TEST:
+                    case ActionProvider.COMMAND_TEST_SINGLE:
+                    case ActionProvider.COMMAND_DEBUG_STEP_INTO:
+                        break;
+
+                    default:
+                        return null;
+                }
+            }
+            if (ctx.getProfiles() != null && !ctx.getProfiles().isEmpty()) {
+                LOG.log(Level.WARNING, "Custom action profiles are not supported yet by Maven projects"); // NOI18N
+            }
+            if (ctx.getConfiguration() != null) {
+                LOG.log(Level.WARNING, "Custom action configurations are not supported yet by Maven projects"); // NOI18N
+            }
+            if (ctx.getProperties() != null && !ctx.getProperties().isEmpty()) {
+                LOG.log(Level.WARNING, "Custom action properties are not supported yet by Maven projects"); // NOI18N
+            }
+        }
+        return new Res(project, query);
+    }
+    
+    static class MavenQuery {
+        final Project project;
+        final NbMavenProject nbMavenProject;
+        final ProjectArtifactsQuery.Filter filter;
+        
+        List<ArtifactSpec> specs;
+
+        public MavenQuery(Project project, NbMavenProject nbMavenProject, ProjectArtifactsQuery.Filter filter) {
+            this.project = project;
+            this.nbMavenProject = nbMavenProject;
+            this.filter = filter;
+        }
+        
+        private void appendPluginOutput(MavenProject evalProject, String pluginId, String goal, String packagingAndType) {
+            if (filter != null) {
+                if (filter.getArtifactType() == null) {
+                    if (!evalProject.getPackaging().equals(packagingAndType)) {
+                        return;
+                    }
+                } else if (!filter.getArtifactType().equals(packagingAndType)) {
+                    if (!ProjectArtifactsQuery.Filter.TYPE_ALL.equals(filter.getArtifactType())) {
+                        return;
+                    }
+                }
+            }
+            Artifact mA = evalProject.getArtifact();
+            Model mdl = evalProject.getModel();
+            
+            Plugin plugin = evalProject.getBuild().getPluginsAsMap().get(Constants.GROUP_APACHE_PLUGINS + ":" + pluginId); // NOI18N
+            if (plugin == null) {
+                return;
+            }
+            
+            for (PluginExecution exec : plugin.getExecutions()) {
+                if (exec.getGoals().contains(goal)) {
+                    Xpp3Dom dom = evalProject.getGoalConfiguration(
+                            Constants.GROUP_APACHE_PLUGINS, pluginId, exec.getId(), goal);
+                    Xpp3Dom domClassifier = dom == null ? null : dom.getChild("classifier"); // NOI18N
+                    Xpp3Dom domOutputDir = dom == null ? null : dom.getChild("outputDirectory"); // NOI18N
+
+                    String classifier = domClassifier == null ? null : domClassifier.getValue();
+
+                    if (filter != null && !ProjectArtifactsQuery.Filter.CLASSIFIER_ANY.equals(filter.getClassifier())) {
+                        if (!Objects.equals(classifier, filter.getClassifier())) {
+                            return;
+                        }
+                    }
+                    StringBuilder finalNameExt = new StringBuilder(mdl.getBuild().getFinalName());
+                    if (domClassifier != null) {
+                        finalNameExt.append("-").append(domClassifier.getValue());
+                    }
+                    finalNameExt.append(".").append(packagingAndType);
+
+                    ArtifactSpec.Builder builder = ArtifactSpec.builder(mA.getGroupId(), mA.getArtifactId(), mA.getVersion(), 
+                            nbMavenProject.getMavenProject().getArtifact())
+                            .classifier(classifier)
+                            .type(packagingAndType);
+                    try {
+                        Path dir = Paths.get(mdl.getBuild().getDirectory());
+                        if (domOutputDir != null) {
+                            dir = mdl.getProjectDirectory().toPath().resolve(domOutputDir.getValue());
+                        }
+
+                        Path artPath = dir.resolve(finalNameExt.toString());
+                        URI uri = artPath.toUri();
+                        builder.location(uri);
+                        if (Files.exists(artPath)) {
+                            builder.forceLocalFile(FileUtil.toFileObject(artPath.toFile()));
+                        }
+                    } catch (InvalidPathException ex) {
+                        // TODO: log 
+                    }
+                    specs.add(builder.build());
+                }
+            }
+        }
+        
+        public void run() {
+            specs = new ArrayList<>();
+            Model mdl;
+            ProjectActionContext buildCtx;
+            
+            if (filter != null && filter.getBuildContext() != null) {
+                if (filter.getBuildContext().getProjectAction() == null) {
+                    buildCtx = filter.getBuildContext().newDerivedBuilder().forProjectAction(ActionProvider.COMMAND_BUILD).context();
+                } else {
+                    buildCtx = filter.getBuildContext();
+                }
+            } else {
+                buildCtx = ProjectActionContext.newBuilder(project).forProjectAction(ActionProvider.COMMAND_BUILD).context();
+            }
+            MavenProject mp = nbMavenProject.getEvaluatedProject(buildCtx);
+            mdl = mp.getModel();
+            
+            String packaging = mdl.getPackaging();
+            if (packaging == null) {
+                packaging = NbMavenProject.TYPE_JAR;
+            }
+            
+            appendPluginOutput(mp, Constants.PLUGIN_JAR, NbMavenProject.TYPE_JAR, NbMavenProject.TYPE_JAR);
+            appendPluginOutput(mp, Constants.PLUGIN_WAR, NbMavenProject.TYPE_WAR, NbMavenProject.TYPE_WAR);
+            appendPluginOutput(mp, Constants.PLUGIN_EAR, NbMavenProject.TYPE_EAR, NbMavenProject.TYPE_EAR);
+            appendPluginOutput(mp, Constants.PLUGIN_EJB, NbMavenProject.TYPE_EJB, NbMavenProject.TYPE_EJB);
+        }
+    }
+    
+    private static final RequestProcessor MAVEN_ARTIFACTS_RP = new RequestProcessor(MavenArtifactsImplementation.class);
+
+    static class Res implements ProjectArtifactsImplementation.Result, PropertyChangeListener {
+        private final Project project;
+        private final ProjectArtifactsQuery.Filter filter;
+        
+        // @GuardedBy(this)
+        private List<ArtifactSpec> artifacts;
+        // @GuardedBy(this)
+        private List<ChangeListener> listeners;
+        
+        private RequestProcessor.Task refreshTask;
+        
+        public Res(Project project, ProjectArtifactsQuery.Filter filter) {
+            this.project = project;
+            this.filter = filter;
+        }
+        
+        @Override
+        public Project getProject() {
+            return project;
+        }
+
+        @Override
+        public List<ArtifactSpec> getArtifacts() {
+            synchronized (this) {
+                if (artifacts != null) {
+                    return artifacts;
+                }
+            }
+            NbMavenProject mvnProject = project.getLookup().lookup(NbMavenProject.class);
+            MavenQuery q = new MavenQuery(project, mvnProject, filter);
+            q.run();
+            synchronized (this) {
+                if (artifacts == null) {
+                    artifacts = q.specs;
+                }
+            }
+            return q.specs;
+        }
+        
+        private void update(List<ArtifactSpec> copy, RequestProcessor.Task self) {
+            NbMavenProject mvnProject = project.getLookup().lookup(NbMavenProject.class);
+            MavenQuery q = new MavenQuery(project, mvnProject, filter);
+            q.run();
+            
+            ChangeListener[] ll;
+            synchronized (this) {
+                if (artifacts == null) {
+                    artifacts = q.specs;
+                    return;
+                } else if (this.artifacts.equals(q.specs)) {
+                    return;
+                } else {
+                    ll = listeners.toArray(new ChangeListener[listeners.size()]);
+                }
+            }
+            ChangeEvent e = new ChangeEvent(this);
+            for (ChangeListener l : ll) {
+                l.stateChanged(e);
+            }
+        }
+        
+        @Override
+        public Collection<ArtifactSpec> getExcludedArtifacts() {
+            return null;
+        }
+
+        @Override
+        public void addChangeListener(ChangeListener l) {
+            synchronized (this) {
+                if (listeners == null) {
+                    NbMavenProject mvnProject = project.getLookup().lookup(NbMavenProject.class);
+                    mvnProject.addPropertyChangeListener(WeakListeners.propertyChange(this, NbMavenProject.PROP_PROJECT, mvnProject));
+                }
+                listeners.add(l);
+            }
+        }
+
+        @Override
+        public void removeChangeListener(ChangeListener l) {
+            synchronized (this) {
+                if (listeners == null) {
+                    return;
+                }
+                listeners.remove(l);
+            }
+        }
+
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            if (!NbMavenProject.PROP_PROJECT.equals(evt.getPropertyName())) {
+                return;
+            }
+            ChangeListener[] ll;
+            final List<ArtifactSpec> copy;
+            
+            synchronized (this) {
+                artifacts = null;
+                if (listeners == null && listeners.isEmpty()) {
+                    return;
+                }
+                if (refreshTask != null) {
+                    refreshTask.cancel();
+                }
+                copy = artifacts == null ? Collections.emptyList() : new ArrayList<>(this.artifacts);
+                RequestProcessor.Task[] arr = new RequestProcessor.Task[1];
+                
+                arr[0] = refreshTask = MAVEN_ARTIFACTS_RP.create(() -> update(copy, arr[0]));
+                
+                ll = listeners.toArray(new ChangeListener[listeners.size()]);
+            }
+            ChangeEvent e = new ChangeEvent(this);
+            for (ChangeListener l : ll) {
+                l.stateChanged(e);
+            }
+        }
+
+        @Override
+        public boolean supportsChanges() {
+            return true;
+        }
+    }
+}

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenArtifactsImplementation.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenArtifactsImplementation.java
@@ -58,7 +58,7 @@ import org.openide.util.WeakListeners;
  * @author sdedic
  */
 @ProjectServiceProvider(service = ProjectArtifactsImplementation.class, projectType = NbMavenProject.TYPE)
-public class MavenArtifactsImplementation implements ProjectArtifactsImplementation {
+public class MavenArtifactsImplementation implements ProjectArtifactsImplementation<MavenArtifactsImplementation.Res> {
     private static final Logger LOG = Logger.getLogger(ProjectArtifactsImplementation.class.getName());
     
     private final Project project;
@@ -66,8 +66,9 @@ public class MavenArtifactsImplementation implements ProjectArtifactsImplementat
     public MavenArtifactsImplementation(Project project) {
         this.project = project;
     }
+
     @Override
-    public Result findArtifacts(ProjectArtifactsQuery.Filter query) {
+    public Res evaluate(ProjectArtifactsQuery.Filter query) {
         ProjectActionContext ctx = query.getBuildContext();
         if (ctx != null) {
             if (ctx.getProjectAction() != null) {
@@ -98,6 +99,35 @@ public class MavenArtifactsImplementation implements ProjectArtifactsImplementat
             }
         }
         return new Res(project, query);
+    }
+
+    @Override
+    public Project findProject(Res r) {
+        return r.getProject();
+    }
+
+    @Override
+    public List<ArtifactSpec> findArtifacts(Res r) {
+        return r.getArtifacts();
+    }
+
+    @Override
+    public Collection<ArtifactSpec> findExcludedArtifacts(Res r) {
+        return r.getExcludedArtifacts();
+    }
+
+    @Override
+    public void handleChangeListener(Res r, ChangeListener l, boolean add) {
+        if (add) {
+            r.addChangeListener(l);
+        } else {
+            r.removeChangeListener(l);
+        }
+    }
+
+    @Override
+    public boolean computeSupportsChanges(Res r) {
+        return r.supportsChanges();
     }
     
     static class MavenQuery {
@@ -208,7 +238,7 @@ public class MavenArtifactsImplementation implements ProjectArtifactsImplementat
     
     private static final RequestProcessor MAVEN_ARTIFACTS_RP = new RequestProcessor(MavenArtifactsImplementation.class);
 
-    static class Res implements ProjectArtifactsImplementation.Result, PropertyChangeListener {
+    static class Res implements PropertyChangeListener {
         private final Project project;
         private final ProjectArtifactsQuery.Filter filter;
         
@@ -224,12 +254,10 @@ public class MavenArtifactsImplementation implements ProjectArtifactsImplementat
             this.filter = filter;
         }
         
-        @Override
         public Project getProject() {
             return project;
         }
 
-        @Override
         public List<ArtifactSpec> getArtifacts() {
             synchronized (this) {
                 if (artifacts != null) {
@@ -269,12 +297,10 @@ public class MavenArtifactsImplementation implements ProjectArtifactsImplementat
             }
         }
         
-        @Override
         public Collection<ArtifactSpec> getExcludedArtifacts() {
             return null;
         }
 
-        @Override
         public void addChangeListener(ChangeListener l) {
             synchronized (this) {
                 if (listeners == null) {
@@ -285,7 +311,6 @@ public class MavenArtifactsImplementation implements ProjectArtifactsImplementat
             }
         }
 
-        @Override
         public void removeChangeListener(ChangeListener l) {
             synchronized (this) {
                 if (listeners == null) {
@@ -324,7 +349,6 @@ public class MavenArtifactsImplementation implements ProjectArtifactsImplementat
             }
         }
 
-        @Override
         public boolean supportsChanges() {
             return true;
         }

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenDependenciesImplementation.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenDependenciesImplementation.java
@@ -18,8 +18,14 @@
  */
 package org.netbeans.modules.maven.queries;
 
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -28,10 +34,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.PlexusContainerException;
 import org.netbeans.api.project.Project;
@@ -98,12 +106,6 @@ public class MavenDependenciesImplementation implements ProjectDependenciesImple
     
     static String mavenScope(Scope s) {
         return mavenScopes.getOrDefault(s, "runtime");
-    }
-    
-    @Override
-    public ArtifactSpec getProjectArtifact() {
-        init();
-        return mavenToArtifactSpec(nbMavenProject.getMavenProject().getArtifact());
     }
     
     private ArtifactSpec mavenToArtifactSpec(Artifact a) {

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenArtifactsImplementationTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenArtifactsImplementationTest.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.queries;
+
+import java.io.File;
+import java.net.URI;
+import java.util.concurrent.Exchanger;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectActionContext;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.maven.api.Constants;
+import org.netbeans.modules.maven.api.NbMavenProject;
+import org.netbeans.modules.maven.embedder.EmbedderFactory;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.netbeans.modules.project.dependency.ProjectArtifactsQuery;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
+import org.openide.modules.DummyInstalledFileLocator;
+import org.openide.util.Exceptions;
+import org.openide.util.lookup.Lookups;
+import org.openide.windows.IOProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+public class MavenArtifactsImplementationTest extends NbTestCase {
+    private FileObject d;
+    private File repo;
+    private FileObject repoFO;
+    private FileObject dataFO;
+
+    public MavenArtifactsImplementationTest(String name) {
+        super(name);
+    }
+
+    private static File getTestNBDestDir() {
+        String destDir = System.getProperty("test.netbeans.dest.dir");
+        // set in project.properties as test-unit-sys-prop.test.netbeans.dest.dir
+        assertNotNull("test.netbeans.dest.dir property has to be set when running within binary distribution", destDir);
+        return new File(destDir);
+    }
+
+    protected @Override void setUp() throws Exception {
+        clearWorkDir();
+        
+        // This is needed, otherwose the core window's startup code will redirect
+        // System.out/err to the IOProvider, and its Trivial implementation will redirect
+        // it back to System.err - loop is formed. Initialize IOProvider first, it gets
+        // the real System.err/out references.
+        IOProvider p = IOProvider.getDefault();
+        d = FileUtil.toFileObject(getWorkDir());
+        System.setProperty("test.reload.sync", "true");
+        repo = EmbedderFactory.getProjectEmbedder().getLocalRepositoryFile();
+        repoFO = FileUtil.toFileObject(repo);
+        dataFO = FileUtil.toFileObject(getDataDir());
+        
+        // Configure the DummyFilesLocator with NB harness dir
+        File destDirF = getTestNBDestDir();
+        DummyInstalledFileLocator.registerDestDir(destDirF);
+    }
+    
+    private void installCompileResources() throws Exception {
+        FileUtil.copyFile(dataFO.getFileObject("projects/dependencies/repo"), repoFO, "nbtest");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        FileObject nbtest = repoFO.getFileObject("nbtest");
+        if (nbtest != null && nbtest.isValid()) {
+            nbtest.delete();
+        }
+    }
+    
+    /**
+     * Checks that the project can report its output artifact even though
+     * it was not built yet.
+     */
+    public void testProjectArtifactWithoutBuild() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        installCompileResources();
+        
+        FileObject testApp = dataFO.getFileObject("projects/dependencies/src/simpleProject");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "simpleProject");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, ProjectArtifactsQuery.newQuery(null));
+        
+        assertNotNull(ar);
+        assertEquals(1, ar.getArtifacts().size());
+        ArtifactSpec spec = ar.getArtifacts().get(0);
+        assertNotNull(spec);
+        URI u = spec.getLocation();
+        assertNotNull(u);
+        assertNull(spec.getLocalFile());
+    }
+    
+    public void testProjectArtifactSpecificType() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        installCompileResources();
+        
+        FileObject testApp = dataFO.getFileObject("projects/dependencies/src/simpleProject");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "simpleProject");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p,
+                ProjectArtifactsQuery.newQuery(NbMavenProject.TYPE_JAR)
+        );
+        
+        assertNotNull(ar);
+        assertEquals(1, ar.getArtifacts().size());
+        ArtifactSpec spec = ar.getArtifacts().get(0);
+        assertNotNull(spec);
+        URI u = spec.getLocation();
+        assertNotNull(u);
+        assertNull(spec.getLocalFile());
+    }
+
+    /**
+     * Checks that a compiled project will report its artifact including the  local file.
+     * @throws Exception 
+     */
+    public void testCompileProjectArtifactWithFile() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        installCompileResources();
+        
+        FileObject testApp = dataFO.getFileObject("projects/dependencies/src/simpleProject");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "simpleProject");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        Exchanger<Boolean> status = new Exchanger<>();
+        
+        ap.invokeAction(ActionProvider.COMMAND_BUILD, Lookups.fixed(new ActionProgress() {
+            @Override
+            protected void started() {
+            }
+
+            @Override
+            public void finished(boolean success) {
+                try {
+                    status.exchange(success);
+                } catch (InterruptedException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+            }
+        }));
+        
+        Boolean s = status.exchange(true);
+        assertTrue(s);
+        // the project has been built
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, ProjectArtifactsQuery.newQuery(null));
+        
+        assertNotNull(ar);
+        assertEquals(1, ar.getArtifacts().size());
+        ArtifactSpec spec = ar.getArtifacts().get(0);
+        assertNotNull(spec.getLocation());
+        assertNotNull(spec.getLocalFile());
+        
+        assertEquals(spec.getLocation(), URLMapper.findURL(spec.getLocalFile(), URLMapper.EXTERNAL).toURI());
+    }
+    
+    
+    public void testArtifactTypeNotProvided() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        installCompileResources();
+        
+        FileObject testApp = dataFO.getFileObject("projects/dependencies/src/simpleProject");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "simpleProject");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
+                ProjectArtifactsQuery.newQuery(NbMavenProject.TYPE_EAR)
+        );
+        
+        assertNotNull(ar);
+        assertEquals(0, ar.getArtifacts().size());
+    }
+
+    public void testArtifactClassifierNotProvided() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        installCompileResources();
+        
+        FileObject testApp = dataFO.getFileObject("projects/dependencies/src/simpleProject");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "simpleProject");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
+                ProjectArtifactsQuery.newQuery(NbMavenProject.TYPE_JAR, "tests", null)
+        );
+        
+        assertNotNull(ar);
+        assertEquals(0, ar.getArtifacts().size());
+    }
+    
+    public void testArtifactForCompileAction() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        installCompileResources();
+        
+        FileObject testApp = dataFO.getFileObject("projects/dependencies/src/simpleProject");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "simpleProject");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
+                ProjectArtifactsQuery.newQuery(NbMavenProject.TYPE_JAR, null, 
+                ProjectActionContext.newBuilder(p)
+                        .forProjectAction(ActionProvider.COMMAND_BUILD)
+                        .context()
+        ));
+        
+        assertNotNull(ar);
+        assertEquals(1, ar.getArtifacts().size());
+    }
+
+    public void testArtifactForRebuildAction() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        installCompileResources();
+        
+        FileObject testApp = dataFO.getFileObject("projects/dependencies/src/simpleProject");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "simpleProject");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
+                ProjectArtifactsQuery.newQuery(NbMavenProject.TYPE_JAR, null, 
+                ProjectActionContext.newBuilder(p)
+                        .forProjectAction(ActionProvider.COMMAND_REBUILD)
+                        .context()
+        ));
+        
+        assertNotNull(ar);
+        assertEquals(1, ar.getArtifacts().size());
+    }
+    
+    public void testArtifactForRunAction() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        installCompileResources();
+        
+        FileObject testApp = dataFO.getFileObject("projects/dependencies/src/simpleProject");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "simpleProject");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
+                ProjectArtifactsQuery.newQuery(NbMavenProject.TYPE_JAR, null, 
+                ProjectActionContext.newBuilder(p)
+                        .forProjectAction(ActionProvider.COMMAND_RUN)
+                        .context()
+        ));
+        
+        assertNotNull(ar);
+        assertEquals(1, ar.getArtifacts().size());
+    }
+    
+    public void testArtifactForCleanAction() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+        installCompileResources();
+        
+        FileObject testApp = dataFO.getFileObject("projects/dependencies/src/simpleProject");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "simpleProject");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
+                ProjectArtifactsQuery.newQuery(NbMavenProject.TYPE_JAR, null, 
+                ProjectActionContext.newBuilder(p)
+                        .forProjectAction(ActionProvider.COMMAND_CLEAN)
+                        .context()
+        ));
+        
+        assertNotNull(ar);
+        assertEquals(0, ar.getArtifacts().size());
+    }
+
+}


### PR DESCRIPTION
This PR actually consists of a series of features. I should probably make separate requests for that, but ... that would prolong the review process, I believe.

The overall goal was to add a project query to get the project's output in form of an identifiable artifact(s) and their supposed (not built yet) or existing locations - and expose the analysis result through LSP.

Overview:
## ProjectActionContext
This one I wanted for a long time already. Many project APIs or services are likely to be affected by project configurations - and it's rather hard to invoke the services for a specific configuration, which is not the active one. By default UI works against the active configuration, which is fine, but API access should have an option to specify it.
Adding configurations to all APIs is hard, and sometimes it is even impossible when the execution goes through some uncooperative layers.; the `ProjectActionContext` is a way how to pass the information 'out of band'.

I needed to pass specifically project action to distinguish different types of build; for example Micronaut plugins (gradle, maven) support a regular build, and a native-image build, that produces different output(s).

Important note for reviewers: while the ProjectActionContext allows to specify a profile or user properties, which can be ignored by the underlying project system, and give almost complete control over project model evaluation to the caller (at least for gradle and maven), I am not 100% sure if the properties + profiles is a good idea. A conservative approach would be to insist on creating a `ProjectConfiguration` for the profile+properties setup and use that.

Reviewers, share your opinion on this; these ProjectActionContext properties could be eventually added (compatibly) later.

## ProjectArtifactsQuery
this is a project query as usual, asking for project output with GAV coordinates (if applicable). I am almost sure the `ArtifactSpec` will satisfy PHP, too ... but I still keep it private until Gradle implementation is complete.

The `Filter` specification does not cover all query cases, but works for the basic ones. When one wants "any output" and a specific output type / classifier.

## Micronaut support for native image build
Added a project action and project action mapping for Maven to execute native-image build of the micronaut app. The action becomes available (and is configurable in project customizer) when one adds Micronaut plugin to the maven project build configuration.

## Maven fixes
During implementation I've realized that the native-build action, contributed to the Maven by `MavenActionsProvider` is not visible in the customizer. I was little shocked when I realized that the customizer essentially hardcodes the list of (standard) actions and only displays user-defined ones in addition to the hardcoded list. I've corrected the behaviour of `M2Configuration` in that it lists just config-specific mappings, the others are retrieved through `ActionToGoalUtils`.
I've also realized that the declarative actions lack proper support for I18N; so I've added a convenience lookup in ` Bundle.proeprties` using the action's (profile's) id, and in additiona specifying `displayName` that starts with '#' also makes a lookup, with the possbility to identify the Bundle path as well.
