### PR TITLE
hide template link as last resort if it appears to be broken.

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/resources/license-default.txt
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/resources/license-default.txt
@@ -1,4 +1,6 @@
 ${licenseFirst!""}
 ${licensePrefix}Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+<#if !.data_model["org.openide.filesystems.FileObject"].getPath()?contains("{") >
 ${licensePrefix}Click nbfs://nbhost/SystemFileSystem/${.data_model["org.openide.filesystems.FileObject"].getPath()} to edit this template
+</#if>
 ${licenseLast!""}


### PR DESCRIPTION
based on the discussion in #3678 we decided to try to hide the template link if it can't be resolved for now.

adding `all:tests` since this could potentially cause some String comparing tests to fail. Ran some locally but everything was green so far.

targets delivery