### PR TITLE
Update FlatLaf from 2.4 to 2.5

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-691E1F12C78F42E0DFD9FC37BC599042A1EBDD0D com.formdev:flatlaf:2.4
+53B5104BDF92CBC7A650E075ED7296DD0AB77CF3 com.formdev:flatlaf:2.5

--- a/platform/libs.flatlaf/external/flatlaf-2.5-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-2.5-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 2.4
-Files: flatlaf-2.4.jar
+Version: 2.5
+Files: flatlaf-2.5.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/manifest.mf
+++ b/platform/libs.flatlaf/manifest.mf
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/flatlaf/Bundle.properties
 OpenIDE-Module: org.netbeans.libs.flatlaf/1
+OpenIDE-Module-Install: org/netbeans/libs/flatlaf/Installer.class
 OpenIDE-Module-Specification-Version: 1.12
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module-Implementation-Version: 2.5

--- a/platform/libs.flatlaf/manifest.mf
+++ b/platform/libs.flatlaf/manifest.mf
@@ -3,4 +3,4 @@ OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/flatlaf/Bundle.properties
 OpenIDE-Module: org.netbeans.libs.flatlaf/1
 OpenIDE-Module-Specification-Version: 1.12
 AutoUpdate-Show-In-Client: false
-
+OpenIDE-Module-Implementation-Version: 2.5

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -33,3 +33,10 @@ spec.version.base.fatal.warning=false
 # in manifest.mf needs to be updated to match the new FlatLaf version.
 release.external/flatlaf-2.5.jar=modules/ext/flatlaf-2.5.jar
 
+release.external/flatlaf-2.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
+release.external/flatlaf-2.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
+release.external/flatlaf-2.5.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
+jnlp.verify.excludes=\
+    modules/lib/flatlaf-windows-x86.dll,\
+    modules/lib/flatlaf-windows-x86_64.dll,\
+    modules/lib/libflatlaf-linux-x86_64.so

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,16 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
+spec.version.base.fatal.warning=false
+
+# It is stated, that access to packages outside com.formdev.flatlaf and
+# com.formdev.flatlaf.util is not a supported API. Setting the implementation
+# version allows modules, that need to do this (SwingX integration) to access
+# internals
+#
+# https://github.com/apache/netbeans/pull/4619
+#
+# So when FlatLaf is updated, the OpenIDE-Module-Implementation-Version entry
+# in manifest.mf needs to be updated to match the new FlatLaf version.
 release.external/flatlaf-2.5.jar=modules/ext/flatlaf-2.5.jar
+

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-2.4.jar=modules/ext/flatlaf-2.4.jar
+release.external/flatlaf-2.5.jar=modules/ext/flatlaf-2.5.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -24,7 +24,24 @@
     <configuration>
         <data xmlns="http://www.netbeans.org/ns/nb-module-project/2">
             <code-name-base>org.netbeans.libs.flatlaf</code-name-base>
-            <module-dependencies/>
+            <module-dependencies>
+                <dependency>
+                    <code-name-base>org.openide.modules</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.66</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.26</specification-version>
+                    </run-dependency>
+                </dependency>
+            </module-dependencies>
             <public-packages>
                 <package>com.formdev.flatlaf</package>
                 <package>com.formdev.flatlaf.util</package>

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-2.4.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-2.4.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-2.5.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-2.5.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/libs.flatlaf/src/org/netbeans/libs/flatlaf/Installer.java
+++ b/platform/libs.flatlaf/src/org/netbeans/libs/flatlaf/Installer.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.flatlaf;
+
+import com.formdev.flatlaf.FlatSystemProperties;
+import java.io.File;
+import org.openide.modules.InstalledFileLocator;
+import org.openide.modules.ModuleInstall;
+
+public class Installer extends ModuleInstall {
+
+    @Override
+    public void validate() {
+        super.validate();
+        File libDirectory = InstalledFileLocator.getDefault().locate("modules/lib", "org.netbeans.libs.flatlaf", false); //NOI18N
+        System.setProperty( FlatSystemProperties.NATIVE_LIBRARY_PATH, libDirectory.getAbsolutePath() );
+    }
+}

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
@@ -38,6 +38,10 @@ public class Installer extends ModuleInstall {
 
         // tell FlatLaf that it should look for .properties files in the given package
         FlatLaf.registerCustomDefaultsSource("org.netbeans.swing.laf.flatlaf", getClass().getClassLoader());
+
+        // don't allow FlatLaf to update UI on system font changes because this would
+        // invoke UIManager.setLookAndFeel() and SwingUtilities.updateComponentTreeUI()
+        System.setProperty( "flatlaf.updateUIOnSystemFontChange", "false" );
     }
 
 }


### PR DESCRIPTION
Update FlatLaf to v2.5.

Changes: https://github.com/JFormDesigner/FlatLaf/releases/tag/2.5
