### PR TITLE
Maven HintsPanel UI layout fixes and minor cleanup.

### DIFF
--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsPanel.form
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsPanel.form
@@ -54,9 +54,6 @@
   <SubComponents>
     <Container class="javax.swing.JSplitPane" name="jSplitPane1">
       <Properties>
-        <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
-          <Border info="null"/>
-        </Property>
         <Property name="dividerLocation" type="int" value="320"/>
         <Property name="opaque" type="boolean" value="false"/>
       </Properties>
@@ -118,17 +115,29 @@
             </Constraint>
           </Constraints>
 
-          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
+          <Layout>
+            <DimensionLayout dim="0">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="descriptionPanel" pref="189" max="32767" attributes="0"/>
+                  <Component id="optionsPanel" alignment="1" pref="0" max="32767" attributes="0"/>
+              </Group>
+            </DimensionLayout>
+            <DimensionLayout dim="1">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" attributes="0">
+                      <Component id="optionsPanel" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace min="-2" max="-2" attributes="0"/>
+                      <Component id="descriptionPanel" pref="219" max="32767" attributes="0"/>
+                      <EmptySpace min="-2" pref="1" max="-2" attributes="0"/>
+                  </Group>
+              </Group>
+            </DimensionLayout>
+          </Layout>
           <SubComponents>
             <Container class="javax.swing.JPanel" name="optionsPanel">
               <Properties>
                 <Property name="opaque" type="boolean" value="false"/>
               </Properties>
-              <Constraints>
-                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                  <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="12" insetsRight="0" anchor="18" weightX="1.0" weightY="0.7"/>
-                </Constraint>
-              </Constraints>
 
               <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
               <SubComponents>
@@ -215,11 +224,6 @@
               <Properties>
                 <Property name="opaque" type="boolean" value="false"/>
               </Properties>
-              <Constraints>
-                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                  <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="0.3"/>
-                </Constraint>
-              </Constraints>
 
               <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
               <SubComponents>

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsPanel.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/HintsPanel.java
@@ -71,18 +71,11 @@ final class HintsPanel extends javax.swing.JPanel implements TreeCellRenderer  {
         
         DefaultTreeModel mdl = new DefaultTreeModel(new DefaultMutableTreeNode());
         errorTree.setModel( mdl );
-        RequestProcessor.getDefault().post(new Runnable() {
-            @Override
-            public void run() {
-                final TreeModel m = RulesManager.getHintsTreeModel();
-                SwingUtilities.invokeLater(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        errorTree.setModel( m );
-                    }
-                });
-            }
+        RequestProcessor.getDefault().post(() -> {
+            final TreeModel m = RulesManager.getHintsTreeModel();
+            SwingUtilities.invokeLater(() -> {
+                errorTree.setModel( m );
+            });
         });
         
         
@@ -115,7 +108,6 @@ final class HintsPanel extends javax.swing.JPanel implements TreeCellRenderer  {
         setBorder(javax.swing.BorderFactory.createEmptyBorder(8, 8, 8, 8));
         setLayout(new java.awt.GridBagLayout());
 
-        jSplitPane1.setBorder(null);
         jSplitPane1.setDividerLocation(320);
         jSplitPane1.setOpaque(false);
 
@@ -132,7 +124,6 @@ final class HintsPanel extends javax.swing.JPanel implements TreeCellRenderer  {
 
         detailsPanel.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 6, 0, 0));
         detailsPanel.setOpaque(false);
-        detailsPanel.setLayout(new java.awt.GridBagLayout());
 
         optionsPanel.setOpaque(false);
         optionsPanel.setLayout(new java.awt.GridBagLayout());
@@ -182,16 +173,6 @@ final class HintsPanel extends javax.swing.JPanel implements TreeCellRenderer  {
         gridBagConstraints.insets = new java.awt.Insets(8, 0, 0, 0);
         optionsPanel.add(customizerPanel, gridBagConstraints);
 
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.weighty = 0.7;
-        gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 0);
-        detailsPanel.add(optionsPanel, gridBagConstraints);
-
         descriptionPanel.setOpaque(false);
         descriptionPanel.setLayout(new java.awt.GridBagLayout());
 
@@ -217,13 +198,21 @@ final class HintsPanel extends javax.swing.JPanel implements TreeCellRenderer  {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         descriptionPanel.add(descriptionLabel, gridBagConstraints);
 
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 1;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.weighty = 0.3;
-        detailsPanel.add(descriptionPanel, gridBagConstraints);
+        javax.swing.GroupLayout detailsPanelLayout = new javax.swing.GroupLayout(detailsPanel);
+        detailsPanel.setLayout(detailsPanelLayout);
+        detailsPanelLayout.setHorizontalGroup(
+            detailsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addComponent(descriptionPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 189, Short.MAX_VALUE)
+            .addComponent(optionsPanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE)
+        );
+        detailsPanelLayout.setVerticalGroup(
+            detailsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(detailsPanelLayout.createSequentialGroup()
+                .addComponent(optionsPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(descriptionPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 219, Short.MAX_VALUE)
+                .addGap(1, 1, 1))
+        );
 
         jSplitPane1.setRightComponent(detailsPanel);
 

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/JavaNetRepositoryErrorCustomizer.form
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/JavaNetRepositoryErrorCustomizer.form
@@ -51,7 +51,7 @@
                           <Component id="rbSelected" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="jLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace min="0" pref="124" max="32767" attributes="0"/>
+                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                   </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
@@ -66,7 +66,7 @@
               <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
               <Component id="rbSelected" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="jScrollPane1" pref="195" max="32767" attributes="0"/>
+              <Component id="jScrollPane1" pref="103" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/JavaNetRepositoryErrorCustomizer.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/JavaNetRepositoryErrorCustomizer.java
@@ -43,7 +43,7 @@ import org.openide.util.NbBundle;
  */
 public class JavaNetRepositoryErrorCustomizer extends javax.swing.JPanel {
     private final Preferences preferences;
-    private final Map<String, Object> id2Saved = new HashMap<String, Object>();
+    private final Map<String, Object> id2Saved = new HashMap<>();
 
     /** Creates new form ReleaseVersionErrorCustomizer */
     public JavaNetRepositoryErrorCustomizer(Preferences prefs) {
@@ -116,8 +116,7 @@ public class JavaNetRepositoryErrorCustomizer extends javax.swing.JPanel {
 
         GroupLayout layout = new GroupLayout(this);
         this.setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(Alignment.LEADING)
@@ -127,18 +126,17 @@ public class JavaNetRepositoryErrorCustomizer extends javax.swing.JPanel {
                             .addComponent(rbAny)
                             .addComponent(rbSelected)
                             .addComponent(jLabel1))
-                        .addGap(0, 124, Short.MAX_VALUE)))
+                        .addGap(0, 0, Short.MAX_VALUE)))
                 .addContainerGap())
         );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setVerticalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(rbAny)
                 .addPreferredGap(ComponentPlacement.UNRELATED)
                 .addComponent(rbSelected)
                 .addPreferredGap(ComponentPlacement.RELATED)
-                .addComponent(jScrollPane1, GroupLayout.DEFAULT_SIZE, 195, Short.MAX_VALUE)
+                .addComponent(jScrollPane1, GroupLayout.DEFAULT_SIZE, 103, Short.MAX_VALUE)
                 .addPreferredGap(ComponentPlacement.RELATED)
                 .addComponent(jLabel1)
                 .addContainerGap())

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/MoveToDependencyManagementPanel.form
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/MoveToDependencyManagementPanel.form
@@ -53,7 +53,7 @@
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="jScrollPane1" pref="193" max="32767" attributes="0"/>
+              <Component id="jScrollPane1" pref="178" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/MoveToDependencyManagementPanel.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/MoveToDependencyManagementPanel.java
@@ -79,12 +79,9 @@ public final class MoveToDependencyManagementPanel extends javax.swing.JPanel im
      *
      */
     public void showWaitNode() {
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-               treeView.setRootVisible(true);
-               explorerManager.setRootContext(createWaitNode());
-            }
+        SwingUtilities.invokeLater(() -> {
+            treeView.setRootVisible(true);
+            explorerManager.setRootContext(createWaitNode());
         });
     }
     private static Node createWaitNode() {
@@ -103,21 +100,18 @@ public final class MoveToDependencyManagementPanel extends javax.swing.JPanel im
             lin = MavenEmbedder.getModelDescriptors(nbprj.getMavenProject());
         }
         if (lin != null) {
-                    final Children ch = new PomChildren(lin);
-                    SwingUtilities.invokeLater(new Runnable() {
-                @Override
-                        public void run() {
-                           treeView.setRootVisible(false);
-                           explorerManager.setRootContext(new AbstractNode(ch));
-                            try {
-                                explorerManager.setSelectedNodes(new Node[]{
-                                    explorerManager.getRootContext().getChildren().getNodes()[0]
-                                });
-                            } catch (PropertyVetoException ex) {
-                                Exceptions.printStackTrace(ex);
-                            }
-                        }
+            final Children ch = new PomChildren(lin);
+            SwingUtilities.invokeLater(() -> {
+                treeView.setRootVisible(false);
+                explorerManager.setRootContext(new AbstractNode(ch));
+                try {
+                    explorerManager.setSelectedNodes(new Node[]{
+                        explorerManager.getRootContext().getChildren().getNodes()[0]
                     });
+                } catch (PropertyVetoException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+            });
         }
     }
 
@@ -140,7 +134,7 @@ public final class MoveToDependencyManagementPanel extends javax.swing.JPanel im
 
         @Override
         protected Node[] createNodes(List<MavenEmbedder.ModelDescription> key) {
-            List<POMNode> nds = new ArrayList<POMNode>();
+            List<POMNode> nds = new ArrayList<>();
             for (MavenEmbedder.ModelDescription mdl : key) {
                 if(mdl.getLocation() != null ) {
                     File fl = mdl.getLocation();
@@ -247,7 +241,7 @@ public final class MoveToDependencyManagementPanel extends javax.swing.JPanel im
                 .addContainerGap()
                 .addComponent(jLabel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 225, Short.MAX_VALUE)
+                .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 178, Short.MAX_VALUE)
                 .addContainerGap())
         );
     }// </editor-fold>//GEN-END:initComponents

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/ParentVersionErrorCustomizer.form
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/ParentVersionErrorCustomizer.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 
@@ -51,7 +51,7 @@
                   <Component id="rbSources" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="rbLatest" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace pref="37" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -64,7 +64,7 @@
               <Component id="rbLatest" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="cbSnapshots" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="215" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/ParentVersionErrorCustomizer.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/ParentVersionErrorCustomizer.java
@@ -31,7 +31,7 @@ import java.util.prefs.Preferences;
  */
 public class ParentVersionErrorCustomizer extends javax.swing.JPanel {
     private Preferences preferences;
-    private final Map<String, Object> id2Saved = new HashMap<String, Object>();
+    private final Map<String, Object> id2Saved = new HashMap<>();
 
     /** Creates new form ParentVersionErrorCustomizer */
     public ParentVersionErrorCustomizer(Preferences prefs) {
@@ -43,20 +43,14 @@ public class ParentVersionErrorCustomizer extends javax.swing.JPanel {
         rbLatest.setSelected(!preferences.getBoolean(ParentVersionError.PROP_SOURCES, true));
         cbSnapshots.setSelected(preferences.getBoolean(ParentVersionError.PROP_SNAPSHOT, false));
         enableSnapshots();
-        ActionListener al = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                preferences.putBoolean(ParentVersionError.PROP_SOURCES, rbSources.isSelected());
-                enableSnapshots();
-            }
+        ActionListener al = (ActionEvent e) -> {
+            preferences.putBoolean(ParentVersionError.PROP_SOURCES, rbSources.isSelected());
+            enableSnapshots();
         };
         rbSources.addActionListener(al);
         rbLatest.addActionListener(al);
-        cbSnapshots.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                preferences.putBoolean(ParentVersionError.PROP_SNAPSHOT, cbSnapshots.isSelected());
-            }
+        cbSnapshots.addActionListener((ActionEvent e) -> {
+            preferences.putBoolean(ParentVersionError.PROP_SNAPSHOT, cbSnapshots.isSelected());
         });
     
         id2Saved.put(ParentVersionError.PROP_SOURCES, rbSources.isSelected());
@@ -108,7 +102,7 @@ public class ParentVersionErrorCustomizer extends javax.swing.JPanel {
                         .addComponent(cbSnapshots))
                     .addComponent(rbSources)
                     .addComponent(rbLatest))
-                .addContainerGap(37, Short.MAX_VALUE))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -119,7 +113,7 @@ public class ParentVersionErrorCustomizer extends javax.swing.JPanel {
                 .addComponent(rbLatest)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(cbSnapshots)
-                .addContainerGap(215, Short.MAX_VALUE))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/ReleaseVersionErrorCustomizer.form
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/ReleaseVersionErrorCustomizer.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 
@@ -44,7 +44,7 @@
                   <Component id="cbLatest" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="cbSnapshot" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace pref="118" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -57,7 +57,7 @@
               <Component id="cbLatest" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="cbSnapshot" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="215" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/ReleaseVersionErrorCustomizer.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/ReleaseVersionErrorCustomizer.java
@@ -37,7 +37,7 @@ import org.openide.util.NbBundle;
  */
 public class ReleaseVersionErrorCustomizer extends javax.swing.JPanel {
     private final Preferences preferences;
-    private final Map<String, Object> id2Saved = new HashMap<String, Object>();
+    private final Map<String, Object> id2Saved = new HashMap<>();
 
     /** Creates new form ReleaseVersionErrorCustomizer */
     public ReleaseVersionErrorCustomizer(Preferences prefs) {
@@ -68,19 +68,22 @@ public class ReleaseVersionErrorCustomizer extends javax.swing.JPanel {
         cbRelease = new JCheckBox();
         cbLatest = new JCheckBox();
         cbSnapshot = new JCheckBox();
-        Mnemonics.setLocalizedText(cbRelease, NbBundle.getMessage(ReleaseVersionErrorCustomizer.class, "ReleaseVersionErrorCustomizer.cbRelease.text"));
+
+        Mnemonics.setLocalizedText(cbRelease, NbBundle.getMessage(ReleaseVersionErrorCustomizer.class, "ReleaseVersionErrorCustomizer.cbRelease.text")); // NOI18N
         cbRelease.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent evt) {
                 cbReleaseActionPerformed(evt);
             }
         });
-        Mnemonics.setLocalizedText(cbLatest, NbBundle.getMessage(ReleaseVersionErrorCustomizer.class, "ReleaseVersionErrorCustomizer.cbLatest.text"));
+
+        Mnemonics.setLocalizedText(cbLatest, NbBundle.getMessage(ReleaseVersionErrorCustomizer.class, "ReleaseVersionErrorCustomizer.cbLatest.text")); // NOI18N
         cbLatest.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent evt) {
                 cbLatestActionPerformed(evt);
             }
         });
-        Mnemonics.setLocalizedText(cbSnapshot, NbBundle.getMessage(ReleaseVersionErrorCustomizer.class, "ReleaseVersionErrorCustomizer.cbSnapshot.text"));
+
+        Mnemonics.setLocalizedText(cbSnapshot, NbBundle.getMessage(ReleaseVersionErrorCustomizer.class, "ReleaseVersionErrorCustomizer.cbSnapshot.text")); // NOI18N
         cbSnapshot.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent evt) {
                 cbSnapshotActionPerformed(evt);
@@ -89,18 +92,16 @@ public class ReleaseVersionErrorCustomizer extends javax.swing.JPanel {
 
         GroupLayout layout = new GroupLayout(this);
         this.setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(Alignment.LEADING)
                     .addComponent(cbRelease)
                     .addComponent(cbLatest)
                     .addComponent(cbSnapshot))
-                .addContainerGap(118, Short.MAX_VALUE))
+                .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setVerticalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(cbRelease)
@@ -108,7 +109,7 @@ public class ReleaseVersionErrorCustomizer extends javax.swing.JPanel {
                 .addComponent(cbLatest)
                 .addPreferredGap(ComponentPlacement.UNRELATED)
                 .addComponent(cbSnapshot)
-                .addContainerGap(215, Short.MAX_VALUE))
+                .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 


### PR DESCRIPTION
 - analog to #3472, this fixes UI component resize behavior of the Maven HintsPanel
 - description panel is now filling the space vertically like in the java version of this panel. Text is now wrapping properly.
 - the option panels had to be adjusted to prefer their minimum default size
 - minor language cleanup: diamonds, lambdas

targets delivery. But this is fairly low priority. Noticed those UI issues while writing the maven release version hint.


![hints-before](https://user-images.githubusercontent.com/114367/199617875-d3572946-1bd3-4f29-b73d-ce9e62f2c155.png)

![hints-after](https://user-images.githubusercontent.com/114367/199617898-9de3461a-e359-4bf1-bc6a-2cbb9e96a196.png)
