### PR TITLE
Cleanup a bunch of raw type error messages related to TreeSet.

### DIFF
--- a/enterprise/web.jspparser/src/org/netbeans/modules/web/jsps/parserapi/PageInfo.java
+++ b/enterprise/web.jspparser/src/org/netbeans/modules/web/jsps/parserapi/PageInfo.java
@@ -635,7 +635,7 @@ public abstract class PageInfo {
     
     // added in NetBeans
     
-    public Map getTagLibraries() {
+    public Map<String, TagLibraryInfo> getTagLibraries() {
         return taglibsMap;
     }
     
@@ -716,7 +716,7 @@ public abstract class PageInfo {
         sb.append(indent).append("doctypeSystem       : ").append(doctypeSystem).append('\n');  // NOI18N
         sb.append(indent).append("doctypePublic       : ").append(doctypePublic).append('\n');  // NOI18N
         sb.append(indent).append("hasJspRoot          : ").append(hasJspRoot).append('\n');  // NOI18N
-        sb.append(indent).append("prefixes:\n").append(collectionToString(new TreeSet(prefixes), indent + "  "));  // NOI18N
+        sb.append(indent).append("prefixes:\n").append(collectionToString(new TreeSet<>(prefixes), indent + "  "));  // NOI18N
         sb.append(indent).append("includePrelude:\n").append(collectionToString(includePrelude, indent + "  "));  // NOI18N
         sb.append(indent).append("includeCoda:\n").append(collectionToString(includeCoda, indent + "  "));  // NOI18N
         sb.append(indent).append("pluginDcls:\n").append(collectionToString(pluginDcls, indent + "  "));  // NOI18N
@@ -736,11 +736,11 @@ public abstract class PageInfo {
         return sb.toString();
     }
     
-    private String taglibsMapToString(Map m, String indent) {
+    private String taglibsMapToString(Map<String, TagLibraryInfo> m, String indent) {
         StringBuilder sb = new StringBuilder();
-        Iterator it = new TreeSet(m.keySet()).iterator();
+        Iterator<String> it = new TreeSet<>(m.keySet()).iterator();
         while (it.hasNext()) {
-            Object key = it.next();
+            String key = it.next();
             sb.append(indent).append("tag library: ").append(key).append('\n');  // NOI18N
             sb.append(tagLibraryInfoToString((TagLibraryInfo)m.get(key), indent + "    "));  // NOI18N
         }
@@ -866,11 +866,11 @@ public abstract class PageInfo {
     } // interface BeanData
 
     // helper methods for help implement toString() 
-    private static String mapToString(Map m, String indent) {
+    private static String mapToString(Map<String, String> m, String indent) {
         StringBuilder sb = new StringBuilder();
-        Iterator it = new TreeSet(m.keySet()).iterator();
+        Iterator<String> it = new TreeSet<>(m.keySet()).iterator();
         while (it.hasNext()) {
-            Object key = it.next();
+            String key = it.next();
             sb.append(indent).append(key).append(" -> ").append(m.get(key)).append('\n');
         }
         return sb.toString();

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
@@ -233,7 +233,7 @@ final class CatalogNode extends BeanNode implements Refreshable, PropertyChangeL
         }
                 
         /** Contains public ID (String) instances. */
-        private final TreeSet keys = new TreeSet();
+        private final Set<String> keys = new TreeSet<>();
         
         public void addNotify() {            
             catalogListener = new Lis();

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogRootNode.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogRootNode.java
@@ -172,7 +172,7 @@ public final class CatalogRootNode extends AbstractNode implements Node.Cookie {
     private static class RootChildren extends Children.Keys implements Comparator, PropertyChangeListener {
         
         /** Contains CatalogReader instances. */
-        private final Set keys = new TreeSet<>(this);
+        private final Set<CatalogReader> keys = new TreeSet<>(this);
         
         /**
           * Create new keys, register itself as listener.
@@ -220,7 +220,7 @@ public final class CatalogRootNode extends AbstractNode implements Node.Cookie {
         private void createKeys(CatalogSettings mounted) {
             keys.clear();
             if (mounted != null) {
-                Iterator it = mounted.getCatalogs(new Class[] {CatalogReader.class});
+                Iterator<CatalogReader> it = mounted.getCatalogs(new Class[] {CatalogReader.class});
                 while (it.hasNext()) {
                     keys.add(it.next());    //!!! use immutable key wrappers, some
                                             // instances may overwrite equals() so

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogRootNode.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogRootNode.java
@@ -172,7 +172,7 @@ public final class CatalogRootNode extends AbstractNode implements Node.Cookie {
     private static class RootChildren extends Children.Keys implements Comparator, PropertyChangeListener {
         
         /** Contains CatalogReader instances. */
-        private final TreeSet keys = new TreeSet(this);
+        private final Set keys = new TreeSet<>(this);
         
         /**
           * Create new keys, register itself as listener.

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDParser.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDParser.java
@@ -123,15 +123,15 @@ public class DTDParser {
     private class Handler extends DefaultHandler implements DeclHandler {
         
         private Map attrs, elements, models, enums, attrDefaults;
-        private Set notations, entities, anys, emptyElements;
+        private Set<String> notations, entities, anys, emptyElements;
         private DTDGrammar dtd;
         
         Handler() {
             attrs = new HashMap();
             elements = new HashMap();
             models = new HashMap();
-            notations = new TreeSet();
-            entities = new TreeSet();
+            notations = new TreeSet<>();
+            entities  = new TreeSet<>();
             anys = new HashSet();
             enums = new HashMap();
             attrDefaults = new HashMap();

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
@@ -616,7 +616,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
 
         /** */
         private Item (NamedClass clazz) {
-            this (clazz, new TreeSet (new NamedClassComparator()), new String());
+            this (clazz, new TreeSet<Item>(new NamedClassComparator()), new String());
         }
 
         /** */

--- a/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
@@ -135,8 +135,8 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
             // Commonly used variables
             Set<String> emptySet = new TreeSet<>();
-            String spaceAtt = "xml:space";  // NOI18N
             Set<String> tmpSet;
+            String spaceAtt = "xml:space";  // NOI18N
 
             ////////////////////////////////////////////////
             // Initialize common sets
@@ -178,39 +178,39 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
             // xsl:import
             elementDecls.put("import", emptySet); // NOI18N
-            attrDecls.put("import", new TreeSet(Arrays.asList(new String[]{"href"}))); // NOI18N
+            attrDecls.put("import", new TreeSet<>(Arrays.asList(new String[]{"href"}))); // NOI18N
 
             // xxsl:include
             elementDecls.put("include", emptySet); // NOI18N
-            attrDecls.put("include", new TreeSet(Arrays.asList(new String[]{"href"}))); // NOI18N
+            attrDecls.put("include", new TreeSet<>(Arrays.asList(new String[]{"href"}))); // NOI18N
 
             // xsl:strip-space
             elementDecls.put("strip-space", emptySet); // NOI18N
-            attrDecls.put("strip-space", new TreeSet(Arrays.asList(new String[]{"elements"}))); // NOI18N
+            attrDecls.put("strip-space", new TreeSet<>(Arrays.asList(new String[]{"elements"}))); // NOI18N
 
             // xsl:preserve-space
             elementDecls.put("preserve-space", emptySet); // NOI18N
-            attrDecls.put("preserve-space", new TreeSet(Arrays.asList(new String[]{"elements"}))); // NOI18N
+            attrDecls.put("preserve-space", new TreeSet<>(Arrays.asList(new String[]{"elements"}))); // NOI18N
 
             // xsl:output
             elementDecls.put("output", emptySet); // NOI18N
-            attrDecls.put("output", new TreeSet(Arrays.asList(new String[]{"method", // NOI18N
+            attrDecls.put("output", new TreeSet<>(Arrays.asList(new String[]{"method", // NOI18N
             "version","encoding","omit-xml-declaration","standalone","doctype-public", // NOI18N
             "doctype-system","cdata-section-elements","indent","media-type"}))); // NOI18N
 
             // xsl:key
             elementDecls.put("key", emptySet); // NOI18N
-            attrDecls.put("key", new TreeSet(Arrays.asList(new String[]{"name","match","use"}))); // NOI18N
+            attrDecls.put("key", new TreeSet<>(Arrays.asList(new String[]{"name","match","use"}))); // NOI18N
 
             // xsl:decimal-format
             elementDecls.put("decimal-format", emptySet); // NOI18N
-            attrDecls.put("decimal-format", new TreeSet(Arrays.asList(new String[]{"name", // NOI18N
+            attrDecls.put("decimal-format", new TreeSet<>(Arrays.asList(new String[]{"name", // NOI18N
             "decimal-separator","grouping-separator","infinity","minus-sign","NaN", // NOI18N
             "percent","per-mille","zero-digit","digit","pattern-separator"}))); // NOI18N
 
             // xsl:namespace-alias
             elementDecls.put("namespace-alias", emptySet); // NOI18N
-            attrDecls.put("namespace-alias", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("namespace-alias", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "stylesheet-prefix","result-prefix"}))); // NOI18N
 
             // xsl:template
@@ -218,28 +218,28 @@ public final class XSLGrammarQuery implements GrammarQuery{
             tmpSet.add(resultElements);
             tmpSet.add("param"); // NOI18N
             elementDecls.put("template", tmpSet); // NOI18N
-            attrDecls.put("template", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("template", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "match","name","priority","mode",spaceAtt}))); // NOI18N
 
             // xsl:value-of
             elementDecls.put("value-of", emptySet); // NOI18N
-            attrDecls.put("value-of", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("value-of", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
             "select","disable-output-escaping"}))); // NOI18N
 
             // xsl:copy-of
             elementDecls.put("copy-of", emptySet); // NOI18N
-            attrDecls.put("copy-of", new TreeSet(Arrays.asList(new String[]{"select"}))); // NOI18N
+            attrDecls.put("copy-of", new TreeSet<>(Arrays.asList(new String[]{"select"}))); // NOI18N
 
             // xsl:number
             elementDecls.put("number", emptySet); // NOI18N
-            attrDecls.put("number", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("number", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "level","count","from","value","format","lang","letter-value", // NOI18N
                 "grouping-separator","grouping-size"}))); // NOI18N
 
             // xsl:apply-templates
-            elementDecls.put("apply-templates", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            elementDecls.put("apply-templates", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "sort","with-param"}))); // NOI18N
-            attrDecls.put("apply-templates", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("apply-templates", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "select","mode"}))); // NOI18N
 
             // xsl:apply-imports
@@ -247,97 +247,97 @@ public final class XSLGrammarQuery implements GrammarQuery{
             attrDecls.put("apply-imports", emptySet); // NOI18N
 
             // xsl:for-each
-            tmpSet = new TreeSet(instructions);
+            tmpSet = new TreeSet<>(instructions);
             tmpSet.add(resultElements);
             tmpSet.add("sort"); // NOI18N
             elementDecls.put("for-each", tmpSet); // NOI18N
-            attrDecls.put("for-each", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("for-each", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
             "select",spaceAtt}))); // NOI18N
 
             // xsl:sort
             elementDecls.put("sort", emptySet); // NOI18N
-            attrDecls.put("sort", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("sort", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "select","lang","data-type","order","case-order"}))); // NOI18N
 
             // xsl:if
             elementDecls.put("if", template); // NOI18N
-            attrDecls.put("if", new TreeSet(Arrays.asList(new String[]{"test",spaceAtt}))); // NOI18N
+            attrDecls.put("if", new TreeSet<>(Arrays.asList(new String[]{"test",spaceAtt}))); // NOI18N
 
             // xsl:choose
-            elementDecls.put("choose", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            elementDecls.put("choose", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "when","otherwise"}))); // NOI18N
-            attrDecls.put("choose", new TreeSet(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
+            attrDecls.put("choose", new TreeSet<>(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
 
             // xsl:when
             elementDecls.put("when", template); // NOI18N
-            attrDecls.put("when", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("when", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "test",spaceAtt}))); // NOI18N
 
             // xsl:otherwise
             elementDecls.put("otherwise", template); // NOI18N
-            attrDecls.put("otherwise", new TreeSet(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
+            attrDecls.put("otherwise", new TreeSet<>(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
 
             // xsl:attribute-set
-            elementDecls.put("sort", new TreeSet(Arrays.asList(new String[]{"attribute"}))); // NOI18N
-            attrDecls.put("attribute-set", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            elementDecls.put("sort", new TreeSet<>(Arrays.asList(new String[]{"attribute"}))); // NOI18N
+            attrDecls.put("attribute-set", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","use-attribute-sets"}))); // NOI18N
 
             // xsl:call-template
-            elementDecls.put("call-template", new TreeSet(Arrays.asList(new String[]{"with-param"}))); // NOI18N
-            attrDecls.put("call-template", new TreeSet(Arrays.asList(new String[]{"name"}))); // NOI18N
+            elementDecls.put("call-template", new TreeSet<>(Arrays.asList(new String[]{"with-param"}))); // NOI18N
+            attrDecls.put("call-template", new TreeSet<>(Arrays.asList(new String[]{"name"}))); // NOI18N
 
             // xsl:with-param
             elementDecls.put("with-param", template); // NOI18N
-            attrDecls.put("with-param", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("with-param", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","select"}))); // NOI18N
 
             // xsl:variable
             elementDecls.put("variable", template); // NOI18N
-            attrDecls.put("variable", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("variable", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","select"}))); // NOI18N
 
             // xsl:param
             elementDecls.put("param", template); // NOI18N
-            attrDecls.put("param", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("param", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","select"}))); // NOI18N
 
             // xsl:text
             elementDecls.put("text", emptySet); // NOI18N
-            attrDecls.put("text", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("text", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "disable-output-escaping"}))); // NOI18N
 
             // xsl:processing-instruction
             elementDecls.put("processing-instruction", charTemplate); // NOI18N
-            attrDecls.put("processing-instruction", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("processing-instruction", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name",spaceAtt}))); // NOI18N
 
             // xsl:element
             elementDecls.put("element", template); // NOI18N
-            attrDecls.put("element", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("element", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","namespace","use-attribute-sets",spaceAtt}))); // NOI18N
 
             // xsl:attribute
             elementDecls.put("attribute", charTemplate); // NOI18N
-            attrDecls.put("attribute", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("attribute", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","namespace",spaceAtt}))); // NOI18N
 
             // xsl:comment
             elementDecls.put("comment", charTemplate); // NOI18N
-            attrDecls.put("comment", new TreeSet(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
+            attrDecls.put("comment", new TreeSet<>(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
 
             // xsl:copy
             elementDecls.put("copy", template); // NOI18N
-            attrDecls.put("copy", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("copy", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 spaceAtt,"use-attribute-sets"}))); // NOI18N
 
             // xsl:message
             elementDecls.put("message", template); // NOI18N
-            attrDecls.put("message", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("message", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 spaceAtt,"terminate"}))); // NOI18N
 
             // xsl:fallback
             elementDecls.put("fallback", template); // NOI18N
-            attrDecls.put("fallback", new TreeSet(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
+            attrDecls.put("fallback", new TreeSet<>(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
         }
         return elementDecls;
     }
@@ -502,13 +502,13 @@ public final class XSLGrammarQuery implements GrammarQuery{
             }
         }
 
-        Set possibleAttributes;
+        Set<String> possibleAttributes;
         if (curXslPrefix != null) {
             // Attributes of XSL element
             possibleAttributes = (Set) getAttrDecls().get(el.getTagName().substring(curXslPrefix.length()));
         } else {
             // XSL Attributes of Result element
-            possibleAttributes = new TreeSet();
+            possibleAttributes = new TreeSet<>();
             if (prefixList.size() > 0) {
                 Iterator it = getResultElementAttr().iterator();
                 while ( it.hasNext()) {

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/RunTargetsAction.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/RunTargetsAction.java
@@ -145,8 +145,8 @@ public final class RunTargetsAction extends AbstractAction implements ContextAwa
                     allTargets = Collections.emptySet();
                 }
                 String defaultTarget = null;
-                SortedSet<String> describedTargets = new TreeSet(Collator.getInstance());
-                SortedSet<String> otherTargets = new TreeSet(Collator.getInstance());
+                SortedSet<String> describedTargets = new TreeSet<>(Collator.getInstance());
+                SortedSet<String> otherTargets     = new TreeSet<>(Collator.getInstance());
                 for (TargetLister.Target t : allTargets) {
                     if (t.isOverridden()) {
                         // Cannot be called.

--- a/platform/openide.filesystems/src/org/openide/filesystems/DefaultAttributes.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/DefaultAttributes.java
@@ -1036,7 +1036,7 @@ public class DefaultAttributes extends Object implements AbstractFileSystem.Attr
          */
         public void writeToXML(PrintWriter pw) /*throws IOException */ {
             // list of names
-            Iterator<String> it = new TreeSet(keySet()).iterator();
+            Iterator<String> it = new TreeSet<String>(keySet()).iterator();
             XMLMapAttr.writeHeading(pw);
 
             while (it.hasNext()) {

--- a/platform/openide.filesystems/src/org/openide/filesystems/DefaultAttributes.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/DefaultAttributes.java
@@ -1036,7 +1036,7 @@ public class DefaultAttributes extends Object implements AbstractFileSystem.Attr
          */
         public void writeToXML(PrintWriter pw) /*throws IOException */ {
             // list of names
-            Iterator<String> it = new TreeSet<String>(keySet()).iterator();
+            Iterator<String> it = new TreeSet<>(keySet()).iterator();
             XMLMapAttr.writeHeading(pw);
 
             while (it.hasNext()) {


### PR DESCRIPTION
Cleanup a bunch of raw type error messages related to TreeSet. Issues like these..

[repeat] /home/bwalker/src/netbeans/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/JspSyntaxSupport.java:512: warning: [unchecked] unchecked call to addAll(Collection<? extends E>) as a member of the raw type TreeSet
[repeat] ts.addAll(mapper.keySet());
[repeat] ^
[repeat] where E is a type-variable:
[repeat] E extends Object declared in class TreeSet


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

