### PR TITLE
Limit ValidateClassFilesTest to scan only JARs referenced from modules

### DIFF
--- a/ide/extexecution.process.jdk9/manifest.mf
+++ b/ide/extexecution.process.jdk9/manifest.mf
@@ -3,5 +3,5 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.extexecution.process.jdk9
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/extexecution/process/jdk9/resources/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.18
-OpenIDE-Module-Java-Dependencies: Java > 1.9.0
+OpenIDE-Module-Java-Dependencies: Java > 9
 OpenIDE-Module-Provides: org.netbeans.spi.extexecution.base.ProcessesImplementation

--- a/platform/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateClassFilesTest.java
+++ b/platform/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateClassFilesTest.java
@@ -78,7 +78,11 @@ public class ValidateClassFilesTest extends NbTestCase {
                 final File file = path.toFile();
                 if (file.getName().endsWith(".jar")) {
 
-                    int classFileVersion = classFileVersions.getOrDefault(file.getName(), 52);
+                    if(! classFileVersions.containsKey(file.getName())) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    int classFileVersion = classFileVersions.get(file.getName());
 
                     JarFile jf = new JarFile(file);
                     Enumeration<JarEntry> en = jf.entries();
@@ -129,7 +133,7 @@ public class ValidateClassFilesTest extends NbTestCase {
                 if (dep.getType() == Dependency.TYPE_JAVA) {
                     String javaVersion = dep.getVersion();
                     if (javaVersion.startsWith("1.")) {
-                        break;
+                        javaVersion = javaVersion.substring(2);
                     }
                     int classFileVersion = Integer.parseInt(javaVersion) + 44;
                     for (File jar : module.getAllJars()) {


### PR DESCRIPTION
With the addition of jakarta ee 10 API jars it was found, that there is an implicit assumption, that all JARs not referenced by modules have to be JDK 8 compatible. In the case of jakarta ee 10 this is an invalid assumption as it explicitly does not support JDK 8. The module that introduces the binaries correctly declares a JDK 11 dependeny, but at runtime the module <-> binary association is lost.

To prevent false positives, the test must be limited to JARs, that are directly referenced from modules.
