### PR TITLE
bump large file warning from 1 to 5MB.

### DIFF
--- a/ide/csl.api/src/org/netbeans/modules/csl/spi/GsfUtilities.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/spi/GsfUtilities.java
@@ -252,6 +252,11 @@ public final class GsfUtilities {
     }
 
     /**
+     * see org.openide.text.DataEditorSupport#BIG_FILE_THRESHOLD_MB
+     */
+    private static final long BIG_FILE_THRESHOLD_MB = Integer.getInteger("org.openide.text.big.file.size", 5) * 1024 * 1024;
+
+    /**
      * Load the document for the given fileObject.
      * @param fileObject the file whose document we want to obtain
      * @param openIfNecessary If true, block if necessary to open the document. If false, will only return the
@@ -275,7 +280,7 @@ public final class GsfUtilities {
             // (see issue http://www.netbeans.org/issues/show_bug.cgi?id=148702 )
             // but for many cases, the user probably doesn't want really large files as indicated
             // by the skipLarge parameter).
-            if (fileObject.getSize () > 1024 * 1024) {
+            if (fileObject.getSize () > BIG_FILE_THRESHOLD_MB) {
                 return null;
             }
         }

--- a/platform/openide.loaders/src/org/openide/text/DataEditorSupport.java
+++ b/platform/openide.loaders/src/org/openide/text/DataEditorSupport.java
@@ -837,9 +837,9 @@ public class DataEditorSupport extends CloneableEditorSupport {
         }
         
         /**
-         * default threshold for big file to warn user (default is 1MB)
+         * default threshold for big file to warn user (default is 5MB)
          */
-        private final transient long BIG_FILE_THRESHOLD_MB = Integer.getInteger("org.openide.text.big.file.size", 1) * 1024 * 1024;
+        private final transient long BIG_FILE_THRESHOLD_MB = Integer.getInteger("org.openide.text.big.file.size", 5) * 1024 * 1024;
         
         /** Obtains the input stream.
         * @exception IOException if an I/O error occurs

--- a/platform/openide.loaders/test/unit/src/org/openide/text/FileSizeThreshholdExceptionTest.java
+++ b/platform/openide.loaders/test/unit/src/org/openide/text/FileSizeThreshholdExceptionTest.java
@@ -126,7 +126,7 @@ public class FileSizeThreshholdExceptionTest extends NbTestCase {
     
     public void testThreshholdDefaultValue() throws Exception {
         System.getProperties().remove(BIG_FILE_PROP);
-        doTestThreshholdValue(1);
+        doTestThreshholdValue(5);
     }
     
     public void testThreshholdNotDefaultValue() throws Exception {


### PR DESCRIPTION
as discussed on the [dev list](https://lists.apache.org/thread/g9w0038rdsksony6xyl4q42vnj4jrjk4), this proposes to bump the large-file warning trigger a little bit.

customizable via the `org.openide.text.big.file.size` property.

System memory and there also heap sizes grew over time, fixed perm gen became dynamic meta space. This should allow to dare a bit more in that area without showing warnings.

old limit (new is 5MB):
![filesize-warning](https://user-images.githubusercontent.com/114367/200869518-e2768829-0ae1-4cd6-8a25-bcf3deffaf8e.png)


going to run this with all tests enabled since this could have side effects in tests, given that I found that CSL module hardcoded that value even though it is configurable via a property.