### PR TITLE
enable some important sounding java tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -729,8 +729,8 @@ jobs:
       - name: java/maven.grammar
         run: ant $OPTS -f java/maven.grammar test
 
-#      - name: java/maven.hints
-#        run: ant $OPTS -f java/maven.hints test
+      - name: java/maven.hints
+        run: ant $OPTS -f java/maven.hints test
 
 #      - name: java/maven.htmlui
 #        run: ant $OPTS -f java/maven.htmlui test
@@ -1211,7 +1211,7 @@ jobs:
     name: Java Modules on Linux/JDK ${{ matrix.java }} (some on 11)
     needs: base-build
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 100
     strategy:
       matrix:
         java: [ '8' ]
@@ -1278,9 +1278,6 @@ jobs:
       - name: editor.htmlui
         run: ant $OPTS -f java/editor.htmlui test
 
-#      - name: java/form
-#        run: ant $OPTS -f java/form test
-
       - name: java.completion
         if: env.test_java == 'true' && success()
         run: ant $OPTS -f java/java.completion test
@@ -1294,9 +1291,6 @@ jobs:
 
 #      - name: java.kit
 #        run: ant $OPTS -f java/java.kit test
-
-#      - name: java.lexer
-#        run: ant $OPTS -f java/java.lexer test
 
 #      - name: java.metrics
 #        run: ant $OPTS -f java/java.metrics test
@@ -1350,9 +1344,6 @@ jobs:
       - name: java.testrunner.ant
         run: ant $OPTS -f java/java.testrunner.ant test
 
-#      - name: javadoc
-#        run: ant $OPTS -f java/javadoc test
-
 #      - name: javawebstart
 #        run: ant $OPTS -f java/javawebstart test
 
@@ -1362,8 +1353,8 @@ jobs:
 #      - name: jshell.support
 #        run: ant $OPTS -f java/jshell.support test
 
-#      - name: junit
-#        run: ant $OPTS -f java/junit test
+      - name: junit
+        run: ant $OPTS -f java/junit test-unit
 
       - name: junit.ant.ui
         run: ant $OPTS -f java/junit.ant.ui test
@@ -1380,14 +1371,8 @@ jobs:
 #      - name: projectimport.eclipse.core
 #        run: ant $OPTS -f java/projectimport.eclipse.core test
 
-#      - name: refactoring.java
-#        run: ant $OPTS -f refactoring.java test
-
       - name: spellchecker.bindings.java
         run: ant $OPTS -f java/spellchecker.bindings.java test
-
-#      - name: spi.java.hints
-#        run: ant $OPTS -f java/spi.java.hints test
 
       - name: spring.beans
         run: ant $OPTS -f java/spring.beans test
@@ -1416,7 +1401,10 @@ jobs:
       - name: Set up opts
         run: echo "OPTS_11=-Dtest.run.args=--limit-modules=java.base,java.logging,java.xml,java.prefs,java.desktop,java.management,java.instrument,jdk.zipfs,java.scripting,java.naming -Dtest.bootclasspath.prepend.args=-Dno.netbeans.bootclasspath.prepend.needed=true" >> $GITHUB_ENV
 
-      - name: java/java.completion
+      - name: java.lexer
+        run: ant $OPTS -f java/java.lexer test
+
+      - name: java.completion
         if: env.test_java == 'true' && success()
         run: ant $OPTS $OPTS_11 -f java/java.completion test
 
@@ -1424,12 +1412,24 @@ jobs:
         if: env.test_java == 'true' && success()
         run: .github/retry.sh ant $OPTs $OPTS_11 -f java/java.editor test-unit
 
-      - name: java/java.source
+      - name: java.source
         run: ant $OPTS $OPTS_11 -f java/java.source test-unit
 
-      - name: java/java.source.base
+      - name: java.source.base
         if: env.test_java == 'true' && success()
         run: .github/retry.sh ant $OPTS $OPTS_11 -f java/java.source.base test
+
+      - name: refactoring.java
+        if: env.test_java == 'true' && success()
+        run: ant $OPTS $OPTS_11 -f java/refactoring.java test-unit
+
+      - name: form
+        if: env.test_java == 'true' && success()
+        run: ant $OPTS -f java/form test-unit
+        
+      - name: javadoc
+        if: env.test_javadoc == 'true' && success()
+        run: ant $OPTS -f java/javadoc test
 
       - name: Create Test Summary
         uses: test-summary/action@v1
@@ -1531,6 +1531,10 @@ jobs:
       - name: java.hints.declarative
         if: ${{ (matrix.config == 'batch2') && success() }}
         run: ant $OPTS -f java/java.hints.declarative test
+
+      - name: spi.java.hints
+        if: ${{ (matrix.config == 'batch2') && success() }}
+        run: ant $OPTS -f java/spi.java.hints test
 
       - name: Create Test Summary
         uses: test-summary/action@v1

--- a/java/java.lexer/nbproject/project.properties
+++ b/java/java.lexer/nbproject/project.properties
@@ -21,6 +21,11 @@ javac.source=1.8
 javadoc.title=Java Lexer API
 javadoc.apichanges=${basedir}/apichanges.xml
 
+# failing or missing test files
+test.config.default.excludes=\
+    **/JavaLexerPerformanceTest.class,\
+    **/JavaFlyTokensTest.class
+
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\
     **/JavaLexerBatchTest.class,\

--- a/java/java.lexer/test/unit/data/testfiles/testInput.java.txt.tokens.txt
+++ b/java/java.lexer/test/unit/data/testfiles/testInput.java.txt.tokens.txt
@@ -41,7 +41,7 @@ CHAR_LITERAL    "'a", la=1
 ----- EOF -----
 
 .t.e.s.t. String Literals
-STRING_LITERAL  """"
+STRING_LITERAL  """", la=1
 WHITESPACE      " ", la=1
 STRING_LITERAL  ""a""
 WHITESPACE      "\n", la=1

--- a/java/javadoc/nbproject/project.properties
+++ b/java/javadoc/nbproject/project.properties
@@ -25,3 +25,6 @@ spec.version.base=1.74.0
 test.config.stableBTD.includes=\
     **/hints/AnalyzerTest.class,\
     **/search/*Test.class
+
+# failing
+test.config.default.excludes=**/search/*Test.class

--- a/java/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/UtilitiesTest.java
+++ b/java/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/UtilitiesTest.java
@@ -366,7 +366,7 @@ public class UtilitiesTest extends TestBase {
         assertTrue(errors.isEmpty());
         assertPositions(result, positions[0], code, "assert true;", "true");
     }
-
+/* TODO: fails
     public void testCasePattern() throws Exception {
         prepareTest("test/Test.java", "package test; public class Test{}");
 
@@ -382,7 +382,7 @@ public class UtilitiesTest extends TestBase {
         assertDiagnostics(errors, "19-19:compiler.err.expected");
         assertPositions(result, positions[0], code, "$expr", "$stmts$", "$stmts$;", "case $expr: foo bar $stmts$;", "foo", "foo bar ");
     }
-
+*/
     public void testLambdaPattern() throws Exception {
         prepareTest("test/Test.java", "package test; public class Test{}");
 


### PR DESCRIPTION
 - java/maven.hints (build tools job)
 - java.lexer (always on since fast)
 - spi.java.hints (Java label)
 - refactoring.java (Java label)
 - form (Java label)
 - junit (always on)
 - javadoc (JavaDoc label)

this required to disable some tests in `java.lexer`, `javadoc` and a single test case in `spi.java.hints`. Everything else worked fine when run directly from the IDE with JDK 19. Lets see what CI says.
