### PR TITLE
VSCode: Hide Run Configuration panel when Java support is disabled.

### DIFF
--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -81,7 +81,7 @@
 					"id": "run-config",
 					"name": "Run Configuration",
 					"contextualTitle": "Run Configuration",
-					"when": "runConfigurationInitialized"
+					"when": "runConfigurationInitialized && config.netbeans.javaSupport.enabled"
 				}
 			]
 		},


### PR DESCRIPTION
Run Configuration panel should be hidden with Java support disabled as the corresponding `Java8+` run/debug configuration is not available.