### PR TITLE
Build action must be included in the cache key

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
@@ -442,6 +442,7 @@ public final class NbMavenProjectImpl implements Project {
                 ProjectActionContext.newBuilder(ctx.getProject())
                     .withProfiles(ctx.getProfiles())
                     .withProperties(ctx.getProperties())
+                    .forProjectAction(ctx.getProjectAction())
                     .context();
         MavenProject result;
         


### PR DESCRIPTION
Minor bugfix: when loading a Maven project, the `ProjectActionContext`'s project action should be included in the cache hash, as it may (through RunConfig) goals and properties of the maven project.
With this bug, query for native-build and build will return the same artifact or even null (if the build query is first, the cached project is not native-image-packaged).