### PR TITLE
fixes an ambiguous method reference in SearchTask.

### DIFF
--- a/platform/api.search/nbproject/project.properties
+++ b/platform/api.search/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
-javac.compilerargs=-Xlint:all -Xlint:-serial -Xlint:-processing -Xlint:-options
+javac.release=11
+javac.compilerargs=-Xlint:all -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/api.search/src/org/netbeans/modules/search/SearchTask.java
+++ b/platform/api.search/src/org/netbeans/modules/search/SearchTask.java
@@ -83,7 +83,7 @@ final class SearchTask implements Runnable, Cancellable {
         try {
             makeResultViewBusy(true);
             searchListener.searchStarted();
-            Mutex.EVENT.writeAccess(resultViewPanel::requestFocusInWindow);
+            Mutex.EVENT.writeAccess((Runnable) resultViewPanel::requestFocusInWindow);
             searchComposition.start(searchListener);
         } catch (RuntimeException e) {
             searchListener.generalError(e);


### PR DESCRIPTION
The compiler can't decide if this is an `ExceptionAction` or a `Runnable` and marks the line as an error in-editor. Interestingly, the module builds fine.

We can help the compiler by casting to Runnable or by using a lambda expression. Cast is more compact.


![ambiguous](https://user-images.githubusercontent.com/114367/198063533-e8e6fc54-07a9-4e95-bb46-709c3fad5eaa.png)
