### PR TITLE
More options for LSP audit command

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditOptions.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditOptions.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.cloud.oracle.adm;
+
+/**
+ *
+ * @author sdedic
+ */
+public class AuditOptions {
+    private boolean forceAuditExecution;
+    private boolean runIfNotExists;
+    private String auditName;
+    
+    public static AuditOptions makeNewAudit() {
+        return new AuditOptions().setForceAuditExecution(true).setRunIfNotExists(true);
+    }
+
+    public boolean isForceAuditExecution() {
+        return forceAuditExecution;
+    }
+
+    public AuditOptions setForceAuditExecution(boolean forceAuditExecution) {
+        this.forceAuditExecution = forceAuditExecution;
+        return this;
+    }
+
+    public boolean isRunIfNotExists() {
+        return runIfNotExists;
+    }
+
+    public AuditOptions setRunIfNotExists(boolean runIfNotExists) {
+        this.runIfNotExists = runIfNotExists;
+        return this;
+    }
+
+    public String getAuditName() {
+        return auditName;
+    }
+
+    public AuditOptions setAuditName(String auditName) {
+        this.auditName = auditName;
+        return this;
+    }
+}

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
@@ -69,14 +69,14 @@ public final class ProjectVulnerability {
         "# {0} - project name",
         "MSG_CreatingAuditFailed=Creating Vulnerablity audit for project {0} failed.",
     })
-    public CompletableFuture<String> runProjectAudit(KnowledgeBaseItem item, boolean force, boolean runIfNoReport) {
+    public CompletableFuture<String> runProjectAudit(KnowledgeBaseItem item, AuditOptions options) {
         if (item != null) {
             setProjectKnowledgeBase(item);
         }
         CompletableFuture<String> result = new CompletableFuture<>();
         AUDIT_PROCESSOR.post(() -> {
             try {
-                result.complete(VulnerabilityWorker.getInstance().findVulnerability(project, force, runIfNoReport));
+                result.complete(VulnerabilityWorker.getInstance().findVulnerability(project, options));
             } catch (ThreadDeath x) {
                 throw x;
             } catch (AuditException ex) {
@@ -91,7 +91,7 @@ public final class ProjectVulnerability {
         return result;
     }
     
-    public CompletableFuture<KnowledgeBaseItem> findKnowledgeBase(String compartmentId, String knowledgeBaseId) {
+    public CompletableFuture<KnowledgeBaseItem> findKnowledgeBase(String knowledgeBaseId) {
         CompletableFuture<KnowledgeBaseItem> result = new CompletableFuture<>();
         CALL_PROCESSOR.post(() -> {
             try ( ApplicationDependencyManagementClient client 

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/RunFileADMAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/RunFileADMAction.java
@@ -77,7 +77,7 @@ public class RunFileADMAction implements ActionListener{
         final String projectDisplayName = ProjectUtils.getInformation(project).getDisplayName();
         if (kbItem != null) {
             try {
-                VulnerabilityWorker.getInstance().findVulnerability(project, true, true);
+                VulnerabilityWorker.getInstance().findVulnerability(project, AuditOptions.makeNewAudit());
             } catch (AuditException exc) {
                 ErrorUtils.processError(exc, Bundle.MSG_CreatingAuditFailed(projectDisplayName));
             }

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -371,8 +371,11 @@ public class VulnerabilityWorker implements ErrorProvider{
      * @param forceAudit
      * @return Returns the audit ID, or {@code null} if no audit is present.
      */
-    public String findVulnerability(Project project, boolean forceAudit, boolean runIfNoReport) throws AuditException {
-        LOG.log(Level.FINER, "Trying to obtain audit for project {0}, force:{1}", new Object[] { project, forceAudit });
+    public String findVulnerability(Project project, AuditOptions auditOptions) throws AuditException {
+        if (auditOptions == null) {
+            auditOptions = new AuditOptions();
+        }
+        LOG.log(Level.FINER, "Trying to obtain audit for project {0}, force:{1}", new Object[] { project, auditOptions.isForceAuditExecution() });
         final String projectDisplayName = ProjectUtils.getInformation(project).getDisplayName();
         KnowledgeBaseItem kbItem = getKnowledgeBaseForProject(project);
         if (kbItem == null) {
@@ -382,9 +385,12 @@ public class VulnerabilityWorker implements ErrorProvider{
         // remove from the cache old values
         ProgressHandle progressHandle = ProgressHandle.createHandle(Bundle.MSG_AuditIsRunning(projectDisplayName));
         AtomicBoolean remoteCall = new AtomicBoolean(false);
+        if (auditOptions.getAuditName() == null) {
+            auditOptions.setAuditName(projectDisplayName);
+        }
         try {
             return doFindVulnerability(project, kbItem.compartmentId, kbItem.getKey().getValue(), 
-                    projectDisplayName, progressHandle, forceAudit, runIfNoReport, remoteCall);
+                    projectDisplayName, auditOptions, progressHandle, remoteCall);
         } finally {
             if (remoteCall.get()) {
                 progressHandle.close();
@@ -393,55 +399,55 @@ public class VulnerabilityWorker implements ErrorProvider{
         }
     }
 
-    private String doFindVulnerability(Project project, String compartmentId, String knowledgeBaseId, String projectDisplayName,
-            ProgressHandle progressHandle, boolean forceAudit, boolean runIfNoReport, AtomicBoolean remoteCall) throws AuditException {
+    private String doFindVulnerability(Project project, String compartmentId, String knowledgeBaseId, String projectDisplayName, AuditOptions auditOptions,
+            ProgressHandle progressHandle, AtomicBoolean remoteCall) throws AuditException {
         DependencyResult dr = null;
         List<ApplicationDependency> result = new ArrayList();
         
         CacheItem cacheItem = null;
         VulnerabilityReport savedAudit = null;
         
-        if (!forceAudit) {
+        boolean auditDone = false;
+
+        if (!auditOptions.isForceAuditExecution()) {
             try {
                 savedAudit = AuditCache.getInstance().loadAudit(knowledgeBaseId);
             } catch (IOException ex) {
                 LOG.log(Level.WARNING, "Could not load cached audit data", ex);
             }
-        }
-        
-        boolean auditDone = false;
-        
-        if (!forceAudit && savedAudit == null) {
-            // attempt to find an active most recent audit:
-            remoteCall.set(true);
-            progressHandle.start();
-            progressHandle.progress(Bundle.MSG_SearchingAuditReport());
-            try (ApplicationDependencyManagementClient admClient
-                    = new ApplicationDependencyManagementClient(OCIManager.getDefault().getConfigProvider())) {
-                ListVulnerabilityAuditsRequest request = ListVulnerabilityAuditsRequest
-                        .builder()
-                        .compartmentId(compartmentId)
-                        .knowledgeBaseId(knowledgeBaseId)
-                        .lifecycleState(LifecycleState.Active)
-                        .sortBy(ListVulnerabilityAuditsRequest.SortBy.TimeCreated)
-                        .sortOrder(SortOrder.Desc).build();
-                ListVulnerabilityAuditsResponse response = admClient.listVulnerabilityAudits(request);
-                if (!response.getVulnerabilityAuditCollection().getItems().isEmpty()) {
-                    VulnerabilityAuditSummary summary = response.getVulnerabilityAuditCollection().getItems().get(0);
-                    progressHandle.progress(Bundle.MSG_AuditCollectDependencies());
-                    dr = ProjectDependencies.findDependencies(project, ProjectDependencies.newQuery(Scopes.RUNTIME));
-                    convert(dr.getRoot(), new HashMap<>(), result);
-                    cacheItem = fetchVulnerabilityItems(project, admClient, dr, summary, projectDisplayName);
-                    savedAudit = new VulnerabilityReport(cacheItem.getAudit(), cacheItem.getVulnerabilities());
+
+            if (savedAudit == null) {
+                // attempt to find an active most recent audit:
+                remoteCall.set(true);
+                progressHandle.start();
+                progressHandle.progress(Bundle.MSG_SearchingAuditReport());
+                try (ApplicationDependencyManagementClient admClient
+                        = new ApplicationDependencyManagementClient(OCIManager.getDefault().getConfigProvider())) {
+                    ListVulnerabilityAuditsRequest request = ListVulnerabilityAuditsRequest
+                            .builder()
+                            .compartmentId(compartmentId)
+                            .knowledgeBaseId(knowledgeBaseId)
+                            .lifecycleState(LifecycleState.Active)
+                            .sortBy(ListVulnerabilityAuditsRequest.SortBy.TimeCreated)
+                            .sortOrder(SortOrder.Desc).build();
+                    ListVulnerabilityAuditsResponse response = admClient.listVulnerabilityAudits(request);
+                    if (!response.getVulnerabilityAuditCollection().getItems().isEmpty()) {
+                        VulnerabilityAuditSummary summary = response.getVulnerabilityAuditCollection().getItems().get(0);
+                        progressHandle.progress(Bundle.MSG_AuditCollectDependencies());
+                        dr = ProjectDependencies.findDependencies(project, ProjectDependencies.newQuery(Scopes.RUNTIME));
+                        convert(dr.getRoot(), new HashMap<>(), result);
+                        cacheItem = fetchVulnerabilityItems(project, admClient, dr, summary, projectDisplayName);
+                        savedAudit = new VulnerabilityReport(cacheItem.getAudit(), cacheItem.getVulnerabilities());
+                    }
+                } catch (BmcException ex) {
+                    LOG.log(Level.FINE, "Unable to list newest audit for knowledgebase {0}, compartment {1}", new Object[] {
+                        knowledgeBaseId, compartmentId
+                    });
                 }
-            } catch (BmcException ex) {
-                LOG.log(Level.FINE, "Unable to list newest audit for knowledgebase {0}, compartment {1}", new Object[] {
-                    knowledgeBaseId, compartmentId
-                });
             }
         }
         
-        if (savedAudit == null && (runIfNoReport || forceAudit)) {
+        if (savedAudit == null && (auditOptions.isRunIfNotExists() || auditOptions.isForceAuditExecution())) {
             if (remoteCall.compareAndSet(false, true)) {
                 progressHandle.start();
             }
@@ -462,7 +468,7 @@ public class VulnerabilityWorker implements ErrorProvider{
                         .builder()
                         .compartmentId(compartmentId)
                         .knowledgeBaseId(knowledgeBaseId)
-                        .displayName(projectDisplayName.replaceAll("[^A-Za-z0-9-_]", "_")) // remove offending characters
+                        .displayName(auditOptions.getAuditName().replaceAll("[^A-Za-z0-9-_]", "_")) // remove offending characters
                         .buildType(VulnerabilityAudit.BuildType.Maven)
                         .configuration(auditConfiguration)
                         .applicationDependencies(result)

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
@@ -21,10 +21,6 @@ package org.netbeans.modules.nbcode.integration.commands;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -37,17 +33,14 @@ import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectInformation;
 import org.netbeans.api.project.ProjectUtils;
-import org.netbeans.modules.cloud.oracle.adm.AuditException;
+import org.netbeans.modules.cloud.oracle.adm.AuditOptions;
 import org.netbeans.modules.cloud.oracle.adm.ProjectVulnerability;
 import org.netbeans.modules.java.lsp.server.protocol.CodeActionsProvider;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
 import org.netbeans.modules.parsing.api.ResultIterator;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
-import org.openide.awt.StatusDisplayer;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
-import org.openide.filesystems.URLMapper;
 import org.openide.util.NbBundle;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -104,22 +97,25 @@ public class ProjectAuditCommand extends CodeActionsProvider {
         if (n == null) {
             n = p.getProjectDirectory().getName();
         }
+        final String fn = n;
         if (v == null) {
             throw new IllegalArgumentException("Project " + n + " does not support vulnerability audits");
         }
-        if (arguments.size() < 3) {
-            throw new IllegalArgumentException("Expected 3 parameters: resource, compartment, knowledgebase");
+        if (arguments.size() < 3 || !(arguments.get(1) instanceof JsonPrimitive)) {
+            throw new IllegalArgumentException("Expected 3 parameters: resource, knowledgebase, options");
         }
-        String compartment = ((JsonPrimitive) arguments.get(2)).getAsString();
+        
         String knowledgeBase = ((JsonPrimitive) arguments.get(1)).getAsString();
-        boolean forceAudit;
-        if (arguments.size() > 4) {
-            forceAudit = ((JsonPrimitive)arguments.get(4)).getAsBoolean();
-        } else {
-            forceAudit = false;
+        Object o = arguments.get(2);
+        if (!(o instanceof JsonObject)) {
+            throw new IllegalArgumentException("Expected structure, got  " + o);
         }
-        final String fn = n;
-        return v.findKnowledgeBase(compartment, knowledgeBase).
+        JsonObject options = (JsonObject)o;
+        
+        boolean forceAudit = options.has("force") && options.get("force").getAsBoolean();
+        String preferredName = options.has("auditName") ? options.get("auditName").getAsString() : null;
+        
+        return v.findKnowledgeBase(knowledgeBase).
                 exceptionally(th -> {
                     DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(Bundle.ERR_KnowledgeBaseSearchFailed(fn, th.getMessage()),
                             NotifyDescriptor.ERROR_MESSAGE));
@@ -132,10 +128,10 @@ public class ProjectAuditCommand extends CodeActionsProvider {
             
             switch (command) {
                 case COMMAND_EXECUTE_AUDIT:
-                    exec = v.runProjectAudit(kb, true, true);
+                    exec = v.runProjectAudit(kb, AuditOptions.makeNewAudit().setAuditName(preferredName));
                     break;
                 case COMMAND_LOAD_AUDIT: {
-                    exec = v.runProjectAudit(kb, false, forceAudit);
+                    exec = v.runProjectAudit(kb, new AuditOptions().setRunIfNotExists(forceAudit).setAuditName(preferredName));
                 }
                 default:
                     return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
This PR cleans up parmeters passed to LSP display and execute: since `knowledgeBase` is required, the `compartment` is not needed, can be derived from `knowledgeBase`.

In addition a requested `auditName` can be passed to the LSP command in case an audit is to be created (either display + force, or execute). Otherwise some default name is made up by the impl.

The PR will be eventually rebased on `delivery`
