### PR TITLE
move ide modules job to JDK 11 and fix tests where needed.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -345,7 +345,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '11' ]
     steps:
 
       - name: Set up JDK ${{ matrix.java }}

--- a/ide/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DateTypeTest.java
+++ b/ide/db.dataview/test/unit/src/org/netbeans/modules/db/dataview/util/DateTypeTest.java
@@ -21,10 +21,7 @@ package org.netbeans.modules.db.dataview.util;
 
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.util.Locale;
 import java.util.TimeZone;
 import org.netbeans.junit.NbTestCase;
 
@@ -33,7 +30,6 @@ import org.netbeans.junit.NbTestCase;
  * @author navaneeth
  */
 public class DateTypeTest extends NbTestCase {
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
     private long now = System.currentTimeMillis();
     private long expectedMillis = 0l;
     private DateType type = null;
@@ -105,21 +101,6 @@ public class DateTypeTest extends NbTestCase {
 
         Date expectedDate = new Date(GMT_2002_0801 - TimeZone.getDefault().getOffset(GMT_2002_0801));
         assertEquals("Should accept", expectedDate, DateType.convert("2002-08-01"));
-
-        // August 1, 2002 12:00 PM CDT
-        expectedDate = new Date(expectedDate.getTime() + 12 * 60 * 60 * 1000L // time (daylight
-                // savings)
-                );
-        DateFormat fmt = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG,
-                Locale.UK);
-        fmt.setTimeZone(TimeZone.getDefault());
-        assertEquals("Make sure 'expected' is as expected",
-                "01 August 2002 12:00:00 "
-                + TimeZone.getDefault().getDisplayName(true, TimeZone.SHORT, Locale.UK),
-                fmt.format(expectedDate));
-
-        String toConvert = DATE_FORMAT.format(expectedDate);
-        assertEquals("Check format", "2002-08-01", toConvert);
 
         String tExpected = "2002-08-01";
         String converted = DateType.convert(tExpected).toString();

--- a/ide/schema2beans/test/unit/data/TestContrivedApp.java
+++ b/ide/schema2beans/test/unit/data/TestContrivedApp.java
@@ -66,7 +66,7 @@ public class TestContrivedApp extends BaseTest {
         out("bean graph created");
 	
         out(app);
-        Module module = app.getModule();
+        application.Module module = app.getModule();
         out("module.myaltDd = "+module.getMyAltDd());
         out("Make sure XML metacharacters get escapped");
         module.setMyAltDd("Foo & Co");

--- a/ide/schema2beans/test/unit/src/tests/MainTest.java
+++ b/ide/schema2beans/test/unit/src/tests/MainTest.java
@@ -21,7 +21,6 @@ package tests;
 import java.io.*;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import junit.framework.*;
 import org.netbeans.junit.*;
 
 import org.netbeans.modules.schema2beans.*;
@@ -481,6 +480,7 @@ public class MainTest extends NbTestCase {
     //protected File dataDir;
     protected String theClassPath = "";
     
+    @Override
     protected void setUp() {
         // when running this code inside IDE, getResource method returns URL in NBFS
         // format, so we need to convert it to filename
@@ -517,6 +517,7 @@ public class MainTest extends NbTestCase {
         }
     }
     
+    @Override
     protected void tearDown() {
         compareReferenceFiles();
     }
@@ -524,6 +525,7 @@ public class MainTest extends NbTestCase {
     // XXX: temporarily overriding compareReferenceFiles() to dump differences as
     // I do not know what problem there is on javaee continual tester as there is
     // no access to diff files
+    @Override
     public void compareReferenceFiles(String testFilename, String goldenFilename, String diffFilename) {
         try {
             File goldenFile = getGoldenFile(goldenFilename);
@@ -535,10 +537,10 @@ public class MainTest extends NbTestCase {
                 message += "; check "+diffFile;
             }
             try {
-            assertFile(message, testFile, goldenFile, diffFile);
+                assertFile(message, testFile, goldenFile, diffFile);
             } catch (AssertionFileFailedError e) {
                 BufferedReader diffFileReader = new BufferedReader(new FileReader(diffFile));
-                StringBuffer diff = new StringBuffer();
+                StringBuilder diff = new StringBuilder();
                 try {
                     String ss = diffFileReader.readLine();
                     while (ss != null) {
@@ -558,20 +560,20 @@ public class MainTest extends NbTestCase {
 
 
     public void ref(File f) throws IOException {
-        Reader r = new FileReader(f);
-        char buf[] = new char[1024];
-        StringBuffer s = new StringBuffer();
-        int len;
-        while ((len = r.read(buf, 0, 1024)) > 0) {
-            s.append(buf, 0, len);
+        try (Reader r = new FileReader(f)) {
+            char buf[] = new char[1024];
+            StringBuilder s = new StringBuilder();
+            int len;
+            while ((len = r.read(buf, 0, 1024)) > 0) {
+                s.append(buf, 0, len);
+            }
+            ref(s.toString());
         }
-        r.close();
-        ref(s.toString());
     }
     
     private String getJdkHome(){
-        if (Utilities.isMac())
-            return System.getProperty("java.home") + File.separator + "bin" + File.separator;
+        if (Utilities.isMac() || System.getProperty("java.version").startsWith("1.") == false)
+            return System.getProperty("java.home") + File.separator + "bin" + File.separator;  // mac or JDK 9+
         else
             return System.getProperty("java.home") + File.separator + ".." + File.separator + "bin" + File.separator;
 

--- a/ide/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/WSDLSchemaValidatorTest.java
+++ b/ide/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/validator/WSDLSchemaValidatorTest.java
@@ -35,6 +35,7 @@ import org.netbeans.modules.xml.wsdl.model.WSDLModelFactory;
 import org.netbeans.modules.xml.xam.ModelSource;
 import org.netbeans.modules.xml.xam.spi.Validation;
 import org.netbeans.modules.xml.xam.spi.ValidationResult;
+import org.netbeans.modules.xml.xam.spi.Validator;
 
 /**
  *
@@ -167,7 +168,13 @@ public class WSDLSchemaValidatorTest extends TestCase {
         assertNotNull(vr.getValidationResult());
         
         ValidationHelper.dumpErrors(vr);
-        assertTrue("expect error " + expectedErrorCount,  vr.getValidationResult().size() == expectedErrorCount);
+        
+        // some missing element errors appear twice on newer JDKs
+        int uniqueErrors = (int) vr.getValidationResult().stream()
+                .map(Validator.ResultItem::getDescription)
+                .distinct().count();
+
+        assertTrue("expect error " + expectedErrorCount,  uniqueErrors == expectedErrorCount);
      }
      
      


### PR DESCRIPTION
 - don't test JDK APIs, lets assume that they work.
 - JDK 11 fixes: javac path and java.lang.Module classname conflict.
 - fix WSDLSchemaValidatorTest assertion, some xml validation errors seem to appear twice on newer JDKs.

meta issue: #4904