### PR TITLE
Fix unix launcher shell script java identification issue

### DIFF
--- a/nbi/engine/native/launcher/unix/src/launcher.sh
+++ b/nbi/engine/native/launcher/unix/src/launcher.sh
@@ -1265,6 +1265,8 @@ verifyJavaHome() {
 
 		    #remove build number
 		    javaVersion=`echo "$javaVersion" | sed 's/-.*$//;s/\ .*//'`
+		    #remove everything after the + sign in case the version is a whole number
+		    javaVersion=`echo $javaVersion | sed 's/+.*$//g'`
 		    verifyResult=$VERIFY_UNCOMPATIBLE
 
 	            if [ -n "$javaVersion" ] ; then


### PR DESCRIPTION
This patch fixes an issue in case the java version used has a whole number (e.g. 19 instead of 19.0.1). In that case it could not be properly parsed.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
