### PR TITLE
Locate sources JAR if it is next to binary JAR

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/classpath/SourceNextToBinaryQueryImpl.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/classpath/SourceNextToBinaryQueryImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.source.classpath;
+
+import java.net.URL;
+import javax.swing.event.ChangeListener;
+import org.netbeans.api.java.queries.SourceForBinaryQuery;
+import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation;
+import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation2;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
+import org.openide.util.lookup.ServiceProvider;
+
+@ServiceProvider(service = SourceForBinaryQueryImplementation.class, position = 100000)
+public final class SourceNextToBinaryQueryImpl implements SourceForBinaryQueryImplementation {
+    @Override
+    public SourceForBinaryQuery.Result findSourceRoots(URL binaryRoot) {
+        URL file = FileUtil.getArchiveFile(binaryRoot);
+        if (file != null) {
+            FileObject fo = URLMapper.findFileObject(file);
+            if (fo != null) {
+                FileObject src = fo.getParent().getFileObject(fo.getName() + "-sources", fo.getExt());
+                if (src != null) {
+                    return new SourceForBinaryQueryImplementation2.Result() {
+                        @Override
+                        public boolean preferSources() {
+                            return false;
+                        }
+
+                        @Override
+                        public FileObject[] getRoots() {
+                            return new FileObject[]{FileUtil.getArchiveRoot(src)};
+                        }
+
+                        @Override
+                        public void addChangeListener(ChangeListener l) {
+                        }
+
+                        @Override
+                        public void removeChangeListener(ChangeListener l) {
+                        }
+                    };
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/classpath/SourceNextToBinaryQueryImplTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/classpath/SourceNextToBinaryQueryImplTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.source.classpath;
+
+import java.net.URL;
+import org.netbeans.api.java.queries.SourceForBinaryQuery;
+import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
+
+public final class SourceNextToBinaryQueryImplTest extends NbTestCase {
+    public SourceNextToBinaryQueryImplTest(String n) {
+        super(n);
+    }
+
+    public void testFindSourceNextToBinary() throws Exception {
+        clearWorkDir();
+        FileObject root = FileUtil.toFileObject(getWorkDir());
+        assertNotNull("Root for testing found", root);
+        FileObject dir = root.createFolder("testFolder");
+        FileObject jar = dir.createData("junit-4.12", "jar");
+        FileObject src = dir.createData("junit-4.12-sources", "jar");
+
+        URL jarRoot = FileUtil.getArchiveRoot(URLMapper.findURL(jar, URLMapper.INTERNAL));
+        SourceNextToBinaryQueryImpl instance = new SourceNextToBinaryQueryImpl();
+        SourceForBinaryQuery.Result result = instance.findSourceRoots(jarRoot);
+        assertNotNull("result is found", result);
+        assertEquals("ONe root", 1, result.getRoots().length);
+        FileObject found = FileUtil.getArchiveFile(result.getRoots()[0]);
+        assertEquals("The right source file found", src, found);
+    }
+}


### PR DESCRIPTION
A year ago I was working on a project that integrates [JavaScript, JVM & etc. into Oracle DB](https://labs.oracle.com/pls/apex/f?p=LABS:project_details:0:15). Most of the colleagues were using Eclipse or IntelliJ, but I was very happy with NetBeans VSCode extension (btw. I needed needed VSCode remote development as the machine with all the sources was over ssh across the Atlantic ocean).

Things were working OK, but over the pair programming with colleagues I realized that NetBeans lacks better integration with sources. When their IDEs could jump to a source code, my just disassembled the `.class` file!

After a while I realized that the project is carefully structured and next to each JAR there is also `-sources.jar` and the other IDEs are able to pick it up. Just NetBeans was missing such functionality. This PR is my attempt to add it. I am putting this functionality next to _classpath_ support - e.g. not associated with any project as it is a general behavior not related to Maven or Gradle or etc. I am associating late `position` with the `@ServiceRegistration` so other registered mechanisms take precedence and this is used just as a fallback.

Btw. Right now I am [working with a project](https://github.com/enso-org/enso) that uses [Scala build tool](https://www.scala-sbt.org/) to assemble Scala and Java sources. It also uses the same convention! There is `$HOME/.cache/coursier/v1/https/repo1.maven.org/maven2/org/openjdk/jmh/jmh-core/1.35/jmh-core-1.35.jar` and next to it `$HOME/.cache/coursier/v1/https/repo1.maven.org/maven2/org/openjdk/jmh/jmh-core/1.35/jmh-core-1.35-sources.jar` - looks like this is a well known convention that is beneficial to support!
