### PR TITLE
Prevent AOBE on empty, bad class files.

### DIFF
--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBClassReader.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBClassReader.java
@@ -88,23 +88,25 @@ public class NBClassReader extends ClassReader {
                 JavaFileObject origFile = c.classfile;
                 try (InputStream in = origFile.openInputStream()) {
                     byte[] data = readFile(in);
-                    int major = (Byte.toUnsignedInt(data[6]) << 8) + Byte.toUnsignedInt(data[7]);
-                    int maxMajor = ClassFile.Version.MAX().major;
-                    if (maxMajor < major) {
-                        if (log.currentSourceFile() != null) {
-                            log.warning(0, Warnings.BigMajorVersion(origFile, major, maxMajor));
-                        }
-                        data[6] = (byte) (maxMajor >> 8);
-                        data[7] = (byte) (maxMajor & 0xFF);
-                        byte[] dataFin = data;
-                        c.classfile = new ForwardingJavaFileObject(origFile) {
-                            @Override
-                            public InputStream openInputStream() throws IOException {
-                                return new ByteArrayInputStream(dataFin);
+                    if (data.length > 8) {
+                        int major = (Byte.toUnsignedInt(data[6]) << 8) + Byte.toUnsignedInt(data[7]);
+                        int maxMajor = ClassFile.Version.MAX().major;
+                        if (maxMajor < major) {
+                            if (log.currentSourceFile() != null) {
+                                log.warning(0, Warnings.BigMajorVersion(origFile, major, maxMajor));
                             }
-                        };
-                        super.readClassFile(c);
-                        return ;
+                            data[6] = (byte) (maxMajor >> 8);
+                            data[7] = (byte) (maxMajor & 0xFF);
+                            byte[] dataFin = data;
+                            c.classfile = new ForwardingJavaFileObject(origFile) {
+                                @Override
+                                public InputStream openInputStream() throws IOException {
+                                    return new ByteArrayInputStream(dataFin);
+                                }
+                            };
+                            super.readClassFile(c);
+                            return ;
+                        }
                     }
                 } catch (IOException ex) {
                     Logger.getLogger(NBClassReader.class.getName()).log(Level.FINE, null, ex);


### PR DESCRIPTION
Today NetBeans greeted me with the following Exception:

```
java.lang.ArrayIndexOutOfBoundsException: Index 6 out of bounds for length 0
	at org.netbeans.lib.nbjavac.services.NBClassReader.readClassFile(NBClassReader.java:91)
	at com.sun.tools.javac.code.ClassFinder.fillIn(ClassFinder.java:374)
	at com.sun.tools.javac.code.ClassFinder.complete(ClassFinder.java:303)
	at org.netbeans.lib.nbjavac.services.NBClassFinder.lambda$getCompleter$1(NBClassFinder.java:95)
	at com.sun.tools.javac.code.Symbol.complete(Symbol.java:682)
	at com.sun.tools.javac.code.Symbol$ClassSymbol.complete(Symbol.java:1410)
	at com.sun.tools.javac.code.ClassFinder.loadClass(ClassFinder.java:447)
...
```

This one is a trivial fix, not to try to get the class version if the class file is actually empty. Could happen in some cases (e.g. a laptop lose power while sleeping for too long.)