### PR TITLE
Accept file paths passed as a plain string, toURL throws IAE.

### DIFF
--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/Utils.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/Utils.java
@@ -42,7 +42,7 @@ class Utils {
             try {
                 URI uri = new URI(s);
                 f = URLMapper.findFileObject(uri.toURL());
-            } catch (URISyntaxException | MalformedURLException ex) {
+            } catch (URISyntaxException | IllegalArgumentException | MalformedURLException ex) {
                 f = FileUtil.toFileObject(new File(s));
             }
         } else {


### PR DESCRIPTION
When passing a file path as a plain string to the command, the `URI.toURL()` throws `IllegalArgumentException` that was not caught, and the fallback path (interpreting the string as file path) was not executed.