### PR TITLE
Fixed end of file indenting and code completion for ANTLR v4

### DIFF
--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AbstractAntlrLexer.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AbstractAntlrLexer.java
@@ -29,13 +29,13 @@ import org.netbeans.spi.lexer.TokenFactory;
  *
  * @author lkishalmi
  */
-public abstract class AbstractAntlrLexer implements Lexer<AntlrTokenId> {
+public abstract class AbstractAntlrLexer<T extends org.antlr.v4.runtime.Lexer> implements Lexer<AntlrTokenId> {
 
     private final TokenFactory<AntlrTokenId> tokenFactory;
-    protected final org.antlr.v4.runtime.Lexer lexer;
+    protected final T lexer;
     private final LexerInputCharStream input;
 
-    public AbstractAntlrLexer(LexerRestartInfo<AntlrTokenId> info, org.antlr.v4.runtime.Lexer lexer) {
+    public AbstractAntlrLexer(LexerRestartInfo<AntlrTokenId> info, T lexer) {
         this.tokenFactory = info.tokenFactory();
         this.lexer = lexer;
         this.input = (LexerInputCharStream) lexer.getInputStream();
@@ -47,11 +47,6 @@ public abstract class AbstractAntlrLexer implements Lexer<AntlrTokenId> {
 
 
     @Override
-    public Object state() {
-        return new LexerState(lexer);
-    }
-
-    @Override
     public void release() {
     }
 
@@ -60,19 +55,19 @@ public abstract class AbstractAntlrLexer implements Lexer<AntlrTokenId> {
         return tokenFactory.createToken(id);
     }
 
-    private static class LexerState {
+    public static class LexerState<T extends org.antlr.v4.runtime.Lexer> {
         final int state;
         final int mode;
         final IntegerList modes;
 
-        LexerState(org.antlr.v4.runtime.Lexer lexer) {
+        public LexerState(T lexer) {
             this.state= lexer.getState();
 
             this.mode = lexer._mode;
             this.modes = new IntegerList(lexer._modeStack);
         }
 
-        public void restore(org.antlr.v4.runtime.Lexer lexer) {
+        public void restore(T lexer) {
             lexer.setState(state);
             lexer._modeStack.addAll(modes);
             lexer._mode = mode;

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrTokenSequence.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/AntlrTokenSequence.java
@@ -85,7 +85,7 @@ public final class AntlrTokenSequence {
                 }
                 
             } else {
-                previous((t) -> t.getStartIndex() > offset);
+                previous((t) -> t.getStartIndex() < offset);
             }
         }
         

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3Lexer.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3Lexer.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.languages.antlr.v3;
 
+import org.antlr.parser.antlr3.ANTLRv3Lexer;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.spi.lexer.LexerRestartInfo;
 
@@ -31,11 +32,11 @@ import org.netbeans.modules.languages.antlr.LexerInputCharStream;
  *
  * @author lkishalmi
  */
-public final class Antlr3Lexer extends AbstractAntlrLexer {
+public final class Antlr3Lexer extends AbstractAntlrLexer<ANTLRv3Lexer> {
 
 
     public Antlr3Lexer(LexerRestartInfo<AntlrTokenId> info) {
-        super(info, new org.antlr.parser.antlr3.ANTLRv3Lexer(new LexerInputCharStream(info.input())));
+        super(info, new ANTLRv3Lexer(new LexerInputCharStream(info.input())));
     }
 
     private org.antlr.v4.runtime.Token preFetchedToken = null;
@@ -141,4 +142,24 @@ public final class Antlr3Lexer extends AbstractAntlrLexer {
         }
     }
 
+    @Override
+    public Object state() {
+        return new State(lexer);
+    }
+
+    public static class State extends AbstractAntlrLexer.LexerState<ANTLRv3Lexer> {
+        final int currentRuleType;
+
+        public State(ANTLRv3Lexer lexer) {
+            super(lexer);
+            this.currentRuleType = lexer.getCurrentRuleType();
+        }
+
+        @Override
+        public void restore(ANTLRv3Lexer lexer) {
+            super.restore(lexer);
+            lexer.setCurrentRuleType(currentRuleType);
+        }
+
+    }
 }

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4CompletionProvider.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4CompletionProvider.java
@@ -51,6 +51,7 @@ import org.netbeans.api.annotations.common.StaticResource;
 import static org.antlr.parser.antlr4.ANTLRv4Lexer.*;
 import org.netbeans.modules.languages.antlr.AntlrParserResult.ReferenceType;
 import static org.netbeans.modules.languages.antlr.AntlrTokenSequence.DEFAULT_CHANNEL;
+import org.openide.util.NbBundle;
 
 /**
  *
@@ -113,6 +114,20 @@ public class Antlr4CompletionProvider implements CompletionProvider {
 
                 if (!tokens.isEmpty()) {
 
+                    boolean inRule = false;
+
+                    while (tokens.hasNext() && (tokens.getOffset() < caretOffset)) {
+                        Optional<Token> next = tokens.next();
+                        switch (next.get().getType()) {
+                            case COLON:
+                                inRule = true;
+                                break;
+                            case SEMI:
+                                inRule = false;
+                                break;
+                        }
+                    }
+
                     tokens.seekTo(caretOffset);
                     // Check if we are in a comment (that is filtered out from the token stream)
 
@@ -133,10 +148,11 @@ public class Antlr4CompletionProvider implements CompletionProvider {
                             return;
                         }
                         tokens.previous();
-                        lookAround(result, tokens, caretOffset, prefix, resultSet);
-                    } else {
-                        //Empty grammar so far offer lexer, parser and grammar
-                        addTokens("", caretOffset, resultSet, "lexer", "parser", "grammar");
+                        if (inRule) {
+                            lookInRule(result, tokens, caretOffset, prefix, resultSet);
+                        } else {
+                            lookNonRule(result, tokens, caretOffset, prefix, resultSet);
+                        }
                     }
                 }
             } finally {
@@ -144,18 +160,86 @@ public class Antlr4CompletionProvider implements CompletionProvider {
             }
         }
 
-        private void lookAround(Antlr4ParserResult result, AntlrTokenSequence tokens, int caretOffset, String prefix, CompletionResultSet resultSet) {
-            AntlrParserResult.GrammarType grammarType = result != null ? result.getGrammarType(): AntlrParserResult.GrammarType.UNKNOWN;
+        private void lookInRule(Antlr4ParserResult result, AntlrTokenSequence tokens, int caretOffset, String prefix, CompletionResultSet resultSet) {
+            AntlrParserResult.GrammarType grammarType = result != null ? result.getGrammarType() : AntlrParserResult.GrammarType.UNKNOWN;
+            Optional<Token> opt = tokens.previous(DEFAULT_CHANNEL);
+            Token pt = opt.get();
+            if (((pt.getType() == RULE_REF) || (pt.getType() == TOKEN_REF)) && (caretOffset == pt.getStopIndex() + 1)) {
+                // Could be start of some keywords
+                prefix = pt.getText();
+                opt = tokens.previous(DEFAULT_CHANNEL);
+            }
+            pt = opt.get();
+            // check our previous token
+            switch (pt.getType()) {
+                case RARROW:
+                    //Command: offer 'channel', 'skip', etc...
+                    addTokens(prefix, caretOffset, resultSet, "skip", "more", "type", "channel", "mode", "pushMode", "popMode");
+                    return;
+                case LPAREN:
+                    Optional<Token> lexerCommand = tokens.previous(DEFAULT_CHANNEL);
+                    // We are not necessary in a lexerCommand here, just taking chances
+                    if (lexerCommand.isPresent()) {
+                        switch (lexerCommand.get().getText()) {
+                            case "channel":
+                                addReferences(result, prefix, caretOffset, resultSet, EnumSet.of(ReferenceType.CHANNEL));
+                                return;
+                            case "mode":
+                            case "pushMode":
+                                addReferences(result, prefix, caretOffset, resultSet, EnumSet.of(ReferenceType.MODE));
+                                return;
+                            case "type":
+                                addReferences(result, prefix, caretOffset, resultSet, EnumSet.of(ReferenceType.TOKEN));
+                                return;
+                        }
+                    }
+                // the fall through is intentional, as of betting on lexerCommand did not come through
+                default:
+
+                    EnumSet<ReferenceType> rtypes = EnumSet.noneOf(ReferenceType.class);
+
+                    //Seek to the rule definition we are in
+                    tokens.seekTo(caretOffset);
+                    tokens.previous(COLON);
+
+                    // check the rule definition type: lexer/parser
+                    Optional<Token> ref = tokens.previous(DEFAULT_CHANNEL);
+                    if (ref.isPresent() && (ref.get().getType() == RULE_REF || ref.get().getType() == TOKEN_REF)) {
+                        if (ref.get().getType() == TOKEN_REF) {
+                            rtypes.add(ReferenceType.FRAGMENT);
+                        } else {
+                            rtypes.add(ReferenceType.TOKEN);
+                            rtypes.add(ReferenceType.RULE);
+                            if (grammarType == AntlrParserResult.GrammarType.MIXED) {
+                                rtypes.add(ReferenceType.FRAGMENT);
+                            }
+                        }
+                    } else {
+                        // A bit odd definition, let's rely on the grammarType
+                        if ((grammarType == AntlrParserResult.GrammarType.LEXER) || (grammarType == AntlrParserResult.GrammarType.MIXED)) {
+                            rtypes.add(ReferenceType.FRAGMENT);
+                        }
+                        if ((grammarType == AntlrParserResult.GrammarType.PARSER) || (grammarType == AntlrParserResult.GrammarType.MIXED)) {
+                            rtypes.add(ReferenceType.TOKEN);
+                            rtypes.add(ReferenceType.RULE);
+                        }
+                    }
+                    addReferences(result, prefix, caretOffset, resultSet, rtypes);
+            }
+        }
+
+        private void lookNonRule(Antlr4ParserResult result, AntlrTokenSequence tokens, int caretOffset, String prefix, CompletionResultSet resultSet) {
+            AntlrParserResult.GrammarType grammarType = result != null ? result.getGrammarType() : AntlrParserResult.GrammarType.UNKNOWN;
             Optional<Token> opt = tokens.previous(DEFAULT_CHANNEL);
             if (!opt.isPresent()) {
                 //At the start of the file;
                 Optional<Token> t = tokens.next(DEFAULT_CHANNEL);
                 if (t.isPresent() && t.get().getType() != LEXER) {
                     addTokens(prefix, caretOffset, resultSet, "lexer");
-                }                
+                }
                 if (t.isPresent() && t.get().getType() != PARSER) {
                     addTokens(prefix, caretOffset, resultSet, "parser");
-                }                
+                }
                 if (t.isPresent() && (t.get().getType() != LEXER) && (t.get().getType() != GRAMMAR)) {
                     addTokens(prefix, caretOffset, resultSet, "grammar");
                 }
@@ -182,67 +266,14 @@ public class Antlr4CompletionProvider implements CompletionProvider {
                             }
                             return;
 
+                        case FRAGMENT:
                         case SEMI:
                             //Could be the begining of a new rule def.
-                            addTokens(prefix, caretOffset, resultSet, "mode", "fragment");
-                            return;
-                        case RARROW:
-                            //Command: offer 'channel', 'skip', etc...
-                            addTokens(prefix, caretOffset, resultSet, "skip", "more", "type", "channel", "mode", "pushMode", "popMode");
-                            return;
-                        case LPAREN:
-                            Optional<Token> lexerCommand = tokens.previous(DEFAULT_CHANNEL);
-                            // We are not necessary in a lexerCommand here, just taking chances
-                            if (lexerCommand.isPresent()) {
-                                switch (lexerCommand.get().getText()) {
-                                    case "channel": 
-                                        addReferences(result, prefix, caretOffset, resultSet, EnumSet.of(ReferenceType.CHANNEL));
-                                        return;
-                                    case "mode":
-                                    case "pushMode":
-                                        addReferences(result, prefix, caretOffset, resultSet, EnumSet.of(ReferenceType.MODE));
-                                        return;
-                                    case "type":
-                                        addReferences(result, prefix, caretOffset, resultSet, EnumSet.of(ReferenceType.TOKEN));
-                                        return;
-                                }
+                            if (grammarType != AntlrParserResult.GrammarType.PARSER) {
+                                addTokens(prefix, caretOffset, resultSet, "mode", "fragment");
                             }
-                            // the fall through is intentional, as of betting on lexerCommand did not come through
-                        default:
-                            tokens.seekTo(caretOffset);
-                            Optional<Token> semi = tokens.previous(SEMI);
-                            tokens.seekTo(caretOffset);
-                            Optional<Token> colon = tokens.previous(COLON);
-                            if (semi.isPresent() && colon.isPresent()
-                                    && semi.get().getStartIndex() < colon.get().getStartIndex()) {
-                                
-                                EnumSet<ReferenceType> rtypes = EnumSet.noneOf(ReferenceType.class);
-                                
-                                // we are in lexer/parser ruledef
-                                Optional<Token> ref = tokens.previous(DEFAULT_CHANNEL);
-                                if (ref.isPresent() && (ref.get().getType() == RULE_REF || ref.get().getType() == TOKEN_REF)) {
-                                    if (ref.get().getType() == TOKEN_REF) {
-                                        rtypes.add(ReferenceType.FRAGMENT);
-                                    } else {
-                                        rtypes.add(ReferenceType.TOKEN);
-                                        rtypes.add(ReferenceType.RULE);
-                                        if (grammarType == AntlrParserResult.GrammarType.MIXED) {
-                                            rtypes.add(ReferenceType.FRAGMENT);
-                                        }
-                                    }
-                                } else {
-                                    // A bit odd definition, let's rely on the grammarType
-                                    if ((grammarType == AntlrParserResult.GrammarType.LEXER) || (grammarType == AntlrParserResult.GrammarType.MIXED)) {
-                                        rtypes.add(ReferenceType.FRAGMENT);
-                                    }
-                                    if ((grammarType == AntlrParserResult.GrammarType.PARSER) || (grammarType == AntlrParserResult.GrammarType.MIXED)) {
-                                        rtypes.add(ReferenceType.TOKEN);
-                                        rtypes.add(ReferenceType.RULE);
-                                    }
-                                }
-                                addReferences(result, prefix, caretOffset, resultSet, rtypes);
-                            }
-
+                            addUnknownReferences(result, prefix, caretOffset, resultSet);
+                            return;
                     }
 
                 }
@@ -265,12 +296,46 @@ public class Antlr4CompletionProvider implements CompletionProvider {
             }
         }
 
-        public void addReferences(Antlr4ParserResult result, String prefix, int caretOffset, CompletionResultSet resultSet, Set<ReferenceType> rtypes) {
-            
-            Map<String,AntlrParserResult.Reference> matching = new HashMap<>();
+        @NbBundle.Messages("newRule=<b>new</b>")
+        public void addUnknownReferences(Antlr4ParserResult result, String prefix, int caretOffset, CompletionResultSet resultSet) {
+            int startOffset = caretOffset - prefix.length();
             String mprefix = caseSensitive ? prefix : prefix.toUpperCase();
-            
-            result.allImports().values().forEach((r) ->{
+            for (String unknownReference : result.unknownReferences) {
+                String mref = caseSensitive ? unknownReference : unknownReference.toUpperCase();
+                if (mref.startsWith(mprefix)) {
+                    boolean ruleRef = Character.isLowerCase(unknownReference.codePointAt(0));
+                    CompletionItem item = null;
+                    if (ruleRef && ((result.getGrammarType() == AntlrParserResult.GrammarType.PARSER) || (result.getGrammarType() == AntlrParserResult.GrammarType.MIXED))) {
+                        item = CompletionUtilities.newCompletionItemBuilder(unknownReference)
+                                .iconResource(getReferenceIcon(ReferenceType.RULE))
+                                .startOffset(startOffset)
+                                .leftHtmlText(unknownReference)
+                                .rightHtmlText(Bundle.newRule())
+                                .sortText(mref)
+                                .build();
+                    }
+                    if (!ruleRef && ((result.getGrammarType() == AntlrParserResult.GrammarType.LEXER) || (result.getGrammarType() == AntlrParserResult.GrammarType.MIXED))) {
+                        item = CompletionUtilities.newCompletionItemBuilder(unknownReference)
+                                .iconResource(getReferenceIcon(ReferenceType.TOKEN))
+                                .startOffset(startOffset)
+                                .leftHtmlText(unknownReference)
+                                .rightHtmlText(Bundle.newRule())
+                                .sortText(mref)
+                                .build();
+                    }
+                    if (item != null) {
+                        resultSet.addItem(item);
+                    }
+                }
+            }
+        }
+
+        private void addReferences(Antlr4ParserResult result, String prefix, int caretOffset, CompletionResultSet resultSet, Set<ReferenceType> rtypes) {
+
+            Map<String, AntlrParserResult.Reference> matching = new HashMap<>();
+            String mprefix = caseSensitive ? prefix : prefix.toUpperCase();
+
+            result.allImports().values().forEach((r) -> {
                 Map<String, AntlrParserResult.Reference> refs = r.references;
                 for (AntlrParserResult.Reference ref : refs.values()) {
                     String mref = caseSensitive ? ref.name : ref.name.toUpperCase();
@@ -280,7 +345,7 @@ public class Antlr4CompletionProvider implements CompletionProvider {
                     }
                 }
             });
- 
+
             int startOffset = caretOffset - prefix.length();
             for (AntlrParserResult.Reference ref : matching.values()) {
                 CompletionItem item = CompletionUtilities.newCompletionItemBuilder(ref.name)
@@ -291,19 +356,20 @@ public class Antlr4CompletionProvider implements CompletionProvider {
                         .build();
                 resultSet.addItem(item);
 
-            }            
+            }
         }
     }
-    
+
     //The folowing is an excrept of org.netbeans.modules.csl.navigation.Icons
-    private static final String ICON_BASE = "org/netbeans/modules/csl/source/resources/icons/";    
+    private static final String ICON_BASE = "org/netbeans/modules/csl/source/resources/icons/";
+
     private static String getReferenceIcon(ReferenceType rtype) {
         switch (rtype) {
             case CHANNEL:
                 return ICON_BASE + "database.gif";
             case FRAGMENT:
                 return ICON_BASE + "constantPublic.png";
-            case MODE: 
+            case MODE:
                 return ICON_BASE + "class.png";
             case RULE:
                 return ICON_BASE + "rule.png";

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4Formatter.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4Formatter.java
@@ -119,6 +119,11 @@ public class Antlr4Formatter implements Formatter {
                 tstart = token.getStartIndex();
                 tstop = token.getStopIndex();
             }
+
+            if ((cstart == cend) && (cstart == doc.getLength())) {
+                // Pressed enter at the end of the file
+                context.modifyIndent(cstart, inRule ? indentSize : 0);
+            }
         } catch (BadLocationException ex) {}
     }
 

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4Lexer.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4Lexer.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.languages.antlr.v4;
 
+import org.antlr.parser.antlr4.ANTLRv4Lexer;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.spi.lexer.LexerRestartInfo;
 
@@ -31,11 +32,11 @@ import org.netbeans.modules.languages.antlr.LexerInputCharStream;
  *
  * @author lkishalmi
  */
-public final class Antlr4Lexer extends AbstractAntlrLexer {
+public final class Antlr4Lexer extends AbstractAntlrLexer<ANTLRv4Lexer> {
 
 
     public Antlr4Lexer(LexerRestartInfo<AntlrTokenId> info) {
-        super(info, new org.antlr.parser.antlr4.ANTLRv4Lexer(new LexerInputCharStream(info.input())));
+        super(info, new ANTLRv4Lexer(new LexerInputCharStream(info.input())));
     }
 
     private org.antlr.v4.runtime.Token preFetchedToken = null;
@@ -136,4 +137,24 @@ public final class Antlr4Lexer extends AbstractAntlrLexer {
         }
     }
 
+    @Override
+    public Object state() {
+        return new State(lexer);
+    }
+
+    public static class State extends AbstractAntlrLexer.LexerState<ANTLRv4Lexer> {
+        final int currentRuleType;
+
+        public State(ANTLRv4Lexer lexer) {
+            super(lexer);
+            this.currentRuleType = lexer.getCurrentRuleType();
+        }
+
+        @Override
+        public void restore(ANTLRv4Lexer lexer) {
+            super.restore(lexer);
+            lexer.setCurrentRuleType(currentRuleType);
+        }
+
+    }
 }

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4ParserResult.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4ParserResult.java
@@ -56,8 +56,10 @@ public final class Antlr4ParserResult extends AntlrParserResult<ANTLRv4Parser> {
     private final List<String> imports = new ArrayList<>();
 
     private static final Logger LOG = Logger.getLogger(Antlr4ParserResult.class.getName());
+
     public static final Reference HIDDEN = new Reference(ReferenceType.CHANNEL, "HIDDEN", OffsetRange.NONE);
-    
+    final Set<String> unknownReferences = new HashSet<>();
+
     public Antlr4ParserResult(Snapshot snapshot) {
         super(snapshot);
         references.put(HIDDEN.name, HIDDEN);
@@ -86,6 +88,7 @@ public final class Antlr4ParserResult extends AntlrParserResult<ANTLRv4Parser> {
         }
         occurrences.forEach((refName, offsets) -> {
             if (!allRefs.containsKey(refName)) {
+                unknownReferences.add(refName);
                 for (OffsetRange offset : offsets) {
                     errors.add(new DefaultError(null, "Unknown Reference: " + refName, null, getFileObject(), offset.getStart(), offset.getEnd(), Severity.ERROR));
                 }


### PR DESCRIPTION

Well, if we would have a 16-rc3 this would be a nice to have.

This one makes the formatting work if the editing happens at the end of the file.

The code completion has a fix and a feature creep. At the end of the file due to the bug in `AntlrTokenSequence` it was offering (`lexer`, `parser`, `grammar`).

The feature creep is a trivial one. We already have the unknown references collected during parsing, so why not offer to define those while not in a rule definition.

