### PR TITLE
ci - run cache action after checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,12 @@ jobs:
         with:
           java-version: ${{ matrix.java }} 
           distribution: 'zulu'
+          
+      - name: Checkout ${{ github.ref }} ( ${{ github.sha }} )
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          submodules: false
 
       - name: Caching dependencies
         uses: actions/cache@v3
@@ -84,12 +90,6 @@ jobs:
           path: ~/.hgexternalcache
           key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-
-          
-      - name: Checkout ${{ github.ref }} ( ${{ github.sha }} )
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          submodules: false
 
       - name: Build NetBeans
         run: ant -quiet -Dcluster.config=release build-nozip


### PR DESCRIPTION
run cache action *after* checkout, otherwise we can't hash the binaries-lists (results in empty string).

the current setup does never update the cache once its built. (I reset it manually yesterday.)

Please note that this was not the cause of the build failures where dependency downloads timed out - but this is how I found the issue in the first place.

targets delivery so that all branches benefit from it.