### PR TITLE
CssSemanticAnalyser needs to flatten OffsetRanges for highlights 

### DIFF
--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -1647,16 +1647,18 @@ public abstract class CslTestBase extends NbTestCase {
 
     protected void checkNoOverlaps(Set<OffsetRange> ranges, Document doc) throws BadLocationException {
         // Make sure there are no overlapping ranges
-        List<OffsetRange> sortedRanges = new ArrayList<OffsetRange>(ranges);
+        List<OffsetRange> sortedRanges = new ArrayList<>(ranges);
         Collections.sort(sortedRanges);
-        OffsetRange prevRange = OffsetRange.NONE;
-        for (OffsetRange range : sortedRanges) {
-            if (range.getStart() < prevRange.getEnd() && range.getEnd() > prevRange.getEnd()) {
-                fail("OffsetRanges should be non-overlapping! " + prevRange +
-                        "(" + doc.getText(prevRange.getStart(), prevRange.getLength()) + ") and " + range +
-                        "(" + doc.getText(range.getStart(), range.getLength()) + ")");
+        for (int i = 0; i < sortedRanges.size(); i++) {
+            OffsetRange prevRange = sortedRanges.get(i);
+            for (int j = i + 1; j < sortedRanges.size(); j++) {
+                OffsetRange targetRange = sortedRanges.get(j);
+                if (prevRange.overlaps(targetRange)) {
+                    fail("OffsetRanges should be non-overlapping! " + prevRange
+                            + "(" + doc.getText(prevRange.getStart(), prevRange.getLength()) + ") and " + targetRange
+                            + "(" + doc.getText(targetRange.getStart(), targetRange.getLength()) + ")");
+                }
             }
-            prevRange = range;
         }
     }
 

--- a/ide/css.editor/test/unit/data/testfiles/coloring1.css
+++ b/ide/css.editor/test/unit/data/testfiles/coloring1.css
@@ -1,0 +1,6 @@
+[type="checkbox"]:nth-child(2n),
+[type="checkbox"]:not([hidden]),
+[type="checkbox"]:not(.active),
+[type="checkbox"]:not(:checked),
+[type="checkbox"]:checked {
+}

--- a/ide/css.editor/test/unit/data/testfiles/coloring1.css.semantic
+++ b/ide/css.editor/test/unit/data/testfiles/coloring1.css.semantic
@@ -1,0 +1,6 @@
+[|>CUSTOM1:type<|="checkbox"]|>CLASS::nth-child(2n)<|,
+[|>CUSTOM1:type<|="checkbox"]|>CLASS::not([|>CUSTOM1:<|hidden|>CLASS:<|])<|,
+[|>CUSTOM1:type<|="checkbox"]|>CLASS::not(|>METHOD:<|.active|>CLASS:<|)<|,
+[|>CUSTOM1:type<|="checkbox"]|>CLASS::not(|>CLASS:<|:checked|>CLASS:<|)<|,
+[|>CUSTOM1:type<|="checkbox"]|>CLASS::checked<| {
+}

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssSemanticAnalyzerTest.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssSemanticAnalyzerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.css.editor.csl;
+
+import org.netbeans.modules.css.editor.module.main.CssModuleTestBase;
+import org.netbeans.modules.css.lib.api.CssParserResult;
+
+public class CssSemanticAnalyzerTest extends CssModuleTestBase {
+
+    public CssSemanticAnalyzerTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        CssParserResult.IN_UNIT_TESTS = true;
+    }
+
+    public void testColoring1() throws Exception {
+        checkSemantic("testfiles/coloring1.css");
+    }
+}


### PR DESCRIPTION
CssSemanticAnalyser reported overlapping ranges for highlights, for
example when an attribute is used in a :not() pseudo class construct.

The formatting behind the embedded range is lost and results in a
broken view.

The embedded OffsetRanges need to be flattened into a sequenze of
non-overlapping ranges.