### PR TITLE
PHP 8.2 Support: Allow `null`, `false`, and `true` as stand-alone types 

### DIFF
--- a/php/php.api.phpmodule/manifest.mf
+++ b/php/php.api.phpmodule/manifest.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.php.api.phpmodule
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/api/phpmodule/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.86
+OpenIDE-Module-Specification-Version: 2.87

--- a/php/php.api.phpmodule/src/org/netbeans/modules/php/api/PhpVersion.java
+++ b/php/php.api.phpmodule/src/org/netbeans/modules/php/api/PhpVersion.java
@@ -38,6 +38,7 @@ import org.openide.util.NbBundle;
     "PhpVersion.PHP_74=PHP 7.4",
     "PhpVersion.PHP_80=PHP 8.0",
     "PhpVersion.PHP_81=PHP 8.1",
+    "PhpVersion.PHP_82=PHP 8.2",
 })
 public enum PhpVersion {
 
@@ -96,7 +97,13 @@ public enum PhpVersion {
      * PHP 8.1.
      * @since 2.80
      */
-    PHP_81(Bundle.PhpVersion_PHP_81());
+    PHP_81(Bundle.PhpVersion_PHP_81()),
+    /**
+     * PHP 8.2.
+     * @since 2.87
+     */
+    PHP_82(Bundle.PhpVersion_PHP_82()),
+    ;
 
     private final String displayName;
     private final boolean namespaces;
@@ -221,6 +228,17 @@ public enum PhpVersion {
     }
 
     /**
+     * Check whether this version supports the null, false, and true types.
+     *
+     * @return {@code true} if this version supports null, false, and true
+     * types, {@code false} otherwise
+     * @since 2.87
+     */
+    public boolean hasNullAndFalseAndTrueTypes() {
+        return this.compareTo(PhpVersion.PHP_82) >= 0;
+    }
+
+    /**
      * Check whether this is supported version yet by PHP official.
      *
      * @return {@code true} if this is supported version, {@code false}
@@ -254,6 +272,7 @@ public enum PhpVersion {
         PHP_74(LocalDate.of(2019, 11, 28), LocalDate.of(2021, 11, 28), LocalDate.of(2022, 11, 28)),
         PHP_80(LocalDate.of(2020, 11, 26), LocalDate.of(2022, 11, 26), LocalDate.of(2023, 11, 26)),
         PHP_81(LocalDate.of(2021, 11, 25), LocalDate.of(2023, 11, 25), LocalDate.of(2024, 11, 25)),
+        PHP_82(LocalDate.of(2022, 11, 24), LocalDate.of(2024, 11, 24), LocalDate.of(2025, 11, 24)),
         ;
 
         private final LocalDate initialRelease;

--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -20,7 +20,7 @@ build.compiler=extJavac
 nbjavac.ignore.missing.enclosing=**/CUP$ASTPHP5Parser$actions.class
 javac.compilerargs=-J-Xmx512m
 nbm.needs.restart=true
-spec.version.base=2.19.0
+spec.version.base=2.20.0
 release.external/predefined_vars-1.0.zip=docs/predefined_vars.zip
 sigtest.gen.fail.on.error=false
 

--- a/php/php.editor/nbproject/project.xml
+++ b/php/php.editor/nbproject/project.xml
@@ -304,7 +304,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>2.83</specification-version>
+                        <specification-version>2.87</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/CompletionContextFinder.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/CompletionContextFinder.java
@@ -1228,6 +1228,7 @@ final class CompletionContextFinder {
                 || id == PHPTokenId.PHP_STATIC
                 || id == PHPTokenId.PHP_NULL
                 || id == PHPTokenId.PHP_FALSE
+                || id == PHPTokenId.PHP_TRUE
                 || id == PHPTokenId.PHP_ARRAY
                 || id == PHPTokenId.PHP_ITERABLE
                 || id == PHPTokenId.PHP_CALLABLE;
@@ -1285,8 +1286,12 @@ final class CompletionContextFinder {
                     break;
                 }
                 Token<PHPTokenId> cToken = tokenSequence.token();
-                if (cToken.id() == PHPTokenId.WHITESPACE
-                        && TokenUtilities.indexOf(cToken.text(), '\n') != -1) { // NOI18N
+                if ((cToken.id() == PHPTokenId.WHITESPACE
+                        && TokenUtilities.indexOf(cToken.text(), '\n') != -1) // NOI18N
+                        || cToken.id() == PHPTokenId.PHP_LINE_COMMENT) {
+                    // e.g.
+                    // public bool $bool = true; // line comment
+                    // public tru^e $true = true;
                     break;
                 }
                 tokens.addLast(cToken);

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -266,7 +266,7 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
             PHPTokenId.WHITESPACE, PHPTokenId.PHP_STRING, PHPTokenId.PHP_NS_SEPARATOR,
             PHPTokenId.PHP_TYPE_BOOL, PHPTokenId.PHP_TYPE_FLOAT, PHPTokenId.PHP_TYPE_INT, PHPTokenId.PHP_TYPE_STRING, PHPTokenId.PHP_TYPE_VOID,
             PHPTokenId.PHP_TYPE_OBJECT, PHPTokenId.PHP_TYPE_MIXED, PHPTokenId.PHP_SELF, PHPTokenId.PHP_PARENT, PHPTokenId.PHP_STATIC,
-            PHPTokenId.PHP_NULL, PHPTokenId.PHP_FALSE, PHPTokenId.PHP_ARRAY, PHPTokenId.PHP_ITERABLE, PHPTokenId.PHP_CALLABLE,
+            PHPTokenId.PHP_NULL, PHPTokenId.PHP_FALSE, PHPTokenId.PHP_TRUE, PHPTokenId.PHP_ARRAY, PHPTokenId.PHP_ITERABLE, PHPTokenId.PHP_CALLABLE,
             PHPTokenId.PHPDOC_COMMENT_START, PHPTokenId.PHPDOC_COMMENT, PHPTokenId.PHPDOC_COMMENT_END,
             PHPTokenId.PHP_COMMENT_START, PHPTokenId.PHP_COMMENT, PHPTokenId.PHP_COMMENT_END
     );
@@ -319,7 +319,6 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
         if (CancelSupport.getDefault().isCancelled()) {
             return CodeCompletionResult.NONE;
         }
-
         CompletionContext context = CompletionContextFinder.findCompletionContext(info, caretOffset);
         LOGGER.log(Level.FINE, "CC context: {0}", context);
 
@@ -534,7 +533,7 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
                         typesForTypeName.addAll(Type.getSpecialTypesForType());
                     }
                     if (isNullableType(info, caretOffset)) {
-                        typesForTypeName.remove(Type.FALSE);
+                        // ?false, ?true is OK since PHP 8.2
                         typesForTypeName.remove(Type.NULL);
                     }
                     if (isUnionType(info, caretOffset)) {
@@ -555,7 +554,7 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
                         typesForReturnTypeName.add(Type.STATIC);
                     }
                     if (isNullableType(info, caretOffset)) {
-                        typesForReturnTypeName.remove(Type.FALSE);
+                        // ?false, ?true is OK since PHP 8.2
                         typesForReturnTypeName.remove(Type.NULL);
                         typesForReturnTypeName.remove(Type.VOID);
                         typesForReturnTypeName.remove(Type.NEVER);
@@ -1154,7 +1153,7 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
                 String prefix = doc.getText(start, 1);
                 if (CodeUtils.NULLABLE_TYPE_PREFIX.equals(prefix)) {
                     List<String> keywords = new ArrayList<>(Type.getTypesForEditor());
-                    keywords.remove(Type.FALSE);
+                    // ?false, ?true is OK since PHP 8.2
                     keywords.remove(Type.NULL);
                     autoCompleteKeywords(completionResult, request, keywords);
                 } else {
@@ -1301,7 +1300,7 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
             }
         }
         if (isNullableType) {
-            keywords.remove(Type.FALSE);
+            // ?false, ?true is OK since PHP 8.2
             keywords.remove(Type.NULL);
         }
         if (isUnionType(info, caretOffset)) {
@@ -1350,6 +1349,7 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
                 PHPTokenId.PHP_ITERABLE,
                 PHPTokenId.PHP_SELF,
                 PHPTokenId.PHP_PARENT,
+                PHPTokenId.PHP_TRUE,
                 PHPTokenId.PHP_FALSE,
                 PHPTokenId.PHP_NULL,
                 PHPTokenId.PHP_STRING,

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/Type.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/Type.java
@@ -90,9 +90,9 @@ public final class Type {
     public static final String STATIC = "static"; //NOI18N NETBEANS-4443 PHP 8.0
     public static final String NEVER = "never"; //NOI18N NETBEANS-5599 PHP 8.1
 
-    private static final List<String> TYPES_FOR_EDITOR = Arrays.asList(ARRAY, CALLABLE, ITERABLE, BOOL, FLOAT, INT, STRING, OBJECT, NULL, FALSE, MIXED);
-    private static final List<String> TYPES_FOR_RETURN_TYPE = Arrays.asList(ARRAY, CALLABLE, ITERABLE, BOOL, FLOAT, INT, STRING, VOID, OBJECT, NULL, FALSE, MIXED, NEVER);
-    private static final List<String> TYPES_FOR_FIELD_TYPE = Arrays.asList(ARRAY, ITERABLE, BOOL, FLOAT, INT, STRING, OBJECT, SELF, PARENT, NULL, FALSE, MIXED); // PHP 7.4 Typed Properties 2.0
+    private static final List<String> TYPES_FOR_EDITOR = Arrays.asList(ARRAY, CALLABLE, ITERABLE, BOOL, FLOAT, INT, STRING, OBJECT, NULL, FALSE, MIXED, TRUE);
+    private static final List<String> TYPES_FOR_RETURN_TYPE = Arrays.asList(ARRAY, CALLABLE, ITERABLE, BOOL, FLOAT, INT, STRING, VOID, OBJECT, NULL, FALSE, MIXED, NEVER, TRUE);
+    private static final List<String> TYPES_FOR_FIELD_TYPE = Arrays.asList(ARRAY, ITERABLE, BOOL, FLOAT, INT, STRING, OBJECT, SELF, PARENT, NULL, FALSE, MIXED, TRUE); // PHP 7.4 Typed Properties 2.0
     private static final List<String> SPECIAL_TYPES_FOR_TYPE = Arrays.asList(SELF, PARENT);
     private static final List<String> TYPES_FOR_PHP_DOC = Arrays.asList(STRING, INTEGER, INT, BOOLEAN, BOOL, FLOAT, DOUBLE, OBJECT, MIXED, ARRAY,
             RESOURCE, VOID, NULL, CALLBACK, CALLABLE, ITERABLE, FALSE, TRUE, SELF);
@@ -107,7 +107,8 @@ public final class Type {
                 || NUMBER.equals(typeName) || CALLBACK.equals(typeName) || RESOURCE.equals(typeName)
                 || DOUBLE.equals(typeName) || STRING.equals(typeName) || NULL.equals(typeName)
                 || VOID.equals(typeName) || CALLABLE.equals(typeName) || ITERABLE.equals(typeName)
-                || FALSE.equals(typeName) || STATIC.equals(typeName) || NEVER.equals(typeName)) {
+                || FALSE.equals(typeName) || STATIC.equals(typeName) || NEVER.equals(typeName)
+                || TRUE.equals(typeName)) {
             retval = true;
         }
         return retval;

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/UnusableTypesHintError.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/UnusableTypesHintError.java
@@ -71,7 +71,7 @@ public class UnusableTypesHintError extends HintErrorRule {
     private static final List<String> INVALID_TYPES_WITH_INTERSECTION_TYPES = Arrays.asList(
             Type.ARRAY, Type.BOOL, Type.CALLABLE, Type.FALSE, Type.FLOAT,
             Type.INT, Type.ITERABLE, Type.MIXED, Type.NEVER, Type.NULL,
-            Type.OBJECT, Type.PARENT, Type.SELF, Type.STATIC, Type.STRING, Type.VOID
+            Type.OBJECT, Type.PARENT, Type.SELF, Type.STATIC, Type.STRING, Type.TRUE, Type.VOID
     );
 
     @Override
@@ -259,7 +259,7 @@ public class UnusableTypesHintError extends HintErrorRule {
                     createError(type, Type.NEVER, UnusableType.Context.Property);
                 }
                 if (!isInUnionType) {
-                    checkFalseAndNullTypes((NamespaceName) type);
+                    checkTrueAndFalseAndNullTypes((NamespaceName) type);
                 }
             } else if (type instanceof UnionType) {
                 ((UnionType) type).getTypes().forEach(unionType -> checkFieldType(unionType, true));
@@ -268,17 +268,21 @@ public class UnusableTypesHintError extends HintErrorRule {
 
         private void checkParameterType(Expression parameterType, boolean isInUnionType) {
             // unusable type: void, never
-            if (parameterType instanceof NamespaceName) {
-                if (isVoidType((NamespaceName) parameterType)) {
-                    createError(parameterType, Type.VOID, UnusableType.Context.Parameter);
-                } else if (isNeverType((NamespaceName) parameterType)) {
-                    createError(parameterType, Type.NEVER, UnusableType.Context.Parameter);
+            Expression paramType = parameterType;
+            if (parameterType instanceof NullableType) {
+                paramType = ((NullableType) parameterType).getType();
+            }
+            if (paramType instanceof NamespaceName) {
+                if (isVoidType((NamespaceName) paramType)) {
+                    createError(paramType, Type.VOID, UnusableType.Context.Parameter);
+                } else if (isNeverType((NamespaceName) paramType)) {
+                    createError(paramType, Type.NEVER, UnusableType.Context.Parameter);
                 }
                 if (!isInUnionType) {
-                    checkFalseAndNullTypes((NamespaceName) parameterType);
+                    checkTrueAndFalseAndNullTypes((NamespaceName) paramType);
                 }
-            } else if (parameterType instanceof UnionType) {
-                ((UnionType) parameterType).getTypes().forEach(type -> checkParameterType(type, true));
+            } else if (paramType instanceof UnionType) {
+                ((UnionType) paramType).getTypes().forEach(type -> checkParameterType(type, true));
             }
         }
 
@@ -291,7 +295,7 @@ public class UnusableTypesHintError extends HintErrorRule {
                     createError(returnType, Type.NEVER, UnusableType.Context.ArrowFunctionReturn);
                 }
                 if (!isInUnionType) {
-                    checkFalseAndNullTypes((NamespaceName) returnType);
+                    checkTrueAndFalseAndNullTypes((NamespaceName) returnType);
                 }
             } else if (returnType instanceof UnionType) {
                 ((UnionType) returnType).getTypes().forEach(type -> checkArrowFunctionReturnType(type, true));
@@ -309,7 +313,7 @@ public class UnusableTypesHintError extends HintErrorRule {
 
             if (type instanceof NamespaceName) {
                 if (!isInUnionType) {
-                    checkFalseAndNullTypes((NamespaceName) type);
+                    checkTrueAndFalseAndNullTypes((NamespaceName) type);
                 } else {
                     // "void" can't be part of a union type
                     if (isVoidType((NamespaceName) type)) {
@@ -333,19 +337,23 @@ public class UnusableTypesHintError extends HintErrorRule {
             }
         }
 
-        private void checkFalseAndNullTypes(NamespaceName type) {
+        private void checkTrueAndFalseAndNullTypes(NamespaceName type) {
             if (isFalseType(type) && !phpVersion.hasNullAndFalseAndTrueTypes()) {
                 createError(type, Type.FALSE, UnusableType.Context.Standalone);
+            } else if (isTrueType(type) && !phpVersion.hasNullAndFalseAndTrueTypes()) {
+                createError(type, Type.TRUE, UnusableType.Context.Standalone);
             } else if (isNullType(type) && !phpVersion.hasNullAndFalseAndTrueTypes()) {
                 createError(type, Type.NULL, UnusableType.Context.Standalone);
             }
         }
 
-        private void checkFalseAndNullTypes(UnionType unionType) {
+        private void checkTrueAndFalseAndNullTypes(UnionType unionType) {
             // null|false or false|null
+            // null|true or true|null
             if (phpVersion.hasNullAndFalseAndTrueTypes() || unionType.getTypes().size() != 2) {
                 return;
             }
+            Expression trueType = null;
             Expression falseType = null;
             boolean hasNull = false;
             for (Expression type : unionType.getTypes()) {
@@ -355,6 +363,8 @@ public class UnusableTypesHintError extends HintErrorRule {
                 if (type instanceof NamespaceName) {
                     if (isFalseType((NamespaceName) type)) {
                         falseType = type;
+                    } else if (isTrueType((NamespaceName) type)) {
+                        trueType = type;
                     } else if (isNullType((NamespaceName) type)) {
                         hasNull = true;
                     }
@@ -362,13 +372,40 @@ public class UnusableTypesHintError extends HintErrorRule {
             }
             if (falseType != null && hasNull) {
                 createError(falseType, Type.FALSE, UnusableType.Context.Standalone);
+            } else if (trueType != null && hasNull) {
+                createError(falseType, Type.TRUE, UnusableType.Context.Standalone);
+            }
+        }
+
+        private void checkBothTrueAndFalseTypes(UnionType unionType) {
+            // e.g. true|false -> bool, false|true -> bool, int|true|false -> int|bool
+            Expression trueType = null;
+            Expression falseType = null;
+            for (Expression type : unionType.getTypes()) {
+                if (CancelSupport.getDefault().isCancelled()) {
+                    return;
+                }
+                QualifiedName qualifiedName = QualifiedName.create(type);
+                assert qualifiedName != null;
+                String name = qualifiedName.toString().toLowerCase(Locale.ENGLISH);
+                if (Type.TRUE.equals(name)) {
+                    trueType = type;
+                } else if (Type.FALSE.equals(name)) {
+                    falseType = type;
+                }
+                if (trueType != null && falseType != null) {
+                    createError(trueType, Type.TRUE, UnusableType.Context.BothTrueAndFalse);
+                    createError(falseType, Type.FALSE, UnusableType.Context.BothTrueAndFalse);
+                    return;
+                }
             }
         }
 
         private void checkUnionType(UnionType unionType) {
             checkDuplicateType(unionType.getTypes());
             checkRedundantTypeCombination(unionType);
-            checkFalseAndNullTypes(unionType); // null|false or false|null
+            checkTrueAndFalseAndNullTypes(unionType); // null|false or false|null
+            checkBothTrueAndFalseTypes(unionType); // true|false -> bool
         }
 
         private void checkDuplicateType(List<Expression> types) {
@@ -380,13 +417,21 @@ public class UnusableTypesHintError extends HintErrorRule {
                 QualifiedName qualifiedName = QualifiedName.create(type);
                 assert qualifiedName != null;
                 String name = qualifiedName.toString().toLowerCase(Locale.ENGLISH);
-                if (Type.FALSE.equals(name)) {
-                    // check bool|false
-                    name = Type.BOOL;
-                }
                 if (checkedTypes.contains(name)) {
                     createDuplicateTypeError(type, qualifiedName.toString());
                     return;
+                } else if (checkedTypes.contains(Type.BOOL)) {
+                    // bool|false bool|true
+                    if (Type.FALSE.equals(name) || Type.TRUE.equals(name)) {
+                        createDuplicateTypeError(type, qualifiedName.toString());
+                        return;
+                    }
+                } else if (checkedTypes.contains(Type.FALSE) || checkedTypes.contains(Type.TRUE)) {
+                    // false|bool true|bool
+                    if (Type.BOOL.equals(name)) {
+                        createDuplicateTypeError(type, qualifiedName.toString());
+                        return;
+                    }
                 }
                 checkedTypes.add(name);
             }
@@ -539,6 +584,10 @@ public class UnusableTypesHintError extends HintErrorRule {
             return Type.NEVER.equals(CodeUtils.extractUnqualifiedName(namespaceName));
         }
 
+        private static boolean isTrueType(NamespaceName namespaceName) {
+            return Type.TRUE.equals(CodeUtils.extractUnqualifiedName(namespaceName));
+        }
+
         private static boolean isFalseType(NamespaceName namespaceName) {
             return Type.FALSE.equals(CodeUtils.extractUnqualifiedName(namespaceName));
         }
@@ -574,6 +623,8 @@ public class UnusableTypesHintError extends HintErrorRule {
         "UnusableType.Context.union=a union",
         "UnusableType.Context.intersection=an intersection",
         "UnusableType.Context.nullable=a nullable",
+        "UnusableType.Context.bothTrueAndFalse=both \"true\" and \"false\"",
+        "UnusableType.Context.bothTrueAndFalse.description=Contains both \"true\" and \"false\", \"bool\" should be used.",
         "# {0} - type",
         "# {1} - context",
         "UnusableType.description=\"{0}\" cannot be used as {1} type.",
@@ -589,6 +640,12 @@ public class UnusableTypesHintError extends HintErrorRule {
             Union(Bundle.UnusableType_Context_union()),
             Intersection(Bundle.UnusableType_Context_intersection()),
             Nullable(Bundle.UnusableType_Context_nullable()),
+            BothTrueAndFalse(Bundle.UnusableType_Context_bothTrueAndFalse()) {
+                @Override
+                public String getDescription(String type) {
+                    return Bundle.UnusableType_Context_bothTrueAndFalse_description();
+                }
+            },
             ;
             private final String context;
 

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/csl/NavigatorTest/structure/standAloneTrueType.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/csl/NavigatorTest/structure/standAloneTrueType.pass
@@ -1,0 +1,8 @@
+|-TrueType [820, 1281] : ESCAPED{TrueType}
+|--$true [848, 852] : ESCAPED{$true}<font color="#999999">:ESCAPED{true}</font>
+|--$true2 [894, 899] : ESCAPED{$true2}<font color="#999999">:ESCAPED{?}ESCAPED{true}</font>
+|--$true3 [944, 949] : ESCAPED{$true3}<font color="#999999">:ESCAPED{int}ESCAPED{|}ESCAPED{true}</font>
+|--$true4 [995, 1000] : ESCAPED{$true4}<font color="#999999">:ESCAPED{true}ESCAPED{|}ESCAPED{int}</font>
+|--test [1046, 1098] : ESCAPED{test}ESCAPED{(}<font color="#999999">ESCAPED{true}ESCAPED{ }</font>ESCAPED{$true}ESCAPED{)}<font color="#999999">:ESCAPED{true}</font>
+|--testNullable [1120, 1182] : ESCAPED{testNullable}ESCAPED{(}<font color="#999999">ESCAPED{?}ESCAPED{true}ESCAPED{ }</font>ESCAPED{$true}ESCAPED{)}<font color="#999999">:ESCAPED{?}ESCAPED{true}</font>
+|--testUnionType [1204, 1279] : ESCAPED{testUnionType}ESCAPED{(}<font color="#999999">ESCAPED{true}ESCAPED{|}ESCAPED{string}ESCAPED{ }</font>ESCAPED{$true}ESCAPED{)}<font color="#999999">:ESCAPED{string}ESCAPED{|}ESCAPED{true}</font>

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences01.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences03.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences05.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences07.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences08.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences10.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences12.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences14.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences14.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences16.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences16.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences18.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences18.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences20.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences20.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences22.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences22.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences24.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences24.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences26.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences26.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences28.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences28.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences30.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences30.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences32.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences32.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences34.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences34.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences36.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/byReferences/byReferences.php.testByReferences36.completion
@@ -16,3 +16,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/netbeans68version/paramdecltypes/paramdecltypes.php.testParamDeclTypes11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/netbeans68version/paramdecltypes/paramdecltypes.php.testParamDeclTypes11.completion
@@ -15,3 +15,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/netbeans68version/paramdecltypes/paramdecltypes.php.testParamDeclTypes14.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/netbeans68version/paramdecltypes/paramdecltypes.php.testParamDeclTypes14.completion
@@ -15,3 +15,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/netbeans68version/paramdecltypes/paramdecltypes.php.testParamDeclTypes5.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/netbeans68version/paramdecltypes/paramdecltypes.php.testParamDeclTypes5.completion
@@ -15,3 +15,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/netbeans68version/paramdecltypes/paramdecltypes.php.testParamDeclTypes8.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/netbeans68version/paramdecltypes/paramdecltypes.php.testParamDeclTypes8.completion
@@ -15,3 +15,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php54/callableTypeHint.php.testCallableTypeHint_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php54/callableTypeHint.php.testCallableTypeHint_01.completion
@@ -22,3 +22,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php54/callableTypeHint.php.testCallableTypeHint_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php54/callableTypeHint.php.testCallableTypeHint_03.completion
@@ -24,3 +24,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType01.completion
@@ -62,4 +62,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType03.completion
@@ -59,4 +59,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType05.completion
@@ -59,4 +59,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType07.completion
@@ -59,4 +59,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType12.completion
@@ -59,4 +59,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType13.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType13.completion
@@ -59,4 +59,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType14.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypes.php.testReturnType14.completion
@@ -59,4 +59,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping01.php.testReturnTypesTyping01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping01.php.testReturnTypesTyping01.completion
@@ -59,4 +59,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping02.php.testReturnTypesTyping02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping02.php.testReturnTypesTyping02.completion
@@ -59,4 +59,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping03.php.testReturnTypesTyping03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping03.php.testReturnTypesTyping03.completion
@@ -59,4 +59,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping04.php.testReturnTypesTyping04a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping04.php.testReturnTypesTyping04a.completion
@@ -59,4 +59,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping04.php.testReturnTypesTyping04b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping04.php.testReturnTypesTyping04b.completion
@@ -59,4 +59,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping05.php.testReturnTypesTyping05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping05.php.testReturnTypesTyping05.completion
@@ -62,4 +62,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping06.php.testReturnTypesTyping06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping06.php.testReturnTypesTyping06.completion
@@ -62,4 +62,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping07.php.testReturnTypesTyping07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping07.php.testReturnTypesTyping07.completion
@@ -62,4 +62,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping08.php.testReturnTypesTyping08a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping08.php.testReturnTypesTyping08a.completion
@@ -62,4 +62,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping08.php.testReturnTypesTyping08b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping08.php.testReturnTypesTyping08b.completion
@@ -62,4 +62,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping09.php.testReturnTypesTyping09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping09.php.testReturnTypesTyping09.completion
@@ -62,4 +62,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping10.php.testReturnTypesTyping10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping10.php.testReturnTypesTyping10.completion
@@ -62,4 +62,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping11.php.testReturnTypesTyping11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping11.php.testReturnTypesTyping11.completion
@@ -62,4 +62,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping12.php.testReturnTypesTyping12a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping12.php.testReturnTypesTyping12a.completion
@@ -62,4 +62,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping12.php.testReturnTypesTyping12b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/returnTypesTyping12.php.testReturnTypesTyping12b.completion
@@ -62,4 +62,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testBoolTypeHint01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testBoolTypeHint01.completion
@@ -58,3 +58,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testBoolTypeHint03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testBoolTypeHint03.completion
@@ -64,3 +64,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testFloatTypeHint01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testFloatTypeHint01.completion
@@ -58,3 +58,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testFloatTypeHint03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testFloatTypeHint03.completion
@@ -64,3 +64,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testIntTypeHint01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testIntTypeHint01.completion
@@ -58,3 +58,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testIntTypeHint03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testIntTypeHint03.completion
@@ -64,3 +64,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testStringTypeHint01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testStringTypeHint01.completion
@@ -58,3 +58,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testStringTypeHint03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/scalarTypeHints.php.testStringTypeHint03.completion
@@ -64,3 +64,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType01.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType03.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType07.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType09.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType11.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType13.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ParameterType13.completion
@@ -26,9 +26,11 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType01.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType03.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType05.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType09.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType11.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType13.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType13.completion
@@ -26,9 +26,11 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType15.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/nullableTypes.php.testNullableTypes_ReturnType15.completion
@@ -26,9 +26,11 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType01.php.testNullableTypes_TypingParameterType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType01.php.testNullableTypes_TypingParameterType01.completion
@@ -26,9 +26,11 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType02.php.testNullableTypes_TypingParameterType02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType02.php.testNullableTypes_TypingParameterType02.completion
@@ -26,9 +26,11 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType03.php.testNullableTypes_TypingParameterType03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType03.php.testNullableTypes_TypingParameterType03.completion
@@ -26,9 +26,11 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType04.php.testNullableTypes_TypingParameterType04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType04.php.testNullableTypes_TypingParameterType04.completion
@@ -26,9 +26,11 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType05.php.testNullableTypes_TypingParameterType05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType05.php.testNullableTypes_TypingParameterType05.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType06.php.testNullableTypes_TypingParameterType06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType06.php.testNullableTypes_TypingParameterType06.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType07.php.testNullableTypes_TypingParameterType07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType07.php.testNullableTypes_TypingParameterType07.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType08.php.testNullableTypes_TypingParameterType08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType08.php.testNullableTypes_TypingParameterType08.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType09.php.testNullableTypes_TypingParameterType09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType09.php.testNullableTypes_TypingParameterType09.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType10.php.testNullableTypes_TypingParameterType10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType10.php.testNullableTypes_TypingParameterType10.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType11.php.testNullableTypes_TypingParameterType11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType11.php.testNullableTypes_TypingParameterType11.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType12.php.testNullableTypes_TypingParameterType12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingParameterType12.php.testNullableTypes_TypingParameterType12.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -34,3 +35,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType01.php.testNullableTypes_TypingReturnType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType01.php.testNullableTypes_TypingReturnType01.completion
@@ -26,9 +26,11 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType02.php.testNullableTypes_TypingReturnType02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType02.php.testNullableTypes_TypingReturnType02.completion
@@ -26,9 +26,11 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType03.php.testNullableTypes_TypingReturnType03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType03.php.testNullableTypes_TypingReturnType03.completion
@@ -26,9 +26,11 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType04.php.testNullableTypes_TypingReturnType04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType04.php.testNullableTypes_TypingReturnType04.completion
@@ -26,9 +26,11 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType05.php.testNullableTypes_TypingReturnType05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType05.php.testNullableTypes_TypingReturnType05.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType06.php.testNullableTypes_TypingReturnType06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType06.php.testNullableTypes_TypingReturnType06.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType07.php.testNullableTypes_TypingReturnType07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType07.php.testNullableTypes_TypingReturnType07.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType08.php.testNullableTypes_TypingReturnType08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType08.php.testNullableTypes_TypingReturnType08.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType09.php.testNullableTypes_TypingReturnType09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType09.php.testNullableTypes_TypingReturnType09.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType10.php.testNullableTypes_TypingReturnType10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType10.php.testNullableTypes_TypingReturnType10.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType11.php.testNullableTypes_TypingReturnType11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType11.php.testNullableTypes_TypingReturnType11.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType12.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType12.php.testNullableTypes_TypingReturnType12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypes/typingReturnType12.php.testNullableTypes_TypingReturnType12.completion
@@ -26,6 +26,7 @@ CLASS      NullableTypesInterface          [PUBLIC]   typingReturnType08.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -35,3 +36,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypesInPHPDoc/nullableTypesInPHPDoc.php.testNullableTypesInPHPDoc_NullableType04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypesInPHPDoc/nullableTypesInPHPDoc.php.testNullableTypesInPHPDoc_NullableType04.completion
@@ -6,9 +6,11 @@ CLASS      PHPDocTags                      [PUBLIC]   nullableTypesInPHPDoc.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypesInPHPDoc/nullableTypesInPHPDoc.php.testNullableTypesInPHPDoc_NullableType06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testNullableTypesInPHPDoc/nullableTypesInPHPDoc.php.testNullableTypesInPHPDoc_NullableType06.completion
@@ -6,9 +6,11 @@ CLASS      PHPDocTags                      [PUBLIC]   nullableTypesInPHPDoc.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testVoidReturnType/voidReturnType.php.testVoidReturnType_Class01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testVoidReturnType/voidReturnType.php.testVoidReturnType_Class01.completion
@@ -19,4 +19,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testVoidReturnType/voidReturnType.php.testVoidReturnType_Function01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testVoidReturnType/voidReturnType.php.testVoidReturnType_Function01.completion
@@ -16,4 +16,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testVoidReturnType/voidReturnType.php.testVoidReturnType_Interface01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php71/testVoidReturnType/voidReturnType.php.testVoidReturnType_Interface01.completion
@@ -19,4 +19,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php72/testObjectTypeHint/objectTypeHint.php.testObjectTypeHint_ParameterType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php72/testObjectTypeHint/objectTypeHint.php.testObjectTypeHint_ParameterType01.completion
@@ -14,3 +14,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php72/testObjectTypeHint/objectTypeHint.php.testObjectTypeHint_ReturnType02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php72/testObjectTypeHint/objectTypeHint.php.testObjectTypeHint_ReturnType02.completion
@@ -15,4 +15,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_03a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_03a.completion
@@ -14,3 +14,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_04a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_04a.completion
@@ -14,3 +14,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_05a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_05a.completion
@@ -15,4 +15,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_06a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_06a.completion
@@ -6,9 +6,11 @@ CLASS      ArrowFunctions                  [PUBLIC]   arrowFunctions.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_17b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_17b.completion
@@ -14,3 +14,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_23a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_23a.completion
@@ -16,3 +16,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_23b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_23b.completion
@@ -6,6 +6,7 @@ CLASS      ArrowFunctions                  [PUBLIC]   arrowFunctions.php
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -15,3 +16,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Class/typedProperties20Class.php.testTypedProperties20Class_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Class/typedProperties20Class.php.testTypedProperties20Class_06.completion
@@ -27,4 +27,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Class/typedProperties20Class.php.testTypedProperties20Class_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Class/typedProperties20Class.php.testTypedProperties20Class_08.completion
@@ -27,4 +27,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Class/typedProperties20Class.php.testTypedProperties20Class_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Class/typedProperties20Class.php.testTypedProperties20Class_10.completion
@@ -8,6 +8,7 @@ CLASS      TypedPropertiesClass            [PUBLIC]   Foo
 ------------------------------------
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -16,3 +17,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Class/typedProperties20Class.php.testTypedProperties20Class_16.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Class/typedProperties20Class.php.testTypedProperties20Class_16.completion
@@ -27,4 +27,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Class/typedProperties20Class.php.testTypedProperties20Class_17.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Class/typedProperties20Class.php.testTypedProperties20Class_17.completion
@@ -27,4 +27,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_06.completion
@@ -26,4 +26,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_08.completion
@@ -26,4 +26,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_09.completion
@@ -7,6 +7,7 @@ CLASS      MyClass                         [PUBLIC]   Bar
 ------------------------------------
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -15,3 +16,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_11.completion
@@ -7,6 +7,7 @@ CLASS      MyClass                         [PUBLIC]   Bar
 ------------------------------------
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -15,3 +16,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_17.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_17.completion
@@ -26,4 +26,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_18.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testTypedProperties20Trait/typedProperties20Trait.php.testTypedProperties20Trait_18.completion
@@ -26,4 +26,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion01a/constructorPropertyPromotion01a.php.testConstructorPropertyPromotion01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion01a/constructorPropertyPromotion01a.php.testConstructorPropertyPromotion01a.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion01b/constructorPropertyPromotion01b.php.testConstructorPropertyPromotion01b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion01b/constructorPropertyPromotion01b.php.testConstructorPropertyPromotion01b.completion
@@ -21,3 +21,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion03a/constructorPropertyPromotion03a.php.testConstructorPropertyPromotion03a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion03a/constructorPropertyPromotion03a.php.testConstructorPropertyPromotion03a.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion03b/constructorPropertyPromotion03b.php.testConstructorPropertyPromotion03b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion03b/constructorPropertyPromotion03b.php.testConstructorPropertyPromotion03b.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion04a/constructorPropertyPromotion04a.php.testConstructorPropertyPromotion04a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion04a/constructorPropertyPromotion04a.php.testConstructorPropertyPromotion04a.completion
@@ -5,9 +5,11 @@ public function __construct(private ?|) {
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
 KEYWORD    mixed                                      null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion04b/constructorPropertyPromotion04b.php.testConstructorPropertyPromotion04b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion04b/constructorPropertyPromotion04b.php.testConstructorPropertyPromotion04b.completion
@@ -6,6 +6,7 @@ CLASS      ConstructorPropertyPromotion    [PUBLIC]   constructorPropertyPromoti
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -14,3 +15,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion05a/constructorPropertyPromotion05a.php.testConstructorPropertyPromotion05a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion05a/constructorPropertyPromotion05a.php.testConstructorPropertyPromotion05a.completion
@@ -15,3 +15,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion05b/constructorPropertyPromotion05b.php.testConstructorPropertyPromotion05b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion05b/constructorPropertyPromotion05b.php.testConstructorPropertyPromotion05b.completion
@@ -15,3 +15,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion06a/constructorPropertyPromotion06a.php.testConstructorPropertyPromotion06a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion06a/constructorPropertyPromotion06a.php.testConstructorPropertyPromotion06a.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion06b/constructorPropertyPromotion06b.php.testConstructorPropertyPromotion06b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion06b/constructorPropertyPromotion06b.php.testConstructorPropertyPromotion06b.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion07a/constructorPropertyPromotion07a.php.testConstructorPropertyPromotion07a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion07a/constructorPropertyPromotion07a.php.testConstructorPropertyPromotion07a.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion07b/constructorPropertyPromotion07b.php.testConstructorPropertyPromotion07b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testConstructorPropertyPromotion07b/constructorPropertyPromotion07b.php.testConstructorPropertyPromotion07b.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_01.completion
@@ -24,4 +24,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_03.completion
@@ -16,3 +16,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_05.completion
@@ -18,4 +18,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_07.completion
@@ -14,3 +14,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_08.completion
@@ -15,3 +15,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testMixedType/mixedType.php.testMixedType_09.completion
@@ -16,3 +16,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFields01/unionTypesFields01.php.testUnionTypesFields01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFields01/unionTypesFields01.php.testUnionTypesFields01.completion
@@ -18,3 +18,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFields03/unionTypesFields03.php.testUnionTypesFields03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFields03/unionTypesFields03.php.testUnionTypesFields03.completion
@@ -18,3 +18,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFields05/unionTypesFields05.php.testUnionTypesFields05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFields05/unionTypesFields05.php.testUnionTypesFields05.completion
@@ -18,3 +18,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFields06/unionTypesFields06.php.testUnionTypesFields06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFields06/unionTypesFields06.php.testUnionTypesFields06.completion
@@ -18,3 +18,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionParameterType01/unionTypesFunctionParameterType01.php.testUnionTypesFunctionParameterType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionParameterType01/unionTypesFunctionParameterType01.php.testUnionTypesFunctionParameterType01.completion
@@ -14,3 +14,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionParameterType03/unionTypesFunctionParameterType03.php.testUnionTypesFunctionParameterType03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionParameterType03/unionTypesFunctionParameterType03.php.testUnionTypesFunctionParameterType03.completion
@@ -14,3 +14,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionParameterType04/unionTypesFunctionParameterType04.php.testUnionTypesFunctionParameterType04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionParameterType04/unionTypesFunctionParameterType04.php.testUnionTypesFunctionParameterType04.completion
@@ -15,3 +15,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionParameterType05/unionTypesFunctionParameterType05.php.testUnionTypesFunctionParameterType05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionParameterType05/unionTypesFunctionParameterType05.php.testUnionTypesFunctionParameterType05.completion
@@ -14,3 +14,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionParameterType07/unionTypesFunctionParameterType07.php.testUnionTypesFunctionParameterType07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionParameterType07/unionTypesFunctionParameterType07.php.testUnionTypesFunctionParameterType07.completion
@@ -14,3 +14,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionReturnType01/unionTypesFunctionReturnType01.php.testUnionTypesFunctionReturnType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionReturnType01/unionTypesFunctionReturnType01.php.testUnionTypesFunctionReturnType01.completion
@@ -15,3 +15,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionReturnType04/unionTypesFunctionReturnType04.php.testUnionTypesFunctionReturnType04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctionReturnType04/unionTypesFunctionReturnType04.php.testUnionTypesFunctionReturnType04.completion
@@ -15,3 +15,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_02.completion
@@ -15,3 +15,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_04.completion
@@ -17,4 +17,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_05.completion
@@ -15,3 +15,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_08.completion
@@ -15,3 +15,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_09.completion
@@ -17,4 +17,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_10.completion
@@ -15,3 +15,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_12.completion
@@ -15,3 +15,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_13.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_13.completion
@@ -15,3 +15,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_15.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_15.completion
@@ -17,4 +17,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_17.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_17.completion
@@ -15,3 +15,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_19.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesFunctions/unionTypesFunctions.php.testUnionTypesFunctions_19.completion
@@ -15,3 +15,4 @@ KEYWORD    iterable                                   null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_01.completion
@@ -23,3 +23,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_03.completion
@@ -22,3 +22,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_05.completion
@@ -23,3 +23,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_07.completion
@@ -25,4 +25,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_08.completion
@@ -23,3 +23,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_11.completion
@@ -22,3 +22,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_12.completion
@@ -23,3 +23,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_14.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_14.completion
@@ -22,3 +22,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_17.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_17.completion
@@ -22,3 +22,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_18.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_18.completion
@@ -23,3 +23,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_20.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_20.completion
@@ -23,3 +23,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_22.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testUnionTypesMethods/unionTypesMethods.php.testUnionTypesMethods_22.completion
@@ -23,3 +23,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_01a.completion
@@ -30,4 +30,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_02a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldType/enumsFieldType.php.testEnumsFieldType_02a.completion
@@ -30,4 +30,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping01/enumsFieldTypeTyping01.php.testEnumsFieldTypeTyping01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping01/enumsFieldTypeTyping01.php.testEnumsFieldTypeTyping01.completion
@@ -30,4 +30,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping03/enumsFieldTypeTyping03.php.testEnumsFieldTypeTyping03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsFieldTypeTyping03/enumsFieldTypeTyping03.php.testEnumsFieldTypeTyping03.completion
@@ -22,3 +22,4 @@ KEYWORD    parent                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_01.completion
@@ -18,3 +18,4 @@ KEYWORD    mixed                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsParamType/enumsParamType.php.testEnumsParamType_09.completion
@@ -10,6 +10,7 @@ CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace1
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -18,3 +19,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_01.completion
@@ -18,4 +18,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_03.completion
@@ -21,4 +21,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testEnumsReturnType/enumsReturnType.php.testEnumsReturnType_08.completion
@@ -9,6 +9,7 @@ CLASS      EnumTest                        [PUBLIC]   EnumTestNamespace
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
 KEYWORD    callable                                   null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -18,3 +19,4 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_04.completion
@@ -18,4 +18,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_09.completion
@@ -18,4 +18,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_15.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesFunctions/intersectionTypesFunctions.php.testIntersectionTypesFunctions_15.completion
@@ -18,4 +18,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_01.completion
@@ -23,3 +23,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_05.completion
@@ -23,3 +23,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testIntersectionTypesMethods/intersectionTypesMethods.php.testIntersectionTypesMethods_07.completion
@@ -25,4 +25,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNeverReturnType/neverReturnType.php.testNeverReturnType_Class01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNeverReturnType/neverReturnType.php.testNeverReturnType_Class01.completion
@@ -19,4 +19,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNeverReturnType/neverReturnType.php.testNeverReturnType_Function01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNeverReturnType/neverReturnType.php.testNeverReturnType_Function01.completion
@@ -16,4 +16,5 @@ KEYWORD    never                                      null
 KEYWORD    null                                       null
 KEYWORD    object                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNeverReturnType/neverReturnType.php.testNeverReturnType_Interface01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNeverReturnType/neverReturnType.php.testNeverReturnType_Interface01.completion
@@ -19,4 +19,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNeverReturnType/neverReturnType.php.testNeverReturnType_Trait01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testNeverReturnType/neverReturnType.php.testNeverReturnType_Trait01.completion
@@ -19,4 +19,5 @@ KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    void                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping01/readonlyPropertiesTyping01.php.testReadonlyPromotedPropertiesTyping01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping01/readonlyPropertiesTyping01.php.testReadonlyPromotedPropertiesTyping01.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping03/readonlyPropertiesTyping03.php.testReadonlyPromotedPropertiesTyping03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping03/readonlyPropertiesTyping03.php.testReadonlyPromotedPropertiesTyping03.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping05/readonlyPropertiesTyping05.php.testReadonlyPromotedPropertiesTyping05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping05/readonlyPropertiesTyping05.php.testReadonlyPromotedPropertiesTyping05.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping06/readonlyPropertiesTyping06.php.testReadonlyPromotedPropertiesTyping06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping06/readonlyPropertiesTyping06.php.testReadonlyPromotedPropertiesTyping06.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping08/readonlyPropertiesTyping08.php.testReadonlyPromotedPropertiesTyping08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping08/readonlyPropertiesTyping08.php.testReadonlyPromotedPropertiesTyping08.completion
@@ -15,3 +15,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping10/readonlyPropertiesTyping10.php.testReadonlyPromotedPropertiesTyping10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping10/readonlyPropertiesTyping10.php.testReadonlyPromotedPropertiesTyping10.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping12/readonlyPropertiesTyping12.php.testReadonlyPromotedPropertiesTyping12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPromotedPropertiesTyping12/readonlyPropertiesTyping12.php.testReadonlyPromotedPropertiesTyping12.completion
@@ -20,3 +20,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping03/readonlyPropertiesTyping03.php.testReadonlyPropertiesTyping03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping03/readonlyPropertiesTyping03.php.testReadonlyPropertiesTyping03.completion
@@ -24,4 +24,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping05/readonlyPropertiesTyping05.php.testReadonlyPropertiesTyping05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping05/readonlyPropertiesTyping05.php.testReadonlyPropertiesTyping05.completion
@@ -15,3 +15,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping07/readonlyPropertiesTyping07.php.testReadonlyPropertiesTyping07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping07/readonlyPropertiesTyping07.php.testReadonlyPropertiesTyping07.completion
@@ -24,4 +24,5 @@ KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    static                                     null
 KEYWORD    string                                     null
+KEYWORD    true                                       null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping09/readonlyPropertiesTyping09.php.testReadonlyPropertiesTyping09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping09/readonlyPropertiesTyping09.php.testReadonlyPropertiesTyping09.completion
@@ -15,3 +15,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping10/readonlyPropertiesTyping10.php.testReadonlyPropertiesTyping10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping10/readonlyPropertiesTyping10.php.testReadonlyPropertiesTyping10.completion
@@ -5,6 +5,7 @@ CLASS      ReadonlyProperties              [PUBLIC]   readonlyPropertiesTyping10
 ------------------------------------
 KEYWORD    array                                      null
 KEYWORD    bool                                       null
+KEYWORD    false                                      null
 KEYWORD    float                                      null
 KEYWORD    int                                        null
 KEYWORD    iterable                                   null
@@ -13,3 +14,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class NullAndFalseType
+{
+    public null $null = null; // PHP 8.2: OK
+    public false $false = false; // PHP 8.2: OK
+    public ?false $false2 = null; // PHP 8.2: OK
+
+    public function testNull(null $null): null {
+        return $null;
+    }
+
+    public function testFalse(false $false): false {
+        return $false;
+    }
+
+    public function testNullableFalse(?false $false): ?false {
+        return $false;
+    }
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_01.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public nu|ll $null = null; // PHP 8.2: OK
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      NullAndFalseType                [PUBLIC]   nullAndFalseType.php
+------------------------------------
+KEYWORD    null                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_02.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+public fal|se $false = false; // PHP 8.2: OK
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+KEYWORD    false                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_03.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+public ?fals|e $false2 = null; // PHP 8.2: OK
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+KEYWORD    false                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_04.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public function testNull(nu|ll $null): null {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      NullAndFalseType                [PUBLIC]   nullAndFalseType.php
+------------------------------------
+KEYWORD    null                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_05.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public function testNull(null $null): nu|ll {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      NullAndFalseType                [PUBLIC]   nullAndFalseType.php
+------------------------------------
+KEYWORD    null                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_06.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+public function testFalse(fal|se $false): false {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+KEYWORD    false                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_07.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+public function testFalse(false $false): fal|se {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+KEYWORD    false                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_08.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+public function testNullableFalse(?fal|se $false): ?false {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+KEYWORD    false                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testNullAndFalseType/nullAndFalseType.php.testNullAndFalseType_09.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+public function testNullableFalse(?false $false): ?fal|se {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+KEYWORD    false                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class TrueType
+{
+    public true $true = true; // PHP 8.2: OK
+    public ?true $true2 = true; // PHP 8.2: OK
+    public int|true $true3 = true; // line comment
+    public true|int $true4 = true; // line comment
+
+    public function test(true $true): true {
+        return $true;
+    }
+
+    public function testNullable(?true $true): ?true {
+        return $true;
+    }
+
+    public function testUnionType(true|string $true): string|true {
+        return $true;
+    }
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_01.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public tru|e $true = true; // PHP 8.2: OK
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TrueType                        [PUBLIC]   trueType.php
+------------------------------------
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_02.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public ?tru|e $true2 = true; // PHP 8.2: OK
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TrueType                        [PUBLIC]   trueType.php
+------------------------------------
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_03.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public int|tr|ue $true3 = true; // line comment
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TrueType                        [PUBLIC]   trueType.php
+------------------------------------
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_04.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public tru|e|int $true4 = true; // line comment
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TrueType                        [PUBLIC]   trueType.php
+------------------------------------
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_05.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public function test(tr|ue $true): true {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TrueType                        [PUBLIC]   trueType.php
+------------------------------------
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_06.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public function test(true $true): tru|e {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TrueType                        [PUBLIC]   trueType.php
+------------------------------------
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_07.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public function testNullable(?tr|ue $true): ?true {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TrueType                        [PUBLIC]   trueType.php
+------------------------------------
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_08.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public function testNullable(?true $true): ?tr|ue {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TrueType                        [PUBLIC]   trueType.php
+------------------------------------
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_09.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public function testUnionType(tr|ue|string $true): string|true {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TrueType                        [PUBLIC]   trueType.php
+------------------------------------
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testTrueType/trueType.php.testTrueType_10.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+public function testUnionType(true|string $true): string|tru|e {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      TrueType                        [PUBLIC]   trueType.php
+------------------------------------
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/test204958/issue204958.php.testUseCase1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/test204958/issue204958.php.testUseCase1.completion
@@ -19,3 +19,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests225089/tests225089.php.testUseCase1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests225089/tests225089.php.testUseCase1.completion
@@ -24,3 +24,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests225089/tests225089.php.testUseCase2.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests225089/tests225089.php.testUseCase2.completion
@@ -24,3 +24,4 @@ KEYWORD    public                                     null
 KEYWORD    readonly                                   null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests225089/tests225089.php.testUseCase3.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests225089/tests225089.php.testUseCase3.completion
@@ -20,3 +20,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests225089/tests225089.php.testUseCase4.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests225089/tests225089.php.testUseCase4.completion
@@ -20,3 +20,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests242398/issue242398_01.php.testUseCase1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests242398/issue242398_01.php.testUseCase1.completion
@@ -17,3 +17,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests242398/issue242398_02.php.testUseCase2.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests242398/issue242398_02.php.testUseCase2.completion
@@ -17,3 +17,4 @@ KEYWORD    object                                     null
 KEYWORD    parent                                     null
 KEYWORD    self                                       null
 KEYWORD    string                                     null
+KEYWORD    true                                       null

--- a/php/php.editor/test/unit/data/testfiles/structure/standAloneTrueType.php
+++ b/php/php.editor/test/unit/data/testfiles/structure/standAloneTrueType.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class TrueType
+{
+    public true $true = true; // PHP 8.2: OK
+    public ?true $true2 = true; // PHP 8.2: OK
+    public int|true $true3 = true; // line comment
+    public true|int $true4 = true; // line comment
+
+    public function test(true $true): true {
+        return $true;
+    }
+
+    public function testNullable(?true $true): ?true {
+        return $true;
+    }
+
+    public function testUnionType(true|string $true): string|true {
+        return $true;
+    }
+}
+

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testIntersectionTypes_01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testIntersectionTypes_01.php
@@ -33,6 +33,7 @@ function testReturnParent(): parent&Iterator {}
 function testReturnSelf(): self&Iterator {}
 function testReturnStatic(): static&Iterator {}
 function testReturnString(): string&Iterator {}
+function testReturnTrue(): true&Iterator {}
 function testReturnVoid(): void&Iterator {}
 
 function testParamArray(Iterator&array $param): Iterator {}
@@ -50,6 +51,7 @@ function testParamParent(Iterator&parent $param): parent {}
 function testParamSelf(Iterator&self $param): self {}
 //function testParamStatic(Iterator&static $param): void {} // syntax error
 function testParamString(Iterator&string $param): string {}
+function testParamString(Iterator&true $param): true {}
 function testParamVoid(Iterator&void $param): void {}
 //function testReturnNullable(): ?Test&Iterator {} // syntax erro
 
@@ -72,6 +74,7 @@ class InvalidField {
     public self&Iterator $self;
 //    public static&Iterator $static; // syntax error
     public string&Iterator $string;
+    public true&Iterator $true;
     public void&Iterator $void;
     public Iterator&Iterator $duplicate;
 }

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testIntersectionTypes_01.php.testIntersectionTypes_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testIntersectionTypes_01.php.testIntersectionTypes_01.hints
@@ -43,6 +43,9 @@ HINT:"static" cannot be used as an intersection type.
 function testReturnString(): string&Iterator {}
                              ------
 HINT:"string" cannot be used as an intersection type.
+function testReturnTrue(): true&Iterator {}
+                           ----
+HINT:"true" cannot be used as an intersection type.
 function testReturnVoid(): void&Iterator {}
                            ----
 HINT:"void" cannot be used as an intersection type.
@@ -88,6 +91,9 @@ HINT:"self" cannot be used as an intersection type.
 function testParamString(Iterator&string $param): string {}
                                   ------
 HINT:"string" cannot be used as an intersection type.
+function testParamString(Iterator&true $param): true {}
+                                  ----
+HINT:"true" cannot be used as an intersection type.
 function testParamVoid(Iterator&void $param): void {}
                                 ----
 HINT:"void" cannot be used as an intersection type.
@@ -139,6 +145,9 @@ HINT:"self" cannot be used as an intersection type.
     public string&Iterator $string;
            ------
 HINT:"string" cannot be used as an intersection type.
+    public true&Iterator $true;
+           ----
+HINT:"true" cannot be used as an intersection type.
     public void&Iterator $void;
            ----
 HINT:"void" cannot be used as an intersection type.

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testNullableTypes_01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testNullableTypes_01.php
@@ -23,6 +23,7 @@ class NullableTypes {
     private ?mixed $mixed;
     private ?null $null;
     private ?false $false;
+    private ?true $true;
 
     public function returnMixed(): ?mixed {
     }
@@ -33,6 +34,9 @@ class NullableTypes {
     public function returnFalse(): ?false {
     }
 
+    public function returnTrue(): ?true {
+    }
+
     public function parameterMixed(?mixed $mixed) {
     }
 
@@ -40,5 +44,8 @@ class NullableTypes {
     }
 
     public function parameterFalse(?false $false) {
+    }
+
+    public function parameterTrue(?true $true) {
     }
 }

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testNullableTypes_01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testNullableTypes_01.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class NullableTypes {
+
+    private ?mixed $mixed;
+    private ?null $null;
+    private ?false $false;
+
+    public function returnMixed(): ?mixed {
+    }
+
+    public function returnNull(): ?null {
+    }
+
+    public function returnFalse(): ?false {
+    }
+
+    public function parameterMixed(?mixed $mixed) {
+    }
+
+    public function parameterNull(?null $null) {
+    }
+
+    public function parameterFalse(?false $false) {
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testNullableTypes_01.php.testNullableTypes_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testNullableTypes_01.php.testNullableTypes_01.hints
@@ -1,0 +1,18 @@
+    private ?mixed $mixed;
+             -----
+HINT:"mixed" cannot be used as a nullable type.
+    private ?null $null;
+             ----
+HINT:"null" cannot be used as a nullable type.
+    public function returnMixed(): ?mixed {
+                                    -----
+HINT:"mixed" cannot be used as a nullable type.
+    public function returnNull(): ?null {
+                                   ----
+HINT:"null" cannot be used as a nullable type.
+    public function parameterMixed(?mixed $mixed) {
+                                    -----
+HINT:"mixed" cannot be used as a nullable type.
+    public function parameterNull(?null $null) {
+                                   ----
+HINT:"null" cannot be used as a nullable type.

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testNullableTypes_01.php.testNullableTypes_01_PHP81.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testNullableTypes_01.php.testNullableTypes_01_PHP81.hints
@@ -1,0 +1,26 @@
+    private ?mixed $mixed;
+             -----
+HINT:"mixed" cannot be used as a nullable type.
+    private ?null $null;
+             ----
+HINT:"null" cannot be used as a nullable type.
+HINT:"null" cannot be used as a standalone type.
+    private ?false $false;
+             -----
+HINT:"false" cannot be used as a standalone type.
+    public function returnMixed(): ?mixed {
+                                    -----
+HINT:"mixed" cannot be used as a nullable type.
+    public function returnNull(): ?null {
+                                   ----
+HINT:"null" cannot be used as a nullable type.
+HINT:"null" cannot be used as a standalone type.
+    public function returnFalse(): ?false {
+                                    -----
+HINT:"false" cannot be used as a standalone type.
+    public function parameterMixed(?mixed $mixed) {
+                                    -----
+HINT:"mixed" cannot be used as a nullable type.
+    public function parameterNull(?null $null) {
+                                   ----
+HINT:"null" cannot be used as a nullable type.

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testNullableTypes_01.php.testNullableTypes_01_PHP81.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testNullableTypes_01.php.testNullableTypes_01_PHP81.hints
@@ -8,6 +8,9 @@ HINT:"null" cannot be used as a standalone type.
     private ?false $false;
              -----
 HINT:"false" cannot be used as a standalone type.
+    private ?true $true;
+             ----
+HINT:"true" cannot be used as a standalone type.
     public function returnMixed(): ?mixed {
                                     -----
 HINT:"mixed" cannot be used as a nullable type.
@@ -18,9 +21,19 @@ HINT:"null" cannot be used as a standalone type.
     public function returnFalse(): ?false {
                                     -----
 HINT:"false" cannot be used as a standalone type.
+    public function returnTrue(): ?true {
+                                   ----
+HINT:"true" cannot be used as a standalone type.
     public function parameterMixed(?mixed $mixed) {
                                     -----
 HINT:"mixed" cannot be used as a nullable type.
     public function parameterNull(?null $null) {
                                    ----
 HINT:"null" cannot be used as a nullable type.
+HINT:"null" cannot be used as a standalone type.
+    public function parameterFalse(?false $false) {
+                                    -----
+HINT:"false" cannot be used as a standalone type.
+    public function parameterTrue(?true $true) {
+                                   ----
+HINT:"true" cannot be used as a standalone type.

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testUnionTypes_01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testUnionTypes_01.php
@@ -23,13 +23,20 @@ class UnusableTypes {
     private int|callable $callable;
     private false $false;
     private null $null;
+    private true $true;
     private bool|false $boolFalse;
+    private true|bool $trueBool;
     private bool|bool $duplicatedBool;
+    private true|false $bothTrueAndFalse;
+    private int|false|true $bothTrueAndFalse2;
     private int|INT $duplicatedInt;
     private iterable|array $iterable1;
     private iterable|Traversable $iterable2;
     private iterable|array|Traversable $iterable3;
     private null|false $nullFalse; // PHP 8.2: OK
+
+    public function returnFalse(): true {
+    }
 
     public function returnFalse(): false {
     }
@@ -38,6 +45,9 @@ class UnusableTypes {
     }
 
     public function returnDuplicatedType(): UnionType2|UnionType2 {
+    }
+
+    public function parameterTrue(true $true) {
     }
 
     public function parameterFalse(false $false) {

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testUnionTypes_01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testUnionTypes_01.php
@@ -29,6 +29,7 @@ class UnusableTypes {
     private iterable|array $iterable1;
     private iterable|Traversable $iterable2;
     private iterable|array|Traversable $iterable3;
+    private null|false $nullFalse; // PHP 8.2: OK
 
     public function returnFalse(): false {
     }

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testUnionTypes_01.php.testUnionTypes_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testUnionTypes_01.php.testUnionTypes_01.hints
@@ -4,9 +4,20 @@ HINT:"callable" cannot be used as a property type.
     private bool|false $boolFalse;
                  -----
 HINT:Type "false" is duplicated.
+    private true|bool $trueBool;
+                 ----
+HINT:Type "bool" is duplicated.
     private bool|bool $duplicatedBool;
                  ----
 HINT:Type "bool" is duplicated.
+    private true|false $bothTrueAndFalse;
+                 -----
+HINT:Contains both "true" and "false", "bool" should be used.
+HINT:Contains both "true" and "false", "bool" should be used.
+    private int|false|true $bothTrueAndFalse2;
+                      ----
+HINT:Contains both "true" and "false", "bool" should be used.
+HINT:Contains both "true" and "false", "bool" should be used.
     private int|INT $duplicatedInt;
                 ---
 HINT:Type "INT" is duplicated.

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testUnionTypes_01.php.testUnionTypes_01_PHP81.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testUnionTypes_01.php.testUnionTypes_01_PHP81.hints
@@ -1,6 +1,12 @@
     private int|callable $callable;
                 --------
 HINT:"callable" cannot be used as a property type.
+    private false $false;
+            -----
+HINT:"false" cannot be used as a standalone type.
+    private null $null;
+            ----
+HINT:"null" cannot be used as a standalone type.
     private bool|false $boolFalse;
                  -----
 HINT:Type "false" is duplicated.
@@ -20,9 +26,24 @@ HINT:Redundant combination: "iterable|Traversable" contains both "iterable" and 
             --------------------------
 HINT:Redundant combination: "iterable|array|Traversable" contains both "iterable" and "Traversable".
 HINT:Redundant combination: "iterable|array|Traversable" contains both "iterable" and "array".
+    private null|false $nullFalse; // PHP 8.2: OK
+                 -----
+HINT:"false" cannot be used as a standalone type.
+    public function returnFalse(): false {
+                                   -----
+HINT:"false" cannot be used as a standalone type.
+    public function returnNull(): null {
+                                  ----
+HINT:"null" cannot be used as a standalone type.
     public function returnDuplicatedType(): UnionType2|UnionType2 {
                                                        ----------
 HINT:Type "UnionType2" is duplicated.
+    public function parameterFalse(false $false) {
+                                   -----
+HINT:"false" cannot be used as a standalone type.
+    public function parameterNull(null $null) {
+                                  ----
+HINT:"null" cannot be used as a standalone type.
     public function parameterDuplicatedType(UnionType2|UnionType2 $duplicatedType) {
                                                        ----------
 HINT:Type "UnionType2" is duplicated.

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testUnionTypes_01.php.testUnionTypes_01_PHP81.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testUnionTypes_01.php.testUnionTypes_01_PHP81.hints
@@ -7,12 +7,26 @@ HINT:"false" cannot be used as a standalone type.
     private null $null;
             ----
 HINT:"null" cannot be used as a standalone type.
+    private true $true;
+            ----
+HINT:"true" cannot be used as a standalone type.
     private bool|false $boolFalse;
                  -----
 HINT:Type "false" is duplicated.
+    private true|bool $trueBool;
+                 ----
+HINT:Type "bool" is duplicated.
     private bool|bool $duplicatedBool;
                  ----
 HINT:Type "bool" is duplicated.
+    private true|false $bothTrueAndFalse;
+                 -----
+HINT:Contains both "true" and "false", "bool" should be used.
+HINT:Contains both "true" and "false", "bool" should be used.
+    private int|false|true $bothTrueAndFalse2;
+                      ----
+HINT:Contains both "true" and "false", "bool" should be used.
+HINT:Contains both "true" and "false", "bool" should be used.
     private int|INT $duplicatedInt;
                 ---
 HINT:Type "INT" is duplicated.
@@ -29,6 +43,9 @@ HINT:Redundant combination: "iterable|array|Traversable" contains both "iterable
     private null|false $nullFalse; // PHP 8.2: OK
                  -----
 HINT:"false" cannot be used as a standalone type.
+    public function returnFalse(): true {
+                                   ----
+HINT:"true" cannot be used as a standalone type.
     public function returnFalse(): false {
                                    -----
 HINT:"false" cannot be used as a standalone type.
@@ -38,6 +55,9 @@ HINT:"null" cannot be used as a standalone type.
     public function returnDuplicatedType(): UnionType2|UnionType2 {
                                                        ----------
 HINT:Type "UnionType2" is duplicated.
+    public function parameterTrue(true $true) {
+                                  ----
+HINT:"true" cannot be used as a standalone type.
     public function parameterFalse(false $false) {
                                    -----
 HINT:"false" cannot be used as a standalone type.

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP82CodeCompletionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP82CodeCompletionTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class PHP82CodeCompletionTest extends PHPCodeCompletionTestBase {
+
+    public PHP82CodeCompletionTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[]{
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/php82/" + getTestDirName()))
+            })
+        );
+    }
+
+    private String getTestDirName() {
+        String name = getName();
+        int indexOf = name.indexOf("_");
+        if (indexOf != -1) {
+            name = name.substring(0, indexOf);
+        }
+        return name;
+    }
+
+    private String getTestPath(String fileName) {
+        return String.format("testfiles/completion/lib/php82/%s/%s.php", getTestDirName(), fileName);
+    }
+
+    private void checkCompletion(String fileName, String caretPosition) throws Exception {
+        checkCompletion(getTestPath(fileName), caretPosition, false);
+    }
+
+    public void testNullAndFalseType_01() throws Exception {
+        checkCompletion("nullAndFalseType", "    public nu^ll $null = null; // PHP 8.2: OK");
+    }
+
+    public void testNullAndFalseType_02() throws Exception {
+        checkCompletion("nullAndFalseType", "    public fal^se $false = false; // PHP 8.2: OK");
+    }
+
+    public void testNullAndFalseType_03() throws Exception {
+        checkCompletion("nullAndFalseType", "    public ?fals^e $false2 = null; // PHP 8.2: OK");
+    }
+
+    public void testNullAndFalseType_04() throws Exception {
+        checkCompletion("nullAndFalseType", "    public function testNull(nu^ll $null): null {");
+    }
+
+    public void testNullAndFalseType_05() throws Exception {
+        checkCompletion("nullAndFalseType", "    public function testNull(null $null): nu^ll {");
+    }
+
+    public void testNullAndFalseType_06() throws Exception {
+        checkCompletion("nullAndFalseType", "    public function testFalse(fal^se $false): false {");
+    }
+
+    public void testNullAndFalseType_07() throws Exception {
+        checkCompletion("nullAndFalseType", "    public function testFalse(false $false): fal^se {");
+    }
+
+    public void testNullAndFalseType_08() throws Exception {
+        checkCompletion("nullAndFalseType", "    public function testNullableFalse(?fal^se $false): ?false {");
+    }
+
+    public void testNullAndFalseType_09() throws Exception {
+        checkCompletion("nullAndFalseType", "    public function testNullableFalse(?false $false): ?fal^se {");
+    }
+
+    public void testTrueType_01() throws Exception {
+        checkCompletion("trueType", "    public tru^e $true = true; // PHP 8.2: OK");
+    }
+
+    public void testTrueType_02() throws Exception {
+        checkCompletion("trueType", "    public ?tru^e $true2 = true; // PHP 8.2: OK");
+    }
+
+    public void testTrueType_03() throws Exception {
+        checkCompletion("trueType", "    public int|tr^ue $true3 = true; // line comment");
+    }
+
+    public void testTrueType_04() throws Exception {
+        checkCompletion("trueType", "    public tru^e|int $true4 = true; // line comment");
+    }
+
+    public void testTrueType_05() throws Exception {
+        checkCompletion("trueType", "    public function test(tr^ue $true): true {");
+    }
+
+    public void testTrueType_06() throws Exception {
+        checkCompletion("trueType", "    public function test(true $true): tru^e {");
+    }
+
+    public void testTrueType_07() throws Exception {
+        checkCompletion("trueType", "    public function testNullable(?tr^ue $true): ?true {");
+    }
+
+    public void testTrueType_08() throws Exception {
+        checkCompletion("trueType", "    public function testNullable(?true $true): ?tr^ue {");
+    }
+
+    public void testTrueType_09() throws Exception {
+        checkCompletion("trueType", "    public function testUnionType(tr^ue|string $true): string|true {");
+    }
+
+    public void testTrueType_10() throws Exception {
+        checkCompletion("trueType", "    public function testUnionType(true|string $true): string|tru^e {");
+    }
+
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/NavigatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/NavigatorTest.java
@@ -120,4 +120,8 @@ public class NavigatorTest extends PhpNavigatorTestBase {
         performTest("structure/enumerations");
     }
 
+    public void testStandAloneTrueType() throws Exception {
+        performTest("structure/standAloneTrueType");
+    }
+
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/UnusableTypesHintErrorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/UnusableTypesHintErrorTest.java
@@ -18,6 +18,9 @@
  */
 package org.netbeans.modules.php.editor.verification;
 
+import org.netbeans.modules.php.api.PhpVersion;
+import org.openide.filesystems.FileObject;
+
 public class UnusableTypesHintErrorTest extends PHPHintsTestBase {
 
     public UnusableTypesHintErrorTest(String testName) {
@@ -36,6 +39,10 @@ public class UnusableTypesHintErrorTest extends PHPHintsTestBase {
         checkHints(new UnusableTypesHintError(), "testUnionTypes_01.php");
     }
 
+    public void testUnionTypes_01_PHP81() throws Exception {
+        checkHints(new UnusableTypesHintErrorStub(PhpVersion.PHP_81), "testUnionTypes_01.php");
+    }
+
     public void testStaticReturnTypes_01() throws Exception {
         checkHints(new UnusableTypesHintError(), "testStaticReturnTypes_01.php");
     }
@@ -52,9 +59,30 @@ public class UnusableTypesHintErrorTest extends PHPHintsTestBase {
         checkHints(new UnusableTypesHintError(), "testIntersectionTypes_01.php");
     }
 
+    public void testNullableTypes_01() throws Exception {
+        checkHints(new UnusableTypesHintError(), "testNullableTypes_01.php");
+    }
+
+    public void testNullableTypes_01_PHP81() throws Exception {
+        checkHints(new UnusableTypesHintErrorStub(PhpVersion.PHP_81), "testNullableTypes_01.php");
+    }
+
     @Override
     protected String getTestDirectory() {
         return TEST_DIRECTORY + "UnusableTypesHintError/";
     }
 
+    private static final class UnusableTypesHintErrorStub extends UnusableTypesHintError {
+
+        private PhpVersion phpVersion;
+
+        public UnusableTypesHintErrorStub(PhpVersion phpVersion) {
+            this.phpVersion = phpVersion;
+        }
+
+        @Override
+        protected PhpVersion getPhpVersion(FileObject fileObject) {
+            return phpVersion;
+        }
+    }
 }

--- a/php/php.project/manifest.mf
+++ b/php/php.project/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Specification-Version: 2.160
+OpenIDE-Module-Specification-Version: 2.161
 OpenIDE-Module: org.netbeans.modules.php.project
 OpenIDE-Module-Layer: org/netbeans/modules/php/project/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/project/resources/Bundle.properties

--- a/php/php.project/nbproject/project.xml
+++ b/php/php.project/nbproject/project.xml
@@ -284,7 +284,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>2.74</specification-version>
+                        <specification-version>2.87</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
#4725

#### Add PHP 8.2 to the `PhpVersion`

- https://wiki.php.net/rfc#php_82
- https://wiki.php.net/todo/php82

![nb-php82-php-version-for-project-properties](https://user-images.githubusercontent.com/738383/198863933-d3633cf8-35c3-4d79-8d55-47a3563126c4.png)

#### Allow `null` and `false` as stand-alone types 

- https://wiki.php.net/rfc/null-false-standalone-types
- Fix `UnusableTypesHintError`
- Add/Fix unit tests

![nb-php82-null-and-false-as-stand-alone-types](https://user-images.githubusercontent.com/738383/198863945-53edaddd-9b3f-48a0-be78-5d54fe46f37a.png)

#### Add true type

- https://wiki.php.net/rfc/true-type
- Fix `UnusableTypesHintError` and CC
- Add/Fix unit tests for the Hint, the Navigator and CC

![nb-php82-add-true-type-hint-errors](https://user-images.githubusercontent.com/738383/198863961-4a87d4eb-9192-4bb7-9cb7-4ce817744b24.png)

![nb-php82-add-true-type-navigator](https://user-images.githubusercontent.com/738383/198863964-c1860021-0bcd-413c-a9d3-f27ebbfe509a.png)

