### PR TITLE
Improving indexing for erroneous sources.

### DIFF
--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -1384,6 +1384,9 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
                 "    \n" +
                 "    void $$anonymousClasses() {\n" +
                 "        new Prop(0){\n" +
+                "            static {\n" +
+                "                throw new java.lang.RuntimeException(\"Uncompilable code\");\n" +
+                "            }\n" +
                 "            \n" +
                 "            (int i) {\n" +
                 "                throw new java.lang.RuntimeException(\"Uncompilable code\");\n" +
@@ -2054,6 +2057,131 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
                                                        "cache/s1/java/15/classes/test/ColoredPoint.sig",
                                                        "cache/s1/java/15/classes/test/Point.sig",
                                                        "cache/s1/java/15/classes/test/Test.sig")), createdFiles);
+    }
+
+    public void testRecordErroneousComponent() throws Exception {
+        setSourceLevel(SourceVersion.latest().name().substring("RELEASE_".length()));
+
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test.java",
+                                                                      "package test;\n" +
+                                                                      "public record Test(Unknown unknown) {\n" +
+                                                                      "}\n")),
+                                           Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
+                     createdFiles);
+    }
+
+    public void testMethodWithErroneousInMemberRef() throws Exception {
+        Map<String, String> file2Fixed = new HashMap<>();
+        VanillaCompileWorker.fixedListener = (file, cut) -> {
+            try {
+                FileObject source = URLMapper.findFileObject(file.toUri().toURL());
+                file2Fixed.put(FileUtil.getRelativePath(getRoot(), source), cut.toString());
+            } catch (MalformedURLException ex) {
+                throw new IllegalStateException(ex);
+            }
+        };
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test.java",
+                                                                      "package test;\n" +
+                                                                      "public class Test {\n" +
+                                                                      "    public void testA() {\n" +
+                                                                      "        r().map(this::test1);\n" +
+                                                                      "    }\n" +
+                                                                      "    public void testB() {\n" +
+                                                                      "        r().map(x -> test1(x));\n" +
+                                                                      "    }\n" +
+                                                                      "    public Object test1(Unknown u) {\n" +
+                                                                      "        return null;\n" +
+                                                                      "    }\n" +
+                                                                      "    public static void doTest(I i) {\n" +
+                                                                      "    }\n" +
+                                                                      "    private static java.util.Optional<Unknown> r() {\n" +
+                                                                      "        return null;\n" +
+                                                                      "    }\n" +
+                                                                      "}\n" +
+                                                                      "interface I {\n" +
+                                                                      "    public Object test(Object o);\n" +
+                                                                      "}\n")),
+                                           Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/I.sig",
+                                                       "cache/s1/java/15/classes/test/Test.sig")),
+                     createdFiles);
+        Map<String, String> expected = Collections.singletonMap("test/Test.java",
+                "package test;\n" +
+                "\n" +
+                "public class Test {\n" +
+                "    static {\n" +
+                "        throw new java.lang.RuntimeException(\"Uncompilable code - compiler.err.cant.resolve.location\");\n" +
+                "    }\n" +
+                "    \n" +
+                "    public Test() {\n" +
+                "        super();\n" +
+                "    }\n" +
+                "    \n" +
+                "    public void testA() {\n" +
+                "        throw new java.lang.RuntimeException(\"Uncompilable code\");\n" +
+                "    }\n" +
+                "    \n" +
+                "    public void testB() {\n" +
+                "        throw new java.lang.RuntimeException(\"Uncompilable code\");\n" +
+                "    }\n" +
+                "    \n" +
+                "    public Object test1(Unknown u) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "    \n" +
+                "    public static void doTest(I i) {\n" +
+                "    }\n" +
+                "    \n" +
+                "    private static java.util.Optional<Unknown> r() {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "}\n" +
+                "interface I {\n" +
+                "    \n" +
+                "    public Object test(Object o);\n" +
+                "}");
+        assertEquals(expected, file2Fixed);
+    }
+
+    public void testComplexDesugaringSupertypes() throws Exception {
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test4.java", "package test; public class Test4 extends extra.Extra { }")),
+                                           Arrays.asList(),
+                                           Arrays.asList(compileTuple("extra/Extra.java", "package extra; public class Extra { private void get() { Extra2.extra(); } }"),
+                                                         compileTuple("extra/Extra2.java", "package extra; public class Extra2 { private void get() { Unknown unknown; } }")));
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
+                     createdFiles);
+        //TODO: check file content!!!
     }
 
     public static void noop() {}

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -2184,6 +2184,67 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
         //TODO: check file content!!!
     }
 
+    public void testPatternSwitch() throws Exception {
+        setSourceLevel(SourceVersion.latest().name().substring("RELEASE_".length()));
+
+        Map<String, String> file2Fixed = new HashMap<>();
+        VanillaCompileWorker.fixedListener = (file, cut) -> {
+            try {
+                FileObject source = URLMapper.findFileObject(file.toUri().toURL());
+                file2Fixed.put(FileUtil.getRelativePath(getRoot(), source), cut.toString());
+            } catch (MalformedURLException ex) {
+                throw new IllegalStateException(ex);
+            }
+        };
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test.java",
+                                                                      "package test;\n" +
+                                                                      "public class Test {\n" +
+                                                                      "    public void test1(Object o) {\n" +
+                                                                      "        switch (o) {\n" +
+                                                                      "            case String s -> {}\n" +
+                                                                      "            case Object oo -> {}\n" +
+                                                                      "        }\n" +
+                                                                      "    }\n" +
+                                                                      "    public void test2(Object o) {\n" +
+                                                                      "        switch (o) {\n" +
+                                                                      "            case String s -> {}\n" +
+                                                                      "            case Object oo -> {}\n" +
+                                                                      "        }\n" +
+                                                                      "    }\n" +
+                                                                      "}\n")),
+                                           Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
+                     createdFiles);
+        Map<String, String> expected = Collections.singletonMap("test/Test.java",
+                "package test;\n" +
+                "\n" +
+                "public class Test {\n" +
+                "    \n" +
+                "    public Test() {\n" +
+                "        super();\n" +
+                "    }\n" +
+                "    \n" +
+                "    public void test1(Object o) {\n" +
+                "        throw new java.lang.RuntimeException(\"Uncompilable code - compiler.err.preview.feature.disabled.plural\");\n" +
+                "    }\n" +
+                "    \n" +
+                "    public void test2(Object o) {\n" +
+                "        throw new java.lang.RuntimeException(\"Uncompilable code\");\n" +
+                "    }\n" +
+                "}");
+        assertEquals(expected, file2Fixed);
+    }
+
     public static void noop() {}
 
     @Override


### PR DESCRIPTION
Recently, I ran into a few problems with indexing massively erroneous source:
- error cleanup does not work for record components. Error should be cleaned for record components.
- if there are multiple pattern switches (preview only feature, currently) only the first may be removed from the code when the errors are being cleared, and the rest might go to `TransPatterns`, failing there. Ensuring pattern switches are cleared while clearing errors if preview is disabled.
- member references referring to methods with erroneous parameters may sometimes be kept, crashing code generator later. Such member references should be removed from the code.
- in some cases, a new source might be parsed while desugaring another, and the current cleaning code fails for that. Need to avoid attempts to clean the code before it is being desugared. (Sadly, for this, I was not able to produce a test.)


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
