### PR TITLE
jna.nosys is required so that JNA tries to load native library via System#loadLibrary

### DIFF
--- a/platform/libs.jna/src/org/netbeans/libs/jna/Installer.java
+++ b/platform/libs.jna/src/org/netbeans/libs/jna/Installer.java
@@ -27,5 +27,6 @@ public class Installer extends ModuleInstall {
         super.validate();
         //#211655
         System.setProperty( "jna.boot.library.name", "jnidispatch-nb" ); //NOI18N
+        System.setProperty( "jna.nosys", "false" ); //NOI18N
     }
 }


### PR DESCRIPTION
Without it the embedded native library is always used.