### PR TITLE
Fix possible NPE in NexusRepositoryIndexerImpl exception handler.

### DIFF
--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
@@ -583,7 +583,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
             File tmpFolder = Places.getCacheDirectory();
             // see also issue #250365
             String noSpaceLeftMsg = null;
-            if(e.getMessage().contains("No space left on device")) {
+            if(e.getMessage() != null && e.getMessage().contains("No space left on device")) {
                 noSpaceLeftMsg = Bundle.MSG_NoSpace(tmpFolder.getAbsolutePath(), repo.getName());
             }
             


### PR DESCRIPTION
fixes #4701

exception handler expected the message of the IOException to be not null. Curious what that exception was.

->
```
java.lang.NullPointerException
	at org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl.indexLoadedRepo(NexusRepositoryIndexerImpl.java:586)
	at org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl.lambda$indexRepo$6(NexusRepositoryIndexerImpl.java:663)
	at org.netbeans.modules.openide.util.DefaultMutexImplementation.writeAccess(DefaultMutexImplementation.java:229)
	at org.openide.util.Mutex.writeAccess(Mutex.java:252)
	at org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl.indexRepo(NexusRepositoryIndexerImpl.java:657)
	at org.netbeans.modules.maven.indexer.api.RepositoryIndexer.indexRepo(RepositoryIndexer.java:42)
	at org.netbeans.modules.maven.ProjectOpenedHookImpl$2.run(ProjectOpenedHookImpl.java:207)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
[catch] at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)
```