### PR TITLE
Fix mapping of dependencies described as key/value maps to the source

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -401,7 +401,6 @@ public class VulnerabilityWorker implements ErrorProvider{
 
     private String doFindVulnerability(Project project, String compartmentId, String knowledgeBaseId, String projectDisplayName, AuditOptions auditOptions,
             ProgressHandle progressHandle, AtomicBoolean remoteCall) throws AuditException {
-        DependencyResult dr = null;
         List<ApplicationDependency> result = new ArrayList();
         
         CacheItem cacheItem = null;
@@ -409,12 +408,14 @@ public class VulnerabilityWorker implements ErrorProvider{
         
         boolean auditDone = false;
 
+        DependencyResult dr = null;
+        
         if (!auditOptions.isForceAuditExecution()) {
             try {
                 savedAudit = AuditCache.getInstance().loadAudit(knowledgeBaseId);
             } catch (IOException ex) {
-                LOG.log(Level.WARNING, "Could not load cached audit data", ex);
-            }
+                LOG.log(Level.WARNING, "Could not load cached audit data", ex); 
+           }
 
             if (savedAudit == null) {
                 // attempt to find an active most recent audit:
@@ -489,7 +490,12 @@ public class VulnerabilityWorker implements ErrorProvider{
             } finally {
                 progressHandle.finish();
             }
-        } else if (savedAudit != null) {
+        } else if (savedAudit != null && cacheItem == null) {
+            if (dr == null) {
+                progressHandle.progress(Bundle.MSG_AuditCollectDependencies());
+                dr = ProjectDependencies.findDependencies(project, ProjectDependencies.newQuery(Scopes.RUNTIME));
+                convert(dr.getRoot(), new HashMap<>(), result);
+            }
             cacheItem = new CacheItem(project, dr, savedAudit);
         }
 

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/DependencyText.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/DependencyText.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.netbeans.modules.gradle.api.GradleDependency;
 import org.netbeans.modules.project.dependency.Dependency;
 import org.netbeans.modules.project.dependency.DependencyResult;
 
@@ -105,6 +104,19 @@ class DependencyText {
         }
         sb.append(" [").append(startPos).append(", ").append(endPos).append("]}");
         return sb.toString();
+    }
+    
+    public String getContentsOrGav() {
+        if (contents != null) {
+            return contents;
+        } else {
+            StringBuilder sb = new StringBuilder();
+            sb.append(group).append(':').append(name);
+            if (version != null && !version.isEmpty()) {
+                sb.append(':').append(version);
+            }
+            return sb.toString();
+        }
     }
 
     /**

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/TextDependencyScanner.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/TextDependencyScanner.java
@@ -634,13 +634,6 @@ public class TextDependencyScanner {
                 if (text.group == null || text.name == null) {
                     continue;
                 }
-                StringBuilder sb = new StringBuilder();
-                sb.append(text.group).append(text.name);
-                if (text.version != null) {
-                    sb.append(text.version);
-                } else {
-                    text.version = "";
-                }
             }
         }
     }
@@ -668,7 +661,7 @@ public class TextDependencyScanner {
             if (DependencyText.KEYWORD_PROJECT.equals(t.keyword) &&
                 t.contents.equals(projectName)) {
                 return t;
-            } else if (t.keyword == null && t.contents != null && t.contents.equals(gav)) {
+            } else if (t.keyword == null && t.getContentsOrGav().equals(gav)) {
                 return t;
             }
         }

--- a/java/gradle.java/test/unit/data/dependencies/parse/variousSyntax.gradle
+++ b/java/gradle.java/test/unit/data/dependencies/parse/variousSyntax.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("io.micronaut.application") version "3.6.3"
+}
+version = "0.1"
+group = "com.example"
+repositories {
+    mavenCentral()
+}
+dependencies {
+    // with parenthesis
+    @@A@@annotationProcessor("io.micronaut:micronaut-http-validation")@@A@@
+    // without parenthesis
+    @@B@@implementation "io.micronaut:micronaut-http-client"@@B@@
+    // several deps in a common group
+    implementation(
+        @@C@@'io.micronaut:micronaut-jackson-databind'@@C@@,
+        @@D@@"jakarta.annotation:jakarta.annotation-api"@@D@@
+    )
+    // with a closure
+    @@E@@runtimeOnly("ch.qos.logback:logback-classic") {
+        transitive = true
+    }@@E@@
+    // map in parenthesis
+    @@F@@implementation(group : "io.micronaut", name: "micronaut-validation", version: "2.5")@@F@@
+    // list of maps in parenthesis
+    runtimeOnly(
+        @@G@@[group: 'org.hibernate', name: 'hibernate', version: '3.0.5', transitive: true]@@G@@,
+        @@H@@[group:'org.ow2.asm', name:'asm', version:'7.1']@@H@@
+    )
+    @@I@@implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.0'@@I@@
+}
+application {
+    mainClass.set("com.example.Application")
+}
+java {
+    sourceCompatibility = JavaVersion.toVersion("17")
+    targetCompatibility = JavaVersion.toVersion("17")
+}
+graalvmNative.toolchainDetection = false
+micronaut {
+    runtime("netty")
+    testRuntime("junit5")
+    processing {
+        incremental(true)
+        annotations("com.example.*")
+    }
+}

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/queries/RegexpGradleScannerTest.java
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/queries/RegexpGradleScannerTest.java
@@ -18,13 +18,20 @@
  */
 package org.netbeans.modules.gradle.java.queries;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.netbeans.modules.project.dependency.Dependency;
+import org.netbeans.modules.project.dependency.ProjectSpec;
+import org.netbeans.modules.project.dependency.Scopes;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
@@ -84,6 +91,7 @@ public class RegexpGradleScannerTest extends NbTestCase {
         List<DependencyText> deps = scanner.parseDependencyList(filteredText);
         assertEquals(12, deps.size());
         checkDependencyBoundaries(deps);
+        checkDependencyMap(scanner, deps);
     }
     
     public void testMicronautStarter() throws Exception {
@@ -96,10 +104,77 @@ public class RegexpGradleScannerTest extends NbTestCase {
         filteredText = filterAndStorePositions(f.asText());
         List<DependencyText> deps = scanner.parseDependencyList(filteredText);
         assertEquals(7, deps.size());
+        checkDependencyMap(scanner, deps);
+    }
+    
+    private static final List<String> expectedGavs = Arrays.asList(
+            "io.micronaut:micronaut-http-validation",
+            "io.micronaut:micronaut-http-client",
+            "io.micronaut:micronaut-jackson-databind",
+            "jakarta.annotation:jakarta.annotation-api",
+            "ch.qos.logback:logback-classic",
+            "io.micronaut:micronaut-validation:2.5",
+            "org.hibernate:hibernate:3.0.5",
+            "org.ow2.asm:asm:7.1",
+            "org.apache.logging.log4j:log4j-core:2.17.0"
+    );
+    
+    /**
+     * Checks that various declaration syntaxes are understood well by the parser.
+     */
+    public void testVariousSyntaxes() throws Exception {
+        FileObject f = FileUtil.toFileObject(getDataDir()).getFileObject("dependencies/parse/variousSyntax.gradle");
+        TextDependencyScanner scanner = new TextDependencyScanner();
+        
+        filteredText = filterAndStorePositions(f.asText());
+        scanner.withConfigurations(Arrays.asList(
+            "runtimeOnly", "implementation", "annotationProcessor"
+        ));
+        List<DependencyText> deps = scanner.parseDependencyList(filteredText);
+        List<String> gavs = deps.stream().map(DependencyText::getContentsOrGav).collect(Collectors.toList());
+        assertEquals(expectedGavs, gavs);
+        checkDependencyBoundaries(deps);
+        checkDependencyMap(scanner, deps);
+    }
+    
+    public void testMapLikeDeclaration() throws Exception {
+        FileObject f = FileUtil.toFileObject(getDataDir()).getFileObject("dependencies/parse/variousSyntax.gradle");
+        TextDependencyScanner scanner = new TextDependencyScanner();
+        
+        filteredText = filterAndStorePositions(f.asText());
+        scanner.withConfigurations(Arrays.asList(
+            "runtimeOnly", "implementation", "annotationProcessor"
+        ));
+        List<DependencyText> deps = scanner.parseDependencyList(filteredText);
+        assertNotNull(deps);
+        checkDependencyBoundaries(deps);
+        checkDependencyMap(scanner, deps);
     }
     
     private Map<String, Integer> startPosition = new HashMap<>();
     private Map<String, Integer> endPosition = new HashMap<>();
+    
+    private void checkDependencyMap(TextDependencyScanner scanner, List<DependencyText> deps) {
+        List<Dependency> list = new ArrayList<>();
+        for (DependencyText t : deps) {
+            if (t.keyword == null && t.name != null && t.group != null && t.version != null) {
+                ArtifactSpec as = ArtifactSpec.builder(t.group, t.name, t.version, null).build();
+                Dependency d = Dependency.create(as, Scopes.RUNTIME, Collections.emptyList(), null);
+                list.add(d);
+            } else if ("project".equals(t.keyword)) {
+                ProjectSpec p = ProjectSpec.create(t.contents, null);
+                ArtifactSpec as = ArtifactSpec.builder(t.group, t.name, t.version, null).build();
+                Dependency d = Dependency.create(p, as, Scopes.RUNTIME, Collections.emptyList(), null);
+                list.add(d);
+            }
+        }
+        
+        DependencyText.Mapping mapping = scanner.mapDependencies(list);
+        for (Dependency d : list) {
+            DependencyText.Part found = mapping.getText(d, null);
+            assertNotNull(found);
+        }
+    }
     
     private void checkDependencyBoundaries(List<DependencyText> deps) {
         int pos = 0;


### PR DESCRIPTION
The implementation of `DependencyResult.getDeclarationRange` failed to find a dependency that was specified using a map, e.g.
```
implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.0'
```
parser was ok, but matching ignored such dependency text. Relevant tests for various dependency entry syntaxes were added.

Additional: a subtle bug in Oracle Cloud Vulnerability Audit feature was found that resulted in NPE in some cases, so a cached audit might not appear.

@MartinBalin might be also included in NB16, if it is not too late. Please decide, I'll eventually rebase.