### PR TITLE
For nb.org projects, use the correct nbjavac prepend for the internal (boot)classpath.

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/Evaluator.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/Evaluator.java
@@ -42,6 +42,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.platform.JavaPlatform;
@@ -423,9 +424,15 @@ public final class Evaluator implements PropertyEvaluator, PropertyChangeListene
             buildDefaults.put(CP, "${module.classpath}:${cp.extra}"); // NOI18N
             buildDefaults.put(RUN_CP, "${module.run.classpath}:${cp.extra}:${build.classes.dir}"); // NOI18N
             if (type == NbModuleType.NETBEANS_ORG && "true".equals(projectProperties.getProperties().get("requires.nb.javac"))) {
-                ModuleEntry javacapi = ml.getEntry("org.netbeans.libs.javacapi");
-                if (javacapi != null) {
-                    buildDefaults.put(ClassPathProviderImpl.BOOTCLASSPATH_PREPEND, javacapi.getClassPathExtensions());
+                ModuleEntry javacLibrary = ml.getEntry("org.netbeans.libs.javacapi");
+                if (javacLibrary != null) {
+                    List<String> bootstrapAPIs = new ArrayList<>();
+                    for (String ext : javacLibrary.getClassPathExtensions().split(Pattern.quote(File.pathSeparator))) {
+                        if (ext.endsWith("-api.jar")) {
+                            bootstrapAPIs.add(ext);
+                        }
+                    }
+                    buildDefaults.put(ClassPathProviderImpl.BOOTCLASSPATH_PREPEND, bootstrapAPIs.stream().collect(Collectors.joining(File.pathSeparator)));
                 }
             }
             

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ClassPathProviderImpl.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ClassPathProviderImpl.java
@@ -112,6 +112,7 @@ public final class ClassPathProviderImpl implements ClassPathProvider {
                     @Override
                     public ClassPath run() {
                         if (boot == null) {
+                            ClassPathImplementation prependCP = createPathFromProperty(BOOTCLASSPATH_PREPEND);
                             final String loc = project.evaluator().getProperty(Evaluator.NBJDK_BOOTCLASSPATH_MODULAR);
                             if(loc != null) {
                                 final File locf = new File(loc);
@@ -122,13 +123,15 @@ public final class ClassPathProviderImpl implements ClassPathProvider {
                                             .findFirst()
                                             .orElse(null);
                                     if (locf.equals(jpLocf)) {
-                                        boot = jp.getBootstrapLibraries();
+                                        boot = ClassPathSupport.createProxyClassPath(
+                                                ClassPathFactory.createClassPath(prependCP),
+                                                jp.getBootstrapLibraries());
                                         break;
                                     }
                                 }
                             } else {
                                 boot = ClassPathFactory.createClassPath(ClassPathSupport.createProxyClassPathImplementation(
-                                        createPathFromProperty(BOOTCLASSPATH_PREPEND),
+                                        prependCP,
                                         createPathFromProperty(Evaluator.NBJDK_BOOTCLASSPATH),
                                         createFxPath()));
                             }


### PR DESCRIPTION
When building the bootclasspath for APISupport (nb.org modules in particular), lookup the correct nbjavac API jar in the particular repository, and prepend it to the bootclasspath.




---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
