### PR TITLE
Add Jakarta EE/Java EE support for Tomcat and TomEE

### DIFF
--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/AntDeploymentProviderImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/AntDeploymentProviderImpl.java
@@ -49,6 +49,7 @@ public class AntDeploymentProviderImpl implements AntDeploymentProvider {
     public void writeDeploymentScript(OutputStream os, Object moduleType) throws IOException {
         String name = null;
         switch (tm.getTomcatVersion()) {
+            case TOMCAT_110:
             case TOMCAT_101:
             case TOMCAT_100:
             case TOMCAT_90:

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/AntDeploymentProviderImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/AntDeploymentProviderImpl.java
@@ -39,7 +39,7 @@ public class AntDeploymentProviderImpl implements AntDeploymentProvider {
     
     private final TomcatManager tm;
     
-    private static final Logger LOGGER = Logger.getLogger("org.netbeans.modules.tomcat5"); // NOI18N
+    private static final Logger LOGGER = Logger.getLogger(AntDeploymentProviderImpl.class.getName()); // NOI18N
     
     public AntDeploymentProviderImpl(DeploymentManager dm) {
         tm = (TomcatManager)dm;
@@ -49,6 +49,10 @@ public class AntDeploymentProviderImpl implements AntDeploymentProvider {
     public void writeDeploymentScript(OutputStream os, Object moduleType) throws IOException {
         String name = null;
         switch (tm.getTomcatVersion()) {
+            case TOMCAT_101:
+            case TOMCAT_100:
+            case TOMCAT_90:
+            case TOMCAT_80:
             case TOMCAT_70:
                 name = "resources/tomcat-ant-deploy70.xml";
                 break;

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
@@ -21,10 +21,7 @@ package org.netbeans.modules.tomcat5;
 
 import org.netbeans.modules.tomcat5.deploy.TomcatManager;
 import java.io.File;
-import java.io.FileFilter;
-import java.io.FilenameFilter;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -53,10 +50,10 @@ import org.openide.util.NbBundle;
 import org.openide.util.Utilities;
 
 /** 
- * Factory capable to create DeploymentManager that can deploy to Tomcat 5 and 6.
+ * Factory capable to create DeploymentManager that can deploy to Tomcat and TomEE.
  *
  * Tomcat URI has following format:
- * <PRE><CODE>tomcat[55|60]:[home=&lt;home_path&gt;:[base=&lt;base_path&gt;:]]&lt;manager_app_url&gt;</CODE></PRE>
+ * <PRE><CODE>tomcat[90|100]:[home=&lt;home_path&gt;:[base=&lt;base_path&gt;:]]&lt;manager_app_url&gt;</CODE></PRE>
  * for example
  * <PRE><CODE>tomcat:http://localhost:8080/manager/</CODE></PRE>
  * where paths values will be used as CATALINA_HOME and CATALINA_BASE properties and manager_app_url
@@ -73,6 +70,7 @@ public final class TomcatFactory implements DeploymentFactory {
     public static final String SERVER_ID_90 = "Tomcat90";   // NOI18N
     public static final String SERVER_ID_100 = "Tomcat100";   // NOI18N
     public static final String SERVER_ID_101 = "Tomcat101";   // NOI18N
+    public static final String SERVER_ID_110 = "Tomcat110";   // NOI18N
     
     public static final String TOMCAT_URI_PREFIX_50 = "tomcat:";    // NOI18N
     public static final String TOMCAT_URI_PREFIX_55 = "tomcat55:";  // NOI18N
@@ -82,6 +80,7 @@ public final class TomcatFactory implements DeploymentFactory {
     public static final String TOMCAT_URI_PREFIX_90 = "tomcat90:";  // NOI18N
     public static final String TOMCAT_URI_PREFIX_100 = "tomcat100:";  // NOI18N
     public static final String TOMCAT_URI_PREFIX_101 = "tomcat101:";  // NOI18N
+    public static final String TOMCAT_URI_PREFIX_110 = "tomcat110:";  // NOI18N
     
     public static final String TOMCAT_URI_HOME_PREFIX = "home=";    // NOI18N
     public static final String TOMCAT_URI_BASE_PREFIX = ":base=";   // NOI18N
@@ -109,13 +108,14 @@ public final class TomcatFactory implements DeploymentFactory {
     private static final String DISCONNECTED_URI_90 = TOMCAT_URI_PREFIX_90 + "apache-tomcat-9.0.x";   // NOI18N
     private static final String DISCONNECTED_URI_100 = TOMCAT_URI_PREFIX_100 + "apache-tomcat-10.0.x";   // NOI18N
     private static final String DISCONNECTED_URI_101 = TOMCAT_URI_PREFIX_101 + "apache-tomcat-10.1.x";   // NOI18N
+    private static final String DISCONNECTED_URI_110 = TOMCAT_URI_PREFIX_110 + "apache-tomcat-11.0.x";   // NOI18N
     
     private static final Set<String> DISCONNECTED_URIS = new HashSet<>();
     static {
         Collections.addAll(DISCONNECTED_URIS, DISCONNECTED_URI_50,
                 DISCONNECTED_URI_55, DISCONNECTED_URI_60, DISCONNECTED_URI_70,
                 DISCONNECTED_URI_80, DISCONNECTED_URI_90, DISCONNECTED_URI_100,
-                DISCONNECTED_URI_101, GENERIC_DISCONNECTED_URI);
+                DISCONNECTED_URI_101, DISCONNECTED_URI_110, GENERIC_DISCONNECTED_URI);
     }
     
     private static TomcatFactory instance;
@@ -209,11 +209,12 @@ public final class TomcatFactory implements DeploymentFactory {
                 || str.startsWith(TOMCAT_URI_PREFIX_80)
                 || str.startsWith(TOMCAT_URI_PREFIX_90)
                 || str.startsWith(TOMCAT_URI_PREFIX_100)
-                || str.startsWith(TOMCAT_URI_PREFIX_101));
+                || str.startsWith(TOMCAT_URI_PREFIX_101)
+                || str.startsWith(TOMCAT_URI_PREFIX_110));
     }
     
     /** 
-     * Retrieve the tomcat version e.g. '8.5.81'
+     * Retrieve the tomcat version e.g. '9.0.70'
      * 
      * @throws IllegalStateException if the version information cannot be retrieved 
      */
@@ -315,6 +316,8 @@ public final class TomcatFactory implements DeploymentFactory {
             return TomcatVersion.TOMCAT_100;
         } else if (version.startsWith("10.1")) { // NOI18N
             return TomcatVersion.TOMCAT_101;
+        } else if (version.startsWith("11.")) { // NOI18N
+            return TomcatVersion.TOMCAT_110;
         }
         int dotIndex = version.indexOf('.');
         if (dotIndex > 0) {
@@ -332,7 +335,9 @@ public final class TomcatFactory implements DeploymentFactory {
     }
 
     private static TomcatVersion getTomcatVersion(String uri) throws IllegalStateException {
-        if (uri.startsWith(TOMCAT_URI_PREFIX_101)) {
+        if (uri.startsWith(TOMCAT_URI_PREFIX_110)) {
+            return TomcatVersion.TOMCAT_110;
+        } else if (uri.startsWith(TOMCAT_URI_PREFIX_101)) {
             return TomcatVersion.TOMCAT_101;
         } else if (uri.startsWith(TOMCAT_URI_PREFIX_100)) {
             return TomcatVersion.TOMCAT_100;
@@ -469,6 +474,8 @@ public final class TomcatFactory implements DeploymentFactory {
             return uri.substring(GENERIC_DISCONNECTED_URI_PREFIX.length());
         }
         switch (tomcatVersion) {
+            case TOMCAT_110:
+                return uri.substring(TomcatFactory.TOMCAT_URI_PREFIX_110.length());
             case TOMCAT_101:
                 return uri.substring(TomcatFactory.TOMCAT_URI_PREFIX_101.length());
             case TOMCAT_100:

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
@@ -135,6 +135,7 @@ public final class TomcatFactory implements DeploymentFactory {
     public static synchronized TomcatFactory getInstance() {
         if (instance == null) {
             instance = new TomcatFactory();
+            LOGGER.log(Level.INFO, "[{0}] instance= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), instance});
             DeploymentFactoryManager.getInstance().registerDeploymentFactory(instance);
         }
         return instance;
@@ -168,6 +169,7 @@ public final class TomcatFactory implements DeploymentFactory {
             if (tm == null) {
                 try {
                     TomcatVersion version = getTomcatVersion(uri);
+                    LOGGER.log(Level.INFO, "[{0}] version= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), version});
                     tm = new TomcatManager(true, stripUriPrefix(uri, version), version);
                     managerCache.put(ip, tm);
                 } catch (IllegalArgumentException iae) {
@@ -175,6 +177,7 @@ public final class TomcatFactory implements DeploymentFactory {
                     throw (DeploymentManagerCreationException)(t.initCause(iae));
                 }
             }
+            LOGGER.log(Level.INFO, "[{0}] tm= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), tm});
             return tm;
         }
     }
@@ -198,7 +201,7 @@ public final class TomcatFactory implements DeploymentFactory {
     
     /**
      * @param str
-     * @return <CODE>true</CODE> for URIs beggining with <CODE>tomcat[55|60]:</CODE> prefix
+     * @return <CODE>true</CODE> for URIs beggining with <CODE>tomcat[55|110]:</CODE> prefix
      */    
     @Override
     public boolean handlesURI(String str) {
@@ -219,35 +222,44 @@ public final class TomcatFactory implements DeploymentFactory {
      * @throws IllegalStateException if the version information cannot be retrieved 
      */
     public static String getTomcatVersionString(File catalinaHome) throws IllegalStateException {
+        LOGGER.log(Level.INFO, "[{0}] catalinaHome= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), catalinaHome});
         File catalinaJar = new File(catalinaHome, "lib/catalina.jar"); // NOI18N
         File coyoteJar = new File(catalinaHome, "lib/tomcat-coyote.jar"); // NOI18N
+        LOGGER.log(Level.INFO, "[{0}] catalinaJar= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), catalinaJar});
+        LOGGER.log(Level.INFO, "[{0}] coyoteJar= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), coyoteJar});
         if (!catalinaJar.exists()) {
             // For Tomcat 5/5.5
+            LOGGER.log(Level.INFO, "[{0}] Catalina jar for Tomcat 5/5.5", String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()));
             catalinaJar = new File(catalinaHome, "server/lib/catalina.jar"); // NOI18N
             coyoteJar = new File(catalinaHome, "server/lib/tomcat-coyote.jar"); // NOI18N
         }
-
+        LOGGER.log(Level.INFO, "[{0}] Calling getTomcatVersionFallback", String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()));
         try {
             URLClassLoader loader = new URLClassLoader(new URL[] {
                 Utilities.toURI(catalinaJar).toURL(), Utilities.toURI(coyoteJar).toURL() });
-            
+            LOGGER.log(Level.INFO, "[{0}] loader= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), loader});
             Class serverInfo = loader.loadClass("org.apache.catalina.util.ServerInfo"); // NOI18N
             try {
                 Method method = serverInfo.getMethod("getServerNumber", new Class[] {}); // NOI18N
                 String version = (String) method.invoke(serverInfo, new Object[] {});
+                LOGGER.log(Level.INFO, "[{0}] version= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), version});
                 return version;
             } catch (NoSuchMethodException ex) {
                 // try getServerInfo
+                LOGGER.log(Level.INFO, "[{0}] serverInfo.getMethod does not exist", String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()));
             }
 
             Method method = serverInfo.getMethod("getServerInfo", new Class[] {}); // NOI18N
+            LOGGER.log(Level.INFO, "[{0}] method= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), method});
             String version = (String) method.invoke(serverInfo, new Object[] {});
             int idx = version.indexOf('/');
             if (idx > 0) {
+                LOGGER.log(Level.INFO, "[{0}] version= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), version.substring(idx + 1)});
                 return version.substring(idx + 1);
             }
             throw new IllegalStateException("Cannot identify the version of the server."); // NOI18N
         } catch (MalformedURLException | ReflectiveOperationException e) {
+            LOGGER.log(Level.INFO, "[{0}] something went wrong", String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()));
             throw new IllegalStateException(e);
         }
     }
@@ -257,18 +269,23 @@ public final class TomcatFactory implements DeploymentFactory {
         try {
             // TODO we might use fallback as primary check - it might be faster
             // than loading jars and executing code in JVM
+            LOGGER.log(Level.INFO, "[{0}] catalinaHome= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), catalinaHome});
             version = getTomcatVersionString(catalinaHome);
         } catch (IllegalStateException | UnsupportedClassVersionError ex) {
             LOGGER.log(Level.INFO, null, ex);
+            LOGGER.log(Level.INFO, "[{0}] Calling getTomcatVersionFallback", String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()));
             return getTomcatVersionFallback(catalinaHome);
         }
         return getTomcatVersion(version, TomcatVersion.TOMCAT_80);
     }
 
     private static TomcatVersion getTomcatVersionFallback(File catalinaHome) throws IllegalStateException {
+        LOGGER.log(Level.INFO, "[{0}] catalinaHome= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), catalinaHome});
         File lib = new File(catalinaHome, "common" + File.separator + "lib"); // NOI18N
+        LOGGER.log(Level.INFO, "[{0}] lib= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), lib});
         if (lib.isDirectory()) {
             // 5 or 5.5
+            LOGGER.log(Level.INFO, "[{0}] lib.isDirectory()", String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()));
             File tasks = new File(catalinaHome, "bin" + File.separator + "catalina-tasks.xml"); // NOI18N
             if (tasks.isFile()) {
                 // 5.5
@@ -277,7 +294,9 @@ public final class TomcatFactory implements DeploymentFactory {
             return TomcatVersion.TOMCAT_50;
         } else {
             // 6 or 7 or 8
+            LOGGER.log(Level.INFO, "[{0}] at least Tomcat 6", String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()));
             File bootstrapJar = new File(catalinaHome, "bin" + File.separator + "bootstrap.jar"); // NOI18N
+            LOGGER.log(Level.INFO, "[{0}] bootstrapJar= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), bootstrapJar});
             if (!bootstrapJar.exists()) {
                 return null;
             }
@@ -287,8 +306,10 @@ public final class TomcatFactory implements DeploymentFactory {
                 if (manifest != null) {
                     specificationVersion = manifest.getMainAttributes()
                             .getValue("Specification-Version"); // NOI18N
+                    LOGGER.log(Level.INFO, "[{0}] manifest= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), manifest});
                 }
                 if (specificationVersion != null) { // NOI18N
+                    LOGGER.log(Level.INFO, "[{0}] specificationVersion= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), specificationVersion});
                     specificationVersion = specificationVersion.trim();
                     return getTomcatVersion(specificationVersion, TomcatVersion.TOMCAT_55);
                 }
@@ -300,6 +321,8 @@ public final class TomcatFactory implements DeploymentFactory {
     }
 
     private static TomcatVersion getTomcatVersion(String version, TomcatVersion defaultVersion) throws IllegalStateException {
+        LOGGER.log(Level.INFO, "[{0}] version= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), version});
+        LOGGER.log(Level.INFO, "[{0}] defaultVersion= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), defaultVersion});
         if (version.startsWith("5.0.")) { // NOI18N
             return TomcatVersion.TOMCAT_50;
         } else if (version.startsWith("5.5.")) { // NOI18N
@@ -323,6 +346,7 @@ public final class TomcatFactory implements DeploymentFactory {
         if (dotIndex > 0) {
             try {
                 int major = Integer.parseInt(version.substring(0, dotIndex));
+                LOGGER.log(Level.INFO, "[{0}] major= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), major});
                 // forward compatibility - handle any newer tomcat as Tomcat 9
                 if (major > 9) {
                     return TomcatVersion.TOMCAT_90;
@@ -335,6 +359,7 @@ public final class TomcatFactory implements DeploymentFactory {
     }
 
     private static TomcatVersion getTomcatVersion(String uri) throws IllegalStateException {
+        LOGGER.log(Level.INFO, "[{0}] uri= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), uri});
         if (uri.startsWith(TOMCAT_URI_PREFIX_110)) {
             return TomcatVersion.TOMCAT_110;
         } else if (uri.startsWith(TOMCAT_URI_PREFIX_101)) {

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
@@ -70,6 +70,8 @@ public final class TomcatFactory implements DeploymentFactory {
     public static final String SERVER_ID_70 = "Tomcat70";   // NOI18N
     public static final String SERVER_ID_80 = "Tomcat80";   // NOI18N
     public static final String SERVER_ID_90 = "Tomcat90";   // NOI18N
+    public static final String SERVER_ID_100 = "Tomcat100";   // NOI18N
+    public static final String SERVER_ID_101 = "Tomcat101";   // NOI18N
     
     public static final String TOMCAT_URI_PREFIX_50 = "tomcat:";    // NOI18N
     public static final String TOMCAT_URI_PREFIX_55 = "tomcat55:";  // NOI18N
@@ -77,16 +79,24 @@ public final class TomcatFactory implements DeploymentFactory {
     public static final String TOMCAT_URI_PREFIX_70 = "tomcat70:";  // NOI18N
     public static final String TOMCAT_URI_PREFIX_80 = "tomcat80:";  // NOI18N
     public static final String TOMCAT_URI_PREFIX_90 = "tomcat90:";  // NOI18N
+    public static final String TOMCAT_URI_PREFIX_100 = "tomcat100:";  // NOI18N
+    public static final String TOMCAT_URI_PREFIX_101 = "tomcat101:";  // NOI18N
     
     public static final String TOMCAT_URI_HOME_PREFIX = "home=";    // NOI18N
     public static final String TOMCAT_URI_BASE_PREFIX = ":base=";   // NOI18N
 
     private static final Pattern TOMEE_JAR_PATTERN = Pattern.compile("tomee-common-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
-
-    private static final Pattern TOMEE_JAXRS_JAR_PATTERN = Pattern.compile("tomee-jaxrs-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
-
-    private static final Pattern TOMEE_GERONIMO_JAR_PATTERN = Pattern.compile("geronimo-connector-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
-
+    
+    private static final Pattern TOMEE_WEBPROFILE_JAR_PATTERN = Pattern.compile("openejb-api-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+    
+    private static final Pattern TOMEE_JAXRS_JAR_PATTERN = Pattern.compile("jettison-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+    
+    private static final Pattern TOMEE_MICROPROFILE_JAR_PATTERN = Pattern.compile("microprofile-config-api-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+    
+    private static final Pattern TOMEE_PLUS_JAR_PATTERN = Pattern.compile("activemq-protobuf-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+    
+    private static final Pattern TOMEE_PLUME_JAR_PATTERN = Pattern.compile("eclipselink-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+    
     private static final String GENERIC_DISCONNECTED_URI_PREFIX = "tomcat-any:"; // NOI18N
     private static final String GENERIC_DISCONNECTED_URI =
             GENERIC_DISCONNECTED_URI_PREFIX + "jakarta-tomcat-generic"; // NOI18N
@@ -96,19 +106,22 @@ public final class TomcatFactory implements DeploymentFactory {
     private static final String DISCONNECTED_URI_70 = TOMCAT_URI_PREFIX_70 + "apache-tomcat-7.0.x";   // NOI18N
     private static final String DISCONNECTED_URI_80 = TOMCAT_URI_PREFIX_80 + "apache-tomcat-8.0.x";   // NOI18N
     private static final String DISCONNECTED_URI_90 = TOMCAT_URI_PREFIX_90 + "apache-tomcat-9.0.x";   // NOI18N
+    private static final String DISCONNECTED_URI_100 = TOMCAT_URI_PREFIX_100 + "apache-tomcat-10.0.x";   // NOI18N
+    private static final String DISCONNECTED_URI_101 = TOMCAT_URI_PREFIX_101 + "apache-tomcat-10.1.x";   // NOI18N
     
     private static final Set<String> DISCONNECTED_URIS = new HashSet<>();
     static {
         Collections.addAll(DISCONNECTED_URIS, DISCONNECTED_URI_50,
                 DISCONNECTED_URI_55, DISCONNECTED_URI_60, DISCONNECTED_URI_70,
-                DISCONNECTED_URI_80, DISCONNECTED_URI_90, GENERIC_DISCONNECTED_URI);
+                DISCONNECTED_URI_80, DISCONNECTED_URI_90, DISCONNECTED_URI_100,
+                DISCONNECTED_URI_101, GENERIC_DISCONNECTED_URI);
     }
     
     private static TomcatFactory instance;
     
     private static final WeakHashMap managerCache = new WeakHashMap();
     
-    private static final Logger LOGGER = Logger.getLogger("org.netbeans.modules.tomcat5");  // NOI18N
+    private static final Logger LOGGER = Logger.getLogger(TomcatFactory.class.getName());  // NOI18N
     
     private TomcatFactory() {
         super();
@@ -193,11 +206,13 @@ public final class TomcatFactory implements DeploymentFactory {
                 || str.startsWith(TOMCAT_URI_PREFIX_60)
                 || str.startsWith(TOMCAT_URI_PREFIX_70)
                 || str.startsWith(TOMCAT_URI_PREFIX_80)
-                || str.startsWith(TOMCAT_URI_PREFIX_90));
+                || str.startsWith(TOMCAT_URI_PREFIX_90)
+                || str.startsWith(TOMCAT_URI_PREFIX_100)
+                || str.startsWith(TOMCAT_URI_PREFIX_101));
     }
     
     /** 
-     * Retrieve the tomcat version e.g. '6.0.10'
+     * Retrieve the tomcat version e.g. '8.5.81'
      * 
      * @throws IllegalStateException if the version information cannot be retrieved 
      */
@@ -242,7 +257,7 @@ public final class TomcatFactory implements DeploymentFactory {
             LOGGER.log(Level.INFO, null, ex);
             return getTomcatVersionFallback(catalinaHome);
         }
-        return getTomcatVersion(version, TomcatVersion.TOMCAT_50);
+        return getTomcatVersion(version, TomcatVersion.TOMCAT_80);
     }
 
     private static TomcatVersion getTomcatVersionFallback(File catalinaHome) throws IllegalStateException {
@@ -290,6 +305,10 @@ public final class TomcatFactory implements DeploymentFactory {
             return TomcatVersion.TOMCAT_80;
         } else if (version.startsWith("9.")) { // NOI18N
             return TomcatVersion.TOMCAT_90;
+        } else if (version.startsWith("10.0")) { // NOI18N
+            return TomcatVersion.TOMCAT_100;
+        } else if (version.startsWith("10.1")) { // NOI18N
+            return TomcatVersion.TOMCAT_101;
         }
         int dotIndex = version.indexOf('.');
         if (dotIndex > 0) {
@@ -307,7 +326,11 @@ public final class TomcatFactory implements DeploymentFactory {
     }
 
     private static TomcatVersion getTomcatVersion(String uri) throws IllegalStateException {
-        if (uri.startsWith(TOMCAT_URI_PREFIX_90)) {
+        if (uri.startsWith(TOMCAT_URI_PREFIX_101)) {
+            return TomcatVersion.TOMCAT_101;
+        } else if (uri.startsWith(TOMCAT_URI_PREFIX_100)) {
+            return TomcatVersion.TOMCAT_100;
+        } else if (uri.startsWith(TOMCAT_URI_PREFIX_90)) {
             return TomcatVersion.TOMCAT_90;
         } else if (uri.startsWith(TOMCAT_URI_PREFIX_80)) {
             return TomcatVersion.TOMCAT_80;
@@ -336,16 +359,28 @@ public final class TomcatFactory implements DeploymentFactory {
     @NonNull
     public static TomEEType getTomEEType(@NonNull File libFolder) {
         File[] children = libFolder.listFiles();
-        TomEEType type = TomEEType.TOMEE_WEB;
+        TomEEType type = TomEEType.TOMEE_OPENEJB;
         if (children != null) {
             for (File file : children) {
-                if (TOMEE_JAXRS_JAR_PATTERN.matcher(file.getName()).matches()) {
-                    if (type.ordinal() < TomEEType.TOMEE_JAXRS.ordinal()) {
+                if (TOMEE_PLUME_JAR_PATTERN.matcher(file.getName()).matches()) {
+                    if(type.ordinal() < TomEEType.TOMEE_PLUME.ordinal()) {
+                        return TomEEType.TOMEE_PLUME;
+                    }
+                } else if (TOMEE_PLUS_JAR_PATTERN.matcher(file.getName()).matches()) {
+                    if(type.ordinal() < TomEEType.TOMEE_PLUS.ordinal()) {
+                        type = TomEEType.TOMEE_PLUS;
+                    }
+                } else if (TOMEE_MICROPROFILE_JAR_PATTERN.matcher(file.getName()).matches()) {
+                    if(type.ordinal() < TomEEType.TOMEE_MICROPROFILE.ordinal()) {
+                        type = TomEEType.TOMEE_MICROPROFILE;
+                    }
+                } else if (TOMEE_JAXRS_JAR_PATTERN.matcher(file.getName()).matches()) {
+                    if(type.ordinal() < TomEEType.TOMEE_JAXRS.ordinal()) {
                         type = TomEEType.TOMEE_JAXRS;
                     }
-                } else if (TOMEE_GERONIMO_JAR_PATTERN.matcher(file.getName()).matches()) {
-                    if (type.ordinal() < TomEEType.TOMEE_PLUS.ordinal()) {
-                        type = TomEEType.TOMEE_PLUS;
+                } else if (TOMEE_JAR_PATTERN.matcher(file.getName()).matches()) {
+                    if(type.ordinal() < TomEEType.TOMEE_WEBPROFILE.ordinal()) {
+                        type = TomEEType.TOMEE_WEBPROFILE;
                     }
                 }
             }
@@ -411,6 +446,14 @@ public final class TomcatFactory implements DeploymentFactory {
             return TomcatManager.TomEEVersion.TOMEE_16;
         } else if (version.startsWith("1.7.")) { // NOI18N
             return TomcatManager.TomEEVersion.TOMEE_17;
+        } else if (version.startsWith("7.")) { // NOI18N
+            return TomcatManager.TomEEVersion.TOMEE_70;
+        } else if (version.startsWith("7.1.")) { // NOI18N
+            return TomcatManager.TomEEVersion.TOMEE_71;
+        } else if (version.startsWith("8.")) { // NOI18N
+            return TomcatManager.TomEEVersion.TOMEE_80;
+        } else if (version.startsWith("9.")) { // NOI18N
+            return TomcatManager.TomEEVersion.TOMEE_90;
         }
         return defaultVersion;
     }
@@ -420,6 +463,10 @@ public final class TomcatFactory implements DeploymentFactory {
             return uri.substring(GENERIC_DISCONNECTED_URI_PREFIX.length());
         }
         switch (tomcatVersion) {
+            case TOMCAT_101:
+                return uri.substring(TomcatFactory.TOMCAT_URI_PREFIX_101.length());
+            case TOMCAT_100:
+                return uri.substring(TomcatFactory.TOMCAT_URI_PREFIX_100.length());
             case TOMCAT_90:
                 return uri.substring(TomcatFactory.TOMCAT_URI_PREFIX_90.length());
             case TOMCAT_80:

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
@@ -86,17 +86,17 @@ public final class TomcatFactory implements DeploymentFactory {
     public static final String TOMCAT_URI_HOME_PREFIX = "home=";    // NOI18N
     public static final String TOMCAT_URI_BASE_PREFIX = ":base=";   // NOI18N
 
-    private static final Pattern TOMEE_JAR_PATTERN = Pattern.compile("tomee-common-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+    static final Pattern TOMEE_JAR_PATTERN = Pattern.compile("tomee-common-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
     
-    private static final Pattern TOMEE_WEBPROFILE_JAR_PATTERN = Pattern.compile("openejb-api-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+    static final Pattern TOMEE_WEBPROFILE_JAR_PATTERN = Pattern.compile("openejb-api-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
     
-    private static final Pattern TOMEE_JAXRS_JAR_PATTERN = Pattern.compile("jettison-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+    static final Pattern TOMEE_JAXRS_JAR_PATTERN = Pattern.compile("jettison-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
     
-    private static final Pattern TOMEE_MICROPROFILE_JAR_PATTERN = Pattern.compile("microprofile-config-api-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+    static final Pattern TOMEE_MICROPROFILE_JAR_PATTERN = Pattern.compile("microprofile-config-api-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
     
-    private static final Pattern TOMEE_PLUS_JAR_PATTERN = Pattern.compile("activemq-protobuf-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+    static final Pattern TOMEE_PLUS_JAR_PATTERN = Pattern.compile("activemq-protobuf-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
     
-    private static final Pattern TOMEE_PLUME_JAR_PATTERN = Pattern.compile("eclipselink-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+    static final Pattern TOMEE_PLUME_JAR_PATTERN = Pattern.compile("eclipselink-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
     
     private static final String GENERIC_DISCONNECTED_URI_PREFIX = "tomcat-any:"; // NOI18N
     private static final String GENERIC_DISCONNECTED_URI =

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
@@ -50,6 +50,7 @@ import org.netbeans.modules.tomcat5.deploy.TomcatManager.TomEEType;
 import org.netbeans.modules.tomcat5.deploy.TomcatManager.TomEEVersion;
 import org.netbeans.modules.tomcat5.deploy.TomcatManager.TomcatVersion;
 import org.openide.util.NbBundle;
+import org.openide.util.Utilities;
 
 /** 
  * Factory capable to create DeploymentManager that can deploy to Tomcat 5 and 6.
@@ -218,14 +219,17 @@ public final class TomcatFactory implements DeploymentFactory {
      */
     public static String getTomcatVersionString(File catalinaHome) throws IllegalStateException {
         File catalinaJar = new File(catalinaHome, "lib/catalina.jar"); // NOI18N
-        if (!catalinaJar.exists()) {
-            catalinaJar = new File(catalinaHome, "server/lib/catalina.jar"); // NOI18N
-        }
         File coyoteJar = new File(catalinaHome, "lib/tomcat-coyote.jar"); // NOI18N
+        if (!catalinaJar.exists()) {
+            // For Tomcat 5/5.5
+            catalinaJar = new File(catalinaHome, "server/lib/catalina.jar"); // NOI18N
+            coyoteJar = new File(catalinaHome, "server/lib/tomcat-coyote.jar"); // NOI18N
+        }
 
         try {
             URLClassLoader loader = new URLClassLoader(new URL[] {
-                catalinaJar.toURI().toURL(), coyoteJar.toURI().toURL() });
+                Utilities.toURI(catalinaJar).toURL(), Utilities.toURI(coyoteJar).toURL() });
+            
             Class serverInfo = loader.loadClass("org.apache.catalina.util.ServerInfo"); // NOI18N
             try {
                 Method method = serverInfo.getMethod("getServerNumber", new Class[] {}); // NOI18N
@@ -295,7 +299,9 @@ public final class TomcatFactory implements DeploymentFactory {
     }
 
     private static TomcatVersion getTomcatVersion(String version, TomcatVersion defaultVersion) throws IllegalStateException {
-        if (version.startsWith("5.5.")) { // NOI18N
+        if (version.startsWith("5.0.")) { // NOI18N
+            return TomcatVersion.TOMCAT_50;
+        } else if (version.startsWith("5.5.")) { // NOI18N
             return TomcatVersion.TOMCAT_55;
         } else if (version.startsWith("6.")) { // NOI18N
             return TomcatVersion.TOMCAT_60;

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/config/TomcatModuleConfiguration.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/config/TomcatModuleConfiguration.java
@@ -91,7 +91,7 @@ public class TomcatModuleConfiguration implements ModuleConfiguration, ContextRo
     
     private static final String ATTR_PATH = "path"; // NOI18N
     
-    private static final Logger LOGGER = Logger.getLogger("org.netbeans.modules.tomcat5"); // NOI18N
+    private static final Logger LOGGER = Logger.getLogger(TomcatModuleConfiguration.class.getName()); // NOI18N
     
     /** Creates a new instance of TomcatModuleConfiguration */
     public TomcatModuleConfiguration(J2eeModule j2eeModule, TomcatVersion tomcatVersion, TomEEVersion tomeeVersion) {
@@ -224,7 +224,7 @@ public class TomcatModuleConfiguration implements ModuleConfiguration, ContextRo
         Context context = getContext();
         Set<Datasource> result = new HashSet<>();
         int length = context.getResource().length;
-        if (tomcatVersion != TomcatVersion.TOMCAT_50) {
+        if (tomcatVersion.isAtLeast(TomcatVersion.TOMCAT_55)) {
             // Tomcat 5.5.x or Tomcat 6.0.x
             for (int i = 0; i < length; i++) {
                 String type = context.getResourceType(i);
@@ -292,7 +292,7 @@ public class TomcatModuleConfiguration implements ModuleConfiguration, ContextRo
         if (conflictingDS.size() > 0) {
             throw new DatasourceAlreadyExistsException(conflictingDS);
         }
-        if (tomcatVersion != TomcatVersion.TOMCAT_50) {
+        if (tomcatVersion.isAtLeast(TomcatVersion.TOMCAT_55)) {
             if (tomeeVersion != null) {
                 // we need to store it to resources.xml
                 TomeeResources resources = getResources(true);

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/customizer/CustomizerDataSupport.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/customizer/CustomizerDataSupport.java
@@ -402,8 +402,11 @@ public class CustomizerDataSupport {
         if (platformAdapters.isEmpty()) {
             jvmModel.setSelectedItem(null);
             return;
+        } else {
+            for (JavaPlatformAdapter platformAdapter : platformAdapters) {
+                jvmModel.addElement(platformAdapter);
+            }
         }
-        jvmModel.addAll(platformAdapters);
         
         // try to set selected item
         for (JavaPlatformAdapter j2sePlatform : platformAdapters) {

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/customizer/CustomizerDataSupport.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/customizer/CustomizerDataSupport.java
@@ -21,7 +21,9 @@ package org.netbeans.modules.tomcat5.customizer;
 
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
-import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.logging.Level;
 import javax.swing.ButtonGroup;
 import javax.swing.ButtonModel;
 import javax.swing.DefaultComboBoxModel;
@@ -39,6 +41,7 @@ import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.api.java.platform.JavaPlatformManager;
 import org.netbeans.api.java.platform.Specification;
 import org.netbeans.modules.tomcat5.deploy.TomcatManager;
+import org.netbeans.modules.tomcat5.j2ee.TomcatPlatformImpl;
 import org.netbeans.modules.tomcat5.util.TomcatProperties;
 import org.openide.util.Exceptions;
 
@@ -372,32 +375,51 @@ public class CustomizerDataSupport {
     public void loadJvmModel() {
         JavaPlatformManager jpm = JavaPlatformManager.getDefault();
         JavaPlatformAdapter curJvm = (JavaPlatformAdapter)jvmModel.getSelectedItem();
-        String curPlatformName = null;
+        final String curPlatformName;
         if (curJvm != null) {
             curPlatformName = curJvm.getName();
         } else {
             curPlatformName = (String)tp.getJavaPlatform().getProperties().get(TomcatProperties.PLAT_PROP_ANT_NAME);
         }
-
         jvmModel.removeAllElements();
         
-        // feed the combo with sorted platform list
+        // Supported jvm platforms for this version of Tomcat or TomEE
+        TomcatPlatformImpl tomcatPlatformImpl = new TomcatPlatformImpl(tm);
+        Set<String> tomcatPlatforms = tomcatPlatformImpl.getSupportedJavaPlatformVersions();
+        
+        // jvm platforms registered in NetBeans
         JavaPlatform[] j2sePlatforms = jpm.getPlatforms(null, new Specification("J2SE", null)); // NOI18N
-        JavaPlatformAdapter[] platformAdapters = new JavaPlatformAdapter[j2sePlatforms.length];
-        for (int i = 0; i < platformAdapters.length; i++) {
-            platformAdapters[i] = new JavaPlatformAdapter(j2sePlatforms[i]);
+        
+        Set<JavaPlatformAdapter> platformAdapters = new TreeSet<>();
+        
+        // Only add the jvm platforms that are supported from the registered set
+        for (JavaPlatform jp : j2sePlatforms) {
+            if (tomcatPlatforms.contains(jp.getSpecification().getVersion().toString())) {
+                platformAdapters.add(new JavaPlatformAdapter(jp));
+            }
         }
-        Arrays.sort(platformAdapters);
-        for (int i = 0; i < platformAdapters.length; i++) {
-            JavaPlatformAdapter platformAdapter = platformAdapters[i];
-            jvmModel.addElement(platformAdapter);
-            // try to set selected item
+        
+        if (platformAdapters.isEmpty()) {
+            jvmModel.setSelectedItem(null);
+            return;
+        }
+        jvmModel.addAll(platformAdapters);
+        
+        // try to set selected item
+        for (JavaPlatformAdapter j2sePlatform : platformAdapters) {
             if (curPlatformName != null) {
-                if (curPlatformName.equals(platformAdapter.getName())) {
-                    jvmModel.setSelectedItem(platformAdapter);
+                if (curPlatformName.equals(j2sePlatform.getName())) {
+                    jvmModel.setSelectedItem(j2sePlatform);
+                    // if we do not change the flag the jvm will not change
+                    jvmModelFlag = true;
+                    break;
+                } else {
+                    jvmModel.setSelectedItem(j2sePlatform);
+                    jvmModelFlag = true;
                 }
-            }   
+            } 
         }
+   
     }
     
     // model getters ----------------------------------------------------------

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/customizer/CustomizerGeneral.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/customizer/CustomizerGeneral.java
@@ -25,7 +25,6 @@ import javax.swing.JTextField;
 import javax.swing.JSpinner;
 import javax.accessibility.AccessibleContext;
 import java.awt.Font;
-import org.netbeans.modules.tomcat5.deploy.TomcatManager.TomcatVersion;
 
 /**
  * Customizer general (connection) tab.

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
@@ -456,6 +456,11 @@ public class TomcatManager implements DeploymentManager {
         loadTomEEInfo();
         return tomEEVersion;
     }
+    
+    public synchronized TomEEType getTomEEType() {
+        loadTomEEInfo();
+        return tomEEType;
+    }
 
     public void loadTomEEInfo() {
         boolean fireListener = false;

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
@@ -73,7 +73,8 @@ public class TomcatManager implements DeploymentManager {
 
     public enum TomcatVersion {
         TOMCAT_50(50), TOMCAT_55(55), TOMCAT_60(60), TOMCAT_70(70), 
-        TOMCAT_80(80), TOMCAT_90(90), TOMCAT_100(100), TOMCAT_101(101);
+        TOMCAT_80(80), TOMCAT_90(90), TOMCAT_100(100), TOMCAT_101(101),
+        TOMCAT_110(110);
         
         TomcatVersion(int version) { this.version = version; }
         private final int version;
@@ -259,6 +260,8 @@ public class TomcatManager implements DeploymentManager {
      */
     public String getUri () {
         switch (tomcatVersion) {
+            case TOMCAT_110:
+                return TomcatFactory.TOMCAT_URI_PREFIX_110 + uri;
             case TOMCAT_101:
                 return TomcatFactory.TOMCAT_URI_PREFIX_101 + uri;
             case TOMCAT_100:
@@ -440,6 +443,10 @@ public class TomcatManager implements DeploymentManager {
    
     public boolean isAboveTomcat70() {
         return tomcatVersion .isAtLeast(TomcatVersion.TOMCAT_70);
+    }
+    
+    public boolean isTomcat110() {
+        return tomcatVersion == TomcatVersion.TOMCAT_110;
     }
     
     public boolean isTomcat101() {

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
@@ -71,11 +71,43 @@ import org.openide.util.NbBundle;
  */
 public class TomcatManager implements DeploymentManager {
 
-    public enum TomcatVersion {TOMCAT_50, TOMCAT_55, TOMCAT_60, TOMCAT_70, TOMCAT_80, TOMCAT_90};
+    public enum TomcatVersion {
+        TOMCAT_50(50), TOMCAT_55(55), TOMCAT_60(60), TOMCAT_70(70), 
+        TOMCAT_80(80), TOMCAT_90(90), TOMCAT_100(100), TOMCAT_101(101);
+        
+        TomcatVersion(int version) { this.version = version; }
+        private final int version;
+        public int version() { return version; }
+        /**
+         * 
+         * @param tv TomcatVersion
+         * @return true if the version is equal or greater, false otherwise
+         */
+        public boolean isAtLeast(TomcatVersion tv) {
+            int comparisonResult = this.compareTo(tv);
+            return (comparisonResult >= 0);
+        }
+    }
 
-    public enum TomEEVersion {TOMEE_15, TOMEE_16, TOMEE_17};
+    public enum TomEEVersion {
+        TOMEE_15(15), TOMEE_16(16), TOMEE_17(17), TOMEE_70(70), 
+        TOMEE_71(71), TOMEE_80(80), TOMEE_90(90);
+        
+        TomEEVersion(int version) { this.version = version; }
+        private final int version;
+        public int version() { return version; }
+        /**
+         * 
+         * @param tv TomEEVersion
+         * @return true if the version is equal or greater, false otherwise
+         */
+        public boolean isAtLeast(TomEEVersion teev) {
+            int comparisonResult = this.compareTo(teev);
+            return (comparisonResult >= 0);
+        }
+    };
 
-    public enum TomEEType {TOMEE_WEB, TOMEE_JAXRS, TOMEE_PLUS};
+    public enum TomEEType {TOMEE_OPENEJB, TOMEE_WEBPROFILE, TOMEE_JAXRS, TOMEE_MICROPROFILE, TOMEE_PLUS, TOMEE_PLUME};
 
     public static final String KEY_UUID = "NB_EXEC_TOMCAT_START_PROCESS_UUID"; //NOI18N
 
@@ -227,6 +259,10 @@ public class TomcatManager implements DeploymentManager {
      */
     public String getUri () {
         switch (tomcatVersion) {
+            case TOMCAT_101:
+                return TomcatFactory.TOMCAT_URI_PREFIX_101 + uri;
+            case TOMCAT_100:
+                return TomcatFactory.TOMCAT_URI_PREFIX_100 + uri;
             case TOMCAT_90:
                 return TomcatFactory.TOMCAT_URI_PREFIX_90 + uri;
             case TOMCAT_80:
@@ -247,7 +283,7 @@ public class TomcatManager implements DeploymentManager {
      * @return URI without home and base specification
      */
     public String getPlainUri () {
-        if (isAboveTomcat70()) {
+        if (tomcatVersion.isAtLeast(TomcatVersion.TOMCAT_70)) {
             return "http://" + tp.getHost() + ":" + getCurrentServerPort() + "/manager/text/"; //NOI18N
         }
         return "http://" + tp.getHost() + ":" + getCurrentServerPort() + "/manager/"; //NOI18N
@@ -401,11 +437,17 @@ public class TomcatManager implements DeploymentManager {
 
         return false;
     }
-
+   
     public boolean isAboveTomcat70() {
-        return tomcatVersion == TomcatVersion.TOMCAT_70
-                || tomcatVersion == TomcatVersion.TOMCAT_80
-                || tomcatVersion == TomcatVersion.TOMCAT_90;
+        return tomcatVersion .isAtLeast(TomcatVersion.TOMCAT_70);
+    }
+    
+    public boolean isTomcat101() {
+        return tomcatVersion == TomcatVersion.TOMCAT_101;
+    }
+    
+    public boolean isTomcat100() {
+        return tomcatVersion == TomcatVersion.TOMCAT_100;
     }
     
     public boolean isTomcat90() {
@@ -439,13 +481,22 @@ public class TomcatManager implements DeploymentManager {
 
     public synchronized boolean isTomEEJaxRS() {
         loadTomEEInfo();
-        return TomEEType.TOMEE_JAXRS.equals(tomEEType) || TomEEType.TOMEE_PLUS.equals(tomEEType);
+        switch (tomEEType) {
+            case TOMEE_PLUME:
+            case TOMEE_PLUS:
+            case TOMEE_MICROPROFILE:
+            case TOMEE_WEBPROFILE:
+            case TOMEE_JAXRS:
+                return true;
+            default:
+                return false;
+        }
     }
 
-    /** Returns Tomcat lib folder: "lib" for  Tomcat 6.0 and "common/lib" for Tomcat 5.x */
+    /** Returns Tomcat lib folder: "lib" for  Tomcat 6.0 or greater and "common/lib" for Tomcat 5.x or less*/
     public String libFolder() {
         // Tomcat 5.x and 6.0 uses different lib folder
-        return isTomcat50() || isTomcat55() ? "common/lib" : "lib"; // NOI18N
+        return tomcatVersion.isAtLeast(TomcatVersion.TOMCAT_60) ? "lib" : "common/lib"; // NOI18N
     }
 
     public TomcatVersion getTomcatVersion() {

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
@@ -480,7 +480,6 @@ public class TomcatManager implements DeploymentManager {
     }
 
     public synchronized boolean isTomEEJaxRS() {
-        loadTomEEInfo();
         switch (tomEEType) {
             case TOMEE_PLUME:
             case TOMEE_PLUS:

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/JaxRsStackSupportImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/JaxRsStackSupportImpl.java
@@ -37,6 +37,7 @@ import org.openide.filesystems.URLMapper;
 public class JaxRsStackSupportImpl implements JaxRsStackSupportImplementation {
 
     private static final String JAX_RS_APPLICATION_CLASS = "javax.ws.rs.core.Application"; //NOI18N
+    private static final String JAX_RS_APPLICATION_CLASS_JAKARTAEE = "jakarta.ws.rs.core.Application"; //NOI18N
 
     private final TomcatPlatformImpl j2eePlatform;
 
@@ -47,14 +48,14 @@ public class JaxRsStackSupportImpl implements JaxRsStackSupportImplementation {
     @Override
     public boolean addJsr311Api(Project project) {
         // return true (behaves like added) when JAX-RS is on classpath
-        return isBundled(JAX_RS_APPLICATION_CLASS);
+        return isBundled(JAX_RS_APPLICATION_CLASS) || isBundled(JAX_RS_APPLICATION_CLASS_JAKARTAEE);
     }
 
     @Override
     public boolean extendsJerseyProjectClasspath(Project project) {
         // declared as extended when JAX-RS is on classpath
         // suppose that TomEE has its own implementation of JAX-RS
-        return isBundled(JAX_RS_APPLICATION_CLASS);
+        return isBundled(JAX_RS_APPLICATION_CLASS) || isBundled(JAX_RS_APPLICATION_CLASS_JAKARTAEE);
     }
 
     @Override

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -49,7 +49,7 @@ import org.openide.util.lookup.Lookups;
  *
  * @author Stepan Herold
  */
-public class TomcatPlatformImpl extends J2eePlatformImpl2 {
+    public class TomcatPlatformImpl extends J2eePlatformImpl2 {
     
     private static final String WSCOMPILE_LIBS[] = new String[] {
         "jaxrpc/lib/jaxrpc-api.jar",        // NOI18N
@@ -456,43 +456,220 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
 
     @Override
     public Set<Profile> getSupportedProfiles() {
-        Set<Profile> profiles = new HashSet<>(5);
-        //if (!manager.isTomEE()) {
-            // TomEE is new and it actually does not support older specs (classloading separation etc).
-            // we will see if that's a problem for anybody
-            profiles.add(Profile.J2EE_13);
-            profiles.add(Profile.J2EE_14);
-            if (manager.isTomcat60() || manager.isAboveTomcat70()) {
-                profiles.add(Profile.JAVA_EE_5);
+        Set<Profile> profiles = new HashSet<Profile>(10);
+
+        if (manager.isTomEE()) {
+            // Only TomEE versions 8/9 of type Plus/PluME support full profile
+            if (manager.getTomEEType().ordinal() >= 3 ) {
+                switch (manager.getTomEEVersion()) {
+                    case TOMEE_90:
+                        profiles.add(Profile.JAKARTA_EE_9_1_FULL);
+                        break;
+                    case TOMEE_80:
+                        profiles.add(Profile.JAKARTA_EE_8_FULL);
+                        profiles.add(Profile.JAVA_EE_8_FULL);
+                        profiles.add(Profile.JAVA_EE_7_FULL);
+                        profiles.add(Profile.JAVA_EE_6_FULL);
+                        break;
+                    default:
+                        break;
+                }
             }
-        //}
-        if (manager.isAboveTomcat70()) {
-            profiles.add(Profile.JAVA_EE_6_WEB);
-        }
-        if (manager.isTomcat80() || manager.isTomcat90()) {
-            profiles.add(Profile.JAVA_EE_7_WEB);
+            switch (manager.getTomEEVersion()) {
+                case TOMEE_90:
+                    profiles.add(Profile.JAKARTA_EE_9_1_WEB);
+                    break;
+                case TOMEE_80:
+                    profiles.add(Profile.JAKARTA_EE_8_WEB);
+                    profiles.add(Profile.JAVA_EE_8_WEB);
+                    profiles.add(Profile.JAVA_EE_7_WEB);
+                    profiles.add(Profile.JAVA_EE_6_WEB);
+                    profiles.add(Profile.JAVA_EE_5);
+                    break;
+                case TOMEE_71:
+                case TOMEE_70:
+                    profiles.add(Profile.JAVA_EE_7_WEB);
+                    profiles.add(Profile.JAVA_EE_6_WEB);
+                    profiles.add(Profile.JAVA_EE_5);
+                    break;
+                case TOMEE_17:
+                case TOMEE_16:
+                case TOMEE_15:
+                    profiles.add(Profile.JAVA_EE_6_WEB);
+                    profiles.add(Profile.JAVA_EE_5);
+                    break;
+                default:
+                    break;
+            }
+        } else {
+            switch (manager.getTomcatVersion()) {
+//                case TOMCAT_101:
+//                    TODO: Add suport for Jakarta EE 10
+//                    profiles.add(Profile.JAKARTA_EE_10_WEB);
+//                    break;
+                case TOMCAT_100:
+                    profiles.add(Profile.JAKARTA_EE_9_1_WEB);
+                    profiles.add(Profile.JAKARTA_EE_9_WEB);
+                    break;
+                case TOMCAT_90:
+                    profiles.add(Profile.JAKARTA_EE_8_WEB);
+                    profiles.add(Profile.JAVA_EE_8_WEB);
+                    profiles.add(Profile.JAVA_EE_7_WEB);
+                    profiles.add(Profile.JAVA_EE_6_WEB);
+                    profiles.add(Profile.JAVA_EE_5);
+                case TOMCAT_80:
+                    profiles.add(Profile.JAVA_EE_7_WEB);
+                    profiles.add(Profile.JAVA_EE_6_WEB);
+                    profiles.add(Profile.JAVA_EE_5);
+                    break;
+                case TOMCAT_70:
+                    profiles.add(Profile.JAVA_EE_6_WEB);
+                    profiles.add(Profile.JAVA_EE_5);
+                    break;
+                case TOMCAT_60:
+                    profiles.add(Profile.JAVA_EE_5);
+                    break;
+                case TOMCAT_55:
+                case TOMCAT_50:
+                    profiles.add(Profile.J2EE_14);
+                    break;
+                default:
+                    break;
+            }
         }
         return profiles;
     }
     
     @Override
     public Set<String> getSupportedJavaPlatformVersions() {
-        Set<String> versions = new HashSet<>(6);
+        Set<String> versions = new HashSet<String>(14);
 
-        if (!manager.isTomcat90()) {
-            if (!manager.isTomcat80()) {
-                if (!manager.isTomcat70()) {
-                    if (!manager.isTomcat60()) {
-                        versions.add("1.4"); // NOI18N
-                        versions.add("1.5"); // NOI18N
-                    }
-                    versions.add("1.5"); // NOI18N
-                }
-                versions.add("1.6"); // NOI18N
+        // TomEE has different supported Java versions
+        if (manager.isTomEE()) {
+            switch (manager.getTomEEVersion()) {
+                case TOMEE_90:
+                    versions.add("11"); // NOI18N
+                    versions.add("12"); // NOI18N
+                    versions.add("13"); // NOI18N
+                    versions.add("14"); // NOI18N
+                    versions.add("15"); // NOI18N
+                    versions.add("16"); // NOI18N
+                    versions.add("17"); // NOI18N
+                    versions.add("18"); // NOI18N
+                    versions.add("19"); // NOI18N
+                    versions.add("20"); // NOI18N
+                    break;
+                case TOMEE_80:
+                    versions.add("1.8"); // NOI18N
+                    versions.add("9"); // NOI18N
+                    versions.add("10"); // NOI18N
+                    versions.add("11"); // NOI18N
+                    versions.add("12"); // NOI18N
+                    versions.add("13"); // NOI18N
+                    versions.add("14"); // NOI18N
+                    versions.add("15"); // NOI18N
+                    versions.add("16"); // NOI18N
+                    versions.add("17"); // NOI18N
+                    versions.add("18"); // NOI18N
+                    versions.add("19"); // NOI18N
+                    versions.add("20"); // NOI18N
+                    break;
+                case TOMEE_71:
+                case TOMEE_70:
+                    versions.add("1.7"); // NOI18N
+                    versions.add("1.8"); // NOI18N
+                    break;
+                case TOMEE_17:
+                case TOMEE_16:
+                case TOMEE_15:
+                    versions.add("1.6"); // NOI18N
+                    versions.add("1.7"); // NOI18N
+                    versions.add("1.8"); // NOI18N
+                    break;
+                default:
+                    break;
             }
-            versions.add("1.7"); // NOI18N
+        } else {
+            switch (manager.getTomcatVersion()) {
+                case TOMCAT_101:
+                    versions.add("11"); // NOI18N
+                    versions.add("12"); // NOI18N
+                    versions.add("13"); // NOI18N
+                    versions.add("14"); // NOI18N
+                    versions.add("15"); // NOI18N
+                    versions.add("16"); // NOI18N
+                    versions.add("17"); // NOI18N
+                    versions.add("18"); // NOI18N
+                    versions.add("19"); // NOI18N
+                    versions.add("20"); // NOI18N
+                    break;
+                case TOMCAT_100:
+                case TOMCAT_90:
+                    versions.add("1.8"); // NOI18N
+                    versions.add("9"); // NOI18N
+                    versions.add("10"); // NOI18N
+                    versions.add("11"); // NOI18N
+                    versions.add("12"); // NOI18N
+                    versions.add("13"); // NOI18N
+                    versions.add("14"); // NOI18N
+                    versions.add("15"); // NOI18N
+                    versions.add("16"); // NOI18N
+                    versions.add("17"); // NOI18N
+                    versions.add("18"); // NOI18N
+                    versions.add("19"); // NOI18N
+                    versions.add("20"); // NOI18N
+                    break;
+                case TOMCAT_80:
+                    versions.add("1.7"); // NOI18N
+                    versions.add("1.8"); // NOI18N
+                    versions.add("9"); // NOI18N
+                    versions.add("10"); // NOI18N
+                    versions.add("11"); // NOI18N
+                    versions.add("12"); // NOI18N
+                    versions.add("13"); // NOI18N
+                    versions.add("14"); // NOI18N
+                    versions.add("15"); // NOI18N
+                    versions.add("16"); // NOI18N
+                    versions.add("17"); // NOI18N
+                    versions.add("18"); // NOI18N
+                    versions.add("19"); // NOI18N
+                    versions.add("20"); // NOI18N
+                    break;
+                case TOMCAT_70:
+                    versions.add("1.6"); // NOI18N
+                    versions.add("1.7"); // NOI18N
+                    versions.add("1.8"); // NOI18N
+                    versions.add("9"); // NOI18N
+                    versions.add("10"); // NOI18N
+                    versions.add("11"); // NOI18N
+                    versions.add("12"); // NOI18N
+                    versions.add("13"); // NOI18N
+                    versions.add("14"); // NOI18N
+                    versions.add("15"); // NOI18N
+                    versions.add("16"); // NOI18N
+                    versions.add("17"); // NOI18N
+                    versions.add("18"); // NOI18N
+                    versions.add("19"); // NOI18N
+                    versions.add("20"); // NOI18N
+                    break;
+                case TOMCAT_60:
+                    versions.add("1.5"); // NOI18N
+                    versions.add("1.6"); // NOI18N
+                    versions.add("1.7"); // NOI18N
+                    versions.add("1.8"); // NOI18N
+                    break;
+                case TOMCAT_55:
+                case TOMCAT_50:
+                    versions.add("1.4"); // NOI18N
+                    versions.add("1.5"); // NOI18N
+                    versions.add("1.6"); // NOI18N
+                    versions.add("1.7"); // NOI18N
+                    versions.add("1.8"); // NOI18N
+                    break;
+                default:
+                    break;
+            }
         }
-        versions.add("1.8"); // NOI18N
         return versions;
     }
     

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -687,9 +687,9 @@ import org.openide.util.lookup.Lookups;
                 new EjbSupportImpl(manager), wsStack);
         if (manager.isTomEE()) {
             content.add(new JpaSupportImpl());
-        }
-        if (manager.isTomEEJaxRS()) {
-            content.add(new JaxRsStackSupportImpl(this));
+            if (manager.isTomEEJaxRS()) {
+                content.add(new JaxRsStackSupportImpl(this));
+            }
         }
 
         Lookup baseLookup = Lookups.fixed(content.toArray());

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -51,7 +51,7 @@ import org.openide.util.lookup.Lookups;
  *
  * @author Stepan Herold
  */
-    public class TomcatPlatformImpl extends J2eePlatformImpl2 {
+public class TomcatPlatformImpl extends J2eePlatformImpl2 {
     
     private static final String WSCOMPILE_LIBS[] = new String[] {
         "jaxrpc/lib/jaxrpc-api.jar",        // NOI18N
@@ -561,7 +561,7 @@ import org.openide.util.lookup.Lookups;
                     break;
                 case TOMEE_71:
                 case TOMEE_70:
-                   versions = versionRange(7, 8);
+                    versions = versionRange(7, 8);
                     break;
                 case TOMEE_17:
                 case TOMEE_16:

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -26,6 +26,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.netbeans.api.j2ee.core.Profile;
 import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.modules.j2ee.deployment.devmodules.api.J2eeModule;
@@ -456,7 +458,7 @@ import org.openide.util.lookup.Lookups;
 
     @Override
     public Set<Profile> getSupportedProfiles() {
-        Set<Profile> profiles = new HashSet<Profile>(10);
+        Set<Profile> profiles = new HashSet<>(10);
 
         if (manager.isTomEE()) {
             // Only TomEE versions 8/9 of type Plus/PluME support full profile
@@ -503,6 +505,10 @@ import org.openide.util.lookup.Lookups;
             }
         } else {
             switch (manager.getTomcatVersion()) {
+//                case TOMCAT_110:
+//                    TODO: Add suport for Jakarta EE 10
+//                    profiles.add(Profile.JAKARTA_EE_10_WEB);
+//                    break;
 //                case TOMCAT_101:
 //                    TODO: Add suport for Jakarta EE 10
 //                    profiles.add(Profile.JAKARTA_EE_10_WEB);
@@ -567,6 +573,9 @@ import org.openide.util.lookup.Lookups;
             }
         } else {
             switch (manager.getTomcatVersion()) {
+                case TOMCAT_110:
+                    versions = versionRange(11, 21);
+                    break;
                 case TOMCAT_101:
                     versions = versionRange(11, 21);
                     break;

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -542,49 +542,25 @@ import org.openide.util.lookup.Lookups;
     
     @Override
     public Set<String> getSupportedJavaPlatformVersions() {
-        Set<String> versions = new HashSet<String>(14);
+        Set<String> versions = new HashSet<>(16);
 
         // TomEE has different supported Java versions
         if (manager.isTomEE()) {
             switch (manager.getTomEEVersion()) {
                 case TOMEE_90:
-                    versions.add("11"); // NOI18N
-                    versions.add("12"); // NOI18N
-                    versions.add("13"); // NOI18N
-                    versions.add("14"); // NOI18N
-                    versions.add("15"); // NOI18N
-                    versions.add("16"); // NOI18N
-                    versions.add("17"); // NOI18N
-                    versions.add("18"); // NOI18N
-                    versions.add("19"); // NOI18N
-                    versions.add("20"); // NOI18N
+                    versions = versionRange(11, 21);
                     break;
                 case TOMEE_80:
-                    versions.add("1.8"); // NOI18N
-                    versions.add("9"); // NOI18N
-                    versions.add("10"); // NOI18N
-                    versions.add("11"); // NOI18N
-                    versions.add("12"); // NOI18N
-                    versions.add("13"); // NOI18N
-                    versions.add("14"); // NOI18N
-                    versions.add("15"); // NOI18N
-                    versions.add("16"); // NOI18N
-                    versions.add("17"); // NOI18N
-                    versions.add("18"); // NOI18N
-                    versions.add("19"); // NOI18N
-                    versions.add("20"); // NOI18N
+                    versions = versionRange(8, 21);
                     break;
                 case TOMEE_71:
                 case TOMEE_70:
-                    versions.add("1.7"); // NOI18N
-                    versions.add("1.8"); // NOI18N
+                   versions = versionRange(7, 8);
                     break;
                 case TOMEE_17:
                 case TOMEE_16:
                 case TOMEE_15:
-                    versions.add("1.6"); // NOI18N
-                    versions.add("1.7"); // NOI18N
-                    versions.add("1.8"); // NOI18N
+                    versions = versionRange(6, 8);
                     break;
                 default:
                     break;
@@ -592,79 +568,24 @@ import org.openide.util.lookup.Lookups;
         } else {
             switch (manager.getTomcatVersion()) {
                 case TOMCAT_101:
-                    versions.add("11"); // NOI18N
-                    versions.add("12"); // NOI18N
-                    versions.add("13"); // NOI18N
-                    versions.add("14"); // NOI18N
-                    versions.add("15"); // NOI18N
-                    versions.add("16"); // NOI18N
-                    versions.add("17"); // NOI18N
-                    versions.add("18"); // NOI18N
-                    versions.add("19"); // NOI18N
-                    versions.add("20"); // NOI18N
+                    versions = versionRange(11, 21);
                     break;
                 case TOMCAT_100:
                 case TOMCAT_90:
-                    versions.add("1.8"); // NOI18N
-                    versions.add("9"); // NOI18N
-                    versions.add("10"); // NOI18N
-                    versions.add("11"); // NOI18N
-                    versions.add("12"); // NOI18N
-                    versions.add("13"); // NOI18N
-                    versions.add("14"); // NOI18N
-                    versions.add("15"); // NOI18N
-                    versions.add("16"); // NOI18N
-                    versions.add("17"); // NOI18N
-                    versions.add("18"); // NOI18N
-                    versions.add("19"); // NOI18N
-                    versions.add("20"); // NOI18N
+                    versions = versionRange(8, 21);
                     break;
                 case TOMCAT_80:
-                    versions.add("1.7"); // NOI18N
-                    versions.add("1.8"); // NOI18N
-                    versions.add("9"); // NOI18N
-                    versions.add("10"); // NOI18N
-                    versions.add("11"); // NOI18N
-                    versions.add("12"); // NOI18N
-                    versions.add("13"); // NOI18N
-                    versions.add("14"); // NOI18N
-                    versions.add("15"); // NOI18N
-                    versions.add("16"); // NOI18N
-                    versions.add("17"); // NOI18N
-                    versions.add("18"); // NOI18N
-                    versions.add("19"); // NOI18N
-                    versions.add("20"); // NOI18N
+                    versions = versionRange(7, 21);
                     break;
                 case TOMCAT_70:
-                    versions.add("1.6"); // NOI18N
-                    versions.add("1.7"); // NOI18N
-                    versions.add("1.8"); // NOI18N
-                    versions.add("9"); // NOI18N
-                    versions.add("10"); // NOI18N
-                    versions.add("11"); // NOI18N
-                    versions.add("12"); // NOI18N
-                    versions.add("13"); // NOI18N
-                    versions.add("14"); // NOI18N
-                    versions.add("15"); // NOI18N
-                    versions.add("16"); // NOI18N
-                    versions.add("17"); // NOI18N
-                    versions.add("18"); // NOI18N
-                    versions.add("19"); // NOI18N
-                    versions.add("20"); // NOI18N
+                    versions = versionRange(6, 21);
                     break;
                 case TOMCAT_60:
-                    versions.add("1.5"); // NOI18N
-                    versions.add("1.6"); // NOI18N
-                    versions.add("1.7"); // NOI18N
-                    versions.add("1.8"); // NOI18N
+                    versions = versionRange(5, 8);
                     break;
                 case TOMCAT_55:
                 case TOMCAT_50:
-                    versions.add("1.4"); // NOI18N
-                    versions.add("1.5"); // NOI18N
-                    versions.add("1.6"); // NOI18N
-                    versions.add("1.7"); // NOI18N
-                    versions.add("1.8"); // NOI18N
+                    versions = versionRange(4, 8);
                     break;
                 default:
                     break;
@@ -704,4 +625,21 @@ import org.openide.util.lookup.Lookups;
         lib.setContent(J2eeLibraryTypeProvider.VOLUME_TYPE_JAVADOC, tp.getJavadocs());
         lib.setContent(J2eeLibraryTypeProvider.VOLUME_TYPE_SRC, tp.getSources());        
     }
+    
+    /**
+     * Create Set containing desired java versions. e.g.
+     * <pre>{@code
+     *  Set<String> versions = versionRange(8, 11)
+     * }</pre>
+     * This Set will contain ["1.8", "9", "10", "11"]
+     * @param min minimum Java version {@code inclusive}
+     * @param max maximum Java version {@code inclusive}
+     * @return {@code Set<String>} of desired Java versions
+     */
+    private static Set<String> versionRange(int min, int max) {
+        return IntStream.range(min, max+1)
+                    .mapToObj((int v) ->  v > 8 ? Integer.toString(v) : "1." + v)
+                    .collect(Collectors.toSet());
+    }
+    
 }

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/registration/AutomaticRegistration.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/registration/AutomaticRegistration.java
@@ -143,6 +143,10 @@ public class AutomaticRegistration {
             urlTmp = new StringBuilder(TomcatFactory.TOMCAT_URI_PREFIX_80);
         } else if (version.startsWith("9.")) { // NOI18N
             urlTmp = new StringBuilder(TomcatFactory.TOMCAT_URI_PREFIX_90);
+        } else if (version.startsWith("10.")) { // NOI18N
+            urlTmp = new StringBuilder(TomcatFactory.TOMCAT_URI_PREFIX_100);
+        } else if (version.startsWith("10.1")) { // NOI18N
+            urlTmp = new StringBuilder(TomcatFactory.TOMCAT_URI_PREFIX_101);
         } else {
             LOGGER.log(Level.INFO, "Cannot register the default Tomcat server.  The version {0} is not supported.", version); // NOI18N
             return 5;
@@ -192,6 +196,8 @@ public class AutomaticRegistration {
                 + "|" + Pattern.quote(TomcatFactory.TOMCAT_URI_PREFIX_70) // NOI18N
                 + "|" + Pattern.quote(TomcatFactory.TOMCAT_URI_PREFIX_80) // NOI18N
                 + "|" + Pattern.quote(TomcatFactory.TOMCAT_URI_PREFIX_90) // NOI18N
+                + "|" + Pattern.quote(TomcatFactory.TOMCAT_URI_PREFIX_100) // NOI18N
+                + "|" + Pattern.quote(TomcatFactory.TOMCAT_URI_PREFIX_101) // NOI18N
                 + ")" + Pattern.quote(TomcatFactory.TOMCAT_URI_HOME_PREFIX) // NOI18N
                 + Pattern.quote(catalinaHomeValue)
                 + "(" + Pattern.quote(TomcatFactory.TOMCAT_URI_BASE_PREFIX) + ".+)?$"); // NOI18N
@@ -233,6 +239,8 @@ public class AutomaticRegistration {
                 + "|" + Pattern.quote(TomcatFactory.TOMCAT_URI_PREFIX_70)  // NOI18N
                 + "|" + Pattern.quote(TomcatFactory.TOMCAT_URI_PREFIX_80)  // NOI18N
                 + "|" + Pattern.quote(TomcatFactory.TOMCAT_URI_PREFIX_90)  // NOI18N
+                + "|" + Pattern.quote(TomcatFactory.TOMCAT_URI_PREFIX_100)  // NOI18N
+                + "|" + Pattern.quote(TomcatFactory.TOMCAT_URI_PREFIX_101)  // NOI18N
                 + ")" + Pattern.quote(TomcatFactory.TOMCAT_URI_HOME_PREFIX)  // NOI18N
                 + "(.+)$"); // NOI18N
 

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/resources/Bundle.properties
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/resources/Bundle.properties
@@ -19,7 +19,7 @@
 
 # Module manifest localization
 OpenIDE-Module-Name=Tomcat (TomEE)
-OpenIDE-Module-Display-Category=Java Web and EE
+OpenIDE-Module-Display-Category=Java/Jakarta Web and EE
 OpenIDE-Module-Short-Description=Tomcat or TomEE server integration
 OpenIDE-Module-Long-Description=\
     Plugin that allows developing and executing web applications with a Apache Tomcat or TomEE server.

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/resources/tomee_resources.dtd
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/resources/tomee_resources.dtd
@@ -28,6 +28,9 @@ We didn't find a DTD or xml schema.
 <!ELEMENT Resource (#PCDATA) >
 <!ATTLIST Resource id CDATA #REQUIRED>
 <!ATTLIST Resource type CDATA #REQUIRED>
+<!ATTLIST Resource class-name CDATA #REQUIRED>
+<!ATTLIST Resource constructor CDATA #REQUIRED>
+<!ATTLIST Resource factory-name CDATA #REQUIRED>
 
 <!ELEMENT Container (#PCDATA) >
 <!ATTLIST Container id CDATA #REQUIRED>

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/AddInstanceIterator.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/AddInstanceIterator.java
@@ -63,8 +63,6 @@ public class AddInstanceIterator implements WizardDescriptor.InstantiatingIterat
     private WizardDescriptor wizard;
     private InstallPanel panel;
     
-    private static final Logger LOGGER = Logger.getLogger(AddInstanceIterator.class.getName());  // NOI18N
-    
     public AddInstanceIterator() {
         super();
     }
@@ -127,10 +125,9 @@ public class AddInstanceIterator implements WizardDescriptor.InstantiatingIterat
             TomcatManager manager = null;
             try {
                 manager = (TomcatManager) TomcatFactory.getInstance().getDeploymentManager(url, username, password);
-                LOGGER.log(Level.INFO, "[{0}] manager= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), manager});
             } catch (DeploymentManagerCreationException e) {
                 // this should never happen
-                LOGGER.log(Level.SEVERE, null, e);
+                Logger.getLogger(AddInstanceIterator.class.getName()).log(Level.SEVERE, null, e);
                 return result;
             }
             manager.ensureCatalinaBaseReady();
@@ -140,7 +137,7 @@ public class AddInstanceIterator implements WizardDescriptor.InstantiatingIterat
             }
         } catch (IOException e) {
             // TODO: remove this catch as soon as the ensureCatalinaBaseReady method is refactored
-            LOGGER.log(Level.WARNING, null, e);
+            Logger.getLogger(AddInstanceIterator.class.getName()).log(Level.WARNING, null, e);
         }
         return result;
     }

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/AddInstanceIterator.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/AddInstanceIterator.java
@@ -63,6 +63,8 @@ public class AddInstanceIterator implements WizardDescriptor.InstantiatingIterat
     private WizardDescriptor wizard;
     private InstallPanel panel;
     
+    private static final Logger LOGGER = Logger.getLogger(AddInstanceIterator.class.getName());  // NOI18N
+    
     public AddInstanceIterator() {
         super();
     }
@@ -125,9 +127,10 @@ public class AddInstanceIterator implements WizardDescriptor.InstantiatingIterat
             TomcatManager manager = null;
             try {
                 manager = (TomcatManager) TomcatFactory.getInstance().getDeploymentManager(url, username, password);
+                LOGGER.log(Level.INFO, "[{0}] manager= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), manager});
             } catch (DeploymentManagerCreationException e) {
                 // this should never happen
-                Logger.getLogger(AddInstanceIterator.class.getName()).log(Level.SEVERE, null, e);
+                LOGGER.log(Level.SEVERE, null, e);
                 return result;
             }
             manager.ensureCatalinaBaseReady();
@@ -137,7 +140,7 @@ public class AddInstanceIterator implements WizardDescriptor.InstantiatingIterat
             }
         } catch (IOException e) {
             // TODO: remove this catch as soon as the ensureCatalinaBaseReady method is refactored
-            Logger.getLogger(AddInstanceIterator.class.getName()).log(Level.WARNING, null, e);
+            LOGGER.log(Level.WARNING, null, e);
         }
         return result;
     }

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/InstallPanelVisual.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/InstallPanelVisual.java
@@ -389,6 +389,7 @@ class InstallPanelVisual extends javax.swing.JPanel {
         if (jCheckBoxShared.isEnabled() && jCheckBoxShared.isSelected()) {
             url += ":base=" + jTextFieldBaseDir.getText();  // NOI18N
         }
+        Logger.getLogger(InstallPanelVisual.class.getName()).log(Level.INFO, "[{0}] url= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), url});
         Logger.getLogger(InstallPanelVisual.class.getName()).log(Level.FINE, "TomcatInstall.getUrl: {0}", url);    // NOI18N
         return url;
     }

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/InstallPanelVisual.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/InstallPanelVisual.java
@@ -354,6 +354,12 @@ class InstallPanelVisual extends javax.swing.JPanel {
     public String getUrl() {
         String url;
         switch (getTomcatVersion()) {
+            case TOMCAT_101:
+                url = TomcatFactory.TOMCAT_URI_PREFIX_101;
+                break;
+            case TOMCAT_100:
+                url = TomcatFactory.TOMCAT_URI_PREFIX_100;
+                break;
             case TOMCAT_90:
                 url = TomcatFactory.TOMCAT_URI_PREFIX_90;
                 break;
@@ -574,9 +580,7 @@ class InstallPanelVisual extends javax.swing.JPanel {
                     infoMessage = true;
                 } else if (!TomcatUsers.hasManagerRole(getTomcatVersion(), tomcatUsersXml, jTextFieldUsername.getText())) {
                     errorMessage = NbBundle.getMessage(InstallPanelVisual.class, "MSG_UserHasNotManagerRole",
-                            TomcatVersion.TOMCAT_70.equals(getTomcatVersion())
-                                    || TomcatVersion.TOMCAT_80.equals(getTomcatVersion())
-                                    || TomcatVersion.TOMCAT_90.equals(getTomcatVersion())
+                            getTomcatVersion().isAtLeast(TomcatVersion.TOMCAT_70)
                                 ? "manager-script"
                                 : "manager");
                     infoMessage = true;

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/InstallPanelVisual.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/InstallPanelVisual.java
@@ -354,6 +354,9 @@ class InstallPanelVisual extends javax.swing.JPanel {
     public String getUrl() {
         String url;
         switch (getTomcatVersion()) {
+            case TOMCAT_110:
+                url = TomcatFactory.TOMCAT_URI_PREFIX_110;
+                break;
             case TOMCAT_101:
                 url = TomcatFactory.TOMCAT_URI_PREFIX_101;
                 break;

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/InstallPanelVisual.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/ui/wizard/InstallPanelVisual.java
@@ -389,7 +389,6 @@ class InstallPanelVisual extends javax.swing.JPanel {
         if (jCheckBoxShared.isEnabled() && jCheckBoxShared.isSelected()) {
             url += ":base=" + jTextFieldBaseDir.getText();  // NOI18N
         }
-        Logger.getLogger(InstallPanelVisual.class.getName()).log(Level.INFO, "[{0}] url= {1}", new Object[]{String.valueOf(Thread.currentThread().getStackTrace()[1].getLineNumber()), url});
         Logger.getLogger(InstallPanelVisual.class.getName()).log(Level.FINE, "TomcatInstall.getUrl: {0}", url);    // NOI18N
         return url;
     }

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogSupport.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogSupport.java
@@ -44,7 +44,7 @@ import org.openide.windows.*;
  * @author  Stepan Herold
  */
 public class LogSupport {
-    private Map/*<Link, Link>*/ links = Collections.synchronizedMap(new HashMap());
+    private Map<Link, Link> links = Collections.synchronizedMap(new HashMap());
     private Annotation errAnnot;
     
     /**

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogViewer.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogViewer.java
@@ -76,7 +76,7 @@ public class LogViewer extends Thread {
     /**
      * List of listeners which are notified when the log viewer is stoped.
      */
-    private List/*<LogViewerStopListener>*/ stopListeners = Collections.synchronizedList(new LinkedList());
+    private List<LogViewerStopListener> stopListeners = Collections.synchronizedList(new LinkedList());
 
     private String displayName;
     

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatProperties.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatProperties.java
@@ -261,6 +261,10 @@ public class TomcatProperties {
         String prefix;
         String serverID;
         switch (tm.getTomcatVersion()) {
+            case TOMCAT_110:
+                prefix = "tomcat110"; // NIO18N
+                serverID = TomcatFactory.SERVER_ID_110;
+                break;
             case TOMCAT_101:
                 prefix = "tomcat101"; // NIO18N
                 serverID = TomcatFactory.SERVER_ID_101;
@@ -733,6 +737,7 @@ public class TomcatProperties {
                     String eeDocs;
                     switch (tm.getTomcatVersion()) {
 //                      TODO: Add support for Jakarta EE 10
+//                      case TOMCAT_110:
 //                      case TOMCAT_101:
 //                           eeDocs = "docs/jakartaee10-doc-api.jar";
 //                           break;

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatProperties.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatProperties.java
@@ -261,6 +261,14 @@ public class TomcatProperties {
         String prefix;
         String serverID;
         switch (tm.getTomcatVersion()) {
+            case TOMCAT_101:
+                prefix = "tomcat101"; // NIO18N
+                serverID = TomcatFactory.SERVER_ID_101;
+                break;
+            case TOMCAT_100:
+                prefix = "tomcat100"; // NIO18N
+                serverID = TomcatFactory.SERVER_ID_100;
+                break;
             case TOMCAT_90:
                 prefix = "tomcat90"; // NIO18N
                 serverID = TomcatFactory.SERVER_ID_90;
@@ -663,7 +671,7 @@ public class TomcatProperties {
             }
         }
 
-        if (tm.isTomcat60()) {
+        if (tm.getTomcatVersion().isAtLeast(TomcatVersion.TOMCAT_60)) {
             try {
                 retValue.add(new File(homeDir, "bin/tomcat-juli.jar").toURI().toURL()); // NOI18N
             } catch (MalformedURLException e) {
@@ -722,7 +730,22 @@ public class TomcatProperties {
                     addFileToList(list, jspApiDoc);
                     addFileToList(list, servletApiDoc);
                 } else {
-                    File j2eeDoc = InstalledFileLocator.getDefault().locate("docs/javaee-doc-api.jar", null, false); // NOI18N
+                    String eeDocs;
+                    switch (tm.getTomcatVersion()) {
+//                      TODO: Add support for Jakarta EE 10
+//                      case TOMCAT_101:
+//                           eeDocs = "docs/jakartaee10-doc-api.jar";
+//                           break;
+                        case TOMCAT_100:
+                            eeDocs = "docs/jakartaee9-doc-api.jar";
+                            break;
+                        case TOMCAT_90:
+                            eeDocs = "docs/jakartaee8-doc-api.jar";
+                            break;
+                        default:
+                            eeDocs = "docs/javaee-doc-api.jar";
+                    }
+                    File j2eeDoc = InstalledFileLocator.getDefault().locate(eeDocs, null, false); // NOI18N
                     if (j2eeDoc != null) {
                         addFileToList(list, j2eeDoc);
                     }

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatUsers.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatUsers.java
@@ -79,9 +79,7 @@ public class TomcatUsers {
             roles = ""; // NOI18N
         }
         StringBuilder newRoles = new StringBuilder(roles.trim());
-        if (TomcatVersion.TOMCAT_70.equals(version)
-                || TomcatVersion.TOMCAT_80.equals(version)
-                || TomcatVersion.TOMCAT_90.equals(version)) {
+        if (version.isAtLeast(TomcatVersion.TOMCAT_70)) {
             if (!hasRole(roles, "manager-script")) { // NOI18N
                 if (newRoles.length() > 0 && !newRoles.toString().endsWith(",")) { // NOI18N
                     newRoles.append(',');
@@ -139,9 +137,7 @@ public class TomcatUsers {
             }
             if (username.equals(name)) { // NOI18N
                 String roles = user.getAttribute("roles"); // NOI18N
-                if (TomcatVersion.TOMCAT_70.equals(version)
-                        || TomcatVersion.TOMCAT_80.equals(version)
-                        || TomcatVersion.TOMCAT_90.equals(version)) {
+                if (version.isAtLeast(TomcatVersion.TOMCAT_70)) {
                     if (hasRole(roles, "manager-script")) { // NOI18N
                         return true;
                     }                    

--- a/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/TomcatFactoryTest.java
+++ b/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/TomcatFactoryTest.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.tomcat5;
 
-import java.util.regex.Pattern;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.tomcat5.deploy.TomcatManager;
 
@@ -37,26 +36,19 @@ public class TomcatFactoryTest extends NbTestCase {
     }
     
     public void testTomEEtype() {
-        
-        Pattern TOMEE_JAR_PATTERN = Pattern.compile("tomee-common-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
-        Pattern TOMEE_JAXRS_JAR_PATTERN = Pattern.compile("jettison-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
-        Pattern TOMEE_WEBPROFILE_JAR_PATTERN = Pattern.compile("openejb-api-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
-        Pattern TOMEE_MICROPROFILE_JAR_PATTERN = Pattern.compile("microprofile-config-api-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
-        Pattern TOMEE_PLUS_JAR_PATTERN = Pattern.compile("activemq-protobuf-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
-        Pattern TOMEE_PLUME_JAR_PATTERN = Pattern.compile("eclipselink-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
 
         TomcatManager.TomEEType type = TomcatManager.TomEEType.TOMEE_WEBPROFILE;
         String file = "activemq-protobuf-1.1.jar";
         
-        if (TOMEE_PLUME_JAR_PATTERN.matcher(file).matches()) {
+        if (TomcatFactory.TOMEE_PLUME_JAR_PATTERN.matcher(file).matches()) {
             type = TomcatManager.TomEEType.TOMEE_PLUME;
-        } else if (TOMEE_PLUS_JAR_PATTERN.matcher(file).matches()) {
+        } else if (TomcatFactory.TOMEE_PLUS_JAR_PATTERN.matcher(file).matches()) {
             type = TomcatManager.TomEEType.TOMEE_PLUS;
-        } else if (TOMEE_MICROPROFILE_JAR_PATTERN.matcher(file).matches()) {
+        } else if (TomcatFactory.TOMEE_MICROPROFILE_JAR_PATTERN.matcher(file).matches()) {
             type = TomcatManager.TomEEType.TOMEE_MICROPROFILE;
-        } else if (TOMEE_WEBPROFILE_JAR_PATTERN.matcher(file).matches()) {
+        } else if (TomcatFactory.TOMEE_WEBPROFILE_JAR_PATTERN.matcher(file).matches()) {
             type = TomcatManager.TomEEType.TOMEE_WEBPROFILE;
-        } else if (TOMEE_JAXRS_JAR_PATTERN.matcher(file).matches()) {
+        } else if (TomcatFactory.TOMEE_JAXRS_JAR_PATTERN.matcher(file).matches()) {
             type = TomcatManager.TomEEType.TOMEE_JAXRS;
         }
         

--- a/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/TomcatFactoryTest.java
+++ b/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/TomcatFactoryTest.java
@@ -18,7 +18,9 @@
  */
 package org.netbeans.modules.tomcat5;
 
+import java.util.regex.Pattern;
 import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.tomcat5.deploy.TomcatManager;
 
 /**
  *
@@ -33,4 +35,34 @@ public class TomcatFactoryTest extends NbTestCase {
     public void testOldCreate50MethodForAutoupdateModule() {
         assertNotNull(TomcatFactory.create50());
     }
+    
+    public void testTomEEtype() {
+        
+        Pattern TOMEE_JAR_PATTERN = Pattern.compile("tomee-common-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+        Pattern TOMEE_JAXRS_JAR_PATTERN = Pattern.compile("jettison-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+        Pattern TOMEE_WEBPROFILE_JAR_PATTERN = Pattern.compile("openejb-api-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+        Pattern TOMEE_MICROPROFILE_JAR_PATTERN = Pattern.compile("microprofile-config-api-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+        Pattern TOMEE_PLUS_JAR_PATTERN = Pattern.compile("activemq-protobuf-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+        Pattern TOMEE_PLUME_JAR_PATTERN = Pattern.compile("eclipselink-(\\d+(\\.\\d+)*).*\\.jar"); // NOI18N
+
+        TomcatManager.TomEEType type = TomcatManager.TomEEType.TOMEE_WEBPROFILE;
+        String file = "activemq-protobuf-1.1.jar";
+        
+        if (TOMEE_PLUME_JAR_PATTERN.matcher(file).matches()) {
+            type = TomcatManager.TomEEType.TOMEE_PLUME;
+        } else if (TOMEE_PLUS_JAR_PATTERN.matcher(file).matches()) {
+            type = TomcatManager.TomEEType.TOMEE_PLUS;
+        } else if (TOMEE_MICROPROFILE_JAR_PATTERN.matcher(file).matches()) {
+            type = TomcatManager.TomEEType.TOMEE_MICROPROFILE;
+        } else if (TOMEE_WEBPROFILE_JAR_PATTERN.matcher(file).matches()) {
+            type = TomcatManager.TomEEType.TOMEE_WEBPROFILE;
+        } else if (TOMEE_JAXRS_JAR_PATTERN.matcher(file).matches()) {
+            type = TomcatManager.TomEEType.TOMEE_JAXRS;
+        }
+        
+        assertEquals(TomcatManager.TomEEType.TOMEE_PLUS, type);
+        assertNotSame(TomcatManager.TomEEType.TOMEE_MICROPROFILE, type);
+        
+    }
+    
 }

--- a/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/TomcatManagerTest.java
+++ b/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/TomcatManagerTest.java
@@ -75,4 +75,30 @@ public class TomcatManagerTest extends TestBase {
         TestRunner.run(suite());
     }
     
+    public void testIsHigherThanTomcat70() {
+        TomcatManager.TomcatVersion tomcatVersion = TomcatManager.TomcatVersion.TOMCAT_70;
+        
+        assertFalse(tomcatVersion.isAtLeast(TomcatManager.TomcatVersion.TOMCAT_101));
+        assertFalse(tomcatVersion.isAtLeast(TomcatManager.TomcatVersion.TOMCAT_100));
+        assertFalse(tomcatVersion.isAtLeast(TomcatManager.TomcatVersion.TOMCAT_90));
+        assertFalse(tomcatVersion.isAtLeast(TomcatManager.TomcatVersion.TOMCAT_80));
+        assertTrue(tomcatVersion.isAtLeast(TomcatManager.TomcatVersion.TOMCAT_60));
+        assertTrue(tomcatVersion.isAtLeast(TomcatManager.TomcatVersion.TOMCAT_55));
+        assertTrue(tomcatVersion.isAtLeast(TomcatManager.TomcatVersion.TOMCAT_50));
+        
+    }
+    
+    public void testIsHigherThanTomee70() {
+        TomcatManager.TomEEVersion tomEEVersion = TomcatManager.TomEEVersion.TOMEE_70;
+        
+        assertFalse(tomEEVersion.isAtLeast(TomcatManager.TomEEVersion.TOMEE_90));
+        assertFalse(tomEEVersion.isAtLeast(TomcatManager.TomEEVersion.TOMEE_80));
+        assertFalse(tomEEVersion.isAtLeast(TomcatManager.TomEEVersion.TOMEE_71));
+        assertTrue(tomEEVersion.isAtLeast(TomcatManager.TomEEVersion.TOMEE_70));
+        assertTrue(tomEEVersion.isAtLeast(TomcatManager.TomEEVersion.TOMEE_17));
+        assertTrue(tomEEVersion.isAtLeast(TomcatManager.TomEEVersion.TOMEE_16));
+        assertTrue(tomEEVersion.isAtLeast(TomcatManager.TomEEVersion.TOMEE_15));
+        
+    }
+    
 }

--- a/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/TomcatManagerTest.java
+++ b/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/TomcatManagerTest.java
@@ -78,6 +78,7 @@ public class TomcatManagerTest extends TestBase {
     public void testIsHigherThanTomcat70() {
         TomcatManager.TomcatVersion tomcatVersion = TomcatManager.TomcatVersion.TOMCAT_70;
         
+        assertFalse(tomcatVersion.isAtLeast(TomcatManager.TomcatVersion.TOMCAT_110));
         assertFalse(tomcatVersion.isAtLeast(TomcatManager.TomcatVersion.TOMCAT_101));
         assertFalse(tomcatVersion.isAtLeast(TomcatManager.TomcatVersion.TOMCAT_100));
         assertFalse(tomcatVersion.isAtLeast(TomcatManager.TomcatVersion.TOMCAT_90));

--- a/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/util/TomcatUsersTest.java
+++ b/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/util/TomcatUsersTest.java
@@ -70,6 +70,7 @@ public class TomcatUsersTest extends NbTestCase {
         assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_90, file, "tomcat7"));
         assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_100, file, "tomcat7"));
         assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_101, file, "tomcat7"));
+        assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_110, file, "tomcat7"));
     }
     
     public void testCreateUser() throws Exception {
@@ -90,6 +91,7 @@ public class TomcatUsersTest extends NbTestCase {
         assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_60, file, "new"));
         
         file = createTomcatUsersXml("tomcat-users3.xml", CONTENT3);
+        assertFalse(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_110, file, "ide"));
         assertFalse(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_101, file, "ide"));
         TomcatUsers.createUser(file, "tomcat6", "tomcat", TomcatVersion.TOMCAT_101);
         assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_101, file, "tomcat7"));

--- a/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/util/TomcatUsersTest.java
+++ b/enterprise/tomcat5/test/unit/src/org/netbeans/modules/tomcat5/util/TomcatUsersTest.java
@@ -66,6 +66,10 @@ public class TomcatUsersTest extends NbTestCase {
         assertFalse(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_70, file, "tomcat6"));
         assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_70, file, "tomcat7"));
         assertFalse(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_60, file, "tomcat7"));
+        assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_80, file, "tomcat7"));
+        assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_90, file, "tomcat7"));
+        assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_100, file, "tomcat7"));
+        assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_101, file, "tomcat7"));
     }
     
     public void testCreateUser() throws Exception {
@@ -84,6 +88,14 @@ public class TomcatUsersTest extends NbTestCase {
         assertFalse(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_60, file, "nonexisting"));
         TomcatUsers.createUser(file, "new", "tomcat", TomcatVersion.TOMCAT_60);
         assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_60, file, "new"));
+        
+        file = createTomcatUsersXml("tomcat-users3.xml", CONTENT3);
+        assertFalse(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_101, file, "ide"));
+        TomcatUsers.createUser(file, "tomcat6", "tomcat", TomcatVersion.TOMCAT_101);
+        assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_101, file, "tomcat7"));
+        assertFalse(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_60, file, "nonexisting"));
+        TomcatUsers.createUser(file, "new", "tomcat", TomcatVersion.TOMCAT_101);
+        assertTrue(TomcatUsers.hasManagerRole(TomcatVersion.TOMCAT_101, file, "new"));
     }
     
     public void testUserExists() throws Exception {


### PR DESCRIPTION
- Add identifiers for Tomcat 10 and 10.1
- Add support for TomEE versions from 1.5 to 9
- Improve support for TomEE types and correctly identify them. (Microprofile, Webprofile, etc.)
- Improve Tomcat/TomEE version enum
- Improve Tomcat/TomEE jvm platform support
- Fix the default jvm platform that is pre-selected for Tomcat/TomEE
- Improve logic for supported profiles and jvm platforms for Tomcat and TomEE
- Improve logic for getJavadoc() method for Tomcat and TomEE
- Add missing tomcat versions to some methods
- Add isAtLeast() method to TomcatVersion
- Use enum isAtLeast() method to improve logic
- Improve support for Jakarta EE JaxRS
- Add Tests for new TomEEtype logic
- Add Tests for new Tomcat version comparison
- Add Tests for new TomEE version comparison
- Use generics
- Bump javac.source to 1.8
- Add missing attributes to a dtd file

Testing:
- Full build done
- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Sigtests
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Download every version of Tomcat and TomEE and successfully:
  - Register it
  - Check correct Java SE support from Java 6 to Java 20
  - Check correct Java/Jakarta EE support from JEE 5 to JakartaEE 9.1
  - Create Web App Project
  - Deploy and run a servlet
