### PR TITLE
LSP Client: Use full complete item to complete, not just the missing suffix

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
@@ -213,9 +213,14 @@ public class CompletionProviderImpl implements CompletionProvider {
                                                 toAdd = i.getLabel();
                                             }
                                             int[] identSpan = Utilities.getIdentifierBlock((BaseDocument) doc, caretOffset);
-                                            String printSuffix = toAdd.substring(identSpan != null ? caretOffset - identSpan[0] : 0);
-                                            doc.insertString(caretOffset, printSuffix, null);
-                                            endPos = caretOffset + printSuffix.length();
+                                            if (identSpan != null) {
+                                                doc.remove(identSpan[0], identSpan[1] - identSpan[0]);
+                                                doc.insertString(identSpan[0], toAdd, null);
+                                                endPos = identSpan[0] + toAdd.length();
+                                            } else {
+                                                doc.insertString(caretOffset, toAdd, null);
+                                                endPos = caretOffset + toAdd.length();
+                                            }
                                         }
                                         doc.insertString(endPos, appendText, null);
                                     } catch (BadLocationException ex) {


### PR DESCRIPTION
This is the test case (typescript):

```typescript
export class test {
    demo() {
        this.runstranget|
    }

    runStrangeThings(): void {
    }
}
```

The codecompletion at the | mark will offer "runStrangeThings", but completion will yield "this.runstrangethings". The reason is, that the CC is invoced case-insensitive, so the original string needs to be replaced with the full result.
