### PR TITLE
Support projects without build.gradle

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
@@ -43,7 +43,12 @@ public final class NbGradleProjectFactory implements ProjectFactory2 {
 
     @Override
     public ProjectManager.Result isProject2(FileObject dir) {
-        return isProject(dir) ? new ProjectManager.Result(NbGradleProject.getIcon()) : null;
+        if (!isProject(dir)) {
+            return null;
+        }
+        // project display name can be only safely determined if the project is loaded
+        return isProject(dir) ? new ProjectManager.Result(
+                null, NbGradleProject.GRADLE_PROJECT_TYPE, NbGradleProject.getIcon()) : null;
     }
 
     @Override

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
@@ -220,7 +220,7 @@ public final class GradleFiles implements Serializable {
     }
 
     public boolean isRootProject() {
-        return (buildScript != null) && rootDir.equals(projectDir);
+        return isProject() && rootDir.equals(projectDir);
     }
 
     public boolean isSubProject() {

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectFactoryTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectFactoryTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.gradle;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
+import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.LocalFileSystem;
@@ -129,9 +130,31 @@ public class NbGradleProjectFactoryTest extends AbstractGradleProjectTestCase {
         }
         FileObject app = FileUtil.createFolder(parentPrj, "app");
         FileObject gradle = FileUtil.createData(app, "build.gradle");
-
+        assertProjectsRecognized(parentPrj, app);
+    }
+    
+    private void assertProjectsRecognized(FileObject parentPrj, FileObject app) {
         assertTrue("Parent Gradle recognized", NbGradleProjectFactory.isProjectCheck(parentPrj, false));
         assertTrue("Child Gradle recognized", NbGradleProjectFactory.isProjectCheck(app, false));
+        NbGradleProjectFactory factoryInstance = new NbGradleProjectFactory();
+        assertEquals("Gradle project type of main project", NbGradleProject.GRADLE_PROJECT_TYPE, factoryInstance.isProject2(parentPrj).getProjectType());
+        assertEquals("Gradle project type of subproject", NbGradleProject.GRADLE_PROJECT_TYPE, factoryInstance.isProject2(app).getProjectType());
+    }
+    
+    /**
+     * Checks that project with just settings.gradle and no build.gradle is recognized as a project.
+     */
+    public void testNoBuildFileProject() throws Exception {
+        FileObject parentPrj = root;
+        FileObject settings = FileUtil.createData(parentPrj, "settings.gradle");
+        try (OutputStream os = settings.getOutputStream()) {
+            os.write(("\n"
+                    + "rootProject.name = 'example'\n"
+                    + "include('app')\n"
+            ).getBytes(StandardCharsets.UTF_8));
+        }
+        FileObject app = FileUtil.createFolder(parentPrj, "app");
+        assertProjectsRecognized(parentPrj, app);
     }
 
 }

--- a/java/maven/src/org/netbeans/modules/maven/NbMavenProjectFactory.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbMavenProjectFactory.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
+import org.netbeans.modules.maven.api.NbMavenProject;
 import org.netbeans.spi.project.ProjectFactory;
 import org.netbeans.spi.project.ProjectFactory2;
 import org.netbeans.spi.project.ProjectState;
@@ -77,7 +78,9 @@ public class NbMavenProjectFactory implements ProjectFactory2 {
 
     public @Override ProjectManager.Result isProject2(FileObject projectDirectory) {
         if (isProject(projectDirectory)) {
-            return new ProjectManager.Result(ImageUtilities.loadImageIcon("org/netbeans/modules/maven/resources/Maven2Icon.gif", true)); //NOI18N
+            return new ProjectManager.Result(
+                    null, NbMavenProject.TYPE, 
+                    ImageUtilities.loadImageIcon("org/netbeans/modules/maven/resources/Maven2Icon.gif", true)); //NOI18N
         }
         return null;
     }


### PR DESCRIPTION
A multiproject build looks, [according to the documentation](https://docs.gradle.org/current/userguide/multi_project_builds.html#sec:creating_multi_project_builds) like
```
├── app
│   ...
│   └── build.gradle
└── settings.gradle
```
there's no `build.gradle` in the root. While `GradleFiles.isSubProject` already works OK with build-less projects, the `isRootProject` does not. This PR fixes that. Simple test added.

During other work, I've realized that the `ProjectFactory2` implementation for both Gradle and Maven do not return project type -- although they could. The display name is not that easy to evaluate, but both project types use a fixed ID, so it's simple to return.

