### PR TITLE
Import local schema to avoid DNS lookup in build

### DIFF
--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/jakartaee_9.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/jakartaee_9.xsd
@@ -49,7 +49,7 @@
   </xsd:annotation>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:include schemaLocation="jakartaee_web_services_client_2_0.xsd"/>
 

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/xml.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/xml.xsd
@@ -1,15 +1,15 @@
 <?xml version='1.0'?>
-<!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd" >
 <!--
 
 W3C Software and Document Notice and License
 
-This work is being provided by the copyright holders under the following license.
+This work is being provided by the copyright holders under the following
+license.
 
 License
 
-By obtaining and/or copying this work, you (the licensee) agree that you have
-read, understood, and will comply with the following terms and conditions.
+By obtaining and/or copying this work, you (the licensee) agree that you
+have read, understood, and will comply with the following terms and conditions.
 
 Permission to copy, modify, and distribute this work, with or without
 modification, for any purpose and without fee or royalty is hereby granted,
@@ -18,18 +18,18 @@ thereof, including modifications:
 
 - The full text of this NOTICE in a location viewable to users of the
   redistributed or derivative work.
-- Any pre-existing intellectual property disclaimers, notices, or terms and
-  conditions. If none exist, the W3C Software and Document Short Notice should
-  be included.
-- Notice of any changes or modifications, through a copyright statement on the
-  new code or document such as "This software or document includes material
-  copied from or derived from [title and URI of the W3C document].
+- Any pre-existing intellectual property disclaimers, notices, or terms
+  and conditions. If none exist, the W3C Software and Document Short Notice
+  should be included.
+- Notice of any changes or modifications, through a copyright statement
+  on the new code or document such as "This software or document includes
+  material copied from or derived from [title and URI of the W3C document].
   Copyright © [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
 
 Disclaimers
 
-THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR
- WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS
+OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF
 MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE
 SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
 TRADEMARKS OR OTHER RIGHTS.
@@ -37,68 +37,114 @@ TRADEMARKS OR OTHER RIGHTS.
 COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
 CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
 
-The name and trademarks of copyright holders may NOT be used in advertising or
-publicity pertaining to the work without specific, written prior permission.
-Title to copyright in this work will at all times remain with copyright
-holders.
+The name and trademarks of copyright holders may NOT be used in advertising
+or publicity pertaining to the work without specific, written prior
+permission. Title to copyright in this work will at all times remain with
+copyright holders.
+
 -->
-<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
 
  <xs:annotation>
   <xs:documentation>
-   See http://www.w3.org/XML/1998/namespace.html and
-   http://www.w3.org/TR/REC-xml for information about this namespace.
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
   </xs:documentation>
  </xs:annotation>
 
- <xs:annotation>
-  <xs:documentation>This schema defines attributes and an attribute group
-        suitable for use by
-        schemas wishing to allow xml:base, xml:lang or xml:space attributes
-        on elements they define.
-
-        To enable this, such a schema must import this schema
-        for the XML namespace, e.g. as follows:
-        &lt;schema . . .>
-         . . .
-         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
-                    schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
-
-        Subsequently, qualified reference to any of the attributes
-        or the group defined below will have the desired effect, e.g.
-
-        &lt;type . . .>
-         . . .
-         &lt;attributeGroup ref="xml:specialAttrs"/>
-
-         will define a type which will schema-validate an instance
-         element with any of those attributes</xs:documentation>
- </xs:annotation>
-
- <xs:annotation>
-  <xs:documentation>In keeping with the XML Schema WG's standard versioning
-   policy, this schema document will persist at
-   http://www.w3.org/2001/03/xml.xsd.
-   At the date of issue it can also be found at
-   http://www.w3.org/2001/xml.xsd.
-   The schema document at that URI may however change in the future,
-   in order to remain compatible with the latest version of XML Schema
-   itself.  In other words, if the XML Schema namespace changes, the version
-   of this document at
-   http://www.w3.org/2001/xml.xsd will change
-   accordingly; the version at
-   http://www.w3.org/2001/03/xml.xsd will not change.
-  </xs:documentation>
- </xs:annotation>
-
- <xs:attribute name="lang" type="xs:language">
+ <xs:attribute name="lang">
   <xs:annotation>
-   <xs:documentation>In due course, we should install the relevant ISO 2- and 3-letter
-         codes as the enumerated possible values . . .</xs:documentation>
+   <xs:documentation>
+    <div>
+
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
   </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
  </xs:attribute>
 
- <xs:attribute name="space" default="preserve">
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+
+    </div>
+   </xs:documentation>
+  </xs:annotation>
   <xs:simpleType>
    <xs:restriction base="xs:NCName">
     <xs:enumeration value="default"/>
@@ -107,10 +153,47 @@ holders.
   </xs:simpleType>
  </xs:attribute>
 
- <xs:attribute name="base" type="xs:anyURI">
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attribute name="id" type="xs:ID">
   <xs:annotation>
-   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
-                     information about this attribute.</xs:documentation>
+   <xs:documentation>
+    <div>
+
+      <h3>id (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
   </xs:annotation>
  </xs:attribute>
 
@@ -118,6 +201,129 @@ holders.
   <xs:attribute ref="xml:base"/>
   <xs:attribute ref="xml:lang"/>
   <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
  </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+
+    <h3>Father (in any context at all)</h3>
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of
+      the original XML Working Group.  This name is reserved by
+      the following decision of the W3C XML Plenary and
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd
+      </a>
+      will change accordingly; the version at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd
+      </a>
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
 
 </xs:schema>


### PR DESCRIPTION
This pull request changes two files to fix [apache/netbeans#4920](https://github.com/apache/netbeans/issues/4920).

1. It modifies `jakartaee_9.xsd` to import the "xml:" namespace from a local copy of `xml.xsd` instead of importing it remotely from `http://www.w3.org/2001/xml.xsd`.
2. It replaces the local `xml.xsd` file with the latest [version dated 2009-01](https://www.w3.org/2009/01/xml.xsd) instead of the previous copy which seems to have been derived from the earliest [version dated 2001-03](https://www.w3.org/2001/03/xml.xsd).

Furthermore, I made the following changes to the `xml.xsd` file from the W3C:

* I removed the XML stylesheet because it causes a same-origin policy error in Firefox when viewing the file locally: "Error loading stylesheet: An unknown error has occurred (805303f4)."
* I added the current [W3C Software and Document Notice and License](https://www.w3.org/Consortium/Legal/copyright-software) as a comment formatted with an 80-character line length.
* I removed all trailing whitespace in the file.

How can I test this fix locally? I tried the following two test targets. The first one worked, but the second one failed.

```console
$ ant -quiet -Dmetabuild.branch=release160 -Dcluster.config=release commit-validation
$ ant -quiet -Dmetabuild.branch=release160 -Dcluster.config=release test-basic
```

Let's add this to NetBeans 16 only if someone far more knowledgeable than I am about JavaEE and Jakarta can review and approve it. Otherwise, I have a workaround and can wait for the fix in NetBeans 17.
