### PR TITLE
NBABasedBulkSearch::encode doesn't return on cancel

### DIFF
--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/NFABasedBulkSearch.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/NFABasedBulkSearch.java
@@ -448,7 +448,9 @@ public class NFABasedBulkSearch extends BulkSearch {
                 throw new IllegalStateException(ex);
             }
         }
-        if (cancel.get());
+        if (cancel.get()) {
+            return;
+        }
         new CollectIdentifiers<Void, Void>(new HashSet<>(), cancel) {
             private boolean encode = true;
             @Override
@@ -511,7 +513,6 @@ public class NFABasedBulkSearch extends BulkSearch {
 
         ctx.setIdentifiers(identifiers);
         ctx.setContent(content);
-        if (cancel.get());
     }
 
     @Override


### PR DESCRIPTION
@BradWalker found in #4781 a minor bug where `cancel.get()` was checked but ignored.

The last check is redundant since it is the end of the method.

This might have been a copy and paste bug, since other methods have checks like `if (cancel.get) return null;`. I suppose it was meant to only remove the `null` but leave the `return`