### PR TITLE
Made FileUtil to copy POSIX permissions

### DIFF
--- a/platform/openide.filesystems/apichanges.xml
+++ b/platform/openide.filesystems/apichanges.xml
@@ -25,6 +25,30 @@
         <apidef name="filesystems">Filesystems API</apidef>
     </apidefs>
     <changes>
+        <change id="fileutil.copyposixperms">
+            <api name="filesystems"/>
+            <summary>FileObject copy preserves source posix permissions.</summary>
+            <version major="9" minor="32"/>
+            <date day="12" month="1" year="2023"/>
+            <author login="lkishalmi"/>
+            <compatibility addition="yes" semantic="compatible"/>
+            <description>
+                <a href="@TOP@/org/openide/filesystems/FileUtil.html#copyFile-org.openide.filesystems.FileObject-org.openide.filesystems.FileObject-java.lang.String-java.lang.String-">FileUtil.copyFile(...)</a> now preserve ATTRIBUTES and POSIX permissions.
+            </description>
+            <class name="FileUtil" package="org.openide.filesystems"/>
+        </change>
+        <change id="fileutil.niofilepath">
+            <api name="filesystems"/>
+            <summary>FileUtil can convert FileObject to/from java.nio.file.Path.</summary>
+            <version major="9" minor="32"/>
+            <date day="12" month="1" year="2023"/>
+            <author login="lkishalmi"/>
+            <compatibility addition="yes" semantic="compatible"/>
+            <description>
+                <a href="@TOP@/org/openide/filesystems/FileUtil.html#">FileUtil</a> has a <code>toPath(FileObject fo)</code> and <code>toFileObject(Path path)</code> utility methods.
+            </description>
+            <class name="FileUtil" package="org.openide.filesystems"/>
+        </change>
         <change id="fileutil.copyattr.trasnform">
             <api name="filesystems"/>
             <summary>Allow to filter or transform attribute values during copying.</summary>

--- a/platform/openide.filesystems/manifest.mf
+++ b/platform/openide.filesystems/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.openide.filesystems
 OpenIDE-Module-Localizing-Bundle: org/openide/filesystems/Bundle.properties
 OpenIDE-Module-Layer: org/openide/filesystems/resources/layer.xml
-OpenIDE-Module-Specification-Version: 9.31
+OpenIDE-Module-Specification-Version: 9.32
 
 

--- a/platform/openide.filesystems/src/org/openide/filesystems/FileObject.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/FileObject.java
@@ -114,7 +114,8 @@ public abstract class FileObject extends Object implements Serializable, Lookup.
 
     /** Copies this file. This allows the filesystem to perform any additional
     * operation associated with the copy. But the default implementation is simple
-    * copy of the file and its attributes
+    * copy of the file and its attributes  Since version 9.32, the file POSIX
+    * permissions are copied as well.
     *
     * @param target target folder to move this file to
     * @param name new basename of file


### PR DESCRIPTION
Well as a DevOps engineer, I copy scripts and other executable inside the IDE. They lose the executable flag. That bothers me for years. Here is how I try to fix that.

Also added `FileObject` `Path` conversion methods, to make the life easier.
