### PR TITLE
Do not inherit "throws Exception" from Callable to compile on JDK8

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCIManager.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCIManager.java
@@ -490,7 +490,7 @@ public final class OCIManager {
     }
     
     @FunctionalInterface
-    public interface OCIOperation<V,E extends Exception> extends Callable<V> {
+    public interface OCIOperation<V,E extends Exception> {
         /**
          * Performs the project operation, returning a value. The method may throw one
          * checked exception.


### PR DESCRIPTION
In #5118, I have created a generic method that rethrows callable's (checked) exception using `sneaky throws` approach - but the code is not compilable on JDK8 because the JDK8 javac fails to infer types properly:
```
 [nb-javac] /space/src/vscode/netbeans/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java:149: error: call() in <anonymous org.netbeans.modules.nbcode.integration.commands.ProjectAuditCommand$> cannot implement call() in OCIOperation
 [nb-javac]         return OCIManager.usingSession(auditWithProfile, () -> v.findKnowledgeBase(knowledgeBase).
 [nb-javac]                                                          ^
 [nb-javac]   overridden method does not throw Exception
```

One way is to typecast the lambda or augment the mehod call using explicit type parameters `<Object, Exception>`, but it seems that removing `extends Callable` from the `OCIOperation` interface does the same - and leaves caller code clean - and compiles on both JDK8 and JDK11 (JDK17)

Please review asap - the code reached `master` branch and failed vscode testsuite ... was not discovered, since I didn't put enough labels on #5118 - sorry for the inconvenience.