### PR TITLE
Adding inline type hint for 'var' variables

### DIFF
--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/SemanticHighlighterBase.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/SemanticHighlighterBase.java
@@ -855,6 +855,13 @@ public abstract class SemanticHighlighterBase extends JavaParserResultTask {
             
             tl.moveNext();
             
+            if (info.getTreeUtilities().isVarType(getCurrentPath())) {
+                int afterName = tl.offset();
+                TypeMirror type = info.getTrees().getTypeMirror(new TreePath(getCurrentPath(), tree.getType()));
+
+                this.preText.put(new int[] {afterName, afterName + 1}, " : " + info.getTypeUtilities().getTypeName(type));
+            }
+
             scan(tree.getInitializer(), p);
             
             return null;

--- a/java/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/DetectorTest.java
+++ b/java/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/DetectorTest.java
@@ -819,6 +819,26 @@ public class DetectorTest extends TestBase {
                     "[UNINDENTED_TEXT_BLOCK], 6:13-6:29");
     }
 
+    public void testVar() throws Exception {
+        setSourceLevel("11");
+        setShowPrependedText(true);
+        performTest("Var",
+                    "public class Var {\n" +
+                    "    private void test(java.util.List<String> l) {\n" +
+                    "        var v1 = l.iterator();\n" +
+                    "    }\n" +
+                    "}\n",
+                    "[PUBLIC, CLASS, DECLARATION], 0:13-0:16",
+                    "[PRIVATE, METHOD, UNUSED, DECLARATION], 1:17-1:21",
+                    "[PUBLIC, INTERFACE], 1:32-1:36",
+                    "[PUBLIC, CLASS], 1:37-1:43",
+                    "[PARAMETER, DECLARATION], 1:45-1:46",
+                    "[LOCAL_VARIABLE, UNUSED, DECLARATION], 2:12-2:14",
+                    "[ : Iterator<String>], 2:14-2:15",
+                    "[PARAMETER], 2:17-2:18",
+                    "[ABSTRACT, PUBLIC, METHOD], 2:19-2:27]");
+    }
+
     private void performTest(String fileName) throws Exception {
         performTest(fileName, new Performer() {
             public void compute(CompilationController parameter, Document doc, final ErrorDescriptionSetter setter) {


### PR DESCRIPTION
Adding inline type hint for 'var' variables:
![var-type](https://user-images.githubusercontent.com/124144/185782318-267e496d-0a6e-48c4-b5f7-5cca03370a18.png)


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

