### PR TITLE
Cleanup debug Exception after an old issue

### DIFF
--- a/ide/editor/src/org/netbeans/modules/editor/NbEditorDocument.java
+++ b/ide/editor/src/org/netbeans/modules/editor/NbEditorDocument.java
@@ -130,7 +130,6 @@ NbDocument.Printable, NbDocument.CustomEditor, NbDocument.CustomToolbar, NbDocum
                 return null;
             }
         });
-        putProperty("Issue-222763-debug", new Exception()); // Issue #222763 debugging - to be removed soon
     }
 
     public @Override int getShiftWidth() {


### PR DESCRIPTION

This is a trivial one. I've found it debugging the editor infrastructure.

The mentioned issue is here: https://bz.apache.org/netbeans/show_bug.cgi?id=222763
