### PR TITLE
fix output window stacktrace parsing when mvnd is used.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/api/output/OutputUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/output/OutputUtils.java
@@ -50,7 +50,9 @@ import org.openide.windows.OutputListener;
  * @author mkleint
  */
 public final class OutputUtils {
-    public static final Pattern linePattern = Pattern.compile("(?:\\[catch\\])?\\sat (.*)\\((?:Native Method|(.*)\\.java\\:(\\d+))\\)"); //NOI18N
+
+    // example: '[WARN]  	at java.base/java.util.ImmutableCollections.uoe(ImmutableCollections.java:142)'
+    public static final Pattern linePattern = Pattern.compile("(?:\\[\\w+\\])?\\s*(?:\\[catch\\]\\s)?at\\s(.*)\\((?:Native Method|(.*)\\.java\\:(\\d+))\\)"); //NOI18N
  
     private static final Map<Project, StacktraceOutputListener> projectStacktraceListeners = new WeakHashMap<>();
     private static final Map<FileObject, StacktraceOutputListener> fileStacktraceListeners = new WeakHashMap<>();
@@ -115,13 +117,10 @@ public final class OutputUtils {
         return null;
     }
     
-    /**
-     * 
-     * @param line
-     * @param classPath
-     * @return 
-     */
     private static StacktraceAttributes matchStackTraceLine(String line) {
+        if (!line.endsWith(")")) {
+            return null; // fast path -> not a stack trace
+        }
         Matcher match = linePattern.matcher(line);
         if (match.matches() && match.groupCount() == 3) {
             String method = match.group(1);

--- a/java/maven/src/org/netbeans/modules/maven/output/DependencyAnalyzeOutputProcessor.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/DependencyAnalyzeOutputProcessor.java
@@ -22,7 +22,6 @@ package org.netbeans.modules.maven.output;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.netbeans.api.project.Project;
-import org.netbeans.modules.maven.NbMavenProjectImpl;
 import org.netbeans.modules.maven.api.ModelUtils;
 import org.netbeans.modules.maven.api.output.OutputProcessor;
 import org.netbeans.modules.maven.api.output.OutputVisitor;
@@ -51,7 +50,7 @@ public class DependencyAnalyzeOutputProcessor implements OutputProcessor {
     DependencyAnalyzeOutputProcessor(Project project) {
         started = false;
         start = Pattern.compile(".*Used undeclared dependencies.*", Pattern.DOTALL); //NOI18N
-        dependency = Pattern.compile("\\s*(?:\\[WARNING\\])?\\s*(.*):(.*):(.*):(.*):(.*)", Pattern.DOTALL); //NOI18N
+        dependency = Pattern.compile("\\s*(?:\\[WARNING|WARN\\])?\\s*(.*):(.*):(.*):(.*):(.*)", Pattern.DOTALL); //NOI18N
         this.project = project;
     }
 

--- a/java/maven/src/org/netbeans/modules/maven/output/JavaOutputListenerProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/JavaOutputListenerProvider.java
@@ -83,7 +83,7 @@ public class JavaOutputListenerProvider implements OutputProcessor {
         this.config = config;
         //[javac] required because of forked compilation
         //DOTALL seems to fix MEVENIDE-455 on windows. one of the characters seems to be a some kind of newline and that's why the line doesnt' get matched otherwise.
-        failPattern = Pattern.compile("\\s*(?:\\[(WARNING|ERROR)\\])?(?:\\[javac\\])?(?:Compilation failure)?\\s*(?<" + GROUP_CLAZZ_NAME + ">.*)\\.java\\:\\[(?<" + GROUP_LINE_NR + ">[0-9]*),([0-9]*)\\] (?<" + GROUP_TEXT + ">.*)", Pattern.DOTALL); //NOI18N
+        failPattern = Pattern.compile("\\s*(?:\\[(WARNING|WARN|ERROR)\\])?(?:\\[javac\\])?(?:Compilation failure)?\\s*(?<" + GROUP_CLAZZ_NAME + ">.*)\\.java\\:\\[(?<" + GROUP_LINE_NR + ">[0-9]*),([0-9]*)\\] (?<" + GROUP_TEXT + ">.*)", Pattern.DOTALL); //NOI18N
     }
     
     private static final Pattern COMPILER_PROBLEM = Pattern.compile(".*module-info\\.java:.*module not found: .*");


### PR DESCRIPTION
mvnd is using `WARN` instead of `WARNING` (switched to SLF4J it seems) and prints the output type `(stderr|stdout)` on exceptions which causes stack traces to be not parsed.

The `Level` enum is public api so we can't really change that. Instead, `WARN` is simply mapped to the `WARNING` enum.

As side effect this also fixes some of the log level parsing which means that some of the maven output is now painted in a yellowish color. This looks good with the dark theme but might need some tweaks for the light theme.

test snippet:
```java
    public static void main(String[] args) {
        List.of(1).clear();
    }
```

NB 16:
![mvnd-stacktrace-before](https://user-images.githubusercontent.com/114367/207933144-7be3c155-790a-4332-b777-0e3a567ec228.png)

PR applied:
![mvnd-stacktrace-after](https://user-images.githubusercontent.com/114367/207933275-35656eb5-0177-48ca-9812-a7b7ef03c987.png)
