### PR TITLE
Multi-release jar support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,6 +198,19 @@ matrix:
             - hide-logs.sh ant $OPTS -f platform/templates test
             - hide-logs.sh ant $OPTS -f platform/templatesui test
             - hide-logs.sh ant $OPTS -f platform/uihandler test
+          
+        - name: Test platform modules on JDK 11, Batch 1
+          jdk: openjdk8
+          env:
+            - OPTS="-Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json -silent -Dcluster.config=platform -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true -Dvanilla.javac.exists=true"
+          before_script:
+            - nbbuild/travis/ant.sh $OPTS clean
+            - nbbuild/travis/ant.sh $OPTS build
+            - wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh
+            - export TEST_JDK=`bash install-jdk.sh --feature 11 --license GPL --emit-java-home --silent | tail -1`
+            - export OPTS="$OPTS  -Dtest.nbjdk.home=$TEST_JDK"
+          script:
+            - hide-logs.sh ant $OPTS -f platform/o.n.bootstrap test
 
         - name: Test ide modules
           jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -206,8 +206,9 @@ matrix:
           before_script:
             - nbbuild/travis/ant.sh $OPTS clean
             - nbbuild/travis/ant.sh $OPTS build
-            - wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh
-            - export TEST_JDK=`bash install-jdk.sh --feature 11 --license GPL --emit-java-home --silent | tail -1`
+            - wget https://cdn.azul.com/zulu/bin/zulu11.58.23-ca-jdk11.0.16.1-linux_x64.tar.gz
+            - tar --extract --gzip --directory $HOME -f zulu11.58.23-ca-jdk11.0.16.1-linux_x64.tar.gz
+            - TEST_JDK=$HOME/zulu11.58.23-ca-jdk11.0.16.1-linux_x64
             - export OPTS="$OPTS  -Dtest.nbjdk.home=$TEST_JDK"
           script:
             - hide-logs.sh ant $OPTS -f platform/o.n.bootstrap test
@@ -454,8 +455,9 @@ matrix:
           env:
             - OPTS="-Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json -quiet -Dcluster.config=java -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true"
           before_script:
-            - wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh
-            - export TEST_JDK=`bash install-jdk.sh --feature 11 --license GPL --emit-java-home --silent | tail -1`
+            - wget https://cdn.azul.com/zulu/bin/zulu11.58.23-ca-jdk11.0.16.1-linux_x64.tar.gz
+            - tar --extract --gzip --directory $HOME -f zulu11.58.23-ca-jdk11.0.16.1-linux_x64.tar.gz
+            - TEST_JDK=$HOME/zulu11.58.23-ca-jdk11.0.16.1-linux_x64
             - export OPTS="-Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json $OPTS  -Dtest.nbjdk.home=$TEST_JDK -Dtest.run.args=--limit-modules=java.base,java.logging,java.xml,java.prefs,java.desktop,java.management,java.instrument,jdk.zipfs,java.scripting,java.naming -Dtest.bootclasspath.prepend.args=-Dno.netbeans.bootclasspath.prepend.needed=true"
             - nbbuild/travis/ant.sh $OPTS clean
             - nbbuild/travis/ant.sh $OPTS build
@@ -633,8 +635,9 @@ matrix:
           before_script:
             - nbbuild/travis/ant.sh $BUILD_OPTS clean
             - nbbuild/travis/ant.sh $BUILD_OPTS build
-            - wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh
-            - export TEST_JDK=`bash install-jdk.sh --feature 11 --license GPL --emit-java-home --silent | tail -1`
+            - wget https://cdn.azul.com/zulu/bin/zulu11.58.23-ca-jdk11.0.16.1-linux_x64.tar.gz
+            - tar --extract --gzip --directory $HOME -f zulu11.58.23-ca-jdk11.0.16.1-linux_x64.tar.gz
+            - TEST_JDK=$HOME/zulu11.58.23-ca-jdk11.0.16.1-linux_x64
             - export OPTS="-Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json $OPTS  -Dtest.nbjdk.home=$TEST_JDK -Dtest.run.args=--limit-modules=java.base,java.logging,java.xml,java.prefs,java.desktop,java.management,java.instrument,jdk.zipfs,java.scripting,java.naming -Dtest.bootclasspath.prepend.args=-Dno.netbeans.bootclasspath.prepend.needed=true"
           script:
             #- ant $TEST_OPTS -f groovy/groovy test

--- a/ide/c.jcraft.jsch/build.xml
+++ b/ide/c.jcraft.jsch/build.xml
@@ -33,6 +33,7 @@
                 <!-- Ensure that the necessary modules/bundles are made available to JSch -->
                 <attribute name="Require-Bundle" value="com.jcraft.jzlib,bcprov,libs.c.kohlschutter.junixsocket,org.netbeans.libs.jna,org.netbeans.libs.jna.platform"/>
                 <attribute name="NB-Original-CRC" value="${c.jcraft.jsch.crc32}"/>
+                <attribute name="Multi-Release" value="true"/>
             </manifest>
         </jar>
     </target>

--- a/platform/netbinox/nbproject/project.properties
+++ b/platform/netbinox/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 release.external/org.eclipse.osgi_3.9.1.nb9.jar=modules/ext/org.eclipse.osgi_3.9.1.nb9.jar
-javac.source=1.6
+javac.source=1.8
 javac.target=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/platform/netbinox/nbproject/project.xml
+++ b/platform/netbinox/nbproject/project.xml
@@ -92,6 +92,11 @@
                         <recursive/>
                         <compile-dependency/>
                     </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.openide.util.ui</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
                 </test-type>
             </test-dependencies>
             <public-packages>

--- a/platform/netbinox/src/org/netbeans/modules/netbinox/NetbinoxLoader.java
+++ b/platform/netbinox/src/org/netbeans/modules/netbinox/NetbinoxLoader.java
@@ -20,8 +20,6 @@ package org.netbeans.modules.netbinox;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.ProtectionDomain;
@@ -34,7 +32,6 @@ import org.eclipse.osgi.baseadaptor.loader.ClasspathEntry;
 import org.eclipse.osgi.baseadaptor.loader.ClasspathManager;
 import org.eclipse.osgi.framework.adaptor.ClassLoaderDelegate;
 import org.eclipse.osgi.internal.baseadaptor.DefaultClassLoader;
-import org.openide.util.Exceptions;
 import org.osgi.framework.FrameworkEvent;
 
 /** Classloader that eliminates some unnecessary disk touches.

--- a/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxMultiversionJarTest.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxMultiversionJarTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.netbinox;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+import org.netbeans.MockEvents;
+import org.netbeans.MockModuleInstaller;
+import org.netbeans.ModuleManager;
+import org.openide.util.test.TestFileUtils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static junit.framework.TestCase.assertEquals;
+
+public class NetbinoxMultiversionJarTest extends NetigsoHid {
+
+    public NetbinoxMultiversionJarTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        Locale.setDefault(new Locale("te", "ST"));
+        clearWorkDir();
+        File ud = new File(getWorkDir(), "ud");
+        ud.mkdirs();
+        System.setProperty("netbeans.user", ud.getPath());
+
+        data = new File(getDataDir(), "jars");
+        jars = new File(getWorkDir(), "space in path");
+        jars.mkdirs();
+
+        File classes = new File(getWorkDir(), "classes");
+        classes.mkdirs();
+        ToolProvider.getSystemJavaCompiler()
+                .getTask(null, null, d -> {
+                    throw new IllegalStateException(d.toString());
+                }, Arrays.asList("-d", classes.getAbsolutePath()), null,
+                        Arrays.asList(new SourceFileObject("test/Impl.java", "package test; public class Impl { public static String get() { return \"base\"; } }"),
+                                new SourceFileObject("api/API.java", "package api; public class API { public static String run() { return test.Impl.get(); } }")))
+                .call();
+        File classes9 = new File(new File(new File(classes, "META-INF"), "versions"), "9");
+        classes9.mkdirs();
+        ToolProvider.getSystemJavaCompiler()
+                .getTask(null, null, d -> {
+                    throw new IllegalStateException(d.toString());
+                }, Arrays.asList("-d", classes9.getAbsolutePath(), "-classpath", classes.getAbsolutePath()), null,
+                        Arrays.asList(new SourceFileObject("test/Impl.java", "package test; public class Impl { public static String get() { return \"9\"; } }")))
+                .call();
+        Map<String, byte[]> jarContent = new LinkedHashMap<>();
+        String manifest
+                = "Manifest-Version: 1.0\n"
+                + "Bundle-SymbolicName: test.module\n"
+                + "Bundle-Version: 1.0\n"
+                + "Multi-Release: true\n"
+                + "";
+        jarContent.put("META-INF/MANIFEST.MF", manifest.getBytes(UTF_8));
+        Path classesPath = classes.toPath();
+        Files.walk(classesPath)
+                .filter(p -> Files.isRegularFile(p))
+                .forEach(p -> {
+                    try {
+                        jarContent.put(classesPath.relativize(p).toString(), TestFileUtils.readFileBin(p.toFile()));
+                    } catch (IOException ex) {
+                        throw new IllegalStateException(ex);
+                    }
+                });
+        jarContent.put("test/dummy.txt", "base".getBytes(UTF_8));
+        jarContent.put("META-INF/versions/9/test/dummy.txt", "9".getBytes(UTF_8));
+        simpleModule = new File(jars, "multi-release.jar");
+        try ( OutputStream out = new FileOutputStream(simpleModule)) {
+            TestFileUtils.writeZipFile(out, jarContent);
+        }
+    }
+
+    public void testMultiReleaseJar() throws Exception {
+        MockModuleInstaller installer = new MockModuleInstaller();
+        MockEvents ev = new MockEvents();
+        ModuleManager mgr = new ModuleManager(installer, ev);
+        mgr.mutexPrivileged().enterWriteAccess();
+        Set<org.netbeans.Module> all = null;
+        try {
+            org.netbeans.Module m1 = mgr.create(simpleModule, null, false, false, false);
+            all = Collections.singleton(m1);
+
+            mgr.enable(all);
+
+            // Check multi release class loading
+            Class<?> impl = m1.getClassLoader().loadClass("test.Impl");
+            Method get = impl.getMethod("get");
+            String output = (String) get.invoke(null);
+
+            String expected;
+            try {
+                Class.forName("java.lang.Runtime$Version");
+                expected = "9";
+            } catch (ClassNotFoundException ex) {
+                expected = "base";
+            }
+            assertEquals(expected, output);
+
+            // Check multi release resource loading
+            try(InputStream is = m1.getClassLoader().getResourceAsStream("test/dummy.txt")) {
+                assertEquals(expected, loadUTF8(is));
+            }
+
+        } finally {
+            if (all != null) {
+                mgr.disable(all);
+            }
+            mgr.mutexPrivileged().exitWriteAccess();
+        }
+
+    }
+
+    private static String loadUTF8(InputStream is) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[2048];
+        int read;
+        while ((read = is.read(buffer)) > 0) {
+            baos.write(buffer, 0, read);
+        }
+        return baos.toString("UTF-8");
+    }
+
+    private static final class SourceFileObject extends SimpleJavaFileObject {
+
+        private final String content;
+
+        public SourceFileObject(String path, String content) throws URISyntaxException {
+            super(new URI("mem://" + path), JavaFileObject.Kind.SOURCE);
+            this.content = content;
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+            return content;
+        }
+
+    }
+}

--- a/platform/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
@@ -85,14 +85,13 @@ public class JarClassLoader extends ProxyClassLoader {
     static {
         int version;
         try {
-                Object runtimeVersion = Runtime.class.getMethod("version").invoke(null);
-                version = (int) runtimeVersion.getClass().getMethod("major").invoke(runtimeVersion);
-        }
-        catch (Throwable ex) {
-                version = BASE_VERSION;
+            Object runtimeVersion = Runtime.class.getMethod("version").invoke(null);
+            version = (int) runtimeVersion.getClass().getMethod("major").invoke(runtimeVersion);
+        } catch (Throwable ex) {
+            version = BASE_VERSION;
         }
         RUNTIME_VERSION = version;
-    }    
+    }
     
     static Archive archive = new Archive(); 
 
@@ -289,8 +288,10 @@ public class JarClassLoader extends ProxyClassLoader {
                     }
                 }
                 Manifest man = new DelayedManifest();
-                
-                src.setMultiRelease(man.getMainAttributes().containsKey(MULTI_RELEASE));
+                if (man.getMainAttributes().containsKey(MULTI_RELEASE)) {
+                    String multiRelease = (String) man.getMainAttributes().get(MULTI_RELEASE);
+                    src.setMultiRelease(multiRelease.equalsIgnoreCase("true"));
+                }
                 if (src.isMultiRelease() && RUNTIME_VERSION != BASE_VERSION) {
                     data = src.getClassData(path);
                 }
@@ -606,8 +607,7 @@ public class JarClassLoader extends ProxyClassLoader {
         @Override
         protected byte[] readClass(String path) throws IOException {
             try {
-                if (isMultiRelease() && RUNTIME_VERSION != BASE_VERSION)
-                {
+                if (isMultiRelease() && RUNTIME_VERSION != BASE_VERSION) {
                     int ver = RUNTIME_VERSION;
                     while (ver > BASE_VERSION) {
                         byte[] data = archive.getData(this, "META-INF/versions/" + ver + "/" + path);

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/JarClassLoaderTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/JarClassLoaderTest.java
@@ -457,6 +457,7 @@ public class JarClassLoaderTest extends NbTestCase {
         try (OutputStream out = new FileOutputStream(jar)) {
             TestFileUtils.writeZipFile(out, jarContent);
         }
+
         JarClassLoader jcl = new JarClassLoader(Arrays.asList(jar), new ProxyClassLoader[0]);
         Class<?> api = jcl.loadClass("api.API");
         Method run = api.getDeclaredMethod("run");


### PR DESCRIPTION
This is an enhanced version of #3860, which implements support for multi-release jars for the JarClassLoader and the Equinox based OSGI integration.

Changes compared to the original PR:

- prevent unnecessary reads from original JAR (JAR content is cached and should be used at startup)
- use descending order for versions in `getVersions`, so that implementations for newer VMs are preferred and move runtime version limitation there
- add support for multi-release jars to NetBinox classloader by using the idea from `JarFile`, where the versioning aspect of class loading is handled below the classloader level and for NetBinox is implemented in the `JarBundleFile`
- mark the JSch module as multi-release. The JSch implementation for communication with the ssh agent can then use the JDK implementation of unix domain socket support and does not rely on junixsocket anymore.