### PR TITLE
Fix for Gradle project sources popup menu invocation error #4755

### DIFF
--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/refactoring/RefactoringActionsProvider.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/refactoring/RefactoringActionsProvider.java
@@ -97,6 +97,7 @@ public class RefactoringActionsProvider extends ActionsImplementationProvider{
         EditorCookie ec = lookup.lookup(EditorCookie.class);
         if (ec != null) {
             Document doc = ec.getDocument();
+            if(doc == null) return ret;
             FileObject file = NbEditorUtilities.getFileObject(doc);
             ret = Antlr3Language.MIME_TYPE.equals(file.getMIMEType())
                     || Antlr4Language.MIME_TYPE.equals(file.getMIMEType());


### PR DESCRIPTION
Check that EditorCookie document may be null and avoid to pass null object to NbEditorUtilities.getFileObject
