### PR TITLE
[NETBEANS-4928] EAR deployment considers outputFileNameMapping Maven EAR plugin property

### DIFF
--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ear/EarImpl.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ear/EarImpl.java
@@ -388,6 +388,10 @@ public class EarImpl implements EarImplementation, EarImplementation2,
         List<Dependency> deps = mp.getRuntimeDependencies();
         String fileNameMapping = PluginPropertyUtils.getPluginProperty(project, Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_EAR, "fileNameMapping", "ear", null); //NOI18N
         if (fileNameMapping == null) {
+            // EAR maven plugin property was renamed from fileNameMapping to outputFileNameMapping in version 3.0.0
+            fileNameMapping = PluginPropertyUtils.getPluginProperty(project, Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_EAR, "outputFileNameMapping", "ear", null); //NOI18N
+        }
+        if (fileNameMapping == null) {
             fileNameMapping = "standard"; //NOI18N
         }
 


### PR DESCRIPTION
If the old property isn't found, try the new one. They can't both be specified, the Maven EAR plugin 3+ will refuse the build if the old property is specified. Therefore it doesn't matter which property is looked up first.

Fixes https://github.com/apache/netbeans/issues/4928.