### PR TITLE
Extend libs.flatlaf public packages

### DIFF
--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -28,6 +28,8 @@
             <public-packages>
                 <package>com.formdev.flatlaf</package>
                 <package>com.formdev.flatlaf.util</package>
+                <package>com.formdev.flatlaf.ui</package>
+                <package>com.formdev.flatlaf.icons</package>
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>ext/flatlaf-2.4.jar</runtime-relative-path>

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -26,10 +26,7 @@
             <code-name-base>org.netbeans.libs.flatlaf</code-name-base>
             <module-dependencies/>
             <public-packages>
-                <package>com.formdev.flatlaf</package>
-                <package>com.formdev.flatlaf.util</package>
-                <package>com.formdev.flatlaf.ui</package>
-                <package>com.formdev.flatlaf.icons</package>
+                <subpackages>com.formdev.flatlaf</subpackages>
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>ext/flatlaf-2.4.jar</runtime-relative-path>


### PR DESCRIPTION
Extension of the **public packages** for module **libs.flatlaf**.

This is needed for users who want to add [FlatLaf's SwingX addon](https://github.com/JFormDesigner/FlatLaf/tree/main/flatlaf-swingx). This addon has dependencies to two packages that are not part of the public packages.

When trying to use this addon - in combination to a module dependency to libs.flatlaf - one currently receives the following error:
```
Private classes referenced in module: [com.formdev.flatlaf.ui.MigLayoutVisualPadding, 
com.formdev.flatlaf.icons.FlatAbstractIcon, com.formdev.flatlaf.ui.FlatRoundBorder, com.formdev.flatlaf.ui.FlatArrowButton, 
com.formdev.flatlaf.ui.FlatUIUtils$RepaintFocusListener, com.formdev.flatlaf.ui.FlatEmptyBorder, 
com.formdev.flatlaf.ui.FlatButtonUI, com.formdev.flatlaf.ui.FlatUIUtils, com.formdev.flatlaf.ui.FlatLineBorder]
```

Adding new public packages should fix this issue.