### PR TITLE
Fix bitshfits in the OS constants after the removal of OS_WIN95 and OS_WIN98

### DIFF
--- a/platform/o.n.swing.tabcontrol/beanstubs/org/openide/util/Utilities.java
+++ b/platform/o.n.swing.tabcontrol/beanstubs/org/openide/util/Utilities.java
@@ -57,7 +57,7 @@ public final class Utilities {
     /** Operating system is Windows NT. */
     public static final int OS_WINNT = 1 << 0;
     /** Operating system is Solaris. */
-    public static final int OS_SOLARIS = OS_WINNT << 1;
+    public static final int OS_SOLARIS = OS_WINNT << 3;
     /** Operating system is Linux. */
     public static final int OS_LINUX = OS_SOLARIS << 1;
     /** Operating system is HP-UX. */

--- a/platform/openide.util/src/org/openide/util/BaseUtilities.java
+++ b/platform/openide.util/src/org/openide/util/BaseUtilities.java
@@ -60,7 +60,7 @@ public abstract class BaseUtilities {
     public static final int OS_WINNT = 1/* << 0*/;
 
     /** Operating system is Solaris. */
-    public static final int OS_SOLARIS = OS_WINNT << 1;
+    public static final int OS_SOLARIS = OS_WINNT << 3;
 
     /** Operating system is Linux. */
     public static final int OS_LINUX = OS_SOLARIS << 1;


### PR DESCRIPTION
This PR restores the bit assignment to the OS constants before #4025 