### PR TITLE
Fix maven classpath listening

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/classpath/ClassPathProviderImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/classpath/ClassPathProviderImpl.java
@@ -712,7 +712,8 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
      * This selector chooses the annotation classpath, if it is not empty (has items, or is broken), or the regular
      * compile classpath if annotation path is empty. The selector reacts 
      */
-    private static class AnnotationPathSelector extends ClassPathSelector {
+    private static class AnnotationPathSelector extends ClassPathSelector
+            implements PropertyChangeListener {
         private final ClassPath annotationCP;
         private final Supplier<ClassPath> compileClassPath;
         
@@ -721,18 +722,14 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
             this.annotationCP = anno;
             this.compileClassPath = compile;
             
-            anno.addPropertyChangeListener(WeakListeners.propertyChange(
-                    e -> {
-                        active = null;
-                        support.firePropertyChange(PROP_ACTIVE_CLASS_PATH, null, null);
-                    }, ClassPath.PROP_ROOTS, anno
-            ));
-//            proj.getProjectWatcher().addPropertyChangeListener((e) -> {
-//                if (NbMavenProject.PROP_PROJECT.equals(e.getPropertyName())) {
-//                    active = null;
-//                    support.firePropertyChange(PROP_ACTIVE_CLASS_PATH, null, null);
-//                }
-//            });
+            anno.addPropertyChangeListener(WeakListeners.propertyChange(this, anno));
+            proj.getProjectWatcher().addPropertyChangeListener(WeakListeners.propertyChange(this, anno));
+        }
+
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            active = null;
+            support.firePropertyChange(PROP_ACTIVE_CLASS_PATH, null, null);
         }
 
         @Override


### PR DESCRIPTION
I noticed, in a project that generates a lot of classes using annotation processors, that frequently the IDE would not reparse after code generation, and so error markers on code that references generated classes and similar would not be updated.

I tracked it down to this:

The previous code calls `WeakListeners.propertyChange()` *with a lambda*. The lambda will be garbage collected instantaneously and never fire changes, which was exactly the behavior.

On JDK-8, lambdas and method references would hang around a while before being garbage collected - so this code might have looked like it worked originally.  On newer JDKs, the lambda will be garbage collected almost as soon as it is allocated, so notifications will never propagate.

I've been running this patch for a month or so without problems.

One slightly questionable thing:  There was commented out code to also listen on `proj.getProjectWatcher()`.  It seemed harmless, now that the class is implementing `PropertyChangeListener` directly, and the code wanted the same listener implementation, to uncomment it, so I did.

I can definitely verify that it works, because I had to fix in a deadlock in the icon-badging support in my Antlr plugins that could only be triggered by the events that were never fired :-)
