### PR TITLE
Recognize nbjrt: protocol and locate JDK9+ src.zip

### DIFF
--- a/java/java.platform/src/org/netbeans/modules/java/platform/queries/PlatformSourceForBinaryQuery.java
+++ b/java/java.platform/src/org/netbeans/modules/java/platform/queries/PlatformSourceForBinaryQuery.java
@@ -97,43 +97,43 @@ public class PlatformSourceForBinaryQuery implements SourceForBinaryQueryImpleme
         return searchUnregisteredPlatform(binaryRoot.toExternalForm());
     }
 
-  static SourceForBinaryQueryImplementation2.Result searchUnregisteredPlatform(String binaryRootS) {
-    String srcZipS = null;
-    String srcZipIn = null;
-    if (binaryRootS.startsWith(JAR_FILE)) {
-      if (binaryRootS.endsWith(RTJAR_PATH)) {
-        //Unregistered platform
-        srcZipS = binaryRootS.substring(4,binaryRootS.length() - RTJAR_PATH.length()) + SRC_ZIP;
-      }
-    } else if (binaryRootS.startsWith("nbjrt:")) {
-      int end = binaryRootS.indexOf('!');
-      if (end >= 0) {
-        srcZipS = binaryRootS.substring(6, end) + "lib/" + SRC_ZIP;
-        String reminder = binaryRootS.substring(end + 1);
-        final String prefix = "/modules/";
-        if (reminder.startsWith(prefix)) {
-          srcZipIn = reminder.substring(prefix.length());
+    static SourceForBinaryQueryImplementation2.Result searchUnregisteredPlatform(String binaryRootS) {
+        String srcZipS = null;
+        String srcZipIn = null;
+        if (binaryRootS.startsWith(JAR_FILE)) {
+            if (binaryRootS.endsWith(RTJAR_PATH)) {
+                //Unregistered platform
+                srcZipS = binaryRootS.substring(4, binaryRootS.length() - RTJAR_PATH.length()) + SRC_ZIP;
+            }
+        } else if (binaryRootS.startsWith("nbjrt:")) {
+            int end = binaryRootS.indexOf('!');
+            if (end >= 0) {
+                srcZipS = binaryRootS.substring(6, end) + "lib/" + SRC_ZIP;
+                String reminder = binaryRootS.substring(end + 1);
+                final String prefix = "/modules/";
+                if (reminder.startsWith(prefix)) {
+                    srcZipIn = reminder.substring(prefix.length());
+                }
+            }
         }
-      }
-    }
-    if (srcZipS != null) {
-      try {
-        URL srcZip = FileUtil.getArchiveRoot(new URL(srcZipS));
-        FileObject fo = URLMapper.findFileObject(srcZip);
-        if (fo != null) {
-          if (srcZipIn != null) {
-            fo = fo.getFileObject(srcZipIn);
-          }
-          if (fo != null) {
-            return new UnregisteredPlatformResult (fo);
-          }
+        if (srcZipS != null) {
+            try {
+                URL srcZip = FileUtil.getArchiveRoot(new URL(srcZipS));
+                FileObject fo = URLMapper.findFileObject(srcZip);
+                if (fo != null) {
+                    if (srcZipIn != null) {
+                        fo = fo.getFileObject(srcZipIn);
+                    }
+                    if (fo != null) {
+                        return new UnregisteredPlatformResult(fo);
+                    }
+                }
+            } catch (MalformedURLException mue) {
+                Exceptions.printStackTrace(mue);
+            }
         }
-      } catch (MalformedURLException mue) {
-        Exceptions.printStackTrace(mue);
-      }
+        return null;
     }
-    return null;
-  }
 
     @Override
     public SourceForBinaryQuery.Result findSourceRoots (URL binaryRoot) {

--- a/java/java.platform/src/org/netbeans/modules/java/platform/queries/PlatformSourceForBinaryQuery.java
+++ b/java/java.platform/src/org/netbeans/modules/java/platform/queries/PlatformSourceForBinaryQuery.java
@@ -94,24 +94,46 @@ public class PlatformSourceForBinaryQuery implements SourceForBinaryQueryImpleme
             this.cache.put (binaryRoot, res);
             return res;
         }
-        String binaryRootS = binaryRoot.toExternalForm();
-        if (binaryRootS.startsWith(JAR_FILE)) {
-            if (binaryRootS.endsWith(RTJAR_PATH)) {
-                //Unregistered platform
-                String srcZipS = binaryRootS.substring(4,binaryRootS.length() - RTJAR_PATH.length()) + SRC_ZIP;
-                try {
-                    URL srcZip = FileUtil.getArchiveRoot(new URL(srcZipS));
-                    FileObject fo = URLMapper.findFileObject(srcZip);
-                    if (fo != null) {
-                        return new UnregisteredPlatformResult (fo);
-                    }
-                } catch (MalformedURLException mue) {
-                    Exceptions.printStackTrace(mue);
-                }
-            }
-        }
-        return null;
+        return searchUnregisteredPlatform(binaryRoot.toExternalForm());
     }
+
+  static SourceForBinaryQueryImplementation2.Result searchUnregisteredPlatform(String binaryRootS) {
+    String srcZipS = null;
+    String srcZipIn = null;
+    if (binaryRootS.startsWith(JAR_FILE)) {
+      if (binaryRootS.endsWith(RTJAR_PATH)) {
+        //Unregistered platform
+        srcZipS = binaryRootS.substring(4,binaryRootS.length() - RTJAR_PATH.length()) + SRC_ZIP;
+      }
+    } else if (binaryRootS.startsWith("nbjrt:")) {
+      int end = binaryRootS.indexOf('!');
+      if (end >= 0) {
+        srcZipS = binaryRootS.substring(6, end) + "lib/" + SRC_ZIP;
+        String reminder = binaryRootS.substring(end + 1);
+        final String prefix = "/modules/";
+        if (reminder.startsWith(prefix)) {
+          srcZipIn = reminder.substring(prefix.length());
+        }
+      }
+    }
+    if (srcZipS != null) {
+      try {
+        URL srcZip = FileUtil.getArchiveRoot(new URL(srcZipS));
+        FileObject fo = URLMapper.findFileObject(srcZip);
+        if (fo != null) {
+          if (srcZipIn != null) {
+            fo = fo.getFileObject(srcZipIn);
+          }
+          if (fo != null) {
+            return new UnregisteredPlatformResult (fo);
+          }
+        }
+      } catch (MalformedURLException mue) {
+        Exceptions.printStackTrace(mue);
+      }
+    }
+    return null;
+  }
 
     @Override
     public SourceForBinaryQuery.Result findSourceRoots (URL binaryRoot) {


### PR DESCRIPTION
The `PlatformForSourceBinaryQuery` class contains support for so called _"unregistered platforms"_. However it seems that the code hasn't been updated to JDK9+ layout. This PR does that. The previously existing test (for JDK8 layout) has been copied and modified to mimic the layout of JDK9+.