### PR TITLE
Cleanup warnings related to empty statement

### DIFF
--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ConnectorPanel.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ConnectorPanel.java
@@ -201,7 +201,6 @@ public class ConnectorPanel extends JPanel implements ActionListener, HelpCtx.Pr
     @Override
     public void actionPerformed (ActionEvent e) {
         if (doNotListen) return;
-        if (e.getActionCommand ().equals ("SwitchMe!")); // NOI18N
         removeAll ();
         refresh (((JComboBox) e.getSource ()).getSelectedIndex ());
         Component w = getParent ();

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/NFABasedBulkSearch.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/NFABasedBulkSearch.java
@@ -448,7 +448,7 @@ public class NFABasedBulkSearch extends BulkSearch {
                 throw new IllegalStateException(ex);
             }
         }
-        if (cancel.get());
+
         new CollectIdentifiers<Void, Void>(new HashSet<>(), cancel) {
             private boolean encode = true;
             @Override
@@ -511,7 +511,6 @@ public class NFABasedBulkSearch extends BulkSearch {
 
         ctx.setIdentifiers(identifiers);
         ctx.setContent(content);
-        if (cancel.get());
     }
 
     @Override


### PR DESCRIPTION
There are a few warnings related to an empty statement.

   [repeat] /home/bwalker/src/netbeans/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ConnectorPanel.java:204: warning: [empty] empty statement after if
   [repeat]         if (e.getActionCommand ().equals ("SwitchMe!")); // NOI18N
   [repeat]                                                        ^

This change cleans up the code to make the warnings go away.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
