### PR TITLE
Make Java Platform available on non-java Gradle Projects

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/LookupProviders.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/LookupProviders.java
@@ -29,6 +29,18 @@ import org.openide.util.lookup.Lookups;
  * @author lkishalmi
  */
 public class LookupProviders {
+
+    @LookupProvider.Registration(projectType = NbGradleProject.GRADLE_PROJECT_TYPE)
+    public static LookupProvider createProvider() {
+        return new LookupProvider() {
+            @Override
+            public Lookup createAdditionalLookup(Lookup baseContext) {
+                Project project = baseContext.lookup(Project.class);
+                return Lookups.singleton(new GradleJavaPlatformProviderImpl(project));
+            }
+        };
+    }
+
     @LookupProvider.Registration(projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
     public static LookupProvider createJavaBaseProvider() {
         return new LookupProvider() {
@@ -37,7 +49,6 @@ public class LookupProviders {
                 Project project = baseContext.lookup(Project.class);
                 return Lookups.fixed(
                         new DebugFixHooks(project),
-                        new GradleJavaPlatformProviderImpl(project),
                         new ShowJavadocHook(project)
                 );
             }


### PR DESCRIPTION
This is a workaround. It enables non-java project (root project, or others) to have a Java Platform specified and used during project discovery.

This should be provided by the base Gradle Project support, not the Gradlle Java Project support, but that's for the future.

