### PR TITLE
Strip protocol part, present e.g. if in KDE + manual proxy mode.

### DIFF
--- a/platform/core.network/src/org/netbeans/core/network/proxy/NetworkProxySettings.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/NetworkProxySettings.java
@@ -157,6 +157,10 @@ public final class NetworkProxySettings {
         if (string == null) {
             return EMPTY_STRING;
         } else {
+            // the proxy string may possibly contain protocol part - strip it.
+            if (string.contains("://")) { // NOI18N
+                string = string.substring(string.indexOf("://") + 3); // NOI18N
+            }
             if (string.contains(COLON)) {
                 return string.substring(0, string.lastIndexOf(COLON));
             } else {


### PR DESCRIPTION
I've noticed bad behaviour in KDE when the system proxy is specified manually. The `kioslaverc` then contains settings like
```
ftpProxy=ftp://proxy.acme.com:80
httpProxy=http://proxy.acme.com:80
httpsProxy=http://proxy.acme.com:80
socksProxy=socks://proxy.acme.com:80
```
and the proxy string then contains not only port specification, but the protocol part as well. The error can be seen in Tools | Options, when System proxy is selected (and KDE has a manual system proxy) - the "Test connection" button action fails with hostname prefixed by `http://`.

This PR strips the PR part from the host string.