### PR TITLE
More precise code-completion for ANTLRv4 Grammars

### DIFF
--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrDeclarationFinder.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrDeclarationFinder.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.languages.antlr;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.Document;
@@ -49,8 +48,17 @@ public class AntlrDeclarationFinder implements DeclarationFinder {
         ts.moveNext();
         Token<?> token = ts.token();
         String ref = String.valueOf(token.text());
+        FileObject fo = info.getSnapshot().getSource().getFileObject();
         Set<FileObject> scannedFiles = new HashSet<>();
-        return getDeclarationLocation(info.getSnapshot().getSource().getFileObject(), ref, DeclarationLocation.NONE, scannedFiles);
+
+        DeclarationLocation ret = getDeclarationLocation(fo, ref, DeclarationLocation.NONE, scannedFiles);
+        if (ret == DeclarationLocation.NONE) {
+            FileObject rfo = fo.getParent().getFileObject(ref, "g4");
+            if (rfo != null) {
+                ret = new DeclarationFinder.DeclarationLocation(rfo, 0);
+            }
+        }
+        return ret;
     }
 
     @Override

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParserResult.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParserResult.java
@@ -75,14 +75,10 @@ public abstract class AntlrParserResult<T extends Parser> extends ParserResult {
             parser.addParseListener(createFoldListener());
             parser.addParseListener(createReferenceListener());
             parser.addParseListener(createImportListener());
-            evaluateParser(parser);
-
-            // Start a second parsing phase for checking;
-            parser = createParser(getSnapshot());
             parser.addParseListener(createStructureListener());
             parser.addParseListener(createOccurancesListener());
-            parser.addParseListener(createCheckReferences());
             evaluateParser(parser);
+
             finished = true;
         }
         return this;
@@ -150,8 +146,6 @@ public abstract class AntlrParserResult<T extends Parser> extends ParserResult {
     protected abstract ParseTreeListener createFoldListener();
     protected abstract ParseTreeListener createStructureListener();
     protected abstract ParseTreeListener createOccurancesListener();
-
-    protected abstract ParseTreeListener createCheckReferences();
 
     protected ANTLRErrorListener createErrorListener() {
         return new BaseErrorListener() {

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParserResult.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrParserResult.java
@@ -44,6 +44,12 @@ import org.openide.filesystems.FileObject;
  */
 public abstract class AntlrParserResult<T extends Parser> extends ParserResult {
 
+    public enum GrammarType {
+        UNKNOWN, LEXER, PARSER, MIXED, TREE;
+    }
+    
+    protected GrammarType grammarType = GrammarType.UNKNOWN;
+    
     public final List<DefaultError> errors = new ArrayList<>();
     public final Map<String, Reference> references = new TreeMap<>();
     public final Map<String, List<OffsetRange>> occurrences = new HashMap<>();
@@ -53,7 +59,7 @@ public abstract class AntlrParserResult<T extends Parser> extends ParserResult {
 
     volatile boolean finished = false;
 
-    public static final Reference EOF = new Reference("EOF", OffsetRange.NONE); //NOI18N
+    public static final Reference EOF = new Reference(ReferenceType.TOKEN, "EOF", OffsetRange.NONE); //NOI18N
     
     public AntlrParserResult(Snapshot snapshot) {
         super(snapshot);
@@ -97,11 +103,21 @@ public abstract class AntlrParserResult<T extends Parser> extends ParserResult {
         return finished;
     }
 
+    public final GrammarType getGrammarType() {
+        return grammarType;
+    }
+
+    public enum ReferenceType {
+        FRAGMENT, TOKEN, RULE, CHANNEL, MODE
+    }
+    
     public static class Reference {
+        public final ReferenceType type;
         public final String name;
         public final OffsetRange defOffset;
 
-        public Reference(String name, OffsetRange defOffset) {
+        public Reference(ReferenceType type, String name, OffsetRange defOffset) {
+            this.type = type;
             this.name = name;
             this.defOffset = defOffset;
         }

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3ParserResult.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3ParserResult.java
@@ -87,18 +87,6 @@ public final class Antlr3ParserResult extends AntlrParserResult<ANTLRv3Parser> {
     }
 
     @Override
-    protected ParseTreeListener createCheckReferences() {
-        return new ANTLRv3OccuranceListener((token) -> {
-            String name = token.getText();
-            if (!references.containsKey(name)) {
-                //TODO: It seems the ANTLRv3 Grammar Occurance finder could be a bit smarter
-                //Adding the following line could produce false positives.
-                //errors.add(new DefaultError(null, "Unknown Reference: " + name, null, source, token.getStartIndex(), token.getStopIndex() + 1, Severity.ERROR));
-            }
-        });
-    }
-
-    @Override
     protected ParseTreeListener createImportListener() {
         return new ANTLRv3ParserBaseListener();
     }

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3ParserResult.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3ParserResult.java
@@ -65,11 +65,22 @@ public final class Antlr3ParserResult extends AntlrParserResult<ANTLRv3Parser> {
     protected ParseTreeListener createReferenceListener() {
         return new ANTLRv3ParserBaseListener() {
             @Override
+            public void exitGrammarDef(ANTLRv3Parser.GrammarDefContext ctx) {
+                grammarType = GrammarType.MIXED;
+                if (ctx.LEXER() != null)  grammarType = GrammarType.LEXER;
+                if (ctx.PARSER() != null) grammarType = GrammarType.PARSER;
+                if (ctx.TREE() != null)   grammarType = GrammarType.TREE;
+            }
+            
+            @Override
             public void exitRule_(ANTLRv3Parser.Rule_Context ctx) {
                 Token token = ctx.id_().getStart();
                 OffsetRange range = new OffsetRange(token.getStartIndex(), token.getStopIndex() + 1);
                 String name = token.getText();
-                Reference ref = new Reference(name, range);
+                ReferenceType rtype = Character.isUpperCase(name.charAt(0)) ? ReferenceType.TOKEN : ReferenceType.RULE;
+                rtype = ((rtype == ReferenceType.TOKEN) && (ctx.FRAGMENT() != null)) ? ReferenceType.FRAGMENT : rtype;
+                
+                Reference ref = new Reference(rtype, name, range);
                 references.put(ref.name, ref);
             }
         };


### PR DESCRIPTION

Well, just a quick one. Lexer grammars, can only reference fragments inside rules, pure parser grammars cannot reference fragments. Add some heuristic to support lexercommands as well. + icons
