### PR TITLE
Fixing error recovery when j.l.MatchException is missing, and patterns are present.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
@@ -19,9 +19,11 @@
 
 package org.netbeans.modules.java.source.indexing;
 
+import com.sun.source.tree.BindingPatternTree;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.DeconstructionPatternTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
@@ -59,6 +61,7 @@ import com.sun.tools.javac.comp.Enter;
 import com.sun.tools.javac.comp.Env;
 import com.sun.tools.javac.comp.Modules;
 import com.sun.tools.javac.main.JavaCompiler;
+import com.sun.tools.javac.model.JavacElements;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
@@ -103,6 +106,7 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
@@ -531,6 +535,8 @@ final class VanillaCompileWorker extends CompileWorker {
         Trees trees = Trees.instance(BasicJavacTask.instance(ctx));
         Types types = Types.instance(ctx);
         TreeMaker make = TreeMaker.instance(ctx);
+        Elements el = JavacElements.instance(ctx);
+        boolean hasMatchException = el.getTypeElement("java.lang.MatchException") != null;
         //TODO: should preserve error types!!!
         new TreePathScanner<Void, Void>() {
             private Set<JCNewClass> anonymousClasses = Collections.newSetFromMap(new LinkedHashMap<>());
@@ -882,6 +888,18 @@ final class VanillaCompileWorker extends CompileWorker {
                     errorFound |= isErroneous(varArgs);
                 }
                 return super.visitMethodInvocation(node, p);
+            }
+
+            @Override
+            public Void visitBindingPattern(BindingPatternTree node, Void p) {
+                errorFound |= !hasMatchException;
+                return super.visitBindingPattern(node, p);
+            }
+
+            @Override
+            public Void visitDeconstructionPattern(DeconstructionPatternTree node, Void p) {
+                errorFound |= !hasMatchException;
+                return super.visitDeconstructionPattern(node, p);
             }
 
             @Override

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -1954,6 +1954,108 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
                                                        "cache/s1/java/15/classes/test/Test.sig")), createdFiles);
     }
 
+    public void testEnhancedSwitch1() throws Exception {
+        setSourceLevel(SourceVersion.latest().name().substring("RELEASE_".length()));
+        setCompilerOptions(Arrays.asList("--enable-preview"));
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test.java", "package test;\n"
+                        + "record Rect(ColoredPoint upperLeft) {}\n"
+                        + "record ColoredPoint(Point p) {}\n"
+                        + "record Point(int x){}\n"
+                        + "public class Test {\n"
+                        + "    private void test(Object o) {\n"
+                        + "        switch (o) {\n"
+                        + "            case Rect r: \n"
+                        + "                System.out.println(\"Hello\");\n"
+                        + "                break;\n"
+                        + "            default:\n"
+                        + "                break;\n"
+                        + "        }\n"
+                        + "    }\n"
+                        + "}\n")), Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Rect.sig",
+                                                       "cache/s1/java/15/classes/test/ColoredPoint.sig",
+                                                       "cache/s1/java/15/classes/test/Point.sig",
+                                                       "cache/s1/java/15/classes/test/Test.sig")), createdFiles);
+    }
+
+    public void testEnhancedSwitch2() throws Exception {
+        setSourceLevel(SourceVersion.latest().name().substring("RELEASE_".length()));
+        setCompilerOptions(Arrays.asList("--enable-preview"));
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test.java", "package test;\n"
+                        + "record Rect(ColoredPoint upperLeft) {}\n"
+                        + "record ColoredPoint(Point p) {}\n"
+                        + "record Point(int x){}\n"
+                        + "public class Test {\n"
+                        + "    private void test(Object o) {\n"
+                        + "        switch (o) {\n"
+                        + "            case null: \n"
+                        + "                System.out.println(\"Hello\");\n"
+                        + "                break;\n"
+                        + "            default:\n"
+                        + "                break;\n"
+                        + "        }\n"
+                        + "    }\n"
+                        + "}\n")), Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Rect.sig",
+                                                       "cache/s1/java/15/classes/test/ColoredPoint.sig",
+                                                       "cache/s1/java/15/classes/test/Point.sig",
+                                                       "cache/s1/java/15/classes/test/Test.sig")), createdFiles);
+    }
+
+    public void testEnhancedSwitch3() throws Exception {
+        setSourceLevel(SourceVersion.latest().name().substring("RELEASE_".length()));
+        setCompilerOptions(Arrays.asList("--enable-preview"));
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test.java", "package test;\n"
+                        + "record Rect(ColoredPoint upperLeft) {}\n"
+                        + "record ColoredPoint(Point p) {}\n"
+                        + "record Point(int x){}\n"
+                        + "public class Test {\n"
+                        + "    private void test(Object o) {\n"
+                        + "        switch (o) {\n"
+                        + "            case (String s): \n"
+                        + "                System.out.println(\"Hello\");\n"
+                        + "                break;\n"
+                        + "            default:\n"
+                        + "                break;\n"
+                        + "        }\n"
+                        + "    }\n"
+                        + "}\n")), Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Rect.sig",
+                                                       "cache/s1/java/15/classes/test/ColoredPoint.sig",
+                                                       "cache/s1/java/15/classes/test/Point.sig",
+                                                       "cache/s1/java/15/classes/test/Test.sig")), createdFiles);
+    }
+
     public static void noop() {}
 
     @Override


### PR DESCRIPTION
When https://github.com/apache/netbeans/pull/4586 was integrated, the `VanillaCompileWorkerTest` started to fail, as error recovery no longer work properly for pattern matching and JDK 19 javac, when running on JDK <19, as `j.l.MatchException` is missing. The `MatchException` is needed by the generated code, and hence javac cannot generate the code if it is missing. This patch proposes to improve the error recovery for patterns when the class is missing - the code using the patterns would be removed, as would be done if the code would be referring to `MatchException` explicitly.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
