### PR TITLE
Gradle hide empty generated folders

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.logging.Logger;
 import java.util.prefs.Preferences;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -56,6 +57,8 @@ import org.openide.util.Utilities;
  * @author Laszlo Kishalmi
  */
 public final class NbGradleProject {
+
+    static final Logger LOG = Logger.getLogger(NbGradleProject.class.getName());
 
     /**
      * As loading a Gradle project information into the memory could be a time
@@ -275,6 +278,10 @@ public final class NbGradleProject {
         //Never listen on resource changes when only FALLBACK quality is needed
         if ((project.getAimedQuality() == Quality.FALLBACK) && !elevateQuality) return;
         synchronized (resources) {
+            if (!resources.isEmpty()) {
+                LOG.warning("Gradle ResourceWatcher Leak: " + resources); //NOI18N
+                resources.clear();
+            }
             Collection<? extends WatchedResourceProvider> all
                     = project.getLookup().lookupAll(WatchedResourceProvider.class);
             for (WatchedResourceProvider pvd : all) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDistributionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDistributionProviderImpl.java
@@ -80,7 +80,7 @@ public class GradleDistributionProviderImpl implements GradleDistributionProvide
     public GradleDistributionProviderImpl(Project project) {
         this.project = (NbGradleProjectImpl) project;
         pcl = (evt) -> {
-            if (NbGradleProject.PROP_RESOURCES.endsWith(evt.getPropertyName())) {
+            if (NbGradleProject.PROP_RESOURCES.equals(evt.getPropertyName())) {
                 URI uri = (URI) evt.getNewValue();
                 if ((uri != null) && (uri.getPath() != null) && uri.getPath().endsWith(GradleFiles.WRAPPER_PROPERTIES)) {
                     URI newDistURI = getWrapperDistributionURI();

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
@@ -85,7 +85,7 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
             if (NbGradleProject.PROP_PROJECT_INFO.equals(evt.getPropertyName())) {
                 updateGroups();
             }
-            if (NbGradleProject.PROP_RESOURCES.endsWith(evt.getPropertyName())) {
+            if (NbGradleProject.PROP_RESOURCES.equals(evt.getPropertyName())) {
                 URI uri = (URI) evt.getNewValue();
                 updateResources(uri);
             }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
@@ -37,12 +37,12 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.swing.Icon;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.project.JavaProjectConstants;
-import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.SourceGroup;
@@ -145,6 +145,7 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
 
     private Map<String, GradleJavaSourceSet> gradleSources = Collections.emptyMap();
     private Map<String, Collection<File>> sourceGroups;
+    private Set<File> emptyGenerated;
     private final Map<Pair<String, File>, SourceGroup> cache = new HashMap<>();
 
     public GradleSourcesImpl(Project project) {
@@ -159,7 +160,7 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
         for (SourceType st : stype) {
             Set<File> processed = new HashSet<>();
             for (String group : gradleSources.keySet()) {
-                Set<File> dirs = gradleSources.get(group).getSourceDirs(st);
+                Set<File> dirs = filterEmptyGeneratedDirs(gradleSources.get(group).getSourceDirs(st));
                 boolean unique = dirs.size() == 1;
                 for (File dir : dirs) {
                     if (!processed.contains(dir) && dir.isDirectory()) {
@@ -254,8 +255,12 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
     private void checkChanges(boolean fireChanges) {
         boolean changed = sourceGroups == null;
 
-        if (GradleJavaProject.get(proj) != null) {
-            Map<String, GradleJavaSourceSet> newSources = GradleJavaProject.get(proj).getSourceSets();
+        GradleJavaProject gjp = GradleJavaProject.get(proj);
+        if ( gjp != null) {
+
+            emptyGenerated = checkEmptyGeneratedSourceDirs(gjp);
+
+            Map<String, GradleJavaSourceSet> newSources = gjp.getSourceSets();
             if (sourceGroups != null) {
                 Set<String> enteringGroups = new HashSet<>(newSources.keySet());
                 Set<String> leavingGroups = new HashSet<>(sourceGroups.keySet());
@@ -266,7 +271,7 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
                 changed = !leavingGroups.isEmpty() || !enteringGroups.isEmpty();
                 if (!changed) {
                     for (String rg : remainingGroups) {
-                        if (!sourceGroups.get(rg).equals(newSources.get(rg).getAvailableDirs(false))) {
+                        if (!sourceGroups.get(rg).equals(filterEmptyGeneratedDirs(newSources.get(rg)))) {
                             changed = true;
                             break;
                         }
@@ -275,7 +280,7 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
             }
             sourceGroups = new HashMap<>();
             for (Map.Entry<String, GradleJavaSourceSet> entry : newSources.entrySet()) {
-                sourceGroups.put(entry.getKey(), entry.getValue().getAvailableDirs(false));
+                sourceGroups.put(entry.getKey(), filterEmptyGeneratedDirs(entry.getValue()));
             }
             gradleSources = newSources;
             cache.clear();
@@ -283,6 +288,39 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
         if (changed && fireChanges) {
             cs.fireChange();
         }
+    }
+
+    private Set<File> checkEmptyGeneratedSourceDirs(GradleJavaProject gjp) {
+        Set<File> ret = new HashSet<>();
+        for (GradleJavaSourceSet ss : gjp.getSourceSets().values()) {
+            for (File dir : ss.getGeneratedSourcesDirs()) {
+                String[] list = dir.list();
+                if ((list == null) || (list.length == 0)) {
+                    ret.add(dir);
+                }
+            }
+        }
+        return ret;
+    }
+
+    private Collection<File> filterEmptyGeneratedDirs(GradleJavaSourceSet ss) {
+        Collection<File> ret = new ArrayList<>();
+        for (File dir : ss.getAvailableDirs(false)) {
+            if (!emptyGenerated.contains(dir)) {
+                ret.add(dir);
+            }
+        }
+        return ret;
+    }
+
+    private Set<File> filterEmptyGeneratedDirs(Set<File> files) {
+        Set<File> ret = new LinkedHashSet<>();
+        for (File dir : files) {
+            if (!emptyGenerated.contains(dir)) {
+                ret.add(dir);
+            }
+        }
+        return ret;
     }
 
     public @Override


### PR DESCRIPTION

When added the support of Generated source directories in Gradle project, the project view become a bit crowded, as the generated folders are always generated by Gradle.

Here there are two empty folder one for java and one for groovy.
![image](https://user-images.githubusercontent.com/1381701/185822259-9f91aaac-c525-4b9b-8c75-69a641f6e50a.png)

Same project with the new code.
![image](https://user-images.githubusercontent.com/1381701/185822341-8a9192d5-af88-45b4-ab1f-11cfdd83d325.png)

While implementing the change, I discovered a bug which prevented the freshly opened project to listen on resource changes. That one is the fist commit.