### PR TITLE
Fixed some Gradle introspection problems wit pre-6.1 Gradle Versions

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
@@ -154,7 +154,7 @@ class GradleBaseProjectBuilder implements ProjectInfoExtractor.Result {
         if (sourceSetNames != null) {
             for (String name : sourceSetNames) {
                 Set<File> dirs = (Set<File>) info.get("sourceset_" + name + "_output_classes");
-                sourceSetOutputs.addAll(dirs);
+                sourceSetOutputs.addAll(dirs != null ? dirs : Collections.emptySet());
                 sourceSetOutputs.add((File) info.get("sourceset_" + name + "_output_resources"));
             }
         }


### PR DESCRIPTION
Yet another fix, restoring some pre-6.1 Gradle Compatibility.

Brief list of the changes:
 * `VersionNumber` -> `GradleVersion` (VersionNumber is deprecated for a while)
 * Also comparing on base version, so no comparisons to RCs are needed.
 * Identify plugin by name instead of class
 * Checking for MissingPropertyException-s in `getProperty` and returning `null` if that would happen.

I'm still unhappy about the issues caused by the mass auto-discovery feature.