### PR TITLE
Recognize generatedDependencies tag

### DIFF
--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/CoreSuite.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/CoreSuite.java
@@ -161,6 +161,13 @@ final class CoreSuite {
             }
 
             @Override
+            public List<String> generatedDependencies() {
+                return Collections.emptyList();
+            }
+
+
+
+            @Override
             public List<String> annotationProcessors() {
                 return annotationProcessors;
             }

--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteSources.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteSources.java
@@ -771,7 +771,10 @@ final class SuiteSources implements Sources,
 
         @Override
         public Collection<String> depNames() {
-            return mxPrj.dependencies();
+            List<String> both = new ArrayList<>();
+            both.addAll(mxPrj.dependencies());
+            both.addAll(mxPrj.generatedDependencies());
+            return both;
         }
 
         @Override

--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/suitepy/MxProject.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/suitepy/MxProject.java
@@ -29,6 +29,8 @@ public interface MxProject {
 
     List<String> dependencies();
 
+    List<String> generatedDependencies();
+
     List<String> annotationProcessors();
 
     String javaCompliance();


### PR DESCRIPTION
On Dec 22, 2021 the `truffle` sources started to use `generatedDependencies` tag: https://github.com/oracle/graal/blob/master/truffle/mx.truffle/suite.py#L496

Since then NetBeans cannot open [GraalVM Truffle sources](https://github.com/oracle/graal/blob/master/truffle/) properly. Shows how much people actually use NetBeans to develop GraalVM and how much of them cares about NetBeans...

This PR adds support for `generatedDependencies` tag which improves handling of the `com.oracle.truffle.api.dsl.Cached` imports in current Truffle sources.