### PR TITLE
Update JDK 19 Javadoc link from EA to GA.

### DIFF
--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
@@ -67,7 +67,7 @@ public final class J2SEPlatformDefaultJavadocImpl implements J2SEPlatformDefault
         OFFICIAL_JAVADOC.put("16", "https://docs.oracle.com/en/java/javase/16/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("17", "https://docs.oracle.com/en/java/javase/17/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("18", "https://docs.oracle.com/en/java/javase/18/docs/api/"); // NOI18N
-        OFFICIAL_JAVADOC.put("19", "https://download.java.net/java/early_access/jdk19/docs/api/"); // NOI18N Early access
+        OFFICIAL_JAVADOC.put("19", "https://docs.oracle.com/en/java/javase/19/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("20", "https://download.java.net/java/early_access/jdk20/docs/api/"); // NOI18N Early access
     }
 


### PR DESCRIPTION
Update JDK 19 Javadoc link from early access to the release location.

Quick fix in delivery as I noticed while testing 16-rc1 on JDK 19 that Javadoc linking is broken.  However, might be good to consider a better way of handling this in future.