### PR TITLE
Fixing error recovery for (current) record patterns.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
@@ -582,7 +582,8 @@ final class VanillaCompileWorker extends CompileWorker {
                 } else {
                     scan(node.getInitializer(), null);
                 }
-                decl.sym.type = decl.type = error2Object(decl.type);
+                decl.type = error2Object(decl.type);
+                decl.sym.type = error2Object(decl.sym.type);
                 clearAnnotations(decl.sym.getMetadata());
                 return null;
             }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -36,6 +36,7 @@ import java.util.logging.LogRecord;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import java.util.stream.Collectors;
+import javax.lang.model.SourceVersion;
 import junit.framework.Test;
 
 import static junit.framework.TestCase.assertFalse;
@@ -1920,6 +1921,37 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
                 "    }\n" +
                 "}");
         assertEquals(expected, file2Fixed);
+    }
+
+    public void testRecordPatterns() throws Exception {
+        setSourceLevel(SourceVersion.latest().name().substring("RELEASE_".length()));
+        setCompilerOptions(Arrays.asList("--enable-preview"));
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test.java", "package test;\n"
+                        + "record Rect(ColoredPoint upperLeft) {}\n"
+                        + "record ColoredPoint(Point p) {}\n"
+                        + "record Point(int x){}\n"
+                        + "public class Test {\n"
+                        + "    private void test(Object o) {\n"
+                        + "        if (o instanceof Rect(ColoredPoint(Point p) ul)) {\n"
+                        + "            int x = p.x();\n"
+                        + "            System.out.println(\"Hello\");\n"
+                        + "        }\n"
+                        + "    }\n"
+                        + "}\n")), Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Rect.sig",
+                                                       "cache/s1/java/15/classes/test/ColoredPoint.sig",
+                                                       "cache/s1/java/15/classes/test/Point.sig",
+                                                       "cache/s1/java/15/classes/test/Test.sig")), createdFiles);
     }
 
     public static void noop() {}


### PR DESCRIPTION
`tree.type` may be `null`, and `error2Object` will return `null` for `null` input, and the current code will reset the `sym.type` to `null` as well, which is obviously problematic/wrong.


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

