### PR TITLE
Allow to run missing ref hint in batch mode, but mark it as not having a fix.

### DIFF
--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/MissingRefOutputHint.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/MissingRefOutputHint.java
@@ -37,7 +37,7 @@ import org.netbeans.spi.java.hints.JavaFix;
 import org.netbeans.spi.java.hints.TriggerTreeKind;
 import org.openide.util.NbBundle.Messages;
 
-@Hint(displayName = "#DN_MissingRefOutputHint", description = "#DESC_MissingRefOutputHint", category = "general", options=Options.NO_BATCH)
+@Hint(displayName = "#DN_MissingRefOutputHint", description = "#DESC_MissingRefOutputHint", category = "general", options=Options.QUERY)
 @Messages({
     "DN_MissingRefOutputHint=Missing Reference Output",
     "DESC_MissingRefOutputHint=Checks for missing reference output in jtreg @compile tags."


### PR DESCRIPTION
The MissingRefOutput hint is marked as NO_BATCH, but it might make sense to run it in a batch mode, it just cannot be used to generate fixes in a non-interactive environment. So, marking it as query instead.




---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
