### PR TITLE
globally enable maven stacktrace processing.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/output/DefaultOutputProcessorFactory.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/DefaultOutputProcessorFactory.java
@@ -33,13 +33,13 @@ import org.openide.util.lookup.ServiceProvider;
 public class DefaultOutputProcessorFactory implements ContextOutputProcessorFactory {
     
     @Override public Set<OutputProcessor> createProcessorsSet(Project project) {
-        Set<OutputProcessor> toReturn = new HashSet<OutputProcessor>();
+        Set<OutputProcessor> toReturn = new HashSet<>();
         if (project != null) {
             toReturn.add(new JavadocOutputProcessor());
             toReturn.add(new TestOutputListenerProvider());
             toReturn.add(new SiteOutputProcessor(project));
             NbMavenProjectImpl nbprj = project.getLookup().lookup(NbMavenProjectImpl.class);
-            toReturn.add(new ExecPluginOutputListenerProvider(nbprj));
+            toReturn.add(new JavaStacktraceOutputProcessor(nbprj));
             toReturn.add(new DependencyAnalyzeOutputProcessor(nbprj));
         }
         return toReturn;

--- a/java/maven/src/org/netbeans/modules/maven/output/ExecPluginOutputListenerProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/ExecPluginOutputListenerProvider.java
@@ -19,64 +19,25 @@
 package org.netbeans.modules.maven.output;
 
 import org.netbeans.modules.maven.NbMavenProjectImpl;
-import org.netbeans.modules.maven.api.output.OutputProcessor;
-import org.netbeans.modules.maven.api.output.OutputUtils;
-import org.netbeans.modules.maven.api.output.OutputVisitor;
-import org.netbeans.api.java.classpath.ClassPath;
-import org.netbeans.api.project.Project;
-import org.netbeans.modules.maven.api.classpath.ProjectSourcesClassPathProvider;
-import org.netbeans.spi.java.classpath.support.ClassPathSupport;
-import org.openide.windows.OutputListener;
-
-
 
 
 /**
  * exec plugin output processing, just handle stacktraces.
  * @author  Milos Kleint
+ * 
+ * @deprecated use JavaStacktraceOutputListenerProvider instead
  */
-public class ExecPluginOutputListenerProvider implements OutputProcessor {
-    
+public class ExecPluginOutputListenerProvider extends JavaStacktraceOutputProcessor {
+
     private static final String[] EXECGOALS = new String[] {
         "mojo-execute#exec:exec", //NOI18N
         "mojo-execute#exec:java", //NOI18N
         "mojo-execute#javafx:run" //NOI18N
     };
-    private final NbMavenProjectImpl project;
-    
+
     /** Creates a new instance of ExecPluginOutputListenerProvider */
     public ExecPluginOutputListenerProvider(NbMavenProjectImpl proj) {
-        project = proj;
-    }
-    
-    @Override
-    public void processLine(String line, OutputVisitor visitor) {
-        OutputVisitor.Context context = visitor.getContext();
-        Project prj = project;
-        if (context != null && context.getCurrentProject() != null) {
-            prj = context.getCurrentProject();
-        }
-        OutputListener list = OutputUtils.matchStackTraceLine(line, prj);
-        if (list != null) {
-            visitor.setOutputListener(list);
-        }
+        super(proj, EXECGOALS);
     }
 
-    @Override
-    public String[] getRegisteredOutputSequences() {
-        return EXECGOALS;
-    }
-
-    @Override
-    public void sequenceStart(String sequenceId, OutputVisitor visitor) {
-    }
-
-    @Override
-    public void sequenceEnd(String sequenceId, OutputVisitor visitor) {
-    }
-    
-    @Override
-    public void sequenceFail(String sequenceId, OutputVisitor visitor) {
-    }
-    
 }

--- a/java/maven/src/org/netbeans/modules/maven/output/JavaStacktraceOutputProcessor.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/JavaStacktraceOutputProcessor.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.output;
+
+import org.netbeans.modules.maven.NbMavenProjectImpl;
+import org.netbeans.modules.maven.api.output.OutputProcessor;
+import org.netbeans.modules.maven.api.output.OutputUtils;
+import org.netbeans.modules.maven.api.output.OutputVisitor;
+import org.netbeans.api.project.Project;
+import org.openide.windows.OutputListener;
+
+
+/**
+ * Provides links for stack traces in the output window.
+ * 
+ * @author mbien
+ */
+public class JavaStacktraceOutputProcessor implements OutputProcessor {
+
+    private final String[] goals;
+    private final NbMavenProjectImpl project;
+
+    /**
+     * Creates a JavaStacktraceOutputProcessor with global scope (goal: "session-execute").
+     */
+    public JavaStacktraceOutputProcessor(NbMavenProjectImpl project) {
+        this(project, new String[] { "session-execute" });
+    }
+
+    /**
+     * Creates a JavaStacktraceOutputProcessor which is only active during the given goals.
+     */
+    public JavaStacktraceOutputProcessor(NbMavenProjectImpl project, String[] goals) {
+        this.project = project;
+        this.goals = goals;
+    }
+
+    @Override
+    public void processLine(String line, OutputVisitor visitor) {
+        OutputVisitor.Context context = visitor.getContext();
+        Project prj = project;
+        if (context != null && context.getCurrentProject() != null) {
+            prj = context.getCurrentProject();
+        }
+        OutputListener list = OutputUtils.matchStackTraceLine(line, prj);
+        if (list != null) {
+            visitor.setOutputListener(list);
+        }
+    }
+
+    @Override
+    public String[] getRegisteredOutputSequences() {
+        return goals;
+    }
+
+    @Override
+    public void sequenceStart(String sequenceId, OutputVisitor visitor) {}
+
+    @Override
+    public void sequenceEnd(String sequenceId, OutputVisitor visitor) {}
+
+    @Override
+    public void sequenceFail(String sequenceId, OutputVisitor visitor) {}
+
+}


### PR DESCRIPTION
stack trace processing is currently only enabled for the exec maven plugin. This PR enables it globally.

Unfortunately this is all public API so I don't think we can simply rename `ExecPluginOutputListenerProvider` and call it a day. So I created a copy and replaced the original provider with the global variant.


![global-stacktrace-scan](https://user-images.githubusercontent.com/114367/207986077-e760f025-5e4c-4780-b43c-71d2a2bbd1df.png)

before:
imagine no links and no happy face

(don't worry this is not my pw it is a integration test)

this works best when #5099 is also applied, since it fixed some of the patterns.