### PR TITLE
FlatLaf: fix font of window title when using `--fontsize` argument (on Windows)

### DIFF
--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/AllLFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/AllLFCustoms.java
@@ -112,7 +112,7 @@ final class AllLFCustoms extends LFCustoms {
         
         Map<Font, Font> fontTranslation = new HashMap<Font, Font>(5);
         
-        if( "Nimbus".equals( UIManager.getLookAndFeel().getID() ) ) { //NOI18N
+        if( UIManager.getFont("defaultFont") != null ) { //NOI18N
             switchFont("defaultFont", fontTranslation, uiFontSize, nbDialogPlain); // NOI18N
         }
         switchFont("controlFont", fontTranslation, uiFontSize, nbDialogPlain); // NOI18N

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/Startup.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/Startup.java
@@ -537,7 +537,7 @@ public final class Startup {
           // Modify default font size to the font size passed as a command-line parameter
             if(uiFontSize>0) {
                 Integer customFontSize = new Integer (uiFontSize);
-                UIManager.put ("customFontSize", customFontSize);
+                UIManager.put (LFCustoms.CUSTOM_FONT_SIZE, customFontSize);
             }
             Startup.uiClass = uiClass;
             Startup.themeURL = themeURL;


### PR DESCRIPTION
Fixes issue #5041

FlatLaf uses `UIManager.getFont("defaultFont")` as base for all fonts (similar to Nimbus).

Edit: tested with FlatLaf, Windows L&F, Nimbus and Metal.