### PR TITLE
[NETBEANS-6519] Maven dependency produces full tree with duplicates, avoids cycles.

### DIFF
--- a/java/maven/test/unit/data/projects/dependencies/duplicates/micronaut/README.md
+++ b/java/maven/test/unit/data/projects/dependencies/duplicates/micronaut/README.md
@@ -1,0 +1,1 @@
+# Sample of a real-world project

--- a/java/maven/test/unit/data/projects/dependencies/duplicates/micronaut/pom.xml
+++ b/java/maven/test/unit/data/projects/dependencies/duplicates/micronaut/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>demo</artifactId>
+  <version>0.1</version>
+  <packaging>${packaging}</packaging>
+
+  <parent>
+    <groupId>io.micronaut</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>3.7.0</version>
+  </parent>
+
+  <properties>
+    <packaging>jar</packaging>
+    <jdk.version>8</jdk.version>
+    <release.version>8</release.version>
+    <micronaut.version>3.7.0</micronaut.version>
+    <micronaut.runtime>netty</micronaut.runtime>
+    <exec.mainClass>com.example.Application</exec.mainClass>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-inject</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-validation</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.build</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut</groupId>
+              <artifactId>micronaut-http-validation</artifactId>
+              <version>${micronaut.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=com.example</arg>
+            <arg>-Amicronaut.processing.module=demo</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/java/maven/test/unit/data/projects/dependencies/duplicates/micronaut/src/main/java/com/example/Application.java
+++ b/java/maven/test/unit/data/projects/dependencies/duplicates/micronaut/src/main/java/com/example/Application.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+}

--- a/java/maven/test/unit/data/projects/dependencies/duplicates/micronaut/src/test/java/com/example/DemoTest.java
+++ b/java/maven/test/unit/data/projects/dependencies/duplicates/micronaut/src/test/java/com/example/DemoTest.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import jakarta.inject.Inject;
+
+@MicronautTest
+class DemoTest {
+
+    @Inject
+    EmbeddedApplication<?> application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}

--- a/java/maven/test/unit/data/projects/dependencies/golden/testCompileDependencies
+++ b/java/maven/test/unit/data/projects/dependencies/golden/testCompileDependencies
@@ -1,6 +1,6 @@
 [ ] nbtest.grp:test-app:12.6[jar] / compilation
  +-- [ ] nbtest.grp:annotation:12.6[jar] / compilation
  +-- [ ] nbtest.grp:test-lib:13[jar] / compilation
- |    +-- [ ] nbtest.grp:annotation:12.6[jar] / compilation
  |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    +-- [ ] nbtest.grp:annotation:12.6[jar] / compilation
  |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation

--- a/java/maven/test/unit/data/projects/dependencies/golden/testDuplicatedDependencies
+++ b/java/maven/test/unit/data/projects/dependencies/golden/testDuplicatedDependencies
@@ -1,0 +1,1832 @@
+[ ] com.example:demo:0.1[jar] / compilation
+ +-- [ ] ch.qos.logback:logback-classic:1.2.11[jar] / runtime
+ |    +-- [ ] ch.qos.logback:logback-core:1.2.11[jar] / runtime
+ |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / runtime
+ +-- [ ] io.micronaut:micronaut-http-client:3.7.0[jar] / compilation
+ |    +-- [ ] io.micronaut:micronaut-http-client-core:3.7.0[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-runtime:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-jackson-databind:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-jackson-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-json-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    +-- [ ] io.micronaut:micronaut-http-netty:3.7.0[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-buffer-netty:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-websocket:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-http-client-core:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-runtime:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-jackson-databind:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-jackson-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-json-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-codec-http2:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-codec-http:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-handler:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport-native-unix-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-handler:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport-native-unix-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-codec-http:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-handler:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport-native-unix-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-handler:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport-native-unix-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    +-- [ ] io.micronaut:micronaut-runtime:3.7.0[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-jackson-databind:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-jackson-core:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-json-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    +-- [ ] io.micronaut:micronaut-websocket:3.7.0[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-http-client-core:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-runtime:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-jackson-databind:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-jackson-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-json-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    +-- [ ] io.netty:netty-handler-proxy:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-codec-http:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-handler:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport-native-unix-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-codec-socks:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ +-- [ ] io.micronaut:micronaut-http-server-netty:3.7.0[jar] / compilation
+ |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    +-- [ ] io.micronaut:micronaut-http-netty:3.7.0[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-buffer-netty:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-websocket:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-http-client-core:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-runtime:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-jackson-databind:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-jackson-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-json-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-codec-http2:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-codec-http:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-handler:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport-native-unix-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-handler:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport-native-unix-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-codec-http:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-handler:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport-native-unix-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-handler:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport-native-unix-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    +-- [ ] io.micronaut:micronaut-http-server:3.7.0[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-router:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-runtime:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-jackson-databind:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-jackson-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-json-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-websocket:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-http-client-core:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-runtime:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-jackson-databind:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-jackson-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-json-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    +-- [ ] io.netty:netty-codec-http:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-handler:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-codec:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport-native-unix-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    +-- [ ] io.netty:netty-transport:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-buffer:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    |    |    +-- [ ] io.netty:netty-resolver:4.1.82.Final[jar] / compilation
+ |    |    |    |    +-- [ ] io.netty:netty-common:4.1.82.Final[jar] / compilation
+ |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ +-- [ ] io.micronaut:micronaut-jackson-databind:3.7.0[jar] / compilation
+ |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4[jar] / compilation
+ |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    +-- [ ] com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4[jar] / compilation
+ |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    +-- [ ] com.fasterxml.jackson.core:jackson-databind:2.13.4[jar] / compilation
+ |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    +-- [ ] io.micronaut:micronaut-jackson-core:3.7.0[jar] / compilation
+ |    |    +-- [ ] com.fasterxml.jackson.core:jackson-annotations:2.13.4[jar] / compilation
+ |    |    +-- [ ] com.fasterxml.jackson.core:jackson-core:2.13.4[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-json-core:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-context:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-aop:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] io.micronaut:micronaut-http:3.7.0[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    |    |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    |    |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    |    |    |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    |    |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ +-- [ ] io.micronaut:micronaut-validation:3.7.0[jar] / compilation
+ |    +-- [ ] io.micronaut:micronaut-core-reactive:3.7.0[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / compilation
+ |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    +-- [ ] io.micronaut:micronaut-inject:3.7.0[jar] / compilation
+ |    |    +-- [ ] io.micronaut:micronaut-core:3.7.0[jar] / compilation
+ |    |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation
+ |    |    +-- [ ] jakarta.inject:jakarta.inject-api:2.0.1[jar] / compilation
+ |    |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ |    |    +-- [ ] org.yaml:snakeyaml:1.32[jar] / compilation
+ |    +-- [ ] io.projectreactor:reactor-core:3.4.23[jar] / runtime
+ |    |    +-- [ ] org.reactivestreams:reactive-streams:1.0.4[jar] / runtime
+ |    +-- [ ] javax.validation:validation-api:2.0.1.Final[jar] / compilation
+ |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
+ +-- [ ] jakarta.annotation:jakarta.annotation-api:2.1.1[jar] / compilation

--- a/java/maven/test/unit/data/projects/dependencies/golden/testRuntimeDependencies
+++ b/java/maven/test/unit/data/projects/dependencies/golden/testRuntimeDependencies
@@ -1,9 +1,9 @@
 [ ] nbtest.grp:test-app:12.6[jar] / compilation
  +-- [ ] nbtest.grp:annotation:12.6[jar] / compilation
- +-- [ ] nbtest.grp:test-lib:13[jar] / compilation
- |    +-- [ ] nbtest.grp:annotation:12.6[jar] / compilation
- |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
- |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
  +-- [ ] nbtest.grp:test-lib4:12.6[jar] / runtime
+ +-- [ ] nbtest.grp:test-lib:13[jar] / compilation
+ |    +-- [ ] javax.annotation:javax.annotation-api:1.3.2[jar] / compilation
+ |    +-- [ ] nbtest.grp:annotation:12.6[jar] / compilation
+ |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / compilation
  +-- [ ] org.slf4j:slf4j-jdk14:1.7.36[jar] / runtime
  |    +-- [ ] org.slf4j:slf4j-api:1.7.36[jar] / runtime

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenDependenciesImplementationTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenDependenciesImplementationTest.java
@@ -75,6 +75,9 @@ public class MavenDependenciesImplementationTest extends NbTestCase {
         return new File(destDir);
     }
     protected @Override void setUp() throws Exception {
+        // this property could be eventually initialized by NB module system, as MavenCacheDisabler i @OnStart, but that's unreliable.
+        System.setProperty("maven.defaultProjectBuilder.disableGlobalModelCache", "true");
+        
         clearWorkDir();
         
         // This is needed, otherwose the core window's startup code will redirect
@@ -128,7 +131,7 @@ public class MavenDependenciesImplementationTest extends NbTestCase {
             }
         };
         ap.invokeAction(ActionProvider.COMMAND_PRIME, Lookups.fixed(prg));
-        primeLatch.await(20, TimeUnit.SECONDS);
+        primeLatch.await(300, TimeUnit.SECONDS);
     }
     
     public void testCompileDependencies() throws Exception {

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenDependenciesImplementationTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenDependenciesImplementationTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -248,12 +249,42 @@ public class MavenDependenciesImplementationTest extends NbTestCase {
         assertTrue(text.contains("<artifactId>test-lib</artifactId>"));
     }
     
+    /**
+     * Checks that a complete dependency graph of a real-world project is printed out. Note that
+     * the dependency graph is enormous as it contains lots of duplicated shared libraries.
+     * 
+     * @throws Exception 
+     */
+    public void testDuplicatedDependencies() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+
+        FileObject testApp = dataFO.getFileObject("projects/dependencies/duplicates/micronaut");
+        FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "micronaut");
+        
+        Project p = ProjectManager.getDefault().findProject(prjCopy);
+        assertNotNull(p);
+
+        primeProject(p);
+        DependencyResult dr = ProjectDependencies.findDependencies(p, ProjectDependencies.newQuery(Scopes.RUNTIME));
+        
+        assertContents(printDependencyTree(dr.getRoot()), getName());
+    }
+    
     void assertContents(String contents, String golden) throws IOException {
         File f = new File(getDataDir(), "projects/dependencies/golden/" + golden);
         Path res = Files.write(getWorkDir().toPath().resolve(getName() + ".output"), 
                 Arrays.asList(contents.split("\n")),
                 StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-        assertFile(res.toFile(), f, new File(getWorkDir(), getName() + ".diff"));
+        File diff = new File(getWorkDir(), getName() + ".diff");
+        try {
+            assertFile(res.toFile(), f, diff);
+        } catch (AssertionError err) {
+            System.err.println("Differences: ");
+            System.err.println(String.join("\n", Files.readAllLines(diff.toPath())));
+            System.err.println("Actual contents:");
+            System.err.println(contents);
+            throw err;
+        }
     }
     
     static String printDependencyTree(Dependency root) {
@@ -280,7 +311,11 @@ public class MavenDependenciesImplementationTest extends NbTestCase {
         }
         sb.append("\n");
         int index = 0;
-        for (Dependency c : (List<Dependency>)from.getChildren()) {
+        List<Dependency> sorted = new ArrayList<>(from.getChildren());
+        Collections.sort(sorted, (d1, d2) -> {
+            return d1.getArtifact().toString().compareToIgnoreCase(d2.getArtifact().toString());
+        });
+        for (Dependency c : sorted) {
             printDependencyTree(c, levels + 1, sb);
             index++;
         }


### PR DESCRIPTION
See also [NETBEANS-6519](https://issues.apache.org/jira/browse/NETBEANS-6519)

The main issue with the implementation was that the 1st encountered Dependency from Maven might be truncated / stripped of its children - and marked as a duplicate. However in the dependency API all dependencies are "equal", we cannot assume that a client does depth-first or breadth-first traversal.
With the fix, the dependency tree will be enormous, as each common library dependency will introduce a full subtree at the library's place in the dependency tree.

I plan to add an additional API to mark duplicates (= subtrees with the same contents) and possibly resolution conflicts (an artifact dependency has been resolved by a different artifact, e.g. a different version of a library). But this fix is simple and allows clients to enumerate all dependencies. Clients can now filter the duplicates themselves, according to their needs.