### PR TITLE
Promote latest Javac features supported by NetBeans

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/newproject/idenative/SimpleJavaTemplateHandler.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/idenative/SimpleJavaTemplateHandler.java
@@ -111,6 +111,11 @@ public class SimpleJavaTemplateHandler extends IDENativeTemplateHandler {
                                 config.setSimpleParameter("compilerId", "frgaal");
                                 config.setSimpleParameter("source", sourceVersion);
                                 config.setSimpleParameter("target", targetVersion);
+                                POMExtensibilityElement compilerArgs = factory.createPOMExtensibilityElement(new QName("compilerArgs"));
+                                POMExtensibilityElement arg = factory.createPOMExtensibilityElement(new QName("arg"));
+                                arg.setElementText("--enable-preview");
+                                compilerArgs.addExtensibilityElement(arg);
+                                config.addExtensibilityElement(compilerArgs);
                                 compiler.setConfiguration(config);
                                 build.addPlugin(compiler);
                             }

--- a/java/maven/src/org/netbeans/modules/maven/resources/App.java.template
+++ b/java/maven/src/org/netbeans/modules/maven/resources/App.java.template
@@ -12,8 +12,17 @@ package ${package};
  * @author ${user}
  */
 public class ${name} {
+    record Hello(String msg, String who) {
+        String message() {
+            return """
+            Enjoy latest Java features provided by NetBeans! And...
+            {msg} {who}!
+            """.replace("{msg}", msg).replace("{who}", who);
+        }
+    }
 
     public static void main(String[] args) {
-        System.out.println("Hello World!");
+        var world = new Hello("Hello", "World");
+        System.out.println(world.message());
     }
 }


### PR DESCRIPTION
This is a proposal PR showing a direction how to promote unique NetBeans features.

One of the biggest strengths of NetBeans Java IDE is the direct integration with [latest JDK's Javac](https://cwiki.apache.org/confluence/display/NETBEANS/Overview%3A+nb-javac). Our ability to deliver best quality support for latest and greatest features of the Java language is amazing. All we need is to give it more visibility.

This PR modifies the _New Project_/_Java with Maven_/_Java Application_ to create a project that _enables all the features_ supported by NetBeans **JavaC** by default. No need for NetBeans users to configure anything - everything works **out of the box**.

By accepting this PR we would offer NetBeans users the latest Java features. By accepting this PR we would shift our QA focus towards these latest features. Every new project would become a testcase to verify whether:
* indentation
* code completion
* refactorings
* and co.

really work well with the **latest Java language features**. Accepting this PR would make support for latest Java the **first class citizen** in the NetBeans Java IDE! In addition to that the 7180167 modifies the `App.java` to promote some of the great Java language features:

```java
public class App {
    record Hello(String msg, String who) {
        String message() {
            return """
            Enjoy latest Java features provided by NetBeans! And...
            {msg} {who}!
            """.replace("{msg}", msg).replace("{who}", who);
        }
    }

    public static void main(String[] args) {
        var world = new Hello("Hello", "World");
        System.out.println(world.message());
    }
}
```
