### PR TITLE
use maven central search service for class name search.

### DIFF
--- a/java/maven.indexer/external/binaries-list
+++ b/java/maven.indexer/external/binaries-list
@@ -20,3 +20,6 @@
 5A44DF2CB26FA1E0E64BE53FE474C7F1D5A3E634 org.apache.lucene:lucene-queryparser:8.11.1
 E50AF506F271A3F7246DA054A2569B42FF73ABB2 org.apache.lucene:lucene-analyzers-common:8.11.1
 479C1E06DB31C432330183F5CAE684163F186146 javax.annotation:javax.annotation-api:1.2
+858C6CC78E1F08A885B1613E1D817C829DF70A6E com.fasterxml.jackson.core:jackson-annotations:2.13.4
+0CF934C681294B97EF6D80082FAEEFBE1EDADF56 com.fasterxml.jackson.core:jackson-core:2.13.4
+325C06BDFEB628CFB80EBAAF1A26CC1EB558A585 com.fasterxml.jackson.core:jackson-databind:2.13.4.2

--- a/java/maven.indexer/manifest.mf
+++ b/java/maven.indexer/manifest.mf
@@ -3,4 +3,4 @@ OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/indexer/Bundle.prop
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module-Specification-Version: 2.60
 OpenIDE-Module: org.netbeans.modules.maven.indexer/2
-
+OpenIDE-Module-Java-Dependencies: Java > 11

--- a/java/maven.indexer/nbproject/project.properties
+++ b/java/maven.indexer/nbproject/project.properties
@@ -17,7 +17,8 @@
 
 test.config.stableBTD.includes=**/*Test.class
 is.autoload=true
-javac.source=1.8
+javac.source=11
+javac.target=11
 javac.compilerargs=-Xlint -Xlint:-serial
 release.external/indexer-core-6.2.2.jar=modules/ext/maven/indexer-core-6.2.2.jar
 release.external/lucene-core-8.11.1.jar=modules/ext/maven/lucene-core-8.11.1.jar
@@ -25,6 +26,9 @@ release.external/lucene-highlighter-8.11.1.jar=modules/ext/maven/lucene-highligh
 release.external/lucene-queryparser-8.11.1.jar=modules/ext/maven/lucene-queryparser-8.11.1.jar
 release.external/lucene-analyzers-common-8.11.1.jar=modules/ext/maven/lucene-analyzers-common-8.11.1.jar
 release.external/javax.annotation-api-1.2.jar=modules/ext/maven/javax.annotation-api-1.2.jar
+release.external/jackson-annotations-2.13.4.jar=modules/ext/maven/jackson-annotations-2.13.4.jar
+release.external/jackson-core-2.13.4.jar=modules/ext/maven/jackson-core-2.13.4.jar
+release.external/jackson-databind-2.13.4.2.jar=modules/ext/maven/jackson-databind-2.13.4.2.jar
 # XXX so long as Lucene is bundled here:
 sigtest.gen.fail.on.error=false
 

--- a/java/maven.indexer/nbproject/project.xml
+++ b/java/maven.indexer/nbproject/project.xml
@@ -198,6 +198,18 @@
                 <runtime-relative-path>ext/maven/javax.annotation-api-1.2.jar</runtime-relative-path>
                 <binary-origin>external/javax.annotation-api-1.2.jar</binary-origin>
             </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/maven/jackson-annotations-2.13.4.jar</runtime-relative-path>
+                <binary-origin>external/jackson-annotations-2.13.4.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/maven/jackson-core-2.13.4.jar</runtime-relative-path>
+                <binary-origin>external/jackson-core-2.13.4.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/maven/jackson-databind-2.13.4.2.jar</runtime-relative-path>
+                <binary-origin>external/jackson-databind-2.13.4.2.jar</binary-origin>
+            </class-path-extension>
         </data>
     </configuration>
 </project>

--- a/java/maven.indexer/src/org/netbeans/modules/maven/centralsearch/JSONArtifactDoc.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/centralsearch/JSONArtifactDoc.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.maven.centralsearch;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/*
+ * Note: dependent on the search query, different fields will be set.
+ * https://search.maven.org/solrsearch/select?q=a:jetty-http will have latestVersion set
+ * https://search.maven.org/solrsearch/select?q=a:jetty-http&core=gav will have version set
+ * the getter returns whatever isn't null.
+ *
+ * see https://github.com/sonatype-nexus-community/search-maven-org/blob/master/src/app/search/api/doc.ts
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({
+    "id",
+    "g",
+    "a",
+    "latestVersion",
+    "v",
+    "p",
+    "timestamp",
+    "versionCount",
+//    "ec",
+//    "tags"
+})
+public class JSONArtifactDoc {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("g")
+    private String group;
+
+    @JsonProperty("a")
+    private String artifact;
+
+    @JsonProperty("v")
+    private String version;
+
+    @JsonProperty("latestVersion")
+    private String latestVersion;
+
+    @JsonProperty("p")
+    private String pgk;
+
+    @JsonProperty("timestamp")
+    private Long timestamp;
+
+    @JsonProperty("versionCount")
+    private Long versionCount;
+
+//    @JsonProperty("text")
+//    private List<String> text = Collections.emptyList();
+
+//    @JsonProperty("ec")
+//    private List<String> ec = Collections.emptyList();
+
+//    @JsonProperty("tags")
+//    private List<String> tags = Collections.emptyList();
+
+    public String getId() {
+        return id;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public String getArtifact() {
+        return artifact;
+    }
+
+    public String getVersion() {
+        return version != null ? version : latestVersion;
+    }
+
+    public String getPackage() {
+        return pgk;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public Long getVersionCount() {
+        return versionCount;
+    }
+
+//    public List<String> getEc() {
+//        return ec;
+//    }
+//
+//    public List<String> getTags() {
+//        return tags;
+//    }
+
+    @Override
+    public String toString() {
+        return JSONArtifactDoc.class.getName()+"{" + "id=" + id + ", group=" + group + ", artifact=" + artifact + ", version=" + getVersion() + ", pgk=" + pgk + ", timestamp=" + timestamp + '}';
+    }
+
+
+}

--- a/java/maven.indexer/src/org/netbeans/modules/maven/centralsearch/JSONSearchResponse.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/centralsearch/JSONSearchResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.maven.centralsearch;
+
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Collections;
+
+// see https://github.com/sonatype-nexus-community/search-maven-org/blob/master/src/app/artifact/api/artifact-search-response.ts
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "numFound",
+    "start",
+    "docs"
+})
+public class JSONSearchResponse {
+
+    @JsonProperty("numFound")
+    private Integer numFound;
+
+    @JsonProperty("start")
+    private Integer start;
+
+    @JsonProperty("docs")
+    private List<JSONArtifactDoc> docs = Collections.emptyList();
+
+    public Integer getNumFound() {
+        return numFound;
+    }
+
+    public Integer getStart() {
+        return start;
+    }
+
+    public List<JSONArtifactDoc> getDocs() {
+        return docs;
+    }
+
+    @Override
+    public String toString() {
+        return "Response{" + "numFound=" + numFound + ", numDocs=" + docs.size() + ", start=" + start + '}';
+    }
+
+}

--- a/java/maven.indexer/src/org/netbeans/modules/maven/centralsearch/MavenCentralClassesQuery.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/centralsearch/MavenCentralClassesQuery.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.maven.centralsearch;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.netbeans.modules.maven.indexer.api.NBVersionInfo;
+import org.netbeans.modules.maven.indexer.api.RepositoryInfo;
+import org.netbeans.modules.maven.indexer.spi.ClassesQuery;
+import org.netbeans.modules.maven.indexer.spi.ResultImplementation;
+import org.openide.util.Exceptions;
+import org.openide.util.RequestProcessor;
+
+/**
+ *
+ * @author mbien
+ */
+public class MavenCentralClassesQuery implements ClassesQuery {
+
+    private static final Logger LOG = Logger.getLogger(MavenCentralClassesQuery.class.getName());
+
+    private static final String REPO_NAME = "central";
+    private static final MavenCentralSearch search = new MavenCentralSearch();
+
+
+    public boolean handlesRepository(RepositoryInfo repo) {
+        return repo.isLocal() == false && REPO_NAME.equals(repo.getName());
+    }
+
+    private boolean checkIfCentralRepo(List<RepositoryInfo> repos) {
+        return repos.size() == 1 && handlesRepository(repos.get(0));
+    }
+
+    @Override
+    public ResultImplementation<NBVersionInfo> findVersionsByClass(String className, List<RepositoryInfo> repos) {
+        if (!checkIfCentralRepo(repos)) {
+            throw new IllegalArgumentException("single, 'central' repository expected, but got: "+repos);
+        }
+        return new SearchResultImpl(() -> search.findArtifactsByClass(className));
+    }
+
+    @FunctionalInterface
+    private interface IOSupplier<T> {
+        T get() throws IOException;
+    }
+
+    private static final class SearchResultImpl implements ResultImplementation<NBVersionInfo> {
+
+        private static final RequestProcessor RP = new RequestProcessor("maven-central-search", 5);
+
+        private JSONSearchResponse response;
+        private List<NBVersionInfo> list = Collections.emptyList();
+
+        private final Future<JSONSearchResponse> request;
+
+        public SearchResultImpl(IOSupplier<JSONSearchResponse> finder) {
+            request = RP.submit(() -> {
+                try {
+                    return finder.get();
+                } catch (IOException ex) {
+                    throw new ExecutionException(ex);
+                }
+            });
+        }
+
+        @Override
+        public List<NBVersionInfo> getResults() {
+            if (response == null) {
+                try {
+                    response = request.get(10, TimeUnit.SECONDS);
+                    list = response.getDocs().stream()
+                            .map((d) -> new NBVersionInfo(REPO_NAME, d.getGroup(), d.getArtifact(), d.getVersion(), d.getPackage(), null, null, null, null))
+                            .collect(Collectors.toList());
+                    LOG.log(Level.INFO, "{0}", response);
+                } catch (TimeoutException ex) {
+                    LOG.log(Level.WARNING, "search request timed out", ex);
+                } catch (ExecutionException ex) {
+                    LOG.log(Level.WARNING, "search request failed", ex);
+                } catch (InterruptedException ex) {
+                    Thread.interrupted();
+                    Exceptions.printStackTrace(ex);
+                }
+            }
+            return list;
+        }
+
+        @Override
+        public boolean isPartial() {
+            return false;
+        }
+
+        @Override
+        public void waitForSkipped() {
+
+        }
+
+        @Override
+        public int getTotalResultCount() {
+            return response.getNumFound();
+        }
+
+        @Override
+        public int getReturnedResultCount() {
+            return list.size();
+        }
+    }
+
+}

--- a/java/maven.indexer/src/org/netbeans/modules/maven/centralsearch/MavenCentralSearch.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/centralsearch/MavenCentralSearch.java
@@ -1,0 +1,62 @@
+
+package org.netbeans.modules.maven.centralsearch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ *
+ * @author mbien
+ */
+class MavenCentralSearch {
+
+    private static final HttpClient client = HttpClient.newHttpClient();
+
+    private static final int MAX_ROWS = 200; // seems to be the current limit, larger values fall back to 20
+
+    private static final String SERVICE = "https://search.maven.org/solrsearch/select";
+    private static final String OPTS = "&rows="+MAX_ROWS+"&wt=json";
+
+    public MavenCentralSearch() {}
+
+    public JSONSearchResponse findArtifactsByClass(String clazz) throws IOException {
+        return find(URI.create(SERVICE + "?q=c:"+clazz+OPTS));
+    }
+
+    public JSONSearchResponse findArtifactsByFQClass(String fqClazz) throws IOException {
+        return find(URI.create(SERVICE + "?q=fc:"+fqClazz+OPTS));
+    }
+
+    public JSONSearchResponse findArtifactVersions(String group, String artifact) throws IOException {
+        return find(URI.create(SERVICE + "?q=g:"+group+"+AND+a:"+artifact+OPTS+"&core=gav"));
+    }
+
+    public JSONSearchResponse findArtifact(String group, String artifact) throws IOException {
+        return find(URI.create(SERVICE + "?q=g:"+group+"+AND+a:"+artifact+OPTS));
+    }
+
+    public JSONSearchResponse findArtifactsByName(String artifact) throws IOException {
+        return find(URI.create(SERVICE + "?q=a:"+artifact+OPTS));
+    }
+
+    public JSONSearchResponse findArtifactsByGroup(String group) throws IOException {
+        return find(URI.create(SERVICE + "?q=g:"+group+OPTS));
+    }
+
+    private JSONSearchResponse find(URI request) throws IOException {
+        try {
+            HttpResponse<InputStream> response = client.send(HttpRequest.newBuilder(request).build(), HttpResponse.BodyHandlers.ofInputStream());
+            try (InputStream body = response.body()) {
+                ObjectMapper mapper = new ObjectMapper();
+                return mapper.treeToValue(mapper.readTree(body).at("/response"), JSONSearchResponse.class);
+            }
+        } catch (InterruptedException ex) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
wip prototype to play around with.

how to test:
open/create maven project, type some class name, use the hint to do a maven search. Results should contain both central and local entries.

The maven central index does not contain class information anymore. As workaround we make a http request and merge the results with the local index.

![augmented-central-search](https://user-images.githubusercontent.com/114367/224249861-56596407-62d6-497f-90ea-52b5206b0355.png)

performance is pretty bad compared to the local index, but this is to be expected from a web service which wasn't really made for this purpose:
```
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: passed on 1,024 clauses processing classnames:logger with 234 hits
INFO [org.netbeans.modules.maven.centralsearch.MavenCentralClassesQuery]: Response{numFound=223981, numDocs=200, start=0}
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: findVersionsByClass time = 4101
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: passed on 1,024 clauses processing classnames:jfr with 50 hits
INFO [org.netbeans.modules.maven.centralsearch.MavenCentralClassesQuery]: Response{numFound=47, numDocs=47, start=0}
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: findVersionsByClass time = 339
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: passed on 1,024 clauses processing classnames:jfrlogger with 2 hits
INFO [org.netbeans.modules.maven.centralsearch.MavenCentralClassesQuery]: Response{numFound=6, numDocs=6, start=0}
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: findVersionsByClass time = 1247
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: passed on 1,024 clauses processing classnames:jfr with 50 hits
INFO [org.netbeans.modules.maven.centralsearch.MavenCentralClassesQuery]: Response{numFound=47, numDocs=47, start=0}
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: findVersionsByClass time = 217
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: passed on 1,024 clauses processing classnames:jfrlogger with 2 hits
INFO [org.netbeans.modules.maven.centralsearch.MavenCentralClassesQuery]: Response{numFound=6, numDocs=6, start=0}
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: findVersionsByClass time = 463
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: passed on 1,024 clauses processing classnames:util with 1,203 hits
INFO [org.netbeans.modules.maven.centralsearch.MavenCentralClassesQuery]: Response{numFound=329503, numDocs=200, start=0}
INFO [org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl]: findVersionsByClass time = 2320
```
It does some caching though, so repeated requests are quite fast.