### PR TITLE
Added multiview [Source|History] for Dockerfile-s

### DIFF
--- a/ide/docker.editor/nbproject/project.xml
+++ b/ide/docker.editor/nbproject/project.xml
@@ -44,6 +44,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.core.multiview</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.61</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.csl.api</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -161,6 +170,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>9.6</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.windows</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>6.94</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/ide/docker.editor/src/org/netbeans/modules/docker/editor/DockerfileLanguage.java
+++ b/ide/docker.editor/src/org/netbeans/modules/docker/editor/DockerfileLanguage.java
@@ -19,6 +19,8 @@
 package org.netbeans.modules.docker.editor;
 
 import org.netbeans.api.lexer.Language;
+import org.netbeans.core.spi.multiview.MultiViewElement;
+import org.netbeans.core.spi.multiview.text.MultiViewEditorElement;
 import org.netbeans.modules.csl.api.CodeCompletionHandler;
 import org.netbeans.modules.csl.spi.DefaultLanguageConfig;
 import org.netbeans.modules.csl.spi.LanguageRegistration;
@@ -26,14 +28,16 @@ import org.netbeans.modules.docker.editor.completion.DockerfileCompletion;
 import org.netbeans.modules.docker.editor.lexer.DockerfileTokenId;
 import org.netbeans.modules.docker.editor.parser.DockerfileParser;
 import org.netbeans.modules.parsing.spi.Parser;
+import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
+import org.openide.windows.TopComponent;
 
 /**
  *
  * @author Tomas Zezula
  */
-@LanguageRegistration(mimeType = DockerfileResolver.MIME_TYPE)
-@NbBundle.Messages({"Dockerfile=Docker Build Files"})
+@NbBundle.Messages("Dockerfile=Docker Build Files")
+@LanguageRegistration(mimeType = DockerfileResolver.MIME_TYPE, useMultiview = true)
 public final class DockerfileLanguage extends DefaultLanguageConfig {
 
     @Override
@@ -60,4 +64,18 @@ public final class DockerfileLanguage extends DefaultLanguageConfig {
     public String getLineCommentPrefix() {
         return "#"; //NOI18N
     }
+
+    @NbBundle.Messages("Source=&Source")
+    @MultiViewElement.Registration(
+            displayName = "#Source",
+            iconBase = "org/netbeans/modules/docker/editor/resources/docker_file.png",
+            persistenceType = TopComponent.PERSISTENCE_ONLY_OPENED,
+            mimeType = DockerfileResolver.MIME_TYPE,
+            preferredID = "dockerfile.source",
+            position = 100
+    )
+    public static MultiViewEditorElement createMultiViewEditorElement(Lookup context) {
+        return new MultiViewEditorElement(context);
+    }
+
 }

--- a/ide/docker.editor/src/org/netbeans/modules/docker/editor/DockerfileResolver.java
+++ b/ide/docker.editor/src/org/netbeans/modules/docker/editor/DockerfileResolver.java
@@ -20,6 +20,9 @@ package org.netbeans.modules.docker.editor;
 
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionReferences;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.MIMEResolver;
 import org.openide.util.lookup.ServiceProvider;
@@ -28,6 +31,64 @@ import org.openide.util.lookup.ServiceProvider;
  *
  * @author Tomas Zezula
  */
+@ActionReferences({
+    @ActionReference(
+            path = "Loaders/text/x-dockerfile/Actions",
+            id = @ActionID(category = "System", id = "org.openide.actions.OpenAction"),
+            position = 100,
+            separatorAfter = 200
+    ),
+    @ActionReference(
+            path = "Loaders/text/x-dockerfile/Actions",
+            id = @ActionID(category = "Edit", id = "org.openide.actions.CutAction"),
+            position = 300
+    ),
+    @ActionReference(
+            path = "Loaders/text/x-dockerfile/Actions",
+            id = @ActionID(category = "Edit", id = "org.openide.actions.CopyAction"),
+            position = 400
+    ),
+    @ActionReference(
+            path = "Loaders/text/x-dockerfile/Actions",
+            id = @ActionID(category = "Edit", id = "org.openide.actions.PasteAction"),
+            position = 500,
+            separatorAfter = 600
+    ),
+    @ActionReference(
+            path = "Loaders/text/x-dockerfile/Actions",
+            id = @ActionID(category = "Edit", id = "org.openide.actions.DeleteAction"),
+            position = 700
+    ),
+    @ActionReference(
+            path = "Loaders/text/x-dockerfile/Actions",
+            id = @ActionID(category = "System", id = "org.openide.actions.RenameAction"),
+            position = 800,
+            separatorAfter = 900
+    ),
+    @ActionReference(
+            path = "Loaders/text/x-dockerfile/Actions",
+            id = @ActionID(category = "System", id = "org.openide.actions.SaveAsTemplateAction"),
+            position = 1000,
+            separatorAfter = 1100
+    ),
+    @ActionReference(
+            path = "Loaders/text/x-dockerfile/Actions",
+            id = @ActionID(category = "System", id = "org.openide.actions.FileSystemAction"),
+            position = 1200,
+            separatorAfter = 1300
+    ),
+    @ActionReference(
+            path = "Loaders/text/x-dockerfile/Actions",
+            id = @ActionID(category = "System", id = "org.openide.actions.ToolsAction"),
+            position = 1400
+    ),
+    @ActionReference(
+            path = "Loaders/text/x-dockerfile/Actions",
+            id = @ActionID(category = "System", id = "org.openide.actions.PropertiesAction"),
+            position = 1500
+    )
+})
+
 @ServiceProvider(service = MIMEResolver.class)
 public final class DockerfileResolver extends MIMEResolver {
 

--- a/ide/docker.editor/src/org/netbeans/modules/docker/editor/layer.xml
+++ b/ide/docker.editor/src/org/netbeans/modules/docker/editor/layer.xml
@@ -24,66 +24,7 @@
     <folder name="Loaders">
         <folder name="text">
             <folder name="x-dockerfile">
-                <attr name="SystemFileSystem.icon" urlvalue="nbresloc:/org/netbeans/modules/docker/editor/resources/docker_file.png"/>
                 <attr name="iconBase" stringvalue="org/netbeans/modules/docker/editor/resources/docker_file.png"/>
-                <folder name="Actions">
-                    <file name="OpenAction.shadow">
-                        <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-OpenAction.instance"/>
-                        <attr name="position" intvalue="100"/>
-                    </file>
-                    <file name="Separator1.instance">
-                        <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
-                        <attr name="position" intvalue="200"/>
-                    </file>
-                    <file name="CutAction.shadow">
-                        <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-CutAction.instance"/>
-                        <attr name="position" intvalue="300"/>
-                    </file>
-                    <file name="CopyAction.shadow">
-                        <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-CopyAction.instance"/>
-                        <attr name="position" intvalue="400"/>
-                    </file>
-                    <file name="PasteAction.shadow">
-                        <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-PasteAction.instance"/>
-                        <attr name="position" intvalue="500"/>
-                    </file>
-                    <file name="Separator2.instance">
-                        <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
-                        <attr name="position" intvalue="600"/>
-                    </file>
-                    <file name="NewAction.shadow">
-                        <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-NewAction.instance"/>
-                        <attr name="position" intvalue="700"/>
-                    </file>
-                    <file name="DeleteAction.shadow">
-                        <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-DeleteAction.instance"/>
-                        <attr name="position" intvalue="800"/>
-                    </file>
-                    <file name="SaveAsTemplateAction.shadow">
-                        <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-SaveAsTemplateAction.instance"/>
-                        <attr name="position" intvalue="1100"/>
-                    </file>
-                    <file name="Separator3.instance">
-                        <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
-                        <attr name="position" intvalue="1200"/>
-                    </file>
-                    <file name="FileSystemAction.shadow">
-                        <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-FileSystemAction.instance"/>
-                        <attr name="position" intvalue="1300"/>
-                    </file>
-                    <file name="Separator4.instance">
-                        <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
-                        <attr name="position" intvalue="1400"/>
-                    </file>
-                    <file name="ToolsAction.shadow">
-                        <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-ToolsAction.instance"/>
-                        <attr name="position" intvalue="1500"/>
-                    </file>
-                    <file name="PropertiesAction.shadow">
-                        <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-PropertiesAction.instance"/>
-                        <attr name="position" intvalue="1600"/>
-                    </file>
-                </folder>
             </folder>
         </folder>
     </folder>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1381701/187016543-20143c0d-0255-4bb6-8f61-e1038a6f545f.png)

I've been missing the History view on Dockerfile-s for a long time. This one adds that.
Also moved the action registration out of ```layer.xml``` which would remove the always disabled ```Add...``` menu item from the popup.