### PR TITLE
Better messages during project audit. Code cleanup.

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditException.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.cloud.oracle.adm;
+
+/**
+ *
+ * @author sdedic
+ */
+public final class AuditException extends Exception {
+    private final int statusCode;
+    private final String requestId;
+
+    public AuditException(int statusCode, String requestId, String message, Throwable cause) {
+        super(message, cause);
+        this.statusCode = statusCode;
+        this.requestId = requestId;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+}

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/CreateKnowledgeBaseAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/CreateKnowledgeBaseAction.java
@@ -103,7 +103,6 @@ public class CreateKnowledgeBaseAction implements ActionListener {
                         ErrorUtils.processError(response, Bundle.MSG_KBNotCreated(result.get()));
                     }
                 } catch (BmcException e) {
-                    System.out.println("Proces exception");
                     ErrorUtils.processError(e, Bundle.MSG_KBNotCreated(result.get()));
                 } finally {
                     progressHandle.finish();

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ErrorUtils.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ErrorUtils.java
@@ -53,6 +53,14 @@ class ErrorUtils {
         } 
     }
     
+    public static void processError(AuditException exc, String errorMessage) {
+        StringBuilder sb = new StringBuilder(errorMessage);
+        sb.append('\n').append(Bundle.MSG_Error_Code(exc.getStatusCode()));
+        sb.append(getErrorDescription(exc.getStatusCode()));
+        sb.append('\n').append(exc.getMessage());
+        DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(sb.toString()));
+    }
+    
     public static void processError(BmcResponse reqest, String errorMessage) {
         StringBuilder sb = new StringBuilder(errorMessage);
         sb.append('\n').append(Bundle.MSG_Error_Code(reqest.get__httpStatusCode__()));
@@ -64,7 +72,7 @@ class ErrorUtils {
        StringBuilder sb = new StringBuilder(errorMessage);
         sb.append('\n').append(Bundle.MSG_Error_Code(exc.getStatusCode()));
         sb.append(getErrorDescription(exc.getStatusCode()));
-        sb.append('n').append(exc.getMessage());
+        sb.append('\n').append(exc.getMessage());
         DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(sb.toString()));
    }
 }

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/KnowledgeBaseItem.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/KnowledgeBaseItem.java
@@ -24,6 +24,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -76,6 +77,9 @@ public class KnowledgeBaseItem extends OCIItem implements URLProvider{
         
         synchronized (KnowledgeBaseItem.class) {
             Collection<Reference<KnowledgeBaseItem>> refItems = itemInstances.get(ocid);
+            if (refItems == null) {
+                return Collections.emptyList();
+            }
             for (Iterator<Reference<KnowledgeBaseItem>> it = refItems.iterator(); it.hasNext(); ) {
                 Reference<KnowledgeBaseItem> r = it.next();
                 KnowledgeBaseItem i = r.get();

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
@@ -22,14 +22,17 @@ import com.oracle.bmc.adm.ApplicationDependencyManagementClient;
 import com.oracle.bmc.adm.model.KnowledgeBase;
 import com.oracle.bmc.adm.requests.GetKnowledgeBaseRequest;
 import com.oracle.bmc.adm.responses.GetKnowledgeBaseResponse;
+import com.oracle.bmc.model.BmcException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.concurrent.CompletableFuture;
 import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.cloud.oracle.OCIManager;
 import org.netbeans.modules.cloud.oracle.items.OCID;
 import org.netbeans.spi.project.LookupProvider.Registration.ProjectType;
 import org.netbeans.spi.project.ProjectServiceProvider;
+import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 
 /**
@@ -62,17 +65,24 @@ public final class ProjectVulnerability {
         }
     }
     
-    public CompletableFuture<Void> runProjectAudit(KnowledgeBaseItem item, boolean force) {
+    @NbBundle.Messages({
+        "# {0} - project name",
+        "MSG_CreatingAuditFailed=Creating Vulnerablity audit for project {0} failed.",
+    })
+    public CompletableFuture<String> runProjectAudit(KnowledgeBaseItem item, boolean force, boolean runIfNoReport) {
         if (item != null) {
             setProjectKnowledgeBase(item);
         }
-        CompletableFuture<Void> result = new CompletableFuture<>();
+        CompletableFuture<String> result = new CompletableFuture<>();
         AUDIT_PROCESSOR.post(() -> {
             try {
-                VulnerabilityWorker.getInstance().findVulnerability(project, force);
-                result.complete(null);
+                result.complete(VulnerabilityWorker.getInstance().findVulnerability(project, force, runIfNoReport));
             } catch (ThreadDeath x) {
                 throw x;
+            } catch (AuditException ex) {
+                final String projectDisplayName = ProjectUtils.getInformation(project).getDisplayName();
+                ErrorUtils.processError(ex, Bundle.MSG_CreatingAuditFailed(projectDisplayName));
+                result.completeExceptionally(ex);
             } catch (Exception | Error e) {
                 result.completeExceptionally(e);
             }
@@ -100,6 +110,8 @@ public final class ProjectVulnerability {
                 );
             } catch (ThreadDeath x) {
                 throw x;
+            } catch (BmcException ex) {
+                result.completeExceptionally(new AuditException(ex.getStatusCode(), ex.getOpcRequestId(), ex.getMessage(), ex));
             } catch (Exception | Error e) {
                 result.completeExceptionally(e);
             }

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/RunFileADMAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/RunFileADMAction.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.cloud.oracle.adm;
 
+import com.oracle.bmc.model.BmcException;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Optional;
@@ -64,31 +65,29 @@ public class RunFileADMAction implements ActionListener{
     }
     
     
+    @NbBundle.Messages({
+        "MSG_ProjectAuditInfo=Project Audits in GraalVM Ext Pack performs check for vulnerable dependencies using Vulnerabilities knowledgebase in Oracle OCI. If you want to learn more and setup OCI account, go to https://www.oracle.com/cloud/free/ .",
+        "# {0} - project display name",
+        "MSG_ProjectAuditNoKB=No Knowlege Base assigned for {0}.\n Select or create in Cloud Explorer a Knowledge Base, where to run Vulnerability Audit for this project."
+    })
     @Override
     public void actionPerformed(ActionEvent e) {
         Project project = FileOwnerQuery.getOwner(file);
-        System.out.println("Running adm action:");
-        System.out.println("  Project: " + project.toString());
-        System.out.println("  File: " + file.getPath());
-//        CloudResourcesStorage storage = project.getLookup().lookup(CloudResourcesStorage.class);
         KnowledgeBaseItem kbItem = VulnerabilityWorker.getKnowledgeBaseForProject(project);
+        final String projectDisplayName = ProjectUtils.getInformation(project).getDisplayName();
         if (kbItem != null) {
-            VulnerabilityWorker.getInstance().findVulnerability(project, true);
+            try {
+                VulnerabilityWorker.getInstance().findVulnerability(project, true, true);
+            } catch (AuditException exc) {
+                ErrorUtils.processError(exc, Bundle.MSG_CreatingAuditFailed(projectDisplayName));
+            }
         } else {
-            System.out.println("!!!!!! KnowledgeBase neni");
             if (OCIManager.getDefault().getConfigProvider() == null
                     || OCIManager.getDefault().getTenancy().equals(Optional.empty())) {
-                String message = "Project Audits in GraalVM Ext Pack performs check for "
-                        + "vulnerable dependencies using Vulnerabilities knowledgebase in Oracle OCI. "
-                        + "If you want to learn more and setup OCI account, go to https://www.oracle.com/cloud/free/ .";
-                DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(message));
+                DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(Bundle.MSG_ProjectAuditInfo()));
             } else {
-                String message = "No Knowlege Base assigned for " + ProjectUtils.getInformation(project).getDisplayName() 
-                        + ".\n Select or create in Cloud Explorer a Knowledge Base, where to run Vulnerability Audit for this project.";
-                DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(message));
+                DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(Bundle.MSG_ProjectAuditNoKB(projectDisplayName)));
             }
-            System.out.println("Config provider: " + OCIManager.getDefault().getConfigProvider());
-            System.out.println("Tenancy: " + OCIManager.getDefault().getTenancy());
         }
     }
     

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.event.ChangeEvent;
@@ -78,24 +79,25 @@ import org.openide.util.RequestProcessor;
  */
 @NbBundle.Messages({
     "# {0} - project name",
-    "MSG_Audit_Pass=Vulnerability audit for project {0} is done.\nNo vulnerable dependency was found.",
+    "MSG_Audit_Pass=Vulnerability audit for project {0} is done.\nNo vulnerability was found.",
     "# {0} - project name",
-    "MSG_Audit_Failed_One=Vulnerability audit for project {0} is done.\nOne vulnerable dependency was found.\nThe vulnerability is listed in Problems window.",
+    "MSG_Audit_Failed_One=Vulnerability audit for project {0} is done.\nOne vulnerability was found.\nThe vulnerability is listed in Problems window.",
     "# {0} - project name",
     "# {1} - number of vulnerabilities",
-    "MSG_Audit_Failed_More=Vulnerability audit for project {0} is done.\n{1} vulnerable dependencies were found.\nThe vulnerabilities are listed in Problems window.",
-    "# {0} - project name",
-    "MSG_CreatingAuditFailed=Creating Vulnerablity audit for project {0} failed.",
+    "MSG_Audit_Failed_More=Vulnerability audit for project {0} is done.\n{1} vulnerabilities were found.\nThe vulnerabilities are listed in Problems window.",
     "# {0} - project name",
     "MSG_ListingAuditFailed=Obtaining newly created vulnerablity audit for project {0} failed.",
     "MSG_ListingVulnerabilitiesFailed=Obtaining vulnerabilities for newly created audit failed.",
     "# {0} - project name",
-    "MSG_AuditIsRunning=Audit of {0} project is running ...",
+    "MSG_AuditIsRunning=Checking for audit of project {0}",
     "MSG_NotAvailable=Not available",
     "MSG_Diagnostic=Vulnerability\n"
             + "  Cvss V2 Score: %s\n"
             + "  Cvss V3 Score: %s\n"
-            + "  Caused by dependence: %s"
+            + "  Caused by dependence: %s",
+    "MSG_SearchingAuditReport=Searching for audit reports...",
+    "MSG_AuditCollectDependencies=Collecting project dependencies...",
+    "MSG_ExecuteAudit=Executing audit..."
 })
  
 @MimeRegistrations({
@@ -364,31 +366,37 @@ public class VulnerabilityWorker implements ErrorProvider{
         return instance;
     }
 
-    public void findVulnerability(Project project, boolean forceAudit) {
+    /**
+     * @param project
+     * @param forceAudit
+     * @return Returns the audit ID, or {@code null} if no audit is present.
+     */
+    public String findVulnerability(Project project, boolean forceAudit, boolean runIfNoReport) throws AuditException {
         LOG.log(Level.FINER, "Trying to obtain audit for project {0}, force:{1}", new Object[] { project, forceAudit });
         final String projectDisplayName = ProjectUtils.getInformation(project).getDisplayName();
         KnowledgeBaseItem kbItem = getKnowledgeBaseForProject(project);
         if (kbItem == null) {
-            return;
+            return null;
         }
         
         // remove from the cache old values
         ProgressHandle progressHandle = ProgressHandle.createHandle(Bundle.MSG_AuditIsRunning(projectDisplayName));
-        progressHandle.start();
+        AtomicBoolean remoteCall = new AtomicBoolean(false);
         try {
-            doFindVulnerability(project, kbItem.compartmentId, kbItem.getKey().getValue(), 
-                    projectDisplayName, progressHandle, forceAudit);
+            return doFindVulnerability(project, kbItem.compartmentId, kbItem.getKey().getValue(), 
+                    projectDisplayName, progressHandle, forceAudit, runIfNoReport, remoteCall);
         } finally {
-            progressHandle.finish();
+            if (remoteCall.get()) {
+                progressHandle.close();
+            }
             kbItem.refresh();
         }
     }
 
-    public void doFindVulnerability(Project project, String compartmentId, String knowledgeBaseId, String projectDisplayName,
-            ProgressHandle progressHandle, boolean forceAudit) {
-        DependencyResult dr = ProjectDependencies.findDependencies(project, ProjectDependencies.newQuery(Scopes.RUNTIME));
+    private String doFindVulnerability(Project project, String compartmentId, String knowledgeBaseId, String projectDisplayName,
+            ProgressHandle progressHandle, boolean forceAudit, boolean runIfNoReport, AtomicBoolean remoteCall) throws AuditException {
+        DependencyResult dr = null;
         List<ApplicationDependency> result = new ArrayList();
-        convert(dr.getRoot(), new HashMap<>(), result);
         
         CacheItem cacheItem = null;
         VulnerabilityReport savedAudit = null;
@@ -405,6 +413,9 @@ public class VulnerabilityWorker implements ErrorProvider{
         
         if (!forceAudit && savedAudit == null) {
             // attempt to find an active most recent audit:
+            remoteCall.set(true);
+            progressHandle.start();
+            progressHandle.progress(Bundle.MSG_SearchingAuditReport());
             try (ApplicationDependencyManagementClient admClient
                     = new ApplicationDependencyManagementClient(OCIManager.getDefault().getConfigProvider())) {
                 ListVulnerabilityAuditsRequest request = ListVulnerabilityAuditsRequest
@@ -417,6 +428,9 @@ public class VulnerabilityWorker implements ErrorProvider{
                 ListVulnerabilityAuditsResponse response = admClient.listVulnerabilityAudits(request);
                 if (!response.getVulnerabilityAuditCollection().getItems().isEmpty()) {
                     VulnerabilityAuditSummary summary = response.getVulnerabilityAuditCollection().getItems().get(0);
+                    progressHandle.progress(Bundle.MSG_AuditCollectDependencies());
+                    dr = ProjectDependencies.findDependencies(project, ProjectDependencies.newQuery(Scopes.RUNTIME));
+                    convert(dr.getRoot(), new HashMap<>(), result);
                     cacheItem = fetchVulnerabilityItems(project, admClient, dr, summary, projectDisplayName);
                     savedAudit = new VulnerabilityReport(cacheItem.getAudit(), cacheItem.getVulnerabilities());
                 }
@@ -427,7 +441,15 @@ public class VulnerabilityWorker implements ErrorProvider{
             }
         }
         
-        if (savedAudit == null && forceAudit) {
+        if (savedAudit == null && (runIfNoReport || forceAudit)) {
+            if (remoteCall.compareAndSet(false, true)) {
+                progressHandle.start();
+            }
+            if (dr == null) {
+                progressHandle.progress(Bundle.MSG_AuditCollectDependencies());
+                dr = ProjectDependencies.findDependencies(project, ProjectDependencies.newQuery(Scopes.RUNTIME));
+                convert(dr.getRoot(), new HashMap<>(), result);
+            }
             try (ApplicationDependencyManagementClient admClient
                     = new ApplicationDependencyManagementClient(OCIManager.getDefault().getConfigProvider())) {
                 final VulnerabilityAuditConfiguration auditConfiguration = VulnerabilityAuditConfiguration
@@ -445,20 +467,19 @@ public class VulnerabilityWorker implements ErrorProvider{
                         .configuration(auditConfiguration)
                         .applicationDependencies(result)
                         .build();
+                progressHandle.progress(Bundle.MSG_ExecuteAudit());
                 CreateVulnerabilityAuditResponse response = admClient.createVulnerabilityAudit(CreateVulnerabilityAuditRequest
                         .builder()
                         .createVulnerabilityAuditDetails(auditDetails)
                         .build());
                 if (response.get__httpStatusCode__() != 201 && response.get__httpStatusCode__() != 200) {
-                    ErrorUtils.processError(response, Bundle.MSG_CreatingAuditFailed(projectDisplayName));
-                    return;
+                    throw new BmcException(response.get__httpStatusCode__(), null, null, response.getOpcRequestId());
                 }
                 // audit is ok
                 cacheItem = waitToAuditFinish(project, admClient, dr, response.getVulnerabilityAudit(), projectDisplayName);
                 auditDone = true;
             } catch (BmcException exc) {
-                ErrorUtils.processError(exc, compartmentId);
-                return;
+                throw new AuditException(exc.getStatusCode(), exc.getOpcRequestId(), exc.getMessage(), exc);
             } finally {
                 progressHandle.finish();
             }
@@ -489,6 +510,10 @@ public class VulnerabilityWorker implements ErrorProvider{
             }
             Diagnostic.ReporterControl reporter = Diagnostic.findReporterControl(Lookup.getDefault(), project.getProjectDirectory());
             reporter.diagnosticChanged(problematicFiles, null);
+            return cacheItem.report.summary.getId();
+        } else {
+            // indicate somehow the KB exists, but empty
+            return "";
         }
     }
     
@@ -527,7 +552,7 @@ public class VulnerabilityWorker implements ErrorProvider{
     }
 
     private CacheItem waitToAuditFinish(Project project, ApplicationDependencyManagementClient client, 
-            DependencyResult dr, VulnerabilityAudit audit, String projectName) {                
+            DependencyResult dr, VulnerabilityAudit audit, String projectName) throws AuditException {                
         ListVulnerabilityAuditsRequest request = ListVulnerabilityAuditsRequest.builder()
                 .knowledgeBaseId(audit.getKnowledgeBaseId()).id(audit.getId()).build();
         VulnerabilityAuditSummary auditSummary;
@@ -544,8 +569,7 @@ public class VulnerabilityWorker implements ErrorProvider{
             }
             ListVulnerabilityAuditsResponse response = client.listVulnerabilityAudits(request);
             if (response.get__httpStatusCode__() != 200) {
-                ErrorUtils.processError(response, Bundle.MSG_ListingAuditFailed(projectName));
-                return null;
+                throw new AuditException(response.get__httpStatusCode__(), response.getOpcRequestId(), Bundle.MSG_ListingAuditFailed(projectName), null);
             }
             List<VulnerabilityAuditSummary> items = response.getVulnerabilityAuditCollection().getItems();
             auditSummary = items.get(0);


### PR DESCRIPTION
The PR provides better feedback for the project audit action:
- when the code is just searching for existing audits, it displays "searching for audits"
- "executing audit" is only displayed when the project is really evaluated by the audit service
- LSP command can demand executing audit none exists in the configured KB

Some debugging leftovers in code cleaned up.