### PR TITLE
Allow to collect contextual actions from layer path.

### DIFF
--- a/platform/openide.util.ui/apichanges.xml
+++ b/platform/openide.util.ui/apichanges.xml
@@ -27,6 +27,22 @@
     <apidef name="actions">Actions API</apidef>
 </apidefs>
 <changes>
+    <change id="actionsForPathLookup">
+         <api name="util"/>
+         <summary>Added variant Utilities.actionsForPath with Lookup that produces context-aware actions</summary>
+         <version major="9" minor="28"/>
+         <date day="5" month="1" year="2023"/>
+         <author login="sdedic"/>
+         <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
+         <description>
+             <p>
+                 Added a variant <a href="@TOP@/org/openide/util/Utilities.html#actionsForPath-java.lang.String-org.openide.util.Lookup-">actionsToPath</a> that instantiates context-bound actions if the registered action(s) implements 
+                 <a href="@TOP@/org/openide/util/ContextAwareAction.html">ContextAwareAction</a>.
+                 Improves consistency with <a href="@TOP@/org/openide/util/Utilities.html#actionsToPopup-javax.swing.Action:A-org.openide.util.Lookup-">actionsToPopup</a> that supports contextual actions. 
+             </p>
+         </description>
+         <class package="org.openide.util" name="Utilities"/>
+    </change>
     <change id="findDialogParent">
          <api name="util"/>
          <summary>static method Utilities.findDialogParent added</summary>

--- a/platform/openide.util.ui/manifest.mf
+++ b/platform/openide.util.ui/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.openide.util.ui
 OpenIDE-Module-Localizing-Bundle: org/openide/util/Bundle.properties
-OpenIDE-Module-Specification-Version: 9.27
+OpenIDE-Module-Specification-Version: 9.28
 

--- a/platform/openide.util.ui/src/org/openide/util/Utilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/Utilities.java
@@ -1843,6 +1843,42 @@ public final class Utilities {
     }
 
     /**
+     * Loads a menu sequence from a path, given a specific context as Lookup. This variant will allow to use action's contextual presence, enablement or selection,
+     * based on Lookup contents. If the registered action implements a {@link ContextAwareAction}, an instance bound to the passed `context' will be created - if
+     * the context factory returns {@code null}, indicating the action is not appropriate for the context, the registration will be skipped.
+     * Use {@link #actionsGlobalContext()} to supply global context.
+     * 
+     * Any {@link Action} instances are returned as is;
+     * any {@link JSeparator} instances are translated to nulls.
+     * Warnings are logged for any other instances.
+     * @param path a path as given to {@link Lookups#forPath}, generally a layer folder name
+     * @param context the context passed to the action(s)
+     * @return a list of actions interspersed with null separators
+     * @since 7.14
+     */
+    public static List<? extends Action> actionsForPath(String path, Lookup context) {
+        List<Action> actions = new ArrayList<Action>();
+        for (Lookup.Item<Object> item : Lookups.forPath(path).lookupResult(Object.class).allItems()) {
+            if (Action.class.isAssignableFrom(item.getType())) {
+                Object instance = item.getInstance();
+                if (instance instanceof ContextAwareAction) {
+                    Object contextAwareInstance = ((ContextAwareAction)instance).createContextAwareInstance(context);
+                    if (contextAwareInstance == null) {
+                        Logger.getLogger(Utilities.class.getName()).log(Level.WARNING,"ContextAwareAction.createContextAwareInstance(context) returns null. That is illegal!" + " action={0}, context={1}", new Object[] {instance, context});
+                    } else {
+                        instance = contextAwareInstance;
+                    }
+                }
+                actions.add((Action) instance);
+            } else if (JSeparator.class.isAssignableFrom(item.getType())) {
+                actions.add(null);
+            } else {
+                Logger.getLogger(Utilities.class.getName()).log(Level.WARNING, "Unrecognized object of {0} found in actions path {1}", new Object[] {item.getType(), path});
+            }
+        }
+        return actions;
+    }
+    /**
      * Global context for actions. Toolbar, menu or any other "global"
      * action presenters shall operate in this context.
      * Presenters for context menu items should <em>not</em> use


### PR DESCRIPTION
During implementation of OCI support, I've noticed that there's no Lookup-aware helper that materializes list of Actions from XML layer registrations - thing that could be generally useful for configurable nodes/features. 
This PR adds a simple variant of `actionsForPath` that creates `ContextAwareActions`.

