### PR TITLE
Improve java platform selection logic for hints.

### DIFF
--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
@@ -109,6 +109,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.AnnotationValueVisitor;
@@ -160,6 +162,7 @@ import org.netbeans.spi.editor.hints.Severity;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.modules.SpecificationVersion;
 import org.openide.util.Lookup;
 import org.openide.util.NbCollections;
 import org.openide.util.WeakListeners;
@@ -1079,21 +1082,22 @@ public class Utilities {
                     return c;
                 }
             }
-            JavaPlatform select = JavaPlatform.getDefault();
+
             final JavaPlatformManager man = JavaPlatformManager.getDefault();
-            if (select.getSpecification().getVersion() != null) {
-                for (JavaPlatform p : JavaPlatformManager.getDefault().getInstalledPlatforms()) {
-                    if (!p.isValid() || !"j2se".equals(p.getSpecification().getName()) || p.getSpecification().getVersion() == null) continue;
-                    if (p.getSpecification().getVersion().compareTo(select.getSpecification().getVersion()) > 0) {
-                        select = p;
-                    }
-                }
-            }
+            final SpecificationVersion maxVersion = new SpecificationVersion(SourceVersion.latest().ordinal()+".99"); // cap at feature version of nb-javac
+            JavaPlatform select = Stream.of(man.getInstalledPlatforms())
+                    .filter(JavaPlatform::isValid)
+                    .filter((p) -> "j2se".equals(p.getSpecification().getName()))
+                    .filter((p) -> p.getSpecification().getVersion() != null)
+                    .filter((p) -> p.getSpecification().getVersion().compareTo(maxVersion) < 0)
+                    .max((p1, p2) -> p1.getSpecification().getVersion().compareTo(p2.getSpecification().getVersion()))
+                    .orElse(JavaPlatform.getDefault());
+
             final ClasspathInfo result = new ClasspathInfo.Builder(select.getBootstrapLibraries())
                                                           .setModuleBootPath(select.getBootstrapLibraries())
                                                           .build();
             if (cached != null) {
-                    this.cached = new WeakReference<>(result);
+                cached = new WeakReference<>(result);
             }
             if (weakL == null) {
                 man.addPropertyChangeListener(weakL = WeakListeners.propertyChange(this, man));

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
@@ -99,6 +99,7 @@ import java.nio.CharBuffer;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1090,7 +1091,7 @@ public class Utilities {
                     .filter((p) -> "j2se".equals(p.getSpecification().getName()))
                     .filter((p) -> p.getSpecification().getVersion() != null)
                     .filter((p) -> p.getSpecification().getVersion().compareTo(maxVersion) < 0)
-                    .max((p1, p2) -> p1.getSpecification().getVersion().compareTo(p2.getSpecification().getVersion()))
+                    .max(Comparator.comparing((p) -> p.getSpecification().getVersion()))
                     .orElse(JavaPlatform.getDefault());
 
             final ClasspathInfo result = new ClasspathInfo.Builder(select.getBootstrapLibraries())

--- a/platform/openide.modules/nbproject/org-openide-modules.sig
+++ b/platform/openide.modules/nbproject/org-openide-modules.sig
@@ -182,9 +182,9 @@ hfds LOG
 
 CLSS public final org.openide.modules.SpecificationVersion
 cons public init(java.lang.String)
-intf java.lang.Comparable
+intf java.lang.Comparable<org.openide.modules.SpecificationVersion>
 meth public boolean equals(java.lang.Object)
-meth public int compareTo(java.lang.Object)
+meth public int compareTo(org.openide.modules.SpecificationVersion)
 meth public int hashCode()
 meth public java.lang.String toString()
 supr java.lang.Object

--- a/platform/openide.modules/src/org/openide/modules/SpecificationVersion.java
+++ b/platform/openide.modules/src/org/openide/modules/SpecificationVersion.java
@@ -29,12 +29,12 @@ import java.util.*;
  * @author Jesse Glick
  * @since 1.24
  */
-public final class SpecificationVersion implements Comparable {
+public final class SpecificationVersion implements Comparable<SpecificationVersion> {
     // Might be a bit wasteful of memory, but many SV's are created during
     // startup, so best to not have to reparse them each time!
     // In fact sharing the int arrays might save a bit of memory overall,
     // since it is unusual for a module to be deleted.
-    private static final Map<String,int[]> parseCache = new HashMap<String,int[]>(200);
+    private static final Map<String,int[]> parseCache = new HashMap<>(200);
     private final int[] digits;
 
     /** Parse from string. Must be Dewey-decimal. */
@@ -86,8 +86,9 @@ public final class SpecificationVersion implements Comparable {
     }
 
     /** Perform a Dewey-decimal comparison. */
-    public int compareTo(Object o) {
-        int[] od = ((SpecificationVersion) o).digits;
+    @Override
+    public int compareTo(SpecificationVersion o) {
+        int[] od = o.digits;
         int len1 = digits.length;
         int len2 = od.length;
         int max = Math.max(len1, len2);
@@ -105,6 +106,7 @@ public final class SpecificationVersion implements Comparable {
     }
 
     /** Overridden to compare contents. */
+    @Override
     public boolean equals(Object o) {
         if (!(o instanceof SpecificationVersion)) {
             return false;
@@ -114,6 +116,7 @@ public final class SpecificationVersion implements Comparable {
     }
 
     /** Overridden to hash by contents. */
+    @Override
     public int hashCode() {
         int hash = 925295;
         int len = digits.length;
@@ -126,6 +129,7 @@ public final class SpecificationVersion implements Comparable {
     }
 
     /** String representation (Dewey-decimal). */
+    @Override
     public String toString() {
         StringBuilder buf = new StringBuilder((digits.length * 3) + 1);
 


### PR DESCRIPTION
followup to #4672. 

 - old logic didn't check installed platforms if the spec version
   of the default platform was null
 - cap at feature version of nb-javac (or javac, if uninstalled)
 - default platform is the fallback
 - converted logic to streams

This code runs when code inspections are manually run (e.g. refactor -> inspect and transform). The editor is probably just using the default platform?

I am actually not sure why this selection logic is needed at all - but this should make it less buggy at least.