### PR TITLE
Update asm from 9.3 to 9.4

### DIFF
--- a/harness/apisupport.harness/build.xml
+++ b/harness/apisupport.harness/build.xml
@@ -39,13 +39,13 @@
                 <pathelement location="${cluster}/tasks.jar"></pathelement>
             </classpath>
         </taskdef>
-        <echo file="build/binaries-list">8E6300EF51C1D801A7ED62D07CD221ACA3A90640 org.ow2.asm:asm:9.3</echo>
+        <echo file="build/binaries-list">B4E0E2D2E023AA317B7CFCFC916377EA348E07D1 org.ow2.asm:asm:9.4</echo>
         <TestDownload>
             <manifest dir="build">
                 <include name="binaries-list"/>
             </manifest>
         </TestDownload>
-        <delete file="build/asm-9.3.jar"/>
+        <delete file="build/asm-9.4.jar"/>
     </target>
 
     <target name="compile-jnlp-launcher" depends="init,compile">

--- a/java/lib.jshell.agent/nbproject/project.properties
+++ b/java/lib.jshell.agent/nbproject/project.properties
@@ -21,5 +21,5 @@ javac.compilerargs=-Xlint -Xlint:-serial
 extra.module.files=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 jnlp.indirect.jars=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 
-agentsrc.asm.cp=${libs.asm.dir}/core/asm-9.3.jar
+agentsrc.asm.cp=${libs.asm.dir}/core/asm-9.4.jar
 agentsrc.jshell.cp=${nb_all}/java/libs.jshell.compile/external/jshell-9.jar

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -82,9 +82,9 @@ extide/gradle/external/gradle-7.4-bin.zip platform/libs.testng/external/jcommand
 extide/gradle/external/gradle-7.4-bin.zip platform/o.apache.commons.io/external/commons-io-2.6.jar
 extide/gradle/external/gradle-7.4-bin.zip enterprise/cloud.oracle/external/jsr305-3.0.2.jar
 extide/gradle/external/gradle-7.4-bin.zip platform/o.apache.commons.codec/external/commons-codec-1.15.jar
-extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-9.3.jar
-extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-commons-9.3.jar
-extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-tree-9.3.jar
+extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-9.4.jar
+extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-commons-9.4.jar
+extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-tree-9.4.jar
 extide/gradle/external/gradle-7.4-bin.zip platform/libs.batik.read/external/xml-apis-1.4.01.jar
 
 # These are the endorsed version of the javaee apis and create libraries, so they are better kept separate

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -79,10 +79,10 @@
         <tstamp>
             <format property="module.build.started.time" pattern="yyyy-MM-dd'T'HH:mm:ss.SSSZ"/>
         </tstamp>
-        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-9.3.jar">
-            <available file="${nbplatform.active.dir}/platform/core/asm-9.3.jar"/>
+        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-9.4.jar">
+            <available file="${nbplatform.active.dir}/platform/core/asm-9.4.jar"/>
         </condition>
-        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-9.3.jar"/>
+        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-9.4.jar"/>
         <property name="tsaurl" value=""/>
         <property name="tsacert" value=""/>
     </target>

--- a/platform/libs.asm/external/asm-9.4-license.txt
+++ b/platform/libs.asm/external/asm-9.4-license.txt
@@ -1,6 +1,6 @@
 Name: OW2 ASM
-Version: 9.3
-Files: asm-tree-9.3.jar asm-commons-9.3.jar asm-9.3.jar
+Version: 9.4
+Files: asm-tree-9.4.jar asm-commons-9.4.jar asm-9.4.jar
 License: BSD-INRIA
 Origin: OW2 Consortium
 URL: https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/

--- a/platform/libs.asm/external/binaries-list
+++ b/platform/libs.asm/external/binaries-list
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-8E6300EF51C1D801A7ED62D07CD221ACA3A90640 org.ow2.asm:asm:9.3
-78D2ECD61318B5A58CD04FB237636C0E86B77D97 org.ow2.asm:asm-tree:9.3
-1F2A432D1212F5C352AE607D7B61DCAE20C20AF5 org.ow2.asm:asm-commons:9.3
+B4E0E2D2E023AA317B7CFCFC916377EA348E07D1 org.ow2.asm:asm:9.4
+A99175A17D7FDC18CBCBD0E8EA6A5D276844190A org.ow2.asm:asm-tree:9.4
+8FC2810DDBCBBEC0A8BBCCB3F8EDA58321839912 org.ow2.asm:asm-commons:9.4

--- a/platform/libs.asm/nbproject/project.properties
+++ b/platform/libs.asm/nbproject/project.properties
@@ -19,7 +19,7 @@ javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 module.jar.dir=core
 
-release.external/asm-9.3.jar=core/asm-9.3.jar
-release.external/asm-tree-9.3.jar=core/asm-tree-9.3.jar
-release.external/asm-commons-9.3.jar=core/asm-commons-9.3.jar
-license.file=../external/asm-9.3-license.txt
+release.external/asm-9.4.jar=core/asm-9.4.jar
+release.external/asm-tree-9.4.jar=core/asm-tree-9.4.jar
+release.external/asm-commons-9.4.jar=core/asm-commons-9.4.jar
+license.file=../external/asm-9.4-license.txt

--- a/platform/libs.asm/nbproject/project.xml
+++ b/platform/libs.asm/nbproject/project.xml
@@ -29,16 +29,16 @@
                 <subpackages>org</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>asm-9.3.jar</runtime-relative-path>
-                <binary-origin>external/asm-9.3.jar</binary-origin>
+                <runtime-relative-path>asm-9.4.jar</runtime-relative-path>
+                <binary-origin>external/asm-9.4.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>asm-tree-9.3.jar</runtime-relative-path>
-                <binary-origin>external/asm-tree-9.3.jar</binary-origin>
+                <runtime-relative-path>asm-tree-9.4.jar</runtime-relative-path>
+                <binary-origin>external/asm-tree-9.4.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>asm-commons-9.3.jar</runtime-relative-path>
-                <binary-origin>external/asm-commons-9.3.jar</binary-origin>
+                <runtime-relative-path>asm-commons-9.4.jar</runtime-relative-path>
+                <binary-origin>external/asm-commons-9.4.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Library Notes:
- JDK 20 support
- more checks in CheckClassAdapter
- Javadoc improvements and fixes
- module-info classes can be built without Gradle and Bnd
- parent POM updated to org.ow2:ow2:1.5.1
- Bug fixes
  - 317977: CheckClassAdapter is no longer transparent for MAXLOCALS
  - 317981: Add public getDelegate method to all visitor classes
  - Analyzer does not compute optimal maxLocals for static methods
  - Fix SignatureWriter when a generic type has a depth over 30
  - Skip remap inner class name if not changed in Remapper

Testing:
- Full build done
- Verify successful execution of libraries and licenses Ant test

[ASM Web Page](https://asm.ow2.io/index.html)
[Release Notes](https://asm.ow2.io/versions.html)