### PR TITLE
[#4865] Register JDPA and Java Compiler Output on Project level

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/output/LookupProviders.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/output/LookupProviders.java
@@ -29,7 +29,7 @@ import org.openide.util.lookup.Lookups;
  */
 public class LookupProviders {
 
-    @LookupProvider.Registration(projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
+    @LookupProvider.Registration(projectType = NbGradleProject.GRADLE_PROJECT_TYPE)
     public static LookupProvider createJavaBaseProvider() {
         return new LookupProvider() {
             @Override
@@ -39,18 +39,6 @@ public class LookupProviders {
                         new JDPAProcessorFactory()
                 );
             }
-        };
-    }
-
-    @LookupProvider.Registration(projectTypes = {
-        @LookupProvider.Registration.ProjectType(id = NbGradleProject.GRADLE_PLUGIN_TYPE + "/com.github.lkishalmi.gatling"),
-        @LookupProvider.Registration.ProjectType(id = NbGradleProject.GRADLE_PLUGIN_TYPE + "/io.gatling.gradle")
-    })
-    public static LookupProvider createGatlingProvider() {
-        return (baseContext) -> {
-            return Lookups.fixed(
-                    new JDPAProcessorFactory()
-            );
         };
     }
 }


### PR DESCRIPTION
This is a small change that registers the Gradle JDPA and JavaCompiler output listener on General Gradle project level instead of individual plugin level, so projects that non necessary Java project, but has Java sub-projects or deals with Java/JVM in some way can have their output processed. 

Fixes #4865 