### PR TITLE
Fix wrong popuppath by changing order of popupPresenterFilePath strings

### DIFF
--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorActionRegistrationProcessor.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorActionRegistrationProcessor.java
@@ -236,10 +236,11 @@ public final class EditorActionRegistrationProcessor extends LayerGeneratingProc
         int popupPosition = annotation.popupPosition();
         if (popupPosition != Integer.MAX_VALUE) {
             StringBuilder popupPresenterFilePath = new StringBuilder(50);
-            popupPresenterFilePath.append("Editors/Popup/");
+            popupPresenterFilePath.append("Editors/");
             if (mimeType.length() > 0) {
                 popupPresenterFilePath.append(mimeType).append("/");
             }
+            popupPresenterFilePath.append("Popup/");
             if (popupPath.length() > 0) {
                 popupPresenterFilePath.append(popupPath).append('/');
             }

--- a/java/jshell.support/src/org/netbeans/modules/jshell/editor/Bundle.properties
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/editor/Bundle.properties
@@ -24,7 +24,7 @@ caret-up=Up
 
 jshell-execute=Execute Shell Input
 jshell-reset=Reset Java Shell
-jshell-stop=Interrupt exeution
+jshell-stop=Interrupt execution
 jshell-save-to-class=Save To Class
 ClassNamePanel.className.text=
 ClassNamePanel.message.text=\ 

--- a/java/jshell.support/src/org/netbeans/modules/jshell/resources/layer.xml
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/resources/layer.xml
@@ -34,15 +34,6 @@
     </folder>
     <folder name="jshell-snippets"/>
     <folder name="Editors">
-        <folder name="Popup">
-            <folder name="text">
-                <attr name="position" intvalue="9800"/>
-                <folder name="x-repl">
-                    <attr name="position" intvalue="9800"/>
-                </folder>
-            </folder>
-        </folder>
-
         <folder name="text">
             <folder name="x-repl">
                 <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.jshell.resources.Bundle"/>


### PR DESCRIPTION
**^Add meaningful description above**
After finding a weird context mentu entry, I started investigating what this is and here you can read more about it: https://github.com/apache/netbeans/discussions/4894

So before the fix, the string looked like Editors/Popup/mimeType which  was wrong and lead to misbehavior of EditorActions in PopupMenus (Context menu). After the fix, it looks correct now Editors/mimeType/Popup. The 2 actions were added just for the Java Shell support but because of wrong order, the action were added for each editor.

Also I removed unnecessary layer.xml entry which led to an empty  entry after the original fix.