### PR TITLE
Use warning rather than error for vulnerability reports.

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -518,7 +518,7 @@ public class VulnerabilityWorker implements ErrorProvider{
             }
             if (auditDone) {
                 DialogDisplayer.getDefault().notifyLater(
-                                new NotifyDescriptor.Message(message, cacheItem.getAudit().getIsSuccess() ? NotifyDescriptor.INFORMATION_MESSAGE : NotifyDescriptor.ERROR_MESSAGE));
+                                new NotifyDescriptor.Message(message, cacheItem.getAudit().getIsSuccess() ? NotifyDescriptor.INFORMATION_MESSAGE : NotifyDescriptor.WARNING_MESSAGE));
             }
             Diagnostic.ReporterControl reporter = Diagnostic.findReporterControl(Lookup.getDefault(), project.getProjectDirectory());
             reporter.diagnosticChanged(problematicFiles, null);


### PR DESCRIPTION
Vulnerabilities should produce "warning" messages rather than errors.