### PR TITLE
put nb-javac modules on the plugin import block list.

### DIFF
--- a/nb/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/Bundle.properties
+++ b/nb/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/Bundle.properties
@@ -39,5 +39,13 @@ ImportManager.Progress.Name=Importing plugins...
 PluginImporter.Importing.Plugin=Importing {0}...
 PluginImporter.Importing.RestartNeeded=Restart needed to import plugins. Do you want to restart NetBeans IDE now?
 #Blacklist codeNameBase of dangerous plugins which cannot be imported like: org.dangerous.plugin,com.nextdangerous.module,... etc.
-plugin.import.blacklist=org.netbeans.shortcuts,org.jmarsault.shortcuts
+plugin.import.blacklist=\
+org.netbeans.shortcuts,\
+org.jmarsault.shortcuts,\
+org.netbeans.lib.nbjavac,\
+org.netbeans.modules.nbjavac,\
+org.netbeans.modules.nbjavac.api,\
+org.netbeans.modules.nbjavac.impl,\
+org.netbeans.modules.java.source.nbjavac
+
 apachenetbeanspreviousversion=@@metabuild.apachepreviousversion@@


### PR DESCRIPTION
Users which import nb-javac plugins from old NB versions complain about not being able to start NB anymore (most recent: #4799). This puts all nbjavac modules which were in NB 12.1 on the block list and will hopefully prevent this in future.

targets delivery