### PR TITLE
enable branch protection for master.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# doc: https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+
 github:
   description: "Apache NetBeans"
   homepage: https://netbeans.apache.org/
@@ -31,6 +33,10 @@ github:
     squash:  true
     merge:   true
     rebase:  true
+  protected_branches:
+    # no force push to master
+    master: {}
+
 notifications:
     commits:      commits@netbeans.apache.org
     issues:       notifications@netbeans.apache.org


### PR DESCRIPTION
should we:
 - ~~enable force push protection for delivery too?~~ [Please don't!](https://github.com/apache/netbeans/pull/4785#issuecomment-1278923154) :)
 - ~~add reviewer requirement for master?~~ [no](https://github.com/apache/netbeans/pull/4785#issuecomment-1278923154)
 - ~~add green CI requirement before merge~~ [rather no](https://github.com/apache/netbeans/pull/4785#issuecomment-1304628234), [no](https://github.com/apache/netbeans/pull/4785#issuecomment-1307075183)
    - This can't lock us out since we use `pull_request` and not `pull_request_target` which means CI uses the workflow file of the PR and not the one of the target branch (master). 
    - There will be always some way to "help" generating a green checkmark. 
    - In the event when CI fails entirely we probably shouldn't merge anything using github until it is resolved
    - push to master will keep working too
 - add force push protection to master

how to test the branch config (see end of file):
```bash
curl -s -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/apache/netbeans/branches/master
```
ASF doc: https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features