### PR TITLE
added more categories for the release notes generator.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 
+# doc: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options
 changelog:
 
   exclude:
@@ -21,17 +22,10 @@ changelog:
     labels:
       - 'Release process'
       - 'ci:no-build'
-      
+  
+  # order matters since this works like a filter, a PR will show up only once.
+  # try to keep similar categories together since this is also the rendering order.
   categories:
-
-    - title: 'API Changes'
-      labels:
-        - 'API Change'
-
-    - title: 'UI Changes'
-      labels:
-        - 'UI'
-        - 'Look and Feel'
 
     - title: 'Gradle'
       labels:
@@ -41,9 +35,22 @@ changelog:
       labels:
         - 'Maven'
 
+    - title: 'Ant'
+      labels:
+        - 'Ant'
+
     - title: 'Java'
       labels:
         - 'Java'
+        - 'JavaDoc'
+
+    - title: 'JavaFX'
+      labels:
+        - 'JavaFX'
+
+    - title: 'Groovy'
+      labels:
+        - 'Groovy'
 
     - title: 'PHP'
       labels:
@@ -65,16 +72,45 @@ changelog:
         - 'JavaScript'
         - 'TypeScript'
         - 'HTML'
+        - 'CSS'
+        - 'CSL'
+
+    - title: 'Versioning'
+      labels:
+        - 'git'
+        - 'subversion'
+        - 'mercurial'
+
+    - title: 'Editor'
+      labels:
+        - 'Editor'
+        - 'ANTLR'
+        - 'Docker'
+
+    - title: 'UI Changes'
+      labels:
+        - 'UI'
+        - 'Look and Feel'
 
     - title: 'Platform'
       labels:
         - 'Platform'
 
+    - title: 'Language Server Protocol'
+      labels:
+        - 'LSP'
+
+    - title: 'VSCode Extension'
+      labels:
+        - 'VSCode Extension'
+
     - title: 'Maintanance'
       labels:
         - 'Code cleanup'
         - 'Upgrade Library'
-      
+        - 'dependencies'
+        - 'CI'
+
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
needs more categories since the `other` section is quite large still.

going to try to update older releases after this is merged by doing some boolean algebra on release notes :)

```java
public class RetroNoter2000 {

    public static void main(String[] args) throws IOException {

        Path base = Path.of("/home/mbien/NetBeansProjects/RetroNoter2000/");

        // second last file is the release of interest
        List<String> files = List.of(
            "HEAD_16.txt",
            "HEAD_15.txt"
//            "HEAD_14.txt",
//            "HEAD_13.txt",
//            "HEAD_126.txt",
//            "HEAD_125.txt"
        );

        Set<String> filter = new HashSet<>();
        for (int i = 0; i < files.size()-1; i++) {
            filter.addAll(readPRsAsSet(base.resolve(files.get(i))));
        }

        Path previous = base.resolve(files.get(files.size()-1)); // tag before release of interest

        try (Stream<String> lines = Files.lines(previous)) {
            List<String> notes = lines.filter((line) -> !filter.contains(line)).toList();
            notes = notes.subList(0, notes.indexOf("## New Contributors"));
            notes.forEach(System.out::println);
        }
    }

    // reads only the changes as Set
    private static Set<String> readPRsAsSet(Path path) throws IOException {
        try (Stream<String> lines = Files.lines(path)) {
            return lines.filter((l) -> l.startsWith("* "))
                        .collect(Collectors.toSet());
        }
    }

}
```