### PR TITLE
Linux launcher: Auto-detect subpixel text rendering mode on KDE

### DIFF
--- a/harness/apisupport.harness/release/launchers/app.sh
+++ b/harness/apisupport.harness/release/launchers/app.sh
@@ -159,8 +159,24 @@ case "`uname`" in
 
        # See longer comments in nb/ide.launcher/unix/netbeans.
        if [ ! -z "$KDE_FULL_SESSION" ] ; then
-           echo "Detected KDE; adding awt.useSystemAAFontSettings=on"
-           extra_automatic_options="-J-Dawt.useSystemAAFontSettings=on"
+           case "`command xrdb -query 2> /dev/null | grep Xft.rgba | cut -d ':' -f2 | xargs`" in
+               rgb)
+                   extra_automatic_options="-J-Dawt.useSystemAAFontSettings=lcd_hrgb"
+                   ;;
+               bgr)
+                   extra_automatic_options="-J-Dawt.useSystemAAFontSettings=lcd_hbgr"
+                   ;;
+               vrgb)
+                   extra_automatic_options="-J-Dawt.useSystemAAFontSettings=lcd_vrgb"
+                   ;;
+               vbgr)
+                   extra_automatic_options="-J-Dawt.useSystemAAFontSettings=lcd_vbgr"
+                   ;;
+               *)
+                   extra_automatic_options="-J-Dawt.useSystemAAFontSettings=on"
+                   ;;
+           esac
+           echo "Detected KDE; use explicit setting for font antialiasing ($extra_automatic_options)"
        fi
 
        # Add extra_automatic_options before default_options, to allow system

--- a/nb/ide.launcher/unix/netbeans
+++ b/nb/ide.launcher/unix/netbeans
@@ -206,8 +206,8 @@ case "`uname`" in
         extra_automatic_options=""
 
         # Java/AWT/Swing will correctly detect text anti-aliasing settings on
-        # GNOME, but not on KDE. Force anti-aliasing on in this case using the
-        # "awt.useSystemAAFontSettings" property, as recommended in
+        # GNOME, but not (always) on KDE. Force anti-aliasing on in this case
+        # using the "awt.useSystemAAFontSettings" property, as recommended in
         # https://bugs.openjdk.java.net/browse/JDK-6408759 . Said bug is old,
         # but the relevant logic (in sun.awt.X11.XToolkit.initXSettingsIfNeeded ,
         # and fontpath.c ) seems not to have changed significantly since then.
@@ -222,8 +222,29 @@ case "`uname`" in
         # information."
         # https://userbase.kde.org/KDE_System_Administration/Environment_Variables
         if [ ! -z "$KDE_FULL_SESSION" ] ; then
-            echo "Detected KDE; adding awt.useSystemAAFontSettings=on"
-            extra_automatic_options="-J-Dawt.useSystemAAFontSettings=on"
+            # Try to detect the correct subpixel antialiasing mode
+            # (https://github.com/apache/netbeans/issues/4228)
+
+            # See https://docs.gtk.org/gtk4/property.Settings.gtk-xft-rgba.html
+            # See https://docs.oracle.com/javase/7/docs/technotes/guides/2d/flags.html#aaFonts
+            case "`command xrdb -query 2> /dev/null | grep Xft.rgba | cut -d ':' -f2 | xargs`" in
+                rgb)
+                    extra_automatic_options="-J-Dawt.useSystemAAFontSettings=lcd_hrgb"
+                    ;;
+                bgr)
+                    extra_automatic_options="-J-Dawt.useSystemAAFontSettings=lcd_hbgr"
+                    ;;
+                vrgb)
+                    extra_automatic_options="-J-Dawt.useSystemAAFontSettings=lcd_vrgb"
+                    ;;
+                vbgr)
+                    extra_automatic_options="-J-Dawt.useSystemAAFontSettings=lcd_vbgr"
+                    ;;
+                *)
+                    extra_automatic_options="-J-Dawt.useSystemAAFontSettings=on"
+                    ;;
+            esac
+            echo "Detected KDE; use explicit setting for font antialiasing ($extra_automatic_options)"
         fi
 
         # Add extra_automatic_options before default_options, to allow system


### PR DESCRIPTION
In a previous PR (https://github.com/apache/netbeans/pull/3113), the Linux launcher was modified to fix missing font anti-aliasing on some KDE installations. This enabled greyscale anti-aliasing only, however, including on KDE installations where subpixel antialiasing was previously seen to be working. See https://github.com/apache/netbeans/issues/4228 .

This PR further enhances the auto-configuration on KDE by taking the subpixel antialiasing setting from the Xft.rgba GTK setting where available, as suggested by [NickLion](https://github.com/NickLion) in the GitHub issue above.

Tested on KDE Plasma on Ubuntu 18.04.01 in VirtualBox (triggers the awt.useSystemAAFontSettings=lcd_hrgb setting), as well as in Gnome (confirming no change in behavior here). Confirmed visually that subpixel rendering got activated in both cases (and that it was previously not enabled on KDE).