### PR TITLE
move enterprise modules job to JDK 11 and fix tests where needed.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1868,7 +1868,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '11' ]
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 

--- a/enterprise/websvc.editor.hints/nbproject/project.xml
+++ b/enterprise/websvc.editor.hints/nbproject/project.xml
@@ -34,6 +34,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.java.j2seplatform</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.62</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.java.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>


### PR DESCRIPTION
wip: this attempts to make the remaining enterprise tests runnable on JDK 11

JDK 11 doesn't have `javax.jws.*` annotations in the boot classpath, additionally the tests would fail since the classpath provider dependency was missing:
```
    [junit] Testcase: testOnewayOperationExceptions(org.netbeans.modules.websvc.editor.hints.WSHintsTest):	Caused an ERROR
    [junit] java.net.MalformedURLException: unknown protocol: nbjrt
    [junit] java.lang.IllegalStateException: java.net.MalformedURLException: unknown protocol: nbjrt
    [junit] 	at org.netbeans.modules.java.source.BootClassPathUtil.getBootClassPath(BootClassPathUtil.java:107)
    [junit] 	at org.netbeans.modules.java.source.TestUtil.getBootClassPath(TestUtil.java:451)
    [junit] 	at org.netbeans.modules.java.source.parsing.TestJavaPlatformProviderImpl$DefaultPlatform.getBootClassPath(TestJavaPlatformProviderImpl.java:81)
    [junit] 	at org.netbeans.modules.java.source.parsing.TestJavaPlatformProviderImpl$DefaultPlatform.getBootstrapLibraries(TestJavaPlatformProviderImpl.java:87)
    [junit] 	at org.netbeans.modules.java.platform.classpath.PlatformClassPathProvider.findClassPath(PlatformClassPathProvider.java:77)
    [junit] 	at org.netbeans.api.java.classpath.ClassPath.getClassPath(ClassPath.java:667)
    [junit] 	at org.netbeans.api.java.source.ClasspathInfo.create(ClasspathInfo.java:407)
    [junit] 	at org.netbeans.api.java.source.ClasspathInfo.create(ClasspathInfo.java:287)
    [junit] 	at org.netbeans.modules.java.source.parsing.JavacParser.init(JavacParser.java:281)
...

```
adding `org.netbeans.modules.java.j2seplatform` as module dependency fixes the exception.

Next step is to figure out how to add `javax.jws.*` to the classpath of the mocked test instance which runs the WS editor hints.
Not sure what the best approach is. Add it via a test `ClassPathProvider` which mixes it to the test boot cp?

This is just a testing issue since I just tried some annotation hints with the following setup: Java EE 8 WEB + Glassfish 5.10 on JDK 11 (project+IDE) and everything worked fine (after adding the dependency to the project)

(the hints don't support the jakarta namespace but this is out of scope for this PR)

meta issue #4904