### PR TITLE
upgrade exec-maven-plugin to 3.1.0.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/defaultActionMappings.xml
+++ b/java/maven/src/org/netbeans/modules/maven/execute/defaultActionMappings.xml
@@ -115,7 +115,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
         </goals>
         <properties>
             <exec.vmArgs></exec.vmArgs>
@@ -132,7 +132,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
         </goals>
         <properties>
             <exec.vmArgs>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address}</exec.vmArgs>
@@ -150,7 +150,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
         </goals>
         <properties>
             <exec.vmArgs></exec.vmArgs>
@@ -168,7 +168,7 @@
         </packagings>
         <goals>
             <goal>process-test-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
         </goals>
         <properties>
             <exec.vmArgs>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address}</exec.vmArgs>
@@ -236,7 +236,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
         </goals>
         <properties>
             <exec.vmArgs></exec.vmArgs>
@@ -253,7 +253,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
         </goals>
         <properties>
             <exec.vmArgs></exec.vmArgs>

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/api/customizer/ModelHandle2Test.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/api/customizer/ModelHandle2Test.java
@@ -162,7 +162,7 @@ public class ModelHandle2Test extends NbTestCase {
 "            </packagings>\n" +
 "            <goals>\n" +
 "                <goal>process-classes</goal>\n" +
-"                <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>\n" +
+"                <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>\n" +
 "            </goals>\n" +
 "            <properties>\n" +
 "                <exec.args>-classpath %classpath ${packageClassName}</exec.args>\n" +
@@ -177,7 +177,7 @@ public class ModelHandle2Test extends NbTestCase {
 "            </packagings>\n" +
 "            <goals>\n" +
 "                <goal>process-classes</goal>\n" +
-"                <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>\n" +
+"                <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>\n" +
 "            </goals>\n" +
 "            <properties>\n" +
 "                <exec.args>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>\n" +
@@ -199,7 +199,7 @@ public class ModelHandle2Test extends NbTestCase {
 "            </packagings>\n" +
 "            <goals>\n" +
 "                <goal>process-classes</goal>\n" +
-"                <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>\n" +
+"                <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>\n" +
 "            </goals>\n" +
 "            <properties>\n" +
 "                <exec.args>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>\n" +
@@ -223,7 +223,7 @@ public class ModelHandle2Test extends NbTestCase {
             RunConfig run = ActionToGoalUtils.createRunConfig("debug.single.main", (NbMavenProjectImpl) project, project.getLookup());
             assertEquals("Two goals: " + run.getGoals(), 2, run.getGoals().size());
             assertEquals("process-classes", run.getGoals().get(0));
-            assertEquals("org.codehaus.mojo:exec-maven-plugin:3.0.0:exec", run.getGoals().get(1));
+            assertEquals("org.codehaus.mojo:exec-maven-plugin:3.1.0:exec", run.getGoals().get(1));
             assertEquals("One profile activated in action: " + run.getActivatedProfiles(), 1, run.getActivatedProfiles().size());
             assertEquals("jetty", run.getActivatedProfiles().get(0));
         }

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/execute/MavenExecutionTestBase.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/execute/MavenExecutionTestBase.java
@@ -183,7 +183,7 @@ public class MavenExecutionTestBase extends NbTestCase {
                 + "            <plugin>\n"
                 + "                <groupId>org.codehaus.mojo</groupId>\n"
                 + "                <artifactId>exec-maven-plugin</artifactId>\n"
-                + "                <version>3.0.0</version>\n"
+                + "                <version>3.1.0</version>\n"
                 + "                <configuration>\n"
                 +                      argsString 
                 + "                </configuration>\n"

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/execute/ModelRunConfigTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/execute/ModelRunConfigTest.java
@@ -20,32 +20,14 @@
 package org.netbeans.modules.maven.execute;
 
 import java.io.IOException;
-import org.netbeans.modules.maven.api.*;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.function.Function;
 import static junit.framework.TestCase.assertEquals;
-import org.apache.maven.project.MavenProject;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.junit.NbTestCase;
-import org.netbeans.modules.maven.api.ModelUtils.Descriptor;
-import org.netbeans.modules.maven.api.ModelUtils.LibraryDescriptor;
 import org.netbeans.modules.maven.api.customizer.ModelHandle2;
 import org.netbeans.modules.maven.configurations.M2ConfigProvider;
-import org.netbeans.modules.maven.configurations.M2Configuration;
 import org.netbeans.modules.maven.execute.ModelRunConfig;
 import org.netbeans.modules.maven.execute.model.NetbeansActionMapping;
-import org.netbeans.modules.maven.model.ModelOperation;
-import org.netbeans.modules.maven.model.Utilities;
-import org.netbeans.modules.maven.model.pom.POMModel;
-import org.netbeans.modules.maven.model.pom.Repository;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.test.TestFileUtils;
@@ -260,7 +242,7 @@ public class ModelRunConfigTest extends NbTestCase {
                 + "            <plugin>\n"
                 + "                <groupId>org.codehaus.mojo</groupId>\n"
                 + "                <artifactId>exec-maven-plugin</artifactId>\n"
-                + "                <version>3.0.0</version>\n"
+                + "                <version>3.1.0</version>\n"
                 + "                <configuration>\n"
                 + "                    <executable>${java.home}/bin/java</executable>\n"
                 +                      argsString 

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/runjar/nbactions-template.xml
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/runjar/nbactions-template.xml
@@ -27,7 +27,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
         </goals>
         <properties>
                 &runProperties;
@@ -40,7 +40,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
         </goals>
         <properties>
                 &debugProperties;
@@ -53,7 +53,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
         </goals>
         <properties>
                 &profileProperties;

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/spi/actions/ProvidedConfigurationsTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/spi/actions/ProvidedConfigurationsTest.java
@@ -144,7 +144,7 @@ public class ProvidedConfigurationsTest extends NbTestCase {
         RunConfig cfg = ActionToGoalUtils.createRunConfig("run", pimpl, Lookup.EMPTY);
         assertEquals(Arrays.asList(
                 "process-classes",
-                "org.codehaus.mojo:exec-maven-plugin:3.0.0:exec"), cfg.getGoals());
+                "org.codehaus.mojo:exec-maven-plugin:3.1.0:exec"), cfg.getGoals());
         
         ProjectConfigurationProvider<MavenConfiguration> pcp = p.getLookup().lookup(ProjectConfigurationProvider.class);
         MavenConfiguration c = pcp.getConfigurations().stream().filter(x -> "Micronaut: dev mode".equals(x.getDisplayName())).findAny().get();


### PR DESCRIPTION
Upgrade the maven exec plugin from 3.0.0 to 3.1.0.

NetBeans is using this specific version no matter what the project defines which confused me a bit initially when comparing the log with CLI log. I suppose this is done for compatibility reasons? 

edit: found [NETBEANS-4595](https://issues.apache.org/jira/browse/NETBEANS-4595)