### PR TITLE
FIX-3732: Prevent possible IAE in DocumentViewOp.

### DIFF
--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
@@ -1391,7 +1391,7 @@ public final class DocumentViewOp
 
     TextLayout createTextLayout(String text, Font font) {
         checkSettingsInfo();
-        if (fontRenderContext != null && font != null) {
+        if (fontRenderContext != null && font != null && text.length() > 0) {
             ViewStats.incrementTextLayoutCreated(text.length());
             FontInfo fontInfo = getFontInfo(font);
             TextLayout textLayout = new TextLayout(text, fontInfo.renderFont, fontRenderContext);


### PR DESCRIPTION

Kind of trivial fix for a rare ```IllegalArgumentException```. There is a small chance that it would result an ```NPE``` later in the code, though as far as I've checked the call stack in #3732 the return value of ```createTextLayout(String text, Font font)``` stored, and when later retrieved it is checked for null. 