### PR TITLE
LSP: Enable custom run config params for 'java' configuration.

### DIFF
--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -81,7 +81,7 @@
 					"id": "run-config",
 					"name": "Run Configuration",
 					"contextualTitle": "Run Configuration",
-					"when": "runConfigurationInitialized && config.netbeans.javaSupport.enabled"
+					"when": "runConfigurationInitialized"
 				}
 			]
 		},
@@ -833,7 +833,7 @@
 				},
 				{
 					"command": "java.workspace.configureRunSettings",
-					"when": "view == run-config && viewItem == configureRunSettings && config.netbeans.javaSupport.enabled",
+					"when": "view == run-config && viewItem == configureRunSettings",
 					"group": "inline@1"
 				}
 			]

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -355,6 +355,7 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
     initializeRunConfiguration().then(initialized => {
 		if (initialized) {
 			context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java8+', runConfigurationProvider));
+			context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java', runConfigurationProvider));
 			context.subscriptions.push(vscode.window.registerTreeDataProvider('run-config', runConfigurationNodeProvider));
 			context.subscriptions.push(vscode.commands.registerCommand('java.workspace.configureRunSettings', (...params: any[]) => {
 				configureRunSettings(context, params);


### PR DESCRIPTION
Custom run config parameters should be enabled also for 'java' configuration in addition to 'java8+'.