### PR TITLE
Fixes for DialogNotifier in LSP

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -512,7 +512,7 @@ public class VulnerabilityWorker implements ErrorProvider{
             }
             if (auditDone) {
                 DialogDisplayer.getDefault().notifyLater(
-                                new NotifyDescriptor.Message(message));
+                                new NotifyDescriptor.Message(message, cacheItem.getAudit().getIsSuccess() ? NotifyDescriptor.INFORMATION_MESSAGE : NotifyDescriptor.ERROR_MESSAGE));
             }
             Diagnostic.ReporterControl reporter = Diagnostic.findReporterControl(Lookup.getDefault(), project.getProjectDirectory());
             reporter.diagnosticChanged(problematicFiles, null);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/NodeChangedParams.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/NodeChangedParams.java
@@ -28,10 +28,10 @@ import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
  */
 public class NodeChangedParams {
     @NonNull
-    private final int rootId;
+    private int rootId;
     
-    private final Integer nodeId;
-
+    private Integer nodeId;
+    
     public NodeChangedParams(int rootId) {
         this.rootId = rootId;
         this.nodeId = null;
@@ -51,5 +51,17 @@ public class NodeChangedParams {
     @Pure
     public Integer getNodeId() {
         return nodeId;
+    }
+
+    // needed for testing, as GSON deserializes the structure on the client side.
+    public NodeChangedParams() {
+    }
+
+    public void setRootId(int rootId) {
+        this.rootId = rootId;
+    }
+
+    public void setNodeId(Integer nodeId) {
+        this.nodeId = nodeId;
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/UIContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/UIContext.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
@@ -38,6 +40,8 @@ import org.openide.awt.StatusDisplayer.Message;
 import org.openide.util.Lookup;
 
 public abstract class UIContext {
+    private static final Logger LOG = Logger.getLogger(UIContext.class.getName());
+    
     private static Reference<UIContext> lastCtx = new WeakReference<>(null);
     
     /**
@@ -50,11 +54,13 @@ public abstract class UIContext {
     public static synchronized UIContext find(Lookup lkp) {
         UIContext ctx = lkp.lookup(UIContext.class);
         if (ctx != null) {
+            LOG.log(Level.FINE, "Acquired user context from lookup: {0}, context instance: {1}", new Object[] { lkp, ctx });
             return ctx;
         }
         Lookup def = Lookup.getDefault();
         if (lkp != def) {
             ctx = def.lookup(UIContext.class);
+            LOG.log(Level.FINE, "Acquired user context from default lookup: {0}, context instance: {1}", new Object[] { lkp, ctx });
         }
         if (ctx == null) {
             // PENDING: better context transfer between threads is needed; this way the UIContext can remote to a bad

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceUIContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceUIContext.java
@@ -21,6 +21,8 @@ package org.netbeans.modules.java.lsp.server.protocol;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
@@ -36,10 +38,13 @@ import org.openide.awt.StatusDisplayer;
  * @author sdedic
  */
 class WorkspaceUIContext extends UIContext {
+    private static final Logger LOG = Logger.getLogger(WorkspaceUIContext.class.getName());
+    
     private final NbCodeLanguageClient client;
 
     public WorkspaceUIContext(NbCodeLanguageClient client) {
         this.client = client;
+        LOG.log(Level.FINE, "Starting WorkspaceUIContext for: {0}, context instance: {1}", new Object[] { client, this });
     }
 
     @Override

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayer.java
@@ -21,6 +21,8 @@ package org.netbeans.modules.java.lsp.server.ui;
 import java.awt.Dialog;
 import java.awt.HeadlessException;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.netbeans.modules.java.lsp.server.LspServerUtils;
 import org.netbeans.modules.java.lsp.server.protocol.UIContext;
 import org.openide.DialogDescriptor;
@@ -35,40 +37,30 @@ import org.openide.util.Lookup;
  * @author sdedic
  */
 public class AbstractDialogDisplayer extends DialogDisplayer {
-    private final Lookup context;
+    private static final Logger LOG = Logger.getLogger(AbstractDialogDisplayer.class.getName());
     
     public AbstractDialogDisplayer() {
-        this(Lookup.getDefault());
-    }
-
-    AbstractDialogDisplayer(Lookup context) {
-        this.context = context;
+        LOG.log(Level.FINE, "Creating dialog displayer with lookup context: {0}", Lookup.getDefault());
     }
     
     @Override
     public Object notify(NotifyDescriptor descriptor) {
-        LspServerUtils.avoidClientMessageThread(context);
-        UIContext ctx = UIContext.find(context);
+        LspServerUtils.avoidClientMessageThread(Lookup.getDefault());
+        UIContext ctx = UIContext.find();
         NotifyDescriptorAdapter adapter = new NotifyDescriptorAdapter(descriptor, ctx);
         return adapter.clientNotify();
     }
     
     @Override
     public void notifyLater(final NotifyDescriptor descriptor) {
-        UIContext ctx = context.lookup(UIContext.class);
-        if (ctx == null) {
-            ctx = UIContext.find();
-        }
+        UIContext ctx = UIContext.find();
         NotifyDescriptorAdapter adapter = new NotifyDescriptorAdapter(descriptor, ctx);
         adapter.clientNotifyLater();
     }
 
     @Override
     public <T extends NotifyDescriptor> CompletableFuture<T> notifyFuture(T descriptor) {
-        UIContext ctx = context.lookup(UIContext.class);
-        if (ctx == null) {
-            ctx = UIContext.find();
-        }
+        UIContext ctx = UIContext.find();
         NotifyDescriptorAdapter adapter = new NotifyDescriptorAdapter(descriptor, ctx);
         return adapter.clientNotifyCompletion();
     }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
@@ -286,6 +286,7 @@ class NotifyDescriptorAdapter {
     }
     
     public CompletableFuture<Object> clientNotifyLater() {
+        LOG.log(Level.FINE, "notifyLater with context: {0}", this.client);
         return clientNotifyCompletion().thenApply(d -> d.getValue()).exceptionally(t -> {
             if (t instanceof CompletionException) {
                 t = t.getCause();


### PR DESCRIPTION
The main issue fixed is the binding between LSP `UIContext` and the **first client that initializes it** and then is stuck with it. The original code gave the 1st client the priority over the client that may have been present in the computational context `Lookup.getDefault()`. The changed code will use the current Lookup.getDefault() that is transferred through various RP.Tasks - this is already implemented in UIContext.find()

* fixes ADM report, so it uses fire-and-forge `notifyLater` instead `notify`. The LSP client may use modeless UI (vscode does) and the server thread is left blocked until the user dismisses the report (in vscode the user may just ignore it or hide it into status line without dismissing)
* minor fix for tests: the structure must gson-deserialize on JDK11, so default ctor + setters are needed
