### PR TITLE
Add ability to load custom FlatLaf properties from user config.

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/nbproject/project.xml
+++ b/platform/o.n.swing.laf.flatlaf/nbproject/project.xml
@@ -99,6 +99,14 @@
                         <specification-version>8.46</specification-version>
                     </run-dependency>
                 </dependency>
+                <dependency>
+                    <code-name-base>org.openide.filesystems</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.30</specification-version>
+                    </run-dependency>
+                </dependency>
             </module-dependencies>
             <public-packages/>
         </data>

--- a/platform/o.n.swing.laf.flatlaf/nbproject/project.xml
+++ b/platform/o.n.swing.laf.flatlaf/nbproject/project.xml
@@ -107,6 +107,22 @@
                         <specification-version>9.30</specification-version>
                     </run-dependency>
                 </dependency>
+                <dependency>
+                    <code-name-base>org.openide.loaders</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.88</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.nodes</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.63</specification-version>
+                    </run-dependency>
+                </dependency>
             </module-dependencies>
             <public-packages/>
         </data>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
@@ -34,3 +34,13 @@ FlatLafOptionsPanel.underlineMenuSelectionCheckBox.text=Use underline menu &sele
 FlatLafOptionsPanel.alwaysShowMnemonicsCheckBox.text=Always show &mnemonics
 
 LookAndFeel.Config.displayName=Look and Feel
+FlatLafOptionsPanel.Advanced.title=Advanced
+FlatLafOptionsPanel.customPropertiesButton.text=Edit custom properties
+FlatLafOptionsPanel.customPropertiesLabel.text=Override FlatLaf properties by editing the custom properties file.
+FlatLafOptionsPanel.customProperties.content=\
+\# FlatLaf custom property overrides.\n\
+\# Save file and restart NetBeans to apply.\n\
+\# For full documentation see https://www.formdev.com/flatlaf/properties-files/\n\
+\#\n\
+\# @accentColor=#dd2222\n\
+\# [dark]@accentColor=#bb3232\n

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
@@ -32,3 +32,5 @@ FlatLafOptionsPanel.unifiedTitleBarCheckBox.text=&Unified window title bar
 FlatLafOptionsPanel.menuBarEmbeddedCheckBox.text=&Embedded menu bar
 FlatLafOptionsPanel.underlineMenuSelectionCheckBox.text=Use underline menu &selection
 FlatLafOptionsPanel.alwaysShowMnemonicsCheckBox.text=Always show &mnemonics
+
+LookAndFeel.Config.displayName=Look and Feel

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.form
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.form
@@ -46,13 +46,19 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" attributes="0">
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="useWindowDecorationsCheckBox" min="-2" max="-2" attributes="0"/>
-                  <Component id="unifiedTitleBarCheckBox" min="-2" max="-2" attributes="0"/>
-                  <Component id="menuBarEmbeddedCheckBox" min="-2" max="-2" attributes="0"/>
-                  <Component id="underlineMenuSelectionCheckBox" min="-2" max="-2" attributes="0"/>
-                  <Component id="alwaysShowMnemonicsCheckBox" min="-2" max="-2" attributes="0"/>
+                  <Group type="102" attributes="0">
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="useWindowDecorationsCheckBox" min="-2" max="-2" attributes="0"/>
+                          <Component id="unifiedTitleBarCheckBox" min="-2" max="-2" attributes="0"/>
+                          <Component id="menuBarEmbeddedCheckBox" min="-2" max="-2" attributes="0"/>
+                          <Component id="underlineMenuSelectionCheckBox" min="-2" max="-2" attributes="0"/>
+                          <Component id="alwaysShowMnemonicsCheckBox" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                  </Group>
+                  <Component id="advPanel" alignment="1" max="32767" attributes="0"/>
               </Group>
-              <EmptySpace pref="73" max="32767" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -68,7 +74,9 @@
               <Component id="underlineMenuSelectionCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="alwaysShowMnemonicsCheckBox" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="25" max="32767" attributes="0"/>
+              <EmptySpace type="separate" max="-2" attributes="0"/>
+              <Component id="advPanel" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -124,5 +132,60 @@
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="alwaysShowMnemonicsCheckBoxActionPerformed"/>
       </Events>
     </Component>
+    <Container class="javax.swing.JPanel" name="advPanel">
+      <Properties>
+        <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+          <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
+            <TitledBorder title="Advanced">
+              <ResourceString PropertyName="titleX" bundle="org/netbeans/swing/laf/flatlaf/Bundle.properties" key="FlatLafOptionsPanel.Advanced.title" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+            </TitledBorder>
+          </Border>
+        </Property>
+      </Properties>
+
+      <Layout>
+        <DimensionLayout dim="0">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" attributes="0">
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Component id="customPropertiesLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="customPropertiesButton" alignment="0" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace max="32767" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+        <DimensionLayout dim="1">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
+                  <Component id="customPropertiesLabel" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="customPropertiesButton" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="54" max="32767" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+      </Layout>
+      <SubComponents>
+        <Component class="javax.swing.JLabel" name="customPropertiesLabel">
+          <Properties>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="org/netbeans/swing/laf/flatlaf/Bundle.properties" key="FlatLafOptionsPanel.customPropertiesLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JButton" name="customPropertiesButton">
+          <Properties>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="org/netbeans/swing/laf/flatlaf/Bundle.properties" key="FlatLafOptionsPanel.customPropertiesButton.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+            </Property>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="customPropertiesButtonActionPerformed"/>
+          </Events>
+        </Component>
+      </SubComponents>
+    </Container>
   </SubComponents>
 </Form>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
@@ -22,6 +22,8 @@ import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.FlatDarkLaf;
 import com.formdev.flatlaf.FlatLightLaf;
 import javax.swing.UIManager;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
 import org.openide.modules.ModuleInstall;
 import org.openide.util.*;
 
@@ -38,6 +40,13 @@ public class Installer extends ModuleInstall {
 
         // tell FlatLaf that it should look for .properties files in the given package
         FlatLaf.registerCustomDefaultsSource("org.netbeans.swing.laf.flatlaf", getClass().getClassLoader());
+
+        // tell FlatLaf to look for possible user .properties files in LookAndFeel folder of config file system
+        FileObject customFolder = FileUtil.getConfigFile("LookAndFeel");
+        if (customFolder != null && customFolder.isFolder()) {
+            FlatLaf.registerCustomDefaultsSource(customFolder.toURL());
+        }
+
     }
 
 }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/layer.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/layer.xml
@@ -248,4 +248,13 @@
             </folder>
         </folder>
     </folder>
+
+    <folder name="OptionsExport">
+        <folder name="Advanced">
+            <file name="LookAndFeel">
+                <attr name="include" stringvalue="config/LookAndFeel/.*"/>
+                <attr name="displayName" bundlevalue="org.netbeans.swing.laf.flatlaf.Bundle#LookAndFeel.Config.displayName"/>
+            </file>
+        </folder>
+    </folder>
 </filesystem>


### PR DESCRIPTION
Adds ability to load custom FlatLaf property files from userdir. Checks for a `LookAndFeel` folder in config, and registers with FlatLaf. Also registers the folder and files for options export. Give user ability to override anything using FlatLaf property support documented at https://www.formdev.com/flatlaf/properties-files/

eg. file in `<userdir>/config/LookAndFeel/FlatLaf.properties` with 

```
@accentColor = #d22
@background = #ddd
```

![Screenshot from 2022-10-02 17-31-18](https://user-images.githubusercontent.com/3975960/193466332-814c0ddc-0297-4c80-b3aa-582e5ce9fbb3.png)

Added button to open file in editor inside FlatLaf options panel, along with basic default content / instructions.

![Screenshot from 2022-10-05 12-23-41](https://user-images.githubusercontent.com/3975960/194049564-9aaa5303-0d17-4d13-90f5-6cc38ddf2513.png)
