### PR TITLE
Recognize Scala class constructor

### DIFF
--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/MethodBreakpointImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/MethodBreakpointImpl.java
@@ -291,12 +291,12 @@ public class MethodBreakpointImpl extends ClassBasedBreakpoint {
         }
         return super.exec (event);
     }
-
+    private static final String CONSTRUCTOR = "<init>";
     static String checkForConstructor(String typeName, String methodName) {
         String constructorName = typeName;
         final int lastDot = constructorName.lastIndexOf('.');
         if (methodName.equals(typeName.substring(lastDot + 1))) {
-            return "<init>";
+            return CONSTRUCTOR;
         }
         int index = Math.max(lastDot,
                 constructorName.lastIndexOf('$'));
@@ -316,7 +316,7 @@ public class MethodBreakpointImpl extends ClassBasedBreakpoint {
             }
         }
         if (methodName.equals(constructorName)) {
-            return "<init>"; // Constructor
+            return CONSTRUCTOR; // Constructor
         } else {
             return methodName;
         }
@@ -353,7 +353,7 @@ public class MethodBreakpointImpl extends ClassBasedBreakpoint {
             String typeName = referenceType.name();
             String methodName = checkForConstructor(typeName, breakpoint.getMethodName());
             String outerArgsSignature = null;   // Signature of arguments from outer classes
-            if (methodName.equals("<init>")) {
+            if (methodName.equals(CONSTRUCTOR)) {
                 if (!ReferenceTypeWrapper.isStatic0(referenceType)) {
                     outerArgsSignature = findOuterArgsSignature(typeName, referenceType);
                 }

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/MethodBreakpointImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/MethodBreakpointImpl.java
@@ -294,7 +294,11 @@ public class MethodBreakpointImpl extends ClassBasedBreakpoint {
 
     static String checkForConstructor(String typeName, String methodName) {
         String constructorName = typeName;
-        int index = Math.max(constructorName.lastIndexOf('.'),
+        final int lastDot = constructorName.lastIndexOf('.');
+        if (methodName.equals(typeName.substring(lastDot + 1))) {
+            return "<init>";
+        }
+        int index = Math.max(lastDot,
                 constructorName.lastIndexOf('$'));
         if (index > 0) {
             constructorName = constructorName.substring(index + 1);

--- a/java/debugger.jpda/test/unit/src/org/netbeans/modules/debugger/jpda/breakpoints/MethodBreakpointImplTest.java
+++ b/java/debugger.jpda/test/unit/src/org/netbeans/modules/debugger/jpda/breakpoints/MethodBreakpointImplTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.debugger.jpda.breakpoints;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class MethodBreakpointImplTest {
+    @Test
+    public void testRecognizeSimpleConstructor() {
+        String res = MethodBreakpointImpl.checkForConstructor("java.lang.String", "String");
+        assertEquals("It is constructor", "<init>", res);
+    }
+    @Test
+    public void testRecognizeInnerConstructor() {
+        String res = MethodBreakpointImpl.checkForConstructor("java.util.Map$Entry", "Entry");
+        assertEquals("It is constructor", "<init>", res);
+    }
+    @Test
+    public void testRecognizeScalaConstructor() {
+        String res = MethodBreakpointImpl.checkForConstructor("org.enso.compiler.core.IR$CallArgument$Specified", "IR$CallArgument$Specified");
+        assertEquals("It is constructor", "<init>", res);
+    }
+}


### PR DESCRIPTION
I am developing mixed [Java+Scala application](https://github.com/enso-org/enso/tree/330612119aba1cbcb310333ca5f06274a67d935b/engine/runtime/src/main) with the NetBeans IDE. I got debugging working, but I have problems to place a breakpoint on constructor of some classes. This is the (disassembled) source I see in the editor:
![image](https://user-images.githubusercontent.com/1842422/199390717-42084b74-5b44-4626-bcec-5cbef3125fe3.png)
I can place a method breakpoint on it (as the triangle in the left editor gutter indicates). However the breakpoint is then later reported as misplaced.

I tracked this down to problems in recognizing constructor of such strangely named Scala classes like: `org.enso.compiler.core.IR$Name$MethodReference`. This PR extracts the _"constructor recognizing logic"_  into its own method and adds few tests to verify current behavior. Then it adds a test and a fix to make the code work for my usage case 3205d10d00ab9c1123b39e407dcaee7bb13c92cc.