### PR TITLE
Netbeans should be able to execute (it) test by maven in non-standard directory

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
@@ -29,6 +29,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import static java.util.stream.Collectors.joining;
+import java.util.stream.Stream;
 import javax.swing.ActionMap;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.java.project.JavaProjectConstants;
@@ -215,8 +217,16 @@ public class DefaultReplaceTokenProvider implements ReplaceTokenProvider, Action
                 HashSet<String> test = new HashSet<String>();
                 addSelectedFiles(false, fos, test);
                 addSelectedFiles(true, fos, test);
-                String files2test = test.toString().replace(" ", "");
-                packClassname.append(files2test.substring(1, files2test.length() - 1));
+                
+                final Stream<String> foundTests = test.isEmpty()
+                        ? TestsWithoutKnowingRootSourceFolder.find(fos)
+                        : test.stream();
+
+                packClassname.append(foundTests
+                        .map(String::trim)
+                        .collect(joining(","))
+                );
+
             }
         }
         if (packClassname.length() > 0) { //#213671

--- a/java/maven/src/org/netbeans/modules/maven/execute/TestsWithoutKnowingRootSourceFolder.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/TestsWithoutKnowingRootSourceFolder.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.execute;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Exceptions;
+
+class TestsWithoutKnowingRootSourceFolder {
+
+    private static final String LAST_FOLDER_BEFORE_PACKAGE = "java/";
+    private static final Pattern packageFinder = Pattern.compile("^.*package\\s*([a-z][a-z0-9_]*(\\s*\\.\\s*[a-z][a-z0-9_]*)*[0-9a-z_]*)\\s*;.*$");
+
+    static Stream<String> find(FileObject[] fos) {
+        List<String> tests = new ArrayList<>();
+
+        for (final FileObject fo : fos) {
+            if (fo.isFolder()) {
+                tests.add(testBasedOnFolder(fo));
+
+            } else if (fo.isData()) {
+                tests.add(testBasedOnFile(fo));
+            }
+
+        }
+        return tests.stream();
+    }
+
+    private static String testBasedOnFolder(final FileObject fo) {
+        final String path = fo.getPath();
+
+        // based on assumption of default maven folder structure
+        final int startFrom = path.indexOf(LAST_FOLDER_BEFORE_PACKAGE);
+        if (startFrom != -1) {
+            final String packageName = path.substring(startFrom + LAST_FOLDER_BEFORE_PACKAGE.length())
+                    .replace("/", ".");
+            return packageName + ".**";
+        }
+
+        return "";
+    }
+
+    private static String testBasedOnFile(final FileObject fo) {
+        try {
+            final BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(fo.getInputStream())
+            );
+            while (reader.ready()) {
+                final String line = reader.readLine()
+                        .trim();
+
+                Matcher matcher = packageFinder.matcher(line);
+
+                if (matcher.matches() && matcher.groupCount() == 2) {
+                    final String packageName = matcher.group(1);
+                    return packageName.replace(" ", "") + "." + fo.getName();
+                }
+            }
+
+            return "**." + fo.getName();
+        } catch (IOException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        return "";
+    }
+}


### PR DESCRIPTION
I noticed sometime ago, that netbeans is not able to execute IT tests which were located in "src/it/java". This folder was added to maven by "build-helper-maven-plugin" as

> <plugin>
    <groupId>org.codehaus.mojo</groupId>
    <artifactId>build-helper-maven-plugin</artifactId>
    <version>1.9.1</version>
    <executions>
        <execution>
            <id>add-test-source</id>
            <phase>generate-test-sources</phase>
            <goals>
                <goal>add-test-source</goal>
            </goals>
            <configuration>
                <sources>
                    <source>src/it/java</source>
                </sources>
            </configuration>
        </execution>
    </executions>
</plugin>

I tried to execute a test in that folder by netbeans, either by CTRL+F6 (or by mouse) but I noticed that netbeans is not able to correctly defined "-Dtest=" as:

`cd /.../repository; JAVA_HOME=/.../jdk-19.0.1 /.../maven/bin/mvn -Dtest=${packageClassName} surefire:test`

I searched in neatbeans source code and the root cause is, that the extra source folder is not consider as root one. It seems that only folders as /src/main/java and /src/test/java are supported. I was not able to find our how to add additional folder, but based on input FileObject, I was able to construct test names for
- 1 test file 
- n test files (even in different folder)
- package
as

After my changes, netbeans is able to resolve _packageClassName_:

`cd /.../repository; JAVA_HOME=/.../jdk-19.0.1 /.../maven/bin/mvn -Dtest=**.It3Test,some.it.pkg.It2Test surefire:test`

It is covered by UT for execution files individually (one as one liner + normal formatting) and by folder/package.