### PR TITLE
Add update centre notifications to Check for Updates dialog

### DIFF
--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/Bundle.properties
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/Bundle.properties
@@ -135,6 +135,7 @@ ValidationWarningPanel_ACD=N/A
 UninstallUnitWizard_Title=Plugin Installer
 LazyOperationDescriptionStep_NoUpdates_Title=<h3>Your application is up to date!</h3>
 LazyOperationDescriptionStep_NoUpdates=There are no updates available.
+LazyOperationDescriptionStep_Notifications_Title=<h3>Notifications</h3>
 LazyOperationDescriptionStep_NoUpdatesWithProblems_Title=<h3>Checking for updates failed.</h3>
 LazyOperationDescriptionStep_NoUpdatesWithProblems=Check your network connection, verify that your proxy settings<br>are configured correctly, or try again later.
 LazyOperationDescriptionStep_FindUpdates_Title=<b>Checking for updates.</b><br>Please wait while the installer checks for available updates.


### PR DESCRIPTION
Quick fix for a long standing annoyance.  We've had a number of users report confusion that using `Help / Check for Updates` only shows plugin updates (which are rare, especially from us) and not new releases of the IDE. In particular, that the text reads "Your IDE is up to date!" when it's not the latest release.

This change adds any update centre notification text to the dialog if no plugin updates are available.  If you want to test, change the NetBeans Distribution update link from https://netbeans.apache.org/nb/updates/dev/updates.xml.gz to https://netbeans.apache.org/nb/updates/14/updates.xml.gz and use Check for Updates.

Image without notification (default as now).

![nb-noupdates](https://user-images.githubusercontent.com/3975960/194364528-b70cd2c6-06f0-4342-af68-2ccb25b0f955.png)

Image with update notification from NB14 catalog.

![nb-hasupdate](https://user-images.githubusercontent.com/3975960/194364609-a41f48de-8fa0-40fe-becb-3d4f88a7e187.png)

I've left the header text as is, although I think it's somewhat confusing too for updates.