### PR TITLE
#4965: Fix issues with gradle pre-6.4

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/GradleInternalAdapter.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/GradleInternalAdapter.java
@@ -111,7 +111,7 @@ public class GradleInternalAdapter {
     }
     
     public ValueAndType findPropertyValueInternal(String propName, Object val) {
-        return safeCall(() -> {
+        return sinceGradleOrDefault("6.4",() -> safeCall(() -> {
             if (val instanceof ProviderInternal) {
                 ProviderInternal provided = (ProviderInternal)val;
                 ValueSupplier.ExecutionTimeValue etv;
@@ -129,7 +129,7 @@ public class GradleInternalAdapter {
             } else {
                 return new ValueAndType(val != null ? val.getClass() : null, val);
             }
-        }, "property " + propName).orElse(null);
+        }, "property " + propName).orElse(null), null);
     }
     
     @SuppressWarnings("unchecked")

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -1615,8 +1615,10 @@ class NbProjectInfoBuilder {
                 sneakyThrow(t);
                 return null;
             }
-        } else {
+        } else if (def != null) {
             return def.get();
+        } else {
+            return null;
         }
     }
     

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/GradleBaseProjectTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/GradleBaseProjectTest.java
@@ -247,6 +247,11 @@ public class GradleBaseProjectTest extends AbstractGradleProjectTestCase {
         return p;
     }
     
+    public void testOldGradle611ProjectLoads() throws Exception {
+        Project p = makeProjectWithWrapper("projects/oldgradle/basic", "6.1.1");
+        assertProjectLoadedWithNoProblems(p, "6.1.1");
+    }
+
     public void testOldGradle683ProjectLoads() throws Exception {
         Project p = makeProjectWithWrapper("projects/oldgradle/basic", "6.8.3");
         assertProjectLoadedWithNoProblems(p, "6.8.3");


### PR DESCRIPTION
Fixes #4965. There are two issues, one NPE: simply the supplier parameter is not checked (can be null) before it is asked to supply a default. Next, another call to internal API, this time introduced by Gradle 6.4 was found - reported just as a warning, not affecting rest of the operation.

Added a unit test that gradle 6.1.1 loads a default project.