### PR TITLE
Add debugger listening connector to LSP.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/ConfigurationAttributes.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/ConfigurationAttributes.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.java.lsp.server.debugging.attach;
 
 import com.sun.jdi.connect.AttachingConnector;
 import com.sun.jdi.connect.Connector;
+import com.sun.jdi.connect.ListeningConnector;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -39,13 +40,14 @@ final class ConfigurationAttributes {
     private static final String CONNECTOR_PROCESS = "com.sun.jdi.ProcessAttach";    // NOI18N
     private static final String CONNECTOR_SOCKET = "com.sun.jdi.SocketAttach";      // NOI18N
     private static final String CONNECTOR_SHMEM = "com.sun.jdi.SharedMemoryAttach"; // NOI18N
+    private static final String CONNECTOR_SOCKET_LISTEN = "com.sun.jdi.SocketListen";      // NOI18N
 
     static final String PROCESS_ARG_PID = "processId";          // NOI18N
     static final String SOCKET_ARG_HOST = "hostName";           // NOI18N
     static final String SOCKET_ARG_PORT = "port";               // NOI18N
     static final String SHMEM_ARG_NAME = "sharedMemoryName";    // NOI18N
 
-    private final AttachingConnector ac;
+    private final Connector ac;
     private final String id;
     private final String name;
     private final String description;
@@ -54,12 +56,14 @@ final class ConfigurationAttributes {
     @NbBundle.Messages({"LBL_AttachToProcess=Attach to Process",
                         "LBL_AttachToPort=Attach to Port",
                         "LBL_AttachToShmem=Attach to Shared Memory",
+                        "LBL_ListenOnPort=Listen on Port",
+                        "LBL_ListenForAttach=Listen for the debuggee to attach",
                         "# {0} - connector name", "LBL_AttachBy=Attach by {0}",
                         "DESC_Process=Process Id of the debuggee",
                         "DESC_HostName=Name or IP address of the host machine to connect to",
                         "DESC_Port=Port number to connect to",
                         "DESC_ShMem=Shared memory transport address at which the target VM is listening"})
-    ConfigurationAttributes(AttachingConnector ac) {
+    ConfigurationAttributes(Connector ac) {
         this.ac = ac;
         String connectorName = ac.name();
         this.id = connectorName;
@@ -82,6 +86,13 @@ final class ConfigurationAttributes {
                 String shmName = getArgumentOrDefault(defaultArguments.get("name"), ""); // NOI18N
                 attributes.put(SHMEM_ARG_NAME, new ConfigurationAttribute(shmName, Bundle.DESC_ShMem(), true));
                 break;
+            case CONNECTOR_SOCKET_LISTEN:
+                this.name = Bundle.LBL_ListenOnPort();
+                hostName = getArgumentOrDefault(defaultArguments.get("hostname"), "localhost"); // NOI18N
+                port = getArgumentOrDefault(defaultArguments.get("port"), "8000"); // NOI18N
+                attributes.put(SOCKET_ARG_HOST, new ConfigurationAttribute(hostName, Bundle.DESC_HostName(), true));
+                attributes.put(SOCKET_ARG_PORT, new ConfigurationAttribute(port, Bundle.DESC_Port(), true));
+                break;
             default:
                 this.name = Bundle.LBL_AttachBy(connectorName);
                 for (Connector.Argument arg : defaultArguments.values()) {
@@ -91,9 +102,12 @@ final class ConfigurationAttributes {
                 }
         }
         for (Connector.Argument arg : defaultArguments.values()) {
-            if (!arg.mustSpecify()) {
+            if (!arg.mustSpecify() && !attributes.containsKey(arg.name())) {
                 attributes.put(arg.name(), new ConfigurationAttribute(arg.value(), arg.description(), false));
             }
+        }
+        if (ac instanceof ListeningConnector) {
+            attributes.put("listen", new ConfigurationAttribute("true", Bundle.LBL_ListenForAttach(), true));
         }
     }
 
@@ -109,7 +123,7 @@ final class ConfigurationAttributes {
         return description;
     }
 
-    public AttachingConnector getConnector() {
+    public Connector getConnector() {
         return ac;
     }
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/NbAttachRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/NbAttachRequestHandler.java
@@ -19,7 +19,9 @@
 package org.netbeans.modules.java.lsp.server.debugging.attach;
 
 import com.sun.jdi.connect.AttachingConnector;
+import com.sun.jdi.connect.Connector;
 import com.sun.jdi.connect.Connector.Argument;
+import com.sun.jdi.connect.ListeningConnector;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -44,6 +46,7 @@ import org.netbeans.api.debugger.Session;
 import org.netbeans.api.debugger.jpda.AttachingDICookie;
 import org.netbeans.api.debugger.jpda.DebuggerStartException;
 import org.netbeans.api.debugger.jpda.JPDADebugger;
+import org.netbeans.api.debugger.jpda.ListeningDICookie;
 import org.netbeans.modules.java.lsp.server.debugging.DebugAdapterContext;
 import org.netbeans.modules.java.lsp.server.debugging.launch.NbDebugSession;
 import org.netbeans.modules.java.lsp.server.debugging.ni.NILocationVisualizer;
@@ -162,7 +165,7 @@ public final class NbAttachRequestHandler {
         CompletableFuture<Void> resultFuture = new CompletableFuture<>();
         ConfigurationAttributes configurationAttributes = AttachConfigurations.get().findConfiguration(attachArguments);
         if (configurationAttributes != null) {
-            AttachingConnector connector = configurationAttributes.getConnector();
+            Connector connector = configurationAttributes.getConnector();
             RP.post(() -> attachTo(connector, attachArguments, context, resultFuture));
         } else {
             context.setDebugMode(true);
@@ -175,7 +178,7 @@ public final class NbAttachRequestHandler {
     }
 
     @Messages({"# {0} - argument name", "# {1} - value", "MSG_ConnectorInvalidValue=Invalid value of {0}: {1}"})
-    private void attachTo(AttachingConnector connector, Map<String, Object> arguments, DebugAdapterContext context, CompletableFuture<Void> resultFuture) {
+    private void attachTo(Connector connector, Map<String, Object> arguments, DebugAdapterContext context, CompletableFuture<Void> resultFuture) {
         Map<String, Argument> args = connector.defaultArguments();
         for (String argName : arguments.keySet()) {
             String argNameTranslated = ATTR_CONFIG_TO_CONNECTOR.getOrDefault(argName, argName);
@@ -192,16 +195,22 @@ public final class NbAttachRequestHandler {
             }
             arg.setValue(value);
         }
-        AttachingDICookie attachingCookie = AttachingDICookie.create(connector, args);
-        resultFuture.complete(null);
-        startAttaching(attachingCookie, context);
+        DebuggerInfo debuggerInfo;
+        if (connector instanceof AttachingConnector) {
+            AttachingDICookie attachingCookie = AttachingDICookie.create((AttachingConnector) connector, args);
+            resultFuture.complete(null);
+            debuggerInfo = DebuggerInfo.create(AttachingDICookie.ID, new Object [] { attachingCookie });
+        } else {
+            assert connector instanceof ListeningConnector : connector;
+            ListeningDICookie listeningCookie = ListeningDICookie.create((ListeningConnector) connector, args);
+            debuggerInfo = DebuggerInfo.create(ListeningDICookie.ID, new Object [] { listeningCookie });
+        }
+        startAttaching(debuggerInfo, context);
     }
 
     @Messages("MSG_FailedToAttach=Failed to attach.")
-    private void startAttaching(AttachingDICookie attachingCookie, DebugAdapterContext context) {
-        DebuggerEngine[] es = DebuggerManager.getDebuggerManager ().startDebugging(
-            DebuggerInfo.create(AttachingDICookie.ID, new Object [] { attachingCookie })
-        );
+    private void startAttaching(DebuggerInfo debuggerInfo, DebugAdapterContext context) {
+        DebuggerEngine[] es = DebuggerManager.getDebuggerManager ().startDebugging(debuggerInfo);
         if (es.length > 0) {
             JPDADebugger debugger = es[0].lookupFirst(null, JPDADebugger.class);
             if (debugger != null) {

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -326,6 +326,11 @@
 								"default": "${command:java.attachDebugger.pickProcess}",
 								"description": "Process Id of the debuggee"
 							},
+							"listen": {
+								"type": "string",
+								"default": "false",
+								"description": "Listen for the debuggee to attach"
+							},
 							"timeout": {
 								"type": "string",
 								"default": "30000",


### PR DESCRIPTION
Add a listening connector to the VSCode extension.
It acts as an attaching connector, but the attach is reversed. VSCode opens a listening socket and the debuggee attaches to it. `"listen":"true"` property flips the attach direction.

The debuggee needs to be started after the listening debugger session is started and with `server=n`, like:
`-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=localhost:8000`
