### PR TITLE
Updates for 15.0.301 release of VSNetBeans

### DIFF
--- a/java/java.lsp.server/vscode/CHANGELOG.md
+++ b/java/java.lsp.server/vscode/CHANGELOG.md
@@ -20,6 +20,22 @@
     under the License.
 
 -->
+## Version 15.0.301
+* Native image CE debugger works on aarch64
+* Organize Imports fixed for clashing star imports
+* Auto import of types in code completion
+* Added inline redundant variable hint
+* Improvements to Maven and Gradle projects to report project artifacts
+* Return all dependencies for Maven and Gradle projects
+* Support Maven and Gradle vulnerability audits in OCI a proxy to nvd.nist.gov
+* NetBeans should not auto-insert `\n\` in Groovy triple quoted strings 
+* nb-javac 19 support
+
+## Version 15.0
+* Open Type command added
+* Present project view files as tree leaves
+* Minor improvements in OCI ui and VSCode icon mapping
+
 ## Version 14.0.301
 * Settings: `NetBeans:UserDir` is set to `Local` as default value. This means each instance of VSCode runs own VSNetBeans LS
 * Format Document and Format Selection added 


### PR DESCRIPTION
Updates to changelog.md to list latest changes since 15.0 and also for 15.0 as I did not update at that time.
