### PR TITLE
Cleanup warnings related to Set raw type

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewNbModuleWizardIterator.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/NewNbModuleWizardIterator.java
@@ -161,7 +161,7 @@ public class NewNbModuleWizardIterator implements WizardDescriptor.AsynchronousI
         return createdProjectFolder;
     }
     
-    public Set instantiate() throws IOException {
+    public Set<FileObject> instantiate() throws IOException {
         final File projectFolder = new File(data.getProjectFolder());
         ModuleUISettings.getDefault().setLastUsedPlatformID(data.getPlatformID());
         WizardDescriptor settings = data.getSettings();

--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteActionsProvider.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteActionsProvider.java
@@ -69,7 +69,7 @@ public final class CPPLiteActionsProvider extends ActionsProviderSupport {
     }
 
     @Override
-    public Set getActions () {
+    public Set<Object> getActions () {
         return ACTIONS;
     }
 

--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/breakpoints/CPPLiteBreakpointActionProvider.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/breakpoints/CPPLiteBreakpointActionProvider.java
@@ -47,7 +47,7 @@ public class CPPLiteBreakpointActionProvider extends ActionsProviderSupport
     private static final String[] C_MIME_TYPES = new String[] {"text/X-c", "text/X-c++", "text/X-h", "text/X-h++"}; // NOI18N
     private static final Set<String> C_MIME_TYPES_SET = new HashSet<>(Arrays.asList(C_MIME_TYPES));
 
-    private static final Set ACTIONS = Collections.singleton (
+    private static final Set<Object> ACTIONS = Collections.singleton (
         ActionsManager.ACTION_TOGGLE_BREAKPOINT
     );
 
@@ -101,7 +101,7 @@ public class CPPLiteBreakpointActionProvider extends ActionsProviderSupport
      * @return set of actions supported by this ActionsProvider
      */
     @Override
-    public Set getActions () {
+    public Set<Object> getActions () {
         return ACTIONS;
     }
 

--- a/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/ui/wizard/CPPLiteProjectWizardIterator.java
+++ b/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/ui/wizard/CPPLiteProjectWizardIterator.java
@@ -72,7 +72,7 @@ public class CPPLiteProjectWizardIterator implements WizardDescriptor.Instantiat
     private int idx;
 
     @Override
-    public Set instantiate() throws IOException {
+    public Set<FileObject> instantiate() throws IOException {
         CPPLiteProjectSettings settings = CPPLiteProjectSettings.get(wizard);
         FileObject projectDirectory = FileUtil.toFileObject(new File(settings.getProjectPath()));
         Preferences prefs = CPPLiteProject.getRootPreferences(projectDirectory);

--- a/enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/serverplugin/AmazonJ2eePlatformImpl2.java
+++ b/enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/serverplugin/AmazonJ2eePlatformImpl2.java
@@ -144,7 +144,7 @@ public class AmazonJ2eePlatformImpl2 extends J2eePlatformImpl2 {
     }
 
     @Override
-    public Set getSupportedJavaPlatformVersions() {
+    public Set<String> getSupportedJavaPlatformVersions() {
         return new HashSet<String>(Arrays.asList(new String[] {"1.6","1.5"}));
     }
 

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/ServerWizardIterator.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/ServerWizardIterator.java
@@ -129,7 +129,7 @@ public class ServerWizardIterator extends PortCollection implements WizardDescri
     }
     
     @Override
-    public Set instantiate() throws IOException {
+    public Set<ServerInstance> instantiate() throws IOException {
         Set<ServerInstance> result = new HashSet<>();
         File ir = new File(installRoot);
         ensureExecutable(ir);

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2JavaEEPlatformImpl.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2JavaEEPlatformImpl.java
@@ -642,7 +642,7 @@ public class Hk2JavaEEPlatformImpl extends J2eePlatformImpl2 {
      * @return Supported JavaSE platforms.
      */
     @Override
-    public Set getSupportedJavaPlatformVersions() {
+    public Set<String> getSupportedJavaPlatformVersions() {
         return platformsSetFromArray(platforms);
     }
 

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDWizardIterator.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDWizardIterator.java
@@ -89,7 +89,7 @@ public final class WebLogicDDWizardIterator implements WizardDescriptor.Instanti
     }
     
     @Override
-    public Set instantiate() throws IOException {
+    public Set<FileObject> instantiate() throws IOException {
         Set<FileObject> result = Collections.emptySet();
         WebLogicDDWizardPanel wizardPanel = (WebLogicDDWizardPanel) panels[0];
         

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/entity/EntityEJBWizard.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/entity/EntityEJBWizard.java
@@ -70,7 +70,7 @@ public final class EntityEJBWizard implements WizardDescriptor.InstantiatingIter
 
     }
 
-    public Set instantiate () {
+    public Set<FileObject> instantiate () {
         boolean isCMP = ejbPanel.isCMP();
         EntityGenerator entityGenerator = EntityGenerator.create(
                 Templates.getTargetName(wiz), 

--- a/enterprise/j2ee.genericserver/src/org/netbeans/modules/j2ee/genericserver/ide/GSJ2eePlatformFactory.java
+++ b/enterprise/j2ee.genericserver/src/org/netbeans/modules/j2ee/genericserver/ide/GSJ2eePlatformFactory.java
@@ -51,13 +51,13 @@ public class GSJ2eePlatformFactory extends J2eePlatformFactory {
             return new File[0];
         }
         
-        public Set getSupportedSpecVersions() {
+        public Set<String> getSupportedSpecVersions() {
             Set<String> result = new HashSet<>();
             result.add(J2eeModule.J2EE_14);
             return result;
         }
         
-        public Set getSupportedModuleTypes() {
+        public Set<Object> getSupportedModuleTypes() {
             Set<Object> result = new HashSet<>();
 //            result.add(J2eeModule.EAR);
 //            result.add(J2eeModule.WAR);
@@ -67,7 +67,7 @@ public class GSJ2eePlatformFactory extends J2eePlatformFactory {
             return result;
         }
         
-        public Set/*<String>*/ getSupportedJavaPlatformVersions() {
+        public Set<String> getSupportedJavaPlatformVersions() {
             Set<String> versions = new HashSet<>();
             versions.add("1.4"); // NOI18N
             versions.add("1.5"); // NOI18N

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/dd/ear/ApplicationXmlWizardIterator.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/dd/ear/ApplicationXmlWizardIterator.java
@@ -79,7 +79,7 @@ public final class ApplicationXmlWizardIterator implements WizardDescriptor.Inst
         return panels;
     }
 
-    public Set instantiate() throws IOException {
+    public Set<FileObject> instantiate() throws IOException {
         ApplicationXmlWizardPanel1 panel = (ApplicationXmlWizardPanel1) panels[0];
         FileObject confRoot = panel.getSelectedLocation();
 

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/newproject/MicronautProjectWizardIterator.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/newproject/MicronautProjectWizardIterator.java
@@ -93,7 +93,7 @@ public class MicronautProjectWizardIterator implements WizardDescriptor.Progress
     private transient WizardDescriptor wiz;
 
     @Override
-    public Set instantiate(ProgressHandle handle) throws IOException {
+    public Set<FileObject> instantiate(ProgressHandle handle) throws IOException {
         try {
             handle.start(4);
             String projectName = (String) wiz.getProperty(PROJECT_NAME);

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDWizardIterator.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDWizardIterator.java
@@ -105,7 +105,7 @@ public final class PayaraDDWizardIterator implements WizardDescriptor.Instantiat
     }
     
     @Override
-    public Set instantiate() throws IOException {
+    public Set<FileObject> instantiate() throws IOException {
         Set<FileObject> result = Collections.emptySet();
         PayaraDDWizardPanel wizardPanel = (PayaraDDWizardPanel) panels[0];
         

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2JavaEEPlatformImpl.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2JavaEEPlatformImpl.java
@@ -630,7 +630,7 @@ public class Hk2JavaEEPlatformImpl extends J2eePlatformImpl2 {
      * @return Supported JavaSE platforms.
      */
     @Override
-    public Set getSupportedJavaPlatformVersions() {
+    public Set<String> getSupportedJavaPlatformVersions() {
         return platformsSetFromArray(platforms);
     }
 

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2OptionalFactory.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2OptionalFactory.java
@@ -228,11 +228,11 @@ public class Hk2OptionalFactory extends OptionalDeploymentManagerFactory {
 
         @Override
         public Set instantiate() throws IOException {
-            Set set = delegate.instantiate();
-            if(!set.isEmpty()) {
+            Set<ServerInstance> set = delegate.instantiate();
+            if (!set.isEmpty()) {
                 Object obj = set.iterator().next();
-                if(obj instanceof ServerInstance) {
-                    ServerInstance instance = (ServerInstance) obj;
+                if (obj instanceof ServerInstance) {
+                    ServerInstance instance = (ServerInstance)obj;
                     Lookup lookup = su.getLookupFor(instance);
                     if (lookup != null) {
                         JavaEEServerModule module = lookup.lookup(JavaEEServerModule.class);

--- a/enterprise/web.client.rest/src/org/netbeans/modules/web/client/rest/wizard/JSClientIterator.java
+++ b/enterprise/web.client.rest/src/org/netbeans/modules/web/client/rest/wizard/JSClientIterator.java
@@ -169,7 +169,7 @@ public class JSClientIterator implements ProgressInstantiatingIterator<WizardDes
      * @see org.openide.WizardDescriptor.InstantiatingIterator#instantiate()
      */
     @Override
-    public Set instantiate(ProgressHandle handle) throws IOException {
+    public Set<FileObject> instantiate(ProgressHandle handle) throws IOException {
         handle.start();
         Project project = Templates.getProject(myWizard);
         

--- a/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/actions/PageFlowPopupProvider.java
+++ b/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/actions/PageFlowPopupProvider.java
@@ -39,7 +39,6 @@ import org.openide.util.Lookup;
 import org.openide.util.Utilities;
 import org.openide.util.lookup.AbstractLookup;
 import org.openide.util.lookup.InstanceContent;
-import org.openide.windows.TopComponent;
 import javax.swing.Action;
 import org.netbeans.modules.web.jsf.navigation.PageFlowView;
 import org.netbeans.modules.web.jsf.navigation.Pin;
@@ -79,9 +78,9 @@ public class PageFlowPopupProvider implements PopupMenuProvider {
 
         if (obj != null) {
 
-            Set elements = scene.getSelectedObjects();            
+            Set<?> elements = scene.getSelectedObjects();            
             if( !elements.contains(obj)) {
-                Set<Object> set = new HashSet<Object>();
+                Set<Object> set = new HashSet<>();
                 set.add(obj);
                 scene.setSelectedObjects(set);
             }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigUtilities.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigUtilities.java
@@ -249,8 +249,8 @@ public class JSFConfigUtilities {
         }
     }
 
-    public static Set extendJsfFramework(FileObject fileObject, boolean createWelcomeFile) {
-        Set result = Collections.emptySet();
+    public static Set<FileObject> extendJsfFramework(FileObject fileObject, boolean createWelcomeFile) {
+        Set<FileObject> result = Collections.emptySet();
         if (fileObject == null) {
             return result;
         }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFFrameworkProvider.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFFrameworkProvider.java
@@ -123,7 +123,7 @@ public class JSFFrameworkProvider extends WebFrameworkProvider {
 
     // not named extend() so as to avoid implementing WebFrameworkProvider.extend()
     // better to move this to JSFConfigurationPanel
-    public Set extendImpl(WebModule webModule, TreeMap<String, JsfComponentCustomizer> jsfComponentCustomizers) {
+    public Set<FileObject> extendImpl(WebModule webModule, TreeMap<String, JsfComponentCustomizer> jsfComponentCustomizers) {
         Set<FileObject> result = new HashSet<>();
         Library jsfLibrary = null;
         Library jstlLibrary = null;

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/DescriptionStep.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/DescriptionStep.java
@@ -327,7 +327,7 @@ public class DescriptionStep implements WizardDescriptor.Panel<WizardDescriptor>
             o = new WizardDescriptor.InstantiatingIterator<WizardDescriptor>() {
                 private TemplateWizard tw;
 
-                public Set instantiate() throws IOException {
+                public Set<DataObject> instantiate() throws IOException {
                     return it.instantiate(tw);
                 }
                 public void initialize(WizardDescriptor wizard) {

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/EnableStep.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/EnableStep.java
@@ -41,6 +41,7 @@ import org.openide.WizardDescriptor;
 import org.openide.WizardDescriptor.Panel;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.loaders.DataObject;
 import org.openide.loaders.TemplateWizard;
 import org.openide.util.Exceptions;
 import org.openide.util.HelpCtx;
@@ -164,7 +165,7 @@ public class EnableStep implements WizardDescriptor.FinishablePanel<WizardDescri
             o = new WizardDescriptor.InstantiatingIterator<WizardDescriptor>() {
                 private TemplateWizard tw;
 
-                public Set instantiate() throws IOException {
+                public Set<DataObject> instantiate() throws IOException {
                     return it.instantiate(tw);
                 }
                 public void initialize(WizardDescriptor wizard) {

--- a/groovy/groovy.samples/src/org/netbeans/modules/groovy/samples/nbprojectgen/NBProjectGeneratorsWizardIterator.java
+++ b/groovy/groovy.samples/src/org/netbeans/modules/groovy/samples/nbprojectgen/NBProjectGeneratorsWizardIterator.java
@@ -73,7 +73,7 @@ public class NBProjectGeneratorsWizardIterator implements WizardDescriptor./*Pro
                 };
     }
 
-    public Set/*<FileObject>*/ instantiate(/*ProgressHandle handle*/) throws IOException {
+    public Set<FileObject> instantiate(/*ProgressHandle handle*/) throws IOException {
         Set<FileObject> resultSet = new LinkedHashSet<FileObject>();
         File dirF = FileUtil.normalizeFile((File) wiz.getProperty("projdir"));
         dirF.mkdirs();

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/wizard/AbstractGroovyWizard.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/wizard/AbstractGroovyWizard.java
@@ -73,7 +73,7 @@ public abstract class AbstractGroovyWizard extends AbstractFileWizard {
     }
 
     @Override
-    public Set instantiate(ProgressHandle handle) throws IOException {
+    public Set<FileObject> instantiate(ProgressHandle handle) throws IOException {
         handle.start();
         handle.progress(NbBundle.getMessage(AbstractGroovyWizard.class, "LBL_NewGroovyFileWizardIterator_WizardProgress_CreatingFile"));
 

--- a/harness/o.n.insane/src/org/netbeans/insane/impl/LiveEngine.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/impl/LiveEngine.java
@@ -195,8 +195,8 @@ public class LiveEngine implements ObjectMap, Visitor {
         return result;
     }
 
-    private Path findRoots(Object obj, Set roots) {
-        Set<Path> visited = new HashSet<Path>();
+    private Path findRoots(Object obj, Set<?> roots) {
+        Set<Path> visited = new HashSet<>();
         Path last = Utils.createPath(obj, null);
 
         List<Path> queue = new LinkedList<Path>();

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/spi/Utilities.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/spi/Utilities.java
@@ -89,7 +89,7 @@ public class Utilities {
             return null;
         }
 
-        Set types = EnumSet.copyOf(Arrays.asList(nodeTypesToMatch));
+        Set<NodeType> types = EnumSet.copyOf(Arrays.asList(nodeTypesToMatch));
         if(!types.contains(current.type())) {
             return null;
         }

--- a/ide/project.ant/src/org/netbeans/spi/project/support/ant/ReferenceHelper.java
+++ b/ide/project.ant/src/org/netbeans/spi/project/support/ant/ReferenceHelper.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/ide/server/src/org/netbeans/modules/server/ui/wizard/AddServerInstanceWizard.java
+++ b/ide/server/src/org/netbeans/modules/server/ui/wizard/AddServerInstanceWizard.java
@@ -379,7 +379,7 @@ public class AddServerInstanceWizard extends WizardDescriptor {
             wd.putProperty(PROP_CONTENT_DATA, getFirstPanelContentData(registry.isCloud()));
         }
 
-        public Set instantiate() throws IOException {
+        public Set<?> instantiate() throws IOException {
             if (iterator != null) {
                 return iterator.instantiate();
             } else {

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
@@ -39,7 +39,7 @@ import org.netbeans.modules.xml.spi.dom.*;
 class DTDGrammar implements ExtendedGrammarQuery {
     
     // element name keyed
-    private Map<String, Set>  elementDecls, attrDecls;
+    private Map<String, Set<String>>  elementDecls, attrDecls;
     
     // Map<elementName:String, model:String || model:ContentModel || null>
     // this map is filled asynchronously as it takes some time
@@ -54,12 +54,13 @@ class DTDGrammar implements ExtendedGrammarQuery {
     private Set<String> entities, notations;
 
     /** Set&lt;elementName:String> holding all emenets with <code>EMPTY</code> content model.*/
-    private Set emptyElements;
+    private Set<String> emptyElements;
 
     private List<String> resolvedEntities;
     
     /** Creates new DTDGrammar */
-    DTDGrammar(Map elementDecls, Map contentModels, Map attrDecls, Map attrDefs, Map enums, Set entities, Set notations, Set emptyElements) {
+    DTDGrammar(Map elementDecls, Map contentModels, Map attrDecls, Map attrDefs, Map enums,
+	       Set<String> entities, Set<String> notations, Set<String> emptyElements) {
         this.elementDecls = elementDecls;
         this.attrDecls = attrDecls;
         this.entities = entities;

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDParser.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDParser.java
@@ -123,7 +123,10 @@ public class DTDParser {
     private class Handler extends DefaultHandler implements DeclHandler {
         
         private Map attrs, elements, models, enums, attrDefaults;
-        private Set<String> notations, entities, anys, emptyElements;
+        private Set<String> notations;
+        private Set<String> entities;
+        private Set<String> anys;
+        private Set<String> emptyElements;
         private DTDGrammar dtd;
         
         Handler() {
@@ -134,8 +137,8 @@ public class DTDParser {
             entities  = new TreeSet<>();
             anys = new HashSet();
             enums = new HashMap();
-            attrDefaults = new HashMap();
-            emptyElements = new HashSet();
+            attrDefaults  = new HashMap();
+            emptyElements = new HashSet<>();
             dtd = new DTDGrammar(elements, models, attrs, attrDefaults, enums, entities, notations, emptyElements);
         }
         
@@ -172,7 +175,7 @@ public class DTDParser {
             // parse content model
             
             StringTokenizer tokenizer = new StringTokenizer(model, " \t\n|,()?+*");
-            Set modelset = new TreeSet();
+            Set<String> modelset = new TreeSet();
             while (tokenizer.hasMoreTokens()) {
                 String next = tokenizer.nextToken().trim();
                 if ("#PCDATA".equals(next)) continue;
@@ -189,9 +192,9 @@ public class DTDParser {
         }
         
         public void attributeDecl(String eName, String aName, String type, String valueDefault, String value) throws SAXException {
-            Set set = (Set) attrs.get(eName);
+            Set<String> set = (Set) attrs.get(eName);
             if (set == null) {
-                set = new TreeSet();
+                set = new TreeSet<>();
                 attrs.put(eName, set);
             }
             set.add(aName);

--- a/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
@@ -349,21 +349,21 @@ public final class XSLGrammarQuery implements GrammarQuery{
         return attrDecls;
     }
 
-    private static Set getResultElementAttr() {
+    private static Set<String> getResultElementAttr() {
         if (resultElementAttr == null) {
             getElementDecls();
         }
         return resultElementAttr;
     }
 
-    private static Set getTemplate() {
+    private static Set<String> getTemplate() {
         if (template == null) {
             getElementDecls();
         }
         return template;
     }
 
-    private static Set getXslFunctions() {
+    private static Set<String> getXslFunctions() {
         if (xslFunctions == null) {
             xslFunctions = new TreeSet<>(Arrays.asList(new String[]{
                 "boolean(","ceiling(","concat(", "contains(","count(","current()","document(", // NOI18N
@@ -376,7 +376,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
         return xslFunctions;
     }
 
-    private static Set getXPathAxes() {
+    private static Set<String> getXPathAxes() {
         if (xpathAxes == null) {
             xpathAxes = new TreeSet<>(Arrays.asList(new String[]{"ancestor::", "ancestor-or-self::", // NOI18N
             "attribute::", "child::", "descendant::", "descendant-or-self::", "following::", // NOI18N
@@ -427,7 +427,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
             if (prefixList.size() == 0) return org.openide.util.Enumerations.empty();
 
             String firstXslPrefixWithColon = prefixList.get(0) + ":"; // NOI18N
-            Set elements;
+            Set<String> elements;
             if (el.getTagName().startsWith(firstXslPrefixWithColon)) {
                 String parentNCName = el.getTagName().substring(firstXslPrefixWithColon.length());
                 elements = (Set) getElementDecls().get(parentNCName);
@@ -645,7 +645,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
                     if (doc != null) {
                         Element docElement = doc.getDocumentElement();
 
-                        Set childNodeNames = new TreeSet();
+                        Set<String> childNodeNames = new TreeSet<>();
 
                         String combinedXPath;
                         if (subPre.startsWith("/")) { // NOI18N
@@ -832,9 +832,9 @@ public final class XSLGrammarQuery implements GrammarQuery{
         }
     }
 
-    private static void addItemsToEnum(QueueEnumeration enumX, Set set, String startWith, String prefix) {
+    private static void addItemsToEnum(QueueEnumeration enumX, Set<String> set, String startWith, String prefix) {
         Iterator it = set.iterator();
-        while ( it.hasNext()) {
+        while (it.hasNext()) {
             String nextText = (String)it.next();
             if (nextText.startsWith(startWith)) {
                 enumX.put(new MyText(prefix + nextText));

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Schema.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Schema.java
@@ -41,7 +41,7 @@ public class Schema {
     private DBMetaDataProvider provider;
     private Catalog catalog;
     private String name;
-    private Set/*<String>*/ tableNames;
+    private Set<String> tableNames;
     
     private ConnectionProvider cp;
     private SchemaElementImpl schemaElementImpl;
@@ -106,8 +106,8 @@ public class Schema {
         tableNames = null;
     }
     
-    private Set/*<String>*/ getTableNamesByType(String type) throws SQLException {
-        Set/*<String>*/ result = new TreeSet();
+    private Set<String> getTableNamesByType(String type) throws SQLException {
+        Set<String> result = new TreeSet();
 
         ResultSet rs = provider.getMetaData().getTables(catalog.getName(), name, "%", new String[] { type }); // NOI18N
         try {

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/Provider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/Provider.java
@@ -48,7 +48,7 @@ public abstract class Provider {
      */
     private final String providerClass;
     
-    private final Set vendorSpecificProperties;
+    private final Set<String> vendorSpecificProperties;
     private final String version;
     
     
@@ -100,8 +100,8 @@ public abstract class Provider {
         return version;
     }
     
-    private Set initPropertyNames(){
-        Set result = new HashSet();
+    private Set<String> initPropertyNames(){
+        Set<String> result = new HashSet();
         result.add(getJdbcDriver());
         result.add(getJdbcUsername());
         result.add(getJdbcUrl());
@@ -118,7 +118,7 @@ public abstract class Provider {
      * Gets the names of all provider specific properties.
      * @return Set of Strings representing names of provider specific properties.
      */
-    public Set getPropertyNames(){
+    public Set<String> getPropertyNames(){
         return this.vendorSpecificProperties;
     }
     

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/SourceRootsUi.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/SourceRootsUi.java
@@ -171,7 +171,7 @@ public final class SourceRootsUi {
      * Opens the standard dialog for warning an user about illegal source roots.
      * @param roots the set of illegal source/test roots
      */
-    public static void showIllegalRootsDialog (Set/*<File>*/ roots) {
+    public static void showIllegalRootsDialog (Set<File> roots) {
         JButton closeOption = new JButton (NbBundle.getMessage(SourceRootsUi.class,"CTL_SourceRootsUi_Close"));
         closeOption.getAccessibleContext ().setAccessibleDescription (NbBundle.getMessage(SourceRootsUi.class,"AD_SourceRootsUi_Close"));
         JPanel warning = new WarningDlg (roots);

--- a/java/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectIterator.java
+++ b/java/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectIterator.java
@@ -93,7 +93,7 @@ public class J2SESampleProjectIterator implements WizardDescriptor.AsynchronousI
         this.wiz.putProperty("name",null);          //NOI18N
     }
     
-    @Override public Set instantiate() throws java.io.IOException {
+    @Override public Set<DataObject> instantiate() throws java.io.IOException {
         File projectLocation = (File) wiz.getProperty(WizardProperties.PROJECT_DIR);
         String name = (String) wiz.getProperty(WizardProperties.NAME);
         FileObject templateFO = Templates.getTemplate(wiz);

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/wizard/J2SEWizardIterator.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/wizard/J2SEWizardIterator.java
@@ -112,7 +112,7 @@ public class J2SEWizardIterator implements WizardDescriptor.InstantiatingIterato
      * @return singleton Set with java platform's instance DO inside.
      */
     @Override
-    public java.util.Set instantiate() throws IOException {
+    public Set<JavaPlatform> instantiate() throws IOException {
         //Workaround #44444
         this.detectPanel.storeSettings (this.wizard);
         Set<JavaPlatform> result = new HashSet<JavaPlatform> ();

--- a/java/java.project.ui/src/org/netbeans/modules/java/project/ui/NewJavaFileWizardIterator.java
+++ b/java/java.project.ui/src/org/netbeans/modules/java/project/ui/NewJavaFileWizardIterator.java
@@ -340,7 +340,7 @@ public class NewJavaFileWizardIterator implements WizardDescriptor.AsynchronousI
             DataObject dobj = dTemplate.createFromTemplate(df, targetName, parameters);
             createdFile = dobj.getPrimaryFile();
         }
-        final Set<FileObject> res = new HashSet<>();
+        final Set res = new HashSet<>();
         res.add(createdFile);
         asInstantiatingIterator(projectSpecificIterator)
                 .map((it)->{

--- a/java/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/TemplateWizardIterator.java
+++ b/java/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/TemplateWizardIterator.java
@@ -103,7 +103,7 @@ class TemplateWizardIterator implements WizardDescriptor.AsynchronousInstantiati
     }
 
     @Override
-    public Set instantiate() throws IOException, IllegalArgumentException {
+    public Set<FileObject> instantiate() throws IOException, IllegalArgumentException {
         Set<FileObject> set = delegateIterator.instantiate();
         FileObject template = set.iterator().next();
         if (wiz instanceof TemplateWizard) {

--- a/java/selenium2.java/src/org/netbeans/modules/selenium2/java/Selenium2JavaTestWizardIterator.java
+++ b/java/selenium2.java/src/org/netbeans/modules/selenium2/java/Selenium2JavaTestWizardIterator.java
@@ -58,7 +58,7 @@ public class Selenium2JavaTestWizardIterator implements WizardDescriptor.Instant
     private transient WizardDescriptor wiz;
 
     @Override
-    public Set instantiate() throws IOException {
+    public Set<FileObject> instantiate() throws IOException {
         FileObject createdFile = null;
         FileObject targetFolder = Templates.getTargetFolder(wiz);
         Selenium2SupportImpl selenium2Support = Selenium2Support.findSelenium2Support(FileOwnerQuery.getOwner(targetFolder));

--- a/php/php.samples/src/org/netbeans/modules/php/samples/PHPSamplesWizardIterator.java
+++ b/php/php.samples/src/org/netbeans/modules/php/samples/PHPSamplesWizardIterator.java
@@ -78,7 +78,7 @@ public class PHPSamplesWizardIterator implements WizardDescriptor./*Progress*/In
                 };
     }
 
-    public Set/*<FileObject>*/ instantiate(/*ProgressHandle handle*/) throws IOException {
+    public Set<FileObject> instantiate(/*ProgressHandle handle*/) throws IOException {
         Set<FileObject> resultSet = new LinkedHashSet<>();
         File dirF = FileUtil.normalizeFile((File) wiz.getProperty(WizardProperties.PROJ_DIR));
         createFolder(dirF);

--- a/php/selenium2.php/src/org/netbeans/modules/selenium2/php/Selenium2PhpTestWizardIterator.java
+++ b/php/selenium2.php/src/org/netbeans/modules/selenium2/php/Selenium2PhpTestWizardIterator.java
@@ -58,7 +58,7 @@ public class Selenium2PhpTestWizardIterator implements WizardDescriptor.Instanti
     private transient WizardDescriptor wiz;
 
     @Override
-    public Set instantiate() throws IOException {
+    public Set<FileObject> instantiate() throws IOException {
         FileObject createdFile = null;
         FileObject targetFolder = Templates.getTargetFolder(wiz);
         Selenium2SupportImpl selenium2Support = Selenium2Support.findSelenium2Support(FileOwnerQuery.getOwner(targetFolder));

--- a/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
+++ b/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
@@ -1942,7 +1942,7 @@ public class WizardDescriptor extends DialogDescriptor {
          * @throws IOException
          * @return a set of objects created (the exact type is at the discretion of the caller)
          */
-        public Set/*<?>*/ instantiate() throws IOException;
+        public Set<?> instantiate() throws IOException;
 
         /** Initializes this iterator, called from WizardDescriptor's constructor.
          *

--- a/platform/openide.filesystems/src/org/openide/filesystems/StreamPool.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/StreamPool.java
@@ -282,8 +282,8 @@ final class StreamPool extends Object {
     private static void closeOutputStream(AbstractFolder fo, OutputStream os, boolean fireFileChanged) {
         StreamPool foPool = find(fo);
         StreamPool fsPool = find(fo.getFileSystem());
-        Set foSet = (foPool != null) ? foPool.oStreams : null;
-        Set fsSet = (fsPool != null) ? fsPool.oStreams : null;
+        Set<OutputStream> foSet = (foPool != null) ? foPool.oStreams : null;
+        Set<OutputStream> fsSet = (fsPool != null) ? fsPool.oStreams : null;
 
         removeStreams(fsSet, foSet, os);
         removeStreamPools(fsPool, foPool, fo);
@@ -293,8 +293,8 @@ final class StreamPool extends Object {
     private static void closeInputStream(AbstractFolder fo, InputStream is) {
         StreamPool foPool = find(fo);
         StreamPool fsPool = find(fo.getFileSystem());
-        Set foSet = (foPool != null) ? foPool.iStreams : null;
-        Set fsSet = (fsPool != null) ? fsPool.iStreams : null;
+        Set<InputStream> foSet = (foPool != null) ? foPool.iStreams : null;
+        Set<InputStream> fsSet = (fsPool != null) ? fsPool.iStreams : null;
 
         removeStreams(fsSet, foSet, is);
         removeStreamPools(fsPool, foPool, fo);

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
@@ -861,10 +861,10 @@ public final class XMLFileSystem extends AbstractFileSystem {
                 foAttrs = new XMLMapAttr();
             }
 
-            Iterator<Map.Entry> it = attrs.entrySet().iterator();
+            Iterator it = attrs.entrySet().iterator();
             boolean ch = false;
             while (it.hasNext()) {
-                Map.Entry attrEntry = it.next();
+                Map.Entry attrEntry = (Map.Entry)it.next();
                 Object prev = foAttrs.put(attrEntry.getKey(), attrEntry.getValue());
                 
                 ch |= (prev == null && attrEntry.getValue() != null) || !prev.equals(attrEntry.getValue());

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.AbstractMap;
@@ -399,7 +398,7 @@ final class XMLMapAttr implements Map {
         return map.hashCode();
     }
 
-    public synchronized java.util.Set<String> keySet() {
+    public synchronized Set<String> keySet() {
         return map.keySet();
     }
 
@@ -408,7 +407,7 @@ final class XMLMapAttr implements Map {
     }
 
     // XXX this is wrong - values not translated
-    public synchronized java.util.Set entrySet() {
+    public synchronized Set<Map.Entry<String, Attr>> entrySet() {
         return map.entrySet();
     }
 

--- a/platform/openide.loaders/src/org/openide/loaders/ExtensionList.java
+++ b/platform/openide.loaders/src/org/openide/loaders/ExtensionList.java
@@ -191,14 +191,14 @@ public class ExtensionList extends Object
     // Note that these are unsorted sets; we don't care about order.
     private static boolean equalSets(Set<String> s1, Set<String> s2, boolean flattenCase) {
         if (s1 == null && s2 == null) return true; // quick return
-        Set s1a = normalizeSet(s1, flattenCase);
-        Set s2a = normalizeSet(s2, flattenCase);
+        Set<String> s1a = normalizeSet(s1, flattenCase);
+        Set<String> s2a = normalizeSet(s2, flattenCase);
         return s1a.equals(s2a);
     }
     private static Set<String> normalizeSet(Set<String> s, boolean flattenCase) {
         if (s == null || s.isEmpty()) return Collections.emptySet();
         if (flattenCase) {
-            Set<String> s2 = new HashSet<String>(s.size() * 4 / 3 + 1);
+            Set<String> s2 = new HashSet<>(s.size() * 4 / 3 + 1);
             for (String item: s) {
                 s2.add(item.toLowerCase(Locale.US));
             }

--- a/platform/openide.util/src/org/openide/util/NbCollections.java
+++ b/platform/openide.util/src/org/openide/util/NbCollections.java
@@ -225,15 +225,16 @@ public class NbCollections {
     public static <E> Set<E> checkedSetByFilter(Set rawSet, Class<E> type, boolean strict) {
         return new CheckedSet<E>(rawSet, type, strict);
     }
+    
     private static final class CheckedSet<E> extends AbstractSet<E> implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
-        private final Set rawSet;
+        private final Set<E> rawSet;
         private final Class<E> type;
         private final boolean strict;
 
-        public CheckedSet(Set rawSet, Class<E> type, boolean strict) {
+        public CheckedSet(Set<E> rawSet, Class<E> type, boolean strict) {
             this.rawSet = rawSet;
             this.type = type;
             this.strict = strict;

--- a/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/ui/wizard/ExistingProjectWizardIterator.java
+++ b/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/ui/wizard/ExistingProjectWizardIterator.java
@@ -104,7 +104,7 @@ public final class ExistingProjectWizardIterator extends BaseWizardIterator {
 
     @NbBundle.Messages("ExisitngProjectWizardIterator.progress.creating=Creating project")
     @Override
-    public Set instantiate(ProgressHandle handle) throws IOException {
+    public Set<FileObject> instantiate(ProgressHandle handle) throws IOException {
         handle.start();
         handle.progress(Bundle.ExisitngProjectWizardIterator_progress_creating());
 

--- a/webcommon/javascript2.doc/src/org/netbeans/modules/javascript2/doc/JsDocumentationFallbackProvider.java
+++ b/webcommon/javascript2.doc/src/org/netbeans/modules/javascript2/doc/JsDocumentationFallbackProvider.java
@@ -36,7 +36,7 @@ import org.netbeans.modules.parsing.api.Snapshot;
 public final class JsDocumentationFallbackProvider implements JsDocumentationProvider {
 
     @Override
-    public Set getSupportedTags() {
+    public Set<String> getSupportedTags() {
         return Collections.emptySet();
     }
 

--- a/webcommon/javascript2.extdoc/src/org/netbeans/modules/javascript2/extdoc/ExtDocDocumentationProvider.java
+++ b/webcommon/javascript2.extdoc/src/org/netbeans/modules/javascript2/extdoc/ExtDocDocumentationProvider.java
@@ -49,9 +49,9 @@ public class ExtDocDocumentationProvider implements JsDocumentationProvider {
     }
 
     @Override
-    public synchronized Set getSupportedTags() {
+    public synchronized Set<String> getSupportedTags() {
         if (supportedTags == null) {
-            supportedTags = new HashSet<String>(ExtDocElementType.values().length);
+            supportedTags = new HashSet<>(ExtDocElementType.values().length);
             for (ExtDocElementType type : ExtDocElementType.values()) {
                 supportedTags.add(type.toString());
             }

--- a/webcommon/javascript2.sdoc/src/org/netbeans/modules/javascript2/sdoc/SDocDocumentationProvider.java
+++ b/webcommon/javascript2.sdoc/src/org/netbeans/modules/javascript2/sdoc/SDocDocumentationProvider.java
@@ -49,9 +49,9 @@ public class SDocDocumentationProvider implements JsDocumentationProvider {
     }
 
     @Override
-    public synchronized Set getSupportedTags() {
+    public synchronized Set<String> getSupportedTags() {
         if (supportedTags == null) {
-            supportedTags = new HashSet<String>(SDocElementType.values().length);
+            supportedTags = new HashSet<>(SDocElementType.values().length);
             for (SDocElementType type : SDocElementType.values()) {
                 supportedTags.add(type.toString());
             }

--- a/webcommon/selenium2.webclient.mocha/src/org/netbeans/modules/selenium2/webclient/mocha/wizard/NewMochaTestcaseWizardIterator.java
+++ b/webcommon/selenium2.webclient.mocha/src/org/netbeans/modules/selenium2/webclient/mocha/wizard/NewMochaTestcaseWizardIterator.java
@@ -57,7 +57,7 @@ public class NewMochaTestcaseWizardIterator implements WizardDescriptor.Instanti
     private transient WizardDescriptor wiz;
 
     @Override
-    public Set instantiate() throws IOException {
+    public Set<FileObject> instantiate() throws IOException {
         FileObject createdFile = null;
         FileObject targetFolder = Templates.getTargetFolder(wiz);
         Selenium2SupportImpl selenium2Support = Selenium2Support.findSelenium2Support(FileOwnerQuery.getOwner(targetFolder));

--- a/webcommon/selenium2.webclient.protractor/src/org/netbeans/modules/selenium2/webclient/protractor/wizard/NewJasmineTestcaseWizardIterator.java
+++ b/webcommon/selenium2.webclient.protractor/src/org/netbeans/modules/selenium2/webclient/protractor/wizard/NewJasmineTestcaseWizardIterator.java
@@ -57,7 +57,7 @@ public class NewJasmineTestcaseWizardIterator implements WizardDescriptor.Instan
     private transient WizardDescriptor wiz;
 
     @Override
-    public Set instantiate() throws IOException {
+    public Set<FileObject> instantiate() throws IOException {
         FileObject createdFile = null;
         FileObject targetFolder = Templates.getTargetFolder(wiz);
         Selenium2SupportImpl selenium2Support = Selenium2Support.findSelenium2Support(FileOwnerQuery.getOwner(targetFolder));

--- a/webcommon/web.client.samples/src/org/netbeans/modules/web/client/samples/wizard/iterator/OnlineSampleWizardIterator.java
+++ b/webcommon/web.client.samples/src/org/netbeans/modules/web/client/samples/wizard/iterator/OnlineSampleWizardIterator.java
@@ -86,7 +86,7 @@ public abstract class OnlineSampleWizardIterator extends AbstractWizardIterator 
         "OnlineSampleWizardIterator.applyingTemplate=Applying template..."
     })
     @Override
-    public Set instantiate(ProgressHandle handle) throws IOException {
+    public Set<FileObject> instantiate(ProgressHandle handle) throws IOException {
         handle.start();
         handle.progress(Bundle.OnlineSampleWizardIterator_creatingProject()); //NOI18N
 


### PR DESCRIPTION
Warnings that look like this:

   [repeat] /home/bwalker/src/netbeans/enterprise/web.client.rest/src/org/netbeans/modules/web/client/rest/wizard/JSClientIterator.java:237: warning: [rawtypes] found raw type: Set
   [repeat]     public Set instantiate() throws IOException {
   [repeat]            ^
   [repeat]   missing type arguments for generic class Set<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in interface Set





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

