### PR TITLE
update OutputUtils to support stacktrace links leading to JDK files.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/classpath/AbstractProjectClassPathImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/classpath/AbstractProjectClassPathImpl.java
@@ -94,11 +94,8 @@ public abstract class AbstractProjectClassPathImpl implements ClassPathImplement
         if (oldValues == null) {
             return (newValues != null);
         }
-        Iterator<PathResourceImplementation> it = oldValues.iterator();
-        ArrayList<PathResourceImplementation> nl = new ArrayList<PathResourceImplementation>();
-        nl.addAll(newValues);
-        while (it.hasNext()) {
-            PathResourceImplementation res = it.next();
+        ArrayList<PathResourceImplementation> nl = new ArrayList<>(newValues);
+        for (PathResourceImplementation res : oldValues) {
             URL oldUrl = res.getRoots()[0];
             boolean found = false;
             if (nl.isEmpty()) {
@@ -144,12 +141,7 @@ public abstract class AbstractProjectClassPathImpl implements ClassPathImplement
     abstract URI[] createPath();
     
     private List<PathResourceImplementation> getPath() {
-        List<PathResourceImplementation> base = getPath(createPath(), new Includer() {
-            @Override public boolean includes(URL root, String resource) {
-                return AbstractProjectClassPathImpl.this.includes(root, resource);
-            }
-        });
-        return Collections.<PathResourceImplementation>unmodifiableList(base);
+        return Collections.unmodifiableList(getPath(createPath(), AbstractProjectClassPathImpl.this::includes));
     }
 
     protected boolean includes(URL root, String resource) {
@@ -160,12 +152,12 @@ public abstract class AbstractProjectClassPathImpl implements ClassPathImplement
         boolean includes(URL root, String resource);
     }
     
-    public static  List<PathResourceImplementation> getPath(URI[] pieces, final Includer includer) {
-        List<PathResourceImplementation> result = new ArrayList<PathResourceImplementation>();
-        for (int i = 0; i < pieces.length; i++) {
+    public static List<PathResourceImplementation> getPath(URI[] pieces, final Includer includer) {
+        List<PathResourceImplementation> result = new ArrayList<>();
+        for (URI piece : pieces) {
             try {
                 // XXX would be cleaner to take a File[] if that is what these all are anyway!
-                final URL entry = FileUtil.urlForArchiveOrDir(Utilities.toFile(pieces[i]));
+                final URL entry = FileUtil.urlForArchiveOrDir(Utilities.toFile(piece));
                 if (entry != null) {
                     result.add(new FilteringPathResourceImplementation() {
                         @Override public boolean includes(URL root, String resource) {
@@ -182,7 +174,7 @@ public abstract class AbstractProjectClassPathImpl implements ClassPathImplement
                     });
                 }
             } catch (IllegalArgumentException exc) {
-                Logger.getLogger(AbstractProjectClassPathImpl.class.getName()).log(Level.INFO, "Cannot use uri " + pieces[i] + " for classpath", exc);
+                Logger.getLogger(AbstractProjectClassPathImpl.class.getName()).log(Level.INFO, "Cannot use uri " + piece + " for classpath", exc);
             }
         }
         return result;

--- a/java/maven/src/org/netbeans/modules/maven/classpath/ClassPathProviderImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/classpath/ClassPathProviderImpl.java
@@ -25,8 +25,8 @@ import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.net.URI;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Iterator;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -49,13 +49,14 @@ import org.netbeans.modules.java.api.common.classpath.ClassPathSupportFactory;
 import org.netbeans.modules.maven.api.NbMavenProject;
 import org.netbeans.spi.java.classpath.ClassPathFactory;
 import org.netbeans.spi.java.classpath.ClassPathProvider;
-import static org.netbeans.spi.java.classpath.support.ClassPathSupport.Selector.PROP_ACTIVE_CLASS_PATH;
 import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Mutex;
 import org.openide.util.Utilities;
 import org.openide.util.WeakListeners;
+
+import static org.netbeans.spi.java.classpath.support.ClassPathSupport.Selector.PROP_ACTIVE_CLASS_PATH;
 
 /**
  * Defines class path for maven2 projects..
@@ -111,46 +112,23 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
      */
     @Override public ClassPath[] getProjectClassPaths(String type) {
         return ProjectManager.mutex().readAccess((Mutex.Action<ClassPath[]>) () -> {
-            if (ClassPath.BOOT.equals(type)) {
-                //TODO
-                return new ClassPath[]{ getBootClassPath(TYPE_SRC), getBootClassPath(TYPE_TESTSRC) };
-            }
-            if (ClassPathSupport.ENDORSED.equals(type)) {
-                return new ClassPath[]{ getEndorsedClassPath() };
-            }
-            if (ClassPath.COMPILE.equals(type)) {
-                List<ClassPath> l = new ArrayList<>(2);
-                l.add(getCompileTimeClasspath(TYPE_SRC));
-                l.add(getCompileTimeClasspath(TYPE_TESTSRC));
-                return l.toArray(new ClassPath[l.size()]);
-            }
-            if (ClassPath.EXECUTE.equals(type)) {
-                List<ClassPath> l = new ArrayList<>(2);
-                l.add(getRuntimeClasspath(TYPE_SRC));
-                l.add(getRuntimeClasspath(TYPE_TESTSRC));
-                return l.toArray(new ClassPath[l.size()]);
-            }
-
-            if (ClassPath.SOURCE.equals(type)) {
-                List<ClassPath> l = new ArrayList<>(2);
-                l.add(getSourcepath(TYPE_SRC));
-                l.add(getSourcepath(TYPE_TESTSRC));
-                return l.toArray(new ClassPath[l.size()]);
-            }
-            if (JavaClassPathConstants.MODULE_BOOT_PATH.equals(type)) {
-                return new ClassPath[] {getModuleBootPath()}; 
-            }
-            if (JavaClassPathConstants.MODULE_COMPILE_PATH.equals(type)) {
-                ClassPath[] l = new ClassPath[2];
-                l[0] = getModuleCompilePath(TYPE_SRC);
-                l[1] = getModuleCompilePath(TYPE_TESTSRC);
-                return l;
-            }
-            if (JavaClassPathConstants.MODULE_CLASS_PATH.equals(type)) {
-                ClassPath[] l = new ClassPath[2];
-                l[0] = getModuleLegacyClassPath(TYPE_SRC);
-                l[1] = getModuleLegacyClassPath(TYPE_TESTSRC);
-                return l;
+            if (null != type) switch (type) {
+                case ClassPath.BOOT:
+                    return new ClassPath[] { getBootClassPath(TYPE_SRC), getBootClassPath(TYPE_TESTSRC) };
+                case ClassPathSupport.ENDORSED:
+                    return new ClassPath[] { getEndorsedClassPath() };
+                case ClassPath.COMPILE:
+                    return new ClassPath[] { getCompileTimeClasspath(TYPE_SRC), getCompileTimeClasspath(TYPE_TESTSRC) };
+                case ClassPath.EXECUTE:
+                    return new ClassPath[] { getRuntimeClasspath(TYPE_SRC), getRuntimeClasspath(TYPE_TESTSRC) };
+                case ClassPath.SOURCE:
+                    return new ClassPath[] { getSourcepath(TYPE_SRC), getSourcepath(TYPE_TESTSRC) };
+                case JavaClassPathConstants.MODULE_BOOT_PATH:
+                    return new ClassPath[] { getModuleBootPath() };
+                case JavaClassPathConstants.MODULE_COMPILE_PATH:
+                    return new ClassPath[] { getModuleCompilePath(TYPE_SRC), getModuleCompilePath(TYPE_TESTSRC) };
+                case JavaClassPathConstants.MODULE_CLASS_PATH:
+                    return new ClassPath[] { getModuleLegacyClassPath(TYPE_SRC), getModuleLegacyClassPath(TYPE_TESTSRC) };
             }
             return new ClassPath[0];
         });
@@ -161,37 +139,18 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
      * (i.e., excluding tests roots).
      */
     @Override public ClassPath getProjectSourcesClassPath(String type) {
-        if (ClassPath.BOOT.equals(type)) {
-            return getBootClassPath(TYPE_SRC);
+        switch (type) {
+            case ClassPath.BOOT: return getBootClassPath(TYPE_SRC);
+            case ClassPath.COMPILE: return getCompileTimeClasspath(TYPE_SRC);
+            case ClassPath.EXECUTE: return getRuntimeClasspath(TYPE_SRC);
+            case ClassPath.SOURCE: return getSourcepath(TYPE_SRC);
+            case ClassPathSupport.ENDORSED: return getEndorsedClassPath();
+            case JavaClassPathConstants.MODULE_BOOT_PATH: return getModuleBootPath();
+            case JavaClassPathConstants.MODULE_COMPILE_PATH: return getModuleCompilePath(TYPE_SRC);
+            case JavaClassPathConstants.MODULE_CLASS_PATH: return getModuleLegacyClassPath(TYPE_SRC);
+            case JavaClassPathConstants.MODULE_EXECUTE_PATH: return getModuleExecutePath(TYPE_SRC);
+            case JavaClassPathConstants.MODULE_EXECUTE_CLASS_PATH: return getModuleLegacyRuntimeClassPath(TYPE_SRC);
         }
-        if (ClassPathSupport.ENDORSED.equals(type)) {
-            return getEndorsedClassPath();
-        }
-        if (ClassPath.COMPILE.equals(type)) {
-            return getCompileTimeClasspath(TYPE_SRC);
-        }
-        if (ClassPath.SOURCE.equals(type)) {
-            return getSourcepath(TYPE_SRC);
-        }
-        if (ClassPath.EXECUTE.equals(type)) {
-            return getRuntimeClasspath(TYPE_SRC);
-        }
-        if (type.equals(JavaClassPathConstants.MODULE_BOOT_PATH)) {            
-            return getModuleBootPath(); 
-        }
-        if (type.equals(JavaClassPathConstants.MODULE_COMPILE_PATH)) {            
-            return getModuleCompilePath(TYPE_SRC);
-        }
-        if (type.equals(JavaClassPathConstants.MODULE_CLASS_PATH)) {            
-            return getModuleLegacyClassPath(TYPE_SRC);
-        }
-        if (JavaClassPathConstants.MODULE_EXECUTE_PATH.equals(type)) {
-            return getModuleExecutePath(TYPE_SRC);
-        }
-        if (JavaClassPathConstants.MODULE_EXECUTE_CLASS_PATH.equals(type)) {
-            return getModuleLegacyRuntimeClassPath(TYPE_SRC);
-        }
-        assert false;
         return null;
     }
     
@@ -206,30 +165,19 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
             LOGGER.log(Level.FINEST, " bad type={0} for {1}", new Object[] {type, file}); //NOI18N
             return null;
         }
-        if (type.equals(ClassPath.COMPILE)) {
-            return getCompileTimeClasspath(fileType);
-        } else if (type.equals(ClassPath.EXECUTE)) {
-            return getRuntimeClasspath(fileType);
-        } else if (ClassPath.SOURCE.equals(type)) {
-            return getSourcepath(fileType);
-        } else if (type.equals(ClassPath.BOOT)) {
-            return getBootClassPath(fileType);
-        } else if (type.equals(ClassPathSupport.ENDORSED)) {
-            return getEndorsedClassPath();
-        } else if (type.equals(JavaClassPathConstants.PROCESSOR_PATH)) {
-            return getAnnotationProcClassPath(fileType);
-        } else if (type.equals(JavaClassPathConstants.MODULE_BOOT_PATH)) {            
-            return getModuleBootPath();
-        } else if (type.equals(JavaClassPathConstants.MODULE_COMPILE_PATH)) {            
-            return getModuleCompilePath(fileType);
-        } else if (type.equals(JavaClassPathConstants.MODULE_CLASS_PATH)) {            
-            return getModuleLegacyClassPath(fileType);
-        } else if (type.equals(JavaClassPathConstants.MODULE_EXECUTE_PATH)) {
-            return getModuleExecutePath(fileType);
-        } else if (type.equals(JavaClassPathConstants.MODULE_EXECUTE_CLASS_PATH)) {
-            return getModuleLegacyRuntimeClassPath(fileType);
-        } else {
-            return null;
+        switch (type) {
+            case ClassPath.BOOT: return getBootClassPath(fileType);
+            case ClassPath.COMPILE: return getCompileTimeClasspath(fileType);
+            case ClassPath.EXECUTE: return getRuntimeClasspath(fileType);
+            case ClassPath.SOURCE: return getSourcepath(fileType);
+            case ClassPathSupport.ENDORSED: return getEndorsedClassPath();
+            case JavaClassPathConstants.PROCESSOR_PATH: return getAnnotationProcClassPath(fileType);
+            case JavaClassPathConstants.MODULE_BOOT_PATH: return getModuleBootPath();
+            case JavaClassPathConstants.MODULE_COMPILE_PATH: return getModuleCompilePath(fileType);
+            case JavaClassPathConstants.MODULE_CLASS_PATH: return getModuleLegacyClassPath(fileType);
+            case JavaClassPathConstants.MODULE_EXECUTE_PATH: return getModuleExecutePath(fileType);
+            case JavaClassPathConstants.MODULE_EXECUTE_CLASS_PATH: return getModuleLegacyRuntimeClassPath(fileType);
+            default: return null;
         }
     }
 
@@ -246,19 +194,6 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
         }
         return false;
     }
-    
-    public static FileObject[] convertStringsToFileObjects(List<String> strings) {
-        FileObject[] fos = new FileObject[strings.size()];
-        int index = 0;
-        Iterator<String> it = strings.iterator();
-        while (it.hasNext()) {
-            String str = it.next();
-            fos[index] = FileUtilities.convertStringToFileObject(str);
-            index++;
-        }
-        return fos;
-    }
-    
     
     private int getType(FileObject file) {
         if(file == null) {
@@ -370,7 +305,13 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
     
     private ClassPath getJava8RunTimeClassPath(int type) {
         final int ftype = type == TYPE_WEB ? TYPE_SRC : type;
-        return computeIfAbsent(JAVA8_RUNTIME_PATH + ftype, () -> ClassPathFactory.createClassPath(ftype == TYPE_SRC ? new RuntimeClassPathImpl(getNBMavenProject()) : new TestRuntimeClassPathImpl(getNBMavenProject(), false)));
+        return computeIfAbsent(JAVA8_RUNTIME_PATH + ftype,
+                () -> ClassPathFactory.createClassPath(
+                        ftype == TYPE_SRC
+                            ? new RuntimeClassPathImpl(getNBMavenProject())
+                            : new TestRuntimeClassPathImpl(getNBMavenProject(), false)
+                )
+        );
     }
     
     private ClassPath getTestScopedRuntimeClasspath() {
@@ -626,11 +567,7 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
             if ( hasTestModuleDescriptor ) {
                 return testPath.get();
             } else {
-                if(hasMainModuleDescriptor) {
-                    return path.get();
-                } else {
-                    return ClassPath.EMPTY;
-                }
+                return hasMainModuleDescriptor ? path.get() : ClassPath.EMPTY;
             }
         }
     }
@@ -650,11 +587,7 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
             if ( hasTestModuleDescriptor ) {
                 return ClassPath.EMPTY;
             } else {
-                if(hasMainModuleDescriptor) {
-                    return testScopedPath.get();
-                } else {
-                    return testPath.get();
-                }
+                return hasMainModuleDescriptor ? testScopedPath.get() : testPath.get();
             }
         }
     }
@@ -672,12 +605,12 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
             ClassPath ret = active;
             if (ret == null) {
                 MavenProject mp = proj.getOriginalMavenProject();
-                boolean hasMainModuleDescriptor = mp.getCompileSourceRoots().stream().anyMatch((sourceRoot) -> (new File(sourceRoot, MODULE_INFO_JAVA).exists()));
+                boolean hasMainModuleDescriptor = hasModuleDescriptor(mp.getCompileSourceRoots());
                 if(hasMainModuleDescriptor) {
                     LOGGER.log(Level.FINER, "TestPathSelector {0} for project {1}: has main module-info.java", new Object [] {logDesc, proj.getProjectDirectory().getPath()}); // NOI18N
                 }
                 
-                boolean hasTestModuleDescriptor = mp.getTestCompileSourceRoots().stream().anyMatch((testSourceRoot) -> (new File(testSourceRoot, MODULE_INFO_JAVA).exists()));
+                boolean hasTestModuleDescriptor = hasModuleDescriptor(mp.getTestCompileSourceRoots());
                 if(hasTestModuleDescriptor) {
                     LOGGER.log(Level.FINER, "TestPathSelector {0} for project {1}: has test module-info.java", new Object [] {logDesc, proj.getProjectDirectory().getPath()}); // NOI18N
                 }
@@ -688,6 +621,10 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
             }            
             LOGGER.log(Level.FINE, "TestPathSelector {0} for project {1} active class path: {2}", new Object[]{logDesc, proj.getProjectDirectory().getPath(), ret}); // NOI18N
             return ret;
+        }
+
+        private boolean hasModuleDescriptor(List<String> roots) {
+            return roots.stream().anyMatch((root) -> Files.exists(Paths.get(root, MODULE_INFO_JAVA)));
         }
 
         protected abstract ClassPath getActiveClassPath(boolean hasTestModuleDescriptor, boolean hasMainModuleDescriptor);
@@ -764,7 +701,7 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
             // maven checks recursively all source roots for module-info,
             // for performace reasons we will be checking and listening only on the root of a source root
             NbMavenProject.addPropertyChangeListener(proj, (evt) -> {
-                    if (isReset(evt)) {
+                if (isReset(evt)) {
                     active = null;
                     support.firePropertyChange(PROP_ACTIVE_CLASS_PATH, null, null);
                 }

--- a/java/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
@@ -193,7 +193,7 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
             if (urls == null) {
                 exec.setClasspathURLs(coreurls);
             } else {
-                List<URL> newones = new ArrayList<URL>();
+                List<URL> newones = new ArrayList<>(urls.length + coreurls.length);
                 newones.addAll(Arrays.asList(urls));
                 newones.addAll(Arrays.asList(coreurls));
                 exec.setClasspathURLs(newones.toArray(new URL[0]));
@@ -365,7 +365,7 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
                     line = nextLine != null ? nextLine : readLine();
                 }
             } catch (IOException ex) {
-                java.util.logging.Logger.getLogger(CommandLineOutputHandler.class.getName()).log(java.util.logging.Level.FINE, null, ex);
+                LOG.log(java.util.logging.Level.FINE, null, ex);
             } finally {
                 if (contextImpl == null) {
                     CommandLineOutputHandler.this.processEnd(getEventId(PRJ_EXECUTE, null), stdOut);
@@ -618,7 +618,7 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
 
     private static final Map<ExecutionEvent.Type, ExecutionEvent.Type> END_TO_START_Mappings;
     static {
-        END_TO_START_Mappings = new EnumMap<ExecutionEvent.Type, ExecutionEvent.Type>(ExecutionEvent.Type.class);
+        END_TO_START_Mappings = new EnumMap<>(ExecutionEvent.Type.class);
         END_TO_START_Mappings.put(ExecutionEvent.Type.ForkFailed, ExecutionEvent.Type.ForkStarted);
         END_TO_START_Mappings.put(ExecutionEvent.Type.ForkSucceeded, ExecutionEvent.Type.ForkStarted);
         END_TO_START_Mappings.put(ExecutionEvent.Type.ForkedProjectFailed, ExecutionEvent.Type.ForkedProjectStarted);

--- a/java/maven/src/org/netbeans/modules/maven/runjar/RunJarPrereqChecker.java
+++ b/java/maven/src/org/netbeans/modules/maven/runjar/RunJarPrereqChecker.java
@@ -77,21 +77,19 @@ public class RunJarPrereqChecker implements PrerequisitesChecker {
 
     @Override public boolean checkRunConfig(RunConfig config) {
         String actionName = config.getActionName();
-        for (Map.Entry<? extends String,? extends String> entry : config.getProperties().entrySet()) {
-            if ("exec.executable".equals(entry.getKey())) { //NOI18N
-                // check for "java" and replace it with absolute path to
-                // project j2seplaform's java.exe
-                if ("java".equals(entry.getValue())) { //NOI18N
-                    //TODO somehow use the config.getMavenProject() call rather than looking up the
-                    // ActiveJ2SEPlatformProvider from lookup. The loaded project can be different from the executed one.
-                    ActiveJ2SEPlatformProvider plat = config.getProject().getLookup().lookup(ActiveJ2SEPlatformProvider.class);
-                    assert plat != null;
-                    FileObject fo = plat.getJavaPlatform().findTool(entry.getValue());
-                    if (fo != null) {
-                        File fl = FileUtil.toFile(fo);
-                        config.setProperty("exec.executable", fl.getAbsolutePath()); //NOI18N
-                    }
-                }
+
+        // check for "java" and replace it with absolute path to
+        // project j2seplaform's java.exe
+        String tool = config.getProperties().get("exec.executable"); //NOI18N
+        if ("java".equals(tool)) { //NOI18N
+            //TODO somehow use the config.getMavenProject() call rather than looking up the
+            // ActiveJ2SEPlatformProvider from lookup. The loaded project can be different from the executed one.
+            ActiveJ2SEPlatformProvider plat = config.getProject().getLookup().lookup(ActiveJ2SEPlatformProvider.class);
+            assert plat != null;
+            FileObject fo = plat.getJavaPlatform().findTool(tool);
+            if (fo != null) {
+                File fl = FileUtil.toFile(fo);
+                config.setProperty("exec.executable", fl.getAbsolutePath()); //NOI18N
             }
         }
 


### PR DESCRIPTION
fixes #4516

 - add active JDK to class path
 - fix the packageName parsing of the line action when modules are involved
 - open class file if no source found -> allows user to download/attach sources

second commit is for cleanup, first has the changes.

test snippet
```java
    public static void main(String[] args) throws Exception {
        // for a JDK/application trace
        new FileReader("nonexistent");

        // for a trace in 3rd party deps (guava)
        ImmutableSet.of("a").iterator().remove();
    }
```

devbuild link (expires in 7 days):
https://github.com/apache/netbeans/suites/10002051531/artifacts/485721202
