### PR TITLE
Various fixes and improvements [1/3]

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,27 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="regular-project-Lookup">
+            <api name="general"/>
+            <summary>Expose regular Lookup in NbGradleProject.</summary>
+            <version major="2" minor="28"/>
+            <date day="4" month="10" year="2022"/>
+            <author login="sdedic"/>
+            <compatibility semantic="compatible" addition="yes"/>
+            <description>
+                <p>
+                    <a href="@TOP@/org/netbeans/modules/gradle/api/NbGradleProject.html">NbGradleProject</a> offered just <a href="org/netbeans/modules/gradle/api/NbGradleProject.html#projectLookup-java.lang.Class-">projectLookup(Class)</a>,
+                    that cannot return more instances or deliver change events. A regular Lookup instance, that switch when the project reloads is now available from
+                    <a href="org/netbeans/modules/gradle/api/NbGradleProject.html#refreshableProjectLookup--">NbGradleProject.refreshableProjectLookup()</a>.
+                </p>
+                <p>
+                    Minor API changes giving access to a complete <a href="org/netbeans/modules/gradle/api/execute/RunConfig.html">RunConfig</a> for a project action or an action
+                    mapping.
+                </p>
+            </description>
+            <class package="org.netbeans.modules.gradle.api" name="NbGradleProject"/>
+            <class package="org.netbeans.modules.gradle.api.execute" name="RunUtils"/>
+        </change>
         <change id="gradle-reports">
             <api name="general"/>
             <summary>Rich exception reports are exported from Gradle process.</summary>

--- a/extide/gradle/manifest.mf
+++ b/extide/gradle/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gradle/2
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.27
+OpenIDE-Module-Specification-Version: 2.28

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -311,7 +311,7 @@ public final class NbGradleProjectImpl implements Project {
         synchronized (this) {
             GradleProject c = project;
             if (c != null) {
-                if (c.getQuality().atLeast(aim)) {
+                if (!force && c.getQuality().atLeast(aim)) {
                     return CompletableFuture.completedFuture(c);
                 }
                 if (!force && attemptedQuality.atLeast(aim)) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -270,7 +270,7 @@ public final class NbGradleProjectImpl implements Project {
        synchronized (this) {
             GradleProject c = project;
             if (c != null) {
-                if (c.getQuality().atLeast(aim)) {
+                if (! force && c.getQuality().atLeast(aim)) {
                     LOG.log(Level.FINER, "Asked for {0}, got {1} already: ", new Object[] { aim, c.getQuality() });
                     return c;
                 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/ActionToTaskUtils.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/ActionToTaskUtils.java
@@ -104,6 +104,10 @@ public final class ActionToTaskUtils {
 
     public static ActionMapping getActiveMapping(String action, Project project, Lookup context) {
         GradleExecConfiguration c = ProjectConfigurationSupport.getEffectiveConfiguration(project, context);
+        return getActiveMapping(action, project, c);
+    }
+    
+    public static ActionMapping getActiveMapping(String action, Project project, GradleExecConfiguration c) {
         ConfigurableActionProvider contextProvider = project.getLookup().lookup(ConfigurableActionProvider.class);
         
         if (c == null) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
@@ -26,6 +26,8 @@ import org.netbeans.modules.gradle.execute.GradleDaemonExecutor;
 import org.netbeans.modules.gradle.execute.GradleExecutor;
 import org.netbeans.modules.gradle.execute.ProxyNonSelectableInputOutput;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
@@ -57,12 +59,15 @@ import org.gradle.util.GradleVersion;
 import org.netbeans.api.project.ProjectInformation;
 
 import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.modules.gradle.NbGradleProjectImpl;
 import org.netbeans.modules.gradle.ProjectTrust;
+import org.netbeans.modules.gradle.actions.ActionToTaskUtils;
 import org.netbeans.modules.gradle.api.execute.GradleDistributionManager.GradleDistribution;
 import org.netbeans.modules.gradle.api.execute.RunConfig.ExecFlag;
 import org.netbeans.modules.gradle.execute.ConfigurableActionProvider;
 import org.netbeans.modules.gradle.spi.GradleSettings;
 import org.netbeans.modules.gradle.execute.ProjectConfigurationSupport;
+import org.netbeans.modules.gradle.spi.actions.BeforeBuildActionHook;
 import org.netbeans.modules.gradle.spi.actions.ProjectActionMappingProvider;
 import org.netbeans.modules.gradle.spi.execute.GradleDistributionProvider;
 import org.netbeans.spi.project.ProjectConfiguration;
@@ -214,7 +219,56 @@ public final class RunUtils {
         RunConfig ret = new RunConfig(project, action, displayName, flags, cmd, cfg);
         return ret;
     }
+    
+    /**
+     * Finds an action mapping for the given action and (optional) configuration. The configuration may be {@code null},
+     * which means the project's active configuration.
+     * 
+     * @param project the project
+     * @param action action name
+     * @param cfg optional configuration or {@code null}
+     * @return action mapping instance, or {@code null}, if the action is not defined for the project or is disabled.
+     * @since 2.28
+     */
+    public static ActionMapping findActionMapping(Project project, String action, GradleExecConfiguration cfg) {
+        return ActionToTaskUtils.getActiveMapping(action, project, cfg);
+    }
 
+    /**
+     * Create Gradle execution configuration (context). It applies the specified configuration
+     * (default / active, if the parameter is null). The RunConfig is further configured using the
+     * action mapping for the project action.
+     * 
+     * @param project The Gradle project
+     * @param action The name of the IDE action 
+     * @param displayName The display name of the output tab
+     * @param flags Execution flags.
+     * @param args Gradle command line arguments
+     * @return the Gradle execution configuration.
+     * @param context action infocation context
+     * @param cfg the desired configuration, or {@code null}.
+     * @since 2.28
+     */
+    public static RunConfig createRunConfigForAction(Project project, String action, String displayName, Lookup context, 
+            GradleExecConfiguration cfg, Set<ExecFlag> flags, boolean allowDisabled, String... args) {
+        NbGradleProject gp = NbGradleProject.get(project);
+        GradleExecConfiguration execCfg = ProjectConfigurationSupport.getEffectiveConfiguration(project, context);
+        return ProjectConfigurationSupport.executeWithConfiguration(project, execCfg, () -> {
+            ActionMapping mapping = ActionToTaskUtils.getActiveMapping(action, project, execCfg);
+            if (ActionMapping.isDisabled(mapping) && !allowDisabled) {
+                return null;
+            }
+            if (!ActionToTaskUtils.isActionEnabled(action, mapping, project, context) && !allowDisabled) {
+                return null;
+            }
+            String argLine = mapping.getArgs();
+            final StringWriter writer = new StringWriter();
+            PrintWriter out = new PrintWriter(writer);
+            final String[] evalArgs = RunUtils.evaluateActionArgs(project, action, argLine, Lookup.EMPTY);
+            return RunUtils.createRunConfig(project, action, displayName, Lookup.EMPTY, execCfg, flags, evalArgs);
+        });
+    }
+    
     /**
      * Create Gradle execution configuration (context). It applies the default
      * setting from the project and the Global Gradle configuration on the

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
@@ -29,8 +29,11 @@ import java.io.PipedOutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -170,7 +173,46 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
             errors.clear();
             AtomicBoolean onlineResult = new AtomicBoolean();
             info = retrieveProjectInfo(ctx.project, goOnline, pconn, cmd, token, pl, onlineResult);
-
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.finer("Retrieved project info:");
+                List<String> keys = new ArrayList<>(info.getInfo().keySet());
+                Collections.sort(keys);
+                for (String s : keys) {
+                    Object o = info.getInfo().get(s);
+                    // format just the 1st level:
+                    if (o instanceof Collection) {
+                        Collection c = (Collection)o;
+                        if (!c.isEmpty()) {
+                            LOG.finer(String.format("    %-20s: [", s));
+                            for (Object x: c) {
+                                if (Object[].class.isInstance(x)) {
+                                    x = Arrays.asList((Object[])x);
+                                }
+                                LOG.finer(String.format("    %-20s", x));
+                            }
+                            LOG.finer("    ]");
+                            continue;
+                        }
+                    } else if (o instanceof Map) {
+                        Map m = (Map)o;
+                        if (!m.isEmpty()) {
+                            LOG.finer(String.format("    %-20s: {", s));
+                            List<String> mkeys = new ArrayList<>(m.keySet());
+                            Collections.sort(mkeys);
+                            for (String k : mkeys) {
+                                Object x = m.get(k);
+                                if (Object[].class.isInstance(x)) {
+                                    x = Arrays.asList((Object[])x);
+                                }
+                                LOG.finer(String.format("        %-20s:%s", k, x));
+                            }
+                            LOG.finer("    }");
+                        }
+                        continue;
+                    }
+                    LOG.finer(String.format("    %-20s:%s", s, o));
+                }
+            }
             if (!info.getProblems().isEmpty()) {
                 errors.openNotification(
                         TIT_LOAD_ISSUES(base.getProjectDir().getName()),
@@ -394,6 +436,13 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
         if (DEBUG_GRADLE_INFO_ACTION) {
             // This would start the Gradle Daemon in Debug Mode, so the Tooling API can be debugged as well
             ret.addJvmArguments("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006");
+        }
+        if (LOG.isLoggable(Level.FINEST)) {
+            ret.addArguments("--debug");
+        } else if (LOG.isLoggable(Level.FINER)) {
+            ret.addArguments("--info");
+        } else {
+            ret.addArguments("--warn");
         }
         if (token != null) {
             ret.withCancellationToken(token);

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ArtifactSpec.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ArtifactSpec.java
@@ -72,7 +72,7 @@ public final class ArtifactSpec<T> {
      * to avoid post-processing or shading, this (abstract) classifier should
      * identify an artifact before those steps.
      * <p>
-     * If used in a query, a non-tagged artifact may be returned if the implementation
+     * If used in a query, a non-tagged artifact may be still returned if the implementation
      * does not support the tag.
      */
     public static final String TAG_BASE = "<basic>"; // NOI18N
@@ -156,7 +156,7 @@ public final class ArtifactSpec<T> {
      * represents the build output, usually in project's build directory. Note that FileObject for 
      * a dependency and its corresponding Project may not be the same.
      * 
-     * @return 
+     * @return local file, if it exists.
      */
     public FileObject getLocalFile() {
         // It's not locked well, but localFile will eventually become non-null, even though
@@ -174,9 +174,25 @@ public final class ArtifactSpec<T> {
                 f = localFile = FileUtil.getConfigRoot();
             }
         }
+        // note: config root is used as 'nothing is here' marker
         return f == FileUtil.getConfigRoot() ? null : f;
     }
     
+    /**
+     * Checks if the artifact has the specific tag. Tags are optional indicators of artifact's purpose or 
+     * characteristics, they are typically technology and/or build system specific. Two 'abstract' tags
+     * are defined (implementations may use additional more specific tags, too):
+     * <ul>
+     * <li>{@link #TAG_BASE} for product of a project, and
+     * <li>{@link #TAG_SHADED} for a bundled product (e.g. with dependencies).
+     * </ul>
+     * The exact meaning is build-system specific.
+     * <p>
+     * Tags are typically not used in dependency specifications.
+     * 
+     * @param tag the tag to test
+     * @return true, if the artifact is tagged.
+     */
     public boolean hasTag(String tag) {
         return tags.contains(tag);
     }
@@ -276,8 +292,8 @@ public final class ArtifactSpec<T> {
     }
     
     /**
-     * Returns opaque project-specific data. If searching for
-     * a project-specific extension, use {@link ProjectDependencies#findAdapters} instead.
+     * Returns opaque project-specific data. You must use project-specific API to
+     * extract information that may be linked in here.
      * 
      * @return unspecified underlying project data
      */
@@ -288,7 +304,7 @@ public final class ArtifactSpec<T> {
     public static <V> ArtifactSpec<V> createVersionSpec(
             @NullAllowed String groupId, @NonNull String artifactId, 
             @NullAllowed String type, @NullAllowed String classifier, 
-            @NonNull String versionSpec, boolean optional, @NullAllowed FileObject localFile, @NonNull V data) {
+            @NullAllowed String versionSpec, boolean optional, @NullAllowed FileObject localFile, @NonNull V data) {
         URL u = localFile == null ? null : URLMapper.findURL(localFile, URLMapper.EXTERNAL);
         URI uri = null;
         if (u != null) {
@@ -302,9 +318,9 @@ public final class ArtifactSpec<T> {
     }
 
     public static <V> ArtifactSpec<V> createSnapshotSpec(
-            @NonNull String groupId, @NonNull String artifactId, 
+            @NullAllowed String groupId, @NullAllowed String artifactId, 
             @NullAllowed String type, @NullAllowed String classifier, 
-            @NonNull String versionSpec, boolean optional, @NullAllowed FileObject localFile, @NonNull V data) {
+            @NullAllowed String versionSpec, boolean optional, @NullAllowed FileObject localFile, @NonNull V data) {
         URI uri = null;
         if (localFile != null) {
             URL u = URLMapper.findURL(localFile, URLMapper.EXTERNAL);
@@ -391,7 +407,8 @@ public final class ArtifactSpec<T> {
          * @return builder instance.
          */
         public Builder forceLocalFile(FileObject localFile) {
-            this.localFile = localFile == null ?FileUtil.getConfigRoot() : localFile;
+            // note: config root is used as 'nothing is here' marker
+            this.localFile = localFile == null ? FileUtil.getConfigRoot() : localFile;
             return this;
         }
 

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenArtifactsImplementation.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenArtifactsImplementation.java
@@ -606,7 +606,6 @@ public class MavenArtifactsImplementation implements ProjectArtifactsImplementat
             if (!NbMavenProject.PROP_PROJECT.equals(evt.getPropertyName())) {
                 return;
             }
-            ChangeListener[] ll;
             final List<ArtifactSpec> copy;
 
             synchronized (this) {
@@ -619,14 +618,9 @@ public class MavenArtifactsImplementation implements ProjectArtifactsImplementat
                 }
                 copy = artifacts == null ? Collections.emptyList() : new ArrayList<>(this.artifacts);
                 RequestProcessor.Task[] arr = new RequestProcessor.Task[1];
+                artifacts = null;
 
                 arr[0] = refreshTask = MAVEN_ARTIFACTS_RP.create(() -> update(copy, arr[0]));
-
-                ll = listeners.toArray(new ChangeListener[listeners.size()]);
-            }
-            ChangeEvent e = new ChangeEvent(this);
-            for (ChangeListener l : ll) {
-                l.stateChanged(e);
             }
         }
 

--- a/platform/core.startup/src/org/netbeans/core/startup/Main.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Main.java
@@ -221,7 +221,11 @@ public final class Main extends Object {
         jdkHome = System.getProperty("java.home");  // NOI18N
 
         if (!BaseUtilities.isMac()) {
-            jdkHome += File.separator + "..";  // NOI18N
+            File binDir = new File(new File(new File(jdkHome), ".."), "bin"); // NOI18N
+            // do not reset jdk.home in the most apparent situation, where the bin/ subdirectory does not exist at all.
+            if (binDir.exists()) {
+                jdkHome += File.separator + "..";  // NOI18N
+            }
         }
 
         System.setProperty("jdk.home", jdkHome);  // NOI18N


### PR DESCRIPTION
Note: this PR is the first from series of 3. I've split the development into 3 PRs since there are different areas that seem to be better reviewed separately. Other PRs in the series depend on this one.

Unrelated fixes:
- Maven fix- - change event is fired only after result refresh from reloaded project completes.
- `ArtfiactSpec` (still private !) API fixes; some project products do not have group at all, some have no version; the API should allow that.
- core module screws up `jdk.home` property when run without a launcher (that sets `jdk.home` beforehand) - visible mainly in tests.

Gradle fixes:
- during `toQuality` that should reload a project if `force` flag is true, the flag was sometimes ignored

Improvement:
- FINER and FINEST loglevel for `LegacyProjectLoader` will print out obtained info and increase verbosity of the gradle plugin (prints into the Output window of the debugging NB)

API:
- Previously `RunConfig` APIs did not add `ActionMapping`'s arguments that specify the actual grade tasks to be run. The new API allows to obtain RunConfig as if the action was about to be run.