### PR TITLE
Fix for not calling auto completion after end tag was already added

### DIFF
--- a/ide/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlCompletionProvider.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlCompletionProvider.java
@@ -386,16 +386,10 @@ public class HtmlCompletionProvider implements CompletionProvider {
                             } else {
                                 ts.move(dotPos - 1);
                                 if (ts.moveNext() || ts.movePrevious()) {
-                                    if (!CharSequenceUtilities.equals("/>", ts.token().text()) && null != LexerUtils.followsToken(ts, HTMLTokenId.TAG_OPEN, true, false,
-                                            HTMLTokenId.ARGUMENT,
-                                            HTMLTokenId.VALUE,
-                                            HTMLTokenId.VALUE_CSS,
-                                            HTMLTokenId.VALUE_JAVASCRIPT,
-                                            HTMLTokenId.OPERATOR,
+                                    if (!CharSequenceUtilities.equals("/>", ts.token().text()) &&
+                                        null == LexerUtils.followsToken(ts, HTMLTokenId.TAG_CLOSE, true, false,
                                             HTMLTokenId.WS,
-                                            HTMLTokenId.EL_CLOSE_DELIMITER,
-                                            HTMLTokenId.EL_CONTENT,
-                                            HTMLTokenId.EL_OPEN_DELIMITER)) {
+                                            HTMLTokenId.TAG_CLOSE_SYMBOL)) {
                                         ret[0] = true;
                                     }
                                 }

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlCompletionProvider.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlCompletionProvider.java
@@ -386,7 +386,16 @@ public class HtmlCompletionProvider implements CompletionProvider {
                             } else {
                                 ts.move(dotPos - 1);
                                 if (ts.moveNext() || ts.movePrevious()) {
-                                    if (ts.token().id() == HTMLTokenId.TAG_CLOSE_SYMBOL && !CharSequenceUtilities.equals("/>", ts.token().text())) {
+                                    if (!CharSequenceUtilities.equals("/>", ts.token().text()) && null != LexerUtils.followsToken(ts, HTMLTokenId.TAG_OPEN, true, false,
+                                            HTMLTokenId.ARGUMENT,
+                                            HTMLTokenId.VALUE,
+                                            HTMLTokenId.VALUE_CSS,
+                                            HTMLTokenId.VALUE_JAVASCRIPT,
+                                            HTMLTokenId.OPERATOR,
+                                            HTMLTokenId.WS,
+                                            HTMLTokenId.EL_CLOSE_DELIMITER,
+                                            HTMLTokenId.EL_CONTENT,
+                                            HTMLTokenId.EL_OPEN_DELIMITER)) {
                                         ret[0] = true;
                                     }
                                 }

--- a/ide/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/HtmlCompletionQueryTest.java
+++ b/ide/html.editor/test/unit/src/org/netbeans/modules/html/editor/completion/HtmlCompletionQueryTest.java
@@ -69,6 +69,7 @@ public class HtmlCompletionQueryTest extends HtmlCompletionTestBase {
     public static Test suite() throws IOException, BadLocationException {
 	TestSuite suite = new TestSuite();
         suite.addTest(new HtmlCompletionQueryTest("testSimpleEndTagBeforeText"));
+        suite.addTest(new HtmlCompletionQueryTest("testNoAutocompletionAfterEndTag"));
         return suite;
     }
 
@@ -330,6 +331,12 @@ public class HtmlCompletionQueryTest extends HtmlCompletionTestBase {
     public void testNoEndTagAutocompletion() throws BadLocationException, ParseException {
         //test end tag ac for unknown tags
         assertItems("<div><bla>|", arr(), Match.EMPTY);
+    }
+    
+    public void testNoAutocompletionAfterEndTag() throws BadLocationException, ParseException {
+        // Test for not calling auto completion after end tag is already added
+        assertItems("<div></div>|", arr(), Match.EMPTY);
+        assertItems("<img />|", arr(), Match.EMPTY);
     }
 
     public void testJustBeforeTag() throws BadLocationException, ParseException {


### PR DESCRIPTION
right after opening tag, while copy and paste or closing tag token was added.

The check was not proper enough for calling auto completion after end tag. It just checked the HtmlToken.TAG_CLOSE_SYMBOL which is also the one at the end of an end tag </div">".
So each time I copy and paste "\<div>\</div>" it calles the auto completion which seemed wrong to me. See my screencapture:

![end-tag-code-completion](https://user-images.githubusercontent.com/795658/190876098-b529d20e-ca55-4e0f-9e76-1ce46e331d1a.gif)

I changed that behaviour and now it always comes up at the end of an open tag. Not on an end tag or on a self closing tag like an image, which was already working before: 

![no-end-tag-code-completion](https://user-images.githubusercontent.com/795658/190876118-813bee90-69a3-496a-911e-f0a0f3ff1d26.gif)

I will test this a couple of days to check whether there are other misbehavior or not and if there are no complaints I will merge this later by myself.