### PR TITLE
hide maven transfer progress via flag instead of regexp filter.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/options/Bundle.properties
+++ b/java/maven/src/org/netbeans/modules/maven/options/Bundle.properties
@@ -56,6 +56,7 @@ FORCE_UPTODATE_CHECK=Force upToDate check for any relevant registered plugins.\n
 SUPPRESS_UPTODATE_CHECK=Suppress upToDate check for any relevant registered plugins.\n\nExclusive with --check-plugin-updates.
 FORCES_A_CHECK=Forces a check for updated releases and snapshots on remote repositories.
 DON'T_USE_PLUGIN-REGISTRY=Don't use ~/.m2/plugin-registry.xml for plugin versions
+NO_TRANSFER_PROGRESS=Don't print the download progress.
 TIT_Add_Globals=Add Global Option(s)
 SettingsPanel.jLabel1.text=Dependency Download Strategy :
 TIT_NEVER=Never

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
@@ -159,7 +159,7 @@ public final class MavenSettings  {
         //import from older versions
         String defOpts = getPreferences().get(PROP_DEFAULT_OPTIONS, null);
         if (defOpts == null) {
-            defOpts = "";
+            defOpts = getDefaultOptions();
             //only when not already set by user or by previous import
             String debug = getPreferences().get(PROP_DEBUG, null);
             if (debug != null) {
@@ -223,7 +223,7 @@ public final class MavenSettings  {
     }
 
     public String getDefaultOptions() {
-        return getPreferences().get(PROP_DEFAULT_OPTIONS, ""); //NOI18N
+        return getPreferences().get(PROP_DEFAULT_OPTIONS, "--no-transfer-progress"); //NOI18N
     }
 
     public void setDefaultOptions(String options) {

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
@@ -245,7 +245,8 @@ public class SettingsPanel extends javax.swing.JPanel {
             "--check-plugin-updates", //NOI18N
             "--no-plugin-updates", //NOI18N
             "--update-snapshots", //NOI18N
-            "--no-plugin-registry" //NOI18N
+            "--no-plugin-registry", //NOI18N
+            "--no-transfer-progress" //NOI18N
         };
 
 
@@ -263,7 +264,8 @@ public class SettingsPanel extends javax.swing.JPanel {
             org.openide.util.NbBundle.getMessage(SettingsPanel.class, "FORCE_UPTODATE_CHECK"),
             org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SUPPRESS_UPTODATE_CHECK"),
             org.openide.util.NbBundle.getMessage(SettingsPanel.class, "FORCES_A_CHECK"),
-            org.openide.util.NbBundle.getMessage(SettingsPanel.class, "DON'T_USE_PLUGIN-REGISTRY")
+            org.openide.util.NbBundle.getMessage(SettingsPanel.class, "DON'T_USE_PLUGIN-REGISTRY"),
+            org.openide.util.NbBundle.getMessage(SettingsPanel.class, "NO_TRANSFER_PROGRESS")
         };
     }
 

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/execute/CommandLineOutputHandlerTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/execute/CommandLineOutputHandlerTest.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.maven.execute;
 
 import java.util.regex.Matcher;
-import static junit.framework.TestCase.fail;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -41,23 +40,6 @@ public class CommandLineOutputHandlerTest {
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-    }
-
-    @Test
-    public void testDownloadPattern() {
-        String[] lines = {
-            "51521/?", "11/12K", "11/12M", "51521/120000b",
-            "51521/? 12/25K", "34/263M 464/500b",
-            "51521/? 13/25K 4034/4640M",
-            // #189465: M3 ConsoleMavenTransferListener.doProgress
-            "59/101 KB    ", "1/3 B  ", "55 KB", "300 B  ",
-            "10/101 KB   48/309 KB   ", // sometimes seems to jam
-        };
-        for (String line : lines) {
-            if (!CommandLineOutputHandler.DOWNLOAD.matcher(line).matches()) {
-                fail("Line " + line + " not skipped");
-            }
-        }
     }
     
     @Test


### PR DESCRIPTION
 - sets `--no-transfer-progress` as default global maven option
 - removes console regexp filter which fixes #4017
 - regexp filter didn't work with current maven anyway
