### PR TITLE
Support directly native build plugin

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/gradle/MicronautGradleArtifactsImpl.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/gradle/MicronautGradleArtifactsImpl.java
@@ -55,7 +55,12 @@ import org.openide.util.Lookup;
  *
  * @author sdedic
  */
-@ProjectServiceProvider(projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/io.micronaut.application", service=ProjectArtifactsImplementation.class)
+@ProjectServiceProvider(service=ProjectArtifactsImplementation.class,
+        projectType = {
+            NbGradleProject.GRADLE_PLUGIN_TYPE + "/io.micronaut.application",
+            NbGradleProject.GRADLE_PLUGIN_TYPE + "/org.graalvm.buildtools.native"
+        }
+)
 public class MicronautGradleArtifactsImpl implements ProjectArtifactsImplementation<MicronautGradleArtifactsImpl.R>{
     private static final String EXTENSION_GRAAL_VM_NATIVE = "graalVmNative";
     private static final String TASK_NATIVE_COMPILE = "nativeCompile";

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
@@ -49,6 +49,13 @@
             <folder name="Plugins">
                 <folder name="io.micronaut.application">
                     <folder name="Lookup">
+                        <file name="micronaut-project-actions.shadow">
+                            <attr name="originalFile" stringvalue="Projects/org-netbeans-modules-gradle/Plugins/org.graalvm.buildtools.native/Lookup/micronaut-project-actions.instance"/>
+                        </file>
+                    </folder>
+                </folder>
+                <folder name="org.graalvm.buildtools.native">
+                    <folder name="Lookup">
                         <file name="micronaut-project-actions.instance">
                             <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
                             <attr name="instanceCreate" methodvalue="org.netbeans.modules.gradle.spi.actions.DefaultGradleActionsProvider.forProjectLayer"/>


### PR DESCRIPTION
The micronaut module supports 'nativeCompile' task indirectly - only if `io.micronaut.application` plugin was included. This PR reacts also on `org.graalvm.buildtools.native` plugin provided by GraalVM community  -- so it would serve native artifacts even for other configuration than just with `io.micronaut.application`.
The GraalVM plugin is also used by SpringBoot and possibly by other 4rd party plugins, too.