### PR TITLE
Fixing project loading issues with micronaut complex project.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -186,7 +186,7 @@ class NbProjectInfoBuilder {
 
         public ValueAndType(Class type, Object value) {
             this.type = type;
-            this.value = Optional.of(value);
+            this.value = Optional.ofNullable(value);
         }
 
         public ValueAndType(Class type) {
@@ -290,7 +290,7 @@ class NbProjectInfoBuilder {
         Map<String, Object> taskProperties = new HashMap<>();
         Map<String, String> taskPropertyTypes = new HashMap<>();
         
-        Map<String, Task> taskList = project.getTasks().getAsMap();
+        Map<String, Task> taskList = new HashMap<>(project.getTasks().getAsMap());
         for (String s : taskList.keySet()) {
             Task task = taskList.get(s);
             Class taskClass = task.getClass();
@@ -307,7 +307,7 @@ class NbProjectInfoBuilder {
     private void detectTaskDependencies(NbProjectInfoModel model) {
         Map<String, Object> tasks = new HashMap<>();
         
-        Map<String, Task> taskList = project.getTasks().getAsMap();
+        Map<String, Task> taskList = new HashMap<>(project.getTasks().getAsMap());
         for (String s : taskList.keySet()) {
             Task task = taskList.get(s);
             Map<String, String> taskInfo = new HashMap<>();
@@ -684,7 +684,7 @@ class NbProjectInfoBuilder {
                     }
 
                     NamedDomainObjectContainer nc = (NamedDomainObjectContainer)value;
-                    Map<String, ?> m = nc.getAsMap();
+                    Map<String, ?> m = new HashMap<>(nc.getAsMap());
                     List<String> ss = new ArrayList<>(m.keySet());
                     propertyTypes.put(prefix + propName + COLLECTION_KEYS_MARKER, String.join(";;", ss));
                     for (String k : m.keySet()) {
@@ -1000,14 +1000,12 @@ class NbProjectInfoBuilder {
 
                             List<String> compilerArgs;
 
-                            try {
-                                compilerArgs = (List<String>) getProperty(compileTask, "options", "allCompilerArgs");
-                            } catch (Throwable ex) {
-                                try {
-                                    compilerArgs = (List<String>) getProperty(compileTask, "options", "compilerArgs");
-                                } catch (Throwable ex2) {
-                                    compilerArgs = (List<String>) getProperty(compileTask, "kotlinOptions", "freeCompilerArgs");
-                                }
+                            compilerArgs = (List<String>) getProperty(compileTask, "options", "allCompilerArgs");
+                            if (compilerArgs == null) {
+                                compilerArgs = (List<String>) getProperty(compileTask, "options", "compilerArgs");
+                            }
+                            if (compilerArgs == null) {
+                                compilerArgs = (List<String>) getProperty(compileTask, "kotlinOptions", "freeCompilerArgs");
                             }
                             model.getInfo().put(propBase + lang + "_compiler_args", new ArrayList<>(compilerArgs));
                         }


### PR DESCRIPTION
The bug that provoked the investigation was
```
java.lang.NullPointerException
    at java.base/java.util.ArrayList.(ArrayList.java:179)
    at org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.detectSources(NbProjectInfoBuilder.java:1012)
    at org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.lambda$runAndRegisterPerf$9(NbProjectInfoBuilder.java:408)
    at org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.runAndRegisterPerf(NbProjectInfoBuilder.java:414)
    at org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.runAndRegisterPerf(NbProjectInfoBuilder.java:408)
    at org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.buildAll(NbProjectInfoBuilder.java:211)
    at org.netbeans.modules.gradle.tooling.NetBeansToolingPlugin$NetBeansToolingModelBuilder.buildAll(NetBeansToolingPlugin.java:71)
```
that was thrown when the project contained `kotlin` sources. The bug was introduced by a change in `getProperty` that stopped throwing exceptions on an unknown property, and started to return `null` instead. The PR just adapts the `detectSource` code to the new error reporting style.

During testing, I've noticed some other bad behaviour I have not seen before on certain projects:
- the task Map is not cloned on return by Gradle (it seems), so I've got a ConcurrentModificationException - apparently some of the looped-over calls lazy-populated the collection
- `null` default property value was not handled well (changed to `Optional.ofNullable`).