### PR TITLE
Improving the Java AST debugging view.

### DIFF
--- a/java/java.debug/src/org/netbeans/modules/java/debug/TreeNode.java
+++ b/java/java.debug/src/org/netbeans/modules/java/debug/TreeNode.java
@@ -19,65 +19,7 @@
 package org.netbeans.modules.java.debug;
 
 import com.sun.source.doctree.DocCommentTree;
-import com.sun.source.tree.AnnotatedTypeTree;
-import com.sun.source.tree.AnnotationTree;
-import com.sun.source.tree.ArrayAccessTree;
-import com.sun.source.tree.ArrayTypeTree;
-import com.sun.source.tree.AssertTree;
-import com.sun.source.tree.AssignmentTree;
-import com.sun.source.tree.BinaryTree;
-import com.sun.source.tree.BlockTree;
-import com.sun.source.tree.BreakTree;
-import com.sun.source.tree.CaseTree;
-import com.sun.source.tree.CatchTree;
-import com.sun.source.tree.ClassTree;
-import com.sun.source.tree.CompilationUnitTree;
-import com.sun.source.tree.CompoundAssignmentTree;
-import com.sun.source.tree.ConditionalExpressionTree;
-import com.sun.source.tree.ContinueTree;
-import com.sun.source.tree.DoWhileLoopTree;
-import com.sun.source.tree.EmptyStatementTree;
-import com.sun.source.tree.EnhancedForLoopTree;
-import com.sun.source.tree.ErroneousTree;
-import com.sun.source.tree.ExportsTree;
-import com.sun.source.tree.ExpressionStatementTree;
-import com.sun.source.tree.ForLoopTree;
-import com.sun.source.tree.IdentifierTree;
-import com.sun.source.tree.IfTree;
-import com.sun.source.tree.ImportTree;
-import com.sun.source.tree.InstanceOfTree;
-import com.sun.source.tree.IntersectionTypeTree;
-import com.sun.source.tree.LabeledStatementTree;
-import com.sun.source.tree.LambdaExpressionTree;
-import com.sun.source.tree.LiteralTree;
-import com.sun.source.tree.MemberReferenceTree;
-import com.sun.source.tree.MemberSelectTree;
-import com.sun.source.tree.MethodTree;
-import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.tree.ModifiersTree;
-import com.sun.source.tree.ModuleTree;
-import com.sun.source.tree.NewArrayTree;
-import com.sun.source.tree.NewClassTree;
-import com.sun.source.tree.PackageTree;
-import com.sun.source.tree.ParameterizedTypeTree;
-import com.sun.source.tree.ParenthesizedTree;
-import com.sun.source.tree.PrimitiveTypeTree;
-import com.sun.source.tree.ProvidesTree;
-import com.sun.source.tree.RequiresTree;
-import com.sun.source.tree.ReturnTree;
-import com.sun.source.tree.SwitchTree;
-import com.sun.source.tree.SynchronizedTree;
-import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
-import com.sun.source.tree.TryTree;
-import com.sun.source.tree.TypeCastTree;
-import com.sun.source.tree.TypeParameterTree;
-import com.sun.source.tree.UnaryTree;
-import com.sun.source.tree.UnionTypeTree;
-import com.sun.source.tree.UsesTree;
-import com.sun.source.tree.VariableTree;
-import com.sun.source.tree.WhileLoopTree;
-import com.sun.source.tree.WildcardTree;
 import com.sun.source.util.DocTrees;
 import com.sun.source.util.TreePath;
 import java.util.ArrayList;
@@ -91,7 +33,7 @@ import javax.lang.model.type.TypeMirror;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.source.CompilationInfo;
-import org.netbeans.api.java.source.support.CancellableTreePathScanner;
+import org.netbeans.api.java.source.support.CancellableTreeScanner;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
@@ -213,764 +155,66 @@ public class TreeNode extends AbstractNode implements OffsetProvider {
         }
     }
     
-    private static class FindChildrenTreeVisitor extends CancellableTreePathScanner<Void, List<Node>> {
+    private static class FindChildrenTreeVisitor extends CancellableTreeScanner<Void, List<Node>> {
         
         private final CompilationInfo info;
+        private TreePath currentPath;
         
         public FindChildrenTreeVisitor(CompilationInfo info, AtomicBoolean cancel) {
             super(cancel);
             this.info = info;
         }
-        
-        @Override
-        public Void visitAnnotation(AnnotationTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            //???
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            
-            super.visitAnnotation(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
+
+        public Void scan(TreePath path, List<Node> d) {
+            currentPath = path.getParentPath();
+
+            scan(path.getLeaf(), d);
+
             return null;
         }
 
         @Override
-        public Void visitMethodInvocation(MethodInvocationTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            
-            super.visitMethodInvocation(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitAssert(AssertTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitAssert(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitAssignment(AssignmentTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitAssignment(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitCompoundAssignment(CompoundAssignmentTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitCompoundAssignment(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitBinary(BinaryTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitBinary(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitBlock(BlockTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitBlock(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitBreak(BreakTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitBreak(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitCase(CaseTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitCase(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitCatch(CatchTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitCatch(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitClass(ClassTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            addCorrespondingJavadoc(below);
-            
-            super.visitClass(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitConditionalExpression(ConditionalExpressionTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitConditionalExpression(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitContinue(ContinueTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitContinue(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitUnionType(UnionTypeTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitUnionType(tree, below);
-
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitDoWhileLoop(DoWhileLoopTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitDoWhileLoop(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitErroneous(ErroneousTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            scan(tree.getErrorTrees(), below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitExports(ExportsTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitExports(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitExpressionStatement(ExpressionStatementTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitExpressionStatement(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitEnhancedForLoop(EnhancedForLoopTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitEnhancedForLoop(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitForLoop(ForLoopTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitForLoop(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitIdentifier(IdentifierTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            
-            super.visitIdentifier(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitIf(IfTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitIf(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitImport(ImportTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitImport(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitArrayAccess(ArrayAccessTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitArrayAccess(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitLabeledStatement(LabeledStatementTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitLabeledStatement(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitLambdaExpression(LambdaExpressionTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitLambdaExpression(tree, below);
-
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitLiteral(LiteralTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitLiteral(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitMemberReference(MemberReferenceTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-
-            super.visitMemberReference(tree, below);
-
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitMethod(MethodTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            addCorrespondingJavadoc(below);
-            
-            super.visitMethod(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitModifiers(ModifiersTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitModifiers(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitModule(ModuleTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitModule(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitNewArray(NewArrayTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            
-            super.visitNewArray(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitNewClass(NewClassTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            
-            super.visitNewClass(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitParenthesized(ParenthesizedTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitParenthesized(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitProvides(ProvidesTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitProvides(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitRequires(RequiresTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitRequires(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitReturn(ReturnTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitReturn(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitMemberSelect(MemberSelectTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            
-            super.visitMemberSelect(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitEmptyStatement(EmptyStatementTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitEmptyStatement(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitSwitch(SwitchTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitSwitch(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitSynchronized(SynchronizedTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitSynchronized(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitThrow(ThrowTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitThrow(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitCompilationUnit(CompilationUnitTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            
-            super.visitCompilationUnit(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitPackage(PackageTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitPackage(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitTry(TryTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitTry(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitAnnotatedType(AnnotatedTypeTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            
-            super.visitAnnotatedType(tree, below);
-
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitParameterizedType(ParameterizedTypeTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            
-            super.visitParameterizedType(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitArrayType(ArrayTypeTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            
-            super.visitArrayType(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitTypeCast(TypeCastTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitTypeCast(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitIntersectionType(IntersectionTypeTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitIntersectionType(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitPrimitiveType(PrimitiveTypeTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitPrimitiveType(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitTypeParameter(TypeParameterTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            
-            super.visitTypeParameter(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitInstanceOf(InstanceOfTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitInstanceOf(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitUnary(UnaryTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitUnary(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitUses(UsesTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitUses(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitVariable(VariableTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingElement(below);
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            addCorrespondingJavadoc(below);
-            
-            super.visitVariable(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitWhileLoop(WhileLoopTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitWhileLoop(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
-            return null;
-        }
-
-        @Override
-        public Void visitWildcard(WildcardTree tree, List<Node> d) {
-            List<Node> below = new ArrayList<Node>();
-            
-            addCorrespondingType(below);
-            addCorrespondingComments(below);
-            super.visitWildcard(tree, below);
-            
-            d.add(new TreeNode(info, getCurrentPath(), below));
+        public Void scan(Tree tree, List<Node> d) {
+            if (tree != null) {
+                TreePath oldPath = currentPath;
+                try {
+                    List<Node> below = new ArrayList<Node>();
+                    currentPath = new TreePath(currentPath, tree);
+
+                    //???
+                    addCorrespondingElement(currentPath, below);
+                    addCorrespondingType(currentPath, below);
+                    addCorrespondingComments(currentPath, below);
+                    addCorrespondingJavadoc(currentPath, below);
+
+                    super.scan(tree, below);
+
+                    d.add(new TreeNode(info, currentPath, below));
+                } finally {
+                    currentPath = oldPath;
+                }
+            }
             return null;
         }
         
-        private void addCorrespondingJavadoc(List<Node> below) {
-            DocCommentTree docCommentTree = ((DocTrees) info.getTrees()).getDocCommentTree(getCurrentPath());
+        private void addCorrespondingJavadoc(TreePath currentPath, List<Node> below) {
+            DocCommentTree docCommentTree = ((DocTrees) info.getTrees()).getDocCommentTree(currentPath);
             
             if (docCommentTree != null) {
-                below.add(new DocTreeNode(info, getCurrentPath(), docCommentTree, docCommentTree));
+                below.add(new DocTreeNode(info, currentPath, docCommentTree, docCommentTree));
             } else {
                 below.add(new NotFoundJavadocNode("<javadoc-not-found>"));
             }
         }
 
-        private void addCorrespondingElement(List<Node> below) {
-            Element el = info.getTrees().getElement(getCurrentPath());
+        private void addCorrespondingElement(TreePath currentPath, List<Node> below) {
+            Element el = info.getTrees().getElement(currentPath);
             
             below.add(nodeForElement(info, el));
         }
 
-        private void addCorrespondingType(List<Node> below) {
-            TypeMirror tm = info.getTrees().getTypeMirror(getCurrentPath());
+        private void addCorrespondingType(TreePath currentPath, List<Node> below) {
+            TypeMirror tm = info.getTrees().getTypeMirror(currentPath);
             
             if (tm != null) {
                 below.add(new TypeNode(tm));
@@ -979,9 +223,9 @@ public class TreeNode extends AbstractNode implements OffsetProvider {
             }
         }
         
-        private void addCorrespondingComments(List<Node> below) {
-            below.add(new CommentsNode(NbBundle.getMessage(TreeNode.class, "NM_Preceding_Comments"), info.getTreeUtilities().getComments(getCurrentPath().getLeaf(), true)));
-            below.add(new CommentsNode(NbBundle.getMessage(TreeNode.class, "NM_Trailing_Comments"), info.getTreeUtilities().getComments(getCurrentPath().getLeaf(), false)));
+        private void addCorrespondingComments(TreePath currentPath, List<Node> below) {
+            below.add(new CommentsNode(NbBundle.getMessage(TreeNode.class, "NM_Preceding_Comments"), info.getTreeUtilities().getComments(currentPath.getLeaf(), true)));
+            below.add(new CommentsNode(NbBundle.getMessage(TreeNode.class, "NM_Trailing_Comments"), info.getTreeUtilities().getComments(currentPath.getLeaf(), false)));
         }
     }
     


### PR DESCRIPTION
The AST debug view for Java (`java/java.debug`) has some trouble:
 - it has hardcoded all AST node kinds, so if a new AST node kind is added, it needs an update
 - the highlight showing the current AST node's span is not cleared when the view is unselected
 - the highlight color is really ugly

This patch attempts to improve these aspects.

---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
