### PR TITLE
org.netbeans.modules.java.hints.bugs.Unused doesn't cancel properly

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.java.hints.bugs;
 
 import com.sun.source.tree.Tree.Kind;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.lang.model.element.ElementKind;
@@ -46,11 +47,18 @@ public class Unused {
 
     @TriggerTreeKind(Kind.COMPILATION_UNIT)
     public static List<ErrorDescription> unused(HintContext ctx) {
-         return UnusedDetector.findUnused(ctx.getInfo(), () -> ctx.isCanceled())
-                             .stream()
-                             .map(ud -> convertUnused(ctx, ud))
-                             .filter(err -> err != null)
-                             .collect(Collectors.toList());
+        List<UnusedDescription> unused = UnusedDetector.findUnused(ctx.getInfo(), () -> ctx.isCanceled());
+        List<ErrorDescription> result = new ArrayList<>(unused.size());
+        for (UnusedDescription ud : unused) {
+            if (ctx.isCanceled()) {
+                break;
+            }
+            ErrorDescription err = convertUnused(ctx, ud);
+            if (err != null) {
+                result.add(err);
+            }
+        }
+        return result;
     }
 
     @Messages({


### PR DESCRIPTION
based on delivery for the slim chance that this gets a review

 - streams are not very good at canceling
 - by using a plain loop we can simply break out of it
 - further: `findUnused` is actually very fast, `convertUnused` is the slow part and wasn't cancelable before, the original code might have worked if `findUnused` returned a stream instead of a list and everything would be one pipeline (this would make the fix more complicated)

issue:

 - a synthetic file with 10k fields pins a thread for about 20s
   at 100%
 - most editor features don't work during that time, e.g completion
 - hint is enabled by default


discussion:

noticed this while benchmarking other issues (#4500)

#3886 mentioned the poor performance of `org.netbeans.modules.java.hints.bugs.Unused` and also that it isn't cancelable.
#4204 attempted to fix some of it, however I am not so sure that this worked.

test:
[FieldsOfJoy10k_Unused_hint.java.txt](https://github.com/apache/netbeans/files/9330547/FieldsOfJoy10k_Unused_hint.java.txt)

scroll down to:
```java
    // hints -> probable bugs -> unused element
    // org.netbeans.modules.java.hints.bugs.Unused#unused
    private void something() {
        this.     // code change triggers hint and pins cpu to 100%,
                  // this blocks completion etc. does cancel work?
    }
```

`Unused#convertUnused `/ `JavaFixUtilities#safelyRemoveFromParent` use most of the time and they were not cancelable.

![unused_element_hint_baseline](https://user-images.githubusercontent.com/114367/184464074-4f512a59-fcef-46b2-802d-246871a97e1a.png)

