### PR TITLE
Fix Gradle/broken task dependency and serialization

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -508,13 +508,7 @@ class NbProjectInfoBuilder {
             return false;
         }
         String n = c.getName();
-        if (n.indexOf('.') == -1) {
-            return true;
-        } else if (n.startsWith("java.lang.")) {
-            return true;
-        }
-        
-        return false;
+        return c.isPrimitive() || n.startsWith("java.lang.");
     }
     
     /**

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -330,11 +330,16 @@ class NbProjectInfoBuilder {
     }
     
     private String dependenciesAsString(Task t, TaskDependency td) {
-        Set<? extends Task> deps = td.getDependencies(t);
-        if (deps.isEmpty()) {
+        try {
+            Set<? extends Task> deps = td.getDependencies(t);
+            if (deps.isEmpty()) {
+                return "";
+            }
+            return deps.stream().map(Task::getPath).collect(Collectors.joining(","));
+        } catch (LinkageError | RuntimeException ex) {
+            LOG.warn("Error getting dependencies for task {}: {}", t.getName(), ex.getLocalizedMessage(), ex);
             return "";
         }
-        return deps.stream().map(Task::getPath).collect(Collectors.joining(","));
     }
     
     private void detectConfigurationArtifacts(NbProjectInfoModel model) {


### PR DESCRIPTION
During debugging of #5015, I've also encountered some broken task that depended on a non-existing class: so I wrapped task dependencies into `try-catch(LinkageError)`. 

The not serializable bug itself was caused by an improper test for primitive that passed on even some generated proxy with no package. The current version will still pass more values than just primitive wrappers (anything from java.lang).