### PR TITLE
Prevent CCE NbGradleProjectImpl to DataObject

### DIFF
--- a/extide/gradle.editor/src/org/netbeans/modules/gradle/editor/cli/GradleCliCompletionProvider.java
+++ b/extide/gradle.editor/src/org/netbeans/modules/gradle/editor/cli/GradleCliCompletionProvider.java
@@ -68,6 +68,9 @@ public class GradleCliCompletionProvider implements CompletionProvider {
     private static final Pattern PROP_INPUT = Pattern.compile("\\$\\{([\\w.]*)$"); //NOI18N
     private static final String INPUT_TOKEN = "input:"; //NOI18N
     private static final Set<GradleCommandLine.GradleOptionItem> GRADLE_OPTIONS;
+
+    //TODO: Move this one to GradleCommandLine in NetBeans 17
+    public static final String GRADLE_PROJECT_PROPERTY = "gradle-project"; //NOI18N
     
     static {
         Set<GradleCommandLine.GradleOptionItem> all = new HashSet<>();
@@ -105,7 +108,7 @@ public class GradleCliCompletionProvider implements CompletionProvider {
                 }
 
                 Project project = null;
-                Object prop = doc.getProperty(Document.StreamDescriptionProperty);
+                Object prop = doc.getProperty(GRADLE_PROJECT_PROPERTY);
                 if (prop != null && prop instanceof Project) {
                     project = (Project) prop;
                 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleCommandLine.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleCommandLine.java
@@ -60,6 +60,7 @@ import org.openide.util.Utilities;
  */
 public final class GradleCommandLine implements Serializable {
 
+    private static final String GRADLE_PROJECT_PROPERTY = "gradle-project"; //NOI18N
     private static final Logger LOGGER = Logger.getLogger(GradleCommandLine.class.getName());
     private static final String PROP_JVMARGS = "org.gradle.jvmargs"; // NOI18N
     /**

--- a/extide/gradle/src/org/netbeans/modules/gradle/configurations/NewConfigurationPanel.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/configurations/NewConfigurationPanel.java
@@ -27,10 +27,10 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
-import javax.swing.text.Document;
 import javax.swing.text.EditorKit;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.api.execute.GradleExecConfiguration;
+import org.netbeans.modules.gradle.customizer.BuildActionsCustomizer;
 import org.openide.NotificationLineSupport;
 import org.openide.filesystems.FileUtil;
 import org.openide.text.CloneableEditorSupport;
@@ -55,7 +55,7 @@ public class NewConfigurationPanel extends javax.swing.JPanel implements Documen
         initComponents();
         EditorKit kit = CloneableEditorSupport.getEditorKit("text/x-gradle-cli"); //NOI18N
         txParameters.setEditorKit(kit);
-        txParameters.getDocument().putProperty(Document.StreamDescriptionProperty, project);
+        txParameters.getDocument().putProperty(BuildActionsCustomizer.GRADLE_PROJECT_PROPERTY, project);
         if (isNew) {
             txId.getDocument().addDocumentListener(this);
             txId.getDocument().addDocumentListener(this);

--- a/extide/gradle/src/org/netbeans/modules/gradle/customizer/BuildActionsCustomizer.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/customizer/BuildActionsCustomizer.java
@@ -40,7 +40,6 @@ import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
-import javax.swing.text.Document;
 import javax.swing.text.EditorKit;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.actions.CustomActionRegistrationSupport;
@@ -57,6 +56,9 @@ import org.openide.util.NbBundle.Messages;
  */
 @Messages("TXT_CUSTOM=Custom...")
 public class BuildActionsCustomizer extends javax.swing.JPanel {
+
+    //TODO: Move this one to GradleCommandLine in NetBeans 17
+    public static final String GRADLE_PROJECT_PROPERTY = "gradle-project"; //NOI18N
 
     private static final String CUSTOM_ACTION = Bundle.TXT_CUSTOM();
     private static final String CARD_NOSELECT = "empty"; //NOI18N
@@ -103,7 +105,7 @@ public class BuildActionsCustomizer extends javax.swing.JPanel {
         tfLabel.getDocument().addDocumentListener(applyListener);
         EditorKit kit = CloneableEditorSupport.getEditorKit("text/x-gradle-cli"); //NOI18N
         taArgs.setEditorKit(kit);
-        taArgs.getDocument().putProperty(Document.StreamDescriptionProperty, project);
+        taArgs.getDocument().putProperty(GRADLE_PROJECT_PROPERTY, project);
         taArgs.getDocument().addDocumentListener(applyListener);
         initDefaultModels();
         comboReady = true;

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleExecutorOptionsPanel.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleExecutorOptionsPanel.java
@@ -20,11 +20,11 @@
 package org.netbeans.modules.gradle.execute;
 
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
-import javax.swing.text.Document;
 import javax.swing.text.EditorKit;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.actions.CustomActionRegistrationSupport;
 import org.netbeans.modules.gradle.api.execute.GradleExecConfiguration;
+import org.netbeans.modules.gradle.customizer.BuildActionsCustomizer;
 import org.openide.text.CloneableEditorSupport;
 
 /**
@@ -50,7 +50,7 @@ public class GradleExecutorOptionsPanel extends javax.swing.JPanel {
         EditorKit kit = CloneableEditorSupport.getEditorKit("text/x-gradle-cli"); //NOI18N
         epCLI.setEditorKit(kit);
         if (project != null) {
-            epCLI.getDocument().putProperty(Document.StreamDescriptionProperty, project);
+            epCLI.getDocument().putProperty(BuildActionsCustomizer.GRADLE_PROJECT_PROPERTY, project);
         } else {
             tfRememberAs.setEnabled(false);
             lbRememberAs.setEnabled(false);


### PR DESCRIPTION
Playing with Ernies composite build in #4865 I've encountered  the following exception

```
java.lang.ClassCastException: class org.netbeans.modules.gradle.NbGradleProjectImpl cannot be cast to class org.openide.loaders.DataObject (org.netbeans.modules.gradle.NbGradleProjectImpl is in unnamed module of loader org.netbeans.StandardModule$OneModuleClassLoader @512bad4a; org.openide.loaders.DataObject is in unnamed module of loader org.netbeans.StandardModule$OneModuleClassLoader @657680c2)
	at org.netbeans.modules.editor.hints.HintsControllerImpl.setErrors(HintsControllerImpl.java:68)
	at org.netbeans.spi.editor.hints.HintsController$1.run(HintsController.java:59)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
```
It seems some other NetBeans parts expecting a `DataObject` in a Document `Document.StreamDescriptionProperty` as Stream descriptor. I used that property ages ago probably seen that on some other editor. This PR just change the property name used for the code completion provider.

It seems if this exception does not happen, then the registration of the JDPA listener would g through, fixing #4865 entirely.