### PR TITLE
Change class=myclass to .myclass and id=myid to #id to reduce noise

### DIFF
--- a/ide/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlStructureItem.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlStructureItem.java
@@ -91,13 +91,13 @@ final class HtmlStructureItem implements StructureItem {
     public String getHtml(HtmlFormatter formatter) {
         formatter.appendHtml(getName());
         if (idAttributeValue != null) {
-            formatter.appendHtml("&nbsp;<font color=808080>id=");
+            formatter.appendHtml("&nbsp;<font color=808080>#");
             formatter.appendText(idAttributeValue);
             formatter.appendHtml("</font>"); //NOI18N
         }
         if (classAttributeValue != null) {
-            formatter.appendHtml("&nbsp;<font color=808080>class=");
-            formatter.appendText(classAttributeValue);
+            formatter.appendHtml("&nbsp;<font color=808080>.");
+            formatter.appendText(classAttributeValue.replace(" ", "."));
             formatter.appendHtml("</font>"); //NOI18N
         }
         return formatter.getText();


### PR DESCRIPTION
and make it cleaner and shorter

Inside the navigator for HTML files you see the elements with their IDs and Classes. NetBeans showed them as id=... and class=... ... .... We don't need this that long. Web developers just know the CSS selectors which are `#` for IDs and `.` for Classes. So I changed those 3 things:
* Changed `div id=myid` to `div #myid`
* Changed `div class=myclass` to `div .myclass`
* Changed `div class=my multi class` to `div .my.multi.class`

Before:
![image](https://user-images.githubusercontent.com/795658/190923990-41f5840b-df1b-4bf3-940b-218dd54f8bd9.png)

After:
![image](https://user-images.githubusercontent.com/795658/190923995-7d7e82ce-183b-4d62-9708-e9d74c08a113.png)

Also, if you want, I can add an option for this but IMHO we don't need one.