### PR TITLE
Never mark overriding methods as unused, fixes GH4276.

### DIFF
--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/UnusedDetector.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/UnusedDetector.java
@@ -141,7 +141,8 @@ public class UnusedDetector {
                     }
                 }
             } else if ((el.getKind() == ElementKind.CONSTRUCTOR || el.getKind() == ElementKind.METHOD) && (isPrivate || isPkgPrivate)) {
-                if (!isSerializationMethod(info, (ExecutableElement)el) && !uses.contains(UseTypes.USED)) {
+                if (!isSerializationMethod(info, (ExecutableElement)el) && !uses.contains(UseTypes.USED)
+                        && !info.getElementUtilities().overridesMethod((ExecutableElement)el)) {
                     if (isPrivate || isUnusedInPkg(info, el, cancel)) {
                         result.add(new UnusedDescription(el, declaration, UnusedReason.NOT_USED));
                     }


### PR DESCRIPTION
Potential fix for #4276 that never marks an overriding method as unused.  The superclass definition will still be marked unused if not called.  IMO the method can be considered "used" by the superclass, and hints should be over-cautious in preference to over-eager anyway.