### PR TITLE
Limit bootstrap libraries to java.se

### DIFF
--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteProject.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteProject.java
@@ -114,7 +114,7 @@ final class SuiteProject implements Project {
         private CompilerOptionsQueryImplementation.Result RESULT = new Result() {
             @Override
             public List<? extends String> getArguments() {
-                return Arrays.asList("--add-modules", "ALL-MODULE-PATH");
+                return Arrays.asList("--add-modules", "ALL-MODULE-PATH", "--limit-modules", "java.se");
             }
 
             @Override


### PR DESCRIPTION
When running the IDE on GraalVM-java11-21.3 and working with `mx` projects I am getting reports that `org.graalvm.polyglot` package is defined in other module. Let's eliminate that problem by `--limit-modules java.se`