### PR TITLE
[NETBEANS-1914] Fix startup problems on Windows after moving NetBeans install directory

### DIFF
--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/layers/CachingPreventsFileTouchesTest.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/layers/CachingPreventsFileTouchesTest.java
@@ -161,9 +161,18 @@ public class CachingPreventsFileTouchesTest extends NbTestCase {
         Collections.shuffle(Arrays.asList(arr));
         for (File f : arr) {
             if (!f.isDirectory()) {
-                System.err.println("checking " + f);
-                cnt++;
-                assertFileDoesNotContain(f, install);
+                if (f.getName().equals("all-checksum.txt")) {
+                    /* In org.netbeans.Stamps, we intentionally include the full netbeans.home path
+                    on Windows as a workaround for NETBEANS-1914. This is meant to invalidate the
+                    cache on changes to netbeans.home in case, despite the intentions of those who
+                    implemented the cache directory system, an absolute path to netbeas.home did end
+                    up in the cache directory. */
+                    System.err.println("skipping checksum file " + f);
+                } else {
+                    System.err.println("checking " + f);
+                    cnt++;
+                    assertFileDoesNotContain(f, install);
+                }
             }
         }
         assertTrue("Some cache files found", cnt > 4);

--- a/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/CachingPreventsFileTouchesTest.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/CachingPreventsFileTouchesTest.java
@@ -238,7 +238,8 @@ public class CachingPreventsFileTouchesTest extends NbTestCase {
         final File[] arr = recursiveFiles(cacheDir, new ArrayList<File>());
         Collections.shuffle(Arrays.asList(arr));
         for (File f : arr) {
-            if (!f.isDirectory()) {
+            // Same as in o.n.core.startup.layers.CachingPreventsFileTouchesTest
+            if (!f.isDirectory() && !f.getName().equals("all-checksum.txt")) {
                 cnt++;
                 assertFileDoesNotContain(f, install);
             }

--- a/platform/o.n.bootstrap/src/org/netbeans/Stamps.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Stamps.java
@@ -55,6 +55,7 @@ import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.openide.modules.Places;
+import org.openide.util.BaseUtilities;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 
@@ -337,6 +338,15 @@ public final class Stamps {
             sb.append("branding=").append(NbBundle.getBranding()).append('\n');
             sb.append("java.version=").append(System.getProperty("java.version")).append('\n');
             sb.append("java.vm.version=").append(System.getProperty("java.vm.version")).append('\n');
+            if (BaseUtilities.isWindows()) {
+              /* NETBEANS-1914: On Windows (but not on Linux or MacOS), the cache directory has been
+              observed to contain absolute paths to the NetBeans install directory (netbeans.home).
+              This can cause errors on startup if said directory is later moved. As a workaround,
+              include the netbeans.home path among the values that will cause the cache to be
+              invalidated if changed. (A better solution would be to get rid of the absolute paths;
+              but after some investigation, I could not figure out how to do this.) */
+              sb.append("netbeans.home=").append(home == null ? "" : home).append('\n');
+            }
                     
             File checkSum = new File(Places.getCacheDirectory(), "lastModified/all-checksum.txt");
             if (!compareAndUpdateFile(checkSum, sb.toString(), result)) {

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/StampsRenameTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/StampsRenameTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.logging.Level;
 import org.netbeans.junit.NbTestCase;
+import org.openide.util.BaseUtilities;
 
 /**
  *
@@ -70,6 +71,12 @@ public class StampsRenameTest extends NbTestCase implements Stamps.Updater{
 
         File i2 = new File(getWorkDir(), "inst2");
         assertTrue("Rename of the dir successful", install.renameTo(i2));
+        if (BaseUtilities.isWindows()) {
+          // See comment in org.netbeans.Stamps.
+          assertTrue("Renamed back to install to permit workaround for NETBEANS-1914",
+              i2.renameTo(install));
+          i2 = install;
+        }
         
         setNetBeansProperties(i2, userdir, Stamps.moduleJARs());
         


### PR DESCRIPTION
On Windows, renaming or moving the NetBeans installation directory caused errors on startup, due to references to old paths in all-layers.dat in the cache directory. The bug did not seem to happen on Linux or MacOS; I'm not sure why. See https://issues.apache.org/jira/browse/NETBEANS-1914 for an example stack trace.

The solution in this patch is to include the netbeans.home path in the all-checksum.txt file. This will invalidate the cache if the installation directory is changed.