### PR TITLE
[NETBEANS-4923]: Problem with Deploy/HotDeploy using Netbeans 12.1 an…

### DIFF
--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentFactory.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentFactory.java
@@ -142,6 +142,7 @@ public class WildflyDeploymentFactory implements DeploymentFactory {
                     String path = name.replace('.', '/').concat(".class"); // NOI18N
                     try (InputStream is = super.getResourceAsStream(path)) {
                         ClassReader cr = new ClassReader(is);
+                        final ClassLoader ld = this;
                         ClassWriter cw = new ClassWriter(cr, ClassWriter.COMPUTE_FRAMES) {
 
                             @Override
@@ -152,6 +153,13 @@ public class WildflyDeploymentFactory implements DeploymentFactory {
                                 }
                                 return super.getCommonSuperClass(string, string1);
                             }
+
+                            @Override
+                            protected ClassLoader getClassLoader() {
+                                return ld;
+                            }
+                            
+                            
                         };
                         ClassNode node = new ClassNode(Opcodes.ASM9);
                         cr.accept(node, 0);


### PR DESCRIPTION
…d Wildfly 18.0.1 for JAVAEE application.

* Fixing classloading issue as the default classloader of ASM ClassWriter didn't have access to WildFly classes.

Jira: https://issues.apache.org/jira/browse/NETBEANS-4923
