### PR TITLE
Project info exported through LSP

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/project/LspProjectInfo.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/project/LspProjectInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.project;
+
+import java.net.URI;
+
+/**
+ *
+ * @author sdedic
+ */
+public class LspProjectInfo {
+    /**
+     * Project's directory
+     */
+    public URI  projectDirectory;
+    
+    /**
+     * Project's name.
+     */
+    public String name;
+    
+    /**
+     * Project's display name as defined in project file(s)
+     */
+    public String displayName;
+    
+    /**
+     * The build system / project type. Ant, Gradle, Maven.
+     */
+    public String projectType;
+    
+    /**
+     * URIs of subprojects. Usually children of the project's own directory.
+     */
+    public URI[] subprojects;
+    
+    /**
+     * If part of a reactor or multi-project, the URI of the root project.
+     */
+    public URI rootProject;
+    
+    /**
+     * Supported project actions. Names.
+     */
+    public String[] projectActionNames;
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -749,7 +749,9 @@ public final class Server {
                         JAVA_SUPER_IMPLEMENTATION,
                         JAVA_SOURCE_FOR,
                         JAVA_CLEAR_PROJECT_CACHES,
-                        NATIVE_IMAGE_FIND_DEBUG_PROCESS_TO_ATTACH));
+                        NATIVE_IMAGE_FIND_DEBUG_PROCESS_TO_ATTACH,
+                        JAVA_PROJECT_INFO
+                ));
                 for (CodeActionsProvider codeActionsProvider : Lookup.getDefault().lookupAll(CodeActionsProvider.class)) {
                     commands.addAll(codeActionsProvider.getCommands());
                 }
@@ -944,6 +946,12 @@ public final class Server {
      * new project files were generated into workspace subtree.
      */
     public static final String JAVA_CLEAR_PROJECT_CACHES =  "java.clear.project.caches";
+    
+    /**
+     * For a project directory, returns basic project information and structure.
+     * Syntax: nbls.project.info(locations : String | String[], options? : { projectStructure? : boolean; actions? : boolean; recursive? : boolean }) : LspProjectInfo
+     */
+    public static final String JAVA_PROJECT_INFO = "nbls.project.info";
 
     static final String INDEXING_COMPLETED = "Indexing completed.";
     static final String NO_JAVA_SUPPORT = "Cannot initialize Java support on JDK ";


### PR DESCRIPTION
LSP client may need some project structure information. This PR exposes basic info on a project on the LSP protocol.
```
nbls.project.info(locations : String | String[], options? : { projectStructure? : boolean; actions? : boolean; recursive? : boolean }) : LspProjectInfo[]
```
The command accepts one or more locations as URIs (vscode.Uri.toString() for example); it will return, for each input parameter, a structure that describes the project and its direct children (if requested). If `recursive` is true, additional entries will be provided for each identified child project, recursively.
