### PR TITLE
Make Apache NetBeans 15 the latest version for issue reports.

### DIFF
--- a/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
@@ -27,8 +27,8 @@ body:
         Latest releases are always available from https://netbeans.apache.org/download/
       multiple: false
       options:
-        - "Apache NetBeans 14"
-        - "Apache NetBeans 15 release candidate"
+        - "Apache NetBeans 15"
+        # - "Apache NetBeans 16 release candidate"
         - "Apache NetBeans latest daily build"
     validations:
       required: true


### PR DESCRIPTION
Make Apache NetBeans 15 the latest version in the template for bug reports.