### PR TITLE
Fixed JBoss EAP regex patterns to match two digit minor/patch versions

### DIFF
--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyOutputSupport.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyOutputSupport.java
@@ -34,15 +34,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import org.netbeans.api.extexecution.ExecutionDescriptor;
 import org.netbeans.api.extexecution.ExecutionService;
 import org.netbeans.api.extexecution.base.input.InputProcessor;
 import org.netbeans.api.extexecution.base.input.InputProcessors;
+import org.netbeans.api.extexecution.base.input.InputReader;
 import org.netbeans.api.extexecution.base.input.InputReaderTask;
 import org.netbeans.api.extexecution.base.input.InputReaders;
 import org.netbeans.api.extexecution.base.input.LineProcessor;
-import org.netbeans.api.extexecution.base.input.InputReader;
 import org.netbeans.modules.j2ee.deployment.plugins.api.InstanceProperties;
 import org.netbeans.modules.j2ee.deployment.profiler.api.ProfilerSupport;
 import org.openide.windows.InputOutput;
@@ -64,18 +63,6 @@ public final class WildflyOutputSupport {
     private static final ExecutorService PROFILER_SERVICE = Executors.newCachedThreadPool();
 
     private static final ExecutorService LOG_FILE_SERVICE = Executors.newCachedThreadPool();
-
-    private static final Pattern JBOSS_7_STARTED_ML = Pattern.compile(".*JBoss AS 7(\\..*)* \\d+ms .*");
-    private static final Pattern WILDFLY_8_STARTED_ML = Pattern.compile(".*JBAS015874: WildFly 8(\\..*)* .* started in \\d+ms .*");
-    private static final Pattern WILDFLY_8_STARTING_ML = Pattern.compile(".*JBAS015899: WildFly 8(\\..*)* .* starting");
-    private static final Pattern WILDFLY_9_STARTED_ML = Pattern.compile(".*WFLYSRV0050: WildFly Full \\d+(\\..*)* .* started in \\d+ms .*");
-    private static final Pattern WILDFLY_STARTING_ML = Pattern.compile(".*WFLYSRV0049: WildFly .* \\d+(\\..*)* .* starting");
-    private static final Pattern WILDFLY_10_STARTED_ML = Pattern.compile(".*WFLYSRV0025: WildFly .* \\d+(\\..*)* .* started in \\d+ms .*");
-
-    private static final Pattern EAP6_STARTED_ML = Pattern.compile(".*JBAS015874: JBoss EAP 6\\.[0-9]?.[0-9]?\\.GA .* \\d+ms .*");
-    private static final Pattern EAP6_STARTING_ML = Pattern.compile(".*JBAS015899: JBoss EAP 6\\.[0-9]?.[0-9]?\\.GA .*");
-    private static final Pattern EAP7_STARTED_ML = Pattern.compile(".*WFLYSRV0025: JBoss EAP 7\\.[0-9]?.[0-9]?\\.GA .* \\d+ms .*");
-    private static final Pattern EAP7_STARTING_ML = Pattern.compile(".*WFLYSRV0049: JBoss EAP 7\\.[0-9]?.[0-9]?\\.GA .*");
 
     private final InstanceProperties props;
 
@@ -368,29 +355,11 @@ public final class WildflyOutputSupport {
         }
 
         private boolean isStarting(String line) {
-            return line.contains("Starting JBoss (MX MicroKernel)") // JBoss 4.x message // NOI18N
-                    || line.contains("Starting JBoss (Microcontainer)") // JBoss 5.0 message // NOI18N
-                    || line.contains("Starting JBossAS") // JBoss 6.0 message // NOI18N
-                    || WILDFLY_8_STARTING_ML.matcher(line).matches()
-                    || WILDFLY_STARTING_ML.matcher(line).matches()
-                    || EAP6_STARTING_ML.matcher(line).matches()
-                    || EAP7_STARTING_ML.matcher(line).matches();
+            return WildflyStartLineParser.isStarting(line);
         }
 
         private boolean isStarted(String line) {
-            return ((line.contains("JBoss (MX MicroKernel)") // JBoss 4.x message // NOI18N
-                    || line.contains("JBoss (Microcontainer)") // JBoss 5.0 message // NOI18N
-                    || line.contains("JBossAS") // JBoss 6.0 message // NOI18N
-                    || line.contains("JBoss AS"))// JBoss 7.0 message // NOI18N
-                    && (line.contains("Started in")) // NOI18N
-                    || line.contains("started in") // NOI18N
-                    || line.contains("started (with errors) in")) // JBoss 7 with some errors (include wrong deployments) // NOI18N
-                    || JBOSS_7_STARTED_ML.matcher(line).matches()
-                    || WILDFLY_8_STARTED_ML.matcher(line).matches()
-                    || WILDFLY_9_STARTED_ML.matcher(line).matches()
-                    || WILDFLY_10_STARTED_ML.matcher(line).matches()
-                    || EAP6_STARTED_ML.matcher(line).matches()
-                    || EAP7_STARTED_ML.matcher(line).matches();
+            return WildflyStartLineParser.isStarted(line);
         }
 
         @Override

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyStartLineParser.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyStartLineParser.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.netbeans.modules.javaee.wildfly.ide;
+
+import java.util.regex.Pattern;
+
+/**
+ * A parser for log lines from a Wildfly server.<br>
+ * The purpose of this class is to detect whether a Wildfly server is starting or has completely started.
+ */
+public class WildflyStartLineParser {
+
+    private static final Pattern JBOSS_7_STARTED_ML = Pattern.compile(".*JBoss AS 7(\\..*)* \\d+ms .*");
+
+    private static final Pattern WILDFLY_8_STARTED_ML = Pattern.compile(".*JBAS015874: WildFly 8(\\..*)* .* started in \\d+ms .*");
+
+    private static final Pattern WILDFLY_8_STARTING_ML = Pattern.compile(".*JBAS015899: WildFly 8(\\..*)* .* starting");
+
+    private static final Pattern WILDFLY_9_STARTED_ML = Pattern.compile(".*WFLYSRV0050: WildFly Full \\d+(\\..*)* .* started in \\d+ms .*");
+
+    private static final Pattern WILDFLY_STARTING_ML = Pattern.compile(".*WFLYSRV0049: WildFly .* \\d+(\\..*)* .* starting");
+
+    private static final Pattern WILDFLY_10_STARTED_ML = Pattern.compile(".*WFLYSRV0025: WildFly .* \\d+(\\..*)* .* started in \\d+ms .*");
+
+    private static final Pattern EAP6_STARTED_ML = Pattern.compile(".*JBAS015874: JBoss EAP 6\\.[0-9]{0,2}?.[0-9]{0,2}?\\.GA .* \\d+ms .*");
+
+    private static final Pattern EAP6_STARTING_ML = Pattern.compile(".*JBAS015899: JBoss EAP 6\\.[0-9]{0,2}?.[0-9]{0,2}?\\.GA .*");
+
+    private static final Pattern EAP7_STARTED_ML = Pattern.compile(".*WFLYSRV0025: JBoss EAP 7\\.[0-9]{0,2}?.[0-9]{0,2}?\\.GA .* \\d+\\s?ms .*");
+
+    private static final Pattern EAP7_STARTING_ML = Pattern.compile(".*WFLYSRV0049: JBoss EAP 7\\.[0-9]{0,2}?.[0-9]{0,2}?\\.GA .*");
+
+    /**
+     * Check whether the given line indicates the wildfly server is starting.
+     * @param line The line to check.
+     * @return {@code true} if this line indicates a starting Wildfly server, {@code false} else.
+     */
+    public static boolean isStarting(String line) {
+        return line.contains("Starting JBoss (MX MicroKernel)") // JBoss 4.x message // NOI18N
+                || line.contains("Starting JBoss (Microcontainer)") // JBoss 5.0 message // NOI18N
+                || line.contains("Starting JBossAS") // JBoss 6.0 message // NOI18N
+                || WILDFLY_8_STARTING_ML.matcher(line).matches()
+                || WILDFLY_STARTING_ML.matcher(line).matches()
+                || EAP6_STARTING_ML.matcher(line).matches()
+                || EAP7_STARTING_ML.matcher(line).matches();
+    }
+
+    /**
+     * Check whether the given line indicates the wildfly server has completely started.
+     * @param line The line to check.
+     * @return {@code true} if this line indicates a started Wildfly server, {@code false} else.
+     */
+    public static boolean isStarted(String line) {
+        return ((line.contains("JBoss (MX MicroKernel)") // JBoss 4.x message // NOI18N
+                || line.contains("JBoss (Microcontainer)") // JBoss 5.0 message // NOI18N
+                || line.contains("JBossAS") // JBoss 6.0 message // NOI18N
+                || line.contains("JBoss AS"))// JBoss 7.0 message // NOI18N
+                && (line.contains("Started in")) // NOI18N
+                || line.contains("started in") // NOI18N
+                || line.contains("started (with errors) in")) // JBoss 7 with some errors (include wrong deployments) // NOI18N
+                || JBOSS_7_STARTED_ML.matcher(line).matches()
+                || WILDFLY_8_STARTED_ML.matcher(line).matches()
+                || WILDFLY_9_STARTED_ML.matcher(line).matches()
+                || WILDFLY_10_STARTED_ML.matcher(line).matches()
+                || EAP6_STARTED_ML.matcher(line).matches()
+                || EAP7_STARTED_ML.matcher(line).matches();
+    }
+}

--- a/enterprise/javaee.wildfly/test/unit/src/org/netbeans/modules/javaee/wildfly/ide/WildflyStartLineParserTest.java
+++ b/enterprise/javaee.wildfly/test/unit/src/org/netbeans/modules/javaee/wildfly/ide/WildflyStartLineParserTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.netbeans.modules.javaee.wildfly.ide;
+
+import org.netbeans.junit.NbTestCase;
+
+public class WildflyStartLineParserTest extends NbTestCase {
+
+    public WildflyStartLineParserTest(String testName) {
+        super(testName);
+    }
+    
+    public void testEap6StartingSingleMajorMinorVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:56:23,970 INFO  [org.jboss.as] (MSC service thread 1-5) JBAS015899: JBoss EAP 6.0.GA (AS 7.5.23.Final-redhat-SNAPSHOT) startet");
+        assertTrue(result);
+    }
+    
+    public void testEap6StartingSingleMajorDoubleMinorVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:56:23,970 INFO  [org.jboss.as] (MSC service thread 1-5) JBAS015899: JBoss EAP 6.14.GA (AS 7.5.23.Final-redhat-SNAPSHOT) startet");
+        assertTrue(result);
+    }
+    
+    public void testEap6StartingSingleMajorMinorPatchVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:56:23,970 INFO  [org.jboss.as] (MSC service thread 1-5) JBAS015899: JBoss EAP 6.4.2.GA (AS 7.5.23.Final-redhat-SNAPSHOT) startet");
+        assertTrue(result);
+    }
+    
+    public void testEap6StartingSingleMajorMinorDoublePatchVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:56:23,970 INFO  [org.jboss.as] (MSC service thread 1-5) JBAS015899: JBoss EAP 6.4.23.GA (AS 7.5.23.Final-redhat-SNAPSHOT) startet");
+        assertTrue(result);
+    }
+    
+    public void testEap6StartingSingleMajorDoubleMinorSinglePatchVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:56:23,970 INFO  [org.jboss.as] (MSC service thread 1-5) JBAS015899: JBoss EAP 6.14.2.GA (AS 7.5.23.Final-redhat-SNAPSHOT) startet");
+        assertTrue(result);
+    }
+    
+    public void testEap6StartingSingleMajorDoubleMinorPatchVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:56:23,970 INFO  [org.jboss.as] (MSC service thread 1-5) JBAS015899: JBoss EAP 6.14.23.GA (AS 7.5.23.Final-redhat-SNAPSHOT) startet");
+        assertTrue(result);
+    }
+    
+    public void testEap6StartedSingleMajorMinorVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:46:48,572 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015874: JBoss EAP 6.0.GA (AS 7.5.23.Final-redhat-SNAPSHOT) wurde gestartet in 73289ms - 3187 von 3223 Diensten gestartet (60 Services sind \"lazy\", passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+    
+    public void testEap6StartedSingleMajorDoubleMinorVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:46:48,572 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015874: JBoss EAP 6.14.GA (AS 7.5.23.Final-redhat-SNAPSHOT) wurde gestartet in 73289ms - 3187 von 3223 Diensten gestartet (60 Services sind \"lazy\", passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+    
+    public void testEap6StartedSingleMajorMinorPatchVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:46:48,572 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015874: JBoss EAP 6.4.2.GA (AS 7.5.23.Final-redhat-SNAPSHOT) wurde gestartet in 73289ms - 3187 von 3223 Diensten gestartet (60 Services sind \"lazy\", passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+    
+    public void testEap6StartedSingleMajorMinorDoublePatchVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:46:48,572 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015874: JBoss EAP 6.4.23.GA (AS 7.5.23.Final-redhat-SNAPSHOT) wurde gestartet in 73289ms - 3187 von 3223 Diensten gestartet (60 Services sind \"lazy\", passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+    
+    public void testEap6StartedSingleMajorDoubleMinorSinglePatchVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:46:48,572 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015874: JBoss EAP 6.14.2.GA (AS 7.5.23.Final-redhat-SNAPSHOT) wurde gestartet in 73289ms - 3187 von 3223 Diensten gestartet (60 Services sind \"lazy\", passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+    
+    public void testEap6StartedSingleMajorDoubleMinorPatchVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:46:48,572 INFO  [org.jboss.as] (Controller Boot Thread) JBAS015874: JBoss EAP 6.14.23.GA (AS 7.5.23.Final-redhat-SNAPSHOT) wurde gestartet in 73289ms - 3187 von 3223 Diensten gestartet (60 Services sind \"lazy\", passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+    
+    public void testEap7StartingSingleMajorMinorVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:49:31,335 INFO  [org.jboss.as] (MSC service thread 1-2) WFLYSRV0049: JBoss EAP 7.4.GA (WildFly Core 15.0.6.Final-redhat-00003) wird gestartet");
+        assertTrue(result);
+    }
+    
+    public void testEap7StartingSingleMajorDoubleMinorVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:49:31,335 INFO  [org.jboss.as] (MSC service thread 1-2) WFLYSRV0049: JBoss EAP 7.14.GA (WildFly Core 15.0.6.Final-redhat-00003) wird gestartet");
+        assertTrue(result);
+    }
+    
+    public void testEap7StartingSingleMajorMinorPatchVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:49:31,335 INFO  [org.jboss.as] (MSC service thread 1-2) WFLYSRV0049: JBoss EAP 7.4.3.GA (WildFly Core 15.0.6.Final-redhat-00003) wird gestartet");
+        assertTrue(result);
+    }
+    
+    public void testEap7StartingSingleMajorMinorDoublePatchVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:49:31,335 INFO  [org.jboss.as] (MSC service thread 1-2) WFLYSRV0049: JBoss EAP 7.4.13.GA (WildFly Core 15.0.6.Final-redhat-00003) wird gestartet");
+        assertTrue(result);
+    }
+    
+    public void testEap7StartingSingleMajorDoubleMinorSinglePatchVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:49:31,335 INFO  [org.jboss.as] (MSC service thread 1-2) WFLYSRV0049: JBoss EAP 7.14.3.GA (WildFly Core 15.0.6.Final-redhat-00003) wird gestartet");
+        assertTrue(result);
+    }
+    
+    public void testEap7StartingSingleMajorDoubleMinorPatchVersion() {
+        boolean result = WildflyStartLineParser.isStarting("14:49:31,335 INFO  [org.jboss.as] (MSC service thread 1-2) WFLYSRV0049: JBoss EAP 7.14.13.GA (WildFly Core 15.0.6.Final-redhat-00003) wird gestartet");
+        assertTrue(result);
+    }
+    
+     public void testEap7StartedSingleMajorMinorVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:50:17,938 ERROR [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: JBoss EAP 7.4.GA (WildFly Core 15.0.6.Final-redhat-00003) wurde in 50723 ms gestartet – 353 von 595 Diensten gestartet (347 Dienste sind verzögert, passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+    
+    public void testEap7StartedSingleMajorDoubleMinorVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:50:17,938 ERROR [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: JBoss EAP 7.14.GA (WildFly Core 15.0.6.Final-redhat-00003) wurde in 50723 ms gestartet – 353 von 595 Diensten gestartet (347 Dienste sind verzögert, passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+    
+    public void testEap7StartedSingleMajorMinorPatchVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:50:17,938 ERROR [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: JBoss EAP 7.4.3.GA (WildFly Core 15.0.6.Final-redhat-00003) wurde in 50723 ms gestartet – 353 von 595 Diensten gestartet (347 Dienste sind verzögert, passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+    
+    public void testEap7StartedSingleMajorMinorDoublePatchVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:50:17,938 ERROR [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: JBoss EAP 7.4.13.GA (WildFly Core 15.0.6.Final-redhat-00003) wurde in 50723 ms gestartet – 353 von 595 Diensten gestartet (347 Dienste sind verzögert, passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+    
+    public void testEap7StartedSingleMajorDoubleMinorSinglePatchVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:50:17,938 ERROR [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: JBoss EAP 7.14.3.GA (WildFly Core 15.0.6.Final-redhat-00003) wurde in 50723 ms gestartet – 353 von 595 Diensten gestartet (347 Dienste sind verzögert, passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+    
+    public void testEap7StartedSingleMajorDoubleMinorPatchVersion() {
+        boolean result = WildflyStartLineParser.isStarted("14:50:17,938 ERROR [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: JBoss EAP 7.14.13.GA (WildFly Core 15.0.6.Final-redhat-00003) wurde in 50723 ms gestartet – 353 von 595 Diensten gestartet (347 Dienste sind verzögert, passiv oder werden bei Bedarf geladen)");
+        assertTrue(result);
+    }
+}
+
+


### PR DESCRIPTION
This PR fixes a flaw in the Wildfly server log line parsing regexes.
In the old version, JBoss EAP 6 (and 7) servers with two digit patch version (e.g. 6.4.23) are not detected, same for minor version.
In EAP 7 it is possible that there is an additional whitespace between the time it took to start the server and the time unit (e.g. 4700 ms instead of 4700ms).
That issue is also fixed.