### PR TITLE
Avoid an `AssertionError` with Maven folds

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
@@ -107,6 +107,7 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
     private boolean inStackTrace = false;
     private boolean addMojoFold = false;
     private boolean addProjectFold = false;
+    private boolean foldsBroken;
     private URL[] mavencoreurls;
 
     public CommandLineOutputHandler(InputOutput io, Project proj, ProgressHandle hand, RunConfig config, boolean createVisitorContext) {
@@ -350,11 +351,11 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
                     //however there's no other way to have the proper line marked as beginning of a section (as the event comes first)
                     //without this, the last line of previous output would be marked as beginning of the fold.
                     if (addMojoFold && line.startsWith("[INFO] ---")) {     //NOI18N
-                        currentTreeNode.startFold(inputOutput);
+                        foldsBroken |= currentTreeNode.startFold(inputOutput);
                         addMojoFold = false;
                     }
                     if (addProjectFold && line.startsWith("[INFO] Building")) {
-                        currentTreeNode.startFold(inputOutput);
+                        foldsBroken |= currentTreeNode.startFold(inputOutput);
                         addProjectFold = false;
                     }
                     line = nextLine != null ? nextLine : readLine();
@@ -545,6 +546,9 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
     }
 
     private void trimTree(ExecutionEventObject obj) {
+        if (foldsBroken) {
+            return;
+        }
         ExecutionEventObject start = currentTreeNode.getStartEvent();
         while (!matchingEvents(obj.type, start.type)) { //#229877
             ExecutionEventObject innerEnd = createEndForStart(start);


### PR DESCRIPTION
Fixes #3675 by just disabling output window folds when they would otherwise lead to errors and loss of output. Observed when using `mvnd` with forked executions in a multimodule build. (The same project gets folds when building one module at a time, or using `mvn`, and probably also when skipping the mojo causing a forked execution though I did not manage to test that.)
