### PR TITLE
API: access to build properties of gradle script [2/3]

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,29 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="build-properties-tasks">
+            <api name="general"/>
+            <summary>New APIs that provide access to values of build properties and tasks.</summary>
+            <version major="2" minor="28"/>
+            <date day="4" month="10" year="2022"/>
+            <author login="sdedic"/>
+            <compatibility semantic="compatible" addition="yes"/>
+            <description>
+                <p>
+                    Gradle buildscript objects are introspected from within the gradle instance. All active plugins are enumerated.
+                    Extensions are detected. An API is provided to get dependent task, or a closure of the dependents, and to check tasks' type 
+                    to identify tasks of interest.
+                    See <a href="@TOP@/org/netbeans/modules/gradle/api/GradleBaseProject.html#getTaskPredecessors-org.netbeans.modules.gradle.api.GradleTask-boolean-">GradleBaseProject.getTaskPredecessors()</a> and
+                    <a href="@TOP@/org/netbeans/modules/gradle/api/GradleBaseProject.html#isTaskInstanceOf-java.lang.String-java.lang.String-">GradleBaseProject.isTaskInstanceOf()</a>
+                </p>
+                <p>
+                    Certain task and extension property values can be accessed by APIs, that allows NetBean plugins to access
+                    configuration of tasks within the script. See <a href="org-netbeans-modules-gradle/org/netbeans/modules/gradle/api/BuildPropertiesSupport.html">BuildPropertiesSupport</a>.
+                </p>
+            </description>
+            <class package="org.netbeans.modules.gradle.api" name="GradleBaseProject"/>
+            <class package="org.netbeans.modules.gradle.api" name="BuildPropertiesSupport"/>
+        </change>
         <change id="regular-project-Lookup">
             <api name="general"/>
             <summary>Expose regular Lookup in NbGradleProject.</summary>

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -372,7 +372,7 @@ class NbProjectInfoBuilder {
                 Class fc = c;
                 // with Gradle 7.1+, plugins can be better enumerated. Prior to 7.1 I can only get IDs for registry-supplied plugins.
                 Optional<PluginId> id = sinceGradleOrDefault("7.1", () -> pmi.findPluginIdForClass(fc), Optional::empty); // NOI18N
-                if (id.isEmpty() && reg != null) {
+                if (!id.isPresent() && reg != null) {
                     id = reg.findPluginForClass(c);
                 }
                 if (id.isPresent()) {

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -19,30 +19,51 @@
 
 package org.netbeans.modules.gradle.tooling;
 
+import groovy.lang.GroovySystem;
+import groovy.lang.MetaBeanProperty;
+import groovy.lang.MetaClass;
+import groovy.lang.MetaProperty;
 import groovy.lang.MissingPropertyException;
 import java.io.File;
 import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import static java.util.Arrays.asList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.codehaus.groovy.runtime.InvokerHelper;
+import org.codehaus.groovy.runtime.metaclass.MultipleSetterProperty;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.FileCollectionDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
@@ -64,15 +85,31 @@ import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.initialization.IncludedBuild;
+import org.gradle.api.internal.plugins.PluginManagerInternal;
+import org.gradle.api.internal.plugins.PluginRegistry;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.provider.PropertyInternal;
+import org.gradle.api.internal.provider.ProviderInternal;
+import org.gradle.api.internal.provider.ValueSupplier.ExecutionTimeValue;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.ExtensionsSchema.ExtensionSchema;
 import org.gradle.api.plugins.JavaPlatformPlugin;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.reflect.HasPublicType;
+import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.jvm.JvmLibrary;
 import org.gradle.language.base.artifact.SourcesArtifact;
 import org.gradle.language.java.artifact.JavadocArtifact;
+import org.gradle.plugin.use.PluginId;
 import org.gradle.util.VersionNumber;
 import org.netbeans.modules.gradle.tooling.internal.NbProjectInfo;
 
@@ -81,6 +118,16 @@ import org.netbeans.modules.gradle.tooling.internal.NbProjectInfo;
  * @author Laszlo Kishalmi
  */
 class NbProjectInfoBuilder {
+    
+    /**
+     * The logger. Use Gradle logging - use {@code lifecycle} level for messages that should
+     * be printed regularly, and {@code info} for verbose debug messages. This is because if
+     * debug loglevel is enabled, gradle will spit out enormous number of diagnostics. This
+     * Plugin is not for 'end-user' use anyway, so INFO level is enabled when the logging level gradle
+     * project loader is enabled to FINER level.
+     */
+    private static final Logger LOG =  Logging.getLogger(NbProjectInfoBuilder.class);
+    
     private static final String NB_PREFIX = "netbeans.";
     private static final Set<String> CONFIG_EXCLUDES = new HashSet<>(asList( new String[]{
         "archives",
@@ -144,15 +191,21 @@ class NbProjectInfoBuilder {
 
     public NbProjectInfo buildAll() {
         NbProjectInfoModel model = new NbProjectInfoModel();
-        detectProjectMetadata(model);
+        runAndRegisterPerf(model, "meta", this::detectProjectMetadata);
         detectProps(model);
         detectLicense(model);
-        detectPlugins(model);
-        detectSources(model);
+        runAndRegisterPerf(model, "plugins", this::detectPlugins);
+        runAndRegisterPerf(model, "sources", this::detectSources);
         detectTests(model);
-        detectDependencies(model);
-        detectArtifacts(model);
+        runAndRegisterPerf(model, "dependencies", this::detectDependencies);
+        runAndRegisterPerf(model, "artifacts", this::detectArtifacts);
         detectDistributions(model);
+        runAndRegisterPerf(model, "detectExtensions", this::detectExtensions);
+        runAndRegisterPerf(model, "detectPlugins2", this::detectAdditionalPlugins);
+        runAndRegisterPerf(model, "taskDependencies", this::detectTaskDependencies);
+        runAndRegisterPerf(model, "taskProperties", this::detectTaskProperties);
+        runAndRegisterPerf(model, "artifacts", this::detectConfigurationArtifacts);
+        storeGlobalTypes(model);
         return model;
     }
 
@@ -172,10 +225,568 @@ class NbProjectInfoBuilder {
         }
         model.getInfo().put("license", license);
     }
+    
+    private void addTypes(Class c, Set<Class> types) {
+        if (c == null || !types.add(c)) {
+            return;
+        }
+        if (c.getSuperclass() != Object.class) {
+            addTypes(c.getSuperclass(), types);
+        }
+        for (Class i : c.getInterfaces()) {
+            addTypes(i, types);
+        }
+    }
+    
+    private String getTaskInheritance(Task t) {
+        Class nonDecorated = findNonDecoratedClass(t.getClass());
+        Set<Class> classes = new HashSet<>();
+        addTypes(nonDecorated, classes);
+        return classes.stream().map(Class::getName).sorted().collect(Collectors.joining(","));
+    }
+    
+    private static final Set<String> EXCLUDE_TASK_PROPERTIES = new HashSet<>(Arrays.asList(
+        "dependsOn",
+        "project",
+        "actions",
+        "taskDependencies",
+        "dependsOn",
+        "ant",
+        "logger",
+        "logging",
+        "outputs",
+        "destroyables",
+        "mustRunAfter",
+        "finalizedBy",
+        "shouldRunAfter",
+        "enabled",
+        "description",
+        "group"
+    ));
+    
+    private void detectTaskProperties(NbProjectInfoModel model) {
+        Map<String, Object> taskProperties = new HashMap<>();
+        Map<String, String> taskPropertyTypes = new HashMap<>();
+        
+        Map<String, Task> taskList = project.getTasks().getAsMap();
+        for (String s : taskList.keySet()) {
+            Task task = taskList.get(s);
+            Class taskClass = task.getClass();
+            Class nonDecorated = findNonDecoratedClass(taskClass);
+            
+            taskPropertyTypes.put(task.getName(), nonDecorated.getName());
+            inspectObjectAndValues(taskClass, task, task.getName() + ".", globalTypes, taskPropertyTypes, taskProperties, EXCLUDE_TASK_PROPERTIES, true); // NOI18N
+        }
+        
+        model.getInfo().put("tasks.propertyValues", taskProperties); // NOI18N
+        model.getInfo().put("tasks.propertyTypes", taskPropertyTypes); // NOI18N
+    }
+    
+    private void detectTaskDependencies(NbProjectInfoModel model) {
+        Map<String, Object> tasks = new HashMap<>();
+        
+        Map<String, Task> taskList = project.getTasks().getAsMap();
+        for (String s : taskList.keySet()) {
+            Task task = taskList.get(s);
+            Map<String, String> taskInfo = new HashMap<>();
+            taskInfo.put("name", task.getPath()); // NOI18N
+            taskInfo.put("enabled", Boolean.toString(task.getEnabled())); // NOI18N
+            taskInfo.put("mustRunAfter", dependenciesAsString(task, task.getMustRunAfter())); // NOI18N
+            taskInfo.put("shouldRunAfter", dependenciesAsString(task, task.getShouldRunAfter())); // NOI18N
+            taskInfo.put("taskDependencies", dependenciesAsString(task, task.getTaskDependencies())); // NOI18N
+            
+            Class taskClass = task.getClass();
+            Class nonDecorated = findNonDecoratedClass(taskClass);
+            
+            taskInfo.put("type", nonDecorated.getName()); // NOI18N
+            taskInfo.put("inherits", getTaskInheritance(task)); // NOI18N
+
+            tasks.put(task.getName(), taskInfo);
+        }
+        
+        model.getInfo().put("taskDetails", tasks); // NOI18N
+    }
+    
+    private String dependenciesAsString(Task t, TaskDependency td) {
+        Set<? extends Task> deps = td.getDependencies(t);
+        if (deps.isEmpty()) {
+            return "";
+        }
+        return deps.stream().map(Task::getPath).collect(Collectors.joining(","));
+    }
+    
+    private void detectConfigurationArtifacts(NbProjectInfoModel model) {
+        List<Configuration> configs = project.getConfigurations()
+            .stream()
+            .filter(Configuration::isCanBeConsumed)
+            .filter(c -> !c.isCanBeResolved())
+            .sorted(Comparator.comparing(Configuration::getName))
+            .collect(Collectors.toList());
+        Map<String, Object> data = new HashMap<>();
+        for (Configuration c : configs) {
+            PublishArtifactSet publishSet = c.getAllArtifacts();
+            if (publishSet.isEmpty()) {
+                continue;
+            }
+            Map<String, Object> confData = new HashMap<>();
+            LOG.lifecycle("Configuration {} artifacts:", c.getName());
+            for (PublishArtifact a : publishSet) {
+                Map<String, String> artData = new HashMap<>();
+                artData.put("name", a.getName()); // NOI18N
+                artData.put("classifier", a.getClassifier()); // NOI18N
+                artData.put("extension", a.getExtension()); // NOI18N
+                artData.put("type", a.getType()); // NOI18N
+                
+                File f = a.getFile();
+                LOG.info("\t{}: name: {}, type: {}, classifier: {}, extension: {}", 
+                        f.getPath(), a.getName(), a.getType(), a.getClassifier(), a.getExtension());
+                Set<? extends Task> tasks = a.getBuildDependencies().getDependencies(null);
+                String taskList = tasks.stream().map(t -> t.getName()).collect(Collectors.joining(","));
+                artData.put("buildDeps", taskList); // NOI18N
+                LOG.info("\tbuilt by: {}", taskList); // NOI18N
+                confData.put(f.getPath(), artData);
+            }
+            data.put(c.getName(), confData);
+        }
+        model.getInfo().put("configurationArtifacts", data); // NOI18N
+    }
+    
+    private void detectAdditionalPlugins(NbProjectInfoModel model) {
+        final PluginManagerInternal pmi;
+        PluginRegistry reg;
+        if (project.getPluginManager() instanceof PluginManagerInternal) {
+            pmi = (PluginManagerInternal)project.getPluginManager();
+        } else {
+            return;
+        }
+        if (project instanceof ProjectInternal) {
+            reg = ((ProjectInternal)project).getServices().get(PluginRegistry.class);
+        } else {
+            reg = null;
+        }
+        LOG.lifecycle("Detecting additional plugins");
+        final Set<String> plugins = new LinkedHashSet<>();
+        
+        project.getPlugins().matching((Plugin p) -> {
+            for (Class c = p.getClass(); c != null && c != Object.class; c = c.getSuperclass()) {
+                Class fc = c;
+                // with Gradle 7.1+, plugins can be better enumerated. Prior to 7.1 I can only get IDs for registry-supplied plugins.
+                Optional<PluginId> id = sinceGradleOrDefault("7.1", () -> pmi.findPluginIdForClass(fc), Optional::empty); // NOI18N
+                if (id.isEmpty() && reg != null) {
+                    id = reg.findPluginForClass(c);
+                }
+                if (id.isPresent()) {
+                    LOG.info("Plugin: {} -> {}", id.get(), p);
+                    plugins.add(id.get().getId());
+                    break;
+                }
+            }
+            return false;
+        }).toArray(); // force iteration, gradle is lazier than I :)
+        // rely on Set to avoid duplicities.
+        ((Set)model.getInfo().get("plugins")).addAll(plugins); // NOI18N
+    }
+    
+    private void runAndRegisterPerf(NbProjectInfoModel model, String s, Consumer<NbProjectInfoModel> r) {
+        runAndRegisterPerf(model, s, () -> r.accept(model));
+    }
+    
+    private void runAndRegisterPerf(NbProjectInfoModel model, String s, Runnable r) {
+        long time = System.currentTimeMillis();
+        try {
+            r.run();
+        } finally {
+            long span = System.currentTimeMillis() - time;
+            model.registerPerf(s, span);
+        }
+    }
+    
+    private void storeGlobalTypes(NbProjectInfoModel model) {
+        model.getInfo().put("extensions.globalTypes", globalTypes); // NOI18N
+    }
+    
+    private void detectExtensions(NbProjectInfoModel model) {
+        StringBuilder sb = new StringBuilder();
+        for (String s : IGNORED_SYSTEM_CLASSES_REGEXP) {
+            if (sb.length() > 0) {
+                sb.append("|"); // NOI18N
+            }
+            sb.append(s);
+        }
+        ignoreClassesPattern = Pattern.compile(sb.toString());
+
+        inspectExtensions("", project.getExtensions());
+        model.getInfo().put("extensions.propertyTypes", propertyTypes); // NOI18N
+        model.getInfo().put("extensions.propertyValues", values); // NOI18N
+    }
+
+    /**
+     * Ignored properties, which are exposed by Groovy's Metaobject protocol, but should have
+     * been hidden.
+     */
+    private static final Set<String> IGNORED_SYSTEM_PROPERTIES = new HashSet<>(Arrays.asList(
+            "asDynamicObject", 
+            "convention", 
+            "class", 
+            "conventionMapping", 
+            "extensions", 
+            "modelIdentityDisplayName",
+            "project", 
+            "taskThatOwnsThisObject",
+            "additionalMethods",
+            "elementsAsDynamicObject",
+            "collectionSchema",
+            "didWork",
+            "onlyIf"
+    ));
+    
+    /**
+     * Classes that are ignored during value/type introspection. 
+     */
+    private static final String[] IGNORED_SYSTEM_CLASSES_REGEXP = {
+            "java\\..*",
+            "org\\.gradle\\.api\\.file\\..*",
+            "org\\.gradle\\.api\\.tasks\\..*",
+            "org\\.gradle\\.api\\.reflect\\..*",
+            "org\\.gradle\\.api\\.NamedDomainObject.*",
+            "org\\.gradle\\.api\\.internal\\..*",
+            "org.gradle.api.internal.tasks.DefaultTaskDependency",
+            "org\\.gradle\\.api\\.specs\\..*"
+    };
+
+    private Class findIterableItemClass(Class clazz) {
+        if (clazz == null) {
+            return null;
+        }
+        Map<TypeVariable<?>, Type> parameters = TypeUtils.getTypeArguments(clazz, Iterable.class);
+        if (parameters == null || parameters.isEmpty()) {
+            return null;
+        }
+        for (Map.Entry<TypeVariable<?>, Type> e : parameters.entrySet()) {
+            TypeVariable<?> tv = e.getKey();
+            if (tv.getGenericDeclaration() == Iterable.class) {
+                Type t = e.getValue();
+                if (!(t instanceof Class) || t == Object.class) {
+                    return null;
+                } else {
+                    return (Class)t;
+                }
+            }
+        }
+        return null;
+    }        
+    
+    public static final String COLLECTION_TYPE_MARKER = "#col"; // NOI18N
+    public static final String COLLECTION_TYPE_NAMED = "named"; // NOI18N
+    public static final String COLLECTION_TYPE_LIST = "list"; // NOI18N
+    public static final String COLLECTION_ITEM_MARKER = "#itemType"; // NOI18N
+    public static final String COLLECTION_ITEM_PREFIX = COLLECTION_ITEM_MARKER + "."; // NOI18N
+    public static final String COLLECTION_CONTENT_PREFIX = "#content"; // NOI18N
+    public static final String COLLECTION_KEYS_MARKER = "#keys"; // NOI18N
+    
+    
+    private static boolean isPrimitiveOrString(Class c) {
+        if (c == Object.class) {
+            return false;
+        }
+        String n = c.getName();
+        if (n.indexOf('.') == -1) {
+            return true;
+        } else if (n.startsWith("java.lang.")) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Inspects extension or plugin objects for properties and their types. Object values are inspected recursively.
+     * Property values are read; values that are {@link ProviderInternal}s are computed
+     * 
+     * @param clazz class to inspect
+     * @param object the value to inspect and dump property values, possibly {@code null}
+     * @param prefix prefix for type and value maps
+     * @param globalTypes map to store information for individual types
+     * @param propertyTypes
+     * @param defaultValues 
+     */
+    private void inspectObjectAndValues(Class clazz, Object object, String prefix, Map<String, Map<String, String>> globalTypes, Map<String, String> propertyTypes, Map<String, Object> defaultValues) {
+        inspectObjectAndValues(clazz, object, prefix, globalTypes, propertyTypes, defaultValues, null, true);
+    }
+    
+    private void inspectObjectAndValues(Class clazz, Object object, String prefix, Map<String, Map<String, String>> globalTypes, Map<String, String> propertyTypes, Map<String, Object> defaultValues, Set<String> excludes, boolean type) {
+        try {
+            inspectObjectAndValues0(clazz, object, prefix, globalTypes, propertyTypes, defaultValues, excludes, type);
+        } catch (RuntimeException ex) {
+            LOG.warn("Error during inspection of {}, value {}, prefix {}", clazz, object, prefix);
+        }
+    }
+    
+    private void inspectObjectAndValues0(Class clazz, Object object, String prefix, Map<String, Map<String, String>> globalTypes, Map<String, String> propertyTypes, Map<String, Object> defaultValues, Set<String> excludes, boolean type) {
+        Class nonDecorated = findNonDecoratedClass(clazz);
+        
+        // record object's type first, even though the value may be excluded (i.e. ignored class). Do not add types for collection or map items -- to much clutter.
+        if (type) {
+            String typeKey = prefix;
+            if (prefix.endsWith(".")) {
+                typeKey = prefix.substring(0, prefix.length() - 1);
+            } else {
+                typeKey = prefix;
+            }
+            propertyTypes.putIfAbsent(typeKey, nonDecorated.getName());
+        }
+        if (clazz == null || (excludes == null && ignoreClassesPattern.matcher(clazz.getName()).matches())) {
+            return;
+        }
+        if (clazz.isEnum() || clazz.isArray()) {
+            return;
+        }
+
+        MetaClass mclazz = GroovySystem.getMetaClassRegistry().getMetaClass(clazz);
+        Map<String, String> globTypes = globalTypes.computeIfAbsent(nonDecorated.getName(), cn -> new HashMap<>());
+        List<MetaProperty> props = mclazz.getProperties();
+        for (MetaProperty mp : props) {
+            Class propertyDeclaringClass = null;
+            String getterName = null;
+            String propName = mp.getName();
+            // some properties are added by DSL wrappers, we should better ignore them.
+            if ((excludes != null && excludes.contains(propName)) || IGNORED_SYSTEM_PROPERTIES.contains(propName)) {
+                continue;
+            }
+            LOG.info("Inspecting {}.{}", clazz.getName(), propName);
+            Class t = mp.getType();
+            if (t == Object.class) {
+                // MultipleSetter is probably for an overloaded setter
+                if (mp instanceof MultipleSetterProperty) {
+                    MultipleSetterProperty msp = (MultipleSetterProperty)mp;
+                    t = msp.getGetter().getReturnType();
+                }
+            }
+
+            if (mp instanceof MetaBeanProperty) {
+                MetaBeanProperty mbp = (MetaBeanProperty)mp;
+
+                if (mbp.getGetter() == null) {
+                    continue;
+                }
+                
+                // PENDING: not all settable stuff has a setter. Some are containers or objects which are always present,
+                // and have to be configured using their properties, i.e. java.modularity. But there are TOOOO MANY things
+                // that have a getter and are DEFINITELY not meant for a DSL. 
+                // Giving up this time, they should be added if a decent way to filter out implementation garbage is found.
+                if (mbp.getSetter() == null) {
+                    if (object == null) {
+                        continue;
+                    }
+                    Object potentialValue;
+                    try {
+                        potentialValue = mclazz.getProperty(object, propName);
+                    } catch (RuntimeException ex) {
+                        // just ignore - the value cannot be obtained
+                        continue;
+                    }
+                    boolean ok = false;
+                    if (potentialValue instanceof PropertyInternal) {
+                        ok = true;
+                    } else if ((potentialValue instanceof NamedDomainObjectContainer) && (potentialValue instanceof HasPublicType)) {
+                        ok = true;
+                    }
+                    if (!ok) {
+                        continue;
+                    }
+                }
+
+                getterName = mbp.getGetter().getName();
+                propertyDeclaringClass = mbp.getGetter().getDeclaringClass().getTheClass();
+            }
+            List<Type> typeParameters = null;
+            if (propertyDeclaringClass != null && t.getTypeParameters().length > 0) {
+                try {
+                    Method m = propertyDeclaringClass.getDeclaredMethod(getterName);
+                    Type rt = m.getGenericReturnType();
+                    if (rt instanceof ParameterizedType) {
+                        typeParameters = new ArrayList<>(Arrays.asList(((ParameterizedType)rt).getActualTypeArguments()));
+                    }
+                } catch (ReflectiveOperationException ex) {
+                }
+            }
+            Object value = null;
+            if ((mp.getModifiers() & Modifier.PUBLIC) == 0) {
+                continue;
+            }
+            if (object != null) {
+                // Provider must NOT be asked for a value, otherwise it might run a Task in order to compute
+                // the value.
+                try {
+                    if (Provider.class.isAssignableFrom(t)) {
+                        Object potentialValue = mclazz.getProperty(object, propName);
+                        if (potentialValue instanceof ProviderInternal) {
+                            ProviderInternal provided = (ProviderInternal) potentialValue;
+                            t = provided.getType();
+                            ExecutionTimeValue etv;
+                            etv = provided.calculateExecutionTimeValue();
+                            if (etv.isFixedValue()) {
+                                value = etv.getFixedValue();
+                            }
+                        } else {
+                            value = potentialValue;
+                            if (value != null) {
+                                t = value.getClass();
+                            }
+                        }
+                    } else {
+                        value = mclazz.getProperty(object, propName);
+                    }
+                } catch (RuntimeException ex) {
+                    // just ignore - the property value cannot be obtained
+                }
+           }
+            if (value != null && !(value instanceof Provider)) {
+                if (isPrimitiveOrString(value.getClass())) {
+                    defaultValues.put(prefix + propName, value);
+                } else {
+                    try {
+                        defaultValues.put(prefix + propName, value.toString());
+                    } catch (RuntimeException ex) {
+                        // just ignore... some properties cannot be computed at this time, and their toString() attempts to do that.
+                        LOG.info("Could not get value of {}", propName, ex);
+                    }
+                }
+            }
+            
+            String cn = findNonDecoratedClass(t).getName();
+            globTypes.put(propName, cn);
+            propertyTypes.put(prefix + propName, cn);
+
+            boolean dumped = false;
+            
+            if (value != null) {
+                // attemtp to enumerate membrs of a Container or an Iterable.
+                Class itemClass = null;
+                if ((value instanceof NamedDomainObjectContainer) && (value instanceof HasPublicType)) {
+                    String newPrefix;
+                    
+                    TypeOf pubType = ((HasPublicType)value).getPublicType();
+                    if (pubType != null && pubType.getComponentType() != null) {
+                        itemClass = pubType.getComponentType().getConcreteClass();
+                    } else {
+                        itemClass = findIterableItemClass(pubType.getConcreteClass());
+                    }
+                    if (itemClass != null) {
+                        propertyTypes.put(prefix + propName + COLLECTION_TYPE_MARKER, COLLECTION_TYPE_NAMED);
+                        propertyTypes.put(prefix + propName + COLLECTION_ITEM_MARKER, itemClass.getName());
+                        newPrefix = prefix + propName + COLLECTION_ITEM_PREFIX; // NOI18N
+                        inspectObjectAndValues(itemClass, null, newPrefix, globalTypes, propertyTypes, defaultValues);
+                    }
+
+                    NamedDomainObjectContainer nc = (NamedDomainObjectContainer)value;
+                    Map<String, ?> m = nc.getAsMap();
+                    List<String> ss = new ArrayList<>(m.keySet());
+                    propertyTypes.put(prefix + propName + COLLECTION_KEYS_MARKER, String.join(";", ss));
+                    for (String k : m.keySet()) {
+                        newPrefix = prefix + propName + "." + k + "."; // NOI18N
+                        Object v = m.get(k);
+                        defaultValues.put(prefix + propName + "." + k, Objects.toString(v)); // NOI18N
+                        inspectObjectAndValues(v.getClass(), v, newPrefix, globalTypes, propertyTypes, defaultValues, null, false);
+                    }
+                    dumped = true;
+                } else if (Iterable.class.isAssignableFrom(t)) {
+                    itemClass = findIterableItemClass(t);
+                    if (itemClass == null && typeParameters != null && !typeParameters.isEmpty()) {
+                        if (typeParameters.get(0) instanceof Class) {
+                            itemClass = (Class)typeParameters.get(0);
+                        }
+                    }
+                    
+                    if (itemClass != null) {
+                        cn = findNonDecoratedClass(itemClass).getName();
+                        propertyTypes.put(prefix + propName + COLLECTION_TYPE_MARKER, COLLECTION_TYPE_LIST);
+                        propertyTypes.put(prefix + propName + COLLECTION_ITEM_MARKER, cn);
+                        String newPrefix = prefix + propName + COLLECTION_ITEM_PREFIX; // NOI18N
+                        if (!cn.startsWith("java.lang.") && !Provider.class.isAssignableFrom(t)) { //NOI18N
+                            inspectObjectAndValues(itemClass, null, newPrefix, globalTypes, propertyTypes, defaultValues);
+                        }
+                    }
+                    
+                    if (value instanceof Iterable) {
+                        int index = 0;
+                        for (Object o : (Iterable)value) {
+                            String newPrefix = prefix + propName + "[" + index + "]."; // NOI18N
+                            defaultValues.put(prefix + propName + "[" + index + "]", Objects.toString(o)); //NOI18N
+                            inspectObjectAndValues(o.getClass(), o, newPrefix, globalTypes, propertyTypes, defaultValues, null, false);
+                            index++;
+                        }
+                        dumped = true;
+                    }
+                }
+                
+                if (!dumped) {
+                    if (!isPrimitiveOrString(t) && !Provider.class.isAssignableFrom(t)) {
+                        String newPrefix = prefix + propName + "."; // NOI18N
+
+                        // recursively inspect a structured value.
+                        inspectObjectAndValues(t, value, newPrefix, globalTypes, propertyTypes, defaultValues);
+                    }
+                }
+            }
+        }
+    }
+    
+    private static Class findNonDecoratedClass(Class clazz) {
+        while (clazz != Object.class && (clazz.getModifiers() & 0x1000 /* Modifiers.SYNTHETIC */) > 0) {
+            clazz = clazz.getSuperclass();
+        }
+        return clazz;
+    }
+
+    /**
+     * Regexp that combines names in {@link #IGNORED_SYSTEM_CLASSES_REGEXP}. Computed at the start of {@link #inspectExtensions}
+     */
+    private Pattern ignoreClassesPattern;
+    
+    Map<String, Map<String, String>> globalTypes = new HashMap<>();
+    Map<String, String> propertyTypes = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
+
+    /**
+     * Inspects extension container on an object. The prefix should be name of the object, including "." delimiter, will be used
+     * to prefix all properties found.
+     * 
+     * @param prefix prefix for the extension, including "." tail delimiter
+     * @param container extension container to enumerate.
+     */
+    private void inspectExtensions(String prefix, ExtensionContainer container) {
+        for (ExtensionSchema es : container.getExtensionsSchema().getElements()) {
+            String extName = es.getName();
+            
+            LOG.info("Extension: {}{}", prefix, extName);
+            
+            Object ext;
+            try {
+                ext = project.getExtensions().getByName(extName);
+                if (ext == null) {
+                    continue;
+                }
+            } catch (UnknownDomainObjectException ex) {
+                // ignore, the extension could not be obtained, ignore.
+                continue;
+            }
+            Class c = findNonDecoratedClass(ext.getClass());
+            propertyTypes.put(prefix + extName, c.getName());
+            inspectObjectAndValues(ext.getClass(), ext, prefix + extName + ".", globalTypes, propertyTypes, values);
+            if (ext instanceof ExtensionAware) {
+                inspectExtensions(prefix + extName + ".", ((ExtensionAware)ext).getExtensions());  // NOI18N
+            }
+        }
+        List<String> propNames = new ArrayList<>(propertyTypes.keySet());
+        Collections.sort(propNames);
+        for (String p : propNames) {
+            LOG.info("Extension property: {}: {} = {}", p, propertyTypes.get(p), values.get(p));  // NOI18N
+        }
+    }
 
     @SuppressWarnings("null")
     private void detectProjectMetadata(NbProjectInfoModel model) {
-        long time = System.currentTimeMillis();
         model.getInfo().put("project_name", project.getName());
         model.getInfo().put("project_path", project.getPath());
         model.getInfo().put("project_status", project.getStatus());
@@ -199,12 +810,12 @@ class NbProjectInfoBuilder {
             sp.put(p.getPath(), p.getProjectDir());
         }
         model.getInfo().put("project_subProjects", sp);
-
+        
         Map<String, File> ib = new HashMap<>();
-        System.out.printf("Gradle Version: %s%n", gradleVersion);
+        LOG.lifecycle("Gradle Version: {}", gradleVersion);
         sinceGradle("3.1", () -> {
             for(IncludedBuild p: project.getGradle().getIncludedBuilds()) {
-                System.out.printf("Include Build: %s%n", p.getName());
+                LOG.lifecycle("Include Build: {}", p.getName());
                 ib.put(p.getName(), p.getProjectDir());
             }
         });
@@ -225,11 +836,9 @@ class NbProjectInfoBuilder {
             tasks.add(arr);
         }
         model.getInfo().put("tasks", tasks);
-        model.registerPerf("meta", System.currentTimeMillis() - time);
     }
 
     private void detectPlugins(NbProjectInfoModel model) {
-        long time = System.currentTimeMillis();
         Set<String> plugins = new HashSet<>();
         for (String plugin : RECOGNISED_PLUGINS) {
             if (project.getPlugins().hasPlugin(plugin)) {
@@ -237,7 +846,6 @@ class NbProjectInfoBuilder {
             }
         }
         model.getInfo().put("plugins", plugins);
-        model.registerPerf("plugins", System.currentTimeMillis() - time);
     }
 
     private void detectTests(NbProjectInfoModel model) {
@@ -297,8 +905,6 @@ class NbProjectInfoBuilder {
     }
 
     private void detectSources(NbProjectInfoModel model) {
-        long time = System.currentTimeMillis();
-
         boolean hasJava = project.getPlugins().hasPlugin("java-base");
         boolean hasGroovy = project.getPlugins().hasPlugin("groovy-base");
         boolean hasScala = project.getPlugins().hasPlugin("scala-base");
@@ -436,11 +1042,9 @@ class NbProjectInfoBuilder {
                 model.noteProblem("No sourceSets found on this project. This project mightbe a Model/Rule based one which is not supported at the moment.");
             }
         }
-        model.registerPerf("plugins", System.currentTimeMillis() - time);
     }
 
     private void detectArtifacts(NbProjectInfoModel model) {
-        long time = System.currentTimeMillis();
         if (project.getPlugins().hasPlugin("java")) {
             model.getInfo().put("main_jar", getProperty(project, "jar", "archivePath"));
         }
@@ -464,7 +1068,6 @@ class NbProjectInfoBuilder {
             archives.put(jar.getClassifier(), jar.getArchivePath());
         });
         model.getInfo().put("archives", archives);
-        model.registerPerf("artifacts", System.currentTimeMillis() - time);
     }
 
     private static boolean resolvable(Configuration conf) {
@@ -631,7 +1234,6 @@ class NbProjectInfoBuilder {
     }
     
     private void detectDependencies(NbProjectInfoModel model) {
-        long time = System.currentTimeMillis();
         Set<ComponentIdentifier> ids = new HashSet();
         Map<String, File> projects = new HashMap();
         Map<String, String> unresolvedProblems = new HashMap();
@@ -883,7 +1485,6 @@ class NbProjectInfoBuilder {
         model.getExt().put("resolved_javadoc_artifacts", resolvedJavadocArtifacts);
         model.getInfo().put("project_dependencies", projects);
         model.getInfo().put("unresolved_problems", unresolvedProblems);
-        model.registerPerf("dependencies", System.currentTimeMillis() - time);
     }
 
     private static Set<File> collectResolvedArtifacts(Set<ArtifactResult> res) {
@@ -952,7 +1553,7 @@ class NbProjectInfoBuilder {
             throw (T) exception;
     }        
     
-    private <T, E extends Throwable> T sinceGradle(String version, ExceptionCallable<T, E> c) {
+    private <T, E extends Throwable> T sinceGradleOrDefault(String version, ExceptionCallable<T, E> c, Supplier<T> def) {
         if (gradleVersion.compareTo(VersionNumber.parse(version)) >= 0) {
             try {
                 return c.call();
@@ -963,8 +1564,12 @@ class NbProjectInfoBuilder {
                 return null;
             }
         } else {
-            return null;
+            return def.get();
         }
+    }
+    
+    private <T, E extends Throwable> T sinceGradle(String version, ExceptionCallable<T, E> c) {
+        return sinceGradleOrDefault(version, c, null);
     }
     
     private void sinceGradle(String version, Runnable r) {

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/TypeUtils.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/TypeUtils.java
@@ -1,0 +1,1431 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.tooling;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Utility methods focusing on type inspection, particularly with regard to
+ * generics.
+ * 
+ * Copied from Apache Commons. Trimmed down to just generic parameters inspection.
+ */
+public class TypeUtils {
+
+   /**
+     * ParameterizedType implementation class.
+     * @since 3.2
+     */
+    private static final class ParameterizedTypeImpl implements ParameterizedType {
+        private final Class<?> raw;
+        private final Type useOwner;
+        private final Type[] typeArguments;
+
+        /**
+         * Constructor
+         * @param rawClass type
+         * @param useOwner owner type to use, if any
+         * @param typeArguments formal type arguments
+         */
+        private ParameterizedTypeImpl(final Class<?> rawClass, final Type useOwner, final Type[] typeArguments) {
+            this.raw = rawClass;
+            this.useOwner = useOwner;
+            this.typeArguments = Arrays.copyOf(typeArguments, typeArguments.length, Type[].class);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean equals(final Object obj) {
+            return obj == this || obj instanceof ParameterizedType && TypeUtils.equals(this, ((ParameterizedType) obj));
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Type[] getActualTypeArguments() {
+            return typeArguments.clone();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Type getOwnerType() {
+            return useOwner;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Type getRawType() {
+            return raw;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public int hashCode() {
+            int result = 71 << 4;
+            result |= raw.hashCode();
+            result <<= 4;
+            result |= Objects.hashCode(useOwner);
+            result <<= 8;
+            result |= Arrays.hashCode(typeArguments);
+            return result;
+        }
+    }
+
+    /**
+     * {@link WildcardType} builder.
+     * @since 3.2
+     */
+    public static class WildcardTypeBuilder {
+        private Type[] upperBounds;
+
+        private Type[] lowerBounds;
+        /**
+         * Constructor
+         */
+        private WildcardTypeBuilder() {
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public WildcardType build() {
+            return new WildcardTypeImpl(upperBounds, lowerBounds);
+        }
+
+        /**
+         * Specify lower bounds of the wildcard type to build.
+         * @param bounds to set
+         * @return {@code this}
+         */
+        public WildcardTypeBuilder withLowerBounds(final Type... bounds) {
+            this.lowerBounds = bounds;
+            return this;
+        }
+
+        /**
+         * Specify upper bounds of the wildcard type to build.
+         * @param bounds to set
+         * @return {@code this}
+         */
+        public WildcardTypeBuilder withUpperBounds(final Type... bounds) {
+            this.upperBounds = bounds;
+            return this;
+        }
+    }
+    
+    private static final Type[] EMPTY_TYPE_ARRAY = new Type[0];
+
+    /**
+     * WildcardType implementation class.
+     * @since 3.2
+     */
+    private static final class WildcardTypeImpl implements WildcardType {
+        private final Type[] upperBounds;
+        private final Type[] lowerBounds;
+
+        /**
+         * Constructor
+         * @param upperBounds of this type
+         * @param lowerBounds of this type
+         */
+        private WildcardTypeImpl(final Type[] upperBounds, final Type[] lowerBounds) {
+            this.upperBounds = upperBounds != null ? upperBounds : EMPTY_TYPE_ARRAY;
+            this.lowerBounds = lowerBounds != null ? lowerBounds : EMPTY_TYPE_ARRAY;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean equals(final Object obj) {
+            return obj == this || obj instanceof WildcardType && TypeUtils.equals(this, (WildcardType) obj);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Type[] getLowerBounds() {
+            return lowerBounds.clone();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Type[] getUpperBounds() {
+            return upperBounds.clone();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public int hashCode() {
+            int result = 73 << 8;
+            result |= Arrays.hashCode(upperBounds);
+            result <<= 8;
+            result |= Arrays.hashCode(lowerBounds);
+            return result;
+        }
+   }
+
+    /**
+     * A wildcard instance matching {@code ?}.
+     * @since 3.2
+     */
+    public static final WildcardType WILDCARD_ALL = wildcardType().withUpperBounds(Object.class).build();
+
+    /**
+     * Helper method to establish the formal parameters for a parameterized type.
+     *
+     * @param mappings map containing the assignments
+     * @param variables expected map keys
+     * @return array of map values corresponding to specified keys
+     */
+    private static Type[] extractTypeArgumentsFrom(final Map<TypeVariable<?>, Type> mappings, final TypeVariable<?>[] variables) {
+        final Type[] result = new Type[variables.length];
+        int index = 0;
+        for (final TypeVariable<?> var : variables) {
+            result[index++] = mappings.get(var);
+        }
+        return result;
+    }
+
+    /**
+     * Tests, recursively, whether any of the type parameters associated with {@code type} are bound to variables.
+     *
+     * @param type the type to check for type variables
+     * @return boolean
+     * @since 3.2
+     */
+    public static boolean containsTypeVariables(final Type type) {
+        if (type instanceof TypeVariable<?>) {
+            return true;
+        }
+        if (type instanceof Class<?>) {
+            return ((Class<?>) type).getTypeParameters().length > 0;
+        }
+        if (type instanceof ParameterizedType) {
+            for (final Type arg : ((ParameterizedType) type).getActualTypeArguments()) {
+                if (containsTypeVariables(arg)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (type instanceof WildcardType) {
+            final WildcardType wild = (WildcardType) type;
+            return containsTypeVariables(getImplicitLowerBounds(wild)[0])
+                || containsTypeVariables(getImplicitUpperBounds(wild)[0]);
+        }
+        if (type instanceof GenericArrayType) {
+            return containsTypeVariables(((GenericArrayType) type).getGenericComponentType());
+        }
+        return false;
+    }
+
+    /**
+     * Tests whether {@code t} equals {@code a}.
+     *
+     * @param genericArrayType LHS
+     * @param type RHS
+     * @return boolean
+     * @since 3.2
+     */
+    private static boolean equals(final GenericArrayType genericArrayType, final Type type) {
+        return type instanceof GenericArrayType
+            && equals(genericArrayType.getGenericComponentType(), ((GenericArrayType) type).getGenericComponentType());
+    }
+
+    /**
+     * Tests whether {@code t} equals {@code p}.
+     *
+     * @param parameterizedType LHS
+     * @param type RHS
+     * @return boolean
+     * @since 3.2
+     */
+    private static boolean equals(final ParameterizedType parameterizedType, final Type type) {
+        if (type instanceof ParameterizedType) {
+            final ParameterizedType other = (ParameterizedType) type;
+            if (equals(parameterizedType.getRawType(), other.getRawType())
+                && equals(parameterizedType.getOwnerType(), other.getOwnerType())) {
+                return equals(parameterizedType.getActualTypeArguments(), other.getActualTypeArguments());
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Tests equality of types.
+     *
+     * @param type1 the first type
+     * @param type2 the second type
+     * @return boolean
+     * @since 3.2
+     */
+    public static boolean equals(final Type type1, final Type type2) {
+        if (Objects.equals(type1, type2)) {
+            return true;
+        }
+        if (type1 instanceof ParameterizedType) {
+            return equals((ParameterizedType) type1, type2);
+        }
+        if (type1 instanceof GenericArrayType) {
+            return equals((GenericArrayType) type1, type2);
+        }
+        if (type1 instanceof WildcardType) {
+            return equals((WildcardType) type1, type2);
+        }
+        return false;
+    }
+
+    /**
+     * Tests whether {@code t1} equals {@code t2}.
+     *
+     * @param type1 LHS
+     * @param type2 RHS
+     * @return boolean
+     * @since 3.2
+     */
+    private static boolean equals(final Type[] type1, final Type[] type2) {
+        if (type1.length == type2.length) {
+            for (int i = 0; i < type1.length; i++) {
+                if (!equals(type1[i], type2[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Tests whether {@code t} equals {@code w}.
+     *
+     * @param wildcardType LHS
+     * @param type RHS
+     * @return boolean
+     * @since 3.2
+     */
+    private static boolean equals(final WildcardType wildcardType, final Type type) {
+        if (type instanceof WildcardType) {
+            final WildcardType other = (WildcardType) type;
+            return equals(getImplicitLowerBounds(wildcardType), getImplicitLowerBounds(other))
+                && equals(getImplicitUpperBounds(wildcardType), getImplicitUpperBounds(other));
+        }
+        return false;
+    }
+
+    /**
+     * Gets the closest parent type to the
+     * super class specified by {@code superClass}.
+     *
+     * @param cls the class in question
+     * @param superClass the super class
+     * @return the closes parent type
+     */
+    private static Type getClosestParentType(final Class<?> cls, final Class<?> superClass) {
+        // only look at the interfaces if the super class is also an interface
+        if (superClass.isInterface()) {
+            // get the generic interfaces of the subject class
+            final Type[] interfaceTypes = cls.getGenericInterfaces();
+            // will hold the best generic interface match found
+            Type genericInterface = null;
+
+            // find the interface closest to the super class
+            for (final Type midType : interfaceTypes) {
+                final Class<?> midClass;
+
+                if (midType instanceof ParameterizedType) {
+                    midClass = getRawType((ParameterizedType) midType);
+                } else if (midType instanceof Class<?>) {
+                    midClass = (Class<?>) midType;
+                } else {
+                    throw new IllegalStateException("Unexpected generic"
+                            + " interface type found: " + midType);
+                }
+
+                // check if this interface is further up the inheritance chain
+                // than the previously found match
+                if (isAssignable(midClass, superClass)
+                        && isAssignable(genericInterface, (Type) midClass)) {
+                    genericInterface = midType;
+                }
+            }
+
+            // found a match?
+            if (genericInterface != null) {
+                return genericInterface;
+            }
+        }
+
+        // none of the interfaces were descendants of the target class, so the
+        // super class has to be one, instead
+        return cls.getGenericSuperclass();
+    }
+
+    /**
+     * Gets an array containing the sole type of {@link Object} if
+     * {@link TypeVariable#getBounds()} returns an empty array. Otherwise, it
+     * returns the result of {@link TypeVariable#getBounds()} passed into
+     * {@link #normalizeUpperBounds}.
+     *
+     * @param typeVariable the subject type variable, not {@code null}
+     * @return a non-empty array containing the bounds of the type variable.
+     */
+    public static Type[] getImplicitBounds(final TypeVariable<?> typeVariable) {
+        final Type[] bounds = typeVariable.getBounds();
+
+        return bounds.length == 0 ? new Type[] { Object.class } : normalizeUpperBounds(bounds);
+    }
+
+    /**
+     * Gets an array containing a single value of {@code null} if
+     * {@link WildcardType#getLowerBounds()} returns an empty array. Otherwise,
+     * it returns the result of {@link WildcardType#getLowerBounds()}.
+     *
+     * @param wildcardType the subject wildcard type, not {@code null}
+     * @return a non-empty array containing the lower bounds of the wildcard
+     * type.
+     */
+    public static Type[] getImplicitLowerBounds(final WildcardType wildcardType) {
+        final Type[] bounds = wildcardType.getLowerBounds();
+
+        return bounds.length == 0 ? new Type[] { null } : bounds;
+    }
+
+    /**
+     * Gets an array containing the sole value of {@link Object} if
+     * {@link WildcardType#getUpperBounds()} returns an empty array. Otherwise,
+     * it returns the result of {@link WildcardType#getUpperBounds()}
+     * passed into {@link #normalizeUpperBounds}.
+     *
+     * @param wildcardType the subject wildcard type, not {@code null}
+     * @return a non-empty array containing the upper bounds of the wildcard
+     * type.
+     */
+    public static Type[] getImplicitUpperBounds(final WildcardType wildcardType) {
+        final Type[] bounds = wildcardType.getUpperBounds();
+
+        return bounds.length == 0 ? new Type[] { Object.class } : normalizeUpperBounds(bounds);
+    }
+
+    /**
+     * Transforms the passed in type to a {@link Class} object. Type-checking method of convenience.
+     *
+     * @param parameterizedType the type to be converted
+     * @return the corresponding {@link Class} object
+     * @throws IllegalStateException if the conversion fails
+     */
+    private static Class<?> getRawType(final ParameterizedType parameterizedType) {
+        final Type rawType = parameterizedType.getRawType();
+
+        // check if raw type is a Class object
+        // not currently necessary, but since the return type is Type instead of
+        // Class, there's enough reason to believe that future versions of Java
+        // may return other Type implementations. And type-safety checking is
+        // rarely a bad idea.
+        if (!(rawType instanceof Class<?>)) {
+            throw new IllegalStateException("Wait... What!? Type of rawType: " + rawType);
+        }
+
+        return (Class<?>) rawType;
+    }
+
+    /**
+     * Gets the raw type of a Java type, given its context. Primarily for use
+     * with {@link TypeVariable}s and {@link GenericArrayType}s, or when you do
+     * not know the runtime type of {@code type}: if you know you have a
+     * {@link Class} instance, it is already raw; if you know you have a
+     * {@link ParameterizedType}, its raw type is only a method call away.
+     *
+     * @param type to resolve
+     * @param assigningType type to be resolved against
+     * @return the resolved {@link Class} object or {@code null} if
+     * the type could not be resolved
+     */
+    public static Class<?> getRawType(final Type type, final Type assigningType) {
+        if (type instanceof Class<?>) {
+            // it is raw, no problem
+            return (Class<?>) type;
+        }
+
+        if (type instanceof ParameterizedType) {
+            // simple enough to get the raw type of a ParameterizedType
+            return getRawType((ParameterizedType) type);
+        }
+
+        if (type instanceof TypeVariable<?>) {
+            if (assigningType == null) {
+                return null;
+            }
+
+            // get the entity declaring this type variable
+            final Object genericDeclaration = ((TypeVariable<?>) type).getGenericDeclaration();
+
+            // can't get the raw type of a method- or constructor-declared type
+            // variable
+            if (!(genericDeclaration instanceof Class<?>)) {
+                return null;
+            }
+
+            // get the type arguments for the declaring class/interface based
+            // on the enclosing type
+            final Map<TypeVariable<?>, Type> typeVarAssigns = getTypeArguments(assigningType,
+                    (Class<?>) genericDeclaration);
+
+            // enclosingType has to be a subclass (or subinterface) of the
+            // declaring type
+            if (typeVarAssigns == null) {
+                return null;
+            }
+
+            // get the argument assigned to this type variable
+            final Type typeArgument = typeVarAssigns.get(type);
+
+            if (typeArgument == null) {
+                return null;
+            }
+
+            // get the argument for this type variable
+            return getRawType(typeArgument, assigningType);
+        }
+
+        if (type instanceof GenericArrayType) {
+            // get raw component type
+            final Class<?> rawComponentType = getRawType(((GenericArrayType) type)
+                    .getGenericComponentType(), assigningType);
+
+            // create array type from raw component type and return its class
+            return Array.newInstance(rawComponentType, 0).getClass();
+        }
+
+        // (hand-waving) this is not the method you're looking for
+        if (type instanceof WildcardType) {
+            return null;
+        }
+
+        throw new IllegalArgumentException("unknown type: " + type);
+    }
+
+    /**
+     * Gets a map of the type arguments of a class in the context of {@code toClass}.
+     *
+     * @param cls the class in question
+     * @param toClass the context class
+     * @param subtypeVarAssigns a map with type variables
+     * @return the {@link Map} with type arguments
+     */
+    private static Map<TypeVariable<?>, Type> getTypeArguments(Class<?> cls, final Class<?> toClass,
+            final Map<TypeVariable<?>, Type> subtypeVarAssigns) {
+        // make sure they're assignable
+        if (!isAssignable(cls, toClass)) {
+            return null;
+        }
+
+        // create a copy of the incoming map, or an empty one if it's null
+        final HashMap<TypeVariable<?>, Type> typeVarAssigns = subtypeVarAssigns == null ? new HashMap<>()
+                : new HashMap<>(subtypeVarAssigns);
+
+        // has target class been reached?
+        if (toClass.equals(cls)) {
+            return typeVarAssigns;
+        }
+
+        // walk the inheritance hierarchy until the target class is reached
+        return getTypeArguments(getClosestParentType(cls, toClass), toClass, typeVarAssigns);
+    }
+
+    /**
+     * Gets all the type arguments for this parameterized type
+     * including owner hierarchy arguments such as
+     * {@code Outer<K, V>.Inner<T>.DeepInner<E>} .
+     * The arguments are returned in a
+     * {@link Map} specifying the argument type for each {@link TypeVariable}.
+     *
+     * @param type specifies the subject parameterized type from which to
+     *             harvest the parameters.
+     * @return a {@link Map} of the type arguments to their respective type
+     * variables.
+     */
+    public static Map<TypeVariable<?>, Type> getTypeArguments(final ParameterizedType type) {
+        return getTypeArguments(type, getRawType(type), null);
+    }
+
+    /**
+     * Gets a map of the type arguments of a parameterized type in the context of {@code toClass}.
+     *
+     * @param parameterizedType the parameterized type
+     * @param toClass the class
+     * @param subtypeVarAssigns a map with type variables
+     * @return the {@link Map} with type arguments
+     */
+    private static Map<TypeVariable<?>, Type> getTypeArguments(
+            final ParameterizedType parameterizedType, final Class<?> toClass,
+            final Map<TypeVariable<?>, Type> subtypeVarAssigns) {
+        final Class<?> cls = getRawType(parameterizedType);
+
+        // make sure they're assignable
+        if (!isAssignable(cls, toClass)) {
+            return null;
+        }
+
+        final Type ownerType = parameterizedType.getOwnerType();
+        final Map<TypeVariable<?>, Type> typeVarAssigns;
+
+        if (ownerType instanceof ParameterizedType) {
+            // get the owner type arguments first
+            final ParameterizedType parameterizedOwnerType = (ParameterizedType) ownerType;
+            typeVarAssigns = getTypeArguments(parameterizedOwnerType,
+                    getRawType(parameterizedOwnerType), subtypeVarAssigns);
+        } else {
+            // no owner, prep the type variable assignments map
+            typeVarAssigns = subtypeVarAssigns == null ? new HashMap<>()
+                    : new HashMap<>(subtypeVarAssigns);
+        }
+
+        // get the subject parameterized type's arguments
+        final Type[] typeArgs = parameterizedType.getActualTypeArguments();
+        // and get the corresponding type variables from the raw class
+        final TypeVariable<?>[] typeParams = cls.getTypeParameters();
+
+        // map the arguments to their respective type variables
+        for (int i = 0; i < typeParams.length; i++) {
+            final Type typeArg = typeArgs[i];
+            typeVarAssigns.put(
+                    typeParams[i],
+                    typeVarAssigns.getOrDefault(typeArg, typeArg)
+            );
+        }
+
+        if (toClass.equals(cls)) {
+            // target class has been reached. Done.
+            return typeVarAssigns;
+        }
+
+        // walk the inheritance hierarchy until the target class is reached
+        return getTypeArguments(getClosestParentType(cls, toClass), toClass, typeVarAssigns);
+    }
+
+    /**
+     * Gets the type arguments of a class/interface based on a subtype. For
+     * instance, this method will determine that both of the parameters for the
+     * interface {@link Map} are {@link Object} for the subtype
+     * {@link java.util.Properties Properties} even though the subtype does not
+     * directly implement the {@link Map} interface.
+     *
+     * <p>
+     * This method returns {@code null} if {@code type} is not assignable to
+     * {@code toClass}. It returns an empty map if none of the classes or
+     * interfaces in its inheritance hierarchy specify any type arguments.
+     * </p>
+     *
+     * <p>
+     * A side effect of this method is that it also retrieves the type
+     * arguments for the classes and interfaces that are part of the hierarchy
+     * between {@code type} and {@code toClass}. So with the above
+     * example, this method will also determine that the type arguments for
+     * {@link java.util.Hashtable Hashtable} are also both {@link Object}.
+     * In cases where the interface specified by {@code toClass} is
+     * (indirectly) implemented more than once (e.g. where {@code toClass}
+     * specifies the interface {@link java.lang.Iterable Iterable} and
+     * {@code type} specifies a parameterized type that implements both
+     * {@link java.util.Set Set} and {@link java.util.Collection Collection}),
+     * this method will look at the inheritance hierarchy of only one of the
+     * implementations/subclasses; the first interface encountered that isn't a
+     * subinterface to one of the others in the {@code type} to
+     * {@code toClass} hierarchy.
+     * </p>
+     *
+     * @param type the type from which to determine the type parameters of
+     * {@code toClass}
+     * @param toClass the class whose type parameters are to be determined based
+     * on the subtype {@code type}
+     * @return a {@link Map} of the type assignments for the type variables in
+     * each type in the inheritance hierarchy from {@code type} to
+     * {@code toClass} inclusive.
+     */
+    public static Map<TypeVariable<?>, Type> getTypeArguments(final Type type, final Class<?> toClass) {
+        return getTypeArguments(type, toClass, null);
+    }
+
+    /**
+     * Gets a map of the type arguments of {@code type} in the context of {@code toClass}.
+     *
+     * @param type the type in question
+     * @param toClass the class
+     * @param subtypeVarAssigns a map with type variables
+     * @return the {@link Map} with type arguments
+     */
+    private static Map<TypeVariable<?>, Type> getTypeArguments(final Type type, final Class<?> toClass,
+            final Map<TypeVariable<?>, Type> subtypeVarAssigns) {
+        if (type instanceof Class<?>) {
+            return getTypeArguments((Class<?>) type, toClass, subtypeVarAssigns);
+        }
+
+        if (type instanceof ParameterizedType) {
+            return getTypeArguments((ParameterizedType) type, toClass, subtypeVarAssigns);
+        }
+
+        if (type instanceof GenericArrayType) {
+            return getTypeArguments(((GenericArrayType) type).getGenericComponentType(), toClass
+                    .isArray() ? toClass.getComponentType() : toClass, subtypeVarAssigns);
+        }
+
+        // since wildcard types are not assignable to classes, should this just
+        // return null?
+        if (type instanceof WildcardType) {
+            for (final Type bound : getImplicitUpperBounds((WildcardType) type)) {
+                // find the first bound that is assignable to the target class
+                if (isAssignable(bound, toClass)) {
+                    return getTypeArguments(bound, toClass, subtypeVarAssigns);
+                }
+            }
+
+            return null;
+        }
+
+        if (type instanceof TypeVariable<?>) {
+            for (final Type bound : getImplicitBounds((TypeVariable<?>) type)) {
+                // find the first bound that is assignable to the target class
+                if (isAssignable(bound, toClass)) {
+                    return getTypeArguments(bound, toClass, subtypeVarAssigns);
+                }
+            }
+
+            return null;
+        }
+        throw new IllegalStateException("found an unhandled type: " + type);
+    }
+
+    /**
+     * Tests whether the specified type denotes an array type.
+     *
+     * @param type the type to be checked
+     * @return {@code true} if {@code type} is an array class or a {@link GenericArrayType}.
+     */
+    public static boolean isArrayType(final Type type) {
+        return type instanceof GenericArrayType || type instanceof Class<?> && ((Class<?>) type).isArray();
+    }
+
+    /**
+     * Tests if the subject type may be implicitly cast to the target class
+     * following the Java generics rules.
+     *
+     * @param type the subject type to be assigned to the target type
+     * @param toClass the target class
+     * @return {@code true} if {@code type} is assignable to {@code toClass}.
+     */
+    private static boolean isAssignable(final Type type, final Class<?> toClass) {
+        if (type == null) {
+            // consistency with ClassUtils.isAssignable() behavior
+            return toClass == null || !toClass.isPrimitive();
+        }
+
+        // only a null type can be assigned to null type which
+        // would have cause the previous to return true
+        if (toClass == null) {
+            return false;
+        }
+
+        // all types are assignable to themselves
+        if (toClass.equals(type)) {
+            return true;
+        }
+
+        if (type instanceof Class<?>) {
+            // just comparing two classes
+            return toClass.isAssignableFrom((Class<?>) type);
+        }
+
+        if (type instanceof ParameterizedType) {
+            // only have to compare the raw type to the class
+            return isAssignable(getRawType((ParameterizedType) type), toClass);
+        }
+
+        // *
+        if (type instanceof TypeVariable<?>) {
+            // if any of the bounds are assignable to the class, then the
+            // type is assignable to the class.
+            for (final Type bound : ((TypeVariable<?>) type).getBounds()) {
+                if (isAssignable(bound, toClass)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // the only classes to which a generic array type can be assigned
+        // are class Object and array classes
+        if (type instanceof GenericArrayType) {
+            return toClass.equals(Object.class)
+                    || toClass.isArray()
+                    && isAssignable(((GenericArrayType) type).getGenericComponentType(), toClass
+                            .getComponentType());
+        }
+
+        // wildcard types are not assignable to a class (though one would think
+        // "? super Object" would be assignable to Object)
+        if (type instanceof WildcardType) {
+            return false;
+        }
+
+        throw new IllegalStateException("found an unhandled type: " + type);
+    }
+
+    /**
+     * Tests if the subject type may be implicitly cast to the target
+     * generic array type following the Java generics rules.
+     *
+     * @param type the subject type to be assigned to the target type
+     * @param toGenericArrayType the target generic array type
+     * @param typeVarAssigns a map with type variables
+     * @return {@code true} if {@code type} is assignable to
+     * {@code toGenericArrayType}.
+     */
+    private static boolean isAssignable(final Type type, final GenericArrayType toGenericArrayType,
+            final Map<TypeVariable<?>, Type> typeVarAssigns) {
+        if (type == null) {
+            return true;
+        }
+
+        // only a null type can be assigned to null type which
+        // would have cause the previous to return true
+        if (toGenericArrayType == null) {
+            return false;
+        }
+
+        // all types are assignable to themselves
+        if (toGenericArrayType.equals(type)) {
+            return true;
+        }
+
+        final Type toComponentType = toGenericArrayType.getGenericComponentType();
+
+        if (type instanceof Class<?>) {
+            final Class<?> cls = (Class<?>) type;
+
+            // compare the component types
+            return cls.isArray()
+                    && isAssignable(cls.getComponentType(), toComponentType, typeVarAssigns);
+        }
+
+        if (type instanceof GenericArrayType) {
+            // compare the component types
+            return isAssignable(((GenericArrayType) type).getGenericComponentType(),
+                    toComponentType, typeVarAssigns);
+        }
+
+        if (type instanceof WildcardType) {
+            // so long as one of the upper bounds is assignable, it's good
+            for (final Type bound : getImplicitUpperBounds((WildcardType) type)) {
+                if (isAssignable(bound, toGenericArrayType)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (type instanceof TypeVariable<?>) {
+            // probably should remove the following logic and just return false.
+            // type variables cannot specify arrays as bounds.
+            for (final Type bound : getImplicitBounds((TypeVariable<?>) type)) {
+                if (isAssignable(bound, toGenericArrayType)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (type instanceof ParameterizedType) {
+            // the raw type of a parameterized type is never an array or
+            // generic array, otherwise the declaration would look like this:
+            // Collection[]< ? extends String > collection;
+            return false;
+        }
+
+        throw new IllegalStateException("found an unhandled type: " + type);
+    }
+
+    /**
+     * Tests if the subject type may be implicitly cast to the target
+     * parameterized type following the Java generics rules.
+     *
+     * @param type the subject type to be assigned to the target type
+     * @param toParameterizedType the target parameterized type
+     * @param typeVarAssigns a map with type variables
+     * @return {@code true} if {@code type} is assignable to {@code toType}.
+     */
+    private static boolean isAssignable(final Type type, final ParameterizedType toParameterizedType,
+            final Map<TypeVariable<?>, Type> typeVarAssigns) {
+        if (type == null) {
+            return true;
+        }
+
+        // only a null type can be assigned to null type which
+        // would have cause the previous to return true
+        if (toParameterizedType == null) {
+            return false;
+        }
+
+        // cannot cast an array type to a parameterized type.
+        if (type instanceof GenericArrayType) {
+            return false;
+        }
+
+        // all types are assignable to themselves
+        if (toParameterizedType.equals(type)) {
+            return true;
+        }
+
+        // get the target type's raw type
+        final Class<?> toClass = getRawType(toParameterizedType);
+        // get the subject type's type arguments including owner type arguments
+        // and supertype arguments up to and including the target class.
+        final Map<TypeVariable<?>, Type> fromTypeVarAssigns = getTypeArguments(type, toClass, null);
+
+        // null means the two types are not compatible
+        if (fromTypeVarAssigns == null) {
+            return false;
+        }
+
+        // compatible types, but there's no type arguments. this is equivalent
+        // to comparing Map< ?, ? > to Map, and raw types are always assignable
+        // to parameterized types.
+        if (fromTypeVarAssigns.isEmpty()) {
+            return true;
+        }
+
+        // get the target type's type arguments including owner type arguments
+        final Map<TypeVariable<?>, Type> toTypeVarAssigns = getTypeArguments(toParameterizedType,
+                toClass, typeVarAssigns);
+
+        // now to check each type argument
+        for (final TypeVariable<?> var : toTypeVarAssigns.keySet()) {
+            final Type toTypeArg = unrollVariableAssignments(var, toTypeVarAssigns);
+            final Type fromTypeArg = unrollVariableAssignments(var, fromTypeVarAssigns);
+
+            if (toTypeArg == null && fromTypeArg instanceof Class) {
+                continue;
+            }
+
+            // parameters must either be absent from the subject type, within
+            // the bounds of the wildcard type, or be an exact match to the
+            // parameters of the target type.
+            if (fromTypeArg != null && toTypeArg != null
+                    && !toTypeArg.equals(fromTypeArg)
+                    && !(toTypeArg instanceof WildcardType && isAssignable(fromTypeArg, toTypeArg,
+                            typeVarAssigns))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Tests if the subject type may be implicitly cast to the target type
+     * following the Java generics rules. If both types are {@link Class}
+     * objects, the method returns the result of
+     * {@link ClassUtils#isAssignable(Class, Class)}.
+     *
+     * @param type the subject type to be assigned to the target type
+     * @param toType the target type
+     * @return {@code true} if {@code type} is assignable to {@code toType}.
+     */
+    public static boolean isAssignable(final Type type, final Type toType) {
+        return isAssignable(type, toType, null);
+    }
+
+    /**
+     * Tests if the subject type may be implicitly cast to the target type
+     * following the Java generics rules.
+     *
+     * @param type the subject type to be assigned to the target type
+     * @param toType the target type
+     * @param typeVarAssigns optional map of type variable assignments
+     * @return {@code true} if {@code type} is assignable to {@code toType}.
+     */
+    private static boolean isAssignable(final Type type, final Type toType,
+            final Map<TypeVariable<?>, Type> typeVarAssigns) {
+        if (toType == null || toType instanceof Class<?>) {
+            return isAssignable(type, (Class<?>) toType);
+        }
+
+        if (toType instanceof ParameterizedType) {
+            return isAssignable(type, (ParameterizedType) toType, typeVarAssigns);
+        }
+
+        if (toType instanceof GenericArrayType) {
+            return isAssignable(type, (GenericArrayType) toType, typeVarAssigns);
+        }
+
+        if (toType instanceof WildcardType) {
+            return isAssignable(type, (WildcardType) toType, typeVarAssigns);
+        }
+
+        if (toType instanceof TypeVariable<?>) {
+            return isAssignable(type, (TypeVariable<?>) toType, typeVarAssigns);
+        }
+
+        throw new IllegalStateException("found an unhandled type: " + toType);
+    }
+
+    /**
+     * Tests if the subject type may be implicitly cast to the target type
+     * variable following the Java generics rules.
+     *
+     * @param type the subject type to be assigned to the target type
+     * @param toTypeVariable the target type variable
+     * @param typeVarAssigns a map with type variables
+     * @return {@code true} if {@code type} is assignable to
+     * {@code toTypeVariable}.
+     */
+    private static boolean isAssignable(final Type type, final TypeVariable<?> toTypeVariable,
+            final Map<TypeVariable<?>, Type> typeVarAssigns) {
+        if (type == null) {
+            return true;
+        }
+
+        // only a null type can be assigned to null type which
+        // would have cause the previous to return true
+        if (toTypeVariable == null) {
+            return false;
+        }
+
+        // all types are assignable to themselves
+        if (toTypeVariable.equals(type)) {
+            return true;
+        }
+
+        if (type instanceof TypeVariable<?>) {
+            // a type variable is assignable to another type variable, if
+            // and only if the former is the latter, extends the latter, or
+            // is otherwise a descendant of the latter.
+            final Type[] bounds = getImplicitBounds((TypeVariable<?>) type);
+
+            for (final Type bound : bounds) {
+                if (isAssignable(bound, toTypeVariable, typeVarAssigns)) {
+                    return true;
+                }
+            }
+        }
+
+        if (type instanceof Class<?> || type instanceof ParameterizedType
+                || type instanceof GenericArrayType || type instanceof WildcardType) {
+            return false;
+        }
+
+        throw new IllegalStateException("found an unhandled type: " + type);
+    }
+
+    /**
+     * Tests if the subject type may be implicitly cast to the target
+     * wildcard type following the Java generics rules.
+     *
+     * @param type the subject type to be assigned to the target type
+     * @param toWildcardType the target wildcard type
+     * @param typeVarAssigns a map with type variables
+     * @return {@code true} if {@code type} is assignable to
+     * {@code toWildcardType}.
+     */
+    private static boolean isAssignable(final Type type, final WildcardType toWildcardType,
+            final Map<TypeVariable<?>, Type> typeVarAssigns) {
+        if (type == null) {
+            return true;
+        }
+
+        // only a null type can be assigned to null type which
+        // would have cause the previous to return true
+        if (toWildcardType == null) {
+            return false;
+        }
+
+        // all types are assignable to themselves
+        if (toWildcardType.equals(type)) {
+            return true;
+        }
+
+        final Type[] toUpperBounds = getImplicitUpperBounds(toWildcardType);
+        final Type[] toLowerBounds = getImplicitLowerBounds(toWildcardType);
+
+        if (type instanceof WildcardType) {
+            final WildcardType wildcardType = (WildcardType) type;
+            final Type[] upperBounds = getImplicitUpperBounds(wildcardType);
+            final Type[] lowerBounds = getImplicitLowerBounds(wildcardType);
+
+            for (Type toBound : toUpperBounds) {
+                // if there are assignments for unresolved type variables,
+                // now's the time to substitute them.
+                toBound = substituteTypeVariables(toBound, typeVarAssigns);
+
+                // each upper bound of the subject type has to be assignable to
+                // each
+                // upper bound of the target type
+                for (final Type bound : upperBounds) {
+                    if (!isAssignable(bound, toBound, typeVarAssigns)) {
+                        return false;
+                    }
+                }
+            }
+
+            for (Type toBound : toLowerBounds) {
+                // if there are assignments for unresolved type variables,
+                // now's the time to substitute them.
+                toBound = substituteTypeVariables(toBound, typeVarAssigns);
+
+                // each lower bound of the target type has to be assignable to
+                // each
+                // lower bound of the subject type
+                for (final Type bound : lowerBounds) {
+                    if (!isAssignable(toBound, bound, typeVarAssigns)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        for (final Type toBound : toUpperBounds) {
+            // if there are assignments for unresolved type variables,
+            // now's the time to substitute them.
+            if (!isAssignable(type, substituteTypeVariables(toBound, typeVarAssigns),
+                    typeVarAssigns)) {
+                return false;
+            }
+        }
+
+        for (final Type toBound : toLowerBounds) {
+            // if there are assignments for unresolved type variables,
+            // now's the time to substitute them.
+            if (!isAssignable(substituteTypeVariables(toBound, typeVarAssigns), type,
+                    typeVarAssigns)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Tests if the given value can be assigned to the target type
+     * following the Java generics rules.
+     *
+     * @param value the value to be checked
+     * @param type the target type
+     * @return {@code true} if {@code value} is an instance of {@code type}.
+     */
+    public static boolean isInstance(final Object value, final Type type) {
+        if (type == null) {
+            return false;
+        }
+
+        return value == null ? !(type instanceof Class<?>) || !((Class<?>) type).isPrimitive()
+                : isAssignable(value.getClass(), type, null);
+    }
+
+    /**
+     * Maps type variables.
+     *
+     * @param <T> the generic type of the class in question
+     * @param cls the class in question
+     * @param parameterizedType the parameterized type
+     * @param typeVarAssigns the map to be filled
+     */
+    private static <T> void mapTypeVariablesToArguments(final Class<T> cls,
+            final ParameterizedType parameterizedType, final Map<TypeVariable<?>, Type> typeVarAssigns) {
+        // capture the type variables from the owner type that have assignments
+        final Type ownerType = parameterizedType.getOwnerType();
+
+        if (ownerType instanceof ParameterizedType) {
+            // recursion to make sure the owner's owner type gets processed
+            mapTypeVariablesToArguments(cls, (ParameterizedType) ownerType, typeVarAssigns);
+        }
+
+        // parameterizedType is a generic interface/class (or it's in the owner
+        // hierarchy of said interface/class) implemented/extended by the class
+        // cls. Find out which type variables of cls are type arguments of
+        // parameterizedType:
+        final Type[] typeArgs = parameterizedType.getActualTypeArguments();
+
+        // of the cls's type variables that are arguments of parameterizedType,
+        // find out which ones can be determined from the super type's arguments
+        final TypeVariable<?>[] typeVars = getRawType(parameterizedType).getTypeParameters();
+
+        // use List view of type parameters of cls so the contains() method can be used:
+        final List<TypeVariable<Class<T>>> typeVarList = Arrays.asList(cls
+                .getTypeParameters());
+
+        for (int i = 0; i < typeArgs.length; i++) {
+            final TypeVariable<?> typeVar = typeVars[i];
+            final Type typeArg = typeArgs[i];
+
+            // argument of parameterizedType is a type variable of cls
+            if (typeVarList.contains(typeArg)
+            // type variable of parameterizedType has an assignment in
+                    // the super type.
+                    && typeVarAssigns.containsKey(typeVar)) {
+                // map the assignment to the cls's type variable
+                typeVarAssigns.put((TypeVariable<?>) typeArg, typeVarAssigns.get(typeVar));
+            }
+        }
+    }
+
+    /**
+     * Strips out the redundant upper bound types in type
+     * variable types and wildcard types (or it would with wildcard types if
+     * multiple upper bounds were allowed).
+     *
+     * <p>
+     * Example, with the variable type declaration:
+     * </p>
+     *
+     * <pre>&lt;K extends java.util.Collection&lt;String&gt; &amp;
+     * java.util.List&lt;String&gt;&gt;</pre>
+     *
+     * <p>
+     * since {@link List} is a subinterface of {@link Collection},
+     * this method will return the bounds as if the declaration had been:
+     * </p>
+     *
+     * <pre>&lt;K extends java.util.List&lt;String&gt;&gt;</pre>
+     *
+     * @param bounds an array of types representing the upper bounds of either
+     * {@link WildcardType} or {@link TypeVariable}, not {@code null}.
+     * @return an array containing the values from {@code bounds} minus the
+     * redundant types.
+     */
+    public static Type[] normalizeUpperBounds(final Type[] bounds) {
+        // don't bother if there's only one (or none) type
+        if (bounds.length < 2) {
+            return bounds;
+        }
+
+        final Set<Type> types = new HashSet<>(bounds.length);
+
+        for (final Type type1 : bounds) {
+            boolean subtypeFound = false;
+
+            for (final Type type2 : bounds) {
+                if (type1 != type2 && isAssignable(type2, type1, null)) {
+                    subtypeFound = true;
+                    break;
+                }
+            }
+
+            if (!subtypeFound) {
+                types.add(type1);
+            }
+        }
+
+        return types.toArray(new Type[0]);
+    }
+
+    /**
+     * Creates a parameterized type instance.
+     *
+     * @param owner the owning type
+     * @param rawClass the raw class to create a parameterized type instance for
+     * @param typeVariableMap the map used for parameterization
+     * @return {@link ParameterizedType}
+     * @since 3.2
+     */
+    public static final ParameterizedType parameterizeWithOwner(final Type owner, final Class<?> rawClass,
+        final Map<TypeVariable<?>, Type> typeVariableMap) {
+        return parameterizeWithOwner(owner, rawClass,
+            extractTypeArgumentsFrom(typeVariableMap, rawClass.getTypeParameters()));
+    }
+
+    /**
+     * Creates a parameterized type instance.
+     *
+     * @param owner the owning type
+     * @param rawClass the raw class to create a parameterized type instance for
+     * @param typeArguments the types used for parameterization
+     *
+     * @return {@link ParameterizedType}
+     * @since 3.2
+     */
+    public static final ParameterizedType parameterizeWithOwner(final Type owner, final Class<?> rawClass,
+        final Type... typeArguments) {
+        final Type useOwner;
+        if (rawClass.getEnclosingClass() == null) {
+            useOwner = null;
+        } else if (owner == null) {
+            useOwner = rawClass.getEnclosingClass();
+        } else {
+            useOwner = owner;
+        }
+
+        return new ParameterizedTypeImpl(rawClass, useOwner, typeArguments);
+    }
+
+    /**
+     * Finds the mapping for {@code type} in {@code typeVarAssigns}.
+     *
+     * @param type the type to be replaced
+     * @param typeVarAssigns the map with type variables
+     * @return the replaced type
+     * @throws IllegalArgumentException if the type cannot be substituted
+     */
+    private static Type substituteTypeVariables(final Type type, final Map<TypeVariable<?>, Type> typeVarAssigns) {
+        if (type instanceof TypeVariable<?> && typeVarAssigns != null) {
+            final Type replacementType = typeVarAssigns.get(type);
+
+            if (replacementType == null) {
+                throw new IllegalArgumentException("missing assignment type for type variable "
+                        + type);
+            }
+            return replacementType;
+        }
+        return type;
+    }
+
+    private static Type[] unrollBounds(final Map<TypeVariable<?>, Type> typeArguments, final Type[] bounds) {
+        Type[] result = bounds;
+        int i = 0;
+        for (; i < result.length; i++) {
+            final Type unrolled = unrollVariables(typeArguments, result[i]);
+            if (unrolled == null) {
+                Type[] copy = new Type[result.length - 1];
+                System.arraycopy(result, 0, copy, 0, i);
+                if (i < result.length - 1) {
+                    System.arraycopy(result, i + 1, copy, i, result.length - i - 1);
+                }
+                result = copy;
+                i--;
+            } else {
+                result[i] = unrolled;
+            }
+        }
+        return result;
+    }
+    /**
+     * Looks up {@code typeVariable} in {@code typeVarAssigns} <em>transitively</em>, i.e. keep looking until the value
+     * found is <em>not</em> a type variable.
+     *
+     * @param typeVariable the type variable to look up
+     * @param typeVarAssigns the map used for the look-up
+     * @return Type or {@code null} if some variable was not in the map
+     * @since 3.2
+     */
+    private static Type unrollVariableAssignments(TypeVariable<?> typeVariable, final Map<TypeVariable<?>, Type> typeVarAssigns) {
+        Type result;
+        do {
+            result = typeVarAssigns.get(typeVariable);
+            if (!(result instanceof TypeVariable<?>) || result.equals(typeVariable)) {
+                break;
+            }
+            typeVariable = (TypeVariable<?>) result;
+        } while (true);
+        return result;
+    }
+
+    /**
+     * Gets a type representing {@code type} with variable assignments "unrolled."
+     *
+     * @param typeArguments as from {@link TypeUtils#getTypeArguments(Type, Class)}
+     * @param type the type to unroll variable assignments for
+     * @return Type
+     * @since 3.2
+     */
+    public static Type unrollVariables(Map<TypeVariable<?>, Type> typeArguments, final Type type) {
+        if (typeArguments == null) {
+            typeArguments = Collections.emptyMap();
+        }
+        if (containsTypeVariables(type)) {
+            if (type instanceof TypeVariable<?>) {
+                return unrollVariables(typeArguments, typeArguments.get(type));
+            }
+            if (type instanceof ParameterizedType) {
+                final ParameterizedType p = (ParameterizedType) type;
+                final Map<TypeVariable<?>, Type> parameterizedTypeArguments;
+                if (p.getOwnerType() == null) {
+                    parameterizedTypeArguments = typeArguments;
+                } else {
+                    parameterizedTypeArguments = new HashMap<>(typeArguments);
+                    parameterizedTypeArguments.putAll(getTypeArguments(p));
+                }
+                final Type[] args = p.getActualTypeArguments();
+                for (int i = 0; i < args.length; i++) {
+                    final Type unrolled = unrollVariables(parameterizedTypeArguments, args[i]);
+                    if (unrolled != null) {
+                        args[i] = unrolled;
+                    }
+                }
+                return parameterizeWithOwner(p.getOwnerType(), (Class<?>) p.getRawType(), args);
+            }
+            if (type instanceof WildcardType) {
+                final WildcardType wild = (WildcardType) type;
+                return wildcardType().withUpperBounds(unrollBounds(typeArguments, wild.getUpperBounds()))
+                    .withLowerBounds(unrollBounds(typeArguments, wild.getLowerBounds())).build();
+            }
+        }
+        return type;
+    }
+
+   /**
+     * Gets a {@link WildcardTypeBuilder}.
+     *
+     * @return {@link WildcardTypeBuilder}
+     * @since 3.2
+     */
+    public static WildcardTypeBuilder wildcardType() {
+        return new WildcardTypeBuilder();
+    }
+
+   /**
+     * {@link TypeUtils} instances should NOT be constructed in standard
+     * programming. Instead, the class should be used as
+     * {@code TypeUtils.isAssignable(cls, toClass)}.
+     * <p>
+     * This constructor is public to permit tools that require a JavaBean instance
+     * to operate.
+     * </p>
+     */
+    public TypeUtils() {
+    }
+
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/BuildPropertiesSupport.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/BuildPropertiesSupport.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.api;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.loaders.BuildPropertiesImplementation;
+
+/**
+ * API to access values of build properties. The Gradle project defines multiple properties at both top level
+ * and at level of individual extensions and tasks. Some of the properties are computed, but many of them are
+ * defined either explicitly in the build script, or derived from the explicit definitions by various conventions.
+ * Such values are computed <b>before</b> any of the build tasks even execute.
+ * <p>
+ * This API provides access to certain such values, which are safe to extract and transport to the IDE process. Not all
+ * properties are computed and ready to be read, and not all properties are supported by the Gradle Projects infrastructure,
+ * but many of them are. Only String values are supported; other values are converted to String using {@link Object#toString()}.
+ * <p>
+ * To access an extension or a task property, obtain an instance of {@code BuildPropertiesSupport} by caling {@link BuildPropertiesSupport#get(org.netbeans.api.project.Project)},
+ * then use
+ * <ul>
+ * <li>{@link BuildPropertiesSupport#findExtensionProperty(java.lang.String, java.lang.String)}, or
+ * <li>{@link BuildPropertiesSupport#findTaskProperty(java.lang.String, java.lang.String)
+ * </ul>
+ * <p>
+ * There's a limited support for maps and lists. If a {@link Property} indicates a {@link BuildPropertiesSupport.PropertyKind#MAP} type, it is
+ * possible to use {@link #keys} to enumerate keys of the map. For {@link PropertyKidn#LIST}s, {@link #items} enumerate items of the list.
+ * @author sdedic
+ * @since 2.28
+ */
+public final class BuildPropertiesSupport {
+    private final List<BuildPropertiesImplementation> impls;
+
+    /**
+     * Scope for extension properties
+     */
+    public static final String EXTENSION = "extension";
+
+    /**
+     * Scope for task properties
+     */
+    public static final String TASK = "task";
+    
+    BuildPropertiesSupport(List<BuildPropertiesImplementation> impls) {
+        this.impls = impls;
+    }
+   
+    /**
+     * Obtain an instance for the project.
+     * @param p the project
+     * @return instance of {@link BuildPropertiesSupport} for the project.
+     */
+    public static BuildPropertiesSupport get(Project p) {
+        List<BuildPropertiesImplementation> impls = new ArrayList<>(NbGradleProject.get(p).refreshableProjectLookup().lookupAll(BuildPropertiesImplementation.class));
+        return new BuildPropertiesSupport(impls);
+    }
+    
+    /**
+     * Attempts to find / locate a property value in the Gradle script. The property
+     * may be written in the script, in the settings or implied by convention.
+     * Even though the property really exists in the buildscript, this method may
+     * not be able to locate its value; in that case the method retuns {@code null}.
+     * In some cases, it's known that the property exists, but its value could not
+     * be computed or obtained - in that case, the return will indicate {@link PropertyKind#EXISTS}.
+     * <p>
+     * The {@code propertyPath} is a dot-separated fully qualified property name.
+     * <p>
+     * If a property is an item of a list or a map, the owning List or Map must be obtained first as a 
+     * Property. Then individual items may be accessed using index or key.
+     * 
+     * @param propertyPath path to the property
+     * @return Property instance or {@code null}
+     */
+    public Property findExtensionProperty(String extensionName, String propertyPath) {
+        for (BuildPropertiesImplementation impl : impls) {
+            Property p = impl.findProperty(new Property(null, EXTENSION, extensionName, PropertyKind.MAP, null, null), propertyPath);
+            if (p != null) {
+                return p;
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Attempts to find property value of a named task. The same as {@link #findExtensionProperty} but works for
+     * task properties. 
+     * @param taskName task name.
+     * @param propertyPath path to the property.
+     * @return Property instance or {@code null}
+     * @see #findExtensionProperty(java.lang.String, java.lang.String) 
+     */
+    public Property findTaskProperty(String taskName, String propertyPath) {
+        for (BuildPropertiesImplementation impl : impls) {
+            Property p = impl.findProperty(new Property(null, TASK, taskName, PropertyKind.MAP, null, null), propertyPath);
+            if (p != null) {
+                return p;
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Enumerates items of a list-style property. Works only for properties of {@link PropertyKind#LIST}. If {@code path} is null,
+     * the contained items are enumerated. If {@code path} is not null, it identifies a property within items - the method enumerates
+     * those properties. If an item does not contain the specified path, {@code null} is returned in the enumeration.
+     * s
+     * @param owner the list property
+     * @param path path into individual items.
+     * @return enumeration of items or item properties.
+     */
+    public Iterable<Property> items(Property owner, String path) {
+        if (owner.getKind() != PropertyKind.LIST) {
+            return Collections.emptyList();
+        }
+        class It implements Iterator<Property> {
+            Iterator<BuildPropertiesImplementation> containers = impls.iterator();
+            Iterator<Property> del;
+
+            @Override
+            public boolean hasNext() {
+                if (!del.hasNext()) {
+                    del = null;
+                }
+                while (del == null) {
+                    if (!containers.hasNext()) {
+                        return false;
+                    }
+                    del = containers.next().items(owner, path);
+                    if (!del.hasNext()) {
+                        del = null;
+                    }
+                }
+                return del.hasNext();
+            }
+
+            @Override
+            public Property next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return del.next();
+            }
+        }
+        return new Iterable<Property>() {
+            @Override
+            public Iterator<Property> iterator() {
+                return new It();
+            }
+        };
+    }
+    
+    /**
+     * Returns keys of map-style properties. Works only for properties of {@link PropertyKind#MAP}.
+     * @param owner
+     * @return 
+     */
+    public Collection<String> keys(Property owner) {
+        if ((owner.getKind() != PropertyKind.STRUCTURE) && (owner.getKind() != PropertyKind.MAP)) {
+            return Collections.emptyList();
+        }
+        Set<String> s = new LinkedHashSet<>();
+        for (BuildPropertiesImplementation impl : impls) {
+            Collection<String> keys = impl.keys(owner);
+            if (keys != null) {
+                s.addAll(keys);
+            }
+        }
+        return s;
+    }
+    
+    /**
+     * Returns a named item, or a property of a named item from map-style property. Works only for
+     * map-style properties.
+     * @param base the map property
+     * @param key map item's key
+     * @param path optional path within an item to the property.
+     * @return map item, or a property of a map item.
+     */
+    public Property get(Property base, String key, String path) {
+        if ((base.getKind() != PropertyKind.MAP)) {
+            return null;
+        }
+        for (BuildPropertiesImplementation impl : impls) {
+            Property p = impl.get(base, key, path);
+            if (p != null) {
+                return p;
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Describes type / kind of the property.
+     */
+    public enum PropertyKind {
+        /**
+         * The property is a primitive value, or String
+         */
+        PRIMITIVE,
+        
+        /**
+         * The property is a structure or object.
+         */
+        STRUCTURE,
+        
+        /**
+         * The property is a Map
+         */
+        MAP,
+        
+        /**
+         * The property is a list of values.
+         */
+        LIST,
+        
+        /**
+         * The property exists, but its value cannot be accessed.
+         */
+        EXISTS
+    }
+    
+    /**
+     * Describes a property and its value.
+     */
+    public static final class Property {
+        private final Object id;
+        private final String scope;
+        private final PropertyKind kind;
+        private final String type;
+        private final String value;
+        private final String name;
+
+        public Property(Object id, String scope, String propertyName, PropertyKind kind, String type, String value) {
+            this.id = id;
+            this.scope = scope;
+            this.kind = kind;
+            this.type = type;
+            this.value = value;
+            this.name = propertyName;
+        }
+        
+        /**
+         * Returns the property id. The ID is a token that could be used to identify
+         * the property, but should not be interpreted: the structure implementation detail
+         * and may change at any time.
+         * @return property ID
+         */
+        public @NonNull Object getId() {
+            return id;
+        }
+
+        /**
+         * Scope of a property. Basic supported scopes are {@link #EXTENSION} and {@link #TASK}. Additional plugins
+         * may add additional scopes.
+         * @return scope of the property
+         */
+        public String getScope() {
+            return scope;
+        }
+
+        /**
+         * @return Basic type of a property.
+         */
+        public PropertyKind getKind() {
+            return kind;
+        }
+
+        /**
+         * @return name of the property.
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Returns type of the property. For {@link PropertyKind#LIST} or {@link PropertyKind#MAP}
+         * it means the type of items in the collection / map. May return {@code null} for {@link PropertyKind#EXISTS}.
+         * Fully qualified type name is returned.
+         * 
+         * @return type of the property or collection item.
+         */
+        public @CheckForNull String getType() {
+            return type;
+        }
+
+        /**
+         * True, if the property is a list.
+         * @return 
+         */
+        public boolean isList() {
+            return kind == PropertyKind.LIST;
+        }
+
+        /**
+         * True, if the property is a Map.
+         * @return 
+         */
+        public boolean isMap() {
+            return kind == PropertyKind.MAP;
+        }
+
+        /**
+         * Returns value of the property, as String. Value can be unknown, in that case it 
+         * returns {@code null}.
+         * @return property value or {@code null}
+         */
+        public @CheckForNull String getStringValue() {
+            return value;
+        }
+    }
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/BuildPropertiesSupport.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/BuildPropertiesSupport.java
@@ -71,13 +71,18 @@ public final class BuildPropertiesSupport {
     }
    
     /**
-     * Obtain an instance for the project.
+     * Obtain an instance for the project. Returns {@code null}, if the project does not support
+     * BuildProperties access. 
      * @param p the project
-     * @return instance of {@link BuildPropertiesSupport} for the project.
+     * @return instance of {@link BuildPropertiesSupport} for the project, or {@code null}.
      */
     public static BuildPropertiesSupport get(Project p) {
-        List<BuildPropertiesImplementation> impls = new ArrayList<>(NbGradleProject.get(p).refreshableProjectLookup().lookupAll(BuildPropertiesImplementation.class));
-        return new BuildPropertiesSupport(impls);
+        NbGradleProject nbgp = NbGradleProject.get(p);
+        if (nbgp == null) {
+            return null;
+        }
+        List<BuildPropertiesImplementation> impls = new ArrayList<>(nbgp.refreshableProjectLookup().lookupAll(BuildPropertiesImplementation.class));
+        return impls.isEmpty() ? null : new BuildPropertiesSupport(impls);
     }
     
     /**
@@ -143,7 +148,7 @@ public final class BuildPropertiesSupport {
 
             @Override
             public boolean hasNext() {
-                if (!del.hasNext()) {
+                if (del != null && !del.hasNext()) {
                     del = null;
                 }
                 while (del == null) {
@@ -151,7 +156,7 @@ public final class BuildPropertiesSupport {
                         return false;
                     }
                     del = containers.next().items(owner, path);
-                    if (!del.hasNext()) {
+                    if (del != null && !del.hasNext()) {
                         del = null;
                     }
                 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
@@ -24,18 +24,22 @@ import org.netbeans.modules.gradle.api.execute.RunUtils;
 import java.io.File;
 import java.io.Serializable;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.GradleModuleFileCache21;
 import org.netbeans.modules.gradle.cache.SubProjectDiskCache;
 import org.netbeans.modules.gradle.cache.SubProjectDiskCache.SubProjectInfo;
+import org.openide.util.TopologicalSortException;
+import org.openide.util.Utilities;
 
 /**
  * This object holds the basic information of the Gradle project.
@@ -77,6 +81,14 @@ public final class GradleBaseProject implements Serializable, ModuleSearchSuppor
     Map<String, String> projectIds = Collections.emptyMap();
     GradleDependency projectDependencyNode;
     Set<GradleReport> problems = Collections.emptySet();
+    Map<String, List<String>> taskDependencies = new HashMap<>();
+    Map<String, Set<String>> taskTypes = new HashMap<>();
+    
+    // @GuardedBy(this)
+    /**
+     * Lazy-computed list of tasks mapped to either tasksByName or created descriptions.
+     */
+    private transient Map<String, List<GradleTask>> taskDeepDependencies = new HashMap<>();
 
     transient Boolean resolved = null;
 
@@ -271,6 +283,103 @@ public final class GradleBaseProject implements Serializable, ModuleSearchSuppor
     public GradleTask getTaskByName(String name) {
         return tasksByName.get(name);
     }
+    
+    /**
+     * For a given task, lists all predecessors of the task within the current project.
+     * If tasks from other projects are referenced, they are returned as mock objects,
+     * that have no group and no description and no dependencies.
+     * <p>
+     * The result is partially sorted so that dependencies always precede the dependent
+     * task.
+     * 
+     * @param gt gradle task to inspect
+     * @param directs if true, only direct predecessors are returned
+     * @return list of predecessor tasks.
+     * @since 2.28
+     */
+    public List<GradleTask> getTaskPredecessors(GradleTask gt, boolean directs) {
+        // do not cache direct dependencies, they're cheap.
+        if (!directs) {
+            synchronized (this) {
+                List<GradleTask> cached = taskDeepDependencies.get(gt.getName());
+                if (cached != null) {
+                    return cached;
+                }
+            }
+        }
+        Set<String> paths = new HashSet<>();
+        Queue<String> toProcess = new ArrayDeque<>();
+        toProcess.add(gt.getPath());
+        
+        String taskPath;
+        Map<String, String> taskNamesAndPaths = new HashMap<>();
+        boolean first = true;
+        while ((taskPath = toProcess.poll()) != null) {
+            if (taskPath.equals("") || !paths.add(taskPath)) {
+                continue;
+            }
+            int lastColon = taskPath.lastIndexOf(':');
+            String p = taskPath.substring(0, lastColon + 1);
+            String n = taskPath.substring(lastColon + 1);
+            if (path.equals(p)) {
+                // taskNamesAndPaths only receives tasks from this project.
+                taskNamesAndPaths.put(taskPath, n);
+            }
+            if (!directs || first) {
+                // if directs, allow just the 1st level to be added to toProcess.
+                toProcess.addAll(taskDependencies.getOrDefault(n, Collections.emptyList()));
+            }
+            first = false;
+        }
+        
+        Map<String, List<String>> edges = new HashMap<>();
+        for (String tn : taskNamesAndPaths.keySet()) {
+            String sn = taskNamesAndPaths.get(tn);
+            for (String pred : taskDependencies.getOrDefault(sn, Collections.emptyList())) {
+                if (pred.isEmpty()) {
+                    continue;
+                }
+                edges.computeIfAbsent(pred, (k) -> new ArrayList<>()).add(tn);
+            }
+        }
+        List<String> orderedTasks;
+        
+        try {
+            orderedTasks = Utilities.topologicalSort(paths, edges);
+        } catch (TopologicalSortException ex) {
+            orderedTasks = new ArrayList<>(taskNamesAndPaths.keySet());
+        }
+        List<GradleTask> result = new ArrayList<>();
+        for (String p : orderedTasks) {
+            String n = taskNamesAndPaths.get(p);
+            GradleTask toAdd = n != null ? getTaskByName(n) : null;
+            if (toAdd != null) {
+                result.add(toAdd);
+            } else {
+                result.add(new GradleTask(p, null, n, null));
+            }
+        }
+        if (!directs) {
+            synchronized (this) {
+                taskDeepDependencies.putIfAbsent(gt.getName(), result);
+            }
+        }
+        return result;
+    }
+    
+    /**
+     * Determines if a task is a subtype of a certain Gradle type. 
+     * User-defined tasks may define different names, but the can be identified
+     * by the gradle type they extend or implement.
+     * Use fully qualified API class names for {@code gradleFQN} parameter.
+     * @param gradleFQN the fully qualified type name
+     * @return true, if the task type matches.
+     * @since 2.28
+     */
+    public boolean isTaskInstanceOf(String name, String gradleFQN) {
+        Set s = taskTypes.get(name);
+        return s == null ? false : s.contains(gradleFQN);
+    }
 
     public Map<String, GradleConfiguration> getConfigurations() {
         return Collections.unmodifiableMap(configurations);
@@ -345,7 +454,7 @@ public final class GradleBaseProject implements Serializable, ModuleSearchSuppor
                 && rootDir.equals(other.rootDir)
                 && !projectDir.equals(other.projectDir);
     }
-
+    
     GradleConfiguration createConfiguration(String name) {
         GradleConfiguration conf = new GradleConfiguration(name);
         configurations.put(name, conf);

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
@@ -133,6 +133,15 @@ class GradleBaseProjectBuilder implements ProjectInfoExtractor.Result {
                 group.add(task);
             }
         }
+        Map<String, Object> taskInfos = (Map<String, Object>)info.getOrDefault("taskDetails", Collections.emptyMap()); // NOI18N
+        for (String tn : prj.getTaskNames()) {
+            Map<String, String> tinfo = (Map<String, String>)taskInfos.get(tn);
+            if (tinfo != null) {
+                prj.taskDependencies.put(tn, Arrays.asList(tinfo.getOrDefault("taskDependencies", "").split(","))); // NOI18N
+                Set<String> inherited = new LinkedHashSet<>(Arrays.asList(tinfo.getOrDefault("inherits", "").split(","))); // NOI18N
+                prj.taskTypes.put(tn, inherited);
+            }
+        }
     }
 
     void processDependencies() {

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/BuildPropertiesImplementation.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/BuildPropertiesImplementation.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import java.util.Collection;
+import java.util.Iterator;
+import org.netbeans.modules.gradle.api.BuildPropertiesSupport;
+
+/**
+ * This is a "private SPI" for {@link BuildPropertiesSupport}. Currently only bridges the public API
+ * to a gradle private implementation. 
+ * @author sdedic
+ */
+public interface BuildPropertiesImplementation {
+    /**
+     * Retrieves property of the specified task. Returns {@code null} if the property does not exist
+     * or is not known. Properties can be indexed, structured, or Map-like: the individual items, members
+     * or keyed values are described using the <b>base property</b> retrieved by a previous call, and 
+     * an index or String selector that points to the specific nested value.
+     * <p>
+     * Property instances with {@code null} ids are special cases; no regular Property instances have {@code null} id. If such a property has {@code null} 
+     * {@link BuildPropertiesSupport.Property#getSourceName()}, it represents the container of tasks, extensions
+     * or other toplevel containers. Non-null {@link BuildPropertiesSupport.Property#getSourceName()} identifies the task, extension
+     * or other particular toplevel container.
+     * <p>
+     * {@code propertyPath} is a structured path to the desired property. Individual path components are separated by dots ('.'). Indexes
+     * or map key accessors are not allowed.
+     * 
+     * @param base the base property.
+     * @param index
+     * @param selector
+     * @param propertyPath
+     * @return {@link BuildPropertiesSupport.Property} or null
+     */
+    public BuildPropertiesSupport.Property findProperty(BuildPropertiesSupport.Property base, String propertyPath);
+    
+    /**
+     * Returns an item on the key, and path-identified property of it, starting from the {@code container} property.
+     * @param base container to index
+     * @param index index to access
+     * @param propertyPath optional; if {@code null} the item itself is returned. Otherwise item's property identified by the path
+     * 
+     * @return item at the specified index or its property.
+     */
+    public default BuildPropertiesSupport.Property get(BuildPropertiesSupport.Property base, String key, String propertyPath) {
+        return null;
+    }
+    
+    /**
+     * Enumerates values in children of the collection property. Should return {@code null} for an unknown property, if the implementation
+     * does not support enumerating the container. The result list may contain {@code null}s. If {@code path} is specified, should return
+     * for each contained item a property (if they exist) at the specified path.
+     * @param container the container property
+     * @param path optional property path, possibly null.
+     * @return iterator or {@code null}
+     */
+    public default Iterator<BuildPropertiesSupport.Property> items(BuildPropertiesSupport.Property container, String path) {
+        return null;
+    }
+    
+    /**
+     * Returns keys of a Map property or a structure. For non-existing properties, or if unsupported for the property {@code null} should be returned. For properties that are not
+     * maps or structures, an empty collection should be returned.
+     * @param p the property
+     * @return keys of map/structure or {@code null}.
+     */
+    public default Collection<String> keys(BuildPropertiesSupport.Property p) {
+        return null;
+    }
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/ExtensionPropertiesExtractor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/ExtensionPropertiesExtractor.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import org.netbeans.modules.gradle.api.BuildPropertiesSupport;
+import org.netbeans.modules.gradle.spi.GradleFiles;
+import org.netbeans.modules.gradle.spi.ProjectInfoExtractor;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+@ServiceProvider(service = ProjectInfoExtractor.class)
+public class ExtensionPropertiesExtractor implements ProjectInfoExtractor {
+
+    @Override
+    public Result fallback(GradleFiles files) {
+        return new Result() {
+            @Override
+            public Set getExtract() {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public Set<String> getProblems() {
+                return Collections.emptySet();
+            }
+        };
+    }
+
+    @Override
+    public Result extract(Map<String, Object> props, Map<Class, Object> otherInfo) {
+        return new Result() {
+            @Override
+            public Set getExtract() {
+                Map<String, String> values = (Map<String, String>)props.getOrDefault("extensions.propertyValues", Collections.emptyMap()); // NOI18N
+                Map<String, String> types = (Map<String, String>)props.getOrDefault("extensions.propertyTypes", Collections.emptyMap()); // NOI18N
+                Map<String, String> taskValues = (Map<String, String>)props.getOrDefault("tasks.propertyValues", Collections.emptyMap()); // NOI18N
+                Map<String, String> taskTypes = (Map<String, String>)props.getOrDefault("tasks.propertyTypes", Collections.emptyMap()); // NOI18N
+                PropertyEvaluator a = new PropertyEvaluator(values, types, taskValues, taskTypes);
+                return Collections.singleton(a);
+            }
+
+            @Override
+            public Set<String> getProblems() {
+                return Collections.emptySet();
+            }
+        };
+    }
+    
+    /**
+     * Extracts properties from the String maps provided by the NbProjectInfoBuilder. The protocol between this Evaluator and the NbProjectInfoBuilder
+     * is 'private', meaning it is not specified in an API - all clients should use BuildPropertiesSupport to access the properties.
+     * <p>
+     * The following maps are present in the info output:
+     * <ul>
+     * <li>extensions.propertyValues
+     * <li>extensions.propertyTypes
+     * <li>tasks.propertyValues
+     * <li>tasks.propertyTypes
+     * </ul>
+     * The values hold the stringified values of the properties; propertyTypes specify type of the property. For properties nested in map- and list-style
+     * properties, the propert ID encodes the map key or the list index.
+     * 
+     */
+    private static class PropertyEvaluator implements BuildPropertiesImplementation {
+        private final Map<String, String> propertyMap;
+        private final Map<String, String> propertyTypes;
+        private final Map<String, String> taskPropertyMap;
+        private final Map<String, String> taskPropertyTypes;
+
+        public PropertyEvaluator(Map<String, String> propertyMap, Map<String, String> propertyTypes,
+                        Map<String, String> taskPropertyMap, Map<String, String> taskPropertyTypes) {
+            this.propertyMap = propertyMap;
+            this.propertyTypes = propertyTypes;
+            this.taskPropertyMap = taskPropertyMap;
+            this.taskPropertyTypes = taskPropertyTypes;
+        }
+
+        @Override
+        public BuildPropertiesSupport.Property findProperty(BuildPropertiesSupport.Property base, String propertyPath) {
+            Map<String, String> values;
+            Map<String, String> types;
+            
+            switch (base.getScope()) {
+                case BuildPropertiesSupport.EXTENSION:  
+                    values = propertyMap; 
+                    types = propertyTypes;
+                    break;
+                case BuildPropertiesSupport.TASK: 
+                    values = taskPropertyMap; 
+                    types = taskPropertyTypes; 
+                    break;
+                
+                default:
+                    return null;
+            }
+            if (base.getName()== null || propertyPath == null) {
+                return null;
+            }
+            Object id = base.getId();
+            String path;
+            if (id == null) {
+                path = base.getName() + "." + propertyPath; // NOI18N
+            } else if (id instanceof String) {
+                path = id.toString() + "." + propertyPath; // NOI18N
+            } else {
+                return null;
+            }
+             
+            return find(base.getScope(), path, values, types);
+        }
+        
+        private Map<String, String> types(BuildPropertiesSupport.Property p) {
+            switch (p.getScope()) {
+                case BuildPropertiesSupport.EXTENSION:  
+                    return propertyTypes;
+                case BuildPropertiesSupport.TASK: 
+                    return taskPropertyTypes; 
+                default:
+                    return Collections.emptyMap();
+            }
+        }
+
+        private Map<String, String> values(BuildPropertiesSupport.Property p) {
+            switch (p.getScope()) {
+                case BuildPropertiesSupport.EXTENSION:  
+                    return propertyMap;
+                case BuildPropertiesSupport.TASK: 
+                    return taskPropertyMap; 
+                default:
+                    return Collections.emptyMap();
+            }
+        }
+
+        @Override
+        public Collection<String> keys(BuildPropertiesSupport.Property container) {
+            if (container.getId() == null) {
+                return null;
+            }
+            String path = container.getId().toString();
+            Map<String, String> types = types(container);
+            String c = types.get(path + "#keys");
+            if (c == null) {
+                return null;
+            }
+            return Arrays.asList(c.split(";"));
+        }
+
+        @Override
+        public BuildPropertiesSupport.Property get(BuildPropertiesSupport.Property container, String key, String propertyPath) {
+            if (container.getId() == null) {
+                return null;
+            }
+            Map<String, String> types = types(container);
+            if (!"named".equals(types.get(container.getId().toString()))) {
+                return null;
+            }
+            String path = container.getId().toString();
+            Map<String, String> values = values(container);
+            
+            String k = path + "." + key;
+            String v = values.get(k);
+            if (v == null) {
+                k = path + "[" + key + "]";
+                v = values.get(k);
+            }
+            if (v == null) {
+                return null;
+            }
+            return find(container.getScope(), k, values, types);
+        }
+
+        @Override
+        public Iterator<BuildPropertiesSupport.Property> items(BuildPropertiesSupport.Property container, String property) {
+            if (container.getId() == null) {
+                return null;
+            }
+            Map<String, String> types = types(container);
+            if (!"list".equals(types.get(container.getId().toString()))) {
+                return null;
+            }
+            Map<String, String> values = values(container);
+            String path = container.getId().toString() + "[";
+            return new Iterator<BuildPropertiesSupport.Property>() {
+                int index = 0;
+                String obj;
+                
+                @Override
+                public boolean hasNext() {
+                    if (obj != null) {
+                        return true;
+                    }
+                    String k = path + index + "]";
+                    obj = values.get(k);
+                    return obj != null;
+                }
+
+                @Override
+                public BuildPropertiesSupport.Property next() {
+                    if (!hasNext()) {
+                        throw new NoSuchElementException();
+                    }
+                    String k = path + index + "]";
+                    obj = null;
+                    index++;
+                    if (property != null) {
+                        k = k + property;
+                    }
+                    return find(container.getScope(), k, 
+                            values, types);
+                }
+            };
+        }
+        
+        private BuildPropertiesSupport.Property find(String src, String propertyPath, Map<String, String> values, Map<String, String> types) {
+            String t = types.get(propertyPath);
+            String c = types.get(propertyPath + "#col");
+            String v = values.get(propertyPath);
+            
+            if (t == null && v == null) {
+                return null;
+            }
+            
+            int lastDot = propertyPath.lastIndexOf('.');
+            String n = propertyPath.substring(lastDot + 1);
+            
+            if (c != null) {
+                // collection values not supported now.
+                return new BuildPropertiesSupport.Property(propertyPath, src, n,
+                        "named".equals(c)  ? BuildPropertiesSupport.PropertyKind.MAP : BuildPropertiesSupport.PropertyKind.LIST, 
+                        t, v);
+            }
+            if ("".equals(t)) { // NOI18N
+                return new BuildPropertiesSupport.Property(propertyPath, src, n, BuildPropertiesSupport.PropertyKind.EXISTS, t, null);
+            }
+            int dot = t.indexOf('.');
+            BuildPropertiesSupport.PropertyKind kind;
+            if (dot == -1 || (t.startsWith("java.lang") && !"java.lang.Object".equals(t))) {
+                kind = BuildPropertiesSupport.PropertyKind.PRIMITIVE;
+            } else {
+                kind = BuildPropertiesSupport.PropertyKind.STRUCTURE;
+            }
+            return new BuildPropertiesSupport.Property(propertyPath, src, n, kind, t, v);
+        }
+    }
+}

--- a/extide/gradle/test/unit/data/buildprops/micronaut/build.gradle
+++ b/extide/gradle/test/unit/data/buildprops/micronaut/build.gradle
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("io.micronaut.application") version "3.5.1"
+}
+
+version = "0.1"
+group = "com.example"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    annotationProcessor("io.micronaut:micronaut-http-validation")
+    implementation("io.micronaut:micronaut-http-client")
+    implementation("io.micronaut:micronaut-jackson-databind")
+    implementation("jakarta.annotation:jakarta.annotation-api")
+    runtimeOnly("ch.qos.logback:logback-classic")
+    implementation("io.micronaut:micronaut-validation")
+
+    implementation("org.apache.logging.log4j:log4j-core:2.17.0")
+}
+
+
+application {
+    mainClass.set("com.example.Application")
+}
+java {
+    sourceCompatibility = JavaVersion.toVersion("11")
+    targetCompatibility = JavaVersion.toVersion("11")
+}
+
+graalvmNative.toolchainDetection = false
+micronaut {
+    runtime("netty")
+    testRuntime("junit5")
+    processing {
+        incremental(true)
+        annotations("com.example.*")
+    }
+}
+
+graalvmNative.binaries.main.systemProperties = [prop1 : 'value1', 'prop2': 'value2', 'prop;;3': 'value3' ];
+
+
+println project.group
+println project.name
+println project.version

--- a/extide/gradle/test/unit/data/buildprops/micronaut/gradle.properties
+++ b/extide/gradle/test/unit/data/buildprops/micronaut/gradle.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+micronautVersion=3.6.0

--- a/extide/gradle/test/unit/data/buildprops/micronaut/settings.gradle
+++ b/extide/gradle/test/unit/data/buildprops/micronaut/settings.gradle
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+rootProject.name="microdemo"
+

--- a/extide/gradle/test/unit/data/buildprops/micronaut/src/main/java/com/example/Application.java
+++ b/extide/gradle/test/unit/data/buildprops/micronaut/src/main/java/com/example/Application.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+}

--- a/extide/gradle/test/unit/data/buildprops/micronaut/src/main/resources/application.yml
+++ b/extide/gradle/test/unit/data/buildprops/micronaut/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+micronaut:
+  application:
+    name: microdemo
+netty:
+  default:
+    allocator:
+      max-order: 3

--- a/extide/gradle/test/unit/data/buildprops/micronaut/src/main/resources/logback.xml
+++ b/extide/gradle/test/unit/data/buildprops/micronaut/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/extide/gradle/test/unit/data/buildprops/micronaut/src/test/java/com/example/MicrodemoTest.java
+++ b/extide/gradle/test/unit/data/buildprops/micronaut/src/test/java/com/example/MicrodemoTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import jakarta.inject.Inject;
+
+@MicronautTest
+class MicrodemoTest {
+
+    @Inject
+    EmbeddedApplication<?> application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/loaders/ExtensionPropertiesExtractorTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/loaders/ExtensionPropertiesExtractorTest.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Iterator;
+import static junit.framework.TestCase.assertNotNull;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.gradle.ProjectTrust;
+import org.netbeans.modules.gradle.api.BuildPropertiesSupport;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.modules.DummyInstalledFileLocator;
+import org.openide.windows.IOProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+public class ExtensionPropertiesExtractorTest extends NbTestCase {
+
+    public ExtensionPropertiesExtractorTest(String name) {
+        super(name);
+    }
+    
+    
+    private static File getTestNBDestDir() {
+        String destDir = System.getProperty("test.netbeans.dest.dir");
+        // set in project.properties as test-unit-sys-prop.test.netbeans.dest.dir
+        assertNotNull("test.netbeans.dest.dir property has to be set when running within binary distribution", destDir);
+        return new File(destDir);
+    }
+
+    File destDirF;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // This is needed, otherwose the core window's startup code will redirect
+        // System.out/err to the IOProvider, and its Trivial implementation will redirect
+        // it back to System.err - loop is formed. Initialize IOProvider first, it gets
+        // the real System.err/out references.
+        IOProvider p = IOProvider.getDefault();
+        System.setProperty("test.reload.sync", "true");
+        
+        destDirF = getTestNBDestDir();
+        clearWorkDir();
+    
+        DummyInstalledFileLocator.registerDestDir(destDirF);
+        GradleExperimentalSettings.getDefault().setOpenLazy(false);
+    }
+
+    FileObject projectDir;
+
+    private Project makeProject(String subdir) throws Exception {
+        FileObject src = FileUtil.toFileObject(getDataDir()).getFileObject(subdir);
+        projectDir = FileUtil.copyFile(src, FileUtil.toFileObject(getWorkDir()), src.getNameExt());
+        
+        Project p = ProjectManager.getDefault().findProject(projectDir);
+        assertNotNull(p);
+        ProjectTrust.getDefault().trustProject(p);
+        
+        OpenProjects.getDefault().open(new Project[] { p }, true);
+        OpenProjects.getDefault().openProjects().get();
+        
+        NbGradleProject.get(p).toQuality("Load data", NbGradleProject.Quality.FULL, false).toCompletableFuture().get();
+        return p;
+    }
+    
+    public void testSimpleExtensionProperty() throws Exception {
+        Project p = makeProject("buildprops/micronaut");
+        BuildPropertiesSupport support = BuildPropertiesSupport.get(p);
+        assertNotNull(support);
+        
+        BuildPropertiesSupport.Property prop = support.findExtensionProperty("application", "mainClass");
+        assertNotNull(prop);
+        assertEquals(BuildPropertiesSupport.PropertyKind.PRIMITIVE, prop.getKind());
+        assertEquals("com.example.Application", prop.getStringValue());
+        assertEquals("java.lang.String", prop.getType());
+        
+        assertTrue(support.keys(prop).isEmpty());
+        assertFalse(support.items(prop, null).iterator().hasNext());
+        
+        prop = support.findExtensionProperty("base", "distsDirectory");
+        assertNotNull(prop);
+        assertEquals(BuildPropertiesSupport.PropertyKind.STRUCTURE, prop.getKind());
+        String s = prop.getStringValue();
+        assertNotNull("Paths and directories are convertible to String", s);
+        assertTrue(s.endsWith(Paths.get("micronaut", "build", "distributions").toString()));
+
+        assertTrue(support.keys(prop).isEmpty());
+        assertFalse(support.items(prop, null).iterator().hasNext());
+    }
+    
+    public void testListExtensionProperty() throws Exception {
+        Project p = makeProject("buildprops/micronaut");
+        BuildPropertiesSupport support = BuildPropertiesSupport.get(p);
+        assertNotNull(support);
+        
+        BuildPropertiesSupport.Property prop;
+        
+        prop = support.findExtensionProperty("nativeTest", "runtimeArgs");
+        assertNotNull(prop);
+        assertEquals(BuildPropertiesSupport.PropertyKind.LIST, prop.getKind());
+        Iterable<BuildPropertiesSupport.Property> it = support.items(prop, null);
+        assertNotNull(it);
+        Iterator<BuildPropertiesSupport.Property> iter = it.iterator();
+        assertTrue(iter.hasNext());
+        
+        assertTrue(support.keys(prop).isEmpty());
+        
+        BuildPropertiesSupport.Property item = iter.next();
+        assertEquals(BuildPropertiesSupport.PropertyKind.PRIMITIVE, item.getKind());
+        assertTrue(item.getStringValue().contains("--xml-output-dir"));
+        assertTrue(iter.hasNext());
+        iter.next();
+        assertFalse(iter.hasNext());
+    }
+    
+    public void testMapExtensionProperty() throws Exception {
+        Project p = makeProject("buildprops/micronaut");
+        BuildPropertiesSupport support = BuildPropertiesSupport.get(p);
+        assertNotNull(support);
+        
+        BuildPropertiesSupport.Property prop;
+        
+
+        prop = support.findExtensionProperty("eclipse", "classpath.sourceSets");
+        assertNotNull(prop);
+        assertEquals(BuildPropertiesSupport.PropertyKind.MAP, prop.getKind());
+        Collection<String> keys = support.keys(prop);
+        assertNotNull(keys);
+        assertEquals(2, keys.size());
+
+        assertFalse(support.items(prop, null).iterator().hasNext());
+        
+        BuildPropertiesSupport.Property item;
+        
+        item = support.get(prop, "main", null);
+        assertNotNull(item);
+        item = support.get(prop, "test", null);
+        assertNotNull(item);
+    }
+
+    public void testMapExtensionProperty2() throws Exception {
+        Project p = makeProject("buildprops/micronaut");
+        BuildPropertiesSupport support = BuildPropertiesSupport.get(p);
+        assertNotNull(support);
+        
+        BuildPropertiesSupport.Property prop;
+        
+
+        prop = support.findExtensionProperty("graalvmNative", "binaries.main.systemProperties");
+        assertNotNull(prop);
+        assertEquals(BuildPropertiesSupport.PropertyKind.MAP, prop.getKind());
+        Collection<String> keys = support.keys(prop);
+        assertNotNull(keys);
+        assertEquals(3, keys.size());
+
+        assertFalse(support.items(prop, null).iterator().hasNext());
+        
+        BuildPropertiesSupport.Property item;
+        
+        item = support.get(prop, "prop1", null);
+        assertNotNull(item);
+        assertEquals("value1", item.getStringValue());
+        item = support.get(prop, "prop2", null);
+        assertNotNull(item);
+        assertEquals("value2", item.getStringValue());
+        item = support.get(prop, "prop;;3", null);
+        assertNotNull(item);
+        assertEquals("value3", item.getStringValue());
+    }
+
+
+    public void testSimpleTaskProperty() throws Exception {
+        Project p = makeProject("buildprops/micronaut");
+        BuildPropertiesSupport support = BuildPropertiesSupport.get(p);
+        assertNotNull(support);
+        
+        BuildPropertiesSupport.Property prop = support.findTaskProperty("installDist", "caseSensitive");
+        assertNotNull(prop);
+        assertEquals(BuildPropertiesSupport.PropertyKind.PRIMITIVE, prop.getKind());
+        assertEquals("true", prop.getStringValue());
+        assertEquals("boolean", prop.getType());
+        
+        assertTrue(support.keys(prop).isEmpty());
+        assertFalse(support.items(prop, null).iterator().hasNext());
+        
+        prop = support.findTaskProperty("nativeCompile", "options");
+        assertNotNull(prop);
+        assertEquals(BuildPropertiesSupport.PropertyKind.STRUCTURE, prop.getKind());
+
+        assertTrue(support.keys(prop).isEmpty());
+        assertFalse(support.items(prop, null).iterator().hasNext());
+
+        prop = support.findTaskProperty("nativeTestCompile", "workingDirectory");
+        assertNotNull(prop);
+        assertEquals(BuildPropertiesSupport.PropertyKind.STRUCTURE, prop.getKind());
+        String s = prop.getStringValue();
+        assertNotNull("Paths and directories are convertible to String", s);
+        assertTrue(s.endsWith(Paths.get("micronaut", "build", "native", "nativeTestCompile").toString()));
+
+        assertTrue(support.keys(prop).isEmpty());
+        assertFalse(support.items(prop, null).iterator().hasNext());
+    }
+    
+}


### PR DESCRIPTION
Important Note: this is 2nd from 3 dependent PRs, depends on #4726. For  review purposes, the PR targets a feature branch in the shared repository, that will be deleted after the related PRs are merged - it allows to inspect/review changes before the base PR (#4726) is merged. The time is becoming a little issue for me :)

Traditionally a module that need information from the gradle build system other than collected by the gradle core and exposed would have to add its 'agent' into `netbeans-gradle-tooling` subproject, then implement `ProjectInfoExtractor`.

This PR allows NetBeans modules to inspect gradle build properties. Clients may even adapt to changes by listening on Gradle project's reload event. The Gradle core module loads a lot more properties from the project model in Gradle process and marshall the information to the IDE. The introduced API allows to inspect individual properties, enumerate lists or access map keys.

NetBeans modules do not need to implement a tooling agent that their `ProjectInfoExtractor` interfaces with, and in fact they do not need the Extractor at all - unless they need to expose a service in projectLookup. I would consider the exact format exchanged between NetBeans gradle tooling (gradle) plugin and the `BuildPropertiesSupport` implementation private: although the data can be read by `ProjectInfoExtractor`s, the intention is to hide the exact wire format behind the API.

The last PR in this group adaps `java.gradle` and `micronaut` modules to declare their file products (artifacts) based on values inspected from the gradle build script.
