### PR TITLE
Fix error in wizard when creating module-info file (GH4628)

### DIFF
--- a/java/java.project.ui/src/org/netbeans/modules/java/project/ui/NewJavaFileWizardIterator.java
+++ b/java/java.project.ui/src/org/netbeans/modules/java/project/ui/NewJavaFileWizardIterator.java
@@ -262,7 +262,7 @@ public class NewJavaFileWizardIterator implements WizardDescriptor.AsynchronousI
         public void run(WorkingCopy copy) throws Exception {
             copy.toPhase(JavaSource.Phase.RESOLVED);
             TreeMaker tm = copy.getTreeMaker();
-            ModuleTree modle = (ModuleTree) copy.getCompilationUnit().getTypeDecls().get(0);
+            ModuleTree modle = copy.getCompilationUnit().getModule();
             ModuleTree newModle = modle;
             for (String mName : mNames) {
                 newModle = tm.addModuleDirective(newModle, tm.Requires(false, false, tm.QualIdent(mName)));

--- a/java/java.project.ui/src/org/netbeans/modules/java/project/ui/NewJavaFileWizardIterator.java
+++ b/java/java.project.ui/src/org/netbeans/modules/java/project/ui/NewJavaFileWizardIterator.java
@@ -231,7 +231,7 @@ public class NewJavaFileWizardIterator implements WizardDescriptor.AsynchronousI
         return res;
     }
     
-    private void addRequires(FileObject createdFile, Set<String> requiredModuleNames) throws IOException {
+    private void addRequires(FileObject createdFile, String createdModuleName, Set<String> requiredModuleNames) throws IOException {
         if (requiredModuleNames == null) {
             requiredModuleNames = new LinkedHashSet<>();
             ClassPath modulePath = ClassPath.getClassPath(createdFile, JavaClassPathConstants.MODULE_COMPILE_PATH);
@@ -241,6 +241,9 @@ public class NewJavaFileWizardIterator implements WizardDescriptor.AsynchronousI
                     requiredModuleNames.add(name);
                 }
             }
+        }
+        if (createdModuleName != null) {
+            requiredModuleNames.remove(createdModuleName);
         }
         if (!requiredModuleNames.isEmpty()) {
             final JavaSource src = JavaSource.forFileObject(createdFile);
@@ -281,6 +284,7 @@ public class NewJavaFileWizardIterator implements WizardDescriptor.AsynchronousI
         FileObject template = Templates.getTemplate( wiz );
         
         FileObject createdFile = null;
+        String createdModuleName = null;
         Set<String> requiredModuleNames = null;
         if (this.type == Type.PACKAGE) {
             targetName = targetName.replace( '.', '/' ); // NOI18N
@@ -324,6 +328,7 @@ public class NewJavaFileWizardIterator implements WizardDescriptor.AsynchronousI
                     targetName,
                     Collections.singletonMap("moduleName", moduleName)); //NOI18N
             createdFile = dobj.getPrimaryFile();
+            createdModuleName = moduleName;
         } else {
             DataObject dTemplate = DataObject.find(template);
             Object superclassProperty = wiz.getProperty(SUPERCLASS);
@@ -353,7 +358,7 @@ public class NewJavaFileWizardIterator implements WizardDescriptor.AsynchronousI
                 })
                 .ifPresent(res::addAll);
         if (this.type == Type.MODULE_INFO) {
-            addRequires(createdFile, requiredModuleNames);
+            addRequires(createdFile, createdModuleName, requiredModuleNames);
         }
         return Collections.unmodifiableSet(res);
     }


### PR DESCRIPTION
Fixes a spurious error message that the file already exists shown when creating a module-info file, as reported in #4628 This is actually an `IndexOutOfBoundsException` caused by [javac changes](https://github.com/openjdk/jdk/commit/d6fb9d7256de94c3cc407b78dde3088aaf649db7) (`ModuleTree` no longer returned from `getTypeDecls()` but available from added `getModule()`).

The second commit filters out the created module name from the list of added requires. This is an older issue that became visible again that shows a cyclic dependency error.