### PR TITLE
NETBEANS-4720 Support custom gradle test sourcesets

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.gradle.java;
 import org.netbeans.modules.gradle.api.execute.RunUtils;
 import org.netbeans.modules.gradle.java.api.GradleJavaProject;
 import org.netbeans.modules.gradle.java.api.GradleJavaSourceSet;
+import static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet.SourceType.*;
 import org.netbeans.modules.gradle.spi.actions.ReplaceTokenProvider;
 import java.io.File;
 import java.util.Arrays;
@@ -42,11 +43,13 @@ import org.openide.util.Lookup;
  */
 public class GradleJavaTokenProvider implements ReplaceTokenProvider {
 
-    private static final String SELECTED_CLASS      = "selectedClass";     //NOI18N
-    private static final String SELECTED_CLASS_NAME = "selectedClassName"; //NOI18N
-    private static final String SELECTED_PACKAGE    = "selectedPackage";   //NOI18N
-    private static final String SELECTED_METHOD     = "selectedMethod";    //NOI18N
-    private static final String AFFECTED_BUILD_TASK = "affectedBuildTasks";//NOI18N
+    private static final String SELECTED_CLASS       = "selectedClass";     //NOI18N
+    private static final String SELECTED_CLASS_NAME  = "selectedClassName"; //NOI18N
+    private static final String SELECTED_PACKAGE     = "selectedPackage";   //NOI18N
+    private static final String SELECTED_METHOD      = "selectedMethod";    //NOI18N
+    private static final String AFFECTED_BUILD_TASK  = "affectedBuildTasks";//NOI18N
+    private static final String TEST_TASK_NAME       = "testTaskName";      //NOI18N
+    private static final String CLEAN_TEST_TASK_NAME = "cleanTestTaskName"; //NOI18N
 
     private static final Set<String> SUPPORTED = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
             SELECTED_CLASS,
@@ -73,6 +76,7 @@ public class GradleJavaTokenProvider implements ReplaceTokenProvider {
         processSelectedPackageAndClass(ret, context);
         processSelectedMethod(ret, context);
         processSourceSets(ret, context);
+        processTestSourceSet(ret, context);
         return ret;
     }
 
@@ -147,4 +151,16 @@ public class GradleJavaTokenProvider implements ReplaceTokenProvider {
         return ret;
     }
 
+    private void processTestSourceSet(final Map<String, String> map, Lookup context) {
+        FileObject fo = RunUtils.extractFileObjectfromLookup(context);
+        GradleJavaProject gjp = GradleJavaProject.get(project);
+        if ((gjp != null) && (fo != null)) {
+            File f = FileUtil.toFile(fo);
+            GradleJavaSourceSet sourceSet = gjp.containingSourceSet(f);
+            if (sourceSet != null && sourceSet.isTestSourceSet() && sourceSet.getSourceType(f) != RESOURCES) {
+                map.put(TEST_TASK_NAME, sourceSet.getName());
+                map.put(CLEAN_TEST_TASK_NAME, sourceSet.getTaskName("clean", null));
+            }
+        }
+    }
 }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
@@ -23,16 +23,16 @@
 <actions>
     <apply-for plugins="java">
         <action name="test.single">
-            <args>cleanTest test --tests "${selectedClass}"</args>
+            <args>"${cleanTestTaskName}" "${testTaskName}" --tests "${selectedClass}"</args>
         </action>
         <action name="run.single.method">
-            <args>cleanTest test --tests "${selectedMethod}"</args>
+            <args>"${cleanTestTaskName}" "${testTaskName}" --tests "${selectedMethod}"</args>
         </action>
         <action name="debug.single.method">
-            <args>cleanTest test --debug-jvm --tests "${selectedMethod}"</args>
+            <args>"${cleanTestTaskName}" "${testTaskName}" --debug-jvm --tests "${selectedMethod}"</args>
         </action>
         <action name="debug.test.single">
-            <args>cleanTest test --debug-jvm --tests "${selectedClass}"</args>
+            <args>"${cleanTestTaskName}" "${testTaskName}" --debug-jvm --tests "${selectedClass}"</args>
         </action>
 
         <action name="javadoc">
@@ -91,10 +91,10 @@
                         <args>-PrunClassName=${selectedClass} ${javaExec.workingDir} ${javaExec.environment} runSingle --continuous ${javaExec.jvmArgs} ${javaExec.args}</args>
                     </action>
                     <action name="test.single">
-                        <args>cleanTest test --tests "${selectedClass}" --continuous</args>
+                        <args>"${cleanTestTaskName}" "${testTaskName}" --tests "${selectedClass}" --continuous</args>
                     </action>
                     <action name="run.single.method">
-                        <args>cleanTest test --tests "${selectedMethod}" --continuous</args>
+                        <args>"${cleanTestTaskName}" "${testTaskName}" --tests "${selectedMethod}" --continuous</args>
                     </action>
                     <action name="debug.single.method">
                         <args></args>


### PR DESCRIPTION
NetBeans 15 hardcodes the 'cleanTest' and 'test' tasks for all tests regardless of the test sourceset the code exists within.  This should be 'clean[TestSourceSetName]' and '[testSourceSetName]' instead (which still works for the default test sourceset 'test'.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

