### PR TITLE
about panel needs a vertical scrollbar if the async plugin update notification appears

### DIFF
--- a/platform/o.n.core/src/org/netbeans/core/ui/ProductInformationPanel.form
+++ b/platform/o.n.core/src/org/netbeans/core/ui/ProductInformationPanel.form
@@ -141,8 +141,6 @@
         <Property name="verticalScrollBarPolicy" type="int" value="21"/>
       </Properties>
       <AuxValues>
-        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
-        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
         <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
       </AuxValues>
 

--- a/platform/o.n.core/src/org/netbeans/core/ui/ProductInformationPanel.java
+++ b/platform/o.n.core/src/org/netbeans/core/ui/ProductInformationPanel.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import javax.swing.Icon;
 import javax.swing.JEditorPane;
 import javax.swing.JPanel;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.event.HyperlinkEvent;
@@ -102,6 +103,7 @@ public class ProductInformationPanel extends JPanel implements HyperlinkListener
             final String updates = getUpdates();
             SwingUtilities.invokeLater(() -> {
                 description.setText(LBL_description(getProductVersionValue(), getJavaValue(), getVMValue(), getOperatingSystemValue(), getEncodingValue(), getSystemLocaleValue(), getUserDirValue(), Places.getCacheDirectory().getAbsolutePath(), updates, FONT_SIZE, getJavaRuntime()));
+                descriptionScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS); // will need a scrollbar now
                 description.setCursor(null);
                 description.revalidate();
                 description.setCaretPosition(0);
@@ -156,7 +158,7 @@ public class ProductInformationPanel extends JPanel implements HyperlinkListener
         javax.swing.JButton closeButton = new javax.swing.JButton();
         javax.swing.JScrollPane copyrightScrollPane = new javax.swing.JScrollPane();
         copyright = new javax.swing.JTextPane();
-        javax.swing.JScrollPane descriptionScrollPane = new javax.swing.JScrollPane();
+        descriptionScrollPane = new javax.swing.JScrollPane();
         description = new javax.swing.JTextPane();
         javax.swing.JPanel imagePanel = new javax.swing.JPanel();
         imageLabel = new javax.swing.JLabel();
@@ -242,6 +244,7 @@ private void closeButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JTextPane copyright;
     private javax.swing.JTextPane description;
+    private javax.swing.JScrollPane descriptionScrollPane;
     private javax.swing.JLabel imageLabel;
     // End of variables declaration//GEN-END:variables
     


### PR DESCRIPTION
fixes #4876

we can't add it right away, otherwise the window can't layout itself without hardcoding the size of the scrollpane. Changing window size once its visible would look weird.

targets delivery