### PR TITLE
Another attempt to fix intermittent clipboard bug on Windows

### DIFF
--- a/platform/o.n.bootstrap/src/org/netbeans/NbClipboard.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/NbClipboard.java
@@ -350,6 +350,8 @@ implements LookupListener, FlavorListener, AWTEventListener
         if (ev.getID() == WindowEvent.WINDOW_ACTIVATED) {
             if( Utilities.isWindows() ) {
                 systemClipboard.addFlavorListener(this);
+                // Catch up on any events missed while we were away.
+                fireChange();
             }
             anyWindowIsActivated = true;
             if (System.currentTimeMillis() - lastWindowDeactivated < 100 &&


### PR DESCRIPTION
Attempt to fix an intermittent clipboard bug on Windows, where cut/paste with external applications would stop working until IDE was restarted. With this fix, the problem still occurs occasionally, but appears to go away the next time the user tries to cut/paste with an external application, without the need to restart the IDE.

This is a follow-up on https://github.com/apache/netbeans/pull/4572, with a slightly alternative approach. Instead of removing the removeFlavorListener/addFlavorListener workaround for a previous bug, we instead call fireChange() after the addFlavorChange, in case we missed some updates. This should probably have been done in any case. The effect of either version of the patch seems the same, but the version in this PR avoids sacrificing the workaround for an unrelated old bug (which may or may not still exist).

The patch probably still needs to be tested for a while to confirm that the original bug is really gone, but calling fireChange() after addFlavorChange() seems to be the right thing to do in any case, and it's good to get multiple people to test this on different machines now.