### PR TITLE
Fixed a NPE from issue #4629

### DIFF
--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateInsertHandler.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateInsertHandler.java
@@ -515,7 +515,7 @@ public final class CodeTemplateInsertHandler implements TextRegionManagerListene
             return false;
         }
         TextSync last = removed.get(removed.size()-1).activeTextSync();
-        return last.isCaretMarker() && last.isCompletionInvoke();
+        return last != null && last.isCaretMarker() && last.isCompletionInvoke();
     }
 
     void release() {


### PR DESCRIPTION
Hello! This PR fixes the NPE error that occurs when you change the existing visibility declaration of a class property or method when you press Enter or click it in the autocomplete list.


