### PR TITLE
Allow to disable warning for specific lifecycle participants.

### DIFF
--- a/enterprise/micronaut/nbproject/project.xml
+++ b/enterprise/micronaut/nbproject/project.xml
@@ -74,7 +74,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.154</specification-version>
+                        <specification-version>2.156</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
@@ -59,6 +59,14 @@
                     </file>
                 </folder>
             </folder>
+            <folder name="LifecycleParticipants">
+                <folder name="org.graalvm.buildtools.maven.NativeExtension">
+                    <attr name="ignoreOnModelLoad" boolvalue="true"/>
+                </folder>
+                <folder name="io.micronaut.build.testresources.TestResourcesLifecycleExtension">
+                    <attr name="ignoreOnModelLoad" boolvalue="true"/>
+                </folder>
+            </folder>
         </folder>
     </folder>
     <folder name="Templates">

--- a/java/maven/apichanges.xml
+++ b/java/maven/apichanges.xml
@@ -83,6 +83,19 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="lifecycle-white-list">
+            <api name="general"/>
+            <summary>LifecycleParticipants can be ignored</summary>
+            <version major="2" minor="156"/>
+            <date day="9" month="9" year="2022"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes" semantic="compatible"/>
+            <description>
+                NetBeans warns if a project / plugin provides AbstractLifecycleParticipants that
+                can reconfigure the project after load. Now some harmless ones can be whitelisted
+                so they do not produce warning / project problem. See <a href="@TOP@/architecture-summary.html#layer-LifecycleParticipants">LifecycleParticipants</a>.
+            </description>
+        </change>
         <change id="evaluated-project">
             <api name="general"/>
             <summary>Project model can be customized for specific action or usage</summary>

--- a/java/maven/arch.xml
+++ b/java/maven/arch.xml
@@ -140,6 +140,14 @@
        It's content is expected to be <code>Action</code> instances.
      </p>
     </api>
+    <api group="layer" name="LifecycleParticipants" type="export" category="official">
+     <p>
+         A module can disable warning for a custom lifecycle participant by creating a <b>folder</b> in 
+         <code>Projects/org-netbeans-modules-maven/LifecycleParticipant</code>. Currently single boolean attribute,
+         <code>ignoreOnModelLoad</code> is supported, which suppresses project problem and warning about
+         the custom participant. The participant's code does not run after project load.         
+     </p>
+    </api>
 
     <api group="layer" name="MavenArchetypes" type="export" category="official">
      <p>

--- a/java/maven/nbproject/project.properties
+++ b/java/maven/nbproject/project.properties
@@ -22,7 +22,7 @@ javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 javahelp.hs=maven.hs
 extra.module.files=maven-nblib/
-spec.version.base: 2.155
+spec.version.base: 2.156
 
 # The CPExtender test fails in library processing (not randomly) since NetBeans 8.2; disabling.
 test.excludes=**/CPExtenderTest.class

--- a/java/maven/src/org/netbeans/modules/maven/layer.xml
+++ b/java/maven/src/org/netbeans/modules/maven/layer.xml
@@ -170,6 +170,12 @@
                     <attr name="position" intvalue="3200"/>
                 </file>
             </folder>
+            <folder name="LifecycleParticipants">
+                <!-- Lifecycle participant classes with special handling; folders with attributes -->
+                <folder name="org.sonatype.nexus.maven.staging.deploy.DeployLifecycleParticipant">
+                    <attr name="ignoreOnModelLoad" boolvalue="true"/>
+                </folder>
+            </folder>
             <file name="nbactions.xml" url="nbactions.xml"/>
         </folder>
     </folder>


### PR DESCRIPTION
During implementation I have found that our Maven support warns if certain plugins are included in the project - since their code should be called after project load, or maven session open, that can have unexpected effects.

This PR adds a way how one can disable such a project warning - and fixes Micronaut support to disable the warning for harmless extensions (that do nothing important in their `afterProjectsRead` etc handlers).