### PR TITLE
#4556 - NetBeans should not auto-insert \n\ in Groovy triple quoted strings

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/typinghooks/GroovyTypedBreakInterceptor.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/typinghooks/GroovyTypedBreakInterceptor.java
@@ -163,6 +163,9 @@ public class GroovyTypedBreakInterceptor implements TypedBreakInterceptor {
         }
 
         if (id == GroovyTokenId.STRING_LITERAL || id == GroovyTokenId.STRING_CH && offset < ts.offset()+ts.token().length()) {
+            if (id == GroovyTokenId.STRING_LITERAL && ts.offsetToken().text().toString().startsWith("\"\"\"")) {
+                return;
+            }
             String str = (id != GroovyTokenId.STRING_LITERAL || offset > ts.offset()) ? "\\n\\\n"  : "\\\n";
             context.setText(str, -1, str.length());
             return;

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/typinghooks/TypedBreakInterceptorTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/typinghooks/TypedBreakInterceptorTest.java
@@ -146,5 +146,20 @@ public class TypedBreakInterceptorTest extends GroovyTestBase {
         // No auto-// on new lines
         insertBreak("foo // ^", "foo // \n^");
     }
+    
+    public void testStringLiteral01() throws Exception {
+        insertBreak("String a = \"\"\" ahoj^how are you? \"\"\"", "String a = \"\"\" ahoj\n^how are you? \"\"\"");            
+    }
+    
+    public void testStringLiteral02() throws Exception {
+        insertBreak("\"\"\" ahoj^how are you?", "\"\"\" ahoj\n^how are you?");
+    }
 
+    public void testStringLiteral03() throws Exception {
+        insertBreak("\"\"\" ahoj^", "\"\"\" ahoj\n^");
+    }
+    
+    public void testStringLiteral04() throws Exception {
+        insertBreak("String a = \" ahoj^how are you? \"", "String a = \" ahoj\\n\\\n^how are you? \"");            
+    }    
 }


### PR DESCRIPTION
The fix is simple. Just check the start of STRING_LITERAL and decide, whether inser new line or not. 