### PR TITLE
Update FlatLaf from 2.5 to 2.6

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-53B5104BDF92CBC7A650E075ED7296DD0AB77CF3 com.formdev:flatlaf:2.5
+4DD2BA228E3C57EB3D80E3927B5A6A33265EB69B com.formdev:flatlaf:2.6

--- a/platform/libs.flatlaf/external/flatlaf-2.6-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-2.6-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 2.5
-Files: flatlaf-2.5.jar
+Version: 2.6
+Files: flatlaf-2.6.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/manifest.mf
+++ b/platform/libs.flatlaf/manifest.mf
@@ -4,4 +4,4 @@ OpenIDE-Module: org.netbeans.libs.flatlaf/1
 OpenIDE-Module-Install: org/netbeans/libs/flatlaf/Installer.class
 OpenIDE-Module-Specification-Version: 1.12
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Implementation-Version: 2.5
+OpenIDE-Module-Implementation-Version: 2.6

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -31,11 +31,11 @@ spec.version.base.fatal.warning=false
 #
 # So when FlatLaf is updated, the OpenIDE-Module-Implementation-Version entry
 # in manifest.mf needs to be updated to match the new FlatLaf version.
-release.external/flatlaf-2.5.jar=modules/ext/flatlaf-2.5.jar
+release.external/flatlaf-2.6.jar=modules/ext/flatlaf-2.6.jar
 
-release.external/flatlaf-2.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
-release.external/flatlaf-2.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
-release.external/flatlaf-2.5.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
+release.external/flatlaf-2.6.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
+release.external/flatlaf-2.6.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
+release.external/flatlaf-2.6.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
 jnlp.verify.excludes=\
     modules/lib/flatlaf-windows-x86.dll,\
     modules/lib/flatlaf-windows-x86_64.dll,\

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -47,8 +47,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-2.5.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-2.5.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-2.6.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-2.6.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/libs.flatlaf/src/org/netbeans/libs/flatlaf/Installer.java
+++ b/platform/libs.flatlaf/src/org/netbeans/libs/flatlaf/Installer.java
@@ -19,8 +19,6 @@
 package org.netbeans.libs.flatlaf;
 
 import com.formdev.flatlaf.FlatSystemProperties;
-import java.io.File;
-import org.openide.modules.InstalledFileLocator;
 import org.openide.modules.ModuleInstall;
 
 public class Installer extends ModuleInstall {
@@ -28,7 +26,6 @@ public class Installer extends ModuleInstall {
     @Override
     public void validate() {
         super.validate();
-        File libDirectory = InstalledFileLocator.getDefault().locate("modules/lib", "org.netbeans.libs.flatlaf", false); //NOI18N
-        System.setProperty( FlatSystemProperties.NATIVE_LIBRARY_PATH, libDirectory.getAbsolutePath() );
+        System.setProperty( FlatSystemProperties.NATIVE_LIBRARY_PATH, "system");
     }
 }


### PR DESCRIPTION
Update FlatLaf to v2.6.

This version now uses `System.loadLibrary()` to load native libs (as suggested [here](https://github.com/apache/netbeans/pull/4696#issuecomment-1264613945)),
always loads `libjawt` (as suggested [here](https://github.com/apache/netbeans/pull/4696#issuecomment-1264336570))
and fixes some minor issues.

Changes: https://github.com/JFormDesigner/FlatLaf/releases/tag/2.6
