### PR TITLE
Cleanup clone usage

### DIFF
--- a/contrib/groovy.grails/test/unit/src/org/netbeans/modules/groovy/grails/api/GrailsRuntimeTest.java
+++ b/contrib/groovy.grails/test/unit/src/org/netbeans/modules/groovy/grails/api/GrailsRuntimeTest.java
@@ -106,7 +106,7 @@ public class GrailsRuntimeTest extends NbTestCase {
         desc.getProps().setProperty("wrong", "wrong");
         assertEquals(props, desc.getProps());
 
-        String[] correctArgs = args.clone();
+        String[] correctArgs = new ArrayList<String>.toArray(args);
         args[0] = "wrong";
         assertEquals(correctArgs, desc.getArguments());
         Properties correctProps = new Properties(props);

--- a/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/SelectClassPanel.java
+++ b/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/SelectClassPanel.java
@@ -60,7 +60,7 @@ public class SelectClassPanel extends JPanel implements ExplorerManager.Provider
     }
     
     public Node[] getSelectedNodes(){
-        return selectedNodes.clone();
+        return (new ArrayList<Node>()).toArray(selectedNodes);
     }
     
     public ExplorerManager getExplorerManager() {

--- a/ide/db/libsrc/org/netbeans/lib/ddl/impl/SpecificationFactory.java
+++ b/ide/db/libsrc/org/netbeans/lib/ddl/impl/SpecificationFactory.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.text.MessageFormat;
 import java.util.Iterator;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
@@ -260,8 +261,8 @@ public class SpecificationFactory implements DatabaseSpecificationFactory, Drive
     /** Creates deep copy of Map.
     * All items will be cloned. Used internally in this object.
     */
-    private HashMap deepClone(HashMap map) {
-        HashMap newone = (HashMap)map.clone();
+    private Map<Object, Object> deepClone(Map map) {
+        Map<Object, Object> newone = new HashMap<>(map);
         Iterator it = newone.keySet().iterator();
         while (it.hasNext()) {
             Object newkey = it.next();
@@ -269,9 +270,9 @@ public class SpecificationFactory implements DatabaseSpecificationFactory, Drive
             if (newobj instanceof HashMap)
                 deepobj = deepClone((HashMap)newobj);
             else if (newobj instanceof String)
-                deepobj = (Object)new String((String)newobj);
+                deepobj = new String((String)newobj);
             else if (newobj instanceof Vector)
-                deepobj = ((Vector)newobj).clone();
+                deepobj = new Vector((Vector)newobj);
             newone.put(newkey, deepobj);
         }
 

--- a/ide/db/src/org/netbeans/api/db/explorer/node/NodeProvider.java
+++ b/ide/db/src/org/netbeans/api/db/explorer/node/NodeProvider.java
@@ -111,8 +111,7 @@ public abstract class NodeProvider implements Lookup.Provider {
 
     public synchronized void refresh() {
         initialized = false;
-        @SuppressWarnings("unchecked")
-        TreeSet<Node> nodes = (TreeSet<Node>)nodeSet.clone();
+        Set<Node> nodes = new TreeSet<>(nodeSet);
 
         for (Node child : nodes) {
             if (child instanceof BaseNode) {

--- a/ide/db/src/org/netbeans/modules/db/explorer/DatabaseConnection.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/DatabaseConnection.java
@@ -580,7 +580,7 @@ public final class DatabaseConnection implements DBConnection {
 
     @Override
     public Properties getConnectionProperties() {
-        return (Properties) connectionProperties.clone();
+        return new Properties(connectionProperties);
     }
 
     @Override
@@ -589,7 +589,7 @@ public final class DatabaseConnection implements DBConnection {
         if (connectionProperties == null) {
             this.connectionProperties = new Properties();
         } else {
-            this.connectionProperties = (Properties) connectionProperties.clone();
+            this.connectionProperties = new Properties(connectionProperties);
         }
         propertySupport.firePropertyChange(PROP_CONNECTIONPROPERTIES, old, connectionProperties);
     }

--- a/ide/editor.lib/src/org/netbeans/editor/PopupManager.java
+++ b/ide/editor.lib/src/org/netbeans/editor/PopupManager.java
@@ -289,7 +289,7 @@ public class PopupManager {
         if (viewParent instanceof JViewport) {
             Rectangle viewBounds = ((JViewport)viewParent).getViewRect();
 
-            Rectangle translatedCursorBounds = (Rectangle)cursorBounds.clone();
+            Rectangle translatedCursorBounds = new Rectangle(cursorBounds);
             if (placement != FixedPoint) {
                 translatedCursorBounds.translate(-viewBounds.x, -viewBounds.y);
             }

--- a/ide/lexer/src/org/netbeans/lib/lexer/TokenHierarchyOperation.java
+++ b/ide/lexer/src/org/netbeans/lib/lexer/TokenHierarchyOperation.java
@@ -598,14 +598,10 @@ public final class TokenHierarchyOperation<I, T extends TokenId> { // "I" stands
                     return Collections.emptySet();
                 Language<?> lang = rootTokenList.language();
                 LanguageOperation<?> langOp = LexerApiPackageAccessor.get().languageOperation(lang);
-                @SuppressWarnings("unchecked")
-                Set<LanguagePath> clps = (Set<LanguagePath>)
-                        ((HashSet<LanguagePath>)langOp.languagePaths()).clone();
+                Set<LanguagePath> clps = new HashSet<>(langOp.languagePaths());
                 lps = clps;
 
-                @SuppressWarnings("unchecked")
-                Set<Language<?>> cel = (Set<Language<?>>)
-                        ((HashSet<Language<?>>)langOp.exploredLanguages()).clone();
+                Set<Language<?>> cel = new HashSet<>(langOp.exploredLanguages());
                 exploredLanguages = cel;
                 languagePaths = lps;
             }

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/BaseBean.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/BaseBean.java
@@ -1255,7 +1255,7 @@ public abstract class BaseBean implements Cloneable, Bean {
         }
         
         if (attrCache != null)
-            bean.attrCache = (HashMap) attrCache.clone();  // This does a shallow clone of the HashMap, but that's fine since they're all just Strings in there.
+            bean.attrCache = new HashMap<>(attrCache);  // This does a shallow clone of the HashMap, but that's fine since they're all just Strings in there.
         
         Iterator it = beanPropsIterator();
         

--- a/ide/versioning.util/src/org/netbeans/modules/versioning/util/ListenersSupport.java
+++ b/ide/versioning.util/src/org/netbeans/modules/versioning/util/ListenersSupport.java
@@ -28,8 +28,8 @@ import java.util.*;
  */
 public class ListenersSupport {
 
-    private final Object    source;
-    private HashSet         listeners = new HashSet(1);
+    private final Object   source;
+    private Set<VersioningListener> listeners = new HashSet<>(1);
 
     public ListenersSupport(Object source) {
         this.source = source;
@@ -37,13 +37,13 @@ public class ListenersSupport {
 
     public synchronized void addListener(VersioningListener listener) {
         if (listener == null) throw new IllegalArgumentException();
-        HashSet copy = (HashSet) listeners.clone();
+        Set<VersioningListener> copy = new HashSet<>(listeners);
         copy.add(listener);
         listeners = copy;
     }
 
     public synchronized void removeListener(VersioningListener listener) {
-        HashSet copy = (HashSet) listeners.clone();
+        Set<VersioningListener> copy = new HashSet<>(listeners);
         copy.remove(listener);
         listeners = copy;
     }

--- a/java/classfile/src/org/netbeans/modules/classfile/Annotation.java
+++ b/java/classfile/src/org/netbeans/modules/classfile/Annotation.java
@@ -88,7 +88,7 @@ public class Annotation {
      * array of AnnotationComponents.
      */
     public final AnnotationComponent[] getComponents() {
-	return components.clone();
+	return new ArrayList<AnnotationComponent>().toArray(components);
     }
 
     /**

--- a/java/classfile/src/org/netbeans/modules/classfile/ArrayElementValue.java
+++ b/java/classfile/src/org/netbeans/modules/classfile/ArrayElementValue.java
@@ -22,6 +22,8 @@
 
 package org.netbeans.modules.classfile;
 
+import java.util.ArrayList;
+
 /**
  * ArrayElementValue:  the value portion of an annotation element that
  * is an array of ElementValue instances.
@@ -39,7 +41,7 @@ public final class ArrayElementValue extends ElementValue {
      * Returns the set of ElementValue instances for this component.
      */
     public ElementValue[] getValues() {
-	return values.clone();
+	return new ArrayList<ElementValue>().toArray(values);
     }
 
     @Override

--- a/java/classfile/src/org/netbeans/modules/classfile/Code.java
+++ b/java/classfile/src/org/netbeans/modules/classfile/Code.java
@@ -24,6 +24,7 @@ package org.netbeans.modules.classfile;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 
 /**
  * The Code attribute of a method.
@@ -127,7 +128,7 @@ public final class Code {
     }
     
     public final ExceptionTableEntry[] getExceptionTable() {
-        return exceptionTable.clone();
+        return new ArrayList<ExceptionTableEntry>().toArray(exceptionTable);
     }
 
     /**
@@ -143,7 +144,7 @@ public final class Code {
      * Returns the local variable table for this code.
      */
     public final LocalVariableTableEntry[] getLocalVariableTable() {
-        return localVariableTable.clone();
+        return new ArrayList<LocalVariableTableEntry>().toArray(localVariableTable);
     }
 
     /**
@@ -152,7 +153,7 @@ public final class Code {
      * are generic.
      */
     public final LocalVariableTypeTableEntry[] getLocalVariableTypeTable() {
-        return localVariableTypeTable.clone();
+        return new ArrayList<LocalVariableTypeTableEntry>().toArray(localVariableTypeTable);
     }
     
     /**
@@ -160,7 +161,7 @@ public final class Code {
      * information needed by the new classfile verifier in Java 6.
      */
     public final StackMapFrame[] getStackMapTable() {
-        return stackMapTable.clone();
+        return new ArrayList<StackMapFrame>().toArray(stackMapTable);
     }
 
     @Override

--- a/java/classfile/src/org/netbeans/modules/classfile/Method.java
+++ b/java/classfile/src/org/netbeans/modules/classfile/Method.java
@@ -26,6 +26,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Arrays;
+import java.util.ArrayList;
 
 /**
  * A Java method object.
@@ -96,7 +97,7 @@ public final class Method extends Field {
 	    if (exceptions == null)
 		exceptions = new CPClassInfo[0];
 	}
-        return exceptions.clone();
+        return new ArrayList<CPClassInfo>().toArray(exceptions);
     }
     
     /**

--- a/java/classfile/src/org/netbeans/modules/classfile/StackMapFrame.java
+++ b/java/classfile/src/org/netbeans/modules/classfile/StackMapFrame.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.classfile;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 
 /**
  * A stack map frame, as defined by a StackMapTable attribute.  A stack map
@@ -270,7 +271,7 @@ public abstract class StackMapFrame {
          * locals.
          */
         public VerificationTypeInfo[] getLocals() {
-            return locals.clone();
+            return new ArrayList<VerificationTypeInfo>().toArray(locals);
         }
     }
     
@@ -302,7 +303,7 @@ public abstract class StackMapFrame {
          * locals.
          */
         public VerificationTypeInfo[] getLocals() {
-            return locals.clone();
+            return new ArrayList<VerificationTypeInfo>().toArray(locals);
         }
         
         /**
@@ -310,7 +311,7 @@ public abstract class StackMapFrame {
          * stack items.
          */
         public VerificationTypeInfo[] getStackItems() {
-            return stackItems.clone();
+            return new ArrayList<VerificationTypeInfo>().toArray(stackItems);
         }
     }
 }

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaConnectionPanel.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaConnectionPanel.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.dbschema.jdbcimpl.wizard;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.ResourceBundle;
 
 import javax.swing.*;
@@ -168,10 +169,10 @@ public class DBSchemaConnectionPanel extends JPanel implements ListDataListener 
     }
 
     public void fireChange (Object source) {
-        ArrayList lst;
+        List<ChangeListener> lst;
 
         synchronized (this) {
-            lst = (ArrayList) this.list.clone();
+            lst = new ArrayList<>(this.list);
         }
 
         ChangeEvent event = new ChangeEvent(source);

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTablesPanel.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTablesPanel.java
@@ -696,10 +696,10 @@ public class DBSchemaTablesPanel extends JPanel implements ListDataListener {
     }
 
     public void fireChange (Object source) {
-        ArrayList lst;
+        List<ChangeListener> lst;
 
         synchronized (this) {
-            lst = (ArrayList) this.list.clone();
+            lst = new ArrayList<>(this.list);
         }
 
         ChangeEvent event = new ChangeEvent(source);

--- a/java/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAStart.java
+++ b/java/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAStart.java
@@ -932,8 +932,6 @@ public class JPDAStart extends Task implements Runnable {
                     pp.setLocation(getLocation());
                     pp.setDescription(getDescription());
                     pp.setRefid(getRefid());
-                    //pp.setChecked(isChecked());
-                    //pp.union = union == null ? union : (Union) union.clone();
                     plainPath = pp;
                 } else {
                     plainPath = this;

--- a/java/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesCurrentModel.java
+++ b/java/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesCurrentModel.java
@@ -388,7 +388,7 @@ NodeActionsProvider {
     }
 
     public void fireTreeChanged () {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++) {
             ((ModelListener) v.get (i)).modelChanged (null);
@@ -397,7 +397,7 @@ NodeActionsProvider {
 
     private void fireSelectedNodes(Object[] nodes) {
         ModelEvent event = new ModelEvent.SelectionChanged(this, nodes);
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++) {
             ((ModelListener) v.get (i)).modelChanged (event);

--- a/java/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesRemoteModel.java
+++ b/java/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/SourcesRemoteModel.java
@@ -229,7 +229,7 @@ NodeActionsProvider {
     }
 
     public void fireTreeChanged () {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++) {
             ((ModelListener) v.get (i)).modelChanged (null);
@@ -238,7 +238,7 @@ NodeActionsProvider {
 
     private void fireSelectedNodes(Object[] nodes) {
         ModelEvent event = new ModelEvent.SelectionChanged(this, nodes);
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++) {
             ((ModelListener) v.get (i)).modelChanged (event);

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsNodeModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsNodeModel.java
@@ -512,7 +512,7 @@ public class BreakpointsNodeModel implements NodeModel {
 //    
     
     private void fireNodeChanged (JPDABreakpoint b) {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             ((ModelListener) v.get (i)).modelChanged (

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JPDASessionActionsProvider.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/JPDASessionActionsProvider.java
@@ -163,14 +163,14 @@ public class JPDASessionActionsProvider implements NodeActionsProviderFilter {
     }
 
     public void addModelListener(ModelListener l) {
-        HashSet newListeners = (listeners == null) ? new HashSet() : (HashSet) listeners.clone();
+        HashSet newListeners = (listeners == null) ? new HashSet() : new HashSet<>(listeners);
         newListeners.add(l);
         listeners = newListeners;
     }
 
     public void removeModelListener(ModelListener l) {
         if (listeners == null) return;
-        HashSet newListeners = (HashSet) listeners.clone();
+        HashSet newListeners = new HashSet<>(listeners);
         newListeners.remove(l);
         listeners = newListeners;
     }

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/NumericDisplayFilter.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/NumericDisplayFilter.java
@@ -146,14 +146,14 @@ NodeActionsProviderFilter, Constants {
 
     public void addModelListener (ModelListener l) {
         HashSet newListeners = (listeners == null) ? 
-            new HashSet () : (HashSet) listeners.clone ();
+            new HashSet () : new HashSet<>(listeners);
         newListeners.add (l);
         listeners = newListeners;
     }
 
     public void removeModelListener (ModelListener l) {
         if (listeners == null) return;
-        HashSet newListeners = (HashSet) listeners.clone();
+        HashSet newListeners = new HashSet<>(listeners);
         newListeners.remove (l);
         listeners = newListeners;
     }

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/SessionsTableModelFilter.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/SessionsTableModelFilter.java
@@ -147,7 +147,7 @@ PropertyChangeListener {
     }
     
     private void fireTreeChanged () {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             ((ModelListener) v.get (i)).modelChanged (null);

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/SourcesModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/SourcesModel.java
@@ -195,7 +195,7 @@ NodeActionsProvider {
     }
 
     public void fireTreeChanged () {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             ((ModelListener) v.get (i)).modelChanged (null);
@@ -203,7 +203,7 @@ NodeActionsProvider {
 
     private void fireSelectedNodes(Object[] nodes) {
         ModelEvent event = new ModelEvent.SelectionChanged(this, nodes);
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             ((ModelListener) v.get (i)).modelChanged (event);

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsNodeModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsNodeModel.java
@@ -236,14 +236,14 @@ public class ThreadsNodeModel implements NodeModel {
     }
     
     private void fireTreeChanged () {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             ((ModelListener) v.get (i)).modelChanged (null);
     }
     
     private void fireNodeChanged (Object node) {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         ModelEvent event = new ModelEvent.NodeChanged(this, node,
                 ModelEvent.NodeChanged.DISPLAY_NAME_MASK |

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTableModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTableModel.java
@@ -212,7 +212,7 @@ public class ThreadsTableModel implements TableModel, Constants {
     }
     
     private void fireTableValueChanged (Object o, String propertyName) {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             ((ModelListener) v.get (i)).modelChanged (
@@ -221,7 +221,7 @@ public class ThreadsTableModel implements TableModel, Constants {
     }
     
     private void fireNodeChanged (Object node) {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             ((ModelListener) v.get (i)).modelChanged (

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/WatchesModel.java
@@ -212,7 +212,7 @@ public class WatchesModel implements TreeModel, JPDAWatchRefreshModel {
                 it.next().setEvaluated(null);
             }
         }
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         ModelEvent event = new ModelEvent.TreeChanged(this);
         for (i = 0; i < k; i++)
@@ -220,7 +220,7 @@ public class WatchesModel implements TreeModel, JPDAWatchRefreshModel {
     }
     
     private void fireWatchesChanged () {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         ModelEvent event = new ModelEvent.NodeChanged(this, ROOT, ModelEvent.NodeChanged.CHILDREN_MASK);
         for (i = 0; i < k; i++)
@@ -233,7 +233,7 @@ public class WatchesModel implements TreeModel, JPDAWatchRefreshModel {
     }
         
     void fireTableValueChangedComputed (Object node, String propertyName) {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             ((ModelListener) v.get (i)).modelChanged (
@@ -242,7 +242,7 @@ public class WatchesModel implements TreeModel, JPDAWatchRefreshModel {
     }
 
     public void fireChildrenChanged(Object node) {
-        Vector v = (Vector) listeners.clone ();
+        Vector<ModelListener> v = new Vector<>(listeners);
         int i, k = v.size ();
         for (i = 0; i < k; i++)
             ((ModelListener) v.get (i)).modelChanged (
@@ -707,7 +707,7 @@ public class WatchesModel implements TreeModel, JPDAWatchRefreshModel {
             }
             DebuggerManager.getDebuggerManager().createWatch(expr);
             
-            Vector v = (Vector) listeners.clone ();
+            Vector<ModelListener> v = new Vector(listeners);
             int i, k = v.size ();
             for (i = 0; i < k; i++)
                 ((ModelListener) v.get (i)).modelChanged (

--- a/java/form/src/org/netbeans/modules/form/FormModel.java
+++ b/java/form/src/org/netbeans/modules/form/FormModel.java
@@ -1300,12 +1300,12 @@ public class FormModel
     }
 
     void fireEvents(FormModelEvent ... events) {
-        java.util.List targets;
+        List<FormModelListener> targets;
         synchronized(this) {
             if (listeners == null || listeners.isEmpty()) {
                 return;
             }
-            targets = (ArrayList) listeners.clone();
+            targets = new ArrayList<>(listeners);
         }
         for (int i=0; i < targets.size(); i++) {
             FormModelListener l = (FormModelListener) targets.get(i);

--- a/java/form/src/org/netbeans/modules/form/layoutsupport/delegates/GridBagLayoutSupport.java
+++ b/java/form/src/org/netbeans/modules/form/layoutsupport/delegates/GridBagLayoutSupport.java
@@ -428,8 +428,8 @@ public class GridBagLayoutSupport extends AbstractLayoutSupport {
         // introduction of new (otherwise redundant) grid lines.
         
         LayoutInfoComparator comp = new LayoutInfoComparator(LayoutInfoComparator.XAXIS);
-        LayoutInfo [] layoutsX = layouts.clone();
-        LayoutInfo [] layoutsY = layouts.clone();
+        LayoutInfo [] layoutsX = new ArrayList<LayoutInfo>().toArray(layouts);
+        LayoutInfo [] layoutsY = new ArrayList<LayoutInfo>().toArray(layouts);
         Arrays.sort(layoutsX, comp);
         comp.cord = LayoutInfoComparator.YAXIS;
         Arrays.sort(layoutsY, comp);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/CheckRenderer.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/CheckRenderer.java
@@ -128,7 +128,7 @@ class CheckRenderer extends JPanel implements TreeCellRenderer {
     }
     
     public Rectangle getCheckBounds() {
-        return (Rectangle)check.getBounds().clone();
+        return new Rectangle(check.getBounds());
     }
         
     enum State {

--- a/platform/core.execution/src/org/netbeans/core/execution/ExecutionEngine.java
+++ b/platform/core.execution/src/org/netbeans/core/execution/ExecutionEngine.java
@@ -190,8 +190,7 @@ public final class
     /** fires event that notifies about new process */
     protected final void fireExecutionStarted (ExecutionEvent ev) {
         runningTasks.add( ev.getProcess() );
-	@SuppressWarnings("unchecked") 
-        Iterator<ExecutionListener> iter = ((HashSet<ExecutionListener>) executionListeners.clone()).iterator();
+        Iterator<ExecutionListener> iter = new HashSet<ExecutionListener>(executionListeners).iterator();
         while (iter.hasNext()) {
             ExecutionListener l = iter.next();
             l.startedExecution(ev);
@@ -201,8 +200,7 @@ public final class
     /** fires event that notifies about the end of a process */
     protected final void fireExecutionFinished (ExecutionEvent ev) {
         runningTasks.remove( ev.getProcess() );
-	@SuppressWarnings("unchecked") 
-        Iterator<ExecutionListener> iter = ((HashSet<ExecutionListener>) executionListeners.clone()).iterator();
+        Iterator<ExecutionListener> iter = new HashSet<ExecutionListener>(executionListeners).iterator();
         while (iter.hasNext()) {
             ExecutionListener l = iter.next();
             l.finishedExecution(ev);

--- a/platform/core.kit/test/perf/src/org/openide/filesystems/multifs/MultiXMLFSTest.java
+++ b/platform/core.kit/test/perf/src/org/openide/filesystems/multifs/MultiXMLFSTest.java
@@ -153,11 +153,11 @@ public class MultiXMLFSTest extends FSTest implements DataManager {
     /** Clones given Map by casting to a cloneable class - HashMap, Hashtable, or TreeMap */
     private static final Map cloneMap(Map toClone) {
         if (toClone instanceof HashMap) {
-            return (Map) ((HashMap) toClone).clone();
+            return new HashMap(toClone);
         } else if (toClone instanceof Hashtable) {
-            return (Map) ((Hashtable) toClone).clone();
+            return new Hashtable(toClone);
         } else if (toClone instanceof TreeMap) {
-            return (Map) ((TreeMap) toClone).clone();
+            return new TreeMap(toClone);
         }
         
         return null;

--- a/platform/core.output2/src/org/netbeans/core/output2/AbstractLines.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/AbstractLines.java
@@ -29,6 +29,7 @@ import java.nio.CharBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -45,6 +46,7 @@ import org.openide.util.Exceptions;
 import org.openide.util.Mutex;
 import org.openide.windows.IOColors;
 import org.openide.windows.OutputListener;
+
 /**
  * Abstract Lines implementation with handling for getLine wrap calculations, etc.
  */
@@ -302,7 +304,7 @@ abstract class AbstractLines implements Lines, Runnable, ActionListener {
         longestLineLen = 0;
         listener = null;
         dirty = false;
-        curDefColors = getDefColors().clone();
+        curDefColors = new ArrayList<Color>().toArray(getDefColors());
     }
 
     private boolean dirty;

--- a/platform/core.startup.base/src/org/netbeans/core/startup/layers/SystemFileSystem.java
+++ b/platform/core.startup.base/src/org/netbeans/core/startup/layers/SystemFileSystem.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Level;
@@ -132,7 +133,7 @@ implements FileChangeListener {
                 s.add (arr[i]);
 
         // create own internal copy of passed filesystems
-        setDelegates(arr.clone());
+        setDelegates(new ArrayList<FileSystem>().toArray(arr));
         firePropertyChange ("layers", null, null); // NOI18N
     }
     
@@ -143,7 +144,7 @@ implements FileChangeListener {
     */
     public FileSystem[] getLayers() {
         // don't return reference to internal buffer
-        return getDelegates().clone();
+	return new ArrayList<FileSystem>().toArray(getDelegates());
     }
     
     protected @Override FileSystem createWritableOnForRename(String oldName, String newName) throws IOException {

--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/ModeParser.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/ModeParser.java
@@ -645,7 +645,7 @@ class ModeParser {
         if (DEBUG) Debug.log(ModeParser.class, "removeTCRef ENTER" + " tcRef:" + tcRefName);
         //Update order
         List<TCRefParser> localList = new ArrayList<TCRefParser>(10);
-        Map localMap = (Map) ((HashMap) tcRefParserMap).clone();
+        Map localMap = new HashMap<>(tcRefParserMap);
         
         tcRefParserMap.remove(tcRefName);
         

--- a/platform/o.n.bootstrap/src/org/netbeans/NetigsoHandle.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/NetigsoHandle.java
@@ -35,7 +35,7 @@ import org.openide.util.lookup.Lookups;
 final class NetigsoHandle {
     private final ModuleManager mgr;
     // @GuardedBy("toEnable")
-    private final ArrayList<Module> toEnable = new ArrayList<Module>();
+    private final ArrayList<Module> toEnable = new ArrayList<>();
     // @GuardedBy("NetigsoFramework.class")    
     private NetigsoFramework framework;
     // @GuardedBy("this")
@@ -166,9 +166,7 @@ final class NetigsoHandle {
         }
         List<Module> clone;
         synchronized (toEnable) {
-            @SuppressWarnings("unchecked")
-            List<Module> cloneTmp = (List<Module>) toEnable.clone();
-            clone = cloneTmp;
+            clone = new ArrayList<>(toEnable);
             toEnable.clear();
         }
         if (!clone.isEmpty()) {

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
@@ -1635,14 +1635,14 @@ public class ETable extends JTable {
         if ((newFormats == null) || (newFormats.length != quickFilterFormatStrings.length)) {
             return;
         }
-        quickFilterFormatStrings = newFormats.clone();
+        quickFilterFormatStrings = new ArrayList<>().toArray(newFormats);
     }
 
     /**
      * Returns the quickFilterFormatStrings array.
      */
     public String[] getQuickFilterFormatStrings() {
-        return quickFilterFormatStrings.clone();
+        return new ArrayList<String>().toArray(quickFilterFormatStrings);
     }
 
     /**

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/SheetTableModel.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/SheetTableModel.java
@@ -251,7 +251,7 @@ final class SheetTableModel implements TableModel, PropertySetModelListener {
     @Override
     public synchronized void addTableModelListener(TableModelListener listener) {
         if (tableModelListenerList == null) {
-            tableModelListenerList = new java.util.ArrayList<TableModelListener>();
+            tableModelListenerList = new ArrayList<>();
         }
 
         tableModelListenerList.add(listener);
@@ -273,7 +273,7 @@ final class SheetTableModel implements TableModel, PropertySetModelListener {
                 return;
             }
 
-            list = (List) ((ArrayList) tableModelListenerList).clone();
+            list = new ArrayList<>(tableModelListenerList);
         }
 
         for (int i = 0; i < list.size(); i++) {

--- a/platform/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
@@ -674,7 +674,8 @@ abstract class AbstractFolder extends FileObject {
     protected final void refresh(String added, String removed, boolean reuseChildren) {
         String[] prev = children;
         if (reuseChildren && removed != null && prev != null) {
-            String[] nc = prev.clone();
+            String[] nc = new ArrayList<>().toArray(prev);
+
             for (int i = nc.length; --i >= 0;) {
                 if (removed.equals(nc[i])) {
                     nc[i] = null;

--- a/platform/openide.nodes/src/org/openide/nodes/Index.java
+++ b/platform/openide.nodes/src/org/openide/nodes/Index.java
@@ -224,11 +224,11 @@ public interface Index extends Node.Cookie {
                 return;
             }
 
-            HashSet cloned;
+            Set cloned;
 
             // clone listener list
             synchronized (this) {
-                cloned = (HashSet) listeners.clone();
+                cloned = new HashSet<>(listeners);
             }
 
             // fire on cloned list to prevent from modifications when firing

--- a/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
@@ -1254,7 +1254,8 @@ public final class ImageUtilities {
         // the heap with useless properties strings. Saves tens of KBs
         @Override
         public void setProperties(Hashtable props) {
-            props = (Hashtable) props.clone();
+            // props = (Hashtable) props.clone();
+            props = new Hashtable(props);
             consumer.setProperties(props);
         }
     }

--- a/platform/sendopts/src/org/netbeans/spi/sendopts/Option.java
+++ b/platform/sendopts/src/org/netbeans/spi/sendopts/Option.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Locale;
@@ -94,8 +95,10 @@ public final class Option {
         this.shortName = old.shortName;
         this.longName = old.longName;
         this.impl = OptionImpl.cloneImpl(old.impl, this, null);
-        this.keys = (String[])old.keys.clone();
-        this.bundles = (String[])old.bundles.clone();
+        // this.keys = (String[])old.keys.clone();
+        this.keys = new ArrayList<String>().toArray(old.keys);
+        // this.bundles = (String[])old.bundles.clone();
+        this.bundles = new ArrayList<String>().toArray(old.bundles);
         
         this.keys[typeOfDescription] = description;
         this.bundles[typeOfDescription] = bundle;

--- a/profiler/lib.profiler.common/src/org/netbeans/lib/profiler/common/Profiler.java
+++ b/profiler/lib.profiler.common/src/org/netbeans/lib/profiler/common/Profiler.java
@@ -292,7 +292,7 @@ public abstract class Profiler {
         final Vector toNotify;
 
         synchronized (this) {
-            toNotify = (Vector) profilingStateListeners.clone();
+            toNotify = new Vector(profilingStateListeners);
         }
 
         final Iterator iterator = toNotify.iterator();
@@ -325,7 +325,7 @@ public abstract class Profiler {
         final Vector toNotify;
 
         synchronized (this) {
-            toNotify = (Vector) profilingStateListeners.clone();
+            toNotify = new Vector(profilingStateListeners);
         }
 
         final Iterator iterator = toNotify.iterator();
@@ -353,7 +353,7 @@ public abstract class Profiler {
         final Vector toNotify;
 
         synchronized (this) {
-            toNotify = (Vector) profilingStateListeners.clone();
+            toNotify = new Vector(profilingStateListeners);
         }
 
         final Iterator iterator = toNotify.iterator();
@@ -380,7 +380,7 @@ public abstract class Profiler {
         final Vector toNotify;
 
         synchronized (this) {
-            toNotify = (Vector) profilingStateListeners.clone();
+            toNotify = new Vector(profilingStateListeners);
         }
 
         final Iterator iterator = toNotify.iterator();
@@ -407,7 +407,7 @@ public abstract class Profiler {
         final Vector toNotify;
 
         synchronized (this) {
-            toNotify = (Vector) profilingStateListeners.clone();
+            toNotify = new Vector(profilingStateListeners);
         }
 
         final Iterator iterator = toNotify.iterator();

--- a/webcommon/cordova/cordovaprojectupdate/src/org/netbeans/modules/cordova/updatetask/PluginTask.java
+++ b/webcommon/cordova/cordovaprojectupdate/src/org/netbeans/modules/cordova/updatetask/PluginTask.java
@@ -56,7 +56,7 @@ public class PluginTask extends Task {
             }
             initCurrent();
 
-            HashSet<CordovaPlugin> pluginsToInstall = (HashSet<CordovaPlugin>) requestedPlugins.clone();
+            Set<CordovaPlugin> pluginsToInstall = new HashSet<>(requestedPlugins);
 
             //plugins to install
             pluginsToInstall.removeAll(currentPlugins);

--- a/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/connection/LinkedJSONObject.java
+++ b/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/connection/LinkedJSONObject.java
@@ -31,7 +31,7 @@ import org.json.simple.JSONObject;
  */
 public class LinkedJSONObject extends JSONObject {
 
-    LinkedHashMap linkedMap = new LinkedHashMap();
+    Map linkedMap = new LinkedHashMap<>();
 
     public LinkedJSONObject() {
     }
@@ -44,7 +44,7 @@ public class LinkedJSONObject extends JSONObject {
     @Override
     public Object clone() {
         LinkedJSONObject ljo = new LinkedJSONObject();
-        ljo.linkedMap = (LinkedHashMap) linkedMap.clone();
+        ljo.linkedMap = new LinkedHashMap<>(linkedMap);
         return ljo;
     }
 


### PR DESCRIPTION
Remove usage of clone() when a copy constructor will work.
    
This reduces the use of reflection in the VM. This has the net effect of making
the application more efficient.

---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

