### PR TITLE
OrganizeImports fixed for clashing star imports.

### DIFF
--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/OrganizeImportsTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/OrganizeImportsTest.java
@@ -49,4 +49,27 @@ public class OrganizeImportsTest extends NbTestCase {
                               "     List l = new ArrayList();\n" +
                               "}\n");
     }
+
+    public void testClashing() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "import java.awt.*;\n" +
+                       "import java.util.List;\n" +
+                       "import java.util.*;\n" +
+                       "public class Test {\n" +
+                       "     List l = new ArrayList();\n" +
+                       "     Button b;\n" +
+                       "}\n")
+                .run(OrganizeImports.class)
+                .findWarning("2:0-2:22:verifier:MSG_OragnizeImports")
+                .applyFix()
+                .assertOutput("package test;\n" +
+                              "import java.awt.*;\n" +
+                              "import java.util.*;\n" +
+                              "import java.util.List;\n" +
+                              "public class Test {\n" +
+                              "     List l = new ArrayList();\n" +
+                              "     Button b;\n" +
+                              "}\n");
+    }
 }

--- a/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
@@ -1278,9 +1278,8 @@ public final class GeneratorUtilities {
                     if (sym.getKind().isClass() || sym.getKind().isInterface()) {
                         if (sym != element) {
                             explicitNamedImports.add(element);
+                            break;// break if explicitNameImport was added
                         }
-                        // break if explicitNameImport was added, or when the symbol is correctly resolved.
-                        break;
                     }
                 }
             }


### PR DESCRIPTION
Running `Organize Imports` action on the following source code removes the necessary import for `java.util.List`
```
package javaapplication;

import java.awt.*;
import java.util.List;
import java.util.*;

public class JavaApplication {

    public static void main(String[] args) {
        List a;
        Map m;
        AWTEvent e;
    }
}
```
This PR should fix this problem.


