### PR TITLE
Fix `NullPointerException` in `MavenSelectionHintsTask`

### DIFF
--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/MavenSelectionHintsTask.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/MavenSelectionHintsTask.java
@@ -24,6 +24,7 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import javax.swing.text.Position;
 import javax.swing.text.StyledDocument;
+import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.maven.hints.pom.spi.SelectionPOMFixProvider;
@@ -68,17 +69,18 @@ public class MavenSelectionHintsTask extends ParserResultTask<MavenResult> {
         List<ErrorDescription> errors = computeErrors(result, ss, se, cursorEvent.getCaretOffset());
         HintsController.setErrors(result.getPomFile(), PomModelUtils.LAYER_POM_SELECTION, errors);
     }
-    
+
+    @NonNull
     static List<ErrorDescription> computeErrors(MavenResult result, int ss, int se, int co) {
+        final List<ErrorDescription> errors = new ArrayList<>();
         FileObject fo = result.getPomFile();
         Project project = FileOwnerQuery.getOwner(fo);
         Document document = result.getSnapshot().getSource().getDocument(false);
         if (fo == null || project == null || project.getProjectDirectory() != fo.getParent()) {
             // ?? pom file ought to form a project!
-            return null;
+            return errors;
         }
         final POMModel model = result.getProjectModel();
-        final List<ErrorDescription> errors = new ArrayList<ErrorDescription>();
         // clear selection hints in case of an error; validation errors are handled by 
         // MavenFileHintsTask.
         StyledDocument styled = null;


### PR DESCRIPTION
Fixes #4993 by code inspection, amending mistake introduced in #3833. Both call sites require the result to be non-null: https://github.com/apache/netbeans/blob/67393d2c6d8dc52aadb3477ac86b40bfc2dc4fef/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/MavenSelectionHintsTask.java#L68-L69 https://github.com/apache/netbeans/blob/67393d2c6d8dc52aadb3477ac86b40bfc2dc4fef/ide/spi.editor.hints/src/org/netbeans/spi/editor/hints/HintsController.java#L72-L75 https://github.com/apache/netbeans/blob/67393d2c6d8dc52aadb3477ac86b40bfc2dc4fef/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/LspMavenErrorProvider.java#L77-L81
