### PR TITLE
tweaks some versioning history settings.

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/ui/history/SearchExecutor.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/history/SearchExecutor.java
@@ -55,7 +55,7 @@ class SearchExecutor extends GitProgressSupport {
     private final String toRevision;
     private final Date from;
     private final Date to;
-    static final int DEFAULT_LIMIT = 10;
+    static final int DEFAULT_LIMIT = 50;
     static final int UNLIMITTED = -1;
     private final SearchCriteria sc;
     private final Mode mode;

--- a/ide/git/src/org/netbeans/modules/git/ui/history/SearchHistoryPanel.form
+++ b/ide/git/src/org/netbeans/modules/git/ui/history/SearchHistoryPanel.form
@@ -92,7 +92,6 @@
     </Container>
     <Container class="javax.swing.JToolBar" name="jToolBar1">
       <Properties>
-        <Property name="floatable" type="boolean" value="false"/>
         <Property name="rollover" type="boolean" value="true"/>
       </Properties>
       <AuxValues>
@@ -192,7 +191,6 @@
               <ResourceString bundle="org/netbeans/modules/git/ui/history/Bundle.properties" key="LBL_TT_SearchHistoryPanel_AllInfo" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
             </Property>
             <Property name="horizontalTextPosition" type="int" value="4"/>
-            <Property name="opaque" type="boolean" value="false"/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="fileInfoCheckBoxActionPerformed"/>

--- a/ide/git/src/org/netbeans/modules/git/ui/history/SearchHistoryPanel.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/history/SearchHistoryPanel.java
@@ -327,6 +327,7 @@ class SearchHistoryPanel extends javax.swing.JPanel implements ExplorerManager.P
         fileInfoCheckBox.setEnabled(tbSummary.isSelected());
 
         searchCriteriaPanel.setVisible(criteriaVisible);
+        bSearch.setVisible(criteriaVisible);
         expandCriteriaButton.setIcon(criteriaVisible ? ICON_EXPANDED : ICON_COLLAPSED);
         if (criteria.getLimit() <= 0) {
             criteria.setLimit(SearchExecutor.UNLIMITTED);
@@ -600,9 +601,10 @@ private void fileInfoCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//
 }//GEN-LAST:event_fileInfoCheckBoxActionPerformed
 
     private void expandCriteriaButtonActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_expandCriteriaButtonActionPerformed
-        searchCriteriaPanel.setVisible(!searchCriteriaPanel.isVisible());
-        expandCriteriaButton.setIcon(searchCriteriaPanel.isVisible() ? ICON_EXPANDED : ICON_COLLAPSED);
-        criteriaVisible = searchCriteriaPanel.isVisible();
+        criteriaVisible = !searchCriteriaPanel.isVisible();
+        searchCriteriaPanel.setVisible(criteriaVisible);
+        bSearch.setVisible(criteriaVisible);
+        expandCriteriaButton.setIcon(criteriaVisible ? ICON_EXPANDED : ICON_COLLAPSED);
     }//GEN-LAST:event_expandCriteriaButtonActionPerformed
 
     private void cmbFilterKindActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cmbFilterKindActionPerformed

--- a/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistorySettings.java
+++ b/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistorySettings.java
@@ -94,7 +94,7 @@ public class HistorySettings {
     }
     
     public boolean getLoadAll() {
-        return getPreferences().getBoolean(PROP_LOAD_ALL, false);
+        return getPreferences().getBoolean(PROP_LOAD_ALL, true);
 }
 
     public void setLoadAll(boolean loadAll) {


### PR DESCRIPTION
as discussed on the [dev list](https://lists.apache.org/thread/g9w0038rdsksony6xyl4q42vnj4jrjk4), this proposes some tweaks to the versioning UI

 - `git -> show history` will start with 50 entries loaded by default
 - file history will show the full history by default
 - search button will only show up if the advanced options are expanded since:
   - everything else searches at realtime
   - results will be shown on first open without the extra click since #3294
   - which means the button is only useful when the advanced options are expanded



