### PR TITLE
Optimize matching for CSS completion queries

### DIFF
--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/StandardPropertiesHelpResolver.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/StandardPropertiesHelpResolver.java
@@ -105,10 +105,15 @@ public class StandardPropertiesHelpResolver extends HelpResolver {
                 
                 String elementName = "dfn";
                 
-                String patternImg = String.format("(?s)<%s[^>]*id=['\"]?\\w*-??propdef-%s\\d?['\"]?[^>]*>", elementName, propertyName);
+                String patternImg = String.format("(?s)<%s[^>]*id=(['\"])propdef-%s\\d?\\1[^>]*>", elementName, propertyName);
                 
                 Pattern pattern = Pattern.compile(patternImg); //DOTALL mode
                 Matcher matcher = pattern.matcher(urlContent);
+                if (!matcher.find(0)){
+                    patternImg = String.format("(?s)<%s[^>]*id=['\"]?\\w*-??propdef-%s\\d?['\"]?[^>]*>", elementName, propertyName);
+                    pattern = Pattern.compile(patternImg); //DOTALL mode
+                    matcher = pattern.matcher(urlContent);
+                }
                 if (!matcher.find(0)){
                     patternImg = String.format("(?s)<%s[^>]*id=['\"]?\\w*-??%s\\d?['\"]?>", elementName, propertyName);
                     pattern = Pattern.compile(patternImg); //DOTALL mode


### PR DESCRIPTION
There are two different issues:

- The documentation is fetched based on the completion result. This was only build based on the prefix. This change sorts the completion result using the node image where the cursor is currently located and sort by levenshtein distance between this image and the completion proposal. This result in preferring better matching entries.

- The documentation is looked up from the W3C specificiation HTML files. To do this the correct location is located using several regular expressions. To make this more precise a less flexible regexp is used. The other matches are retained and used as fallbacks.

Closes: #4778
