### PR TITLE
Remove Abandoned Cache Dirs Automatically [Janitor]

### DIFF
--- a/platform/janitor/src/org/netbeans/modules/janitor/Bundle.properties
+++ b/platform/janitor/src/org/netbeans/modules/janitor/Bundle.properties
@@ -17,7 +17,8 @@
 OpenIDE-Module-Name=Janitor
 
 OpenIDE-Module-Short-Description=Removes unused cache/data
-JanitorOptionsPanel.jLabel1.text=Removal threshold (number of days):
 JanitorOptionsPanel.btRunNow.text=Run Janitor Now
 JanitorOptionsPanel.cbEnabled.text=Run Janitor on Startup
 JanitorPanel.cbEnabled.text=Enable Janitor Scan on Startup
+JanitorOptionsPanel.lbUnusedDays.text=Removal threshold (number of days):
+JanitorOptionsPanel.cbAutoRemove.text=Auto Remove Abandoned Cache Directories

--- a/platform/janitor/src/org/netbeans/modules/janitor/Janitor.java
+++ b/platform/janitor/src/org/netbeans/modules/janitor/Janitor.java
@@ -92,6 +92,7 @@ public class Janitor {
 
     public static final String PROP_JANITOR_ENABLED = "janitorEnabled"; //NOI18N
     public static final String PROP_UNUSED_DAYS = "UnusedDays"; //NOI18N
+    public static final String PROP_AUTO_REMOVE_ABANDONED_CACHE = "autoRemoveAbandonedCache";
 
     private static final String LOGFILE_NAME = "var/log/messages.log"; //NOI18N
     private static final String ALL_CHECKSUM_NAME = "lastModified/all-checksum.txt"; //NOI18N
@@ -100,7 +101,8 @@ public class Janitor {
 
     static final RequestProcessor JANITOR_RP = new RequestProcessor("janitor", 1); //NOI18N
     static final Map<ActionListener, Notification> CLEANUP_TASKS = new WeakHashMap<>();
-    static final Runnable SCAN_FOR_JUNK = () -> {
+
+    static void scanForJunk() {
         // Remove previously opened notifications
         CLEANUP_TASKS.values().forEach((nf) -> nf.clear());
         CLEANUP_TASKS.clear();
@@ -113,28 +115,31 @@ public class Janitor {
             Integer age = ver.second();
             long toFree = size(getUserDir(name)) + size(getCacheDir(name));
             toFree = toFree / (1_000_000) + 1;
-            ActionListener cleanupListener;
-            Notification nf;
             if (getUserDir(name) != null) {
-                cleanupListener = cleanupAction(name, Bundle.TXT_CONFIRM_CLEANUP(name));
-                nf = NotificationDisplayer.getDefault().notify(
+                ActionListener cleanupListener = cleanupAction(name, Bundle.TXT_CONFIRM_CLEANUP(name));
+                Notification nf = NotificationDisplayer.getDefault().notify(
                         Bundle.TIT_ABANDONED_USERDIR(name, age, toFree),
                         clean,
                         Bundle.DESC_ABANDONED_USERDIR(name, age, toFree),
                         cleanupListener);
 
+                CLEANUP_TASKS.put(cleanupListener, nf);
             } else {
-                cleanupListener = cleanupAction(name, Bundle.TXT_CONFIRM_CACHE_CLEANUP(name));
-                nf = NotificationDisplayer.getDefault().notify(
-                        Bundle.TIT_ABANDONED_CACHEDIR(name, toFree),
-                        clean,
-                        Bundle.DESC_ABANDONED_CACHEDIR(name, toFree),
-                        cleanupListener);
+                if (isAutoRemoveAbanconedCache()) {
+                    JANITOR_RP.post(() -> cleanup(name));
+                } else {
+                    ActionListener cleanupListener = cleanupAction(name, Bundle.TXT_CONFIRM_CACHE_CLEANUP(name));
+                    Notification nf = NotificationDisplayer.getDefault().notify(
+                            Bundle.TIT_ABANDONED_CACHEDIR(name, toFree),
+                            clean,
+                            Bundle.DESC_ABANDONED_CACHEDIR(name, toFree),
+                            cleanupListener);
+                    CLEANUP_TASKS.put(cleanupListener, nf);
+                }
             }
-            CLEANUP_TASKS.put(cleanupListener, nf);
-        }
-    };
-
+        }        
+    }
+    
     static ActionListener cleanupAction(String name, String label) {
         return new ActionListener() {
             @Override
@@ -149,13 +154,7 @@ public class Janitor {
                         null
                 );
                 if (DialogDescriptor.YES_OPTION == DialogDisplayer.getDefault().notify(descriptor)) {
-                    JANITOR_RP.post(() -> {
-                        try (ProgressHandle handle = ProgressHandle.createHandle(Bundle.LBL_CLEANUP(name))){
-                            handle.start();
-                            deleteDir(getUserDir(name));
-                            deleteDir(getCacheDir(name));
-                        }
-                    });
+                    JANITOR_RP.post(() -> cleanup(name));
                 }
                 Janitor.setEnabled(panel.isEnabledOnStartup());
                 Notification nf = CLEANUP_TASKS.get(this);
@@ -166,6 +165,14 @@ public class Janitor {
         };
     }
 
+    static void cleanup(String name) {
+        try (ProgressHandle handle = ProgressHandle.createHandle(Bundle.LBL_CLEANUP(name))){
+            handle.start();
+            deleteDir(getUserDir(name));
+            deleteDir(getCacheDir(name));
+        }        
+    }
+    
     public static final Preferences getPreferences() {
         return NbPreferences.forModule(Janitor.class);
     }
@@ -177,14 +184,14 @@ public class Janitor {
         public void run() {
             if (isEnabled()) {
                 // Starting delayed, not to interfere with other startup IO operations
-                JANITOR_RP.post(SCAN_FOR_JUNK, 60_000);
+                JANITOR_RP.post(Janitor::scanForJunk, 60_000);
             }
         }
 
     }
 
     static void runNow() {
-        JANITOR_RP.post(SCAN_FOR_JUNK);
+        JANITOR_RP.post(Janitor::scanForJunk);
     }
 
     static File getUserDir(String version) {
@@ -321,6 +328,14 @@ public class Janitor {
 
     static int getUnusedDays() {
         return getPreferences().getInt(PROP_UNUSED_DAYS, UNUSED_DAYS);
+    }
+
+    static boolean isAutoRemoveAbanconedCache() {
+        return getPreferences().getBoolean(PROP_AUTO_REMOVE_ABANDONED_CACHE, true);
+    }
+
+    static void setAutoRemoveAbanconedCache(boolean b) {
+        getPreferences().putBoolean(PROP_AUTO_REMOVE_ABANDONED_CACHE, b);
     }
 
 }

--- a/platform/janitor/src/org/netbeans/modules/janitor/JanitorOptionsPanel.form
+++ b/platform/janitor/src/org/netbeans/modules/janitor/JanitorOptionsPanel.form
@@ -38,27 +38,27 @@
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" attributes="0">
+              <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
+                  <Group type="102" attributes="0">
+                      <Component id="btRunNow" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
+                      <Component id="lbRunNowInfo" max="32767" attributes="0"/>
+                  </Group>
+                  <Component id="cbEnabled" alignment="0" max="32767" attributes="0"/>
+                  <Group type="102" attributes="0">
                       <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="cbEnabled" alignment="0" max="32767" attributes="0"/>
                           <Group type="102" attributes="0">
-                              <Group type="103" groupAlignment="0" attributes="0">
-                                  <Group type="102" attributes="0">
-                                      <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
-                                      <EmptySpace max="-2" attributes="0"/>
-                                      <Component id="spUnusedDays" min="-2" max="-2" attributes="0"/>
-                                  </Group>
-                                  <Component id="btRunNow" alignment="0" min="-2" max="-2" attributes="0"/>
-                              </Group>
-                              <EmptySpace min="0" pref="65" max="32767" attributes="0"/>
+                              <EmptySpace min="21" pref="21" max="-2" attributes="0"/>
+                              <Component id="cbAutoRemove" min="-2" max="-2" attributes="0"/>
+                          </Group>
+                          <Group type="102" alignment="0" attributes="0">
+                              <Component id="lbUnusedDays" min="-2" max="-2" attributes="0"/>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Component id="spUnusedDays" min="-2" max="-2" attributes="0"/>
                           </Group>
                       </Group>
-                  </Group>
-                  <Group type="102" attributes="0">
-                      <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
-                      <Component id="lbRunNowInfo" max="32767" attributes="0"/>
+                      <EmptySpace min="0" pref="45" max="32767" attributes="0"/>
                   </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
@@ -70,16 +70,24 @@
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Component id="cbEnabled" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="cbAutoRemove" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="separate" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="jLabel1" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="lbUnusedDays" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="spUnusedDays" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace type="separate" max="-2" attributes="0"/>
-              <Component id="btRunNow" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
-              <Component id="lbRunNowInfo" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="176" max="32767" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" attributes="0">
+                      <EmptySpace min="-2" pref="32" max="-2" attributes="0"/>
+                      <Component id="lbRunNowInfo" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <Group type="102" alignment="0" attributes="0">
+                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                      <Component id="btRunNow" min="-2" max="-2" attributes="0"/>
+                  </Group>
+              </Group>
+              <EmptySpace pref="166" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -92,13 +100,20 @@
         </Property>
       </Properties>
     </Component>
-    <Component class="javax.swing.JLabel" name="jLabel1">
+    <Component class="javax.swing.JLabel" name="lbUnusedDays">
       <Properties>
         <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
           <ComponentRef name="spUnusedDays"/>
         </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/janitor/Bundle.properties" key="JanitorOptionsPanel.jLabel1.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+          <ResourceString bundle="org/netbeans/modules/janitor/Bundle.properties" key="JanitorOptionsPanel.lbUnusedDays.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="cbAutoRemove">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/janitor/Bundle.properties" key="JanitorOptionsPanel.cbAutoRemove.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>

--- a/platform/janitor/src/org/netbeans/modules/janitor/JanitorOptionsPanel.java
+++ b/platform/janitor/src/org/netbeans/modules/janitor/JanitorOptionsPanel.java
@@ -39,12 +39,14 @@ public class JanitorOptionsPanel extends javax.swing.JPanel {
 
     void loadValues() {
         cbEnabled.setSelected(Janitor.isEnabled());
+        cbAutoRemove.setSelected(Janitor.isAutoRemoveAbanconedCache());
         spinnerModel.setValue(Janitor.getUnusedDays());
         resetRunNow();
     }
 
     void saveValues() {
         Janitor.setEnabled(cbEnabled.isSelected());
+        Janitor.setAutoRemoveAbanconedCache(cbAutoRemove.isSelected());
         Janitor.setUnusedDays(spinnerModel.getNumber().intValue());
         resetRunNow();
     }
@@ -52,6 +54,7 @@ public class JanitorOptionsPanel extends javax.swing.JPanel {
     boolean isChanged() {
         boolean changed = false;
         changed |= cbEnabled.isSelected() != Janitor.isEnabled();
+        changed |= cbAutoRemove.isSelected() != Janitor.isAutoRemoveAbanconedCache();
         changed |= spinnerModel.getNumber().intValue() != Janitor.getUnusedDays();
         changed |= !btRunNow.isEnabled();
         return changed;
@@ -67,15 +70,18 @@ public class JanitorOptionsPanel extends javax.swing.JPanel {
     private void initComponents() {
 
         cbEnabled = new javax.swing.JCheckBox();
-        jLabel1 = new javax.swing.JLabel();
+        lbUnusedDays = new javax.swing.JLabel();
+        cbAutoRemove = new javax.swing.JCheckBox();
         spUnusedDays = new javax.swing.JSpinner();
         btRunNow = new javax.swing.JButton();
         lbRunNowInfo = new javax.swing.JLabel();
 
         org.openide.awt.Mnemonics.setLocalizedText(cbEnabled, org.openide.util.NbBundle.getMessage(JanitorOptionsPanel.class, "JanitorOptionsPanel.cbEnabled.text")); // NOI18N
 
-        jLabel1.setLabelFor(spUnusedDays);
-        org.openide.awt.Mnemonics.setLocalizedText(jLabel1, org.openide.util.NbBundle.getMessage(JanitorOptionsPanel.class, "JanitorOptionsPanel.jLabel1.text")); // NOI18N
+        lbUnusedDays.setLabelFor(spUnusedDays);
+        org.openide.awt.Mnemonics.setLocalizedText(lbUnusedDays, org.openide.util.NbBundle.getMessage(JanitorOptionsPanel.class, "JanitorOptionsPanel.lbUnusedDays.text")); // NOI18N
+
+        org.openide.awt.Mnemonics.setLocalizedText(cbAutoRemove, org.openide.util.NbBundle.getMessage(JanitorOptionsPanel.class, "JanitorOptionsPanel.cbAutoRemove.text")); // NOI18N
 
         org.openide.awt.Mnemonics.setLocalizedText(btRunNow, org.openide.util.NbBundle.getMessage(JanitorOptionsPanel.class, "JanitorOptionsPanel.btRunNow.text")); // NOI18N
         btRunNow.addActionListener(new java.awt.event.ActionListener() {
@@ -89,22 +95,23 @@ public class JanitorOptionsPanel extends javax.swing.JPanel {
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
+                .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(layout.createSequentialGroup()
-                        .addContainerGap()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(cbEnabled, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                            .addGroup(layout.createSequentialGroup()
-                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                                    .addGroup(layout.createSequentialGroup()
-                                        .addComponent(jLabel1)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(spUnusedDays, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addComponent(btRunNow))
-                                .addGap(0, 65, Short.MAX_VALUE))))
+                        .addComponent(btRunNow)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(lbRunNowInfo, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .addComponent(cbEnabled, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addGroup(layout.createSequentialGroup()
-                        .addGap(12, 12, 12)
-                        .addComponent(lbRunNowInfo, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addGroup(layout.createSequentialGroup()
+                                .addGap(21, 21, 21)
+                                .addComponent(cbAutoRemove))
+                            .addGroup(layout.createSequentialGroup()
+                                .addComponent(lbUnusedDays)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(spUnusedDays, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                        .addGap(0, 45, Short.MAX_VALUE)))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -112,15 +119,20 @@ public class JanitorOptionsPanel extends javax.swing.JPanel {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(cbEnabled)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(cbAutoRemove)
                 .addGap(18, 18, 18)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jLabel1)
+                    .addComponent(lbUnusedDays)
                     .addComponent(spUnusedDays, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addGap(18, 18, 18)
-                .addComponent(btRunNow)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addComponent(lbRunNowInfo)
-                .addContainerGap(176, Short.MAX_VALUE))
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(layout.createSequentialGroup()
+                        .addGap(32, 32, 32)
+                        .addComponent(lbRunNowInfo))
+                    .addGroup(layout.createSequentialGroup()
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                        .addComponent(btRunNow)))
+                .addContainerGap(166, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -138,9 +150,10 @@ public class JanitorOptionsPanel extends javax.swing.JPanel {
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btRunNow;
+    private javax.swing.JCheckBox cbAutoRemove;
     private javax.swing.JCheckBox cbEnabled;
-    private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel lbRunNowInfo;
+    private javax.swing.JLabel lbUnusedDays;
     private javax.swing.JSpinner spUnusedDays;
     // End of variables declaration//GEN-END:variables
 }


### PR DESCRIPTION
This one adds an option to the Janitor to remove abandoned cache directories automatically.

Well, I've set the default true, as even this is a delete operation. it is just cache.  Usually it bothers me, as a user of `netbeans-dev` Snap package, which is updated weekly and leaves a cache directory behind each week.
