### PR TITLE
use grep -E instead of egrep

### DIFF
--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyKiller.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyKiller.java
@@ -72,14 +72,14 @@ public class WildflyKiller {
 
     private boolean killLinux(Runtime rt) {
         try {
-            String getPidCommand = getJps() + " | egrep -i \"jboss-modules\" | awk '{ print $1; }'";
+            String getPidCommand = getJps() + " | grep -i \"jboss-modules\" | awk '{ print $1; }'";
             //get a jstack of all the processes
             Process process = rt.exec(new String[]{"/bin/sh", "-c", getPidCommand});
             InputStream in = process.getInputStream();
             String processTable = readString(in);
             readString(process.getErrorStream());
             if (!processTable.isEmpty()) {
-                readString(rt.exec(new String[]{"/bin/sh", "-c", getJps() + " | egrep -i \"jboss-modules\" | awk '{ print $1; }' | xargs --no-run-if-empty kill -9"}).getInputStream());
+                readString(rt.exec(new String[]{"/bin/sh", "-c", getJps() + " | grep -i \"jboss-modules\" | awk '{ print $1; }' | xargs --no-run-if-empty kill -9"}).getInputStream());
                 errorProcessTable = processTable;
             }
             long end = System.currentTimeMillis() + 5000;

--- a/platform/o.n.bootstrap/launcher/unix/nbexec
+++ b/platform/o.n.bootstrap/launcher/unix/nbexec
@@ -216,7 +216,7 @@ append_jars_to_cp() {
         if [ "`echo "${dir}"/*.$ex`" != "${dir}/*.$ex" ] ; then
             for x in "${dir}"/*.$ex ; do
                 subx=`basename "$x"`
-                if [ -z "`echo "$paths" | egrep "$subpath$subx"`" ] ; then
+                if [ -z "`echo "$paths" | grep -E "$subpath$subx"`" ] ; then
                     if [ ! -z "$cp" ] ; then cp="$cp:" ; fi
                     cp="$cp$x"
                     if [ ! -z "$paths" ] ; then paths="$paths:" ; fi


### PR DESCRIPTION
gets rid of this warning:
`egrep: warning: egrep is obsolescent; using grep -E`

when using NetBeans from CLI eg.
`./netbeans --help`