### PR TITLE
Initial implementation of (experimental) Dependency API in Gradle

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
@@ -41,7 +41,7 @@ import org.openide.util.RequestProcessor;
  */
 @ProjectServiceProvider(service = ProjectVulnerability.class, projectTypes = {
     @ProjectType(id = "org-netbeans-modules-maven"),
-    @ProjectType(id = "org.netbeans.modules-gradle")
+    @ProjectType(id = "org-netbeans-modules-gradle")
 })
 public final class ProjectVulnerability {
     private final RequestProcessor AUDIT_PROCESSOR = new RequestProcessor(ProjectVulnerability.class);

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -166,10 +166,11 @@ public class VulnerabilityWorker implements ErrorProvider{
         
         private void buildDependecyMap(Dependency dependency, Map<String, Dependency> result) {
             String gav = createGAV(dependency.getArtifact());
-            result.putIfAbsent(gav, dependency);
-            dependency.getChildren().forEach((childDependency) -> {
-                buildDependecyMap(childDependency, result);
-            });
+            if (result.putIfAbsent(gav, dependency) == null) {
+                dependency.getChildren().forEach((childDependency) -> {
+                    buildDependecyMap(childDependency, result);
+                });
+            }
         }
         
         public Set<FileObject> getProblematicFiles() {

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -51,6 +51,7 @@ import java.util.logging.Logger;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.editor.mimelookup.MimeRegistrations;
 import org.netbeans.api.lsp.Diagnostic;
 import org.netbeans.api.progress.ProgressHandle;
 import org.netbeans.api.project.Project;
@@ -97,7 +98,11 @@ import org.openide.util.RequestProcessor;
             + "  Caused by dependence: %s"
 })
  
-@MimeRegistration(mimeType = "text/x-maven-pom+xml", service = ErrorProvider.class)
+@MimeRegistrations({
+    @MimeRegistration(mimeType = "text/x-maven-pom+xml", service = ErrorProvider.class),
+    @MimeRegistration(mimeType = "text/x-gradle+x-groovy", service = ErrorProvider.class)  
+})
+
 public class VulnerabilityWorker implements ErrorProvider{
     private static final RequestProcessor SOURCE_REFRESH_PROCESSOR = new RequestProcessor(VulnerabilityWorker.class.getName());
     
@@ -161,7 +166,7 @@ public class VulnerabilityWorker implements ErrorProvider{
         
         private void buildDependecyMap(Dependency dependency, Map<String, Dependency> result) {
             String gav = createGAV(dependency.getArtifact());
-            result.put(gav, dependency);
+            result.putIfAbsent(gav, dependency);
             dependency.getChildren().forEach((childDependency) -> {
                 buildDependecyMap(childDependency, result);
             });
@@ -382,7 +387,7 @@ public class VulnerabilityWorker implements ErrorProvider{
             ProgressHandle progressHandle, boolean forceAudit) {
         DependencyResult dr = ProjectDependencies.findDependencies(project, ProjectDependencies.newQuery(Scopes.RUNTIME));
         List<ApplicationDependency> result = new ArrayList();
-        convert(dr.getRoot(), 0, result);
+        convert(dr.getRoot(), new HashMap<>(), result);
         
         CacheItem cacheItem;
         VulnerabilityReport savedAudit = null;
@@ -493,18 +498,25 @@ public class VulnerabilityWorker implements ErrorProvider{
         return vs != null ? vs.getProjectKnowledgeBase() : null;
     }
     
-    private int convert(Dependency dependency, int counter, List<ApplicationDependency> result) {
+    private int convert(Dependency dependency, Map<String, Integer> gavIndex, List<ApplicationDependency> result) {
+        String gav = createGAV(dependency.getArtifact());
+        Integer n = gavIndex.get(gav);
+        if (n != null) {
+            return n;
+        }
+        gavIndex.put(gav, n = gavIndex.size() + 1);
         ApplicationDependency.Builder builder = ApplicationDependency.builder();
-        builder.gav(createGAV(dependency.getArtifact()));
+        builder.gav(gav);
+        builder.nodeId(Integer.toString(n));
+        
         List<String> childrenNodeIds = new ArrayList(dependency.getChildren().size());
         for (Dependency childDependency : dependency.getChildren()) {
-            counter = convert(childDependency, counter, result);
-            childrenNodeIds.add(Integer.toString(counter));
+            int cid = convert(childDependency, gavIndex, result);
+            childrenNodeIds.add(Integer.toString(cid));
         }
         builder.applicationDependencyNodeIds(childrenNodeIds);
-        builder.nodeId(Integer.toString(++counter));
         result.add(builder.build());
-        return counter;
+        return n;
     }
 
     private static String createGAV(ArtifactSpec artifact) {

--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,20 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="configuration-dependencies">
+            <api name="general"/>
+            <summary>Allow to inspect dependency tree</summary>
+            <version major="2" minor="27"/>
+            <date day="12" month="8" year="2022"/>
+            <author login="sdedic"/>
+            <compatibility semantic="compatible" addition="yes"/>
+            <description>
+                Gradle APIs allow to list dependencies as a flat list, mixing the 4th+ party dependencies in. The API extension allows
+                to inspect the dependency structure and determine what configuration the dependency originates from.
+            </description>
+            <class package="org.netbeans.modules.gradle.api" name="GradleBaseProject"/>
+            <class package="org.netbeans.modules.gradle.api" name="GradleConfiguration"/>
+        </change>
         <change id="gradlefiles-versioncatalog">
             <api name="general"/>
             <summary>GradleFiles.Kind.VERSION_CATALOG introduced</summary>

--- a/extide/gradle/manifest.mf
+++ b/extide/gradle/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gradle/2
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.26
+OpenIDE-Module-Specification-Version: 2.27

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
@@ -229,7 +229,7 @@ public final class GradleBaseProject implements Serializable, ModuleSearchSuppor
             String n = getName();
             String g = getGroup();
             String v = getVersion();
-            if (n == null || "".equals(n) || g == null || "".equals(g) || v == null || "".equals(v) || "unspecified".equals(v)) {  // NOI18N
+            if (n == null || n.isEmpty() || g == null || g.isEmpty() || v == null || v.isEmpty() || "unspecified".equals(v)) {  // NOI18N
                 return null;
             }
             return String.format("%s:%s:%s", g, n, v);

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
@@ -116,6 +116,10 @@ public final class GradleBaseProject implements Serializable, ModuleSearchSuppor
     public String getDisplayName() {
         return displayName;
     }
+    
+    public boolean isVersionSpecified() {
+        return version != null && !"".equals(version) && !"unspecified".equals(version); // NOI18N
+    }
 
     public String getVersion() {
         return version;
@@ -213,13 +217,23 @@ public final class GradleBaseProject implements Serializable, ModuleSearchSuppor
     /**
      * Finds a GAV for the given project. Returns {@code null} if the project path
      * is not known (it is not referenced anywhere by this project), or has no known
-     * GAV. The project's own GAV should be always present.
+     * GAV. The project's own GAV should be always present, if defined by the project 
+     * file(s).
      * 
      * @param projectPath Gradle project path
      * @return GAV coordinates, or {@code null}
      * @since 2.27
      */
     public String findProjectGav(@NonNull String projectPath) {
+        if ("".equals(projectPath) || getPath().equals(projectPath)) {
+            String n = getName();
+            String g = getGroup();
+            String v = getVersion();
+            if (n == null || "".equals(n) || g == null || "".equals(g) || v == null || "".equals(v) || "unspecified".equals(v)) {  // NOI18N
+                return null;
+            }
+            return String.format("%s:%s:%s", g, n, v);
+        }
         return projectIds.get(projectPath);
     }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
@@ -53,7 +53,7 @@ public final class GradleBaseProject implements Serializable, ModuleSearchSuppor
     String name;
     String group = "";
     String description;
-    String version = "";
+    String version;
     String path;
     String status;
     String parentName;
@@ -335,9 +335,6 @@ public final class GradleBaseProject implements Serializable, ModuleSearchSuppor
      *         {@code null} for non-Gradle projects.
      */
     public static GradleBaseProject get(Project project) {
-        if (project == null) {
-            return null;
-        }
         NbGradleProject gp = NbGradleProject.get(project);
         return gp != null ? gp.projectLookup(GradleBaseProject.class) : null;
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleConfiguration.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleConfiguration.java
@@ -20,9 +20,12 @@
 package org.netbeans.modules.gradle.api;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.ArrayDeque;
+import java.util.Queue;
 import java.util.Set;
 import org.netbeans.modules.gradle.GradleModuleFileCache21;
 
@@ -40,6 +43,9 @@ public final class GradleConfiguration implements Serializable, ModuleSearchSupp
     Set<GradleDependency.UnresolvedDependency> unresolved = Collections.emptySet();
     Set<GradleConfiguration> extendsFrom = Collections.emptySet();
     GradleDependency.FileCollectionDependency files;
+    Map<GradleDependency, Collection<GradleDependency>> dependencyMap = Collections.emptyMap();
+    Set<GradleDependency> directChildren = Collections.emptySet();
+    
     boolean transitive;
     boolean canBeResolved = true;
     boolean canBeConsumed;
@@ -71,6 +77,81 @@ public final class GradleConfiguration implements Serializable, ModuleSearchSupp
 
     public Set<GradleConfiguration> getExtendsFrom() {
         return extendsFrom;
+    }
+    
+    /**
+     * Returns set of dependencies configured for this configuration directly. Other
+     * (direct) dependencies may be supplied by {@link #getExtendsFrom()} configurations.
+     * @return direct dependencies
+     */
+    public Collection<? extends GradleDependency> getConfiguredDependencies() {
+        return directChildren;
+    }
+    
+    /**
+     * Determines the origin of a given dependency. This works only for direct
+     * dependencies (see {@link #getDependencies()} - as a dependency can be present
+     * more than once in a dependency tree graph introduced by different intermediates in
+     * different configurations.
+     * <p>
+     * The method retuns {@code null} if the origin cannot be determined.
+     * 
+     * @param d dependency to inspect
+     * @return configuration of origin or {@code null}.
+     */
+    public GradleConfiguration getDependencyOrigin(GradleDependency d) {
+        if (!getDependencies().contains(d)) {
+            return null;
+        }
+        // TODO: possibly create a dependency-to-config cache in this instance to speed up further queries
+        Set<GradleConfiguration> done = new HashSet<>();
+        Queue<GradleConfiguration> toProcess = new ArrayDeque<>(getExtendsFrom());
+        
+        GradleConfiguration conf;
+        while ((conf = toProcess.poll()) != null) {
+            if (!done.add(conf)) {
+                continue;
+            }
+            toProcess.addAll(conf.getExtendsFrom());
+            if (conf.getConfiguredDependencies().contains(d)) {
+                return conf;
+            }
+            if (!conf.isCanBeResolved()) {
+                // unresolvable configurations (just buckets for dependencies) have unresolved dependencies,
+                // that may lack version; compare the base g:a: against the id.
+                String fullId = d.getId();
+                String partialId;
+                
+                if (d instanceof GradleDependency.ModuleDependency) {
+                    GradleDependency.ModuleDependency md = (GradleDependency.ModuleDependency)d;
+                    partialId = String.format("%s:%s:", md.getGroup(), md.getName());
+                } else {
+                    try {
+                        String[] split = GradleModuleFileCache21.gavSplit(fullId);
+                        partialId = String.format("%s:%s:", split[0], split[1]);
+                    } catch (IllegalArgumentException ex) {
+                        continue; // next configuration
+                    }
+                }
+                for (GradleDependency x : conf.getConfiguredDependencies()) {
+                    if (x instanceof GradleDependency.UnresolvedDependency) {
+                        if (x.getId().equals(fullId) || x.getId().equals(partialId)) {
+                            return conf;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+    
+    public Collection<GradleDependency> getDependencies() {
+        return dependencyMap.getOrDefault(SELF_DEPENDENCY, Collections.emptySet());
+    }
+    
+    public Collection<GradleDependency> getDependenciesOf(GradleDependency... path) {
+        GradleDependency parent = path == null || path.length == 0 ? SELF_DEPENDENCY : path[path.length - 1];
+        return dependencyMap.get(parent);
     }
 
     @Override
@@ -171,5 +252,11 @@ public final class GradleConfiguration implements Serializable, ModuleSearchSupp
                 + extendsFrom + ", files=" + files + ", transitive=" + transitive + '}';
     }
 
+    static final GradleDependency SELF_DEPENDENCY = new GradleDependency("") {
+        @Override
+        public Type getType() {
+            return Type.PROJECT;
+        }
+    };
 
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleDependency.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleDependency.java
@@ -237,6 +237,30 @@ public abstract class GradleDependency implements Serializable, Comparable<Gradl
         public Set<File> getFiles() {
             return files;
         }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash = 73 * hash + Objects.hashCode(this.files);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final FileCollectionDependency other = (FileCollectionDependency) obj;
+            return Objects.equals(this.files, other.files);
+        }
+
+
     }
 
     /**

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ArtifactSpec.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ArtifactSpec.java
@@ -183,7 +183,7 @@ public final class ArtifactSpec<T> {
     }
     
     public static <V> ArtifactSpec<V> createVersionSpec(
-            @NonNull String groupId, @NonNull String artifactId, 
+            @NullAllowed String groupId, @NonNull String artifactId, 
             @NullAllowed String type, @NullAllowed String classifier, 
             @NonNull String versionSpec, boolean optional, @NullAllowed FileObject localFile, @NonNull V data) {
         return new ArtifactSpec<V>(VersionKind.REGULAR, groupId, artifactId, versionSpec, type, classifier, optional, localFile, data);

--- a/java/gradle.java/manifest.mf
+++ b/java/gradle.java/manifest.mf
@@ -3,4 +3,3 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gradle.java
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/java/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/java/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.20

--- a/java/gradle.java/nbproject/project.properties
+++ b/java/gradle.java/nbproject/project.properties
@@ -25,3 +25,5 @@ javadoc.apichanges=${basedir}/apichanges.xml
 test-unit-sys-prop.test.netbeans.dest.dir=${netbeans.dest.dir}
 test-unit-sys-prop.java.awt.headless=true
 test.use.jdk.javac=true
+spec.version.base=1.19.0
+

--- a/java/gradle.java/nbproject/project.xml
+++ b/java/gradle.java/nbproject/project.xml
@@ -324,6 +324,7 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.gradle</code-name-base>
+                        <recursive/>
                         <compile-dependency/>
                         <test/>
                     </test-dependency>
@@ -334,10 +335,12 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
+                        <recursive/>
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.projectui</code-name-base>
+                        <recursive/>
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
@@ -368,6 +371,10 @@
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.java.j2seplatform</code-name-base>
                         <recursive/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.project.dependency</code-name-base>
+                        <compile-dependency/>
                     </test-dependency>
                 </test-type>
             </test-dependencies>

--- a/java/gradle.java/nbproject/project.xml
+++ b/java/gradle.java/nbproject/project.xml
@@ -31,7 +31,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.21</specification-version>
+                        <specification-version>2.27</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -304,6 +304,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>9.4.1</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.project.dependency</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <implementation-version/>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/DependencyText.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/DependencyText.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.queries;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.netbeans.modules.gradle.api.GradleDependency;
+import org.netbeans.modules.project.dependency.Dependency;
+import org.netbeans.modules.project.dependency.DependencyResult;
+
+/**
+ * Single dependency information.
+ */
+class DependencyText {
+
+    /**
+     * True if the dependency is a single statement, false if declared in
+     * a container block.
+     */
+    boolean single;
+    /**
+     * Container / target configuration name
+     */
+    String configuration;
+    /**
+     * Custom API call or "project" for project dependencies.
+     */
+    String keyword;
+    boolean custom;
+    /**
+     * Starting position of this dependency. For {@link #single single=true}, the start
+     * of the configuration name. Otherwise the first character of the string or
+     * first char of the map key identifier.
+     */
+    int startPos;
+    /**
+     * End position, exclusive. After last quote, parenthesis.
+     */
+    int endPos;
+    /**
+     * If the dependency is defined as a map or sequence of Strings, contains
+     * individual parts.
+     */
+    List<Part> partList = new ArrayList<>();
+    
+    /**
+     * Textual contents of the dependency, if defined as a simple String. May be
+     * computed from parts.
+     */
+    String contents;
+    
+    /**
+     * GAV coordinates for dependency matching. In the future, the variable references may be
+     * interpolated to their values.
+     */
+    String group;
+    String name;
+    String version;
+
+    public DependencyText(String container, int startPos) {
+        this.configuration = container;
+        this.startPos = startPos;
+    }
+    
+    public String getProjectPath() {
+        return KEYWORD_PROJECT.equals(keyword) ? contents : null;
+    }
+    static final String KEYWORD_PROJECT = "project";
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{").append(configuration).append(" += ");
+        if (keyword != null) {
+            sb.append(keyword).append("(");
+            if (!partList.isEmpty()) {
+                sb.append(partList.stream().map(p -> p.value).collect(Collectors.joining(", ")));
+            } else if (contents != null) {
+                sb.append(contents);
+            }
+            sb.append(")");
+        } else {
+            if (contents != null) {
+                sb.append(contents);
+            } else {
+                sb.append(partList.stream().map(p -> p.toString()).collect(Collectors.joining(", ")));
+            }
+        }
+        sb.append(" [").append(startPos).append(", ").append(endPos).append("]}");
+        return sb.toString();
+    }
+
+    /**
+     * Dependency part information
+     */
+    static final class Part {
+
+        /**
+         * Id of the part
+         */
+        String partId;
+        /**
+         * Starting position. If the part is in form key: value, the first character of the key.
+         */
+        int startPos;
+        /**
+         * Part value, interpreted
+         */
+        String value;
+        /**
+         * Ending position, exclusive.
+         */
+        int endPos;
+        /**
+         * True, if the part is quoted.
+         */
+        int quoted;
+
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            if (partId != null) {
+                sb.append(partId).append(": ");
+            }
+            sb.append(value);
+            sb.append(" [").append(startPos).append(", ").append(endPos).append("]");
+            return sb.toString();
+        }
+    }
+    
+    
+    final static class Mapping {
+        private final Map<Dependency, DependencyText> textMapping;
+        private final DependencyText.Part container;
+
+        public Mapping(Map<Dependency, DependencyText> textMapping, Part container) {
+            this.textMapping = textMapping;
+            this.container = container;
+        }
+
+        public DependencyText.Part getText(Dependency d, String part) {
+            if (DependencyResult.PART_CONTAINER.equals(part)) {
+                return container;
+            }
+            DependencyText t = textMapping.get(d);
+            if (t == null) {
+                return null;
+            }
+            if (part == null) {
+                DependencyText.Part p = new DependencyText.Part();
+                p.startPos = t.startPos;
+                p.endPos = t.endPos;
+                p.value = t.contents;
+                return p;
+            }
+            for (DependencyText.Part p : t.partList) {
+                if (part.equals(p.partId)) {
+                    return p;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementation.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementation.java
@@ -214,7 +214,8 @@ public class GradleDependenciesImplementation implements ProjectDependenciesImpl
             if (gav != null) {
                 String[] split = gavSplit(gav);
                 if (split != null) {
-                    boolean snap = split[2].toLowerCase().contains("snapshot-");
+                    String v = split.length > 2 ? split[2] : null;
+                    boolean snap = v == null || v.toLowerCase().contains("snapshot-"); // NOI18N
                     spec = snap ? 
                             ArtifactSpec.createSnapshotSpec(split[0], split[1], null, null, split[2], false, null, info) :
                             ArtifactSpec.createVersionSpec(split[0], split[1], null, null, split[2], false, null, info);

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementation.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementation.java
@@ -203,7 +203,7 @@ public class GradleDependenciesImplementation implements ProjectDependenciesImpl
             ArtifactSpec part = createProjectArtifact(null, base.getPath(), rootDeps);
             ProjectSpec pspec = ProjectSpec.create(base.getPath(), pf);
             
-            Dependency root = Dependency.create(pspec, part, null, rootDeps, null);
+            Dependency root = Dependency.create(pspec, part, null, rootDeps, project);
             
             return new GradleDependencyResult(project, root);
         }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementation.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementation.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.queries;
+
+import java.io.File;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.api.GradleConfiguration;
+import org.netbeans.modules.gradle.api.GradleDependency;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.netbeans.modules.project.dependency.Dependency;
+import org.netbeans.modules.project.dependency.DependencyResult;
+import org.netbeans.modules.project.dependency.ProjectDependencies;
+import org.netbeans.modules.project.dependency.ProjectOperationException;
+import org.netbeans.modules.project.dependency.ProjectSpec;
+import org.netbeans.modules.project.dependency.Scope;
+import org.netbeans.modules.project.dependency.Scopes;
+import org.netbeans.modules.project.dependency.spi.ProjectDependenciesImplementation;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.NbBundle;
+
+/**
+ *
+ * @author sdedic
+ */
+@ProjectServiceProvider(service = ProjectDependenciesImplementation.class, projectType=NbGradleProject.GRADLE_PROJECT_TYPE)
+public class GradleDependenciesImplementation implements ProjectDependenciesImplementation {
+    private final Project project;
+    private final NbGradleProject nbgp;
+    
+    private static final Set<Scope> SCOPES = new HashSet<>();
+
+    public GradleDependenciesImplementation(Project project) {
+        this.project = project;
+        nbgp = NbGradleProject.get(project);
+    }
+    
+    static {
+        SCOPES.add(Scopes.PROCESS);
+        SCOPES.add(Scopes.COMPILE);
+        SCOPES.add(Scopes.RUNTIME);
+        SCOPES.add(Scopes.EXTERNAL);
+        SCOPES.add(Scopes.TEST);
+        SCOPES.add(Scopes.TEST_COMPILE);
+        SCOPES.add(Scopes.TEST_RUNTIME);
+    }
+    
+    static final Map<Scope, String> SCOPE_TO_CONFIURATION = new HashMap<>();
+    
+    static {
+        SCOPE_TO_CONFIURATION.put(Scopes.PROCESS, "annotationProcessor");
+        SCOPE_TO_CONFIURATION.put(Scopes.COMPILE, "compileClasspath");
+        SCOPE_TO_CONFIURATION.put(Scopes.RUNTIME, "runtimeClasspath");
+        SCOPE_TO_CONFIURATION.put(Scopes.TEST_COMPILE, "testCompileClasspath");
+        SCOPE_TO_CONFIURATION.put(Scopes.TEST_RUNTIME, "testRuntimeClasspath");
+    }
+
+    @NbBundle.Messages({
+        "DESC_ObtainDependencies=Collect dependencies",
+        "ERR_DependenciesCancelled=Cancelled",
+        "# {0} - error message",
+        "ERR_Unexpected=Unexpected error: {0}"
+    })
+    @Override
+    public DependencyResult findDependencies(ProjectDependencies.DependencyQuery query) throws ProjectOperationException {
+        CompletableFuture<DependencyResult> result = new CompletableFuture<>();
+        
+        nbgp.toQuality(Bundle.DESC_ObtainDependencies(), query.isOffline() ? NbGradleProject.Quality.FULL : NbGradleProject.Quality.FULL_ONLINE, query.isFlushChaches()).thenApply(p -> {
+            DependencyResult dr = new Collector(query).processDependencies(nbgp);
+            result.complete(dr);
+            return null;
+        });
+        try {
+            return result.get();
+        } catch (InterruptedException ex) {
+            throw new ProjectOperationException(project, ProjectOperationException.State.OK, Bundle.ERR_DependenciesCancelled(), ex);
+        } catch (ExecutionException ex) {
+            Throwable t = ex.getCause();
+            if (t instanceof ProjectOperationException) {
+                throw (ProjectOperationException)t;
+            } else {
+                throw new ProjectOperationException(project, ProjectOperationException.State.ERROR, Bundle.ERR_Unexpected(ex.getLocalizedMessage()), t);
+            }
+        }
+    }
+
+    // Interim, will vanish after PR#4495 merges
+    @Override
+    public ArtifactSpec getProjectArtifact() {
+        return null;
+    }
+    
+    @NbBundle.Messages({
+        "# {0} - project directory path",
+        "ERR_NoProjectDirectory=Unable to find project directory: {0}"
+    })
+    class Collector {
+        final ProjectDependencies.DependencyQuery query;
+        final GradleBaseProject base;
+        GradleConfiguration cfg;
+        Scope scope;
+        List<Dependency> problems = new ArrayList<>();
+        
+        /**
+         * Marks files in file2FileObject without a FileObject.
+         */
+        final FileObject marker = FileUtil.getConfigRoot();
+
+        /**
+         * Fast cache: there may be many replicas of an artifact (and its file) in the tree,
+         * and official FileUtil.toFileObject() goes through File > URI > URL > URMapper transitions.
+         */
+        final Map<File, FileObject> file2FileObject = new HashMap<>();
+        
+        public Collector(ProjectDependencies.DependencyQuery query) {
+            this.query = query;
+            base = GradleBaseProject.get(project);
+        }
+        
+        DependencyResult processDependencies(NbGradleProject nbgp) {
+            GradleBaseProject base =  GradleBaseProject.get(project);
+            Collection<Scope> scopes = query.getScopes();
+            
+            ArrayDeque<Scope> processScopes = new ArrayDeque<>(scopes);
+            Set<Scope> allScopes = new HashSet<>(scopes);
+            allScopes.retainAll(SCOPE_TO_CONFIURATION.keySet());
+            processScopes.removeAll(allScopes);
+            
+            // process unknown scopes
+            while (!processScopes.isEmpty()) {
+                Scope s = processScopes.poll();
+                Set<Scope> newScopes = new HashSet<>();
+                newScopes.add(s);
+                for (Scope t : SCOPES) {
+                    if (s.includes(t)) {
+                        newScopes.add(t);
+                    } else if (t.implies(s)) {
+                        newScopes.add(t);
+                    }
+                }
+                newScopes.removeAll(allScopes);
+                allScopes.addAll(newScopes);
+                processScopes.addAll(newScopes);
+            }
+            
+            List<Dependency> rootDeps = new ArrayList<>();
+            for (Scope s : allScopes) {
+                String cfgName = SCOPE_TO_CONFIURATION.get(s);
+                if (cfgName == null) {
+                    continue;
+                }
+                GradleConfiguration cfg = base.getConfigurations().get(cfgName);
+                if (cfg == null) {
+                    continue;
+                }
+                
+                this.scope = s;
+                
+                for (GradleDependency dep : cfg.getDependencies()) {
+                    this.cfg = cfg.getDependencyOrigin(dep);
+                    List<Dependency> ch = processLevel(cfg, dep, new HashSet<>());
+                    Dependency n = createDependency(dep, ch);
+                    rootDeps.add(n);
+                }
+            }
+            
+            File f = nbgp.getGradleFiles().getProjectDir();
+            FileObject pf = f == null ? null : FileUtil.toFileObject(f);
+            if (pf == null) {
+                throw new ProjectOperationException(project, ProjectOperationException.State.ERROR, Bundle.ERR_NoProjectDirectory(f));
+            }
+            ArtifactSpec part = createProjectArtifact(null, base.getPath(), rootDeps);
+            ProjectSpec pspec = ProjectSpec.create(base.getPath(), pf);
+            
+            Dependency root = Dependency.create(pspec, part, null, rootDeps, null);
+            
+            return new GradleDependencyResult(project, root);
+        }
+        
+        ArtifactSpec createProjectArtifact(GradleDependencyResult.Info info, String projectId, List<Dependency> children) {
+            ArtifactSpec spec = null;
+            String gav = base.findProjectGav(projectId);
+            if (gav != null) {
+                String[] split = gavSplit(gav);
+                if (split != null) {
+                    boolean snap = split[2].toLowerCase().contains("snapshot-");
+                    spec = snap ? 
+                            ArtifactSpec.createSnapshotSpec(split[0], split[1], null, null, split[2], false, null, info) :
+                            ArtifactSpec.createVersionSpec(split[0], split[1], null, null, split[2], false, null, info);
+                }
+            }
+            if (spec == null) {
+                if (children != null && !children.isEmpty()) {
+                    spec = ArtifactSpec.createVersionSpec(null, projectId, null, null, null, false, null, info);
+                    Dependency ret = Dependency.create(spec, scope, children, info);
+                    if (info != null && info.gradleDependency != null) {
+                        problems.add(ret);
+                    }
+                }
+            }
+            return spec;
+        }
+        
+        Dependency createDependency(GradleDependency dep, List<Dependency> children) {
+            GradleDependencyResult.Info info = new GradleDependencyResult.Info(cfg, dep);
+            if (dep instanceof GradleDependency.UnresolvedDependency) {
+                return null;
+            }            
+            
+            if (dep instanceof GradleDependency.ProjectDependency) {
+                GradleDependency.ProjectDependency pd = (GradleDependency.ProjectDependency)dep;
+                String projectId = pd.getId();
+                File f = pd.getPath();
+                FileObject fo = FileUtil.toFileObject(f);
+                ArtifactSpec spec = null;
+                
+
+                if (fo != null && ProjectManager.getDefault().isProject(fo)) {
+                    ProjectSpec pspec = ProjectSpec.create(projectId, fo);
+                    // will not declare output artifact at, requires some more digging in the configuration.
+                    return Dependency.create(pspec, spec, scope, children, info);
+                }
+            } 
+            if (!(dep instanceof GradleDependency.ModuleDependency)) {
+                if (children != null && !children.isEmpty()) {
+                    ArtifactSpec spec = ArtifactSpec.createVersionSpec(null, dep.getId(), null, null, null, false, null, info);
+                    Dependency ret = Dependency.create(spec, scope, children, info);
+                    problems.add(ret);
+                    return ret;
+                } else {
+                    return null;
+                }
+            }
+            // regular dependency
+            GradleDependency.ModuleDependency md = (GradleDependency.ModuleDependency)dep;
+            boolean snap = md.getVersion().toLowerCase().contains("snapshot-");
+            FileObject file;
+            
+            if (md.getArtifacts().size() == 1) {
+                File f = md.getArtifacts().iterator().next();
+                FileObject cached = file2FileObject.get(f);
+                if (cached == null) {
+                    cached = FileUtil.toFileObject(f);
+                    file2FileObject.put(f, cached != null ? cached : marker);
+                }
+                if (cached == marker) {
+                    cached = null;
+                }
+                file = cached;
+            } else {
+                file = null;
+            }
+            ArtifactSpec spec = snap ?
+                    ArtifactSpec.createSnapshotSpec(md.getGroup(), md.getName(), null, null, md.getVersion(), false, file, dep) :
+                    ArtifactSpec.createVersionSpec(md.getGroup(), md.getName(), null, null, md.getVersion(), false, file, dep);
+            Dependency ret = Dependency.create(spec, scope, children, info);
+            return ret;
+        }
+        
+        List<Dependency> processLevel(GradleConfiguration c, GradleDependency d, Set<GradleDependency> allParents) {
+            Collection<GradleDependency> deps = c.getDependenciesOf(d);
+            if (deps == null) {
+                return Collections.emptyList();
+            }
+            List<Dependency> res = new ArrayList<>();
+            if (!allParents.add(d)) {
+                return res;
+            }
+            for (GradleDependency child : deps) {
+                List<Dependency> grandChildren = processLevel(c, child, allParents);
+                Dependency n = createDependency(child, grandChildren);
+                if (n != null) {
+                    res.add(n);
+                }
+            }
+            allParents.remove(d);
+            return res;
+        }
+    }
+    
+    public static String[] gavSplit(String gav) {
+        // the general GAV format is - <group>:<artifact>:<version/snapshot>[:<classifier>][@extension]
+        int firstColon = gav.indexOf(':'); // NOI18N
+        int versionColon = gav.indexOf(':', firstColon + 1); // NOI18N
+        int versionEnd = versionColon > firstColon ? gav.indexOf(':', versionColon + 1) : -1; // NO18N
+
+        if (firstColon == -1 || versionColon == -1 || firstColon == versionColon) {
+            throw new IllegalArgumentException("Invalid GAV format: '" + gav + "'"); //NOI18N
+        }
+        int end = versionEnd == -1 ? gav.length() : versionEnd;
+
+        return new String[]{
+            gav.substring(0, firstColon),
+            gav.substring(firstColon + 1, versionColon),
+            gav.substring(versionColon + 1, end)
+        };
+    }
+}

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependencyResult.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependencyResult.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.queries;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.api.GradleConfiguration;
+import org.netbeans.modules.gradle.api.GradleDependency;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.netbeans.modules.project.dependency.Dependency;
+import org.netbeans.modules.project.dependency.DependencyResult;
+import org.netbeans.modules.project.dependency.SourceLocation;
+import org.openide.cookies.EditorCookie;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Lookup;
+import org.openide.util.WeakListeners;
+
+/**
+ * Exports dependency information through dependency API
+ * 
+ * @author sdedic
+ */
+public final class GradleDependencyResult implements DependencyResult, PropertyChangeListener {
+    private final NbGradleProject gp;
+    private final Project gradleProject;
+    private final Dependency root;
+    private boolean valid;
+
+    // @GuardedBy(this)
+    PropertyChangeListener wL;
+    // @GuardedBy(this)
+    private List<ChangeListener> listeners;
+    // @GuardedBy(this)
+    private List<ChangeListener> sourceListeners;
+    // @GuardedBy(this)
+    private Collection<ArtifactSpec> problems;
+    // DWs are kept by document
+    private Map<FileObject, DW> documentWatchers = new HashMap<>();
+    
+    private final FileObject projectFile;
+
+    public GradleDependencyResult(Project gradleProject, Dependency root) {
+        this.gradleProject = gradleProject;
+        this.root = root;
+        this.gp = NbGradleProject.get(gradleProject);
+        this.projectFile = FileUtil.toFileObject(gp.getGradleFiles().getBuildScript());
+    }
+    
+    @Override
+    public Project getProject() {
+        return gradleProject;
+    }
+
+    @Override
+    public Dependency getRoot() {
+        return root;
+    }
+
+    @Override
+    public boolean isValid() {
+        return valid;
+    }
+
+    @Override
+    public Collection<ArtifactSpec> getProblemArtifacts() {
+        return Collections.unmodifiableCollection(problems);
+    }
+
+    @Override
+    public void addChangeListener(ChangeListener l) {
+        synchronized (this) {
+            if (listeners == null) {
+                listeners = new ArrayList<>();
+                wL = WeakListeners.propertyChange(this, gradleProject);
+                NbGradleProject.addPropertyChangeListener(gradleProject, wL);
+            }
+            listeners.add(l);
+        }
+    }
+
+    @Override
+    public void removeChangeListener(ChangeListener l) {
+        synchronized (this) {
+            if (listeners == null) {
+                return;
+            }
+            listeners.remove(l);
+            if (listeners.isEmpty()) {
+                listeners = null;
+                NbGradleProject.removePropertyChangeListener(gradleProject, wL);
+            }
+        }
+    }
+    
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (!NbGradleProject.PROP_PROJECT_INFO.equals(evt.getPropertyName())) {
+            return;
+        }
+        List<ChangeListener> ll;
+        synchronized (this) {
+            valid = false;
+            if (listeners == null || listeners.isEmpty()) {
+                return;
+            }
+            ll = new ArrayList<>(listeners);
+        }
+        ChangeEvent e = new ChangeEvent(this);
+        for (ChangeListener l : ll) {
+            l.stateChanged(e);
+        }
+    }
+
+    // @GuardedBy(this)
+    private DependencyText.Mapping  sourceMapping;
+
+    @Override
+    public SourceLocation getDeclarationRange(Dependency d, String part) throws IOException {
+        DependencyText.Mapping  mapping;
+        DependencyText.Part p = null;
+        
+        synchronized (this) {
+            mapping = sourceMapping;
+            if (mapping != null) {
+                return getDeclarationRange0(mapping, d, part);
+            }
+        }
+        
+        GradleBaseProject gbp = GradleBaseProject.get(gradleProject);
+        Collection<String> cfgNames = gbp.getConfigurations().keySet();
+        TextDependencyScanner ts = new TextDependencyScanner().withConfigurations(cfgNames);
+        
+        root.getChildren().forEach(rd -> {
+            Info info = (Info)rd.getProjectData();
+            GradleConfiguration org = info.config.getDependencyOrigin(info.gradleDependency);
+            if (org == null) {
+                org = info.config;
+            }
+            ts.addDependencyOrigin(info.gradleDependency, org.getName());
+        });
+        
+        String contents = null;
+        EditorCookie cake = projectFile.getLookup().lookup(EditorCookie.class);
+        if (cake != null) {
+            Document doc = cake.getDocument();
+            if (doc != null) {
+                String[] docContent = new String[1];
+                doc.render(() -> {
+                    try {
+                        docContent[0] = doc.getText(0, doc.getLength());
+                    } catch (BadLocationException ex) {
+                        // ignore
+                    }
+                });
+            }
+        }
+        if (contents == null) {
+            contents = projectFile.asText();
+        }
+        ts.parseDependencyList(contents);
+        
+        mapping = ts.mapDependencies(root.getChildren());
+        
+        synchronized (this) {
+            if (sourceMapping == null) {
+                sourceMapping = mapping;
+            }
+        }
+        return getDeclarationRange0(mapping, d, part);
+    }
+    
+    private SourceLocation getDeclarationRange0(DependencyText.Mapping mapping, Dependency d, String part) {
+        Dependency direct = d;
+        while (direct.getParent() != null && direct.getParent() != root) {
+            direct = direct.getParent();
+        }
+        DependencyText.Part found = mapping.getText(direct, part);
+        if (found == null) {
+            return null;
+        }
+        return partToLocation(direct == d ? null : direct, found);
+    }
+    
+    private SourceLocation partToLocation(Dependency rootDep, DependencyText.Part p) {
+        return new SourceLocation(projectFile, p.startPos, p.endPos, rootDep);
+    }
+
+    @Override
+    public Lookup getLookup() {
+        return Lookup.EMPTY;
+    }
+
+    @Override
+    public Collection<FileObject> getDependencyFiles() {
+        FileObject fo = FileUtil.toFileObject(gp.getGradleFiles().getBuildScript());
+        return fo == null ? Collections.emptyList() : Collections.singletonList(fo);
+    }
+    
+    static class Info {
+        final GradleConfiguration config;
+        final GradleDependency gradleDependency;
+
+        public Info(GradleConfiguration config, GradleDependency gradleDependency) {
+            this.config = config;
+            this.gradleDependency = gradleDependency;
+        }
+    }
+
+    class DW implements DocumentListener {
+        final Document doc;
+        final FileObject file;
+
+        public DW(FileObject file, Document doc) {
+            this.file = file;
+            this.doc = doc;
+        }
+        
+        @Override
+        public void insertUpdate(DocumentEvent e) {
+            documentChanged(file);
+        }
+
+        @Override
+        public void removeUpdate(DocumentEvent e) {
+            documentChanged(file);
+        }
+
+        @Override
+        public void changedUpdate(DocumentEvent e) {
+        }
+    }
+    
+    @Override
+    public void addSourceChangeListener(ChangeListener l) {
+        boolean attach = false;
+        synchronized (this) {
+            if (sourceListeners == null) {
+                sourceListeners = new ArrayList<>();
+                attach = true;
+            }
+            sourceListeners.add(l);
+        }
+        if (attach) {
+            FileObject fo = FileUtil.toFileObject(gp.getGradleFiles().getBuildScript());
+            if (fo != null) {
+                addDocumentWatcher(fo);
+            }
+        }
+    }
+
+    @Override
+    public void removeSourceChangeListener(ChangeListener l) {
+        synchronized (this) {
+            if (sourceListeners == null || sourceListeners.isEmpty()) {
+                return;
+            }
+        }
+    }
+
+    private void addDocumentWatcher(FileObject f) {
+        synchronized (this) {
+            if (f == null || documentWatchers.containsKey(f)) {
+                return;
+            }
+        }
+        EditorCookie cake = f.getLookup().lookup(EditorCookie.class);
+        Document doc = null;
+        if (cake != null) {
+            doc = cake.getDocument();
+        }
+        DW dw;
+        synchronized (this) {
+            if (documentWatchers.containsKey(f)) {
+                return;
+            }
+            dw = new DW(f, doc);
+            documentWatchers.put(f, dw);
+        }
+        if (doc != null) {
+            doc.addDocumentListener(WeakListeners.create(DocumentListener.class, dw, doc));
+        }
+    }
+    
+    void documentChanged(FileObject f) {
+        ChangeListener[] ll;
+        synchronized (this) {
+            sourceMapping = null;
+            if (sourceListeners == null || sourceListeners.isEmpty()) {
+                return;
+            }
+            ll = sourceListeners.toArray(new ChangeListener[sourceListeners.size()]);
+        }
+        ChangeEvent e = new ChangeEvent(this);
+        for (ChangeListener l : ll) {
+            l.stateChanged(e);
+        }
+    }
+}

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/TextDependencyScanner.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/TextDependencyScanner.java
@@ -1,0 +1,708 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.queries;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.netbeans.modules.gradle.api.GradleDependency;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.netbeans.modules.project.dependency.Dependency;
+import org.netbeans.modules.project.dependency.DependencyResult;
+import org.netbeans.modules.project.dependency.SourceLocation;
+import org.openide.util.BaseUtilities;
+
+/**
+ *
+ * @author sdedic
+ */
+public class TextDependencyScanner {
+    private Set<String> configurationNames = new HashSet<>();
+    
+    private final Map<GradleDependency, String> origins = new HashMap<>();
+    private final Map<GradleDependency, Map<String, SourceLocation>> locations = new HashMap<>();
+    
+    private List<DependencyText> dependencies = new ArrayList<>();
+    
+    public void addDependencyOrigin(GradleDependency dep, String originConfig) {
+        origins.put(dep, originConfig);
+    }
+    
+    private int lastPos;
+    private int pos;
+    private String contents;
+    
+    public List<DependencyText> getDependencies() {
+        return dependencies;
+    }
+    
+    private enum Token {
+        NONE,
+        LINECOMMENT,
+        BLOCKCOMMENT,
+        QUOTED,
+        IDENTIFIER,
+        SYMBOL,
+        OTHER
+    }
+    
+    /**
+     * The current dependency being built / added to.
+     */
+    private DependencyText dep;
+    
+    /**
+     * Start of the token scanned by {@link #nextToken}
+     */
+    private int tokenStart;
+    
+    /**
+     * Token text scanned by {@link #nextToken}. For quoted Strings, the 
+     * value is unquoted and unescaped.
+     */
+    private String tokenText;
+    
+    /**
+     * Token type of the last token read by {@link #nextToken}.
+     */
+    private Token tokenType;
+    
+    /**
+     * Position of the last newline encountered in the whitespaces preceding
+     * the current position. Will be reset when a non-whitespace character is
+     * read.
+     */
+    int newLinePos;
+    
+    
+    /**
+     * End of the last item in the group
+     */
+    private int groupItemsEnd;
+
+    private void backChar() {
+        pos--;
+        lastPos--;
+    }
+    
+    private int nextChar() {
+        if (pos == contents.length()) {
+            pos++;
+            return -1;
+        }
+        if (pos < contents.length()) {
+            lastPos = pos;
+            char c = contents.charAt(pos++);
+            return c;
+        } else {
+            throw new EndInputException();
+        }
+    }
+    
+    
+    private String readQuotedString(int q) {
+        int s = lastPos;
+        int c;
+
+        do {
+            c = nextChar();
+            if (c == '\\') {
+                nextChar();
+            } 
+        } while (c != q);
+        newLinePos = -1;
+        String r = contents.substring(s, lastPos + 1);
+        String[] args = BaseUtilities.parseParameters(r);
+        return args.length == 1 ? args[0] : r;
+    }
+    
+    private int groupStartPos;
+    private int groupItemCount;
+
+    
+    /*
+        dependencies {
+            antContrib files('ant/antcontrib.jar')
+            runtimeOnly group: 'org.springframework', name: 'spring-core', version: '2.5'
+            runtimeOnly 'org.springframework:spring-core:2.5',
+                    'org.springframework:spring-aop:2.5'
+            runtimeOnly(
+                [group: 'org.springframework', name: 'spring-core', version: '2.5'],
+                [group: 'org.springframework', name: 'spring-aop', version: '2.5']
+            )
+            runtimeOnly('org.hibernate:hibernate:3.0.5') {
+                transitive = true
+            }
+            runtimeOnly group: 'org.hibernate', name: 'hibernate', version: '3.0.5', transitive: true
+            runtimeOnly(group: 'org.hibernate', name: 'hibernate', version: '3.0.5') {
+                transitive = true
+            }
+            implementation project(':utils')
+            implementation projects.utils
+            implementation gradleApi()
+            implementation('org.ow2.asm:asm:7.1') {
+                because 'we require a JDK 9 compatible bytecode generator'
+            }
+        }    
+    */
+    
+    /**
+     * Finishes the current dependency, if any; adds the dependency to the result list and
+     * clears the current dependency.
+     */
+    private void finishDependency() {
+        if (dep == null) {
+            return;
+        }
+        groupItemCount++;
+        dependencies.add(dep);
+        dep = null;
+    }
+    private int nextToken() {
+        skipWhitespace();
+        int c = nextChar();
+        if (c == '"' || c == '\'') {
+            tokenText = readQuotedString(c);
+            tokenType = Token.QUOTED;
+            return c;
+        }
+        int s = lastPos;
+        if (Character.isJavaIdentifierStart(c)) {
+            int c2;
+            do {
+                c2 = nextChar();
+            } while (Character.isJavaIdentifierPart(c2));
+            tokenText = contents.substring(s, lastPos);
+            tokenType = Token.IDENTIFIER;
+            tokenStart = s;
+            backChar();
+        } else {
+            tokenType = Token.OTHER;
+        }
+        return c;
+    }
+    
+    private void skipNestedBlock(int brace) {
+        int c;
+        
+        while ((c = nextToken()) != -1) {
+            if (tokenType != Token.OTHER) {
+                continue;
+            }
+            switch (c) {
+                case '{':
+                    skipNestedBlock('}');
+                    break;
+                case '(':
+                    skipNestedBlock(')');
+                    break;
+                case '[':
+                    skipNestedBlock(']');
+                    break;
+                default:
+                    if (c == brace) {
+                        newLinePos = -1;
+                        return;
+                    }
+                    break;
+            }
+        }
+    }
+    
+    boolean wasEndOfLine() {
+        return newLinePos != -1;
+    }
+    
+    /**
+     * Skips whitespace AND comments. Returns the first non-whitespace character,
+     * but does not advance the position, so that character will be returned from {@link #nextChar}.
+     */
+    private int skipWhitespace() {
+        Token skipMode = Token.NONE;
+        
+        newLinePos = -1;
+        while (pos < contents.length()) {
+            int c = contents.charAt(pos);
+            switch (skipMode) {
+                case LINECOMMENT:
+                    if (c == '\n') {
+                        newLinePos = -1;
+                        skipMode = Token.NONE;
+                        break;
+                    } else {
+                        pos++;
+                        continue;
+                    }
+                case BLOCKCOMMENT:
+                    if (c == '*') {
+                        if (pos + 1 < contents.length()) {
+                            if (contents.charAt(pos + 1) == '/') {
+                                skipMode = Token.NONE;
+                                newLinePos = -1;
+                            }
+                            pos++;
+                        }
+                    }
+                    pos++;
+                    continue;
+            }
+
+            if (c == '/') {
+                if (pos + 1 < contents.length()) {
+                    c = contents.charAt(pos + 1);
+                    if (c == '/') {
+                        // skip until the newline
+                        skipMode = Token.LINECOMMENT;
+                        newLinePos = -1;
+                        pos += 2;
+                        continue;
+                    } else if (c == '*') {
+                        skipMode = Token.BLOCKCOMMENT;
+                        newLinePos = -1;
+                        pos += 2;
+                        continue;
+                    }
+                }
+            }
+            if (!Character.isWhitespace(c)) {
+                return c;
+            }
+            if (c == '\n') {
+                newLinePos = pos;
+            }
+            pos++;
+        }
+        return -1;
+    }
+    
+    private void scanDepdendencyContainer(String container) {
+        int c;
+        int braceLevel = 0;
+        int kPos = -1;
+        int startKpos = -1;
+        String kwd = null;
+        boolean singleStatement = true;
+        boolean continuation = false;
+        DependencyText.Part openPart = null;
+        StringBuilder typedProjects = null;
+        groupItemsEnd = -1;
+        
+        while (true) {
+            if (kPos < 0) {
+                int e = pos;
+                skipWhitespace();
+                if (braceLevel == 0 && singleStatement && !continuation && wasEndOfLine()) {
+                    if (dep != null) {
+                        if (typedProjects != null) {
+                            if (kwd != null) {
+                                typedProjects.append(':').append(kwd);
+                            }
+                            dep.contents = typedProjects.toString();
+                        }
+                        dep.endPos = e;
+                    }
+                    return;
+                }
+                newLinePos = -1;
+            }
+            c = nextChar();
+            
+            if (kPos >= 0) {
+                if (Character.isJavaIdentifierPart(c)) {
+                    newLinePos = -1;
+                    continue;
+                }
+                startKpos = kPos;
+                kwd = contents.substring(kPos, lastPos);
+                kPos = -1;
+                
+                if (openPart != null) {
+                    openPart.value = kwd;
+                    openPart.endPos = lastPos;
+                    openPart = null;
+                    kwd = null;
+                }
+            }
+            
+            if (braceLevel == 0 && singleStatement && !continuation && (c == '\n' || c == ';')) {
+                if (dep != null) {
+                    if (typedProjects != null) {
+                        if (kwd != null) {
+                            typedProjects.append(':').append(kwd);
+                        }
+                        dep.contents = typedProjects.toString();
+                    }
+                    dep.endPos = c == '\n' ? lastPos : pos;
+                }
+                return;
+            }
+
+            if (Character.isJavaIdentifierStart(c)) {
+                kPos = lastPos;
+                continue;
+            }
+            
+            continuation = false;
+            
+            switch (c) {
+                case '.':
+                    if (braceLevel == 0) {
+                        if (dep == null) {
+                            if ("projects".equals(kwd)) {
+                                dep = new DependencyText(container, startKpos);
+                                dep.keyword = "project";
+                                kwd = null;
+                                typedProjects = new StringBuilder();
+                            }
+                        } else if (typedProjects != null) {
+                            typedProjects.append(':').append(kwd);
+                            kwd = null;
+                        }
+                    }
+                    break;
+                case '{':
+                    skipNestedBlock('}');
+                    if (braceLevel == 0) {
+                        groupItemsEnd = pos;
+                        return;
+                    }
+                    break;
+                case '}':
+                    if (braceLevel == 0) {
+                        groupItemsEnd = pos;
+                        return;
+                    }
+                    braceLevel--;
+                    break;
+                    
+                case ',':
+                    if (braceLevel == 0) {
+                        continuation = true;
+                    }
+                    break;
+                    
+                case '(':
+                    if (braceLevel > 0) {
+                        skipNestedBlock(')');
+                        break;
+                    }
+                    // list of dependencies, or arguments
+                    if (kwd != null) {
+                        if (dep == null) {
+                            dep = new DependencyText(container, groupStartPos);
+                        }
+                        dep.keyword = kwd;
+                        kwd = null;
+                    } else if (dep == null) {
+                        singleStatement = false;
+                    }
+                    break;
+                    
+                case ')':
+                    if (braceLevel == 0) {
+                        groupItemsEnd = pos;
+                        singleStatement = true;
+                        int x = skipWhitespace();
+                        if (wasEndOfLine() || x == ';') {
+                            if (dep != null) {
+                                dep.endPos = newLinePos;
+                                return;
+                            }
+                        }
+                        if (x == '{') {
+                            break;
+                        } else {
+                            if (dep != null) {
+                                dep.endPos = groupItemsEnd;
+                            }
+                            return;
+                        }
+                    } 
+                    braceLevel--;
+                    if (braceLevel == 0 && dep != null) {
+                        dep.endPos = pos;
+                        finishDependency();
+                        openPart = null;
+                    }
+                    break;
+                    
+                case '[':
+                    if (braceLevel > 0) {
+                        braceLevel++;
+                        break;
+                    }
+                    // dependency as a Map
+                    dep = new DependencyText(container, lastPos);
+                    break;
+                    
+                case ']':
+                    // end dependency Map
+                    if (braceLevel == 0 && dep != null) {
+                        dep.endPos = pos;
+                        finishDependency();
+                    } else {
+                        braceLevel--;
+                    }
+                    break;
+                    
+                case ':':
+                    if (braceLevel > 0) {
+                        break;
+                    }
+                    // dependency part, keyed
+                    int s;
+                    if (dep == null) {
+                        dep = new DependencyText(container, groupStartPos);
+                        s = startKpos;
+                    } else {
+                        s = startKpos;
+                    }
+                    openPart = new DependencyText.Part();
+                    openPart.startPos = startKpos;
+                    openPart.partId = kwd;
+                    dep.partList.add(openPart);
+                    kwd = null;
+                    break;
+                    
+                case '\'':
+                case '"':
+                    // single String dependency
+                    if (dep == null) {
+                        dep = new DependencyText(container, lastPos);
+                    }
+                    if (braceLevel > 0 && openPart == null) {
+                        openPart = new DependencyText.Part();
+                        openPart.startPos = lastPos;
+                        dep.partList.add(openPart);
+                    }
+                    
+                    String qval = readQuotedString(c);
+                    String[] parts = BaseUtilities.parseParameters(qval);
+                    String v = String.join(" ", parts);
+                    if (!v.trim().isEmpty()) {
+                        if (openPart != null) {
+                            openPart.value = v;
+                            openPart.endPos = pos;
+
+                            openPart = null;
+                        } else if (dep != null) {
+                            dep.contents = qval;
+                            dep.endPos = pos;
+                            finishDependency();
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+    
+    private void buildDependencies() {
+        boolean onlyAfterNewline = false;
+        int c;
+        while ((c = nextToken()) != '}') {
+            if ((!onlyAfterNewline || wasEndOfLine()) && (tokenType == Token.IDENTIFIER)) {
+                if (configurationNames.contains(tokenText)) {
+                    groupStartPos = tokenStart;
+                    groupItemCount = 0;
+                    scanDepdendencyContainer(tokenText);
+                    finishDependency();
+                    if (groupItemCount == 1) {
+                        DependencyText last = dependencies.get(dependencies.size() - 1);
+                        last.startPos = groupStartPos;
+                        if (groupItemsEnd != -1) {
+                            last.endPos = groupItemsEnd;
+                        }
+                    }
+                    onlyAfterNewline = false;
+                    continue;
+                } else {
+                    // ignore up to the semicolon or newline
+                    onlyAfterNewline = true;
+                }
+            } else {
+                if (c == ';') {
+                    onlyAfterNewline = false;
+                } else {
+                    skipNestedBlocks(c);
+                }
+            }
+        }
+    }
+    
+    public TextDependencyScanner withConfigurations(Collection<String> configNames) {
+        this.configurationNames.addAll(configNames);
+        return this;
+    }
+    
+    public List<DependencyText> parseDependencyList(String contents) {
+        this.contents = contents;
+        try {
+            findDependencyBlock();
+            buildDependencies();
+            computeGAV();
+        } catch (EndInputException ex) {
+            // no op, just terminate processing
+        }
+        return dependencies;
+    }
+    
+    private void skipNestedBlocks(int c) {
+        switch (c) {
+            case '"': case '\'':
+                readQuotedString(c);
+                break;
+            case '(': 
+                skipNestedBlock(')');
+                break;
+            case '{': 
+                skipNestedBlock('}');
+                break;
+            case '[':
+                skipNestedBlock(']');
+                break;
+        }
+    }
+    
+    private int dependencyBlockStart;
+    private int dependencyBlockEnd;
+    
+    private void findDependencyBlock() {
+        L: for (int i = 0; i < contents.length(); i++) {
+            
+            int c = nextToken();
+            if (tokenType == Token.IDENTIFIER) {
+                if ("dependencies".equals(tokenText)) {
+                    dependencyBlockStart = tokenStart;
+                    c = skipWhitespace();
+                    if (c == '{') {
+                        nextChar();
+                        dependencyBlockEnd = pos;
+                        return;
+                    }
+                }
+            } else if (tokenType != Token.QUOTED) {
+                skipNestedBlocks(c);
+            }
+        }
+    }
+    
+    private void computeGAV() {
+        for (DependencyText text : dependencies) {
+            if (text.contents != null) {
+                String[] split = text.contents.split(":");
+                text.group = split[0];
+                text.name = split[1];
+                if (split.length > 2) {
+                    text.version = split[2];
+                } else {
+                    text.version = "";
+                }
+            } else {
+                for (DependencyText.Part p : text.partList) {
+                    switch (p.partId) {
+                        case "group":
+                            text.group = p.value;
+                            break;
+                        case "name":
+                            text.name = p.value;
+                            break;
+                        case "version":
+                            text.version = p.value;
+                            break;
+                    }
+                }
+                if (text.group == null || text.name == null) {
+                    continue;
+                }
+                StringBuilder sb = new StringBuilder();
+                sb.append(text.group).append(text.name);
+                if (text.version != null) {
+                    sb.append(text.version);
+                } else {
+                    text.version = "";
+                }
+            }
+        }
+    }
+    
+    private DependencyText findDependency(Dependency d) {
+        String projectName = null;
+        String gav = null;
+        String groupAndName = null;
+        if (d.getProject() != null) {
+            projectName = d.getProject().getProjectId();
+        } else {
+            StringBuilder sb = new StringBuilder();
+            ArtifactSpec as = d.getArtifact();
+            if (as == null) {
+                return null;
+            }
+            sb.append(as.getGroupId()).append(":").append(as.getArtifactId());
+            groupAndName = sb.toString();
+            if (as.getVersionSpec() != null) {
+                sb.append(":").append(as.getVersionSpec());
+            }
+            gav = sb.toString();
+        }
+        for (DependencyText t : dependencies) {
+            if (DependencyText.KEYWORD_PROJECT.equals(t.keyword) &&
+                t.contents.equals(projectName)) {
+                return t;
+            } else if (t.keyword == null && t.contents != null && t.contents.equals(gav)) {
+                return t;
+            }
+        }
+        
+        for (DependencyText t : dependencies) {
+            if (t.keyword == null && t.contents != null && t.contents.equals(groupAndName)) {
+                return t;
+            }
+        }
+        
+        return null;
+    }
+    
+    public DependencyText.Mapping mapDependencies(Collection<Dependency> rootDeps) {
+        Map<Dependency, DependencyText> result = new HashMap<>();
+        
+        for (Dependency d : rootDeps) {
+            DependencyText found = findDependency(d);
+            if (found != null) {
+                result.put(d, found);
+            }
+        }
+        
+        DependencyText.Part containerPart = new DependencyText.Part();
+        containerPart.partId = DependencyResult.PART_CONTAINER;
+        containerPart.startPos = dependencyBlockStart;
+        containerPart.endPos = dependencyBlockEnd;
+        containerPart.value = "";
+        
+        return new DependencyText.Mapping(result, containerPart);
+    }
+    
+    /**
+     * End of input reached.
+     */
+    private static final class EndInputException extends RuntimeException {}
+}

--- a/java/gradle.java/test/unit/data/dependencies/micronaut/build.gradle
+++ b/java/gradle.java/test/unit/data/dependencies/micronaut/build.gradle
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("io.micronaut.application") version "3.5.1"
+}
+
+version = "0.1"
+group = "com.example"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    annotationProcessor("io.micronaut:micronaut-http-validation")
+    implementation("io.micronaut:micronaut-http-client")
+    implementation("io.micronaut:micronaut-jackson-databind")
+    implementation("jakarta.annotation:jakarta.annotation-api")
+    runtimeOnly("ch.qos.logback:logback-classic")
+    implementation("io.micronaut:micronaut-validation")
+
+    implementation("org.apache.logging.log4j:log4j-core:2.17.0")
+}
+
+
+application {
+    mainClass.set("com.example.Application")
+}
+java {
+    sourceCompatibility = JavaVersion.toVersion("11")
+    targetCompatibility = JavaVersion.toVersion("11")
+}
+
+graalvmNative.toolchainDetection = false
+micronaut {
+    runtime("netty")
+    testRuntime("junit5")
+    processing {
+        incremental(true)
+        annotations("com.example.*")
+    }
+}
+
+
+println project.group
+println project.name
+println project.version

--- a/java/gradle.java/test/unit/data/dependencies/micronaut/gradle.properties
+++ b/java/gradle.java/test/unit/data/dependencies/micronaut/gradle.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+micronautVersion=3.6.0

--- a/java/gradle.java/test/unit/data/dependencies/micronaut/settings.gradle
+++ b/java/gradle.java/test/unit/data/dependencies/micronaut/settings.gradle
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+rootProject.name="microdemo"
+

--- a/java/gradle.java/test/unit/data/dependencies/micronaut/src/main/java/com/example/Application.java
+++ b/java/gradle.java/test/unit/data/dependencies/micronaut/src/main/java/com/example/Application.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+}

--- a/java/gradle.java/test/unit/data/dependencies/micronaut/src/main/resources/application.yml
+++ b/java/gradle.java/test/unit/data/dependencies/micronaut/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+micronaut:
+  application:
+    name: microdemo
+netty:
+  default:
+    allocator:
+      max-order: 3

--- a/java/gradle.java/test/unit/data/dependencies/micronaut/src/main/resources/logback.xml
+++ b/java/gradle.java/test/unit/data/dependencies/micronaut/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/java/gradle.java/test/unit/data/dependencies/micronaut/src/test/java/com/example/MicrodemoTest.java
+++ b/java/gradle.java/test/unit/data/dependencies/micronaut/src/test/java/com/example/MicrodemoTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import jakarta.inject.Inject;
+
+@MicronautTest
+class MicrodemoTest {
+
+    @Inject
+    EmbeddedApplication<?> application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}

--- a/java/gradle.java/test/unit/data/dependencies/parse/complexPrologue.gradle
+++ b/java/gradle.java/test/unit/data/dependencies/parse/complexPrologue.gradle
@@ -1,0 +1,90 @@
+// This file should contain complex structures to fool the parser before the
+// real dependencies {} block. Collect the most weird things including
+// conditional or scripted dependencies here.
+
+/*
+    Ignored dependency
+    
+    dependencies {
+    }
+
+*/
+plugins {
+    id "io.spring.dependency-management" version "1.0.6.RELEASE"
+    id "com.github.johnrengelman.shadow" version "4.0.2"
+    id "jp.classmethod.aws.lambda" version "0.38"
+    id "groovy"
+    id "application"
+}
+
+repositories {
+    mavenCentral()
+    maven { url "https://jcenter.bintray.com" }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom 'io.micronaut:micronaut-bom:1.1.0'
+    }
+}
+
+configurations {
+    // for dependencies that are needed for development only
+    developmentOnly
+}
+
+test.classpath += configurations.developmentOnly
+shadowJar {
+    transform(com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer)
+}
+tasks.withType(GroovyCompile) {
+    groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
+}
+
+shadowJar {
+    mergeServiceFiles()
+}
+
+run.classpath += configurations.developmentOnly
+run.jvmArgs('-noverify', '-XX:TieredStopAtLevel=1', '-Dcom.sun.management.jmxremote')
+
+mainClassName = "example.HelloWorldFunction"
+applicationDefaultJvmArgs = [""]
+ignoredDeps1 = "dependencies { }"
+ignoredDeps2 = 'dependencies { }'
+
+jar {
+    manifest {
+        attributes 'Main-Class': mainClassName
+    }
+}
+
+if (new File("${System.getProperty("user.home")}/.aws/credentials").exists()) {
+    task deploy(type: jp.classmethod.aws.gradle.lambda.AWSLambdaMigrateFunctionTask, dependsOn: shadowJar) {
+        functionName = "hello-world"
+        handler = "example.HelloWorldFunction::hello"
+        role = "arn:aws:iam::${aws.accountId}:role/lambda_basic_execution"
+        runtime = com.amazonaws.services.lambda.model.Runtime.Java8
+        zipFile = shadowJar.archivePath
+        memorySize = 256
+        timeout = 60
+    }
+
+}
+
+task invoke(type: jp.classmethod.aws.gradle.lambda.AWSLambdaInvokeTask) {
+    functionName = "hello-world"
+    invocationType = com.amazonaws.services.lambda.model.InvocationType.RequestResponse
+    payload = '{"name":"Fred"}'
+    doLast {
+        println "Lambda function result: " + new String(invokeResult.payload.array(), "UTF-8")
+    }
+}
+
+dependencies {
+    runtimeOnly('org.hibernate:hibernate:3.0.5') {
+        transitive = true
+    }
+    runtimeOnly group: 'org.hibernate', name: 'hibernate', version: '3.0.5', transitive: true
+}
+

--- a/java/gradle.java/test/unit/data/dependencies/parse/executableCodeInDependencies.gradle
+++ b/java/gradle.java/test/unit/data/dependencies/parse/executableCodeInDependencies.gradle
@@ -1,0 +1,13 @@
+
+dependencies {
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
+        testImplementation libs.bcpkix  // this should be skipped
+    }
+    whatever = runtimeOnly("ignoredIdentifier") // should be ignored, it's not configuration, but function invocation
+
+    runtimeOnly('org.hibernate:hibernate:3.0.5') {
+        transitive = true
+    }
+    runtimeOnly group: 'org.hibernate', name: 'hibernate', version: '3.0.5', transitive: true
+}
+

--- a/java/gradle.java/test/unit/data/dependencies/parse/simple.gradle
+++ b/java/gradle.java/test/unit/data/dependencies/parse/simple.gradle
@@ -1,0 +1,32 @@
+apply plugin: 'java'
+apply plugin: 'application'
+
+mainClassName = 'test.App'
+
+run {
+    jvmArgs '-Dtest.foo=bar', '-Dtest.bar=foo'
+}
+
+dependencies {
+    antContrib files('ant/antcontrib.jar')
+    @@A@@runtimeOnly group: 'org.springframework', name: 'spring-beans', version: '2.5'@@A@@
+    runtimeOnly @@B@@'org.springframework:spring-core:3.5'@@B@@,
+            @@C@@'org.springframework:spring-aop:3.5'@@C@@
+    runtimeOnly(
+        @@D@@[group: 'org.springframework', name: 'spring-core', version: '2.5']@@D@@,
+        @@E@@[group: 'org.springframework', name: 'spring-aop', version: '2.5']@@E@@
+    )
+    @@F@@runtimeOnly('org.hibernate:hibernate:3.0.3') {
+        transitive = true
+    }@@F@@
+    @@G@@runtimeOnly group: 'org.hibernate', name: 'hibernate', version: '3.0.5', transitive: true@@G@@
+    @@H@@runtimeOnly(group: 'org.hibernate', name: 'hibernate-test', version: '3.0.5') {
+        transitive = true
+    }@@H@@
+    @@I@@implementation project(':utils')@@I@@
+    @@J@@implementation projects.utils@@J@@
+    @@K@@implementation gradleApi()@@K@@
+    @@L@@implementation('org.ow2.asm:asm:7.1') {
+        because 'we require a JDK 9 compatible bytecode generator'
+    }@@L@@
+}    

--- a/java/gradle.java/test/unit/data/dependencies/parse/starter.gradle
+++ b/java/gradle.java/test/unit/data/dependencies/parse/starter.gradle
@@ -1,0 +1,42 @@
+plugins {
+    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("io.micronaut.application") version "3.5.1"
+}
+
+version = "0.1"
+group = "com.example"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    annotationProcessor("io.micronaut:micronaut-http-validation")
+    implementation("io.micronaut:micronaut-http-client")
+    implementation("io.micronaut:micronaut-jackson-databind")
+    implementation("jakarta.annotation:jakarta.annotation-api")
+    runtimeOnly("ch.qos.logback:logback-classic")
+    implementation("io.micronaut:micronaut-validation")
+
+    implementation("org.apache.logging.log4j:log4j-core:2.17.0")
+}
+
+
+application {
+    mainClass.set("com.example.Application")
+}
+java {
+    sourceCompatibility = JavaVersion.toVersion("11")
+    targetCompatibility = JavaVersion.toVersion("11")
+}
+
+graalvmNative.toolchainDetection = false
+micronaut {
+    runtime("netty")
+    testRuntime("junit5")
+    processing {
+        incremental(true)
+        annotations("com.example.*")
+    }
+}
+

--- a/java/gradle.java/test/unit/data/dependencies/simple1/build.gradle
+++ b/java/gradle.java/test/unit/data/dependencies/simple1/build.gradle
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+println project.group
+println project.name
+println project.version

--- a/java/gradle.java/test/unit/data/dependencies/simple2/build.gradle
+++ b/java/gradle.java/test/unit/data/dependencies/simple2/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+group = 'nbtest'
+version = '0.1'
+
+println project.group
+println project.name
+println project.version

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementationTest.java
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementationTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.queries;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import static junit.framework.TestCase.assertNotNull;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.gradle.ProjectTrust;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.netbeans.modules.project.dependency.Dependency;
+import org.netbeans.modules.project.dependency.DependencyResult;
+import org.netbeans.modules.project.dependency.ProjectDependencies;
+import org.netbeans.modules.project.dependency.Scopes;
+import org.netbeans.modules.project.dependency.SourceLocation;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.modules.DummyInstalledFileLocator;
+import org.openide.windows.IOProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+public class GradleDependenciesImplementationTest extends NbTestCase {
+    FileObject projectDir;
+    File destDirF;
+    
+    @org.openide.util.lookup.ServiceProvider(service=org.openide.modules.InstalledFileLocator.class, position = 1000)
+    public static class InstalledFileLocator extends DummyInstalledFileLocator {
+    }
+
+   public GradleDependenciesImplementationTest(String name) {
+        super(name);
+    }
+
+    private static File getTestNBDestDir() {
+        String destDir = System.getProperty("test.netbeans.dest.dir");
+        // set in project.properties as test-unit-sys-prop.test.netbeans.dest.dir
+        assertNotNull("test.netbeans.dest.dir property has to be set when running within binary distribution", destDir);
+        return new File(destDir);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // This is needed, otherwose the core window's startup code will redirect
+        // System.out/err to the IOProvider, and its Trivial implementation will redirect
+        // it back to System.err - loop is formed. Initialize IOProvider first, it gets
+        // the real System.err/out references.
+        IOProvider p = IOProvider.getDefault();
+        System.setProperty("test.reload.sync", "true");
+        
+        destDirF = getTestNBDestDir();
+        clearWorkDir();
+    
+        DummyInstalledFileLocator.registerDestDir(destDirF);
+        GradleExperimentalSettings.getDefault().setOpenLazy(false);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+    
+    private Project makeProject(String subdir) throws Exception {
+        FileObject src = FileUtil.toFileObject(getDataDir()).getFileObject(subdir);
+        projectDir = FileUtil.copyFile(src, FileUtil.toFileObject(getWorkDir()), src.getNameExt());
+        
+        Project p = ProjectManager.getDefault().findProject(projectDir);
+        assertNotNull(p);
+        ProjectTrust.getDefault().trustProject(p);
+        
+        OpenProjects.getDefault().open(new Project[] { p }, true);
+        OpenProjects.getDefault().openProjects().get();
+        
+        NbGradleProject.get(p).toQuality("Load data", NbGradleProject.Quality.FULL, false).toCompletableFuture().get();
+        return p;
+    }
+    
+    public void testSimpleProject() throws Exception {
+        Project p = makeProject("dependencies/simple1");
+        DependencyResult r = ProjectDependencies.findDependencies(p, 
+            ProjectDependencies.newQuery(Scopes.RUNTIME)
+        );
+        assertNotNull("Dependency service is supported", r);
+        
+        assertNull("Project has no group or version, no artifact should be given", r.getRoot().getArtifact());
+        assertNotNull("Project specification must be present", r.getRoot().getProject());
+        assertSame("Project location is reported", projectDir, r.getRoot().getProject().getLocation());
+        assertSame("Project is passed as project data - internal", p, r.getRoot().getProjectData());
+    }
+    
+    public void testSimpleWithGav() throws Exception {
+        Project p = makeProject("dependencies/simple2");
+        DependencyResult r = ProjectDependencies.findDependencies(p, 
+            ProjectDependencies.newQuery(Scopes.RUNTIME)
+        );
+        assertNotNull("Dependency service is supported", r);
+        
+        ArtifactSpec a = r.getRoot().getArtifact();
+        assertNotNull("Project has GAV, should be manifested as artifact", a);
+        GradleBaseProject gbp = GradleBaseProject.get(p);
+        assertEquals(gbp.getName(), a.getArtifactId());
+        assertEquals(gbp.getGroup(), a.getGroupId());
+        assertEquals(gbp.getVersion(), a.getVersionSpec());
+        assertNotNull("Project specification must be present", r.getRoot().getProject());
+        assertSame("Project location is reported", projectDir, r.getRoot().getProject().getLocation());
+        assertSame("Project is passed as project data - internal", p, r.getRoot().getProjectData());
+    }
+    
+    public void testMicronautProject() throws Exception {
+        Project p = makeProject("dependencies/micronaut");
+        DependencyResult r = ProjectDependencies.findDependencies(p, 
+            ProjectDependencies.newQuery(Scopes.RUNTIME)
+        );
+        assertNotNull("Dependency service is supported", r);
+        
+        assertEquals(9, r.getRoot().getChildren().size());
+        Optional<Dependency> dep = r.getRoot().getChildren().stream().filter(d -> d.getArtifact().toString().equals("io.micronaut:micronaut-bom:3.6.0")).findFirst();
+        assertTrue("Plugin - injected dependency should be present", dep.isPresent());
+        
+        SourceLocation srcLoc = r.getDeclarationRange(dep.get(), null);
+        
+        assertNull("Implied dependencies do not have source location(s) - yet!", srcLoc);
+
+        dep = r.getRoot().getChildren().stream().filter(d -> d.getArtifact().toString().equals("org.apache.logging.log4j:log4j-core:2.17.0")).findFirst();
+        assertTrue("Explicit dependency is present", dep.isPresent());
+        
+        srcLoc = r.getDeclarationRange(dep.get(), null);
+        
+        assertNotNull("Explicit dependency should have a location");
+        assertNull("Explicit dependencies are not implied", srcLoc.getImpliedBy());
+        
+        // there are more paths to io.micronaut:micronaut-websocket:3.6.0; some of them are through an explicit dependency,
+        // some through an injected one, micronaut-bom, which does not have any SourceLocation atm.
+        List<Dependency> deps = r.getRoot().getChildren().stream().flatMap(d -> d.getChildren().stream()).filter(d -> 
+                d.getArtifact().toString().equals("io.micronaut:micronaut-websocket:3.6.0")).collect(Collectors.toList());
+        assertFalse("Implied dependency is present", deps.isEmpty());
+        
+        Dependency rd = null;
+        for (Dependency d : deps) {
+            srcLoc = r.getDeclarationRange(d, null);
+            if (srcLoc != null) {
+                assertNotNull("4th party artifact should not have null location", srcLoc);
+                assertNotNull("4th party artifacts should report 'implied'", srcLoc.getImpliedBy());
+                for (rd = d.getParent(); rd.getParent() != r.getRoot(); rd = rd.getParent() ) ;
+                break;
+            }
+        }
+        assertNotNull("Implied dependency should have a root dep", rd);
+        assertSame(rd, srcLoc.getImpliedBy());
+  }
+}

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/queries/RegexpGradleScannerTest.java
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/queries/RegexpGradleScannerTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.queries;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+/**
+ *
+ * @author sdedic
+ */
+public class RegexpGradleScannerTest extends NbTestCase {
+
+    public RegexpGradleScannerTest(String name) {
+        super(name);
+    }
+    
+    
+    /**
+     * Checks various complex constructs in the prologue that should be skipped before dependencies block is identified.
+     * - curly braces (nested)
+     * - parenthesis after an identifier
+     * - valid dependencies block in a block comment
+     * - strings in quotes and doublequotes
+     * @throws Exception 
+     */
+    public void testComplexPrologue() throws Exception {
+        FileObject f = FileUtil.toFileObject(getDataDir()).getFileObject("dependencies/parse/complexPrologue.gradle");
+        TextDependencyScanner scanner = new TextDependencyScanner();
+        
+        scanner.withConfigurations(Arrays.asList(
+            "runtimeOnly", "implementation"
+        ));
+        List<DependencyText> deps = scanner.parseDependencyList(f.asText());
+        assertEquals(2, deps.size());
+        assertTrue(deps.get(0).toString().contains("org.hibernate:hibernate:3.0.5"));
+    }
+    
+    public void testSkipExecutableCodeInDependencies() throws Exception {
+        FileObject f = FileUtil.toFileObject(getDataDir()).getFileObject("dependencies/parse/executableCodeInDependencies.gradle");
+        TextDependencyScanner scanner = new TextDependencyScanner();
+        
+        scanner.withConfigurations(Arrays.asList(
+            "runtimeOnly", "implementation"
+        ));
+        List<DependencyText> deps = scanner.parseDependencyList(f.asText());
+        assertEquals(2, deps.size());
+    }
+    
+    String filteredText;
+    
+    public void testScanSimpleScript() throws Exception {
+        FileObject f = FileUtil.toFileObject(getDataDir()).getFileObject("dependencies/parse/simple.gradle");
+        TextDependencyScanner scanner = new TextDependencyScanner();
+        
+        scanner.withConfigurations(Arrays.asList(
+            "runtimeOnly", "implementation"
+        ));
+        filteredText = filterAndStorePositions(f.asText());
+
+        List<DependencyText> deps = scanner.parseDependencyList(filteredText);
+        assertEquals(12, deps.size());
+        checkDependencyBoundaries(deps);
+    }
+    
+    public void testMicronautStarter() throws Exception {
+        FileObject f = FileUtil.toFileObject(getDataDir()).getFileObject("dependencies/parse/starter.gradle");
+        TextDependencyScanner scanner = new TextDependencyScanner();
+        
+        scanner.withConfigurations(Arrays.asList(
+            "runtimeOnly", "implementation", "annotationProcessor"
+        ));
+        filteredText = filterAndStorePositions(f.asText());
+        List<DependencyText> deps = scanner.parseDependencyList(filteredText);
+        assertEquals(7, deps.size());
+    }
+    
+    private Map<String, Integer> startPosition = new HashMap<>();
+    private Map<String, Integer> endPosition = new HashMap<>();
+    
+    private void checkDependencyBoundaries(List<DependencyText> deps) {
+        int pos = 0;
+        for (DependencyText d : deps) {
+            String key = (char)(pos + 'A') + "";
+            pos++;
+            
+            Integer s = startPosition.get(key);
+            Integer e = endPosition.get(key);
+            if (s == null || e == null) {
+                fail("No positions for " + d);
+            }
+            
+            assertEquals("Invalid start pos for " + d, (int)s, d.startPos);
+            assertEquals("Invalid end pos for " + d, (int)e, d.endPos);
+        }
+    }
+    
+    private String filterAndStorePositions(String code) {
+        Matcher m = Pattern.compile("@@([A-Z])@@").matcher(code);
+        StringBuilder sb = new StringBuilder();
+        int last = 0;
+        
+        while (m.find()) {
+            int s = m.start();
+            sb.append(code.substring(last, s));
+            String id = m.group(1);
+            Integer sp = startPosition.get(id);
+            if (sp == null) {
+                startPosition.put(id, sb.length());
+            } else {
+                endPosition.put(id, sb.length());
+            }
+            last = m.end();
+        }
+        sb.append(code.substring(last));
+        return sb.toString();
+    }
+
+    /*
+    public void testTestScan() throws Exception {
+        FileObject f = FileUtil.toFileObject(getDataDir()).getFileObject("dependencies/parse/test.gradle");
+        TextDependencyScanner scanner = new TextDependencyScanner();
+        
+        scanner.withConfigurations(Arrays.asList(
+            "runtimeOnly", "implementation"
+        ));
+        String text = filterAndStorePositions(f.asText());
+        List<TextDependencyScanner.Dependency> deps = scanner.parseDependencyList(text);
+        assertEquals(6, deps.size());
+    }
+    */
+}

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenDependencyResult.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenDependencyResult.java
@@ -130,19 +130,15 @@ class MavenDependencyResult implements org.netbeans.modules.project.dependency.D
             if (listeners == null) {
                 attach = true;
                 listeners = new ArrayList<>();
+                wL = WeakListeners.propertyChange(this, mavenProject);
+                mavenProject.addPropertyChangeListener(wL);
             }
             listeners.add(l);
         }
-        if (!attach) {
-            return;
-        }
-        wL = WeakListeners.propertyChange(this, mavenProject);
-        mavenProject.addPropertyChangeListener(wL);
     }
 
     @Override
     public void removeChangeListener(ChangeListener l) {
-        boolean detach = false;
         synchronized (this) {
             if (listeners == null) {
                 return;
@@ -150,6 +146,7 @@ class MavenDependencyResult implements org.netbeans.modules.project.dependency.D
             listeners.remove(l);
             if (listeners.isEmpty()) {
                 mavenProject.removePropertyChangeListener(wL);
+                listeners = null;
             }
         }
     }


### PR DESCRIPTION
Dependency tree is exported from Gradle, using *still nonpublic* `project.dependency` API. I admit I need it functioning for the NBLS server, so I propose to go short-term with **implementation** dependency on `project.dependency` module. I plan to stabilize and publish the project.dependency as a regular API in NB16 timeframe with `ProjectArtifactsQuery` that exposes project output artifact(s) for further analysis or processing.  I hope I will be able to adapt Maven Graph module to serve for both Maven and Gradle connecting using the new APIs.

Part of this commit is an adjustment to the OCI enterprise feature so it is able to exploit this new Gradle ability to serve dependency tree. During testing it seems that an initial dependency graph of 100 nodes would explode to 10.000+ nodes when converted to a proper tree, so the Dependency API will receive some tweak to allow implementations to compute the nodes lazily and to indicate to the client that two nodes are truly equivalent. In the meantime, I've changed the ADM feature to send a graph instead of tree - it appears working.

Minor fix to Maven implementation.
