### PR TITLE
Fix missing ICON_RESOURCE in git tag actions

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/ui/tag/CreateTagAction.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/tag/CreateTagAction.java
@@ -48,6 +48,16 @@ import org.openide.util.NbBundle;
 public class CreateTagAction extends SingleRepositoryAction {
 
     private static final Logger LOG = Logger.getLogger(CreateTagAction.class.getName());
+    private static final String ICON_RESOURCE = "org/netbeans/modules/git/resources/icons/tag.png"; //NOI18N
+
+    public CreateTagAction() {
+        super(ICON_RESOURCE);
+    }
+
+    @Override
+    protected String iconResource() {
+        return ICON_RESOURCE;
+    }
 
     @Override
     protected void performAction (File repository, File[] roots, VCSContext context) {

--- a/ide/git/src/org/netbeans/modules/git/ui/tag/ManageTagsAction.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/tag/ManageTagsAction.java
@@ -47,6 +47,16 @@ import org.openide.util.NbBundle;
 public class ManageTagsAction extends SingleRepositoryAction {
 
     private static final Logger LOG = Logger.getLogger(ManageTagsAction.class.getName());
+    private static final String ICON_RESOURCE = "org/netbeans/modules/git/resources/icons/tags.png"; //NOI18N
+
+    public ManageTagsAction() {
+        super(ICON_RESOURCE);
+    }
+
+    @Override
+    protected String iconResource() {
+        return ICON_RESOURCE;
+    }
 
     @Override
     protected void performAction (File repository, File[] roots, VCSContext context) {


### PR DESCRIPTION
This PR adds missing IMAGE_RESOURCE in actions related to git tag operations. Because of the missing IMAGE_RESOURCES the toolbar configuration tool couldn't find them.

Fixes #4914
