### PR TITLE
Test bugfixes: preparation for GH action migration

### DIFF
--- a/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesProvider.java
+++ b/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesProvider.java
@@ -155,7 +155,10 @@ public final class ProjectTemplateAttributesProvider implements CreateFromTempla
             // in order to get through the freemarker, the path needs to "absolute" in freemarker terms - http://freemarker.sourceforge.net/docs/ref_directive_include.html
             // relative would mean relative to the template and we cannot be sure what the path from template to license template is..
             // it used to be, ../Licenses/ or ../../Licenses but can be anything similar, just based on where the template resides.
-            map.put(ATTR_LICENSE_PATH, "/" + url);
+            // Note: ensure reentrancy, so if 'url' starts with slash, do not prepend
+            if (!url.startsWith("/")) { // NOI18N
+                map.put(ATTR_LICENSE_PATH, "/" + url); // NOI18N
+            }
             //appears to cover both the new and old default value of the include path
         }  
         if (map.get(ATTR_ENCODING) == null) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -1088,10 +1088,17 @@ public final class Server {
     private static void hackConfigureGroovySupport(NbCodeClientCapabilities caps) {
         boolean b = caps != null && caps.wantsGroovySupport();
         try {
-            Class clazz = Lookup.getDefault().lookup(ClassLoader.class).loadClass("org.netbeans.modules.groovy.editor.api.GroovyIndexer");
+            Class<?> clazz = Lookup.getDefault().lookup(ClassLoader.class).loadClass("org.netbeans.modules.groovy.editor.api.GroovyIndexer");
             Method m = clazz.getDeclaredMethod("setIndexingEnabled", Boolean.TYPE);
             m.setAccessible(true);
             m.invoke(null, b);
+        } catch (ClassNotFoundException ex) {
+            // java.lang.ClassNotFoundException is expected when Groovy support is not activated / enabled. Do not log, if the
+            // client wants groovy disabled, which is obviuously true in this case :)
+            if (b && !groovyClassWarningLogged) {
+                groovyClassWarningLogged = true;
+                LOG.log(Level.WARNING, "Unable to configure Groovy indexing: Groovy support is not enabled");
+            }
         } catch (ReflectiveOperationException ex) {
             if (!groovyClassWarningLogged) {
                 groovyClassWarningLogged = true;

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -143,14 +143,9 @@ import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolLocation;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
-import org.eclipse.lsp4j.jsonrpc.Endpoint;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
-import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.jsonrpc.RemoteEndpoint;
-import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
-import org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
 import org.eclipse.lsp4j.launch.LSPLauncher;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
@@ -213,7 +208,8 @@ import org.openide.windows.IOProvider;
  */
 @SuppressWarnings({"unchecked", "rawtypes", "deprecation"})
 public class ServerTest extends NbTestCase {
-
+    static final boolean ENABLE_MESSAGE_LOGGING = Boolean.getBoolean(ServerTest.class.getName() + ".traceMessages");
+    
     private final Gson gson = new Gson();
     private Socket client;
     private Thread serverThread;
@@ -4345,17 +4341,20 @@ public class ServerTest extends NbTestCase {
     }
     
     private Launcher<LanguageServer> createClientLauncherWithLogging(LanguageClient client, InputStream input, OutputStream output) {
-        return new LSPLauncher.Builder<LanguageServer>() 
+        Launcher.Builder<LanguageServer> builder = new LSPLauncher.Builder<LanguageServer>() 
             .setLocalService(client)
             .setExceptionHandler((t) -> {
                 System.err.println("Error during dispatch at client: ");
                 t.printStackTrace();
                 return RemoteEndpoint.DEFAULT_EXCEPTION_HANDLER.apply(t);
             })
-            .traceMessages(new PrintWriter(System.out))
             .setRemoteInterface(LanguageServer.class)
             .setInput(input)
-            .setOutput(output).create();
+            .setOutput(output);
+        if (ENABLE_MESSAGE_LOGGING) {
+            builder = builder.traceMessages(new PrintWriter(System.out));
+        }
+        return builder.create();
     }
 
     public void testChangeMethodParameters() throws Exception {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
@@ -226,12 +226,16 @@ public class CustomJavac extends Javac {
                 continue;
             }
             int i = clazz.indexOf('$');
-            File enclosing = new File(d, clazz.substring(0, i) + ".class");
-            if (!enclosing.isFile()) {
-                File enclosed = new File(d, clazz);
-                log(clazz + " will be deleted since " + enclosing.getName() + " is missing", Project.MSG_VERBOSE);
-                if (!enclosed.delete()) {
-                    throw new BuildException("could not delete " + enclosed, getLocation());
+            // ignore filenames that start right with '$' (separatorChar preceded), these could not be inner classes.
+            if (i > 0 && clazz.charAt(i - 1) != File.separatorChar) {
+                File enclosing = new File(d, clazz.substring(0, i) + ".class");
+                // no inner class' filename may begin directly with '$', it must be preceded by an outer class' name.
+                if (!enclosing.isFile()) {
+                    File enclosed = new File(d, clazz);
+                    log(clazz + " will be deleted since " + enclosing.getName() + " is missing", Project.MSG_VERBOSE);
+                    if (!enclosed.delete()) {
+                        throw new BuildException("could not delete " + enclosed, getLocation());
+                    }
                 }
             }
         }

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -123,7 +123,7 @@
         </condition>
     </target>
     <target name="-init-bootclasspath-prepend-run9" depends="-init-bootclasspath-prepend-compile" if="have-jdk-1.9">
-        <condition property="test.bootclasspath.prepend.args" value="--limit-modules=java.base,java.logging,java.xml,java.prefs,java.desktop,java.management,java.instrument,jdk.zipfs,java.scripting,java.naming,jdk.jdi">
+        <condition property="test.bootclasspath.prepend.args" value="--limit-modules=java.base,java.logging,java.xml,java.prefs,java.desktop,java.management,java.instrument,jdk.zipfs,java.scripting,java.naming,jdk.jdi,jdk.unsupported">
             <and>
                 <istrue value="${requires.nb.javac}"/>
                 <not>


### PR DESCRIPTION
A follow-up to #4921. 

The most important fix is a fix to `nbjavac` task that prevents classes like `$JsCallback$` and similar to be deleted just before an incremental compilation because they are considered inner classes (without a matching outer class).

I've added additional logging to both server and client, because some thrown errors are wrapped into uninformative "Internal error". Added possibility to log-trace LSP messages (enabled by System property)


I've cleaned up the test a little:
- the exception about missing Groovy support turned into a WARNING line, if the client demands Groovy enabled, but it is simply not available. Other Reflective exceptions show stacktrace.
- fixed error that manifested by a print about 'not normalized' license template filename/path
- suppressed SocketClosed exceptions in test output
- fixed potential CNFE when running on JDK11: Truffle could not access `sun.misc.Unsafe` during script engine initialization
