### PR TITLE
Fix completion in Gradle Tasks UI

### DIFF
--- a/extide/gradle.editor/manifest.mf
+++ b/extide/gradle.editor/manifest.mf
@@ -1,5 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: true
 OpenIDE-Module: org.netbeans.modules.gradle.editor
+OpenIDE-Module-Layer: org/netbeans/modules/gradle/editor/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/editor/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.0

--- a/extide/gradle.editor/src/org/netbeans/modules/gradle/editor/layer.xml
+++ b/extide/gradle.editor/src/org/netbeans/modules/gradle/editor/layer.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
+<filesystem>
+  <folder name="Editors">
+    <folder name="text">
+      <folder name="x-gradle-cli">
+        <file name="EditorKit.instance">
+          <attr name="instanceClass" stringvalue="org.netbeans.modules.gradle.editor.cli.GradleCliEditorKit"/>
+          <attr name="instanceOf" stringvalue="javax.swing.text.EditorKit,org.netbeans.modules.gradle.editor.cli.GradleCliEditorKit"/>
+          <attr name="beaninfo" boolvalue="false"/>
+        </file>
+      </folder>
+    </folder>
+  </folder>
+</filesystem>

--- a/extide/gradle/src/org/netbeans/modules/gradle/layer.xml
+++ b/extide/gradle/src/org/netbeans/modules/gradle/layer.xml
@@ -158,13 +158,6 @@
                     </file>
                 </folder>
             </folder>
-            <folder name="x-gradle-cli">
-                <file name="EditorKit.instance">
-                    <attr name="instanceClass" stringvalue="org.netbeans.modules.gradle.execute.GradleCliEditorKit"/>
-                    <attr name="instanceOf" stringvalue="javax.swing.text.EditorKit,org.netbeans.modules.gradle.execute.GradleCliEditorKit"/>
-                    <attr name="beaninfo" boolvalue="false"/>
-                </file>
-            </folder>
         </folder>
     </folder>
 </filesystem>


### PR DESCRIPTION
While testing #4943 I noticed that completion in Gradle Tasks UI no longer works, which is a regression from 15.  @lkishalmi looks like the refactor in #4518 missed actually registering the CLI editor kit?  I wonder if this was what triggered the CCE starting to appear?  Does this look correct?