### PR TITLE
Improve support for ANTLRv4 Grammars

### DIFF
--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/AccessorImpl.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/AccessorImpl.java
@@ -28,7 +28,9 @@ final class AccessorImpl extends SPIUIAccessor {
 
     @Override
     public void reset(FiltersDescription desc) {
-        desc.reset();
+        if (desc != null) {
+            desc.reset();
+        }
     }
     
 }

--- a/java/languages.antlr/nbproject/project.xml
+++ b/java/languages.antlr/nbproject/project.xml
@@ -26,6 +26,15 @@
             <code-name-base>org.netbeans.modules.languages.antlr</code-name-base>
             <module-dependencies>
                 <dependency>
+                    <code-name-base>org.netbeans.api.annotations.common</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.46</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.core.multiview</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -84,6 +93,15 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>1.26</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.editor.indent</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <specification-version>1.61</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -212,6 +230,20 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
             <public-packages/>
         </data>
     </configuration>

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrDeclarationFinder.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrDeclarationFinder.java
@@ -90,7 +90,7 @@ public class AntlrDeclarationFinder implements DeclarationFinder {
         Reference ref = ((Map<String, Reference>) result.references).get(name);
 
         if(ref != null && ref.defOffset != null) {
-            AntlrStructureItem asi = new AntlrStructureItem.RuleStructureItem(name, fo, ref.defOffset.getStart(), ref.defOffset.getEnd());
+            AntlrStructureItem asi = new AntlrStructureItem.RuleStructureItem(name, false, fo, ref.defOffset.getStart(), ref.defOffset.getEnd());
             DeclarationLocation dln = new DeclarationFinder.DeclarationLocation(fo, ref.defOffset.getStart(), asi);
             if (resultDL == DeclarationLocation.NONE) {
                 resultDL = dln;

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrDeclarationFinder.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrDeclarationFinder.java
@@ -85,11 +85,11 @@ public class AntlrDeclarationFinder implements DeclarationFinder {
         }
         scannedFiles.add(fo);
 
-        AntlrParserResult result = AntlrParser.getParserResult(fo);
+        AntlrParserResult<?> result = AntlrParser.getParserResult(fo);
 
-        Reference ref = ((Map<String, Reference>) result.references).get(name);
+        Reference ref = result.references.get(name);
 
-        if(ref != null && ref.defOffset != null) {
+        if(ref != null && ref.defOffset != OffsetRange.NONE) {
             AntlrStructureItem asi = new AntlrStructureItem.RuleStructureItem(name, false, fo, ref.defOffset.getStart(), ref.defOffset.getEnd());
             DeclarationLocation dln = new DeclarationFinder.DeclarationLocation(fo, ref.defOffset.getStart(), asi);
             if (resultDL == DeclarationLocation.NONE) {

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrOccurrencesFinder.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrOccurrencesFinder.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.languages.antlr;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.api.lexer.TokenHierarchy;
@@ -33,7 +34,7 @@ import org.netbeans.modules.parsing.spi.SchedulerEvent;
  *
  * @author lkishalmi
  */
-public class AntlrOccurancesFinder extends OccurrencesFinder<AntlrParserResult> {
+public class AntlrOccurrencesFinder extends OccurrencesFinder<AntlrParserResult> {
 
     private int caretPosition;
     private boolean cancelled;
@@ -82,7 +83,7 @@ public class AntlrOccurancesFinder extends OccurrencesFinder<AntlrParserResult> 
         return false;
     }
 
-    private void computeOccurrences(AntlrParserResult result) {
+    private void computeOccurrences(AntlrParserResult<?> result) {
         TokenHierarchy<?> tokenHierarchy = result.getSnapshot().getTokenHierarchy();
         TokenSequence<?> ts = tokenHierarchy.tokenSequence();
         ts.move(caretPosition);
@@ -91,15 +92,8 @@ public class AntlrOccurancesFinder extends OccurrencesFinder<AntlrParserResult> 
             Token<?> token = ts.token();
             if (token.id() == AntlrTokenId.RULE || token.id() == AntlrTokenId.TOKEN) {
                 String refName = String.valueOf(token.text());
-                Map<String, AntlrParserResult.Reference> refs = result.references;
-                AntlrParserResult.Reference ref = refs.get(refName);
-                if (ref != null) {
-                    if(ref.defOffset != null) {
-                        occurrences.put(ref.defOffset, ColoringAttributes.MARK_OCCURRENCES);
-                    }
-                    for (OffsetRange occurance : ref.occurances) {
-                        occurrences.put(occurance, ColoringAttributes.MARK_OCCURRENCES);
-                    }
+                for (OffsetRange occurance : result.getOccurrences(refName)) {
+                    occurrences.put(occurance, ColoringAttributes.MARK_OCCURRENCES);
                 }
             }
         }

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParser.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParser.java
@@ -82,8 +82,8 @@ public abstract class AntlrParser extends org.netbeans.modules.parsing.spi.Parse
         }
     }
 
-    public static AntlrParserResult getParserResult(FileObject fo) {
-        AntlrParserResult result = null;
+    public static AntlrParserResult<?> getParserResult(FileObject fo) {
+        AntlrParserResult<?> result = null;
         java.lang.ref.Reference<AntlrParserResult> ceReference;
         synchronized (CACHE) {
             ceReference = CACHE.get(fo);
@@ -94,7 +94,7 @@ public abstract class AntlrParser extends org.netbeans.modules.parsing.spi.Parse
 
         if (result == null) {
             try {
-                AntlrParserResult[] parserResult = new AntlrParserResult[1];
+                AntlrParserResult<?>[] parserResult = new AntlrParserResult<?>[1];
                 ParserManager.parse(Collections.singleton(Source.create(fo)), new UserTask() {
                     @Override
                     public void run(ResultIterator resultIterator) throws Exception {

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParserResult.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParserResult.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.languages.antlr;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -121,16 +120,11 @@ public abstract class AntlrParserResult<T extends Parser> extends ParserResult {
         if (occurrences.containsKey(refName)) {
             ret.addAll(occurrences.get(refName));
         }
-        return !ret.isEmpty() ? ret : Collections.emptyList();
+        return ret;
     } 
     
     protected final void markOccurrence(String refName, OffsetRange or) {
-        List<OffsetRange> ol = occurrences.get(refName);
-        if (ol == null) {
-            ol = new ArrayList<>();
-            occurrences.put(refName, ol);
-        }
-        ol.add(or);
+        occurrences.computeIfAbsent(refName, s -> new ArrayList<>()).add(or);
     }
 
     protected abstract T createParser(Snapshot snapshot);

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParserResult.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParserResult.java
@@ -19,6 +19,9 @@
 package org.netbeans.modules.languages.antlr;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -45,14 +48,20 @@ public abstract class AntlrParserResult<T extends Parser> extends ParserResult {
 
     public final List<DefaultError> errors = new ArrayList<>();
     public final Map<String, Reference> references = new TreeMap<>();
+    public final Map<String, List<OffsetRange>> occurrences = new HashMap<>();
 
     public final List<OffsetRange> folds = new ArrayList<>();
     public final List<AntlrStructureItem> structure = new ArrayList<>();
 
     volatile boolean finished = false;
 
+    public static final Reference EOF = new Reference("EOF", OffsetRange.NONE); //NOI18N
+    
     public AntlrParserResult(Snapshot snapshot) {
         super(snapshot);
+        
+        references.put(EOF.name, EOF);
+        
     }
 
     public AntlrParserResult get() {
@@ -63,12 +72,12 @@ public abstract class AntlrParserResult<T extends Parser> extends ParserResult {
             parser.addParseListener(createFoldListener());
             parser.addParseListener(createReferenceListener());
             parser.addParseListener(createImportListener());
-            parser.addParseListener(createStructureListener());
-            parser.addParseListener(createOccurancesListener());
             evaluateParser(parser);
 
             // Start a second parsing phase for checking;
             parser = createParser(getSnapshot());
+            parser.addParseListener(createStructureListener());
+            parser.addParseListener(createOccurancesListener());
             parser.addParseListener(createCheckReferences());
             evaluateParser(parser);
             finished = true;
@@ -93,19 +102,29 @@ public abstract class AntlrParserResult<T extends Parser> extends ParserResult {
 
     public static class Reference {
         public final String name;
-        public FileObject source;
-        public OffsetRange defOffset;
-        public final List<OffsetRange> occurances = new ArrayList<>();
+        public final OffsetRange defOffset;
 
-        public Reference(String name, FileObject source, OffsetRange defOffset) {
+        public Reference(String name, OffsetRange defOffset) {
             this.name = name;
-            this.source = source;
             this.defOffset = defOffset;
         }
     }
 
     protected final FileObject getFileObject() {
         return getSnapshot().getSource().getFileObject();
+    }
+    
+    public final List<? extends OffsetRange> getOccurrences(String refName) {
+        return occurrences.getOrDefault(refName, Collections.emptyList());
+    } 
+    
+    protected final void markOccurrence(String refName, OffsetRange or) {
+        List<OffsetRange> ol = occurrences.get(refName);
+        if (ol == null) {
+            ol = new ArrayList<>();
+            occurrences.put(refName, ol);
+        }
+        ol.add(or);
     }
 
     protected abstract T createParser(Snapshot snapshot);

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParserResult.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParserResult.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.languages.antlr;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -115,7 +114,14 @@ public abstract class AntlrParserResult<T extends Parser> extends ParserResult {
     }
     
     public final List<? extends OffsetRange> getOccurrences(String refName) {
-        return occurrences.getOrDefault(refName, Collections.emptyList());
+        ArrayList<OffsetRange> ret = new ArrayList<>();
+        if (references.containsKey(refName)) {
+            ret.add(references.get(refName).defOffset);
+        }
+        if (occurrences.containsKey(refName)) {
+            ret.addAll(occurrences.get(refName));
+        }
+        return !ret.isEmpty() ? ret : Collections.emptyList();
     } 
     
     protected final void markOccurrence(String refName, OffsetRange or) {

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrStructureItem.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrStructureItem.java
@@ -148,8 +148,10 @@ public abstract class AntlrStructureItem implements ElementHandle, StructureItem
 
     public static final class RuleStructureItem extends AntlrStructureItem {
 
-        public RuleStructureItem(String name, FileObject source, int startOffset, int stopOffset) {
+        final boolean fragment;
+        public RuleStructureItem(String name, boolean fragment, FileObject source, int startOffset, int stopOffset) {
             super(name, source, startOffset, stopOffset);
+            this.fragment = fragment;
         }
 
         @Override
@@ -164,7 +166,11 @@ public abstract class AntlrStructureItem implements ElementHandle, StructureItem
 
         @Override
         public ElementKind getKind() {
-            return Character.isUpperCase(name.charAt(0)) ? ElementKind.FIELD : ElementKind.RULE;
+            if (fragment) {
+                return ElementKind.CONSTANT;
+            } else {
+                return Character.isUpperCase(name.charAt(0)) ? ElementKind.FIELD : ElementKind.RULE;
+            }
         }
     }
 }

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrStructureScanner.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrStructureScanner.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.languages.antlr;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrStructureScanner.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrStructureScanner.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.languages.antlr;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrTokenSequence.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrTokenSequence.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.languages.antlr;
+
+import java.util.ArrayList;
+import java.util.ListIterator;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.antlr.v4.runtime.Lexer;
+import static org.antlr.v4.runtime.Recognizer.EOF;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenSource;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public final class AntlrTokenSequence {
+
+    private final TokenSource tokens;
+    private boolean eofRead = false;
+    private int readIndex;
+    private int cursorOffset;
+    private ListIterator<Token> cursor;
+    
+    private final ArrayList<Token> tokenList = new ArrayList<>(200);
+
+    public static final Predicate<Token> DEFAULT_CHANNEL = new ChannelFilter(Lexer.DEFAULT_TOKEN_CHANNEL);
+    
+    public static final class ChannelFilter implements Predicate<Token> {
+        private final int channel;
+
+        public ChannelFilter(int channel) {
+            this.channel = channel;
+        }
+
+        @Override
+        public boolean test(Token t) {
+            return channel == t.getChannel();
+        }
+    }
+    
+    public AntlrTokenSequence(TokenSource tokens) {
+        this.tokens = tokens;
+        this.cursor = tokenList.listIterator();
+    }
+    
+    public void seekTo(int offset) {
+        if (offset > readIndex) {
+            if (cursor.hasNext()) {
+                //replace the cursor if it is not at the end of the list.
+                cursor = tokenList.listIterator(tokenList.size());
+            }
+            Token t = read();
+            while ((t != null) && (t.getStopIndex() + 1 < offset)) {
+                t = read();
+            }
+            if (t != null && (offset < t.getStopIndex() + 1)) {
+                cursor.previous();
+                cursorOffset = t.getStartIndex();
+            } else {
+                cursorOffset = readIndex;
+            }
+        } else {
+            if (offset > getOffset()) {
+                next((t) -> t.getStopIndex() > offset);
+                if (cursor.hasPrevious()) {
+                    cursor.previous();
+                }
+                
+            } else {
+                previous((t) -> t.getStartIndex() > offset);
+            }
+        }
+        
+    }
+    
+    public boolean isEmpty() {
+        return tokenList.isEmpty() && !hasNext();
+    }
+    
+    public boolean hasNext() {
+        if (!eofRead && (cursorOffset == readIndex) && !cursor.hasNext()) {
+            Token t = read();
+            if (t != null) {
+                cursor.previous();
+            }
+        }
+        return !(eofRead && !cursor.hasNext());
+    }
+    
+    public boolean hasPrevious() {
+        return cursor.hasPrevious();
+    }
+    
+    public int getOffset() {
+        return cursorOffset;
+    }
+    
+    public Optional<Token> previous() {
+        Optional<Token> ret = cursor.hasPrevious() ? Optional.of(cursor.previous()) : Optional.empty();
+        cursorOffset = cursor.hasPrevious() ? ret.get().getStartIndex() : 0;
+        return ret;
+        
+    }
+    
+    public Optional<Token> previous(Predicate<Token> filter) {
+        Optional<Token> ot = previous();
+        while (ot.isPresent() && !filter.test(ot.get())) {
+            ot = previous();
+        }
+        return ot;
+    }
+    
+    public Optional<Token> previous(int tokenType){
+        return previous((Token t) -> t.getType() == tokenType);
+    }
+    
+    public Optional<Token> next() {
+        if (hasNext()) {
+            Token t = cursor.next();
+            cursorOffset = t.getStopIndex() + 1;
+            return Optional.of(t);
+        } else {
+            return Optional.empty();
+        }
+    }
+    
+    public Optional<Token> next(Predicate<Token> filter) {
+        Optional<Token> ot = next();
+        while (ot.isPresent() && !filter.test(ot.get())) {
+            ot = next();
+        }
+        return ot;
+    }
+    
+    public Optional<Token> next(int tokenType){
+        return next((Token t) -> t.getType() == tokenType);
+    }
+
+    private Token read() {
+        if (eofRead) {
+            return null;
+        }
+        Token t = tokens.nextToken();
+        if (t.getType() != EOF) {
+            cursor.add(t);
+            readIndex = t.getStopIndex() + 1;
+            return t;
+        } else {
+            eofRead = true;
+            return null;
+        }
+    }
+    
+}

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/refactoring/Refactoring.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/refactoring/Refactoring.java
@@ -148,8 +148,8 @@ public class Refactoring {
                         if(ref.defOffset != null) {
                             ranges.add(ref.defOffset);
                         }
-                        ranges.addAll(result.getOccurrences(name));
                     }
+                    ranges.addAll(result.getOccurrences(name));
 
                     for(OffsetRange or : ranges) {
                         PositionBounds bounds;

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/refactoring/Refactoring.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/refactoring/Refactoring.java
@@ -148,7 +148,7 @@ public class Refactoring {
                         if(ref.defOffset != null) {
                             ranges.add(ref.defOffset);
                         }
-                        ranges.addAll(ref.occurances);
+                        ranges.addAll(result.getOccurrences(name));
                     }
 
                     for(OffsetRange or : ranges) {

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3CompletionProvider.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3CompletionProvider.java
@@ -18,9 +18,7 @@
  */
 package org.netbeans.modules.languages.antlr.v3;
 
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.prefs.Preferences;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3Language.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3Language.java
@@ -27,7 +27,7 @@ import org.netbeans.modules.csl.api.StructureScanner;
 import org.netbeans.modules.csl.spi.DefaultLanguageConfig;
 import org.netbeans.modules.csl.spi.LanguageRegistration;
 import org.netbeans.modules.languages.antlr.AntlrDeclarationFinder;
-import org.netbeans.modules.languages.antlr.AntlrOccurancesFinder;
+import org.netbeans.modules.languages.antlr.AntlrOccurrencesFinder;
 import org.netbeans.modules.languages.antlr.AntlrParser;
 import org.netbeans.modules.languages.antlr.AntlrParserResult;
 import org.netbeans.modules.languages.antlr.AntlrStructureScanner;
@@ -172,7 +172,7 @@ public final class Antlr3Language extends DefaultLanguageConfig {
 
     @Override
     public OccurrencesFinder getOccurrencesFinder() {
-        return new AntlrOccurancesFinder();
+        return new AntlrOccurrencesFinder();
     }
 
     @Override

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4CompletionProvider.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4CompletionProvider.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.languages.antlr.v4;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import org.netbeans.modules.languages.antlr.*;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.prefs.Preferences;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.JTextComponent;
+import org.antlr.parser.antlr4.ANTLRv4Lexer;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.Token;
+import org.netbeans.api.editor.document.EditorDocumentUtils;
+import org.netbeans.api.editor.document.LineDocument;
+import org.netbeans.api.editor.document.LineDocumentUtils;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.api.editor.mimelookup.MimePath;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.editor.settings.SimpleValueNames;
+import org.netbeans.spi.editor.completion.CompletionItem;
+import org.netbeans.spi.editor.completion.CompletionProvider;
+import org.netbeans.spi.editor.completion.CompletionResultSet;
+import org.netbeans.spi.editor.completion.CompletionTask;
+import org.netbeans.spi.editor.completion.support.AsyncCompletionQuery;
+import org.netbeans.spi.editor.completion.support.AsyncCompletionTask;
+import org.netbeans.spi.editor.completion.support.CompletionUtilities;
+import org.openide.filesystems.FileObject;
+
+import org.netbeans.api.annotations.common.StaticResource;
+
+import static org.antlr.parser.antlr4.ANTLRv4Lexer.*;
+import static org.netbeans.modules.languages.antlr.AntlrTokenSequence.DEFAULT_CHANNEL;
+
+/**
+ *
+ * @author Laszlo Kishalmi
+ */
+@MimeRegistration(mimeType = Antlr4Language.MIME_TYPE, service = CompletionProvider.class)
+public class Antlr4CompletionProvider implements CompletionProvider {
+
+    @StaticResource
+    private static final String ANTLR_ICON = "org/netbeans/modules/languages/antlr/resources/antlr.png";
+
+    @Override
+    public CompletionTask createTask(int queryType, JTextComponent component) {
+        return new AsyncCompletionTask(new AntlrCompletionQuery(isCaseSensitive()), component);
+    }
+
+    @Override
+    public int getAutoQueryTypes(JTextComponent component, String typedText) {
+        return 0;
+    }
+
+    private static boolean isCaseSensitive() {
+        Preferences prefs = MimeLookup.getLookup(MimePath.EMPTY).lookup(Preferences.class);
+        return prefs.getBoolean(SimpleValueNames.COMPLETION_CASE_SENSITIVE, false);
+    }
+
+    private class AntlrCompletionQuery extends AsyncCompletionQuery {
+
+        final boolean caseSensitive;
+
+        public AntlrCompletionQuery(boolean caseSensitive) {
+            this.caseSensitive = caseSensitive;
+        }
+
+        //TODO: This is a Lexer based pretty dumb implementation. Only offer
+        //      prefix if the cursor is at the end of a start of token/lexer rule.
+        //      Shall be replaced with a better approach.
+        private String getPrefix(Document doc, int caretOffset, boolean upToOffset) throws BadLocationException {
+            LineDocument lineDoc = LineDocumentUtils.asRequired(doc, LineDocument.class);
+            int start = LineDocumentUtils.getWordStart(lineDoc, caretOffset);
+            int end = LineDocumentUtils.getWordEnd(lineDoc, caretOffset);
+            String prefix = doc.getText(start, (upToOffset ? caretOffset : end) - start);
+
+            return (prefix.length() > 0) && !Character.isWhitespace(prefix.codePointAt(prefix.length() - 1)) ? prefix : "";
+        }
+
+        @Override
+        protected void query(CompletionResultSet resultSet, Document doc, int caretOffset) {
+            AbstractDocument adoc = (AbstractDocument) doc;
+            try {
+                FileObject fo = EditorDocumentUtils.getFileObject(doc);
+                if (fo == null) {
+                    return;
+                }
+
+                String prefix = "";
+                adoc.readLock();
+                AntlrTokenSequence tokens;
+                try {
+                    String text = doc.getText(0, doc.getLength());
+                    tokens = new AntlrTokenSequence(new ANTLRv4Lexer(CharStreams.fromString(text)));
+                } catch (BadLocationException ex) {
+                    return;
+                } finally {
+                    adoc.readUnlock();
+                }
+
+                if (!tokens.isEmpty()) {
+
+                    tokens.seekTo(caretOffset);
+                    // Check if we are in a comment (that is filtered out from the token stream)
+
+                    int tokenOffset = tokens.getOffset();
+                    if (tokens.hasNext()) {
+                        Token nt = tokens.next().get();
+                        if (caretOffset > tokenOffset) {
+                            // Caret is in a token
+                            if ((nt.getChannel() == COMMENT) || (nt.getType() == ACTION_CONTENT)) {
+                                // We are in comment or action, no code completion
+                                return;
+                            }
+                            if (nt.getChannel() == DEFAULT_TOKEN_CHANNEL) {
+                                prefix = nt.getText().substring(0, caretOffset - tokenOffset);
+                            }
+                        } else if (nt.getType() == ACTION_CONTENT) {
+                            //We are in action
+                            return;
+                        }
+                        tokens.previous();
+                        lookAround(fo, tokens, caretOffset, prefix, resultSet);
+                    } else {
+                        //Empty grammar so far offer lexer and grammar
+                        addTokens("", caretOffset, resultSet, "lexer", "grammar");
+                    }
+                }
+            } catch (Throwable th) {
+                System.out.println(th);
+            } finally {
+                resultSet.finish();
+            }
+        }
+
+        private void lookAround(FileObject fo, AntlrTokenSequence tokens, int caretOffset, String prefix, CompletionResultSet resultSet) {
+            Optional<Token> opt = tokens.previous(DEFAULT_CHANNEL);
+            if (!opt.isPresent()) {
+                //At the start of the file;
+                Optional<Token> t = tokens.next(DEFAULT_CHANNEL);
+                if (t.isPresent() && t.get().getType() != LEXER) {
+                    addTokens(prefix, caretOffset, resultSet, "lexer");
+                }                
+                if (t.isPresent() && (t.get().getType() != LEXER) && (t.get().getType() != GRAMMAR)) {
+                    addTokens(prefix, caretOffset, resultSet, "grammar");
+                }
+                return;
+            } else {
+                Token pt = opt.get();
+                if (((pt.getType() == RULE_REF) || (pt.getType() == TOKEN_REF)) && (caretOffset == pt.getStopIndex() + 1)) {
+                    // Could be start of some keywords
+                    prefix = pt.getText();
+                    opt = tokens.previous(DEFAULT_CHANNEL);
+                }
+                if (!opt.isPresent()) {
+                    addTokens(prefix, caretOffset, resultSet, "lexer", "grammar");
+                    return;
+                } else {
+                    pt = opt.get();
+                    switch (pt.getType()) {
+                        case LEXER:
+                            Optional<Token> t = tokens.next(DEFAULT_CHANNEL);
+                            if (!t.isPresent() || t.get().getType() != GRAMMAR) {
+                                addTokens(prefix, caretOffset, resultSet, "grammar");
+                            }
+                            return;
+
+                        case SEMI:
+                            //Could be the begining of a new rule def.
+                            addTokens(prefix, caretOffset, resultSet, "mode", "fragment");
+                            return;
+                        case RARROW:
+                            //Command: offer 'channel', 'skip', etc...
+                            addTokens(prefix, caretOffset, resultSet, "skip", "more", "type", "channel", "mode", "pushMode", "popMode");
+                            return;
+                        default:
+                            tokens.seekTo(caretOffset);
+                            Optional<Token> semi = tokens.previous(SEMI);
+                            tokens.seekTo(caretOffset);
+                            Optional<Token> colon = tokens.previous(COLON);
+                            if (semi.isPresent() && colon.isPresent()
+                                    && semi.get().getStartIndex() < colon.get().getStartIndex()) {
+                                // we are in lexer/parser ruledef
+                                
+                                Set<FileObject> scanned = new HashSet<>();
+                                Map<String,AntlrParserResult.Reference> matchingRefs = new HashMap<>();
+                                addReferencesForFile(fo, prefix, matchingRefs, scanned);
+                                
+                                int startOffset = caretOffset - prefix.length();
+                                for (AntlrParserResult.Reference ref : matchingRefs.values()) {
+                                    CompletionItem item = CompletionUtilities.newCompletionItemBuilder(ref.name)
+                                            .startOffset(startOffset)
+                                            .leftHtmlText(ref.name)
+                                            .sortText(ref.name)
+                                            .build();
+                                    resultSet.addItem(item);
+                                    
+                                }
+                            }
+
+                    }
+
+                }
+            }
+
+        }
+
+        public void addTokens(String prefix, int caretOffset, CompletionResultSet resultSet, String... tokens) {
+            String uprefix = caseSensitive ? prefix : prefix.toUpperCase();
+            for (String token : tokens) {
+                String utoken = caseSensitive ? token : token.toUpperCase();
+                if (utoken.startsWith(uprefix)) {
+                    CompletionItem item = CompletionUtilities.newCompletionItemBuilder(token)
+                            .iconResource(ANTLR_ICON)
+                            .startOffset(caretOffset - prefix.length())
+                            .leftHtmlText(token)
+                            .build();
+                    resultSet.addItem(item);
+                }
+            }
+        }
+
+        public void addReferencesForFile(FileObject fo, String prefix, Map<String,AntlrParserResult.Reference> matching, Set<FileObject> scannedFiles) {
+            if (scannedFiles.contains(fo)) {
+                return;
+            }
+            scannedFiles.add(fo);
+
+            String mprefix = caseSensitive ? prefix : prefix.toUpperCase();
+
+            AntlrParserResult<?> result = AntlrParser.getParserResult(fo);
+            Map<String, AntlrParserResult.Reference> refs = result.references;
+            for (String ref : refs.keySet()) {
+                String mref = caseSensitive ? ref : ref.toUpperCase();
+                boolean match = mref.startsWith(mprefix);
+                if (match && !matching.containsKey(ref)) {
+                    matching.put(ref, refs.get(ref));
+                }
+            }
+
+            if (result instanceof Antlr4ParserResult) {
+                for (String s : ((Antlr4ParserResult) result).getImports()) {
+                    FileObject importedFo = fo.getParent().getFileObject(s, "g4");
+                    if (importedFo != null) {
+                        addReferencesForFile(importedFo, prefix, matching, scannedFiles);
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4Language.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4Language.java
@@ -168,7 +168,7 @@ public final class Antlr4Language extends DefaultLanguageConfig {
 
     @Override
     public OccurrencesFinder getOccurrencesFinder() {
-        return new AntlrOccurancesFinder();
+        return new AntlrOccurrencesFinder();
     }
 
     @Override

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4ParserResult.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4ParserResult.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.logging.Logger;
 import org.antlr.parser.antlr4.ANTLRv4Lexer;
 import org.antlr.parser.antlr4.ANTLRv4Parser;
 import org.antlr.parser.antlr4.ANTLRv4ParserBaseListener;
@@ -47,8 +48,10 @@ import org.openide.filesystems.FileObject;
  */
 public final class Antlr4ParserResult extends AntlrParserResult<ANTLRv4Parser> {
 
-    private List<String> imports = new ArrayList<>();
+    private final List<String> imports = new ArrayList<>();
 
+    private static final Logger LOG = Logger.getLogger(Antlr4ParserResult.class.getName());
+    
     public Antlr4ParserResult(Snapshot snapshot) {
         super(snapshot);
     }
@@ -94,12 +97,8 @@ public final class Antlr4ParserResult extends AntlrParserResult<ANTLRv4Parser> {
             public void addReference(Token token) {
                 OffsetRange range = new OffsetRange(token.getStartIndex(), token.getStopIndex() + 1);
                 String name = token.getText();
-                if(references.containsKey(name)) {
-                    references.get(name).defOffset = range;
-                } else {
-                    Reference ref = new Reference(name, getFileObject(), range);
-                    references.put(ref.name, ref);
-                }
+                Reference ref = new Reference(name, range);
+                references.put(ref.name, ref);
             }
 
         };
@@ -118,7 +117,7 @@ public final class Antlr4ParserResult extends AntlrParserResult<ANTLRv4Parser> {
         }
         return new ANTLRv4OccuranceListener((token) -> {
             String name = token.getText();
-            if(!"EOF".equals(name) && (!allRefs.containsKey(name) || (allRefs.get(name).defOffset == null))) {
+            if(!allRefs.containsKey(name)) {
                 errors.add(new DefaultError(null, "Unknown Reference: " + name, null, getFileObject(), token.getStartIndex(), token.getStopIndex() + 1, Severity.ERROR));
             }
         });
@@ -211,17 +210,22 @@ public final class Antlr4ParserResult extends AntlrParserResult<ANTLRv4Parser> {
 
             @Override
             public void exitLexerRuleSpec(ANTLRv4Parser.LexerRuleSpecContext ctx) {
-                if ((ctx.FRAGMENT() == null) && (ctx.TOKEN_REF() != null)) {
+                boolean fragment = ctx.FRAGMENT() == null;
+                if (ctx.TOKEN_REF() != null) {
                     // Do not represent fragments in the structure
-                    AntlrStructureItem.RuleStructureItem rule = new AntlrStructureItem.RuleStructureItem(ctx.TOKEN_REF().getText(), getFileObject(), ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex() + 1);
-                    lexerStructure.add(rule);
+                    AntlrStructureItem.RuleStructureItem rule = new AntlrStructureItem.RuleStructureItem(ctx.TOKEN_REF().getText(), fragment, getFileObject(), ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex() + 1);
+                    if (fragment) {
+                        structure.add(rule);
+                    } else {
+                        lexerStructure.add(rule);
+                    }
                 }
             }
 
             @Override
             public void exitParserRuleSpec(ANTLRv4Parser.ParserRuleSpecContext ctx) {
                 if (ctx.RULE_REF() != null) {
-                    AntlrStructureItem.RuleStructureItem rule = new AntlrStructureItem.RuleStructureItem(ctx.RULE_REF().getText(), getFileObject(), ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex() + 1);
+                    AntlrStructureItem.RuleStructureItem rule = new AntlrStructureItem.RuleStructureItem(ctx.RULE_REF().getText(), false, getFileObject(), ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex() + 1);
                     structure.add(rule);
                 }
             }
@@ -250,12 +254,8 @@ public final class Antlr4ParserResult extends AntlrParserResult<ANTLRv4Parser> {
 
     private void addOccurance(Token token) {
         String refName = token.getText();
-        Reference ref = references.get(refName);
-        if (ref == null) {
-            ref = new Reference(refName, getSnapshot().getSource().getFileObject(), null);
-            references.put(ref.name, ref);
-        }
-       ref.occurances.add(new OffsetRange(token.getStartIndex(), token.getStopIndex() + 1));
+        OffsetRange or = new OffsetRange(token.getStartIndex(), token.getStopIndex() + 1);
+        markOccurrence(refName, or);
     }
 
     @Override

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4ParserResult.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4ParserResult.java
@@ -231,7 +231,7 @@ public final class Antlr4ParserResult extends AntlrParserResult<ANTLRv4Parser> {
 
             @Override
             public void exitLexerRuleSpec(ANTLRv4Parser.LexerRuleSpecContext ctx) {
-                boolean fragment = ctx.FRAGMENT() == null;
+                boolean fragment = ctx.FRAGMENT() != null;
                 if (ctx.TOKEN_REF() != null) {
                     // Do not represent fragments in the structure
                     AntlrStructureItem.RuleStructureItem rule = new AntlrStructureItem.RuleStructureItem(ctx.TOKEN_REF().getText(), fragment, getFileObject(), ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex() + 1);

--- a/java/languages.antlr/test/unit/src/org/netbeans/modules/languages/antlr/AntlrTokenSequenceTest.java
+++ b/java/languages.antlr/test/unit/src/org/netbeans/modules/languages/antlr/AntlrTokenSequenceTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.languages.antlr;
+
+import org.antlr.parser.antlr4.ANTLRv4Lexer;
+import org.antlr.v4.runtime.CharStreams;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.netbeans.modules.languages.antlr.AntlrTokenSequence.DEFAULT_CHANNEL;
+/**
+ *
+ * @author lkishalmi
+ */
+public class AntlrTokenSequenceTest {
+    
+    public AntlrTokenSequenceTest() {
+    }
+    
+    /**
+     * Test of seekTo method, of class AntlrTokenSequence.
+     */
+    @Test
+    public void testSeekTo1() {
+        System.out.println("seekTo");
+        int offset = 0;
+        AntlrTokenSequence instance = sequence("");
+        instance.seekTo(offset);
+        assertTrue(instance.isEmpty());
+    }
+
+    @Test
+    public void testSeekTo2() {
+        System.out.println("seekTo");
+        int offset = 0;
+        AntlrTokenSequence instance = sequence("/**/");
+        instance.seekTo(offset);
+        assertFalse(instance.isEmpty());
+        assertTrue(instance.next().isPresent());
+    }
+
+    @Test
+    public void testSeekTo3() {
+        System.out.println("seekTo");
+        int offset = 4;
+        AntlrTokenSequence instance = sequence("/**/");
+        instance.seekTo(offset);
+        assertFalse(instance.isEmpty());
+        assertFalse(instance.next().isPresent());
+        assertTrue(instance.hasPrevious());
+    }
+
+    @Test
+    public void testSeekTo4() {
+        System.out.println("seekTo");
+        int offset = 5;
+        AntlrTokenSequence instance = sequence("/* */lexer");
+        instance.seekTo(offset);
+        assertFalse(instance.isEmpty());
+        assertTrue(instance.next().isPresent());
+        assertTrue(instance.hasPrevious());
+    }
+
+    @Test
+    public void testSeekTo5() {
+        System.out.println("seekTo");
+        AntlrTokenSequence instance = sequence("/* */lexer");
+        instance.seekTo(10);
+        assertFalse(instance.next().isPresent());
+        instance.seekTo(5);
+        assertFalse(instance.isEmpty());
+        assertTrue(instance.next().isPresent());
+        assertTrue(instance.previous().isPresent());
+        assertFalse(instance.hasPrevious());
+    }
+
+    /**
+     * Test of isEmpty method, of class AntlrTokenSequence.
+     */
+    @Test
+    public void testIsEmpty() {
+        System.out.println("isEmpty");
+        AntlrTokenSequence instance = sequence("");
+        assertTrue(instance.isEmpty());
+    }
+
+    @Test
+    public void testHasNext1() {
+        System.out.println("hasNext");
+        AntlrTokenSequence instance = sequence("lexer");
+        assertTrue(instance.hasNext());
+    }
+
+    @Test
+    public void testHasNext2() {
+        System.out.println("hasNext");
+        AntlrTokenSequence instance = sequence("");
+        assertFalse(instance.hasNext());
+    }
+
+    @Test
+    public void testHasNext3() {
+        System.out.println("hasNext");
+        AntlrTokenSequence instance = sequence("lexer");
+        assertTrue(instance.hasNext());
+        instance.next();
+        assertFalse(instance.hasNext());
+    }
+
+    @Test
+    public void testHasPrevious1() {
+        AntlrTokenSequence instance = sequence("lexer");
+        instance.next();
+        assertTrue(instance.hasPrevious());
+    }
+
+    @Test
+    public void testHasPrevious2() {
+        AntlrTokenSequence instance = sequence("");
+        assertFalse(instance.hasPrevious());
+    }
+
+    @Test
+    public void testGetOffset1() {
+        AntlrTokenSequence instance = sequence("/* */lexer");
+        instance.seekTo(7);
+        assertTrue(instance.hasNext());
+        assertEquals(5, instance.getOffset());
+        instance.previous();
+        assertEquals(0, instance.getOffset());
+    }
+
+    @Test
+    public void testNextPredicate1() {
+        AntlrTokenSequence instance = sequence("/* */lexer grammar");
+        assertTrue(instance.hasNext());
+        instance.next(DEFAULT_CHANNEL).ifPresent((t) -> assertEquals("lexer", t.getText()));
+        instance.next(DEFAULT_CHANNEL).ifPresent((t) -> assertEquals("grammar", t.getText()));
+        assertFalse(instance.hasNext());        
+    }
+
+    @Test
+    public void testPreviousPredicate1() {
+        AntlrTokenSequence instance = sequence("/* */lexer grammar");
+        instance.seekTo(18);
+        assertFalse(instance.hasNext());
+        instance.previous(DEFAULT_CHANNEL).ifPresent((t) -> assertEquals("grammar", t.getText()));
+        instance.previous(DEFAULT_CHANNEL).ifPresent((t) -> assertEquals("lexer", t.getText()));
+        assertTrue(instance.hasPrevious());        
+    }
+
+    private AntlrTokenSequence sequence(String s) {
+        return new AntlrTokenSequence(new ANTLRv4Lexer(CharStreams.fromString(s)));
+    }
+}


### PR DESCRIPTION
This one adds support for occurrence finder for modes and channels.

The code completion has been separated for ANTLVv3 and ANTLRv4. I've added some heuristics to make it better for v4, based on the real ANTLRv4 Lexer. Though there is still room for improvement.

I'd like to finish mu indentation support before NB16, but I thought this is complete enough for review.