### PR TITLE
Fix extra space added in try with resources

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -1151,7 +1151,7 @@ public class Reformatter implements ReformatTask {
                                 newline();
                             else
                                 space();
-                        } else {
+                        } else if (sp.getStartPosition(root, mods) != sp.getStartPosition(root, node.getType())) {
                             space();
                         }
                     } else if (afterAnnotation) {

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -6099,6 +6099,61 @@ public class FormatingTest extends NbTestCase {
         reformat(doc, content, golden);
     }
 
+    public void testTryWithResources() throws Exception {
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie) testSourceDO.getCookie(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+
+        String content
+                = "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        try (PrintStream out = System.out) {\n"
+                + "            System.out.println(\"TEST\");\n"
+                + "        } catch (Exception e) {\n"
+                + "            System.out.println(\"CATCH\");\n"
+                + "        } finally {\n"
+                + "            System.out.println(\"FINALLY\");\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+        String golden
+                = "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        try (PrintStream out = System.out) {\n"
+                + "            System.out.println(\"TEST\");\n"
+                + "        } catch (Exception e) {\n"
+                + "            System.out.println(\"CATCH\");\n"
+                + "        } finally {\n"
+                + "            System.out.println(\"FINALLY\");\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+        reformat(doc, content, golden);
+
+        content = "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        try ( final   PrintStream  out = System.out) {\n"
+                + "            System.out.println(\"TEST\");\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+        golden = "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        try (final PrintStream out = System.out) {\n"
+                + "            System.out.println(\"TEST\");\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+        reformat(doc, content, golden);
+    }
 
     public void testSynchronizedBlockAfterFor() throws Exception {
         testFile = new File(getWorkDir(), "Test.java");


### PR DESCRIPTION
Fix for #3720 

The space seems to occur due to the start and end positions reported for the implicit hidden final modifier, which seem to be the same as the type start and end. The issue can't be seen if `final` is added explicitly.  

This adds an extra check for whether the modifiers and type start at the same position.  I haven't checked if the reported positions of `mods` have changed from earlier versions. The might explain why the issue started appearing, and it's possible the whole enclosing `if` wasn't hit in that case. I've kept localized for now.

The issue with new lines being removed may also be related to this, but haven't managed to track down exactly what's happening - it's possibly related to the token locations. Leaving that for another fix.