### PR TITLE
move webcommon job to JDK 11 and fix tests where needed.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1591,7 +1591,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '11' ]
     steps:
 
       - name: Set up JDK ${{ matrix.java }}

--- a/webcommon/javascript2.jsdoc/test/unit/src/org/netbeans/modules/javascript2/jsdoc/JsDocCodeCompletionTest.java
+++ b/webcommon/javascript2.jsdoc/test/unit/src/org/netbeans/modules/javascript2/jsdoc/JsDocCodeCompletionTest.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import org.netbeans.modules.javascript2.editor.*;
-import org.openide.filesystems.FileUtil;
 
 /**
  *
@@ -49,7 +48,7 @@ public class JsDocCodeCompletionTest extends JsCodeCompletionBase {
         // this breaks our assumption, that we can prepare the JS on-the-fly in the
         // build directory. This redirects the resolution of the reference files
         // to the build directory (they are also copied on test begin)
-        return FileUtil.toFile(getTestFile(relFilePath));
+        return new File(getDataDir(), relFilePath);
     }
 
     public void testAllCompletion() throws Exception {


### PR DESCRIPTION
only a single test failed:
`JsDocCodeCompletionTest` can't use `getTestFile()` in overwritten method since the method fails the test if the file does not exist. The Test file logic in `CslTestBase::assertDescriptionMatches` has to be able to call `exists()` on a potentially not existing file when it is trying to find JDK version specific (golden) test files.

everything else in this job should be ready for 11.

meta issue: #4904