### PR TITLE
tomcat5: Enable usage of javac release and remove internal class use (fix JDK8 and JDK17+)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1896,6 +1896,9 @@ jobs:
       - name: spring.webmvc
         run: ant $OPTS -f enterprise/spring.webmvc test
 
+      - name: tomcat5
+        run: ant $OPTS -f enterprise/tomcat5 test
+
       - name: websvc.editor.hints
         run: ant $OPTS -f enterprise/websvc.editor.hints test
 

--- a/enterprise/tomcat5/nbproject/project.properties
+++ b/enterprise/tomcat5/nbproject/project.properties
@@ -17,7 +17,6 @@
 
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-bootclasspath.prepend=${build.dir}/disable-release
 javahelp.base=org/netbeans/modules/tomcat5/docs
 javahelp.hs=tomcat.hs
 

--- a/enterprise/tomcat5/nbproject/project.xml
+++ b/enterprise/tomcat5/nbproject/project.xml
@@ -96,6 +96,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.libs.xerces</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.57</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.db</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -313,7 +322,9 @@
                     <code-name-base>org.openide.loaders</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
-                    <run-dependency><specification-version>7.61</specification-version></run-dependency>
+                    <run-dependency>
+                        <specification-version>7.61</specification-version>
+                    </run-dependency>
                 </dependency>
                 <dependency>
                     <code-name-base>org.openide.modules</code-name-base>
@@ -340,14 +351,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.openide.util.ui</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>9.3</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.openide.util</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -361,6 +364,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>8.0</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.3</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/config/TomcatModuleConfiguration.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/config/TomcatModuleConfiguration.java
@@ -744,7 +744,7 @@ public class TomcatModuleConfiguration implements ModuleConfiguration, ContextRo
 
         // create a resource link to the global resource
         modifyContext( (Context ctx) -> {
-            int idx = context.addResourceLink(true);
+            int idx = ctx.addResourceLink(true);
             ctx.setResourceLinkName(idx, referenceName);
             ctx.setResourceLinkGlobal(idx, jndiName);
             ctx.setResourceLinkType(idx, "javax.sql.DataSource"); // NOI18N

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManagerImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManagerImpl.java
@@ -333,10 +333,10 @@ public class TomcatManagerImpl implements ProgressObject, Runnable {
             }
             StringBuilder result = new StringBuilder();
             while (st.hasMoreTokens()) {
-                result.append("/").append(URLEncoder.encode(st.nextToken(), StandardCharsets.UTF_8)); // NOI18N
+                result.append("/").append(URLEncoder.encode(st.nextToken(), StandardCharsets.UTF_8.name()));
             }
             return result.toString();
-        } catch (Exception e) {
+        } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e); // this should never happen
         }
     }
@@ -358,7 +358,7 @@ public class TomcatManagerImpl implements ProgressObject, Runnable {
         }
         // http://www.netbeans.org/issues/show_bug.cgi?id=167139
         URL url = tmpContextXml.toURI().toURL();
-        String ret = URLEncoder.encode(url.toString(), StandardCharsets.UTF_8); // NOI18N
+        String ret = URLEncoder.encode(url.toString(), StandardCharsets.UTF_8.name());
         return ret;
     }
     

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatInstallUtil.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatInstallUtil.java
@@ -25,12 +25,12 @@
 
 package org.netbeans.modules.tomcat5.util;
 
-import com.sun.org.apache.xml.internal.serialize.OutputFormat;
-import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
 import java.io.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.text.BadLocationException;
+import org.apache.xml.serialize.OutputFormat;
+import org.apache.xml.serialize.XMLSerializer;
 import org.netbeans.modules.tomcat5.config.gen.Engine;
 import org.netbeans.modules.tomcat5.config.gen.Host;
 import org.netbeans.modules.tomcat5.config.gen.Server;


### PR DESCRIPTION
The tomcat5 module used the internal classes:

com.sun.org.apache.xml.internal.serialize.OutputFormat
com.sun.org.apache.xml.internal.serialize.XMLSerializer

to modify the tomcat configuration. For this to work the usage of the
javac release option had to be disabled as only exported classes are
then accessible. This is done by specifying bootclasspath.prepend.

Having this masked a different issue which rendered the tomcat module
JDK 9+. The method:

URLEncoder#encode(String s, Charset enc)

was used, which was introduced with JDK9. The alternative

URLEncoder#encode(String s, String enc)

can be used as a drop-in replacement.

Closes: https://github.com/apache/netbeans/issues/5134
Closes: https://github.com/apache/netbeans/issues/5154