### PR TITLE
Removed double null check with instance operator

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteSubprojectProviderImpl.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/suite/SuiteSubprojectProviderImpl.java
@@ -89,7 +89,7 @@ final class SuiteSubprojectProviderImpl implements SubprojectProvider {
                 if (dir != null) {
                     try {
                         Project subp = ProjectManager.getDefault().findProject(dir);
-                        if (subp != null && subp instanceof NbModuleProject) {
+                        if (subp instanceof NbModuleProject) {
                             newProjects.add((NbModuleProject) subp);
                         }
                     } catch (IOException e) {

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/BasicCustomizer.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/BasicCustomizer.java
@@ -142,7 +142,7 @@ public abstract class BasicCustomizer implements CustomizerProvider {
     }
     
     private String findLastSelectedCategory() {
-        if (dialog != null && dialog instanceof JDialog) {
+        if (dialog instanceof JDialog) {
             return (String)((JDialog)dialog).getRootPane().getClientProperty(BasicCustomizer.LAST_SELECTED_PANEL);
         }
         return null;

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizer.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizer.java
@@ -136,7 +136,7 @@ public final class NbPlatformCustomizer extends JPanel {
             detailPane.addTab(CTL_JavadocTab(), javadocTab);
             detailPane.addTab(CTL_HarnessTab(), harnessTab);
             Container window = this.getTopLevelAncestor();
-            if (window != null && window instanceof Window) {
+            if (window instanceof Window) {
                 ((Window) window).pack();
             }
         }

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/TypeChooserPanelImpl.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/TypeChooserPanelImpl.java
@@ -636,7 +636,7 @@ JFileChooser chooser = ProjectChooser.projectChooser();
         static File getProjectFolder( WizardDescriptor settings) {
             if (settings != null) {
                 Object value = settings.getProperty(PROJECT_FOLDER);
-                if (value != null && value instanceof File) {
+                if (value instanceof File) {
                     return (File) value;
                 }
             }

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/spi/ModuleTypePanel.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/wizard/spi/ModuleTypePanel.java
@@ -214,21 +214,21 @@ public class ModuleTypePanel{
     
     private static NbPlatform getActiveNbPlatform(WizardDescriptor wizard){
         Object value = wizard.getProperty(ACTIVE_NB_PLATFORM);
-        if (value != null && value instanceof NbPlatform){
+        if (value instanceof NbPlatform){
             return (NbPlatform)value;
         }
         return null;
     }
     
     private static boolean extractBoolean(Object value, boolean defaultValue){
-        if (value != null && value instanceof Boolean){
+        if (value instanceof Boolean){
             return (Boolean)value;
         }
         return defaultValue;
     }
     
     private static String extractString(Object value, String defaultValue){
-        if (value != null && value instanceof String){
+        if (value instanceof String){
             return (String)value;
         }
         return defaultValue;

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/BadgingSupport.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/BadgingSupport.java
@@ -212,7 +212,7 @@ final class BadgingSupport implements SynchronousStatus, FileChangeListener {
             }
             if (fo.hasExt("shadow")) { // NOI18N
                 Object originalFile = fo.getAttribute("originalFile"); // NOI18N
-                if (originalFile != null && originalFile instanceof String) {
+                if (originalFile instanceof String) {
                     FileObject orig;
                     try {
                         orig = fo.getFileSystem().findResource((String) originalFile);

--- a/apisupport/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/AbstractRefactoringElement.java
+++ b/apisupport/apisupport.refactoring/src/org/netbeans/modules/apisupport/refactoring/AbstractRefactoringElement.java
@@ -76,7 +76,7 @@ public abstract class AbstractRefactoringElement extends SimpleRefactoringElemen
             DataObject dobj = DataObject.find(getParentFile());
             if (dobj != null) {
                 EditorCookie.Observable obs = (EditorCookie.Observable)dobj.getCookie(EditorCookie.Observable.class);
-                if (obs != null && obs instanceof CloneableEditorSupport) {
+                if (obs instanceof CloneableEditorSupport) {
                     CloneableEditorSupport supp = (CloneableEditorSupport)obs;
 
                     if (loc == null) {

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/BasicWizardIterator.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/BasicWizardIterator.java
@@ -247,7 +247,7 @@ public abstract class BasicWizardIterator implements WizardDescriptor.Asynchrono
         // mkleint: copied from the NewJavaFileWizardIterator.. there must be something painfully wrong..
         String[] beforeSteps = null;
         Object prop = wiz.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         position = 0;

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenPackageModifierImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenPackageModifierImpl.java
@@ -135,7 +135,7 @@ public class MavenPackageModifierImpl implements PackageModifierImplementation {
                         @Override
                         public void run() {
                             TopComponent projecttc = WindowManager.getDefault().findTopComponent(ID_LOGICAL);
-                            if (projecttc != null && projecttc instanceof ExplorerManager.Provider) {
+                            if (projecttc instanceof ExplorerManager.Provider) {
                                 ExplorerManager.Provider em = (ExplorerManager.Provider) projecttc;
                                 Node root = em.getExplorerManager().getRootContext();
                                 toRet[0] = root;

--- a/contrib/groovy.grailsproject/src/org/netbeans/modules/groovy/grailsproject/ui/wizards/GrailsArtifactWizardIterator.java
+++ b/contrib/groovy.grailsproject/src/org/netbeans/modules/groovy/grailsproject/ui/wizards/GrailsArtifactWizardIterator.java
@@ -250,7 +250,7 @@ public class GrailsArtifactWizardIterator implements WizardDescriptor.ProgressIn
         // Make sure list of steps is accurate.
         String[] beforeSteps = null;
         Object prop = wiz.getProperty(WizardDescriptor.PROP_CONTENT_DATA);
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/service/subpanels/TargetsPanel.java
+++ b/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/service/subpanels/TargetsPanel.java
@@ -65,7 +65,7 @@ public class TargetsPanel extends javax.swing.JPanel {
         while (!(b instanceof Binding) && (b != null)) {
             b = b.getParent();
         }
-        if ((b != null) && (b instanceof Binding)) {
+        if (b instanceof Binding) {
             binding = (Binding) b;
         }
         

--- a/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/wizard/STSWizard.java
+++ b/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/wizard/STSWizard.java
@@ -346,7 +346,7 @@ public class STSWizard implements TemplateWizard.Iterator {
         // Creating steps.
         Object prop = this.wiz.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDWizardIterator.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDWizardIterator.java
@@ -223,7 +223,7 @@ public final class WebLogicDDWizardIterator implements WizardDescriptor.Instanti
     private String[] createSteps() {
         String[] beforeSteps = null;
         Object prop = wizard.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ProjectAppClientProvider.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ProjectAppClientProvider.java
@@ -36,7 +36,7 @@ public class ProjectAppClientProvider implements CarProvider, CarsInProject {
     
     public Car findCar (FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
-        if (project != null && project instanceof AppClientProject) {
+        if (project instanceof AppClientProject) {
             return ((AppClientProject) project).getAPICar();
         }
         return null;

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/wsclient/AppClientProjectWebServicesSupportProvider.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/wsclient/AppClientProjectWebServicesSupportProvider.java
@@ -40,7 +40,7 @@ public class AppClientProjectWebServicesSupportProvider implements WebServicesCl
 
     public WebServicesClientSupport findWebServicesClientSupport (FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
-        if (project != null && project instanceof AppClientProject) {
+        if (project instanceof AppClientProject) {
             return ((AppClientProject) project).getAPIWebServicesClientSupport();
         }
         return null;
@@ -48,7 +48,7 @@ public class AppClientProjectWebServicesSupportProvider implements WebServicesCl
         
     public JAXWSClientSupport findJAXWSClientSupport(FileObject file) {
         Project project = FileOwnerQuery.getOwner(file);
-        if (project != null && project instanceof AppClientProject) {
+        if (project instanceof AppClientProject) {
             return ((AppClientProject) project).getAPIJAXWSClientSupport();
         }
         return null;

--- a/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/NoSelectedServerWarning.java
+++ b/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/NoSelectedServerWarning.java
@@ -119,7 +119,7 @@ final class NoSelectedServerWarning extends JPanel {
                 public void propertyChange(PropertyChangeEvent evt) {
                     if (evt.getPropertyName().equals(NoSelectedServerWarning.OK_ENABLED)) {
                         Object newvalue = evt.getNewValue();
-                        if ((newvalue != null) && (newvalue instanceof Boolean)) {
+                        if (newvalue instanceof Boolean) {
                             desc.setValid(((Boolean)newvalue));
                         }
                     }

--- a/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/impl/commonws/EnclosingBean.java
+++ b/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/impl/commonws/EnclosingBean.java
@@ -80,7 +80,7 @@ public abstract class EnclosingBean extends BaseBean implements CommonDDBean, Cr
                         break;
                     }
                 }
-            if (keyValue!=null && keyValue instanceof String) {
+            if (keyValue instanceof String) {
                 if (findBeanByName(beanName, keyProperty,(String)keyValue)!=null) {
                     throw new NameAlreadyUsedException(beanName,  keyProperty, (String)keyValue);
                 }   

--- a/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/impl/webservices/WebServicesProxy.java
+++ b/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/impl/webservices/WebServicesProxy.java
@@ -405,7 +405,7 @@ public class WebServicesProxy implements Webservices {
             } catch (org.openide.filesystems.FileAlreadyLockedException ex) {
                 // trying to use OutputProvider for writing changes
                 org.openide.loaders.DataObject dobj = org.openide.loaders.DataObject.find(fo);
-                if (dobj != null && dobj instanceof WebServicesProxy.OutputProvider)
+                if (dobj instanceof OutputProvider)
                     ((WebServicesProxy.OutputProvider)dobj).write(this);
                 else 
                     throw ex;

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/ApplicationProxy.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/ApplicationProxy.java
@@ -399,7 +399,7 @@ public class ApplicationProxy implements Application {
             } catch (org.openide.filesystems.FileAlreadyLockedException ex) {
                 // trying to use OutputProvider for writing changes
                 org.openide.loaders.DataObject dobj = org.openide.loaders.DataObject.find(fo);
-                if (dobj!=null && dobj instanceof ApplicationProxy.OutputProvider)
+                if (dobj instanceof OutputProvider)
                     ((ApplicationProxy.OutputProvider)dobj).write(this);
                 else throw ex;
             }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/client/AppClientProxy.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/client/AppClientProxy.java
@@ -364,7 +364,7 @@ public class AppClientProxy implements AppClient {
             } catch (FileAlreadyLockedException ex) {
                 // trying to use OutputProvider for writing changes
                 org.openide.loaders.DataObject dobj = org.openide.loaders.DataObject.find(fo);
-                if (dobj!=null && dobj instanceof AppClientProxy.OutputProvider)
+                if (dobj instanceof OutputProvider)
                     ((AppClientProxy.OutputProvider)dobj).write(this);
                 else throw ex;
             }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/EnclosingBean.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/EnclosingBean.java
@@ -95,7 +95,7 @@ public abstract class EnclosingBean extends BaseBean implements CommonDDBean, Cr
                         break;
                     }
                 }
-            if (keyValue!=null && keyValue instanceof String) {
+            if (keyValue instanceof String) {
                 if (findBeanByName(beanName, keyProperty,(String)keyValue)!=null) {
                     throw new NameAlreadyUsedException(beanName,  keyProperty, (String)keyValue);
                 }

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/xmlutils/XMLJ2eeUtils.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/xmlutils/XMLJ2eeUtils.java
@@ -444,7 +444,7 @@ public class XMLJ2eeUtils {
         // removing the next text element (only if this element was the last non text element in parent)
         if (firstElement) {
             Node next = element.getNextSibling();
-            if (next!=null && next instanceof CharacterData && next.getNextSibling()==null)
+            if (next instanceof CharacterData && next.getNextSibling() == null)
                      parent.removeChild(next);        
         }
      
@@ -535,11 +535,11 @@ public class XMLJ2eeUtils {
                 Node previous = lastInList.getPreviousSibling();
                 Node next = lastInList.getNextSibling();
                 if (next != null) {
-                    if (previous!=null && previous instanceof CharacterData)
+                    if (previous instanceof CharacterData)
                         element.insertBefore(previous.cloneNode(false),next);
                     element.insertBefore(newElement,next);
                 } else {
-                    if (previous!=null && previous instanceof CharacterData)
+                    if (previous instanceof CharacterData)
                         element.appendChild(previous.cloneNode(false));
                     element.appendChild(newElement);
                 }
@@ -611,11 +611,11 @@ public class XMLJ2eeUtils {
                 Node previous = lastInList.getPreviousSibling();
                 Node next = lastInList.getNextSibling();
                 if (next != null) {
-                    if (previous!=null && previous instanceof CharacterData)
+                    if (previous instanceof CharacterData)
                         element.insertBefore(previous.cloneNode(false),next);
                     element.insertBefore(newElement,next);
                 } else {
-                    if (previous!=null && previous instanceof CharacterData)
+                    if (previous instanceof CharacterData)
                         element.appendChild(previous.cloneNode(false));
                     element.appendChild(newElement);
                 }
@@ -675,13 +675,13 @@ public class XMLJ2eeUtils {
         // removing the next text element (only if this element was the last non text element in parent)
         if (firstElement) {
             Node next = list.item(list.getLength()-1).getNextSibling();
-            if (next!=null && next instanceof CharacterData && next.getNextSibling()==null)
+            if (next instanceof CharacterData && next.getNextSibling() == null)
                      element.removeChild(next);        
         }
         for(int i=list.getLength()-1;i>=0;i--){
             Node item = list.item(i);
             Node previous = item.getPreviousSibling();
-            if (previous!=null && previous instanceof CharacterData)
+            if (previous instanceof CharacterData)
                 element.removeChild(previous);
             element.removeChild(item);
         }

--- a/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ProjectEarProvider.java
+++ b/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ProjectEarProvider.java
@@ -30,7 +30,7 @@ public final class ProjectEarProvider implements EarProvider {
     
     public Ear findEar (FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
-        if (project != null && project instanceof EarProject) {
+        if (project instanceof EarProject) {
             EarProject ep = (EarProject) project;
             FileObject prjdir = ep.getProjectDirectory();
             if (prjdir != null && (prjdir.equals (file) || FileUtil.isParentOf(prjdir, file))) {

--- a/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ui/customizer/CustomizerRun.java
+++ b/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ui/customizer/CustomizerRun.java
@@ -570,7 +570,7 @@ private void jCheckBoxDisplayBrowserActionPerformed(java.awt.event.ActionEvent e
 
         @Override
         public boolean equals(Object obj) {
-            if (obj == null || !(obj instanceof ClientModuleItem)) {
+            if (!(obj instanceof ClientModuleItem)) {
                 return false;
             }
             return uri.equals(((ClientModuleItem)obj).uri);
@@ -582,7 +582,7 @@ private void jCheckBoxDisplayBrowserActionPerformed(java.awt.event.ActionEvent e
         }
 
         public int compareTo(Object obj) {
-            if (obj == null || !(obj instanceof ClientModuleItem)) {
+            if (!(obj instanceof ClientModuleItem)) {
                 return -1;
             }
             return uri.compareTo(((ClientModuleItem)obj).uri);

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/api/methodcontroller/AbstractMethodController.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/api/methodcontroller/AbstractMethodController.java
@@ -419,7 +419,7 @@ public abstract class AbstractMethodController extends EjbMethodController {
                         if (typeElement != null) {
                             TypeMirror superCls = typeElement.getSuperclass();
                             TypeMirror objectCls = controller.getElements().getTypeElement("java.lang.Object").asType(); //NOI18N
-                            while ((superCls != null) && (superCls instanceof DeclaredType) && !types.isSameType(superCls, objectCls)) {
+                            while ((superCls instanceof DeclaredType) && !types.isSameType(superCls, objectCls)) {
                                 TypeElement superElem = (TypeElement) ((DeclaredType) superCls).asElement();
                                 result.add(superElem.getQualifiedName().toString());
                                 superCls = superElem.getSuperclass();

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/dd/EjbJarXmlWizardIterator.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/dd/EjbJarXmlWizardIterator.java
@@ -190,7 +190,7 @@ public final class EjbJarXmlWizardIterator implements WizardDescriptor.Instantia
     private String[] createSteps() {
         String[] beforeSteps = null;
         Object prop = wizard.getProperty(WizardDescriptor.PROP_CONTENT_DATA);
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
 

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/mdb/MessageDestinationUiSupport.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/mdb/MessageDestinationUiSupport.java
@@ -180,7 +180,7 @@ public abstract class MessageDestinationUiSupport {
                 new PropertyChangeListener() {
                     public void propertyChange(PropertyChangeEvent evt) {
                         Object newvalue = evt.getNewValue();
-                        if ((newvalue != null) && (newvalue instanceof Boolean)) {
+                        if (newvalue instanceof Boolean) {
                             dialogDescriptor.setValid(((Boolean) newvalue));
                         }
                     }

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/CallEjbDialog.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/CallEjbDialog.java
@@ -105,7 +105,7 @@ public class CallEjbDialog {
             public void propertyChange(PropertyChangeEvent evt) {
                 if (evt.getPropertyName().equals(CallEjbPanel.IS_VALID)) {
                     Object newvalue = evt.getNewValue();
-                    if ((newvalue != null) && (newvalue instanceof Boolean)) {
+                    if (newvalue instanceof Boolean) {
                         dialogDescriptor.setValid(((Boolean)newvalue));
                     }
                 }

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/SelectDatabasePanel.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/SelectDatabasePanel.java
@@ -205,7 +205,7 @@ public class SelectDatabasePanel extends javax.swing.JPanel implements ChangeLis
             public void propertyChange(PropertyChangeEvent evt) {
                 if (DataSourceReferencePanel.IS_VALID.equals(evt.getPropertyName())) {
                     Object newvalue = evt.getNewValue();
-                    if ((newvalue != null) && (newvalue instanceof Boolean)) {
+                    if (newvalue instanceof Boolean) {
                         dialogDescriptor.setValid(((Boolean) newvalue));
                     }
                 }

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/SendEmailCodeGenerator.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/SendEmailCodeGenerator.java
@@ -139,7 +139,7 @@ public class SendEmailCodeGenerator implements CodeGenerator {
             public void propertyChange(PropertyChangeEvent evt) {
                 if (evt.getPropertyName().equals(SendEmailPanel.IS_VALID)) {
                     Object newvalue = evt.getNewValue();
-                    if ((newvalue != null) && (newvalue instanceof Boolean)) {
+                    if (newvalue instanceof Boolean) {
                         boolean isValid = ((Boolean) newvalue);
                         dialogDescriptor.setValid(isValid);
                         if (isValid) {

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/SendJMSMessageCodeGenerator.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/SendJMSMessageCodeGenerator.java
@@ -146,7 +146,7 @@ public class SendJMSMessageCodeGenerator implements CodeGenerator {
                         @Override
                         public void propertyChange(PropertyChangeEvent evt) {
                             Object newvalue = evt.getNewValue();
-                            if ((newvalue != null) && (newvalue instanceof Boolean)) {
+                            if (newvalue instanceof Boolean) {
                                 boolean isValid = ((Boolean) newvalue);
                                 dialogDescriptor.setValid(isValid);
                                 if (isValid) {

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/SendJmsMessagePanel.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/SendJmsMessagePanel.java
@@ -317,7 +317,7 @@ public class SendJmsMessagePanel extends javax.swing.JPanel implements ChangeLis
             @Override
                     public void propertyChange(PropertyChangeEvent evt) {
                         Object newvalue = evt.getNewValue();
-                        if ((newvalue != null) && (newvalue instanceof Boolean)) {
+                        if (newvalue instanceof Boolean) {
                             boolean isServiceLocatorOk = ((Boolean) newvalue);
                             if (isServiceLocatorOk) {
                                 verifyAndFire();

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/UseDatabaseCodeGenerator.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ui/logicalview/entries/UseDatabaseCodeGenerator.java
@@ -156,7 +156,7 @@ public class UseDatabaseCodeGenerator implements CodeGenerator {
             public void propertyChange(PropertyChangeEvent evt) {
                 if (evt.getPropertyName().equals(SelectDatabasePanel.IS_VALID)) {
                     Object newvalue = evt.getNewValue();
-                    if ((newvalue != null) && (newvalue instanceof Boolean)) {
+                    if (newvalue instanceof Boolean) {
                         Boolean booleanValue = (Boolean) newvalue;
                         if (booleanValue) {
                             dialogDescriptor.setValid(true);

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ProjectWebServicesSupportProvider.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ProjectWebServicesSupportProvider.java
@@ -45,7 +45,7 @@ public class ProjectWebServicesSupportProvider implements
 
     public WebServicesSupport findWebServicesSupport (FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
-        if (project != null && project instanceof EjbJarProject) {
+        if (project instanceof EjbJarProject) {
             return ((EjbJarProject) project).getAPIWebServicesSupport();
         }
         return null;
@@ -53,7 +53,7 @@ public class ProjectWebServicesSupportProvider implements
 
     public WebServicesClientSupport findWebServicesClientSupport (FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
-        if (project != null && project instanceof EjbJarProject) {
+        if (project instanceof EjbJarProject) {
             return ((EjbJarProject) project).getAPIWebServicesClientSupport();
         }
         return null;
@@ -61,7 +61,7 @@ public class ProjectWebServicesSupportProvider implements
     
     public JAXWSSupport findJAXWSSupport(FileObject file) {
         Project project = FileOwnerQuery.getOwner(file);
-        if (project != null && project instanceof EjbJarProject) {
+        if (project instanceof EjbJarProject) {
             return ((EjbJarProject) project).getAPIJAXWSSupport();
         }
         return null;
@@ -69,7 +69,7 @@ public class ProjectWebServicesSupportProvider implements
 
     public JAXWSClientSupport findJAXWSClientSupport(FileObject file) {
         Project project = FileOwnerQuery.getOwner(file);
-        if (project != null && project instanceof EjbJarProject) {
+        if (project instanceof EjbJarProject) {
             return ((EjbJarProject) project).getAPIJAXWSClientSupport();
         }
         return null;

--- a/enterprise/j2ee.ejbrefactoring/src/org/netbeans/modules/j2ee/ejbrefactoring/EjbRefactoringPlugin.java
+++ b/enterprise/j2ee.ejbrefactoring/src/org/netbeans/modules/j2ee/ejbrefactoring/EjbRefactoringPlugin.java
@@ -254,7 +254,7 @@ public class EjbRefactoringPlugin implements RefactoringPlugin {
                 //mkleint: see subprojectprovider for official contract, maybe classpath should be checked instead? see #210465
                 //in this case J2eeApplicationprovider might provide the same results though.
                 Object obj = project.getLookup().lookup(SubprojectProvider.class);
-                if ((obj != null) && (obj instanceof SubprojectProvider)) {
+                if (obj instanceof SubprojectProvider) {
                     Set<? extends Project> subprojects = ((SubprojectProvider) obj).getSubprojects();
                     if (subprojects.contains(affectedProject)) {
                         org.netbeans.modules.j2ee.api.ejbjar.EjbJar em = org.netbeans.modules.j2ee.api.ejbjar.EjbJar

--- a/enterprise/j2ee.sun.appsrv/src/org/netbeans/modules/j2ee/sun/api/restricted/ResourceUtils.java
+++ b/enterprise/j2ee.sun.appsrv/src/org/netbeans/modules/j2ee/sun/api/restricted/ResourceUtils.java
@@ -1285,7 +1285,7 @@ public class ResourceUtils implements WizardConstants{
 
     public static void createSampleDataSource(J2eeModuleProvider provider){
         DeploymentManager dm = getDeploymentManager(provider);
-        if ((dm != null) && (dm instanceof SunDeploymentManagerInterface)) {
+        if (dm instanceof SunDeploymentManagerInterface) {
             SunDeploymentManagerInterface eightDM = (SunDeploymentManagerInterface) dm;
             try {
                 ObjectName configObjName = new ObjectName(MAP_RESOURCES);

--- a/enterprise/j2ee.sun.appsrv/src/org/netbeans/modules/j2ee/sun/ide/editors/ui/DDTablePanel.java
+++ b/enterprise/j2ee.sun.appsrv/src/org/netbeans/modules/j2ee/sun/ide/editors/ui/DDTablePanel.java
@@ -272,8 +272,8 @@ public class DDTablePanel extends JPanel
 	    Component comp = cellR.getTableCellRendererComponent 
 				        (tab, c.getHeaderValue (), false, 
 					 false, -1, i);
-	    if ((comp != null) && (comp instanceof JComponent) 
-		 && i<toolTips.length) {
+	    if (comp instanceof JComponent
+			&& i < toolTips.length) {
     		JComponent jComp = (JComponent) comp;
     		jComp.setToolTipText (toolTips [i]);
 	    } 

--- a/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/share/configbean/templates/SunDDWizardIterator.java
+++ b/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/share/configbean/templates/SunDDWizardIterator.java
@@ -240,7 +240,7 @@ public final class SunDDWizardIterator implements WizardDescriptor.Instantiating
     private String[] createSteps() {
         String[] beforeSteps = null;
         Object prop = wizard.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         

--- a/enterprise/javaee.beanvalidation/src/org/netbeans/modules/javaee/beanvalidation/AbstractIterator.java
+++ b/enterprise/javaee.beanvalidation/src/org/netbeans/modules/javaee/beanvalidation/AbstractIterator.java
@@ -77,7 +77,7 @@ public abstract class AbstractIterator implements TemplateWizard.Iterator{
         // Creating steps.
         Object prop = wizard.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/enterprise/javaee.beanvalidation/src/org/netbeans/modules/javaee/beanvalidation/ConstraintIterator.java
+++ b/enterprise/javaee.beanvalidation/src/org/netbeans/modules/javaee/beanvalidation/ConstraintIterator.java
@@ -110,7 +110,7 @@ public class ConstraintIterator implements TemplateWizard.Iterator{
         // Creating steps.
         Object prop = wizard.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/dd/ear/ApplicationXmlWizardIterator.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/dd/ear/ApplicationXmlWizardIterator.java
@@ -168,7 +168,7 @@ public final class ApplicationXmlWizardIterator implements WizardDescriptor.Inst
     private String[] createSteps() {
         String[] beforeSteps = null;
         Object prop = wizard.getProperty(WizardDescriptor.PROP_CONTENT_DATA);
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
 

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ear/EarImpl.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ear/EarImpl.java
@@ -723,7 +723,7 @@ public class EarImpl implements EarImplementation, EarImplementation2,
 
     private MavenModule[] checkConfiguration(MavenProject prj, Object conf) {
         List<MavenModule> toRet = new ArrayList<MavenModule>();
-        if (conf != null && conf instanceof Xpp3Dom) {
+        if (conf instanceof Xpp3Dom) {
             ExpressionEvaluator eval = PluginPropertyUtils.createEvaluator(project);
             Xpp3Dom dom = (Xpp3Dom) conf;
             Xpp3Dom modules = dom.getChild("modules"); //NOI18N

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/web/WebCopyOnSave.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/web/WebCopyOnSave.java
@@ -95,7 +95,7 @@ public class WebCopyOnSave extends CopyOnSave implements PropertyChangeListener,
 
     private WebModule getWebModule() {
         final J2eeModuleProvider moduleProvider = getJ2eeModuleProvider();
-        if (moduleProvider != null && moduleProvider instanceof WebModuleProviderImpl) {
+        if (moduleProvider instanceof WebModuleProviderImpl) {
             return ((WebModuleProviderImpl) moduleProvider).findWebModule(getProject().getProjectDirectory());
         }
         return null;

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/refactor/MicronautRefactoringFactory.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/refactor/MicronautRefactoringFactory.java
@@ -258,7 +258,7 @@ public class MicronautRefactoringFactory implements RefactoringPluginFactory {
                 DataObject dobj = DataObject.find(getParentFile());
                 if (dobj != null) {
                     EditorCookie.Observable obs = dobj.getCookie(EditorCookie.Observable.class);
-                    if (obs != null && obs instanceof CloneableEditorSupport) {
+                    if (obs instanceof CloneableEditorSupport) {
                         CloneableEditorSupport supp = (CloneableEditorSupport)obs;
                         return new PositionBounds(supp.createPositionRef(startOffset, Position.Bias.Forward), supp.createPositionRef(Math.max(startOffset, endOffset), Position.Bias.Forward));
                     }

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDWizardIterator.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDWizardIterator.java
@@ -229,7 +229,7 @@ public final class PayaraDDWizardIterator implements WizardDescriptor.Instantiat
     private String[] createSteps() {
         String[] beforeSteps = null;
         Object prop = wizard.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/wizard/BeansXmlIterator.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/wizard/BeansXmlIterator.java
@@ -137,7 +137,7 @@ public class BeansXmlIterator implements TemplateWizard.Iterator {
         // Creating steps.
         Object prop = wizard.getProperty (WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/xml/impl/WebBeansComponentImpl.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/xml/impl/WebBeansComponentImpl.java
@@ -57,7 +57,7 @@ abstract class WebBeansComponentImpl extends
     
     protected static Element createNewElement(String name, WebBeansModelImpl model){
         String ns = WebBeansComponent.WEB_BEANS_NAMESPACE;
-        if( model.getRootComponent()!=null && model.getRootComponent() instanceof AbstractDocumentComponent) {
+        if(model.getRootComponent() instanceof AbstractDocumentComponent) {
             ns = ((AbstractDocumentComponent)model.getRootComponent()).getQName().getNamespaceURI();
         }
         return model.getDocument().createElementNS( ns, name );

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/xml/impl/WebBeansElements.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/xml/impl/WebBeansElements.java
@@ -57,7 +57,7 @@ public enum WebBeansElements {
 
     public QName getQName(WebBeansModelImpl model) {
         String ns = WebBeansComponent.WEB_BEANS_NAMESPACE;
-        if( model.getRootComponent()!=null && model.getRootComponent() instanceof AbstractDocumentComponent) {
+        if( model.getRootComponent() instanceof AbstractDocumentComponent) {
             ns = ((AbstractDocumentComponent)model.getRootComponent()).getQName().getNamespaceURI();
         }
         return new QName( ns, getName() );

--- a/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/JSPELPlugin.java
+++ b/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/JSPELPlugin.java
@@ -137,7 +137,7 @@ public class JSPELPlugin extends ELPlugin {
     public List<Function> getFunctions(FileObject file) {
         List<Function> functions =  new ArrayList<Function>();
         Document document = getDocumentForFile(file);
-        if (document == null || !(document instanceof BaseDocument)) {
+        if (!(document instanceof BaseDocument)) {
             return functions;
         }
 

--- a/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/JspSyntaxSupport.java
+++ b/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/JspSyntaxSupport.java
@@ -375,7 +375,7 @@ public class JspSyntaxSupport extends ExtSyntaxSupport implements FileChangeList
                     try {
                         //check if the cursor is behind an open tag
                         SyntaxElement se = getElementChain(tracking.getOffset());
-                        if(se != null && (se instanceof SyntaxElement.Tag)) {
+                        if(se instanceof SyntaxElement.Tag) {
                             return COMPLETION_POPUP;
                         }
                     }catch(BadLocationException e) {
@@ -1752,7 +1752,7 @@ public class JspSyntaxSupport extends ExtSyntaxSupport implements FileChangeList
     public CompletionItem getAutocompletedEndTag(int offset) {
         try {
             SyntaxElement elem = getElementChain( offset - 1);
-            if(elem != null && elem instanceof SyntaxElement.Tag) {
+            if(elem instanceof SyntaxElement.Tag) {
                 String tagName = ((SyntaxElement.Tag)elem).getName();
                 return HtmlCompletionItem.createAutocompleteEndTag(tagName, offset);
             }

--- a/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/completion/AttrSupports.java
+++ b/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/completion/AttrSupports.java
@@ -278,7 +278,7 @@ public class AttrSupports {
                         //do nothing
                     } finally {
                         // avoids JAR locking
-                        if (cld != null && (cld instanceof Closeable)) {
+                        if (cld instanceof Closeable) {
                             try {
                                 ((Closeable) cld).close();
                             } catch (IOException ex) {

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/BaseJspEditorSupport.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/BaseJspEditorSupport.java
@@ -92,7 +92,7 @@ class BaseJspEditorSupport extends DataEditorSupport implements EditCookie, Edit
     public BaseJspEditorSupport(JspDataObject obj) {
         super(obj, null, new BaseJspEnv(obj));
         DataObject data = getDataObject();
-        if ((data != null) && (data instanceof JspDataObject)) {
+        if (data instanceof JspDataObject) {
             setMIMEType(JspLoader.getMimeType((JspDataObject) data));
         }
 

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/JspLoader.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/JspLoader.java
@@ -57,7 +57,7 @@ public class JspLoader extends UniFileLoader {
     public static final String TAG_MIME_TYPE  = "text/x-tag"; // NOI18N
     
     public static String getMimeType(JspDataObject data) {
-        if ((data == null) || !(data instanceof JspDataObject)) {
+        if (!(data instanceof JspDataObject)) {
             return "";          // NOI18N
         }
         String ext = data.getPrimaryFile().getExt();

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/JspServletDataObject.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/JspServletDataObject.java
@@ -125,10 +125,10 @@ public final class JspServletDataObject extends MultiDataObject {
             EditorCookie newCurrent = computeCurrentEditorCookie();
             if (currentEditor != newCurrent) {
                 // re-register a property change listener to the new editor
-                if ((currentEditor != null) && (currentEditor instanceof EditorCookie.Observable)) {
+                if (currentEditor instanceof EditorCookie.Observable) {
                     ((EditorCookie.Observable)currentEditor).removePropertyChangeListener(this);
                 }
-                if ((newCurrent != null) && (newCurrent instanceof EditorCookie.Observable)) {
+                if (newCurrent instanceof EditorCookie.Observable) {
                     ((EditorCookie.Observable)newCurrent).addPropertyChangeListener(this);
                 }
                 // remember the new editor
@@ -139,7 +139,7 @@ public final class JspServletDataObject extends MultiDataObject {
         
         private EditorCookie computeCurrentEditorCookie() {
             DataObject jsp = servlet.getSourceJspPage();
-            if ((jsp != null) && (jsp instanceof JspDataObject)) {
+            if (jsp instanceof JspDataObject) {
                 if (((JspDataObject)jsp).getServletDataObject() == servlet) {
                     EditorCookie newCookie = ((JspDataObject) jsp).getServletEditor();
                     if (newCookie != null)

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/palette/JspPaletteUtilities.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/palette/JspPaletteUtilities.java
@@ -64,7 +64,7 @@ public final class JspPaletteUtilities {
 
     public static void insert(String s, JTextComponent target, boolean reformat) throws BadLocationException {
         Document _doc = target.getDocument();
-        if (_doc == null || !(_doc instanceof BaseDocument)) {
+        if (!(_doc instanceof BaseDocument)) {
             return;
         }
 
@@ -270,7 +270,7 @@ public final class JspPaletteUtilities {
     /**************************************************************************/
     private static void insertTagLibRef(JTextComponent target, String prefix, String uri) {
         Document doc = target.getDocument();
-        if (doc != null && doc instanceof BaseDocument) {
+        if (doc instanceof BaseDocument) {
             BaseDocument baseDoc = (BaseDocument)doc;
             baseDoc.atomicLock();
             try {

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/ListenerIterator.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/ListenerIterator.java
@@ -243,7 +243,7 @@ public class ListenerIterator implements TemplateWizard.AsynchronousInstantiatin
         // Creating steps.
         Object prop = wiz.getProperty (WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = Utilities.createSteps (beforeSteps, panels);

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/PageIterator.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/PageIterator.java
@@ -361,7 +361,7 @@ public class PageIterator implements TemplateWizard.Iterator {
         // Creating steps.
         Object prop = wiz.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         String[] steps = Utilities.createSteps(beforeSteps, panels);

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/ServletIterator.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/ServletIterator.java
@@ -129,7 +129,7 @@ public class ServletIterator implements TemplateWizard.AsynchronousInstantiating
         // Creating steps.
         Object prop = wizard.getProperty (WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = Utilities.createSteps(beforeSteps, panels);

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/TagHandlerIterator.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/TagHandlerIterator.java
@@ -229,7 +229,7 @@ public class TagHandlerIterator implements TemplateWizard.AsynchronousInstantiat
         // Creating steps.
         Object prop = wiz.getProperty (WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = Utilities.createSteps (beforeSteps, panels);

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/dd/WebFragmentXmlWizardIterator.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/dd/WebFragmentXmlWizardIterator.java
@@ -149,7 +149,7 @@ public final class WebFragmentXmlWizardIterator implements WizardDescriptor.Inst
     private String[] createSteps() {
         String[] beforeSteps = null;
         Object prop = wizard.getProperty(WizardDescriptor.PROP_CONTENT_DATA);
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
 

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/dd/WebXmlWizardIterator.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/dd/WebXmlWizardIterator.java
@@ -148,7 +148,7 @@ public final class WebXmlWizardIterator implements WizardDescriptor.Instantiatin
     private String[] createSteps() {
         String[] beforeSteps = null;
         Object prop = wizard.getProperty(WizardDescriptor.PROP_CONTENT_DATA);
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
 

--- a/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/actions/MapActionUtility.java
+++ b/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/actions/MapActionUtility.java
@@ -511,7 +511,7 @@ public class MapActionUtility {
             PageFlowSceneElement selElement = getSelectedPageFlowSceneElement(scene);
             Widget selectedWidget;
             Point popupPoint;
-            if (selElement != null && selElement instanceof PageFlowSceneElement) {
+            if (selElement instanceof PageFlowSceneElement) {
                 selectedWidget = scene.findWidget(selElement);
                 assert selectedWidget != null;
 
@@ -601,7 +601,7 @@ public class MapActionUtility {
         assert scene != null;
 
         PageFlowSceneElement element = getSelectedPageFlowSceneElement(scene);
-        if (element != null && element instanceof Page) {
+        if (element instanceof Page) {
             return (Page) element;
         }
         return null;

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JsfTemplateUtils.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JsfTemplateUtils.java
@@ -85,7 +85,7 @@ public class JsfTemplateUtils {
         while (children.hasMoreElements()) {
             FileObject folder = children.nextElement();
             Object position = folder.getAttribute("position");
-            if (position == null || !(position instanceof Integer)) {
+            if (!(position instanceof Integer)) {
                 result.add(new Template(folder.getName(), getLocalizedName(folder)));
             } else {
                 result.add(new Template(folder.getName(), getLocalizedName(folder), (Integer) position));

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/editor/JspJsfELPlugin.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/editor/JspJsfELPlugin.java
@@ -216,7 +216,7 @@ public class JspJsfELPlugin extends ELPlugin {
         }
         
         final ParserResult parserResult = completionContext.getParserResult();
-        if (parserResult == null || !(parserResult instanceof ELParserResult)) {
+        if (!(parserResult instanceof ELParserResult)) {
             return null;
         }
         
@@ -238,7 +238,7 @@ public class JspJsfELPlugin extends ELPlugin {
         }
         
         Parser.Result result = results[0];
-        if (result == null || !(result instanceof HtmlParserResult)) {
+        if (!(result instanceof HtmlParserResult)) {
             // unexpected instance of Result
             return null;
         }
@@ -258,7 +258,7 @@ public class JspJsfELPlugin extends ELPlugin {
         CharSequence htmlParserResultText = htmlParserSnapshot.getText();
 
         Element element = htmlParserResult.findByPhysicalRange(elementAtCaretEmbeddedOffset, true);
-        if (element == null || !(element instanceof OpenTag)) {
+        if (!(element instanceof OpenTag)) {
             return null;
         }
         

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/JSFPaletteUtilities.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/JSFPaletteUtilities.java
@@ -135,7 +135,7 @@ public final class JSFPaletteUtilities {
 
     public static void insert(String s, final JTextComponent target) throws BadLocationException {
         Document doc = target.getDocument();
-        if (doc != null && doc instanceof BaseDocument) {
+        if (doc instanceof BaseDocument) {
             final String str = (s == null) ? "" : s;
 
             final BaseDocument baseDoc = (BaseDocument) doc;

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/CompositeComponentWizardIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/CompositeComponentWizardIterator.java
@@ -119,7 +119,7 @@ public final class CompositeComponentWizardIterator implements TemplateWizard.It
 
         Object prop = wizard.getProperty (WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = Utilities.createSteps(beforeSteps, panels);

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/FacesComponentIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/FacesComponentIterator.java
@@ -99,7 +99,7 @@ public class FacesComponentIterator implements TemplateWizard.Iterator {
         // Creating steps.
         Object prop = wiz.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/FacesConfigIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/FacesConfigIterator.java
@@ -260,7 +260,7 @@ public class FacesConfigIterator implements TemplateWizard.Iterator {
         // Creating steps.
         Object prop = wizard.getProperty (WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = Utilities.createSteps(beforeSteps, panels);

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/ManagedBeanIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/ManagedBeanIterator.java
@@ -121,7 +121,7 @@ public class ManagedBeanIterator implements TemplateWizard.Iterator {
         // Creating steps.
         Object prop = wizard.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/ResourceLibraryIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/ResourceLibraryIterator.java
@@ -216,7 +216,7 @@ public class ResourceLibraryIterator implements TemplateWizard.Iterator {
     private String[] createSteps() {
         String[] beforeSteps = null;
         Object prop = descriptor.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
 

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/TemplateClientIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/TemplateClientIterator.java
@@ -138,7 +138,7 @@ public class TemplateClientIterator implements TemplateWizard.Iterator {
         // Creating steps.
         Object prop = wiz.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/TemplateIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/TemplateIterator.java
@@ -159,7 +159,7 @@ public class TemplateIterator implements TemplateWizard.Iterator {
         // Creating steps.
         Object prop = wiz.getProperty(WizardDescriptor.PROP_CONTENT_DATA);
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/enterprise/web.jspparser/src/org/netbeans/modules/web/jspparser/ParserServletContext.java
+++ b/enterprise/web.jspparser/src/org/netbeans/modules/web/jspparser/ParserServletContext.java
@@ -462,7 +462,7 @@ public class ParserServletContext implements ServletContext {
         } catch (DataObjectNotFoundException e) {
             LOGGER.log(Level.INFO, null, e);
         }
-        if (ec != null && (ec instanceof CloneableEditorSupport)) {
+        if ((ec instanceof CloneableEditorSupport)) {
             try {
                 result = ((CloneableEditorSupport) ec).getInputStream();
             } catch (IOException e) {

--- a/enterprise/web.monitor/serversrc/org/netbeans/modules/web/monitor/server/MonitorFilter.java
+++ b/enterprise/web.monitor/serversrc/org/netbeans/modules/web/monitor/server/MonitorFilter.java
@@ -634,7 +634,7 @@ public class MonitorFilter extends Logger implements Filter {
 	if(debug) log ("handleDispatchBefore: start");//NOI18N
 
 	Object w  = req.getAttribute(attNameRequest); 
-	if(w == null || !(w instanceof MonitorRequestWrapper)) { 
+	if(!(w instanceof MonitorRequestWrapper)) {
 	    return; 
 	} 
 	// get the dispatch data 
@@ -668,7 +668,7 @@ public class MonitorFilter extends Logger implements Filter {
 	if(debug) log ("handleDispatchedAfter()");//NOI18N
 
 	Object w  = req.getAttribute(attNameRequest); 
-	if(w == null || !(w instanceof MonitorRequestWrapper)) { 
+	if(!(w instanceof MonitorRequestWrapper)) {
 	    return; 
 	} 
 

--- a/enterprise/web.primefaces/src/org/netbeans/modules/web/primefaces/ui/PrimefacesCustomizerPanel.java
+++ b/enterprise/web.primefaces/src/org/netbeans/modules/web/primefaces/ui/PrimefacesCustomizerPanel.java
@@ -120,7 +120,7 @@ public class PrimefacesCustomizerPanel extends javax.swing.JPanel implements Hel
      */
     public Library getPrimefacesLibrary() {
         Object selectedItem = primefacesLibrariesComboBox.getSelectedItem();
-        if (selectedItem != null && selectedItem instanceof Library) {
+        if (selectedItem instanceof Library) {
             return (Library) selectedItem;
         }
         return null;

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ProjectWebModuleProvider.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ProjectWebModuleProvider.java
@@ -32,7 +32,7 @@ public class ProjectWebModuleProvider implements WebModuleProvider {
 
     public WebModule findWebModule (FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
-        if (project != null && project instanceof WebProject) {
+        if (project instanceof WebProject) {
             return ((WebProject) project).getAPIWebModule();
         }
         return null;

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ProjectWebServicesSupportProvider.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ProjectWebServicesSupportProvider.java
@@ -44,7 +44,7 @@ public class ProjectWebServicesSupportProvider implements WebServicesSupportProv
 
     public WebServicesSupport findWebServicesSupport (FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
-        if (project != null && project instanceof WebProject) {
+        if (project instanceof WebProject) {
             return ((WebProject) project).getAPIWebServicesSupport();
         }
         return null;
@@ -52,7 +52,7 @@ public class ProjectWebServicesSupportProvider implements WebServicesSupportProv
 
     public WebServicesClientSupport findWebServicesClientSupport (FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
-        if (project != null && project instanceof WebProject) {
+        if (project instanceof WebProject) {
             return ((WebProject) project).getAPIWebServicesClientSupport();
         }
         return null;
@@ -60,7 +60,7 @@ public class ProjectWebServicesSupportProvider implements WebServicesSupportProv
 
     public JAXWSSupport findJAXWSSupport(FileObject file) {
         Project project = FileOwnerQuery.getOwner (file);
-        if (project != null && project instanceof WebProject) {
+        if (project instanceof WebProject) {
             return ((WebProject) project).getAPIJAXWSSupport();
         }
         return null;
@@ -68,7 +68,7 @@ public class ProjectWebServicesSupportProvider implements WebServicesSupportProv
     
     public JAXWSClientSupport findJAXWSClientSupport(FileObject file) {
         Project project = FileOwnerQuery.getOwner(file);
-        if (project != null && project instanceof WebProject) {
+        if (project instanceof WebProject) {
             return ((WebProject) project).getAPIJAXWSClientSupport();
         }
         return null;

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsConfigUtilities.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsConfigUtilities.java
@@ -111,7 +111,7 @@ public class StrutsConfigUtilities {
                         } catch (DataObjectNotFoundException e){
                             dOb = null;
                         }
-                        if (dOb !=null && dOb instanceof StrutsConfigDataObject){
+                        if (dOb instanceof StrutsConfigDataObject){
                             StrutsConfigDataObject con = (StrutsConfigDataObject)dOb;
                             // the conf file is not in any module (is not declared in the web.xml)
                             try{
@@ -449,7 +449,7 @@ public class StrutsConfigUtilities {
         try {
             while (resource == null && index < files.length){
                 configDO = DataObject.find(files[index]);
-                if (configDO != null && configDO instanceof StrutsConfigDataObject){
+                if (configDO instanceof StrutsConfigDataObject){
                     StrutsConfig strutsConfig = ((StrutsConfigDataObject)configDO).getStrutsConfig();
                     // we need to chech, whether the config is parseable
                     if (strutsConfig != null){

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/wizards/ActionIterator.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/wizards/ActionIterator.java
@@ -98,7 +98,7 @@ public class ActionIterator implements TemplateWizard.Iterator {
         // Creating steps.
         Object prop = wizard.getProperty (WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = createSteps (beforeSteps, panels);

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/wizards/FormBeanIterator.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/wizards/FormBeanIterator.java
@@ -103,7 +103,7 @@ public class FormBeanIterator implements TemplateWizard.Iterator {
         // Creating steps.
         Object prop = wizard.getProperty (WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = createSteps (beforeSteps, panels);

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/client/wizard/WebServiceClientWizardIterator.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/client/wizard/WebServiceClientWizardIterator.java
@@ -73,7 +73,7 @@ public class WebServiceClientWizardIterator implements TemplateWizard.Iterator {
 
         Object prop = wiz.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = JaxWsUtils.createSteps (beforeSteps, panels);

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/NewWebServiceFromWSDLWizardIterator.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/NewWebServiceFromWSDLWizardIterator.java
@@ -123,7 +123,7 @@ public class NewWebServiceFromWSDLWizardIterator implements TemplateWizard.Itera
         // Creating steps.
         Object prop = this.wiz.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/NewWebServiceWizardIterator.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/NewWebServiceWizardIterator.java
@@ -125,7 +125,7 @@ public class NewWebServiceWizardIterator implements TemplateWizard.Iterator /*, 
         // Creating steps.
         Object prop = this.wiz.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
         String[] beforeSteps = null;
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/WebServiceFromWSDLPanel.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/WebServiceFromWSDLPanel.java
@@ -331,7 +331,7 @@ public class WebServiceFromWSDLPanel extends javax.swing.JPanel implements HelpC
             public void propertyChange(PropertyChangeEvent evt) {
                 if (evt.getPropertyName().equals(PortChooser.IS_VALID)) {
                     Object newvalue = evt.getNewValue();
-                    if ((newvalue != null) && (newvalue instanceof Boolean)) {
+                    if (newvalue instanceof Boolean) {
                         dd.setValid(((Boolean) newvalue));
                     }
                 }

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/WebServiceTypePanel.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/WebServiceTypePanel.java
@@ -254,7 +254,7 @@ public class WebServiceTypePanel extends javax.swing.JPanel implements HelpCtx.P
             public void propertyChange(PropertyChangeEvent evt) {
                 if (evt.getPropertyName().equals(EjbChooser.IS_VALID)) {
                     Object newvalue = evt.getNewValue();
-                    if ((newvalue != null) && (newvalue instanceof Boolean)) {
+                    if (newvalue instanceof Boolean) {
                         dd.setValid(((Boolean) newvalue));
                     }
                 }

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/ArrayTypeTreeNode.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/ArrayTypeTreeNode.java
@@ -58,7 +58,7 @@ public class ArrayTypeTreeNode extends AbstractParameterTreeNode {
         
         // Update the parent node
         DefaultMutableTreeNode parentNode = (DefaultMutableTreeNode) this.getParent();
-        if (parentNode != null && parentNode instanceof ParameterTreeNode) {
+        if (parentNode instanceof ParameterTreeNode) {
             ((ParameterTreeNode)parentNode).updateValueFromChildren(data);
         }
     }

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/ListTypeTreeNode.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/ListTypeTreeNode.java
@@ -60,7 +60,7 @@ public class ListTypeTreeNode extends AbstractParameterTreeNode {
         }
         
         DefaultMutableTreeNode parentNode = (DefaultMutableTreeNode) this.getParent();
-        if (parentNode != null && parentNode instanceof ParameterTreeNode) {
+        if (parentNode instanceof ParameterTreeNode) {
             ((ParameterTreeNode)parentNode).updateValueFromChildren(data);
         }
     }

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/StructureTypeTreeNode.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/StructureTypeTreeNode.java
@@ -62,7 +62,7 @@ public class StructureTypeTreeNode extends AbstractParameterTreeNode {
          * If this node is a member of a structure type, update it's parent.
          */
         DefaultMutableTreeNode parentNode = (DefaultMutableTreeNode) this.getParent();
-        if (parentNode != null && parentNode instanceof ParameterTreeNode) {
+        if (parentNode instanceof ParameterTreeNode) {
             ((ParameterTreeNode)parentNode).updateValueFromChildren(data);
             
         }

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/TypeRowModel.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/TypeRowModel.java
@@ -123,14 +123,14 @@ public class TypeRowModel implements RowModel {
          */
 
         DefaultMutableTreeNode parentNode = (DefaultMutableTreeNode) node.getParent();
-        if(null != parentNode && parentNode instanceof ListTypeTreeNode) {
+        if(parentNode instanceof ListTypeTreeNode) {
             ((ListTypeTreeNode)parentNode).updateValueFromChildren(data);
-        } else if(null != parentNode && parentNode instanceof StructureTypeTreeNode) {
+        } else if(parentNode instanceof StructureTypeTreeNode) {
             /**
              * This type should be a JavaStructureMember
              */
             ((StructureTypeTreeNode)parentNode).updateValueFromChildren(data);
-        } else if(null != parentNode && parentNode instanceof HolderTypeTreeNode) {
+        } else if(parentNode instanceof HolderTypeTreeNode) {
 
             ((HolderTypeTreeNode)parentNode).updateValueFromChildren(data);
         }

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/client/JerseyClientWizardIterator.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/client/JerseyClientWizardIterator.java
@@ -185,7 +185,7 @@ public final class JerseyClientWizardIterator implements WizardDescriptor.Instan
     private String[] createSteps() {
         String[] beforeSteps = null;
         Object prop = wizard.getProperty("WizardPanel_contentData");
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
 

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/editor/AsyncConverter.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/editor/AsyncConverter.java
@@ -117,7 +117,7 @@ abstract class AsyncConverter {
         }
 
         Element enclosingElement = element.getEnclosingElement();
-        if ( enclosingElement== null || !(enclosingElement instanceof TypeElement)){
+        if (!(enclosingElement instanceof TypeElement)){
             return false;
         }
         return true;

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/wizard/fromdb/DatabaseResourceWizardIterator.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/wizard/fromdb/DatabaseResourceWizardIterator.java
@@ -577,7 +577,7 @@ public final class DatabaseResourceWizardIterator implements WizardDescriptor.In
     private String[] createSteps() {
         String[] beforeSteps = null;
         Object prop = wizard.getProperty(WizardDescriptor.PROP_CONTENT_DATA);
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
 

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/DescriptionStep.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/DescriptionStep.java
@@ -193,7 +193,7 @@ public class DescriptionStep implements WizardDescriptor.Panel<WizardDescriptor>
     public void readSettings (WizardDescriptor settings) {
         wd = settings;
         Object o = settings.getProperty (FeatureOnDemandWizardIterator.CHOSEN_TEMPLATE);
-        assert o != null && o instanceof FileObject : o + " is not null and instanceof FileObject.";
+        assert o instanceof FileObject : o + " is not null and instanceof FileObject.";
         FileObject fileObject = (FileObject) o;
         info = FoDLayersProvider.getInstance ().whichProvides(fileObject);
         assert info != null : "No info for " + fileObject;
@@ -214,7 +214,7 @@ public class DescriptionStep implements WizardDescriptor.Panel<WizardDescriptor>
 
     private void waitForDelegateWizard (final boolean fire) {
         Object o = wd.getProperty (FeatureOnDemandWizardIterator.CHOSEN_TEMPLATE);
-        assert o != null && o instanceof FileObject :
+        assert o instanceof FileObject :
             o + " is not null and instanceof FileObject";
         String templateResource = ((FileObject) o).getPath ();
         FileObject fo = null;
@@ -383,7 +383,7 @@ public class DescriptionStep implements WizardDescriptor.Panel<WizardDescriptor>
             };
         }
 
-        assert o != null && o instanceof WizardDescriptor.InstantiatingIterator :
+        assert o instanceof InstantiatingIterator :
             o + " is not null and instanceof WizardDescriptor.InstantiatingIterator";
         return (WizardDescriptor.InstantiatingIterator<?>)o;
     }

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/EnableStep.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/EnableStep.java
@@ -126,7 +126,7 @@ public class EnableStep implements WizardDescriptor.FinishablePanel<WizardDescri
             o + " is instanceof Collection<UpdateElement> or null.";
         forEnable = ((Collection<UpdateElement>) o);
         Object templateO = settings.getProperty (FeatureOnDemandWizardIterator.CHOSEN_TEMPLATE);
-        assert templateO != null && templateO instanceof FileObject : templateO + " is not null and instanceof FileObject.";
+        assert templateO instanceof FileObject : templateO + " is not null and instanceof FileObject.";
         FileObject templateFO = (FileObject) templateO;
         FeatureInfo info = FoDLayersProvider.getInstance().whichProvides(templateFO);
         RequestProcessor.Task t = FeatureManager.getInstance().create(doEnable(info));
@@ -222,7 +222,7 @@ public class EnableStep implements WizardDescriptor.FinishablePanel<WizardDescri
     
     private void waitForDelegateWizard () {
         Object o = wd.getProperty (FeatureOnDemandWizardIterator.CHOSEN_TEMPLATE);
-        assert o != null && o instanceof FileObject :
+        assert o instanceof FileObject :
             o + " is not null and instanceof FileObject";
         final String templateResource = ((FileObject) o).getPath ();
         fo = null;

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/FeatureOnDemandWizardIterator.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/newproject/FeatureOnDemandWizardIterator.java
@@ -85,7 +85,7 @@ implements WizardDescriptor.ProgressInstantiatingIterator<WizardDescriptor>, Cha
             if (o == null) {
                 o = fo.getAttribute ("templateWizardIterator");
             }
-            assert o != null && o instanceof WizardDescriptor.InstantiatingIterator :
+            assert o instanceof InstantiatingIterator :
                 o + " is not null and instanceof WizardDescriptor.InstantiatingIterator";
             WizardDescriptor.InstantiatingIterator iterator = (WizardDescriptor.InstantiatingIterator) o;
             if (! FeatureOnDemandWizardIterator.class.equals (o.getClass ())) {

--- a/extide/gradle.editor/src/org/netbeans/modules/gradle/editor/cli/GradleCliCompletionProvider.java
+++ b/extide/gradle.editor/src/org/netbeans/modules/gradle/editor/cli/GradleCliCompletionProvider.java
@@ -109,7 +109,7 @@ public class GradleCliCompletionProvider implements CompletionProvider {
 
                 Project project = null;
                 Object prop = doc.getProperty(GRADLE_PROJECT_PROPERTY);
-                if (prop != null && prop instanceof Project) {
+                if (prop instanceof Project) {
                     project = (Project) prop;
                 }
                 Matcher tokenMatcher = PROP_INPUT.matcher(filter);

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
@@ -396,7 +396,7 @@ public final class NbGradleProject {
      * @param l
      */
     public static void addPropertyChangeListener(Project project, PropertyChangeListener l) {
-        if (project != null && project instanceof NbGradleProjectImpl) {
+        if (project instanceof NbGradleProjectImpl) {
             ((NbGradleProjectImpl) project).getProjectWatcher().addPropertyChangeListener(l);
         } else {
             assert false : "Attempted to add PropertyChangeListener to project " + project; //NOI18N
@@ -410,7 +410,7 @@ public final class NbGradleProject {
      * @param l
      */
     public static void removePropertyChangeListener(Project project, PropertyChangeListener l) {
-        if (project != null && project instanceof NbGradleProjectImpl) {
+        if (project instanceof NbGradleProjectImpl) {
             ((NbGradleProjectImpl) project).getProjectWatcher().removePropertyChangeListener(l);
         } else {
             assert false : "Attempted to remove PropertyChangeListener to project " + project; //NOI18N

--- a/extide/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.java
@@ -919,7 +919,7 @@ public class SettingsPanel extends javax.swing.JPanel {
             if (cmp instanceof JLabel) {
                 JLabel label = (JLabel) cmp;
                 label.setHorizontalAlignment(RIGHT);
-                if (value != null && value instanceof GradleDistribution) {
+                if (value instanceof GradleDistribution) {
                     GradleDistribution dist = (GradleDistribution) value;
                     label.setText(dist.getVersion());
                     if (!dist.isAvailable()) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/PathFinderVisitor.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/PathFinderVisitor.java
@@ -783,8 +783,8 @@ public class PathFinderVisitor extends ClassCodeVisitorSupport {
                 code = ((ClosureExpression) node).getCode();
             }
 
-            if (code != null && code instanceof BlockStatement
-                    && ((code.getLineNumber() < 0 && code.getColumnNumber() < 0)
+            if (code instanceof BlockStatement
+                && ((code.getLineNumber() < 0 && code.getColumnNumber() < 0)
                     || (code.getLastLineNumber() < 0 && code.getLastColumnNumber() < 0))) {
                 BlockStatement block = (BlockStatement) code;
                 List<Statement> statements = block.getStatements();

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/CompletionContext.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/CompletionContext.java
@@ -767,7 +767,7 @@ public final class CompletionContext {
      * @return a valid ASTNode or null
      */
     private ClassNode getBeforeDotDeclaringClass() {
-        if (declaringClass != null && declaringClass instanceof ClassNode) {
+        if (declaringClass instanceof ClassNode) {
             return declaringClass;
         }
         

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/SpockMethodParamCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/SpockMethodParamCompletion.java
@@ -129,7 +129,7 @@ public class SpockMethodParamCompletion  extends BaseCompletion {
                 AnnotationNode unroll = null;
                 
                 ParserResult pr = request.getParserResult();
-                if(pr != null && pr instanceof GroovyParserResult) {
+                if(pr instanceof GroovyParserResult) {
                     GroovyParserResult gpr = (GroovyParserResult)request.getParserResult();
                     ClassNode unrollCN = gpr.resolveClassName(UNROLL_CLASS);
                     if (unrollCN != null) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/SpockUtils.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/SpockUtils.java
@@ -44,7 +44,7 @@ public class SpockUtils {
             return false;
         }
         ParserResult pr = context.getParserResult();
-        if (pr != null && pr instanceof GroovyParserResult) {
+        if (pr instanceof GroovyParserResult) {
             GroovyParserResult gpr = (GroovyParserResult) pr;
             ClassNode specCN = gpr.resolveClassName("spock.lang.Specification");   //NOI18N
             if (specCN != null) {

--- a/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/ui/WhereUsedPanelMethod.java
+++ b/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/ui/WhereUsedPanelMethod.java
@@ -146,7 +146,7 @@ public class WhereUsedPanelMethod extends WhereUsedPanel.WhereUsedInnerPanel {
                 boolean cellHasFocus) {
             setName("ComboBox.listRenderer"); // NOI18N
 
-            if (value != null && value instanceof ClassNode) {
+            if (value instanceof ClassNode) {
                 ClassNode classNode = ((ClassNode) value);
                 setText(ElementUtils.getNameWithoutPackage(classNode));
 

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/wizard/AbstractFileWizard.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/wizard/AbstractFileWizard.java
@@ -72,7 +72,7 @@ public abstract class AbstractFileWizard implements WizardDescriptor.ProgressIns
         // Make sure list of steps is accurate.
         String[] beforeSteps = null;
         Object prop = wiz.getProperty(WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[]) prop;
         }
         String[] steps = createSteps(beforeSteps, panels);

--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/NodeTableModel.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/NodeTableModel.java
@@ -147,7 +147,7 @@ class NodeTableModel extends AbstractTableModel {
             Object o = props[i].getValue(ATTR_TREE_COLUMN);
             boolean x;
 
-            if ((o != null) && o instanceof Boolean) {
+            if (o instanceof Boolean) {
                 if (((Boolean) o).booleanValue()) {
                     treeColumnProperty = props[i];
                     size--;
@@ -175,7 +175,7 @@ class NodeTableModel extends AbstractTableModel {
 
                     Object o = props[i].getValue(ATTR_ORDER_NUMBER);
 
-                    if ((o != null) && o instanceof Integer) {
+                    if (o instanceof Integer) {
                         sort.put(new Double(((Integer) o).doubleValue()), Integer.valueOf(ia));
                     } else {
                         sort.put(new Double(ia + 0.1), Integer.valueOf(ia));
@@ -185,7 +185,7 @@ class NodeTableModel extends AbstractTableModel {
 
                     Object o = props[i].getValue(ATTR_SORTING_COLUMN);
 
-                    if ((o != null) && o instanceof Boolean) {
+                    if (o instanceof Boolean) {
                         props[i].setValue(ATTR_SORTING_COLUMN, Boolean.FALSE);
                     }
                 }
@@ -193,7 +193,7 @@ class NodeTableModel extends AbstractTableModel {
                 if (!existsComparableColumn) {
                     Object o = props[i].getValue(ATTR_COMPARABLE_COLUMN);
 
-                    if ((o != null) && o instanceof Boolean) {
+                    if (o instanceof Boolean) {
                         existsComparableColumn = ((Boolean) o).booleanValue();
                     }
                 }
@@ -261,7 +261,7 @@ class NodeTableModel extends AbstractTableModel {
 
                 Object o = p.getValue(ATTR_SORTING_COLUMN);
 
-                if ((o != null) && o instanceof Boolean) {
+                if (o instanceof Boolean) {
                     if (((Boolean) o).booleanValue()) {
                         p.setValue(ATTR_SORTING_COLUMN, Boolean.FALSE);
                         p.setValue(ATTR_DESCENDING_ORDER, Boolean.FALSE);
@@ -343,7 +343,7 @@ class NodeTableModel extends AbstractTableModel {
         Property p = allPropertyColumns[column].getProperty();
         Object o = p.getValue(ATTR_COMPARABLE_COLUMN);
 
-        if ((o != null) && o instanceof Boolean) {
+        if (o instanceof Boolean) {
             return ((Boolean) o).booleanValue();
         }
 
@@ -378,7 +378,7 @@ class NodeTableModel extends AbstractTableModel {
         Property p = allPropertyColumns[column].getProperty();
         Object o = p.getValue(ATTR_SORTING_COLUMN);
 
-        if ((o != null) && o instanceof Boolean) {
+        if (o instanceof Boolean) {
             return ((Boolean) o).booleanValue();
         }
 
@@ -464,7 +464,7 @@ class NodeTableModel extends AbstractTableModel {
         Property p = allPropertyColumns[sortColumn].getProperty();
         Object o = p.getValue(ATTR_DESCENDING_ORDER);
 
-        if ((o != null) && o instanceof Boolean) {
+        if (o instanceof Boolean) {
             return ((Boolean) o).booleanValue();
         }
 

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/ui/issue/IssueTopComponent.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/ui/issue/IssueTopComponent.java
@@ -472,7 +472,7 @@ public final class IssueTopComponent extends TopComponent implements PropertyCha
 
     private RepositoryImpl getRepository() {
         Object item = repositoryComboBox.getSelectedItem();
-        if (item == null || !(item instanceof Repository)) {
+        if (!(item instanceof Repository)) {
             return null;
         }
         return APIAccessor.IMPL.getImpl((Repository) item);

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/ui/query/QueryTopComponent.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/ui/query/QueryTopComponent.java
@@ -423,8 +423,7 @@ public final class QueryTopComponent extends TopComponent
         } else if(evt.getPropertyName().equals(RepositoryRegistry.EVENT_REPOSITORIES_CHANGED)) {
             if(query != null) {
                 Object cOld = evt.getOldValue();
-                if(cOld != null &&
-                   cOld instanceof Collection)
+                if(cOld instanceof Collection)
                 {
                     RepositoryImpl thisRepo = query.getRepositoryImpl();
                     if(contains((Collection) cOld, thisRepo)) {
@@ -695,7 +694,7 @@ public final class QueryTopComponent extends TopComponent
 
     private RepositoryImpl getRepository() {
         Object item = repositoryComboBox.getSelectedItem();
-        if (item == null || !(item instanceof Repository)) {
+        if (!(item instanceof Repository)) {
             return null;
         }
         return APIAccessor.IMPL.getImpl((Repository)item);

--- a/ide/bugzilla/src/org/netbeans/modules/bugzilla/commands/BugzillaExecutor.java
+++ b/ide/bugzilla/src/org/netbeans/modules/bugzilla/commands/BugzillaExecutor.java
@@ -423,7 +423,7 @@ public class BugzillaExecutor {
                 return null;
             }
             Throwable cause = status.getException();
-            if(cause != null && cause instanceof RedirectException) {
+            if(cause instanceof RedirectException) {
                 String msg = cause.getMessage();
                 if(msg.contains(KENAI_LOGIN_REDIRECT)) {
                     Bugzilla.LOG.log(Level.FINER, "returned error message [{0}]", msg);                     // NOI18N

--- a/ide/bugzilla/src/org/netbeans/modules/bugzilla/issue/CommentsPanel.java
+++ b/ide/bugzilla/src/org/netbeans/modules/bugzilla/issue/CommentsPanel.java
@@ -435,7 +435,7 @@ public class CommentsPanel extends JPanel {
                 StyledDocument doc = pane.getStyledDocument();
                 Element elem = doc.getCharacterElement(pane.viewToModel(clickPoint));
                 Object l = elem.getAttributes().getAttribute(HyperlinkSupport.LINK_ATTRIBUTE);
-                if (l != null && l instanceof AttachmentLink) {
+                if (l instanceof AttachmentLink) {
                     BugzillaIssue.Attachment attachment = ((AttachmentLink) l).attachment;
                     if (attachment != null) {
                         add(new JMenuItem(attachment.getOpenAction()));

--- a/ide/csl.api/src/org/netbeans/modules/csl/core/CslEditorKit.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/core/CslEditorKit.java
@@ -438,7 +438,7 @@ public final class CslEditorKit extends NbEditorKit {
 
                         Object helpID = a.getValue("helpID"); // NOI18N
 
-                        if ((helpID != null) && (helpID instanceof String)) {
+                        if (helpID instanceof String) {
                             item.putClientProperty("HelpID", helpID); // NOI18N
                         }
                     } else {

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/SequenceElement.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/SequenceElement.java
@@ -59,7 +59,7 @@ class SequenceElement implements Comparable<SequenceElement> {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof SequenceElement)) {
+        if (!(obj instanceof SequenceElement)) {
             return false;
         }
         SequenceElement other = (SequenceElement)obj;

--- a/ide/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/GsfHintsManager.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/GsfHintsManager.java
@@ -381,9 +381,8 @@ public class GsfHintsManager extends HintsProvider.HintsManager {
                 Object nonGuiObject = fo.getAttribute(NON_GUI);
                 boolean toGui = true;
                 
-                if ( nonGuiObject != null && 
-                     nonGuiObject instanceof Boolean &&
-                     ((Boolean)nonGuiObject).booleanValue() ) {
+                if (nonGuiObject instanceof Boolean &&
+                    ((Boolean) nonGuiObject).booleanValue()) {
                     toGui = false;
                 }
                 

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/CreateRulePanel.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/CreateRulePanel.java
@@ -966,7 +966,7 @@ public class CreateRulePanel extends javax.swing.JPanel {
     private static void saveDocumentIfNotOpened(Document document) throws IOException {
 
         Object o = document.getProperty(Document.StreamDescriptionProperty);
-        if (o == null || !(o instanceof DataObject)) {
+        if (!(o instanceof DataObject)) {
             return;
         }
         DataObject dobj = (DataObject) o;

--- a/ide/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/BlobFieldTableCellEditor.java
+++ b/ide/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/BlobFieldTableCellEditor.java
@@ -272,9 +272,9 @@ public class BlobFieldTableCellEditor extends AbstractCellEditor
         }
         is.close();
         os.close();
-        if (t != null && t instanceof RuntimeException) {
+        if (t instanceof RuntimeException) {
             throw (RuntimeException) t;
-        } else if (t != null && t instanceof IOException) {
+        } else if (t instanceof IOException) {
             throw (IOException) t;
         } else if (t != null) {
             throw new RuntimeException(t);

--- a/ide/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/ClobFieldTableCellEditor.java
+++ b/ide/db.dataview/src/org/netbeans/modules/db/dataview/table/celleditor/ClobFieldTableCellEditor.java
@@ -275,9 +275,9 @@ public class ClobFieldTableCellEditor extends AbstractCellEditor
         }
         in.close();
         out.close();
-        if (t != null && t instanceof RuntimeException) {
+        if (t instanceof RuntimeException) {
             throw (RuntimeException) t;
-        } else if (t != null && t instanceof IOException) {
+        } else if (t instanceof IOException) {
             throw (IOException) t;
         } else if (t != null) {
             throw new RuntimeException(t);

--- a/ide/db.mysql/src/org/netbeans/modules/db/mysql/Database.java
+++ b/ide/db.mysql/src/org/netbeans/modules/db/mysql/Database.java
@@ -58,8 +58,8 @@ public class Database implements Node.Cookie {
     
     @Override
     public boolean equals(Object other) {
-        return other != null && other instanceof Database &&
-                ((Database)other).getDbName().equals(getDbName());
+        return other instanceof Database &&
+               ((Database) other).getDbName().equals(getDbName());
     }
     
     @Override

--- a/ide/db.mysql/src/org/netbeans/modules/db/mysql/util/DatabaseUtils.java
+++ b/ide/db.mysql/src/org/netbeans/modules/db/mysql/util/DatabaseUtils.java
@@ -331,7 +331,7 @@ public class DatabaseUtils {
     }
 
     public static boolean isCommunicationsException(DatabaseException dbe) {
-        if (dbe.getCause() == null || !(dbe.getCause() instanceof SQLException)) {
+        if (!(dbe.getCause() instanceof SQLException)) {
             return false;
         }
 

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderGraphFrame.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderGraphFrame.java
@@ -2039,7 +2039,7 @@ public class QueryBuilderGraphFrame extends JPanel
         public void select(Widget widget, Point localLocation, boolean invertSelection) {
 
             Object object = _scene.findObject(widget);
-            if ((object != null) && (object instanceof AbstractNode)) {
+            if (object instanceof AbstractNode) {
 		AbstractNode an = (AbstractNode)object;
 		_queryBuilder.setActivatedNodes(new Node[] { an });
                 _scene.userSelectionSuggested(Collections.singleton(object), invertSelection);

--- a/ide/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergeDialogComponent.java
+++ b/ide/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergeDialogComponent.java
@@ -301,7 +301,7 @@ public class MergeDialogComponent extends TopComponent implements ChangeListener
     
     public MergePanel getSelectedMergePanel() {
         Component selected = mergeTabbedPane.getSelectedComponent();
-        if (selected == null || !(selected instanceof MergePanel)) return null;
+        if (!(selected instanceof MergePanel)) return null;
         return ((MergePanel) selected);
     }
     

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/JschSupport.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/JschSupport.java
@@ -123,7 +123,7 @@ public final class JschSupport {
             } catch (JSchException ex) {
                 String message = ex.getMessage();
                 Throwable cause = ex.getCause();
-                if (cause != null && cause instanceof NullPointerException) {
+                if (cause instanceof NullPointerException) {
                     // Jsch bug... retry?
                     log.log(Level.INFO, "JSch exception opening channel to " + env + ". Retrying", ex); // NOI18N
                 } else if ("java.io.InterruptedIOException".equals(message)) { // NOI18N

--- a/ide/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/OpenInEditorActionProvider.java
+++ b/ide/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/OpenInEditorActionProvider.java
@@ -85,7 +85,7 @@ public class OpenInEditorActionProvider extends ExternalCommandActionProvider {
             URL url = null;
             try {
 
-                if (key != null && (key instanceof String)) {
+                if (key instanceof String) {
                     ExecutionEnvironment env = ExecutionEnvironmentFactory.fromUniqueID((String) key);
                     if (env.isRemote()) {
                         url = new URL("rfs://" + key + filePath); //NOI18N

--- a/ide/editor.actions/src/org/netbeans/modules/editor/actions/AddCaretAction.java
+++ b/ide/editor.actions/src/org/netbeans/modules/editor/actions/AddCaretAction.java
@@ -51,7 +51,7 @@ public class AddCaretAction extends AbstractEditorAction {
     protected void actionPerformed(ActionEvent evt, final JTextComponent target) {
         if (target != null) {
             Caret caret = target.getCaret();
-            if (caret != null && caret instanceof EditorCaret) {
+            if (caret instanceof EditorCaret) {
                 final EditorCaret editorCaret = (EditorCaret) caret;
                 final BaseDocument doc = (BaseDocument) target.getDocument();
                 final boolean upAction = EditorActionNames.addCaretUp.equals(actionName());

--- a/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionActionsMainMenu.java
+++ b/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionActionsMainMenu.java
@@ -107,7 +107,7 @@ public abstract class CompletionActionsMainMenu extends MainMenuAction implement
 
         presenter.setEnabled(action != null);
         JTextComponent comp = Utilities.getFocusedComponent();
-        if (comp != null && comp instanceof JEditorPane){
+        if (comp instanceof JEditorPane){
             addAccelerators(this, presenter, comp);
         } else {
             presenter.setAccelerator(getDefaultAccelerator());

--- a/ide/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationView.java
+++ b/ide/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationView.java
@@ -500,7 +500,7 @@ public class AnnotationView extends JComponent implements FoldHierarchyListener,
             scrollPaneCandidade = scrollPaneCandidade.getParent();
         }
         
-        if (scrollPaneCandidade == null || !(scrollPaneCandidade instanceof JScrollPane) || scrollBar == null) {
+        if (!(scrollPaneCandidade instanceof JScrollPane) || scrollBar == null) {
             //no help for #54080:
             return getHeight() - HEIGHT_OFFSET;
         }

--- a/ide/editor.indent/src/org/netbeans/modules/editor/indent/TaskHandler.java
+++ b/ide/editor.indent/src/org/netbeans/modules/editor/indent/TaskHandler.java
@@ -561,9 +561,9 @@ public final class TaskHandler {
         }
 
         private Lookup getLookup() {
-            if (indentTask != null && indentTask instanceof Lookup.Provider) {
+            if (indentTask instanceof Lookup.Provider) {
                 return ((Lookup.Provider)indentTask).getLookup();
-            } else if (reformatTask != null && reformatTask instanceof Lookup.Provider) {
+            } else if (reformatTask instanceof Lookup.Provider) {
                 return ((Lookup.Provider)reformatTask).getLookup();
             } else {
                 return null;

--- a/ide/editor.lib/src/org/netbeans/editor/GlyphGutter.java
+++ b/ide/editor.lib/src/org/netbeans/editor/GlyphGutter.java
@@ -898,7 +898,7 @@ public class GlyphGutter extends JComponent implements Annotations.AnnotationsLi
                             Object defAction = a.getValue("default-action");
                             if (toInvoke == null && defAction != null && ((Boolean) defAction)) {
                                 Object supportedAnnotationTypes = a.getValue("default-action-excluded-annotation-types");
-                                if (supportedAnnotationTypes == null || !(supportedAnnotationTypes instanceof String[]) || Collections.disjoint(Arrays.asList((String[]) supportedAnnotationTypes), annotationTypes)) {
+                                if (!(supportedAnnotationTypes instanceof String[]) || Collections.disjoint(Arrays.asList((String[]) supportedAnnotationTypes), annotationTypes)) {
                                     toInvoke = a;
                                 }
                             }

--- a/ide/editor.lib/src/org/netbeans/editor/WeakEventListenerList.java
+++ b/ide/editor.lib/src/org/netbeans/editor/WeakEventListenerList.java
@@ -192,7 +192,7 @@ public class WeakEventListenerList extends EventListenerList {
         for (int i = 0; i < listenerSize; i += 2) {
             Class t = (Class)listenerList[i];
             EventListener l = (EventListener)((WeakReference)listenerList[i + 1]).get();
-            if ((l != null) && (l instanceof Serializable)) {
+            if (l instanceof Serializable) {
                 os.writeObject(t.getName());
                 os.writeObject(l);
             }

--- a/ide/editor.lib/src/org/netbeans/editor/ext/ExtKit.java
+++ b/ide/editor.lib/src/org/netbeans/editor/ext/ExtKit.java
@@ -317,7 +317,7 @@ public class ExtKit extends BaseKit {
                         }
                         item.setEnabled(a.isEnabled());
                         Object helpID = a.getValue ("helpID"); // NOI18N
-                        if (helpID != null && (helpID instanceof String))
+                        if (helpID instanceof String)
                             item.putClientProperty ("HelpID", helpID); // NOI18N
                     }
                 }

--- a/ide/editor.search/src/org/netbeans/modules/editor/search/EditorFindSupport.java
+++ b/ide/editor.search/src/org/netbeans/modules/editor/search/EditorFindSupport.java
@@ -521,7 +521,7 @@ public final class EditorFindSupport {
         incSearchReset();
         props = getValidFindProperties(props);
         boolean back = isBackSearch(props, oppositeDir);
-        if (props.get(FIND_WHAT) == null || !(props.get(FIND_WHAT) instanceof String)) {
+        if (!(props.get(FIND_WHAT) instanceof String)) {
             return null;
         }
         String findWhat = (String) props.get(FIND_WHAT);

--- a/ide/editor.search/src/org/netbeans/modules/editor/search/SearchNbEditorKit.java
+++ b/ide/editor.search/src/org/netbeans/modules/editor/search/SearchNbEditorKit.java
@@ -124,7 +124,7 @@ public final class SearchNbEditorKit extends NbEditorKit {
 
     public static void openFindIfNecessary(JTextComponent component, ActionEvent evt) {
         Object findWhat = EditorFindSupport.getInstance().getFindProperty(EditorFindSupport.FIND_WHAT);
-        if (findWhat == null || !(findWhat instanceof String) || ((String) findWhat).isEmpty()) {
+        if (!(findWhat instanceof String) || ((String) findWhat).isEmpty()) {
 
             Action findAction = ((BaseKit) component.getUI().getEditorKit(
                     component)).getActionByName("find");

--- a/ide/editor/src/org/netbeans/modules/editor/MainMenuAction.java
+++ b/ide/editor/src/org/netbeans/modules/editor/MainMenuAction.java
@@ -245,7 +245,7 @@ public abstract class MainMenuAction implements Presenter.Menu, ChangeListener, 
         
         presenter.setEnabled(action != null);
         JTextComponent comp = Utilities.getFocusedComponent();
-        if (comp != null && comp instanceof JEditorPane){
+        if (comp instanceof JEditorPane){
             addAccelerators(action, presenter, comp);
         } else {
             presenter.setAccelerator(getDefaultAccelerator());

--- a/ide/editor/src/org/netbeans/modules/editor/NbEditorDocument.java
+++ b/ide/editor/src/org/netbeans/modules/editor/NbEditorDocument.java
@@ -144,7 +144,7 @@ NbDocument.Printable, NbDocument.CustomEditor, NbDocument.CustomToolbar, NbDocum
                                        boolean replace) {
         if (s != null) {
             Object val = s.getAttribute(NbDocument.GUARDED);
-            if (val != null && val instanceof Boolean) {
+            if (val instanceof Boolean) {
                 if (((Boolean)val).booleanValue() == true) { // want make guarded
                     super.setCharacterAttributes(offset, length, guardedSet, replace);
                 } else { // want make unguarded

--- a/ide/editor/src/org/netbeans/modules/editor/NbEditorKit.java
+++ b/ide/editor/src/org/netbeans/modules/editor/NbEditorKit.java
@@ -766,7 +766,7 @@ public class NbEditorKit extends ExtKit implements Callable {
                     } else {
                         item.setEnabled(action.isEnabled());
                         Object helpID = action.getValue ("helpID"); // NOI18N
-                        if (helpID != null && (helpID instanceof String)) {
+                        if ((helpID instanceof String)) {
                             item.putClientProperty ("HelpID", helpID); // NOI18N
                         }
                         assignAccelerator(component.getKeymap(), action, item);
@@ -1060,7 +1060,7 @@ public class NbEditorKit extends ExtKit implements Callable {
                         Mnemonics.setLocalizedText(item, itemText);
                         addAcceleretors(a, item, target);
                         Object helpID = a.getValue ("helpID"); // NOI18N
-                        if (helpID != null && (helpID instanceof String))
+                        if ((helpID instanceof String))
                             item.putClientProperty ("HelpID", helpID); // NOI18N
                     }
                 }
@@ -1243,7 +1243,7 @@ public class NbEditorKit extends ExtKit implements Callable {
                     addAcceleretors(nonContextAction, item, target);
                     item.setEnabled(action.isEnabled());
                     Object helpID = action.getValue ("helpID"); // NOI18N
-                    if (helpID != null && (helpID instanceof String)) {
+                    if (helpID instanceof String) {
                         item.putClientProperty ("HelpID", helpID); // NOI18N
                     }
                 }

--- a/ide/editor/src/org/netbeans/modules/editor/impl/CustomizableSideBar.java
+++ b/ide/editor/src/org/netbeans/modules/editor/impl/CustomizableSideBar.java
@@ -474,7 +474,7 @@ public final class CustomizableSideBar {
                 position = fo.getAttribute("position"); // NOI18N
             }
             
-            if (position != null && position instanceof String) {
+            if (position instanceof String) {
                 String positionName = (String) position;
                 
                 if (WEST_NAME.equals(positionName)) {
@@ -503,7 +503,7 @@ public final class CustomizableSideBar {
             
             Object scrollable = fo.getAttribute("scrollable"); // NOI18N
             
-            if (scrollable != null && scrollable instanceof Boolean) {
+            if (scrollable instanceof Boolean) {
                 this.scrollable = ((Boolean) scrollable).booleanValue();
             } else {
                 this.scrollable = true;

--- a/ide/extbrowser/src/org/netbeans/modules/extbrowser/ExtWebBrowser.java
+++ b/ide/extbrowser/src/org/netbeans/modules/extbrowser/ExtWebBrowser.java
@@ -243,7 +243,7 @@ public class ExtWebBrowser implements HtmlBrowser.Factory, java.io.Serializable,
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals(ExtWebBrowser.PROP_BROWSER_EXECUTABLE)) {
             Object np = evt.getNewValue();
-            if ((np != null) && (np instanceof NbProcessDescriptor)) {
+            if (np instanceof NbProcessDescriptor) {
                 String processName = ((NbProcessDescriptor)np).getProcessName();
                 if (err.isLoggable(Level.FINE)) {
                     err.log(Level.FINE, "" + System.currentTimeMillis() + "> propertychange: " + processName);

--- a/ide/extbrowser/src/org/netbeans/modules/extbrowser/SystemDefaultBrowser.java
+++ b/ide/extbrowser/src/org/netbeans/modules/extbrowser/SystemDefaultBrowser.java
@@ -179,7 +179,7 @@ public class SystemDefaultBrowser extends ExtWebBrowser {
             return;
         }
         final HtmlBrowser.Impl impl = createHtmlBrowserImpl();
-        final ExtBrowserImpl extImpl = impl != null && impl instanceof ExtBrowserImpl ? (ExtBrowserImpl)impl : null;
+        final ExtBrowserImpl extImpl = impl instanceof ExtBrowserImpl ? (ExtBrowserImpl)impl : null;
         if (extImpl != null) {
             RP.post(new Runnable() {
                 @Override

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/HtmlElementProperties.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/HtmlElementProperties.java
@@ -197,7 +197,7 @@ public class HtmlElementProperties {
 
     private static String[] findTags(String tagName, String attrName) {
         ValueCompletion support = AttrValuesCompletion.getSupport(tagName, attrName);
-        if (support != null && support instanceof AttrValuesCompletion.ValuesSetSupport) {
+        if (support instanceof AttrValuesCompletion.ValuesSetSupport) {
             AttrValuesCompletion.ValuesSetSupport fixedValuesSupport = (AttrValuesCompletion.ValuesSetSupport) support;
             return fixedValuesSupport.getTags();
         }

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/Utils.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/Utils.java
@@ -51,7 +51,7 @@ public class Utils {
     public static void saveDocumentIfNotOpened(Document document) throws IOException {
 
         Object o = document.getProperty(Document.StreamDescriptionProperty);
-        if (o == null || !(o instanceof DataObject)) {
+        if (!(o instanceof DataObject)) {
             return;
         }
         DataObject dobj = (DataObject) o;

--- a/ide/html/src/org/netbeans/modules/html/api/HtmlDataNode.java
+++ b/ide/html/src/org/netbeans/modules/html/api/HtmlDataNode.java
@@ -72,7 +72,7 @@ public final class HtmlDataNode extends org.openide.loaders.DataNode {
                 Action a = actions[i];
                 if (a != null) {
                     Object value = a.getValue("type"); //NOI18N
-                    if (value != null && (value instanceof String)) {
+                    if (value instanceof String) {
                         String type = (String) value;
                         if (VIEWABLE_CLASS_NAME.equals(type)) {
                             continue;

--- a/ide/html/src/org/netbeans/modules/html/palette/HtmlPaletteUtilities.java
+++ b/ide/html/src/org/netbeans/modules/html/palette/HtmlPaletteUtilities.java
@@ -126,7 +126,7 @@ public final class HtmlPaletteUtilities {
     public static void insert(final String s, final JTextComponent target, final boolean reformat)
             throws BadLocationException {
         final Document _doc = target.getDocument();
-        if (_doc == null || !(_doc instanceof BaseDocument)) {
+        if (!(_doc instanceof BaseDocument)) {
             return;
         }
 

--- a/ide/hudson.ui/src/org/netbeans/modules/hudson/ui/spi/ProjectHudsonProvider.java
+++ b/ide/hudson.ui/src/org/netbeans/modules/hudson/ui/spi/ProjectHudsonProvider.java
@@ -324,7 +324,7 @@ public abstract class ProjectHudsonProvider {
         }
 
         public @Override boolean equals(Object obj) {
-            if (obj == null || !(obj instanceof Association)) {
+            if (!(obj instanceof Association)) {
                 return false;
             }
             return toString().equals(obj.toString());

--- a/ide/languages/src/org/netbeans/modules/languages/LanguagesManager.java
+++ b/ide/languages/src/org/netbeans/modules/languages/LanguagesManager.java
@@ -147,7 +147,7 @@ public class LanguagesManager extends org.netbeans.api.languages.LanguagesManage
     
     private void languageChanged (String mimeType) {
         Language language = mimeTypeToLanguage.get (mimeType);
-        if (language != null && language instanceof LanguageImpl) {
+        if (language instanceof LanguageImpl) {
             try {
                 FileSystem fs = Repository.getDefault ().getDefaultFileSystem ();
                 FileObject fo = fs.findResource ("Editors/" + mimeType + "/language.nbs");

--- a/ide/languages/src/org/netbeans/modules/languages/features/ASTBrowserTopComponent.java
+++ b/ide/languages/src/org/netbeans/modules/languages/features/ASTBrowserTopComponent.java
@@ -244,7 +244,7 @@ final class ASTBrowserTopComponent extends TopComponent {
             lastPane = pane;
         }
         Document document = editorCookie.getDocument ();
-        if (document == null || !(document instanceof NbEditorDocument)) return null;
+        if (!(document instanceof NbEditorDocument)) return null;
         return ParserManagerImpl.getImpl (document).getAST ();
     }
 

--- a/ide/languages/src/org/netbeans/modules/languages/features/HyperlinkListener.java
+++ b/ide/languages/src/org/netbeans/modules/languages/features/HyperlinkListener.java
@@ -180,7 +180,7 @@ public class HyperlinkListener implements MouseMotionListener, MouseListener,
             DatabaseContext root = DatabaseManager.getRoot (ast);
             if (root != null) {
                 final DatabaseItem item = root.getDatabaseItem (offset);
-                if (item != null && item instanceof DatabaseUsage) {
+                if (item instanceof DatabaseUsage) {
                     highlight = Highlighting.getHighlighting (document).highlight (
                         path.getLeaf ().getOffset (),
                         path.getLeaf ().getEndOffset (),

--- a/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryChooserUI.java
+++ b/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryChooserUI.java
@@ -2021,7 +2021,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             // #89393: GTK needs name to render cell renderer "natively"
             setName("ComboBox.listRenderer"); // NOI18N
             
-            if (value != null && value instanceof FileFilter) {
+            if (value instanceof FileFilter) {
                 setText(((FileFilter)value).getDescription());
             }
             

--- a/ide/projectui/src/org/netbeans/modules/project/ui/NewFileIterator.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/NewFileIterator.java
@@ -201,7 +201,7 @@ public class NewFileIterator implements WizardDescriptor.AsynchronousInstantiati
         // Make sure list of steps is accurate.
         String[] beforeSteps = null;
         Object prop = wiz.getProperty (WizardDescriptor.PROP_CONTENT_DATA);
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
         String[] steps = createSteps (beforeSteps);

--- a/ide/properties/src/org/netbeans/modules/properties/Element.java
+++ b/ide/properties/src/org/netbeans/modules/properties/Element.java
@@ -599,7 +599,7 @@ public abstract class Element implements Serializable {
 
         /** Checks for equality of two ItemElem-s */
         public boolean equals(Object item) {
-            if (item == null || !(item instanceof ItemElem))
+            if (!(item instanceof ItemElem))
                 return false;
             ItemElem ie = (ItemElem)item;
             return isKeyEqual(ie) && isValueEqual(ie) && isCommentEqual(ie);

--- a/ide/properties/src/org/netbeans/modules/properties/PropertiesTableModel.java
+++ b/ide/properties/src/org/netbeans/modules/properties/PropertiesTableModel.java
@@ -487,7 +487,7 @@ public class PropertiesTableModel extends AbstractTableModel {
         /** Overrides superclass method. */
         @Override
         public boolean equals(Object obj) {
-            if(obj == null || !(obj instanceof StringPair))
+            if(!(obj instanceof StringPair))
                 return false;
             
             StringPair compared = (StringPair)obj;

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/UndoableWrapper.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/UndoableWrapper.java
@@ -60,9 +60,9 @@ public class UndoableWrapper implements UndoableEditWrapper {
             return ed;
         final Object stream = doc.getProperty(BaseDocument.StreamDescriptionProperty);
         DataObject dob = null;
-        if(stream != null && stream instanceof DataObject) {
+        if(stream instanceof DataObject) {
             dob = (DataObject) stream;
-        } else if(stream != null && stream instanceof FileObject) {
+        } else if(stream instanceof FileObject) {
             FileObject fileObject = (FileObject) stream;
             try {
                 dob = DataObject.find(fileObject);

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
@@ -309,7 +309,7 @@ public class DebuggerManagerListener extends DebuggerManagerAdapter {
                     }
                 }
             }
-            if (a != null && a instanceof DebuggerAction) {
+            if (a instanceof DebuggerAction) {
                 return (DebuggerAction) a;
             }
         }

--- a/ide/spi.navigator/src/org/netbeans/modules/navigator/NavigatorTC.java
+++ b/ide/spi.navigator/src/org/netbeans/modules/navigator/NavigatorTC.java
@@ -316,7 +316,7 @@ public final class NavigatorTC extends TopComponent implements NavigatorDisplaye
 
     @Override
     public UndoRedo getUndoRedo() {
-        if (selectedPanel == null || !(selectedPanel instanceof NavigatorPanelWithUndo)) {
+        if (!(selectedPanel instanceof NavigatorPanelWithUndo)) {
             return UndoRedo.NONE;
         }
         return ((NavigatorPanelWithUndo)selectedPanel).getUndoRedo();

--- a/ide/spi.palette/src/org/netbeans/modules/palette/DefaultItem.java
+++ b/ide/spi.palette/src/org/netbeans/modules/palette/DefaultItem.java
@@ -80,7 +80,7 @@ public class DefaultItem implements Item {
     }
 
     public boolean equals(Object obj) {
-        if( null == obj || !(obj instanceof DefaultItem) )
+        if(!(obj instanceof DefaultItem))
             return false;
         
         return itemNode.equals( ((DefaultItem) obj).itemNode );

--- a/ide/spi.palette/src/org/netbeans/modules/palette/Utils.java
+++ b/ide/spi.palette/src/org/netbeans/modules/palette/Utils.java
@@ -199,7 +199,7 @@ public final class Utils {
     public static boolean isOpenedByUser( TopComponent tc ) {
         Object val = tc.getClientProperty( "userOpened" );
         tc.putClientProperty("userOpened", null);
-        return null != val && val instanceof Boolean && ((Boolean)val).booleanValue();
+        return val instanceof Boolean && ((Boolean) val).booleanValue();
     }
 
     /**

--- a/ide/spi.palette/src/org/netbeans/modules/palette/ui/CategoryButton.java
+++ b/ide/spi.palette/src/org/netbeans/modules/palette/ui/CategoryButton.java
@@ -275,7 +275,7 @@ class CategoryButton extends JCheckBox implements Autoscroll {
                 policy = kfm.getDefaultFocusTraversalPolicy();
             Component next = moveDown ? policy.getComponentAfter( container, CategoryButton.this )
                                       : policy.getComponentBefore( container, CategoryButton.this );
-            if( null != next && next instanceof CategoryList ) {
+            if(next instanceof CategoryList) {
                 if( ((CategoryList)next).getModel().getSize() != 0 ) {
                     ((CategoryList)next).takeFocusFrom( CategoryButton.this );
                     return;
@@ -284,7 +284,7 @@ class CategoryButton extends JCheckBox implements Autoscroll {
                                     : policy.getComponentBefore( container, next );
                 }
             }
-            if( null != next && next instanceof CategoryButton ) {
+            if(next instanceof CategoryButton) {
                 next.requestFocus();
             }
         }

--- a/ide/spi.palette/src/org/netbeans/modules/palette/ui/CategoryList.java
+++ b/ide/spi.palette/src/org/netbeans/modules/palette/ui/CategoryList.java
@@ -564,7 +564,7 @@ public class CategoryList extends JList implements Autoscroll {
                 policy = kfm.getDefaultFocusTraversalPolicy();
             Component next = focusNext ? policy.getComponentAfter( container, CategoryList.this )
                                       : policy.getComponentBefore( container, CategoryList.this );
-            if( null != next && next instanceof CategoryButton ) {
+            if(next instanceof CategoryButton) {
                 clearSelection();
                 next.requestFocus();
             }

--- a/ide/subversion/src/org/netbeans/modules/subversion/HistoryProvider.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/HistoryProvider.java
@@ -192,7 +192,7 @@ public class HistoryProvider implements VCSHistoryProvider {
                 FileUtils.copyFile(file, revisionFile); // XXX lets be faster - LH should cache that somehow ...
             } catch (IOException e) {
                 Exception ex = e;
-                if (e.getCause() != null && e.getCause() instanceof SVNClientException) {
+                if (e.getCause() instanceof SVNClientException) {
                     ex = (SVNClientException) e.getCause();
                 }
                 if (SvnClientExceptionHandler.isCancelledAction(ex.getMessage())) {

--- a/ide/subversion/src/org/netbeans/modules/subversion/client/SvnClientInvocationHandler.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/client/SvnClientInvocationHandler.java
@@ -394,7 +394,7 @@ public class SvnClientInvocationHandler implements InvocationHandler {
         if (args != null) {
             for (int i = 0; i < args.length; ++i) {
                 Object arg = args[i];
-                if (arg != null && arg instanceof SVNUrl) {
+                if (arg instanceof SVNUrl) {
                     try {
                         args[i] = SvnUtils.decodeAndEncodeUrl((SVNUrl) arg);
                     } catch (MalformedURLException ex) {

--- a/ide/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Terminal.java
+++ b/ide/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Terminal.java
@@ -670,7 +670,7 @@ public final class Terminal extends JComponent {
         }
         findState.setVisible(true);
         Container ancestor = SwingUtilities.getAncestorOfClass(TerminalContainer.class, this);
-        if (ancestor != null && ancestor instanceof TerminalContainer) {
+        if (ancestor instanceof TerminalContainer) {
             Task t = new Task.ActivateSearch((TerminalContainer) ancestor, this);
             t.post();
         }
@@ -1043,7 +1043,7 @@ public final class Terminal extends JComponent {
 	findAction.setEnabled(false);
         
         Container container = SwingUtilities.getAncestorOfClass(TerminalContainer.class, this);
-        boolean isTerminalContainer = (container != null && container instanceof TerminalContainer);
+        boolean isTerminalContainer = container instanceof TerminalContainer;
 	
 	JPopupMenu menu = Utilities.actionsToPopup(
 		new Action[]{

--- a/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/SwitchTabAction.java
+++ b/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/SwitchTabAction.java
@@ -65,7 +65,7 @@ public class SwitchTabAction extends TerminalAction {
     @Override
     protected void performAction() {
         Container container = SwingUtilities.getAncestorOfClass(TerminalContainer.class, getTerminal());
-        if (container != null && container instanceof TerminalContainer) {
+        if (container instanceof TerminalContainer) {
             TerminalContainer tc = (TerminalContainer) container;
             List<? extends Component> allTabs = tc.getAllTabs();
             try {

--- a/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/TerminalAction.java
+++ b/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/TerminalAction.java
@@ -58,7 +58,7 @@ public abstract class TerminalAction extends AbstractAction implements ContextAw
              */
             if (source instanceof Component) {
                 Container container = SwingUtilities.getAncestorOfClass(Terminal.class, (Component) source);
-                if (container != null && container instanceof Terminal) {
+                if (container instanceof Terminal) {
                     this.context = (Terminal) container;
                 }
             }

--- a/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/TextmateTokenId.java
+++ b/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/TextmateTokenId.java
@@ -126,11 +126,11 @@ public enum TextmateTokenId implements TokenId {
                 while (en.hasMoreElements()) {
                     FileObject candidate = en.nextElement();
                     Object attr = candidate.getAttribute(GRAMMAR_MARK);
-                    if (attr != null && attr instanceof String) {
+                    if (attr instanceof String) {
                         String scope = (String) attr;
                         scope2File.put(scope, candidate);
                         attr = candidate.getAttribute(INJECTION_MARK);
-                        if (attr != null && attr instanceof String) {
+                        if (attr instanceof String) {
                             for (String s : ((String)attr).split(",")) {
                                 scope2Injections.computeIfAbsent(s, str -> new ArrayList<>()).add(scope);
                             }

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/filesystems/VCSFilesystemInterceptor.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/filesystems/VCSFilesystemInterceptor.java
@@ -421,7 +421,7 @@ public final class VCSFilesystemInterceptor {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || !(o instanceof FileEx)) return false;
+            if (!(o instanceof FileEx)) return false;
             FileEx fileEx = (FileEx) o;
             return isFolder == fileEx.isFolder && name.equals(fileEx.name) && parent.equals(fileEx.parent);
         }

--- a/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffSidebar.java
+++ b/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/diff/DiffSidebar.java
@@ -1102,7 +1102,7 @@ class DiffSidebar extends JPanel implements DocumentListener, ComponentListener,
 
         if (dao instanceof MultiDataObject) {
             MultiDataObject.Entry entry = findEntryForFile((MultiDataObject) dao, fileObj);
-            if ((entry != null) && (entry instanceof CookieSet.Factory)) {
+            if (entry instanceof CookieSet.Factory) {
                 CookieSet.Factory factory = (CookieSet.Factory) entry;
                 return factory.createCookie(EditorCookie.class);   //can be null
             }

--- a/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryFileView.java
+++ b/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryFileView.java
@@ -116,7 +116,7 @@ class HistoryFileView implements PreferenceChangeListener, VCSHistoryProvider.Hi
     
     private HistoryRootNode getRootNode() {
         Node rootContext = tablePanel.getExplorerManager().getRootContext();
-        if(rootContext == null || !(rootContext instanceof HistoryRootNode)) {
+        if(!(rootContext instanceof HistoryRootNode)) {
             return null;
         }  
         return (HistoryRootNode) rootContext;

--- a/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/history/RevisionNode.java
+++ b/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/history/RevisionNode.java
@@ -150,7 +150,7 @@ class RevisionNode extends AbstractNode implements Comparable {
 
     @Override
     public int compareTo(Object obj) {
-        if( !(obj instanceof RevisionNode) || obj == null) {
+        if(!(obj instanceof RevisionNode)) {
             return -1;
         }
         RevisionNode node = (RevisionNode) obj;
@@ -436,7 +436,7 @@ class RevisionNode extends AbstractNode implements Comparable {
         
         @Override
         public int compareTo(Object obj) {
-            if( !(obj instanceof FileNode) || obj == null) {
+            if(!(obj instanceof FileNode)) {
                 return -1;
             }
             FileNode node = (FileNode) obj;        

--- a/ide/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowserPane.java
+++ b/ide/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowserPane.java
@@ -217,13 +217,13 @@ public final class WebBrowserPane {
     
     public void setProjectContext(Lookup projectContext) {
         lastProjectContext = projectContext;
-        if ( impl != null && impl instanceof EnhancedBrowser ){
+        if ( impl instanceof EnhancedBrowser ){
             ((EnhancedBrowser) impl).setProjectContext(projectContext);
         }
     }
 
     public boolean ignoreChange(FileObject fo) {
-        if (impl != null && impl instanceof EnhancedBrowser) {
+        if (impl instanceof EnhancedBrowser) {
             return ((EnhancedBrowser)impl).ignoreChange(fo);
         }
         return false;

--- a/ide/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowsers.java
+++ b/ide/web.browser.api/src/org/netbeans/modules/web/browser/api/WebBrowsers.java
@@ -408,9 +408,9 @@ public final class WebBrowsers {
 
     static BrowserFamilyId getIDEOptionsBrowserFamily() {
         HtmlBrowser.Factory factory = IDESettings.getWWWBrowser();
-        if (factory != null && factory instanceof ExtWebBrowser) {
+        if (factory instanceof ExtWebBrowser) {
             return WebBrowserFactoryDescriptor.convertBrowserFamilyId(((ExtWebBrowser)factory).getPrivateBrowserFamilyId());
-        } else if (factory != null && factory instanceof EnhancedBrowserFactory) {
+        } else if (factory instanceof EnhancedBrowserFactory) {
             return ((EnhancedBrowserFactory)factory).getBrowserFamilyId();
         }
         return BrowserFamilyId.UNKNOWN;

--- a/ide/web.common/src/org/netbeans/modules/web/common/api/ByteStack.java
+++ b/ide/web.common/src/org/netbeans/modules/web/common/api/ByteStack.java
@@ -169,7 +169,7 @@ public final class ByteStack {
             return true;
         }
 
-        if (obj == null || !(obj instanceof ByteStack)) {
+        if (!(obj instanceof ByteStack)) {
             return false;
         }
 

--- a/ide/xml.axi/src/org/netbeans/modules/xml/axi/AXIContainer.java
+++ b/ide/xml.axi/src/org/netbeans/modules/xml/axi/AXIContainer.java
@@ -114,7 +114,7 @@ public abstract class AXIContainer extends AXIComponent {
     public void addElement(AbstractElement child) {
         if(this instanceof Element) {
             AXIType type = ((Element)this).getType();
-            if(type != null && type instanceof ContentModel) {
+            if(type instanceof ContentModel) {
                 ((ContentModel)type).addElement(child);
                 return;
             }

--- a/ide/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelUpdater.java
+++ b/ide/xml.axi/src/org/netbeans/modules/xml/axi/impl/AXIModelUpdater.java
@@ -307,7 +307,7 @@ public class AXIModelUpdater extends DeepAXITreeVisitor {
         }
         //the element ref now points to a different global element
         AXIComponent newElement = Util.lookup(elementRef.getModel(), newGE);
-        if(newElement != null && newElement instanceof Element) {
+        if(newElement instanceof Element) {
             elementRef.setRef((Element)newElement);
             elementRef.forceFireEvent();
         }
@@ -350,7 +350,7 @@ public class AXIModelUpdater extends DeepAXITreeVisitor {
         
         //the attribute ref now points to a different global attribute
         AXIComponent newAttr = Util.lookup(attributeRef.getModel(), newGA);
-        if(newAttr != null && newAttr instanceof Attribute) {
+        if(newAttr instanceof Attribute) {
             attributeRef.setRef((Attribute)newAttr);
             attributeRef.forceFireEvent();
         }

--- a/ide/xml.axi/src/org/netbeans/modules/xml/axi/impl/ElementImpl.java
+++ b/ide/xml.axi/src/org/netbeans/modules/xml/axi/impl/ElementImpl.java
@@ -341,7 +341,7 @@ public final class ElementImpl extends Element {
         }
         
         //remove listener from old content model
-        if(oldValue != null && oldValue instanceof ContentModel) {
+        if(oldValue instanceof ContentModel) {
             ContentModel cm = (ContentModel)oldValue;
             cm.removeListener(this);
         }
@@ -382,7 +382,7 @@ public final class ElementImpl extends Element {
      * Overwrites addCompositor of AXIContainer.
      */
     public void addCompositor(Compositor compositor) {
-        if( getType() != null && getType() instanceof ContentModel &&
+        if( getType() instanceof ContentModel &&
                 getModel() != ((ContentModel)getType()).getModel() ) {
             //no drops allowed when the element's type
             //belongs to some other model
@@ -400,7 +400,7 @@ public final class ElementImpl extends Element {
      */
     public void addAttribute(AbstractAttribute attribute) {
         AXIType type = getType();
-        if(type != null && type instanceof ContentModel) {
+        if(type instanceof ContentModel) {
             ((ContentModel)type).addAttribute(attribute);
             return;
         }

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogPanel.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogPanel.java
@@ -97,7 +97,7 @@ public class CatalogPanel extends TopComponent implements ExplorerManager.Provid
         private void invokeInplaceEditing() {
             if (startEditing == null) {
                 Object o = tree.getActionMap().get("startEditing"); // NOI18N
-                if (o != null && o instanceof Action) {
+                if (o instanceof Action) {
                     startEditing = (Action) o;
                 }
             }

--- a/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionUtil.java
+++ b/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionUtil.java
@@ -309,8 +309,8 @@ public class CompletionUtil {
         if(element == null)
             return null;
         AXIType type = element.getType();
-        if( type == null || !(type instanceof Datatype) ||
-            ((Datatype)type).getEnumerations() == null)
+        if(!(type instanceof Datatype) ||
+           ((Datatype) type).getEnumerations() == null)
             return null;
         for(Object value: ((Datatype)type).getEnumerations()) {
             if(context.getTypedChars() == null || context.getTypedChars().equals("")) {
@@ -345,8 +345,8 @@ public class CompletionUtil {
         if(attr == null)
             return null;
         AXIType type = attr.getType();
-        if(type == null || !(type instanceof Datatype) ||
-           ((Datatype)type).getEnumerations() == null)
+        if(!(type instanceof Datatype) ||
+           ((Datatype) type).getEnumerations() == null)
             return null;                
         for(Object value: ((Datatype)type).getEnumerations()) {
             String str = (value != null) ? value.toString() : null;
@@ -589,7 +589,7 @@ public class CompletionUtil {
             parent = child;
         }
         
-        if(child != null && (child instanceof Element))
+        if((child instanceof Element))
             return (Element)child;
         
         return null;

--- a/ide/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/RefCacheSupport.java
+++ b/ide/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/RefCacheSupport.java
@@ -91,7 +91,7 @@ public class RefCacheSupport {
      */
     public SchemaModelImpl getCachedModel(SchemaModelReference ref) {
         Object cachedValue = refModelCache.get(ref);
-        if (cachedValue != null && cachedValue instanceof SmAttachment) {
+        if (cachedValue instanceof SmAttachment) {
             return SmAttachment.class.cast(cachedValue).mSchemaModel;
         } else {
             return null;
@@ -199,7 +199,7 @@ public class RefCacheSupport {
                     //
                     if (SchemaModelReference.SCHEMA_LOCATION_PROPERTY.equals(propName)) {
                         Object source = evt.getSource();
-                        if (source != null && source instanceof SchemaModelReference) {
+                        if (source instanceof SchemaModelReference) {
                             excludeModelRef((SchemaModelReference)source);
                             // System.out.println("schema location changed");
                         }
@@ -207,7 +207,7 @@ public class RefCacheSupport {
                     //
                     if (Import.NAMESPACE_PROPERTY.equals(propName)) {
                         Object source = evt.getSource();
-                        if (source != null && source instanceof Import) {
+                        if (source instanceof Import) {
                             excludeModelRef((Import)source);
                             // System.out.println("Import's namespace changed");
                         }
@@ -288,7 +288,7 @@ public class RefCacheSupport {
     private synchronized void excludeModelRef(SchemaModelReference sModelRef) {
         Object oldValue = refModelCache.remove(sModelRef);
         //
-        if (oldValue != null && oldValue instanceof SmAttachment) {
+        if (oldValue instanceof SmAttachment) {
             SmAttachment sma = SmAttachment.class.cast(oldValue);
             sma.mSchemaModel.removePropertyChangeListener(sma.mPCL);
         }

--- a/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
+++ b/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
@@ -618,7 +618,7 @@ public final class XMLSyntaxSupport extends ExtSyntaxSupport implements XMLToken
                     dotPos = target.getCaret().getDot();
                     try {
                         SyntaxElement sel = getElementChain(dotPos);
-                        if(sel != null && sel instanceof StartTag) {
+                        if(sel instanceof StartTag) {
                             retVal = COMPLETION_POPUP;
                         }
                     } catch (BadLocationException e) {

--- a/ide/xml.text/src/org/netbeans/modules/xml/text/completion/XMLCompletionProvider.java
+++ b/ide/xml.text/src/org/netbeans/modules/xml/text/completion/XMLCompletionProvider.java
@@ -64,7 +64,7 @@ public class XMLCompletionProvider implements CompletionProvider {
     @Override
     public int getAutoQueryTypes(JTextComponent component, String typedText) {
         XMLSyntaxSupport support = XMLSyntaxSupport.getSyntaxSupport(component.getDocument());
-        if( (support == null) || !(support instanceof XMLSyntaxSupport))
+        if(!(support instanceof XMLSyntaxSupport))
             return 0;
         
         int type = checkCompletion(support, component, typedText, false);

--- a/ide/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/validation/MessagePart.java
+++ b/ide/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap/validation/MessagePart.java
@@ -47,7 +47,7 @@ public class MessagePart {
         if (other == this) {
             return true;
         }
-        if (other == null || !(other instanceof MessagePart)) {
+        if (!(other instanceof MessagePart)) {
             return false;
         }
 

--- a/ide/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/validation/MessagePart.java
+++ b/ide/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/model/extensions/soap12/validation/MessagePart.java
@@ -47,7 +47,7 @@ public class MessagePart {
         if (other == this) {
             return true;
         }
-        if (other == null || !(other instanceof MessagePart)) {
+        if (!(other instanceof MessagePart)) {
             return false;
         }
 

--- a/ide/xml/src/org/netbeans/modules/xml/wizard/impl/DTDPanel.java
+++ b/ide/xml/src/org/netbeans/modules/xml/wizard/impl/DTDPanel.java
@@ -252,8 +252,8 @@ public class DTDPanel extends AbstractPanel {
     // does user entered a PID
     private boolean existsPID() {
         Object pid = pidModel.getSelectedItem();
-        return (pid != null) && (pid instanceof String)
-            && (((String)pid).trim().equals("") == false);
+        return (pid instanceof String)
+               && (((String) pid).trim().equals("") == false);
     }
 
     private void updatePossibilities() {

--- a/ide/xml/src/org/netbeans/modules/xml/wizard/impl/XMLWizardIterator.java
+++ b/ide/xml/src/org/netbeans/modules/xml/wizard/impl/XMLWizardIterator.java
@@ -152,7 +152,7 @@ public class XMLWizardIterator implements TemplateWizard.Iterator {
         }
         model = new DocumentModel(targetFolderURL);
         Object prop = templateWizard.getProperty (WizardDescriptor.PROP_CONTENT_DATA); // NOI18N
-        if (prop != null && prop instanceof String[]) {
+        if (prop instanceof String[]) {
             beforeSteps = (String[])prop;
         }
     }

--- a/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitNodeOpener.java
+++ b/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitNodeOpener.java
@@ -63,7 +63,7 @@ public final class MavenJUnitNodeOpener extends NodeOpener {
         Children childrens = node.getChildren();
         if (childrens != null) {
             Node child = childrens.getNodeAt(0);
-            if ((child != null) && (child instanceof MavenJUnitTestMethodNode)) {
+            if (child instanceof MavenJUnitTestMethodNode) {
                 final FileObject fo = ((MavenJUnitTestMethodNode) child).getTestcaseFileObject();
                 if (fo != null) {
                     final long[] line = new long[]{0};

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Hacks.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Hacks.java
@@ -113,7 +113,7 @@ public class Hacks {
             if (TreeUtilities.CLASS_TREE_KINDS.contains(tp.getLeaf().getKind())) {
                 Element currentElement = info.getTrees().getElement(tp);
 
-                if (currentElement == null || !(currentElement instanceof ClassSymbol)) return null;
+                if (!(currentElement instanceof ClassSymbol)) return null;
 
                 Enter enter = Enter.instance(JavaSourceAccessor.getINSTANCE().getJavacTask(info).getContext());
                 Env<AttrContext> env = enter.getEnv((ClassSymbol) currentElement);

--- a/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/GeneratorUtils.java
+++ b/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/GeneratorUtils.java
@@ -88,7 +88,7 @@ public final class GeneratorUtils {
         GuardedDocument gdoc = null;
         try {
             Document doc = wc.getDocument();
-            if (doc != null && doc instanceof GuardedDocument) {
+            if (doc instanceof GuardedDocument) {
                 gdoc = (GuardedDocument)doc;
             }
         } catch (IOException ioe) {}

--- a/nb/welcome/src/org/netbeans/modules/welcome/content/ActionButton.java
+++ b/nb/welcome/src/org/netbeans/modules/welcome/content/ActionButton.java
@@ -40,7 +40,7 @@ public class ActionButton extends LinkButton {
         this.action = a;
         this.urlString = urlString;
         Object icon = a.getValue( Action.SMALL_ICON );
-        if( null != icon && icon instanceof Icon )
+        if(icon instanceof Icon)
             setIcon( (Icon)icon );
         Object tooltip = a.getValue( Action.SHORT_DESCRIPTION );
         if( null != tooltip )

--- a/nbi/engine/src/org/netbeans/installer/Installer.java
+++ b/nbi/engine/src/org/netbeans/installer/Installer.java
@@ -151,7 +151,7 @@ public class Installer implements FinishHandler {
     public void finish() {
         int exitCode = NORMAL_ERRORCODE;
         final Object prop = System.getProperties().get(EXIT_CODE_PROPERTY);
-        if ( prop!= null && prop instanceof Integer) {
+        if (prop instanceof Integer) {
             try {
                 exitCode = ((Integer)prop).intValue();
             } catch (NumberFormatException e) {

--- a/nbi/engine/src/org/netbeans/installer/utils/UiUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/UiUtils.java
@@ -370,8 +370,7 @@ public final class UiUtils {
                             } else if (e instanceof ExceptionInInitializerError) {
                                 final Throwable cause = e.getCause();
                                 
-                                if ((cause != null) &&
-                                        (cause instanceof HeadlessException)) {
+                                if (cause instanceof HeadlessException) {
                                     System.err.println(cause.getMessage());
                                 }
                             }                            

--- a/nbi/engine/src/org/netbeans/installer/wizard/components/panels/JdkLocationPanel.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/components/panels/JdkLocationPanel.java
@@ -317,7 +317,7 @@ public class JdkLocationPanel extends ApplicationLocationPanel {
         final Object obj = getWizard().
                 getContext().
                 get(Product.class);
-        if (obj != null && obj instanceof Product) {
+        if (obj instanceof Product) {
             final Product product = (Product) obj;
             final String jdkSysPropName = product.getUid() + StringUtils.DOT +
                     JdkLocationPanel.JDK_LOCATION_PROPERTY;
@@ -563,7 +563,7 @@ public class JdkLocationPanel extends ApplicationLocationPanel {
         
         final Object objectContext = getWizard().getContext().get(Product.class);
         boolean sort = false;
-        if(objectContext != null && objectContext instanceof Product) {
+        if(objectContext instanceof Product) {
             final Product product = (Product) objectContext;
             for (Dependency dependency : product.getDependencies(InstallAfter.class)) {
                 

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/breakpoints/LineBreakpoint.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/breakpoints/LineBreakpoint.java
@@ -104,7 +104,7 @@ public class LineBreakpoint extends AbstractBreakpoint {
                 DataObject dataObject = DataEditorSupport.findDataObject(myLine);
                 EditorCookie editorCookie = (EditorCookie) dataObject.getLookup().lookup(EditorCookie.class);
                 final StyledDocument styledDocument = editorCookie.getDocument();
-                if (styledDocument != null && styledDocument instanceof BaseDocument) {
+                if (styledDocument instanceof BaseDocument) {
                     try {
                         final BaseDocument baseDocument = (BaseDocument) styledDocument;
                         Source source = Source.create(baseDocument);
@@ -113,7 +113,7 @@ public class LineBreakpoint extends AbstractBreakpoint {
                             @Override
                             public void run(ResultIterator resultIterator) throws Exception {
                                 Parser.Result parserResult = resultIterator.getParserResult();
-                                if (parserResult != null && parserResult instanceof PHPParseResult) {
+                                if (parserResult instanceof PHPParseResult) {
                                     PHPParseResult phpParserResult = (PHPParseResult) parserResult;
                                     int rowStart = LineDocumentUtils.getLineStartFromIndex(baseDocument, myLine.getLineNumber());
                                     int contentStart = Utilities.getRowFirstNonWhite(baseDocument, rowStart);

--- a/php/php.project/src/org/netbeans/modules/php/project/PhpProject.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/PhpProject.java
@@ -1034,7 +1034,7 @@ public final class PhpProject implements Project {
         public List<Object> getTestSourceRoots(Collection<SourceGroup> createdSourceRoots, FileObject refFileObject) {
             ArrayList<Object> folders = new ArrayList<>();
             Project p = FileOwnerQuery.getOwner(refFileObject);
-            if (p != null && (p instanceof PhpProject)) {
+            if (p instanceof PhpProject) {
                 List<FileObject> seleniumDirectories = ProjectPropertiesSupport.getSeleniumDirectories((PhpProject) p, true);
                 SourceGroup[] sourceGroups = PhpProjectUtils.getSourceGroups((PhpProject) p);
                 for (SourceGroup sg : sourceGroups) {

--- a/php/php.refactoring/src/org/netbeans/modules/refactoring/php/RefactoringTask.java
+++ b/php/php.refactoring/src/org/netbeans/modules/refactoring/php/RefactoringTask.java
@@ -114,7 +114,7 @@ public abstract class RefactoringTask extends UserTask implements Runnable {
         @Override
         public void run(ResultIterator resultIterator) throws Exception {
             Result parserResult = resultIterator.getParserResult();
-            if (parserResult != null && parserResult instanceof PHPParseResult) {
+            if (parserResult instanceof PHPParseResult) {
                 Program root = RefactoringUtils.getRoot((PHPParseResult) parserResult);
                 if (root != null) {
                     uiHolder = createRefactoringUIHolder((PHPParseResult) parserResult);

--- a/php/php.refactoring/src/org/netbeans/modules/refactoring/php/findusages/WhereUsedSupport.java
+++ b/php/php.refactoring/src/org/netbeans/modules/refactoring/php/findusages/WhereUsedSupport.java
@@ -205,7 +205,7 @@ public final class WhereUsedSupport {
                             @Override
                             public void run(ResultIterator resultIterator) throws Exception {
                                 Result parserResult = resultIterator.getParserResult();
-                                if (parserResult != null && parserResult instanceof PHPParseResult) {
+                                if (parserResult instanceof PHPParseResult) {
                                     Model modelForDeclaration = ModelFactory.getModel((PHPParseResult) parserResult);
                                     declarations.add(modelForDeclaration.findDeclaration(declarationElement));
                                 }

--- a/platform/api.visual/src/org/netbeans/api/visual/widget/Widget.java
+++ b/platform/api.visual/src/org/netbeans/api/visual/widget/Widget.java
@@ -254,7 +254,7 @@ public class Widget implements Accessible, Lookup.Provider {
         child.updateResources(this, true);
         child.revalidate ();
         revalidate ();
-        if (accessibleContext != null  &&  accessibleContext instanceof WidgetAccessibleContext)
+        if (accessibleContext instanceof WidgetAccessibleContext)
             ((WidgetAccessibleContext) accessibleContext).notifyChildAdded (this, child);
         scene.dispatchNotifyAdded (child);
     }
@@ -272,7 +272,7 @@ public class Widget implements Accessible, Lookup.Provider {
         child.updateResources(this, false);
         child.revalidate ();
         revalidate ();
-        if (accessibleContext != null  &&  accessibleContext instanceof WidgetAccessibleContext)
+        if (accessibleContext instanceof WidgetAccessibleContext)
             ((WidgetAccessibleContext) accessibleContext).notifyChildRemoved (this, child);
         scene.dispatchNotifyRemoved (child);
     }

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleUpdateUnitImpl.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleUpdateUnitImpl.java
@@ -83,7 +83,7 @@ public class ModuleUpdateUnitImpl extends UpdateUnitImpl {
                 UpdateElementImpl visibleImpl = Trampoline.API.impl(visibleAncestor.getInstalled());
                 String visTargetCluster = null;
                 String visCat = null;
-                if (visibleImpl != null && visibleImpl instanceof ModuleUpdateElementImpl) {
+                if (visibleImpl instanceof ModuleUpdateElementImpl) {
                     visTargetCluster = ((ModuleUpdateElementImpl) visibleImpl).getInstallationCluster();
                     visCat = visibleImpl.getCategory();
                 }

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/OperationValidator.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/OperationValidator.java
@@ -516,7 +516,7 @@ abstract class OperationValidator {
             boolean res = false;
             UpdateElementImpl impl = Trampoline.API.impl (uElement);
             assert impl != null;
-            if (impl != null && impl instanceof NativeComponentUpdateElementImpl) {
+            if (impl instanceof NativeComponentUpdateElementImpl) {
                 NativeComponentUpdateElementImpl ni = (NativeComponentUpdateElementImpl) impl;
                 if (ni.getInstallInfo ().getCustomInstaller () != null) {
                     res = containsElement (uElement, unit);
@@ -538,7 +538,7 @@ abstract class OperationValidator {
             boolean res = false;
             UpdateElementImpl impl = Trampoline.API.impl (uElement);
             assert impl != null;
-            if (impl != null && impl instanceof NativeComponentUpdateElementImpl) {
+            if (impl instanceof NativeComponentUpdateElementImpl) {
                 NativeComponentUpdateElementImpl ni = (NativeComponentUpdateElementImpl) impl;
                 res = ni.getNativeItem ().getUpdateItemDeploymentImpl ().getCustomUninstaller () != null;
             }

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/NetworkAccess.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/NetworkAccess.java
@@ -100,7 +100,7 @@ public class NetworkAccess {
                         listener.notifyException (ix);
                     } catch (ExecutionException ex) {
                         Throwable t = ex.getCause();
-                        if(t!=null && t instanceof Exception) {
+                        if(t instanceof Exception) {
                             listener.notifyException ((Exception) t);
                         } else {
                             listener.notifyException (ex);

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitTab.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/UnitTab.java
@@ -1299,7 +1299,7 @@ public final class UnitTab extends javax.swing.JPanel {
         @Override
         protected boolean isEnabled(Unit u) {
             boolean retval = false;
-            if ((u != null) && (u instanceof Unit.Update)) {
+            if (u instanceof Unit.Update) {
                 retval = u.canBeMarked();
             }
             return retval;
@@ -1386,7 +1386,7 @@ public final class UnitTab extends javax.swing.JPanel {
         @Override
         protected boolean isEnabled(Unit u) {
             boolean retval = false;
-            if ((u != null) && (u instanceof Unit.Available)) {
+            if (u instanceof Unit.Available) {
                 retval = u.canBeMarked();
             }
             return retval;
@@ -1675,7 +1675,7 @@ public final class UnitTab extends javax.swing.JPanel {
 
         protected boolean isEnabled (Unit u) {
             boolean retval = false;
-            if ((u != null) && (u instanceof Unit.Installed)) {
+            if (u instanceof Unit.Installed) {
                 Unit.Installed i = (Unit.Installed)u;
                 if (!i.getRelevantElement ().isEnabled ()) {
                      retval = Unit.Installed.isOperationAllowed (u.updateUnit, u.getRelevantElement (), Containers.forEnable ());
@@ -1700,7 +1700,7 @@ public final class UnitTab extends javax.swing.JPanel {
             String category = uu.getCategoryName();
             List<Unit> units = model.getUnits();
             for (Unit u : units) {
-                if ((u != null) && (u instanceof Unit.Installed) && category.equals(u.getCategoryName())) {
+                if ((u instanceof Unit.Installed) && category.equals(u.getCategoryName())) {
                     Unit.Installed installed = (Unit.Installed) u;
                     if (!installed.getRelevantElement().isEnabled()) {
                         retval = Unit.Installed.isOperationAllowed(installed.updateUnit, installed.getRelevantElement(), Containers.forEnable());
@@ -1712,7 +1712,7 @@ public final class UnitTab extends javax.swing.JPanel {
         }
         @Override
         protected String getContextName (Unit u) {
-            if ((u != null) && (u instanceof Unit.Installed)) {
+            if (u instanceof Unit.Installed) {
                 return getActionName ()+ " \"" + u.getCategoryName () + "\"";
             }
             return getActionName ();
@@ -1726,7 +1726,7 @@ public final class UnitTab extends javax.swing.JPanel {
             int count = model.getRowCount ();
             for (int i = 0; i < count; i++) {
                 Unit u = model.getUnitAtRow (i);
-                if ((u != null) && (u instanceof Unit.Installed) && category.equals (u.getCategoryName ())) {
+                if ((u instanceof Unit.Installed) && category.equals(u.getCategoryName())) {
                     Unit.Installed installed = (Unit.Installed)u;
                     if (!installed.getRelevantElement().isEnabled() && !installed.updateUnit.isPending()) {
                         OperationInfo info = Containers.forEnable ().add (installed.updateUnit, installed.getRelevantElement ());
@@ -1807,7 +1807,7 @@ public final class UnitTab extends javax.swing.JPanel {
 
         protected boolean isEnabled (Unit u) {
             boolean retval = false;
-            if ((u != null) && (u instanceof Unit.Installed)) {
+            if (u instanceof Unit.Installed) {
                 Unit.Installed i = (Unit.Installed)u;
                 if (i.getRelevantElement ().isEnabled ()) {
                     retval = Unit.Installed.isOperationAllowed (u.updateUnit, u.getRelevantElement (), Containers.forDisable ());
@@ -1828,7 +1828,7 @@ public final class UnitTab extends javax.swing.JPanel {
         @Override
         protected boolean isEnabled(Unit u) {
             boolean retval = false;
-            if ((u != null) && (u instanceof Unit.Installed)) {
+            if (u instanceof Unit.Installed) {
                 Unit.Installed i = (Unit.Installed) u;
                 if (! i.getRelevantElement().isEnabled()) {
                     retval = Unit.Installed.isOperationAllowed(u.updateUnit, u.getRelevantElement(), Containers.forEnable());
@@ -1865,7 +1865,7 @@ public final class UnitTab extends javax.swing.JPanel {
 
         @Override
         protected String getContextName(Unit u) {
-            if ((u != null) && (u instanceof Unit.Installed)) {
+            if (u instanceof Unit.Installed) {
                 return getActionName() + " \"" + u.getDisplayName() + "\""; //NOI18N
             }
             return getActionName();
@@ -1881,7 +1881,7 @@ public final class UnitTab extends javax.swing.JPanel {
         @Override
         protected boolean isEnabled(Unit u) {
             boolean retval = false;
-            if ((u != null) && (u instanceof Unit.Installed)) {
+            if (u instanceof Unit.Installed) {
                 Unit.Installed i = (Unit.Installed) u;
                 if (i.getRelevantElement().isEnabled()) {
                     retval = Unit.Installed.isOperationAllowed(u.updateUnit, u.getRelevantElement(), Containers.forDisable());
@@ -1918,7 +1918,7 @@ public final class UnitTab extends javax.swing.JPanel {
 
         @Override
         protected String getContextName(Unit u) {
-            if ((u != null) && (u instanceof Unit.Installed)) {
+            if (u instanceof Unit.Installed) {
                 return getActionName() + " \"" + u.getDisplayName() + "\""; //NOI18N
             }
             return getActionName();
@@ -1934,7 +1934,7 @@ public final class UnitTab extends javax.swing.JPanel {
         @Override
         protected boolean isEnabled(Unit u) {
             boolean retval = false;
-            if ((u != null) && (u instanceof Unit.Installed)) {
+            if (u instanceof Unit.Installed) {
                 retval = ((Unit.Installed)u).isUninstallAllowed();
             }
             return retval;
@@ -1968,7 +1968,7 @@ public final class UnitTab extends javax.swing.JPanel {
 
         @Override
         protected String getContextName(Unit u) {
-            if ((u != null) && (u instanceof Unit.Installed)) {
+            if (u instanceof Unit.Installed) {
                 return getActionName() + " \"" + u.getDisplayName() + "\""; //NOI18N
             }
             return getActionName();
@@ -1988,7 +1988,7 @@ public final class UnitTab extends javax.swing.JPanel {
             String category = uu.getCategoryName();
             List<Unit> units = model.getUnits();
             for (Unit u : units) {
-                if ((u != null) && (u instanceof Unit.Installed) && category.equals(u.getCategoryName())) {
+                if ((u instanceof Unit.Installed) && category.equals(u.getCategoryName())) {
                     Unit.Installed installed = (Unit.Installed) u;
                     if (installed.getRelevantElement().isEnabled()) {
                         retval = Unit.Installed.isOperationAllowed(installed.updateUnit, installed.getRelevantElement(), Containers.forDisable());
@@ -2000,7 +2000,7 @@ public final class UnitTab extends javax.swing.JPanel {
         
         @Override
         protected String getContextName (Unit u) {
-            if ((u != null) && (u instanceof Unit.Installed)) {
+            if (u instanceof Unit.Installed) {
                 return getActionName ()+ " \"" + u.getCategoryName () + "\"";//NOI18N
             }
             return getActionName ();
@@ -2014,7 +2014,7 @@ public final class UnitTab extends javax.swing.JPanel {
             int count = model.getRowCount ();
             for (int i = 0; i < count; i++) {
                 Unit u = model.getUnitAtRow (i);
-                if ((u != null) && (u instanceof Unit.Installed) && category.equals (u.getCategoryName ())) {
+                if ((u instanceof Unit.Installed) && category.equals(u.getCategoryName())) {
                     Unit.Installed installed = (Unit.Installed)u;
                     if (installed.getRelevantElement().isEnabled() && !installed.updateUnit.isPending()) {
                         OperationInfo info = Containers.forDisable ().add (installed.updateUnit, installed.getRelevantElement ());

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
@@ -622,7 +622,7 @@ public final class MultiViewPeer implements PropertyChangeListener {
             if (descs[i].getPersistenceType() != TopComponent.PERSISTENCE_NEVER) {
                 // only those requeTopsted and previously created elements are serialized.
                 MultiViewElement elem = model.getElementForDescription(descs[i], false);
-                if (elem != null && elem instanceof Serializable) {
+                if (elem instanceof Serializable) {
                     out.writeObject(elem);
                 }
             }

--- a/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
@@ -146,7 +146,7 @@ public class LocalAddressUtils {
         try (final DatagramSocket socket = new DatagramSocket()) {
             socket.connect(SOMEADDR_IPV4, 10002);   // doesn¨t need to be reachable .. and port it irrelevant
             InetAddress addr = socket.getLocalAddress();
-            if (addr != null && (addr instanceof Inet4Address) && (!addr.isAnyLocalAddress() && (!addr.isLoopbackAddress()))) {
+            if ((addr instanceof Inet4Address) && (!addr.isAnyLocalAddress() && (!addr.isLoopbackAddress()))) {
                 list.add(addr);
             }
         } catch (SecurityException | SocketException ex) {
@@ -155,7 +155,7 @@ public class LocalAddressUtils {
         try (final DatagramSocket socket = new DatagramSocket()) {
             socket.connect(SOMEADDR_IPV6, 10002);   // doesn¨t need to be reachable .. and port it irrelevant
             InetAddress addr = socket.getLocalAddress();
-            if (addr != null && (addr instanceof Inet6Address) && (!addr.isAnyLocalAddress() && (!addr.isLoopbackAddress()))) {
+            if ((addr instanceof Inet6Address) && (!addr.isAnyLocalAddress() && (!addr.isLoopbackAddress()))) {
                 list.add(addr);
             }
         } catch (SecurityException | SocketException ex) {

--- a/platform/core.output2/src/org/netbeans/core/output2/Controller.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/Controller.java
@@ -413,7 +413,7 @@ public class Controller {
             case IOEvent.CMD_DEF_COLORS:
                 if (tab != null) {
                     Document doc = tab.getOutputPane().getDocument();
-                    if (doc != null && doc instanceof OutputDocument) {
+                    if (doc instanceof OutputDocument) {
                         Lines lines = ((OutputDocument) doc).getLines();
                         if (lines != null) {
                             IOColors.OutputType type = (IOColors.OutputType) data;

--- a/platform/core.output2/src/org/netbeans/core/output2/OutputTab.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/OutputTab.java
@@ -164,7 +164,7 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
         Document old = getDocument();
         hasOutputListeners = false;
         super.setDocument(doc);
-        if (old != null && old instanceof OutputDocument) {
+        if (old instanceof OutputDocument) {
             ((OutputDocument) old).dispose();
         }
         applyOptions();

--- a/platform/core.windows/src/org/netbeans/core/windows/PersistenceHandler.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/PersistenceHandler.java
@@ -192,7 +192,7 @@ public final class PersistenceHandler implements PersistenceObserver {
             //some TopComponents want to be always active when the window system starts (e.g. welcome screen)
             for( TopComponent tc : mode.getOpenedTopComponents() ) {
                 Object val = tc.getClientProperty( Constants.ACTIVATE_AT_STARTUP );
-                if( null != val && val instanceof Boolean && ((Boolean)val).booleanValue() ) {
+                if(val instanceof Boolean && ((Boolean) val).booleanValue()) {
                     activeTopComponentOverride = tc;
                     break;
                 }

--- a/platform/core.windows/src/org/netbeans/core/windows/actions/CloneDocumentAction.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/actions/CloneDocumentAction.java
@@ -55,7 +55,7 @@ public class CloneDocumentAction extends AbstractAction implements PropertyChang
     @Override
     public void actionPerformed(java.awt.event.ActionEvent ev) {
         TopComponent tc = TopComponent.getRegistry().getActivated();
-        if(tc == null || !(tc instanceof TopComponent.Cloneable)) {
+        if(!(tc instanceof TopComponent.Cloneable)) {
             return;
         }
         

--- a/platform/core.windows/src/org/netbeans/core/windows/services/DialogDisplayerImpl.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/services/DialogDisplayerImpl.java
@@ -116,7 +116,7 @@ public class DialogDisplayerImpl extends DialogDisplayer {
                             // all docked windows implements ModeUIBase interface
                             if (! (w instanceof DefaultSeparateContainer.ModeUIBase)) {
                                 Container cont = SwingUtilities.getAncestorOfClass(Window.class, w);
-                                if (cont != null && (cont instanceof DefaultSeparateContainer.ModeUIBase)) {
+                                if (cont instanceof DefaultSeparateContainer.ModeUIBase) {
                                     w = (Window) cont;
                                 } else {
                                     // don't set non-ide window as parent

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/CloseButtonTabbedPane.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/CloseButtonTabbedPane.java
@@ -281,9 +281,9 @@ final class CloseButtonTabbedPane extends JTabbedPane implements PropertyChangeL
     }
 
     private boolean hideCloseButton(Component c) {
-        if (c!=null && c instanceof JComponent) {
+        if (c instanceof JComponent) {
             Object prop = ((JComponent) c).getClientProperty(TabbedPaneFactory.NO_CLOSE_BUTTON);
-            if (prop!=null && prop instanceof Boolean && (Boolean) prop) {
+            if (prop instanceof Boolean && (Boolean) prop) {
                 return true;
             }
         }

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/slides/CommandManager.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/slides/CommandManager.java
@@ -204,7 +204,7 @@ final class CommandManager implements ActionListener {
     public void actionPerformed(ActionEvent e) {
         if (TabbedContainer.COMMAND_POPUP_REQUEST.equals(e.getActionCommand())) {
             TabActionEvent tae = (TabActionEvent) e;
-            if (curSlidedComp != null && curSlidedComp instanceof TopComponent) {
+            if (curSlidedComp instanceof TopComponent) {
                 TopComponent tc = (TopComponent)curSlidedComp;
                 Action[] actions = slideBar.getTabbed().getPopupActions(tc.getActions(), curSlidedIndex);
                 if (actions == null) {

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/tabbedpane/NBTabbedPaneController.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/tabbedpane/NBTabbedPaneController.java
@@ -308,7 +308,7 @@ public class NBTabbedPaneController {
 
                     sel.setSelectedIndex( tabIndex );
                     Component tc = container.getDataModel().getTab( tabIndex ).getComponent();
-                    if( null != tc && tc instanceof TopComponent && !(( TopComponent ) tc).isAncestorOf( KeyboardFocusManager.getCurrentKeyboardFocusManager().getPermanentFocusOwner() ) ) {
+                    if(tc instanceof TopComponent && !((TopComponent) tc).isAncestorOf(KeyboardFocusManager.getCurrentKeyboardFocusManager().getPermanentFocusOwner())) {
                         (( TopComponent ) tc).requestActive();
                     }
                 }

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/DnDSupport.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/DnDSupport.java
@@ -579,7 +579,7 @@ final class DnDSupport implements DragSourceListener, DragGestureListener, DropT
             if( t.isDataFlavorSupported(buttonDataFlavor) ) {
                 o = t.getTransferData(buttonDataFlavor);
             }
-            if( null != o && o instanceof DataObject ) {
+            if(o instanceof DataObject) {
                 ((DataObject) o).delete();
                 sourceToolbar.repaint();
             }

--- a/platform/javahelp/src/org/netbeans/modules/javahelp/JavaHelpQuery.java
+++ b/platform/javahelp/src/org/netbeans/modules/javahelp/JavaHelpQuery.java
@@ -126,7 +126,7 @@ class JavaHelpQuery implements Comparator<SearchTOCItem> {
     private SearchEngine createSearchEngine() {
         SearchEngine se = null;
         Help h = (Help)Lookup.getDefault().lookup(Help.class);
-        if (h != null && h instanceof JavaHelp ) {
+        if (h instanceof JavaHelp) {
             JavaHelp jh = (JavaHelp)h;
             se = jh.createSearchEngine();
             if( null == se ) {

--- a/platform/javahelp/src/org/netbeans/modules/javahelp/JavaHelpQuickSearchProviderImpl.java
+++ b/platform/javahelp/src/org/netbeans/modules/javahelp/JavaHelpQuickSearchProviderImpl.java
@@ -55,7 +55,7 @@ public class JavaHelpQuickSearchProviderImpl implements SearchProvider {
         return new Runnable() {
             public void run() {
                 Help h = (Help)Lookup.getDefault().lookup(Help.class);
-                if (h != null && h instanceof JavaHelp ) {
+                if (h instanceof JavaHelp) {
                     JavaHelp jh = (JavaHelp)h;
                     jh.showHelp(url);
                 } else {

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
@@ -2701,7 +2701,7 @@ public class ETable extends JTable {
         if (c == editorComp) {
             return true;
         }
-        if (editorComp != null && (editorComp instanceof Container) &&
+        if (editorComp instanceof Container &&
             ((Container) editorComp).isAncestorOf(c)) {
                 return true;
         }

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/AdaptiveMatteBorder.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/AdaptiveMatteBorder.java
@@ -138,7 +138,7 @@ public class AdaptiveMatteBorder implements Border {
         if (c.getParent() instanceof JComponent) {
             JComponent jc = (JComponent) c.getParent();
             Object o = jc.getClientProperty("viewType");
-            if (o != null && o instanceof Integer) {
+            if (o instanceof Integer) {
                 return ((Integer) o).intValue() == 0;
             }
         }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabbedContainer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabbedContainer.java
@@ -931,7 +931,7 @@ public class TabbedContainer extends JComponent implements Accessible {
             Component c = getModel().getTab(0).getComponent();
             if( c instanceof JComponent ) {
                 Object val = ((JComponent)c).getClientProperty("isSliding"); //NOI18N
-                res = null != val && val instanceof Boolean && ((Boolean)val).booleanValue();
+                res = val instanceof Boolean && ((Boolean) val).booleanValue();
             }
         }
         return res;

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractViewTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractViewTabDisplayerUI.java
@@ -742,8 +742,8 @@ public abstract class AbstractViewTabDisplayerUI extends TabDisplayerUI {
                     getSelectionModel().setSelectedIndex(i);
                     tabState.setSelected(i);
                     Component tc = i >= 0 ? getDataModel().getTab(i).getComponent() : null;
-                    if( null != tc && tc instanceof TopComponent
-                        && !((TopComponent)tc).isAncestorOf( KeyboardFocusManager.getCurrentKeyboardFocusManager().getPermanentFocusOwner() ) ) {
+                    if(tc instanceof TopComponent
+                       && !((TopComponent) tc).isAncestorOf(KeyboardFocusManager.getCurrentKeyboardFocusManager().getPermanentFocusOwner())) {
                         ((TopComponent)tc).requestActive();
                     }
                 }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusEditorTabCellRenderer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusEditorTabCellRenderer.java
@@ -115,7 +115,7 @@ final class NimbusEditorTabCellRenderer extends AbstractTabCellRenderer {
         } else {
             o = UIManager.get("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter");
         }
-        if ((o != null) && (o instanceof javax.swing.Painter)) {
+        if (o instanceof javax.swing.Painter) {
             javax.swing.Painter painter = (javax.swing.Painter) o;
             BufferedImage bufIm = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
             Graphics2D g2d = bufIm.createGraphics();

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusViewTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusViewTabDisplayerUI.java
@@ -235,7 +235,7 @@ key:TabbedPane:TabbedPaneTab[Selected].backgroundPainter
             }
         }
 
-        if ((o != null) && (o instanceof javax.swing.Painter)) {
+        if (o instanceof javax.swing.Painter) {
             javax.swing.Painter painter = (javax.swing.Painter) o;
             BufferedImage bufIm = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
             Graphics2D g2d = bufIm.createGraphics();
@@ -261,7 +261,7 @@ key:TabbedPane:TabbedPaneTab[Selected].backgroundPainter
         Object o = null;
         o = UIManager.get("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter");
 
-        if ((o != null) && (o instanceof javax.swing.Painter)) {
+        if (o instanceof javax.swing.Painter) {
             javax.swing.Painter painter = (javax.swing.Painter) o;
             BufferedImage bufIm = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
             Graphics2D g2d = bufIm.createGraphics();

--- a/platform/openide.awt/src/org/openide/awt/SplittedPanel.java
+++ b/platform/openide.awt/src/org/openide/awt/SplittedPanel.java
@@ -779,10 +779,10 @@ public class SplittedPanel extends JComponent implements Accessible {
         getAccessibleContext().setAccessibleName(
             nameFormat.format(
                 new Object[] {
-                    ((firstComponent == null) || !(firstComponent instanceof Accessible)) ? null
+                    (!(firstComponent instanceof Accessible)) ? null
                                                                                           : firstComponent.getAccessibleContext()
                                                                                                           .getAccessibleName(),
-                    ((secondComponent == null) || !(secondComponent instanceof Accessible)) ? null
+                    (!(secondComponent instanceof Accessible)) ? null
                                                                                             : secondComponent.getAccessibleContext()
                                                                                                              .getAccessibleName()
                 }
@@ -797,10 +797,10 @@ public class SplittedPanel extends JComponent implements Accessible {
         getAccessibleContext().setAccessibleDescription(
             descriptionFormat.format(
                 new Object[] {
-                    ((firstComponent == null) || !(firstComponent instanceof Accessible)) ? null
+                    (!(firstComponent instanceof Accessible)) ? null
                                                                                           : firstComponent.getAccessibleContext()
                                                                                                           .getAccessibleDescription(),
-                    ((secondComponent == null) || !(secondComponent instanceof Accessible)) ? null
+                    (!(secondComponent instanceof Accessible)) ? null
                                                                                             : secondComponent.getAccessibleContext()
                                                                                                              .getAccessibleDescription()
                 }

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropUtils.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropUtils.java
@@ -1514,7 +1514,7 @@ final class PropUtils {
      * Just a helper method which delegates to shallBeRDVEnabled(Node.Property).
      */
     static boolean shallBeRDVEnabled(FeatureDescriptor fd) {
-        if ((fd != null) && fd instanceof Node.Property) {
+        if (fd instanceof Property) {
             return shallBeRDVEnabled((Node.Property) fd);
         }
 

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDialogManager.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertyDialogManager.java
@@ -120,7 +120,7 @@ final class PropertyDialogManager implements VetoableChangeListener, ActionListe
         if (env != null) {
             Object helpID = env.getFeatureDescriptor().getValue(ExPropertyEditor.PROPERTY_HELP_ID);
 
-            if ((helpID != null) && helpID instanceof String && (component != null) && component instanceof JComponent) {
+            if (helpID instanceof String && (component != null) && component instanceof JComponent) {
                 HelpCtx.setHelpIDString((JComponent) component, (String) helpID);
                 helpCtx = new HelpCtx((String) helpID);
             }

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertyPanel.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertyPanel.java
@@ -945,7 +945,7 @@ public class PropertyPanel extends JComponent implements javax.accessibility.Acc
      * @since 2.20
      */
     public final Object getState() {
-        if ((displayer != null) && displayer instanceof PropertyDisplayer_Editable) {
+        if (displayer instanceof PropertyDisplayer_Editable) {
             return ((PropertyDisplayer_Editable) displayer).getPropertyEnv().getState();
         } else {
             PropertyEditor ed = propertyEditor();
@@ -974,7 +974,7 @@ public class PropertyPanel extends JComponent implements javax.accessibility.Acc
      * is used.
      */
     public void updateValue() {
-        if ((displayer != null) && displayer instanceof PropertyDisplayer_Editable) {
+        if (displayer instanceof PropertyDisplayer_Editable) {
             PropertyEnv env = ((PropertyDisplayer_Editable) displayer).getPropertyEnv();
 
             if (PropertyEnv.STATE_NEEDS_VALIDATION.equals(env.getState())) {
@@ -1277,7 +1277,7 @@ public class PropertyPanel extends JComponent implements javax.accessibility.Acc
         public void actionPerformed(ActionEvent e) {
             if( inner == e.getSource() && "enterPressed".equals(e.getActionCommand()) ) { //NOI18N
                 Object beanBridge = getClientProperty("beanBridgeIdentifier"); //NOI18N
-                if( null != beanBridge && beanBridge instanceof CellEditor ) {
+                if( beanBridge instanceof CellEditor ) {
                     boolean wasCommitted = false;
                     if (e instanceof CellEditorActionEvent) {
                         // Prevent from a second commit on stop of cell editing:

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertySheet.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertySheet.java
@@ -1130,7 +1130,7 @@ public class PropertySheet extends JPanel {
             String id = null;
 
             //First look on the individual property
-            if ((fd != null) && fd instanceof Node.Property) {
+            if (fd instanceof Node.Property) {
                 id = (String) fd.getValue("helpID"); //NOI18N
             }
 

--- a/platform/openide.explorer/src/org/openide/explorer/view/NodeTableModel.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/NodeTableModel.java
@@ -134,7 +134,7 @@ public class NodeTableModel extends AbstractTableModel {
             Object o = props[i].getValue(ATTR_TREE_COLUMN);
             boolean x;
 
-            if ((o != null) && o instanceof Boolean) {
+            if (o instanceof Boolean) {
                 if (((Boolean) o).booleanValue()) {
                     treeColumnProperty = props[i];
                     size--;
@@ -162,7 +162,7 @@ public class NodeTableModel extends AbstractTableModel {
 
                     Object o = props[i].getValue(ATTR_ORDER_NUMBER);
 
-                    if ((o != null) && o instanceof Integer) {
+                    if (o instanceof Integer) {
                         sort.put(new Double(((Integer) o).doubleValue()), Integer.valueOf(ia));
                     } else {
                         sort.put(new Double(ia + 0.1), new Integer(ia));
@@ -172,7 +172,7 @@ public class NodeTableModel extends AbstractTableModel {
 
                     Object o = props[i].getValue(ATTR_SORTING_COLUMN);
 
-                    if ((o != null) && o instanceof Boolean) {
+                    if (o instanceof Boolean) {
                         props[i].setValue(ATTR_SORTING_COLUMN, Boolean.FALSE);
                     }
                 }
@@ -180,7 +180,7 @@ public class NodeTableModel extends AbstractTableModel {
                 if (!existsComparableColumn) {
                     Object o = props[i].getValue(ATTR_COMPARABLE_COLUMN);
 
-                    if ((o != null) && o instanceof Boolean) {
+                    if (o instanceof Boolean) {
                         existsComparableColumn = ((Boolean) o).booleanValue();
                     }
                 }
@@ -240,7 +240,7 @@ public class NodeTableModel extends AbstractTableModel {
 
                 Object o = p.getValue(ATTR_SORTING_COLUMN);
 
-                if ((o != null) && o instanceof Boolean) {
+                if (o instanceof Boolean) {
                     if (((Boolean) o).booleanValue()) {
                         p.setValue(ATTR_SORTING_COLUMN, Boolean.FALSE);
                         p.setValue(ATTR_DESCENDING_ORDER, Boolean.FALSE);
@@ -322,7 +322,7 @@ public class NodeTableModel extends AbstractTableModel {
         Property p = allPropertyColumns[column].getProperty();
         Object o = p.getValue(ATTR_COMPARABLE_COLUMN);
 
-        if ((o != null) && o instanceof Boolean) {
+        if (o instanceof Boolean) {
             return ((Boolean) o).booleanValue();
         }
 
@@ -357,7 +357,7 @@ public class NodeTableModel extends AbstractTableModel {
         Property p = allPropertyColumns[column].getProperty();
         Object o = p.getValue(ATTR_SORTING_COLUMN);
 
-        if ((o != null) && o instanceof Boolean) {
+        if (o instanceof Boolean) {
             return ((Boolean) o).booleanValue();
         }
 
@@ -443,7 +443,7 @@ public class NodeTableModel extends AbstractTableModel {
         Property p = allPropertyColumns[sortColumn].getProperty();
         Object o = p.getValue(ATTR_DESCENDING_ORDER);
 
-        if ((o != null) && o instanceof Boolean) {
+        if (o instanceof Boolean) {
             return ((Boolean) o).booleanValue();
         }
 
@@ -544,7 +544,7 @@ public class NodeTableModel extends AbstractTableModel {
     private boolean isVisible(Property p) {
         Object o = p.getValue(ATTR_INVISIBLE);
 
-        if ((o != null) && o instanceof Boolean) {
+        if (o instanceof Boolean) {
             return !((Boolean) o).booleanValue();
         }
 

--- a/platform/openide.explorer/src/org/openide/explorer/view/OutlineView.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/OutlineView.java
@@ -2475,8 +2475,8 @@ public class OutlineView extends JScrollPane {
 
         @Override
         public boolean equals(Object o) {
-            return o != null && o instanceof Property &&
-                    getName().equals(((Property)o).getName());
+            return o instanceof Property &&
+                   getName().equals(((Property) o).getName());
         }
 
         @Override

--- a/platform/openide.explorer/src/org/openide/explorer/view/TreeTable.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/TreeTable.java
@@ -836,7 +836,7 @@ class TreeTable extends JTable implements Runnable {
             return true;
         }
 
-        if ((editorComp != null) && (editorComp instanceof Container) && ((Container) editorComp).isAncestorOf(c)) {
+        if ((editorComp instanceof Container) && ((Container) editorComp).isAncestorOf(c)) {
             return true;
         }
 

--- a/platform/openide.explorer/src/org/openide/explorer/view/TreeTableView.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/TreeTableView.java
@@ -1812,7 +1812,7 @@ public class TreeTableView extends BeanTreeView {
 
             Object o = p.getValue(NodeTableModel.ATTR_COMPARABLE_COLUMN);
 
-            if ((o != null) && o instanceof Boolean) {
+            if (o instanceof Boolean) {
                 return ((Boolean) o).booleanValue();
             }
 
@@ -1826,7 +1826,7 @@ public class TreeTableView extends BeanTreeView {
 
             Object o = p.getValue(NodeTableModel.ATTR_SORTING_COLUMN);
 
-            if ((o != null) && o instanceof Boolean) {
+            if (o instanceof Boolean) {
                 return ((Boolean) o).booleanValue();
             }
 
@@ -1848,7 +1848,7 @@ public class TreeTableView extends BeanTreeView {
 
             Object o = p.getValue(NodeTableModel.ATTR_DESCENDING_ORDER);
 
-            if ((o != null) && o instanceof Boolean) {
+            if (o instanceof Boolean) {
                 return ((Boolean) o).booleanValue();
             }
 

--- a/platform/openide.explorer/src/org/openide/explorer/view/TreeView.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/TreeView.java
@@ -1782,7 +1782,7 @@ public abstract class TreeView extends JScrollPane {
         public void updateUI() {
             super.updateUI();
             setBorder(BorderFactory.createEmptyBorder());
-            if( getTransferHandler() != null && getTransferHandler() instanceof UIResource ) {
+            if( getTransferHandler() instanceof UIResource ) {
                 //we handle drag and drop in our own way, so let's just fool the UI with a dummy
                 //TransferHandler to ensure that multiple selection is not lost when drag starts
                 setTransferHandler( new DummyTransferHandler() );

--- a/platform/openide.explorer/src/org/openide/explorer/view/TreeViewCellEditor.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/TreeViewCellEditor.java
@@ -191,7 +191,7 @@ class TreeViewCellEditor extends DefaultTreeCellEditor implements CellEditorList
     */
     @Override
     public boolean isCellEditable(EventObject event) {
-        if ((event != null) && (event instanceof MouseEvent)) {
+        if (event instanceof MouseEvent) {
             if (!SwingUtilities.isLeftMouseButton((MouseEvent) event) || ((MouseEvent) event).isPopupTrigger()) {
                 abortTimer();
                 return false;

--- a/platform/openide.filesystems/src/org/openide/filesystems/StreamPool.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/StreamPool.java
@@ -69,7 +69,7 @@ final class StreamPool extends Object {
             }
         }
 
-        if ((retVal != null) && (retVal instanceof NotifyInputStream)) {
+        if (retVal instanceof NotifyInputStream) {
             AbstractFileSystem abstractFileSystem = ((AbstractFileSystem) fo.getFileSystem());
             ((NotifyInputStream) retVal).setOriginal(abstractFileSystem.info.inputStream(fo.getPath()));
         } else {
@@ -112,7 +112,7 @@ final class StreamPool extends Object {
             }
         }
 
-        if ((retVal != null) && (retVal instanceof NotifyOutputStream)) {
+        if (retVal instanceof NotifyOutputStream) {
             AbstractFileSystem abstractFileSystem = ((AbstractFileSystem) fo.getFileSystem());
             ((NotifyOutputStream) retVal).setOriginal(abstractFileSystem.info.outputStream(fo.getPath()));
         } else {

--- a/platform/openide.filesystems/src/org/openide/filesystems/URLMapper.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/URLMapper.java
@@ -315,7 +315,7 @@ public abstract class URLMapper {
                 if (root == null) {
                     Object rootPath = fsRoot.getAttribute("FileSystem.rootPath"); //NOI18N
 
-                    if ((rootPath != null) && (rootPath instanceof String)) {
+                    if (rootPath instanceof String) {
                         rootName = (String) rootPath;
                     } else {
                         continue;

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
@@ -358,7 +358,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
     private boolean isFolder(String name) {
         Reference<? extends FileObject> ref = findReference(name);
 
-        if ((ref != null) && (ref instanceof FileObjRef)) {
+        if (ref instanceof FileObjRef) {
             return ((FileObjRef) ref).isFolder();
         }
 
@@ -375,7 +375,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
     private InputStream getInputStream(String name) throws java.io.FileNotFoundException {
         Reference<? extends FileObject> ref = findReference(name);
 
-        if ((ref != null) && (ref instanceof FileObjRef)) {
+        if (ref instanceof FileObjRef) {
             return (((FileObjRef) ref).getInputStream(name));
         }
 
@@ -392,7 +392,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
     URL getURL(String name) throws java.io.FileNotFoundException {
         Reference<? extends FileObject> ref = findReference(name);
 
-        if ((ref != null) && (ref instanceof FileObjRef)) {
+        if (ref instanceof FileObjRef) {
             return ((FileObjRef) ref).createAbsoluteUrl(name);
         }
 
@@ -403,7 +403,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
     private long getSize(String name) {
         Reference<? extends FileObject> ref = findReference(name);
 
-        if ((ref != null) && (ref instanceof FileObjRef)) {
+        if (ref instanceof FileObjRef) {
             return ((FileObjRef) ref).getSize(name);
         }
 
@@ -414,7 +414,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
     private java.util.Date lastModified(String name) {
         Reference<? extends FileObject> ref = findReference(name);
 
-        if ((ref != null) && (ref instanceof FileObjRef)) {
+        if (ref instanceof FileObjRef) {
             return ((FileObjRef) ref).lastModified(name);
         }
 
@@ -1056,7 +1056,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
             URL url = null;
             Date retval = null;
             
-            if ((content == null) || !(content instanceof String)) {
+            if (!(content instanceof String)) {
                 URL[] all = getLayers();
                 url = (all != null && all.length > 0) ? all[0] : null;
             } else {

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
@@ -255,7 +255,7 @@ final class XMLMapAttr implements Map {
     }
 
     synchronized Object put(final Object p1, final Object p2, boolean decode) {
-        if ((p1 == null) || !(p1 instanceof String)) {
+        if (!(p1 instanceof String)) {
             return null;
         }
 
@@ -712,7 +712,7 @@ final class XMLMapAttr implements Map {
         }
 
         final String getKeyForPrint() {
-            if ((obj != null) && obj instanceof ModifiedAttribute) {
+            if (obj instanceof ModifiedAttribute) {
                 Attr modifAttr = (Attr) ((ModifiedAttribute) obj).getValue();
                 int keyIdx = Attr.isValid("SERIALVALUE"); //NOI18N
 
@@ -729,7 +729,7 @@ final class XMLMapAttr implements Map {
         }
 
         final String getAttrNameForPrint(String attrName) {
-            if ((obj != null) && obj instanceof ModifiedAttribute) {
+            if (obj instanceof ModifiedAttribute) {
                 Object[] retVal = ModifiedAttribute.revert(attrName, obj);
 
                 return encode((String) retVal[0]);
@@ -1156,7 +1156,7 @@ final class XMLMapAttr implements Map {
          * This method is opposite to method translateInto
          */
         static Object[] revert(String attrName, Object value) {
-            if (!(value instanceof ModifiedAttribute) || (value == null)) {
+            if (!(value instanceof ModifiedAttribute)) {
                 return new Object[] { attrName, value };
             }
 

--- a/platform/openide.loaders/src/org/openide/loaders/OpenSupport.java
+++ b/platform/openide.loaders/src/org/openide/loaders/OpenSupport.java
@@ -258,15 +258,15 @@ public abstract class OpenSupport extends CloneableOpenSupport {
         */
         public CloneableOpenSupport findCloneableOpenSupport() {
             OpenCookie oc = getDataObject().getCookie(OpenCookie.class);
-            if (oc != null && oc instanceof CloneableOpenSupport) {
+            if (oc instanceof CloneableOpenSupport) {
                 return (CloneableOpenSupport) oc;
             }
             EditCookie edc = getDataObject().getCookie(EditCookie.class);
-            if (edc != null && edc instanceof CloneableOpenSupport) {
+            if (edc instanceof CloneableOpenSupport) {
                 return (CloneableOpenSupport) edc;
             }
             EditorCookie ec = getDataObject().getCookie(EditorCookie.class);
-            if (ec != null && ec instanceof CloneableOpenSupport) {
+            if (ec instanceof CloneableOpenSupport) {
                 return (CloneableOpenSupport) ec;
             }
             return null;
@@ -404,15 +404,15 @@ public abstract class OpenSupport extends CloneableOpenSupport {
             DataObject obj = entry.getDataObject ();
             OpenSupport os = null;
             OpenCookie oc = obj.getCookie(OpenCookie.class);
-            if (oc != null && oc instanceof OpenSupport) {
+            if (oc instanceof OpenSupport) {
                 os = (OpenSupport) oc;
             } else {
                 EditCookie edc = obj.getCookie(EditCookie.class);
-                if (edc != null && edc instanceof OpenSupport) {
+                if (edc instanceof OpenSupport) {
                     os = (OpenSupport) edc;
                 } else {
                     EditorCookie ec = obj.getCookie(EditorCookie.class);
-                    if (ec != null && ec instanceof OpenSupport) {
+                    if (ec instanceof OpenSupport) {
                         os = (OpenSupport) ec;
                     }
                 }

--- a/platform/openide.nodes/src/org/openide/nodes/BeanNode.java
+++ b/platform/openide.nodes/src/org/openide/nodes/BeanNode.java
@@ -512,7 +512,7 @@ public class BeanNode<T> extends AbstractNode {
             // Propagate helpID's.
             Object help = propertyDescriptor[i].getValue("helpID"); // NOI18N
 
-            if ((help != null) && (help instanceof String)) {
+            if (help instanceof String) {
                 prop.setValue("helpID", help); // NOI18N
             }
 

--- a/platform/openide.text/src/org/openide/text/CloneableEditorSupport.java
+++ b/platform/openide.text/src/org/openide/text/CloneableEditorSupport.java
@@ -833,8 +833,8 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
                 }
                 
                 if ((last == ed) ||
-                    ((last != null) && (last instanceof Component) && (ed instanceof Container)
-                    && ((Container) ed).isAncestorOf((Component) last))) {
+                    ((last instanceof Component) && (ed instanceof Container)
+                     && ((Container) ed).isAncestorOf((Component) last))) {
                     ll.addFirst(p);
                 } else {
                     ll.add(p);
@@ -878,8 +878,8 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
             if (ed != null) {
                 JEditorPane p = null;
                 if ((last == ed) ||
-                    ((last != null) && (last instanceof Component) && (ed instanceof Container)
-                    && ((Container) ed).isAncestorOf((Component) last))) {
+                    ((last instanceof Component) && (ed instanceof Container)
+                     && ((Container) ed).isAncestorOf((Component) last))) {
                     if (ed instanceof CloneableEditor) {
                         if (((CloneableEditor) ed).isEditorPaneReady()) {
                             p = ed.getEditorPane();

--- a/platform/openide.util.ui/src/org/openide/util/VectorIcon.java
+++ b/platform/openide.util.ui/src/org/openide/util/VectorIcon.java
@@ -83,7 +83,7 @@ public abstract class VectorIcon implements Icon, Serializable {
         Object desktopHints =
                 Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
         Map<Object, Object> hints = new LinkedHashMap<Object, Object>();
-        if (desktopHints != null && desktopHints instanceof Map<?, ?>)
+        if (desktopHints instanceof Map<?, ?>)
             hints.putAll((Map<?, ?>) desktopHints);
         /* Enable antialiasing by default. Adding this is required in order to get non-text
         antialiasing on Windows. */

--- a/platform/openide.util/src/org/openide/util/io/NbMarshalledObject.java
+++ b/platform/openide.util/src/org/openide/util/io/NbMarshalledObject.java
@@ -145,7 +145,7 @@ public final class NbMarshalledObject implements Serializable {
             return true;
         }
 
-        if ((obj != null) && obj instanceof NbMarshalledObject) {
+        if (obj instanceof NbMarshalledObject) {
             NbMarshalledObject other = (NbMarshalledObject) obj;
 
             return Arrays.equals(objBytes, other.objBytes);

--- a/platform/options.api/src/org/netbeans/modules/options/QuickSearchProvider.java
+++ b/platform/options.api/src/org/netbeans/modules/options/QuickSearchProvider.java
@@ -74,7 +74,7 @@ public class QuickSearchProvider implements SearchProvider {
 	String categoryID = it.getId();
 
 	Map<String, Set<String>> kws = new HashMap<String, Set<String>>();
-	if (category != null && (category instanceof OptionsCategoryImpl)) {
+	if (category instanceof OptionsCategoryImpl) {
 	    Set<String> categoryKeywords = ((OptionsCategoryImpl) category).getKeywordsByCategory();
 	    String categoryPath = categoryID.substring(categoryID.indexOf('/') + 1);
 	    Map<String, Set<String>> mergedMap = new HashMap<String, Set<String>>();

--- a/platform/options.api/src/org/netbeans/modules/options/classic/SettingChildren.java
+++ b/platform/options.api/src/org/netbeans/modules/options/classic/SettingChildren.java
@@ -278,7 +278,7 @@ public final class SettingChildren extends FilterNode.Children {
         public String getDisplayName() {
             String retVal = null;
             DataObject dobj= (DataObject) getCookie (DataObject.class);
-            if (dobj != null && dobj instanceof DataShadow) {
+            if (dobj instanceof DataShadow) {
                 DataShadow dsh = (DataShadow)dobj;
                 Node origNode = dsh.getOriginal().getNodeDelegate();
                 if (origNode != null) {

--- a/platform/settings/src/org/netbeans/modules/settings/Env.java
+++ b/platform/settings/src/org/netbeans/modules/settings/Env.java
@@ -106,7 +106,7 @@ public final class Env implements Environment.Provider {
      * @return set of items
      */
     public static java.util.Set<String> parseAttribute(Object attr) {
-        if (attr != null && attr instanceof String) {
+        if (attr instanceof String) {
             java.util.StringTokenizer s = 
                 new java.util.StringTokenizer((String) attr, ","); //NOI18N
             java.util.Set<String> set = new java.util.HashSet<String>(10);

--- a/platform/settings/src/org/netbeans/modules/settings/InstanceProvider.java
+++ b/platform/settings/src/org/netbeans/modules/settings/InstanceProvider.java
@@ -205,7 +205,7 @@ implements java.beans.PropertyChangeListener, FileSystem.AtomicAction {
     Convertor getConvertor() throws IOException {
         if (convertor == null) {
             Object attrb = providerFO.getAttribute(Env.EA_CONVERTOR);
-            if (attrb == null || !(attrb instanceof Convertor)) {
+            if (!(attrb instanceof Convertor)) {
                 throw new IOException("cannot create convertor: " + attrb + ", provider:" +providerFO); //NOI18N
             }
             convertor = (Convertor) attrb;
@@ -217,7 +217,7 @@ implements java.beans.PropertyChangeListener, FileSystem.AtomicAction {
     private synchronized String getInstanceClassName() {
         if (instanceClassName == null) {
             Object name = providerFO.getAttribute(Env.EA_INSTANCE_CLASS_NAME);
-            if (name != null && name instanceof String) {
+            if (name instanceof String) {
                 instanceClassName = org.openide.util.Utilities.translate((String) name);
             } else {
                 instanceClassName = null;

--- a/platform/settings/src/org/netbeans/modules/settings/SaveSupport.java
+++ b/platform/settings/src/org/netbeans/modules/settings/SaveSupport.java
@@ -97,7 +97,7 @@ final class SaveSupport {
                     return convertor;
                 }
                 Object attrb = newProviderFO.getAttribute(Env.EA_CONVERTOR);
-                if (attrb == null || !(attrb instanceof Convertor)) {
+                if (!(attrb instanceof Convertor)) {
                     throw new IOException("cannot create convertor: " + attrb + ", provider: " + newProviderFO); //NOI18N
                 } else {
                     convertor = (Convertor) attrb;
@@ -116,7 +116,7 @@ final class SaveSupport {
         FileObject foEntity = Env.findEntityRegistration(fo);
         if (foEntity == null) foEntity = fo;
         Object publicId = foEntity.getAttribute(Env.EA_PUBLICID);
-        if (publicId == null || !(publicId instanceof String)) {
+        if (!(publicId instanceof String)) {
             throw new IOException("missing or invalid attribute: " + //NOI18N
                 Env.EA_PUBLICID + ", provider: " + foEntity); //NOI18N
         }

--- a/platform/settings/src/org/netbeans/modules/settings/convertors/SerialDataConvertor.java
+++ b/platform/settings/src/org/netbeans/modules/settings/convertors/SerialDataConvertor.java
@@ -224,7 +224,7 @@ implements PropertyChangeListener, FileSystem.AtomicAction {
     
     private static boolean isSystemOption(final Object obj) {
         boolean b =  false;
-        if (obj != null && obj instanceof SharedClassObject){
+        if (obj instanceof SharedClassObject){
             for(Class c = obj.getClass(); !b && c != null; c = c.getSuperclass()) {
                 b =  "org.openide.options.SystemOption".equals(c.getName());//NOI18N
             }
@@ -543,7 +543,7 @@ implements PropertyChangeListener, FileSystem.AtomicAction {
         /** store setting or provide just SaveCookie? */
         private boolean acceptSave() {
             Object inst = instance.get();
-            if (inst == null || !(inst instanceof Serializable) ||
+            if (!(inst instanceof Serializable) ||
                 // XXX bad dep; should perhaps have some marker in the .settings file for this??
                 inst instanceof TopComponent) return false;
             
@@ -581,7 +581,7 @@ implements PropertyChangeListener, FileSystem.AtomicAction {
                     FileObject foEntity = Env.findEntityRegistration(newProviderFO);
                     if (foEntity == null) foEntity = newProviderFO;
                     Object attrb = foEntity.getAttribute(Env.EA_PUBLICID);
-                    if (attrb == null || !(attrb instanceof String)) {
+                    if (!(attrb instanceof String)) {
                         throw new IOException("missing or invalid attribute: " + //NOI18N
                             Env.EA_PUBLICID + ", provider: " + foEntity); //NOI18N
                     }
@@ -591,7 +591,7 @@ implements PropertyChangeListener, FileSystem.AtomicAction {
                     }
                     
                     attrb = newProviderFO.getAttribute(Env.EA_CONVERTOR);
-                    if (attrb == null || !(attrb instanceof Convertor)) {
+                    if (!(attrb instanceof Convertor)) {
                         throw new IOException("cannot create convertor: " + //NOI18N
                             attrb + ", provider: " + newProviderFO); //NOI18N
                     } else {

--- a/platform/settings/src/org/netbeans/modules/settings/convertors/SerialDataNode.java
+++ b/platform/settings/src/org/netbeans/modules/settings/convertors/SerialDataNode.java
@@ -481,7 +481,7 @@ public final class SerialDataNode extends DataNode {
         convertProps (p, descr.expert, this);
         if (bd != null) {
             Object helpID = bd.getValue("expertHelpID"); // NOI18N
-            if (helpID != null && helpID instanceof String) {
+            if (helpID instanceof String) {
                 p.setValue("helpID", helpID); // NOI18N
             }
         }
@@ -497,7 +497,7 @@ public final class SerialDataNode extends DataNode {
         if (bd != null) {
             // #29550: help from the beaninfo on property tabs
             Object helpID = bd.getValue("propertiesHelpID"); // NOI18N
-            if (helpID != null && helpID instanceof String) {
+            if (helpID instanceof String) {
                 props.setValue("helpID", helpID); // NOI18N
             }
         }

--- a/platform/settings/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertor.java
+++ b/platform/settings/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertor.java
@@ -82,7 +82,7 @@ public final class XMLPropertiesConvertor extends Convertor implements PropertyC
         FileObject foEntity = Env.findEntityRegistration(providerFO);
         if (foEntity == null) foEntity = providerFO;
         Object publicId = foEntity.getAttribute(Env.EA_PUBLICID);
-        if (publicId == null || !(publicId instanceof String)) {
+        if (!(publicId instanceof String)) {
             throw new IOException("missing or invalid attribute: " + //NOI18N
                 Env.EA_PUBLICID + ", provider: " + foEntity); //NOI18N
         }
@@ -211,7 +211,7 @@ public final class XMLPropertiesConvertor extends Convertor implements PropertyC
     private Class getInstanceClass() throws IOException, ClassNotFoundException {
         if (instanceClass == null) {
             Object name = providerFO.getAttribute(Env.EA_INSTANCE_CLASS_NAME);
-            if (name == null || !(name instanceof String)) {
+            if (!(name instanceof String)) {
                 throw new IllegalStateException(
                     "missing or invalid ea attribute: " +
                     Env.EA_INSTANCE_CLASS_NAME); //NOI18N

--- a/platform/settings/src/org/netbeans/spi/settings/ConvertorResolver.java
+++ b/platform/settings/src/org/netbeans/spi/settings/ConvertorResolver.java
@@ -66,7 +66,7 @@ final class ConvertorResolver {
             
             fo = org.netbeans.modules.settings.Env.findEntityRegistration(fo);
             Object attrib = fo.getAttribute(org.netbeans.modules.settings.Env.EA_PUBLICID);
-            return (attrib == null || !(attrib instanceof String))? null: (String) attrib;
+            return (!(attrib instanceof String))? null: (String) attrib;
         } catch (IOException ex) {
             Logger.getLogger(ConvertorResolver.class.getName()).log(Level.WARNING, null, ex);
             return null;
@@ -90,7 +90,7 @@ final class ConvertorResolver {
     /** extract convertor from file attributes */
     private Convertor getConvertor(FileObject fo) {
         Object attrb = fo.getAttribute(org.netbeans.modules.settings.Env.EA_CONVERTOR);
-        return (attrb == null || !(attrb instanceof Convertor))? null: (Convertor) attrb;
+        return (!(attrb instanceof Convertor))? null: (Convertor) attrb;
     }
     
     /** Converts the publicID into filesystem friendly name.

--- a/platform/templates/src/org/netbeans/modules/templates/ui/TemplatesPanel.java
+++ b/platform/templates/src/org/netbeans/modules/templates/ui/TemplatesPanel.java
@@ -181,7 +181,7 @@ public class TemplatesPanel extends TopComponent implements ExplorerManager.Prov
         private void invokeInplaceEditing () {
             if (startEditing == null) {
                 Object o = tree.getActionMap ().get ("startEditing"); // NOI18N
-                if (o != null && o instanceof Action) {
+                if (o instanceof Action) {
                     startEditing = (Action) o;
                 }
             }

--- a/profiler/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/models/HeapActionsFilter.java
+++ b/profiler/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/models/HeapActionsFilter.java
@@ -111,7 +111,7 @@ public class HeapActionsFilter implements NodeActionsProviderFilter {
         new Models.ActionPerformer () {
             @Override
             public boolean isEnabled (Object node) {
-                if ((node == null) || (!(node instanceof ObjectVariable))) {
+                if ((!(node instanceof ObjectVariable))) {
                     return false;
                 }
                 ObjectVariable var = (ObjectVariable) node;

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JCheckTree.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JCheckTree.java
@@ -225,7 +225,7 @@ public class JCheckTree extends JExtendedTree {
     public void processMouseEvent(MouseEvent e) {
         if (e instanceof MouseWheelEvent) {
             Component target = JCheckTree.this.getParent();
-            if (target == null || !(target instanceof JViewport))
+            if (!(target instanceof JViewport))
                 target = JCheckTree.this;
             MouseEvent mwe = SwingUtilities.convertMouseEvent(
                     JCheckTree.this, (MouseWheelEvent)e, target);

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedComboBox.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedComboBox.java
@@ -43,7 +43,7 @@ public class JExtendedComboBox extends JComboBox {
 
         public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected,
                                                       boolean cellHasFocus) {
-            if ((value != null) && value instanceof JSeparator) {
+            if (value instanceof JSeparator) {
                 return (JSeparator) value;
             } else {
                 return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedTable.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedTable.java
@@ -251,7 +251,7 @@ public class JExtendedTable extends JTable implements CellTipAware, MouseListene
     public void processMouseEvent(final MouseEvent e) {
         if (e instanceof MouseWheelEvent) {
             Component target = JExtendedTable.this.getParent();
-            if (target == null || !(target instanceof JViewport))
+            if (!(target instanceof JViewport))
                 target = JExtendedTable.this;
             MouseEvent mwe = SwingUtilities.convertMouseEvent(
                     JExtendedTable.this, (MouseWheelEvent)e, target);

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedTree.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JExtendedTree.java
@@ -126,7 +126,7 @@ public class JExtendedTree extends JTree implements CellTipAware {
     public void processMouseEvent(MouseEvent e) {
         if (e instanceof MouseWheelEvent) {
             Component target = JExtendedTree.this.getParent();
-            if (target == null || !(target instanceof JViewport))
+            if (!(target instanceof JViewport))
                 target = JExtendedTree.this;
             MouseEvent mwe = SwingUtilities.convertMouseEvent(
                     JExtendedTree.this, (MouseWheelEvent)e, target);

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JTreeTable.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/JTreeTable.java
@@ -852,7 +852,7 @@ public class JTreeTable extends JTable implements CellTipAware, MouseListener, M
     public void processMouseEvent(MouseEvent e) {
         if (e instanceof MouseWheelEvent) {
             Component target = JTreeTable.this.getParent();
-            if (target == null || !(target instanceof JViewport))
+            if (!(target instanceof JViewport))
                 target = JTreeTable.this;
             MouseEvent mwe = SwingUtilities.convertMouseEvent(
                     JTreeTable.this, (MouseWheelEvent)e, target);

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/CheckTreeNode.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/components/tree/CheckTreeNode.java
@@ -125,7 +125,7 @@ public class CheckTreeNode extends DefaultMutableTreeNode {
         // Update checkState of parent
         TreeNode parent = getParent();
 
-        if ((parent != null) && parent instanceof CheckTreeNode) {
+        if (parent instanceof CheckTreeNode) {
             changedNodes.addAll(((CheckTreeNode) parent).setPartiallyChecked());
         }
 
@@ -162,7 +162,7 @@ public class CheckTreeNode extends DefaultMutableTreeNode {
         // Update checkState of parent
         TreeNode parent = getParent();
 
-        if ((parent != null) && parent instanceof CheckTreeNode) {
+        if (parent instanceof CheckTreeNode) {
             if (areSiblingsFullyChecked()) {
                 changedNodes.addAll(((CheckTreeNode) parent).setFullyChecked());
             } else {
@@ -200,7 +200,7 @@ public class CheckTreeNode extends DefaultMutableTreeNode {
         // Update checkState of parent
         TreeNode parent = getParent();
 
-        if ((parent != null) && parent instanceof CheckTreeNode) {
+        if (parent instanceof CheckTreeNode) {
             if (areSiblingsUnchecked()) {
                 changedNodes.addAll(((CheckTreeNode) parent).setUnchecked());
             } else {

--- a/profiler/profiler.attach/src/org/netbeans/modules/profiler/attach/providers/TargetPlatformEnum.java
+++ b/profiler/profiler.attach/src/org/netbeans/modules/profiler/attach/providers/TargetPlatformEnum.java
@@ -59,7 +59,7 @@ public class TargetPlatformEnum {
     //~ Methods ------------------------------------------------------------------------------------------------------------------
 
     public boolean equals(Object obj) {
-        if ((obj == null) || !(obj instanceof TargetPlatformEnum)) {
+        if (!(obj instanceof TargetPlatformEnum)) {
             return false;
         }
 

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/CompareSnapshotsHelper.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/CompareSnapshotsHelper.java
@@ -108,7 +108,7 @@ class CompareSnapshotsHelper {
             if (fromProjectRadio.isSelected()) {
                 Object selectedItem = projectSnapshotsList.getSelectedValue();
 
-                if ((selectedItem == null) || !(selectedItem instanceof FileObject)) {
+                if (!(selectedItem instanceof FileObject)) {
                     return null;
                 }
 

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/ArrayValueView.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/basic/ArrayValueView.java
@@ -249,21 +249,21 @@ final class ArrayValueView extends DetailsProvider.View implements Scrollable, E
     public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {
         // Scroll almost one screen
         Container parent = getParent();
-        if ((parent == null) || !(parent instanceof JViewport)) return 50;
+        if (!(parent instanceof JViewport)) return 50;
         return (int)(((JViewport)parent).getHeight() * 0.95f);
     }
 
     public boolean getScrollableTracksViewportHeight() {
         // Allow dynamic vertical enlarging of the panel but request the vertical scrollbar when needed
         Container parent = getParent();
-        if ((parent == null) || !(parent instanceof JViewport)) return false;
+        if (!(parent instanceof JViewport)) return false;
         return getMinimumSize().height < ((JViewport)parent).getHeight();
     }
 
     public boolean getScrollableTracksViewportWidth() {
         // Allow dynamic horizontal enlarging of the panel but request the vertical scrollbar when needed
         Container parent = getParent();
-        if ((parent == null) || !(parent instanceof JViewport)) return false;
+        if (!(parent instanceof JViewport)) return false;
         return getMinimumSize().width < ((JViewport)parent).getWidth();
     }
 

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/Utils.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/Utils.java
@@ -328,21 +328,21 @@ final class Utils {
         public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {
             // Scroll almost one screen
             Container parent = getParent();
-            if ((parent == null) || !(parent instanceof JViewport)) return 50;
+            if (!(parent instanceof JViewport)) return 50;
             return (int)(((JViewport)parent).getHeight() * 0.95f);
         }
 
         public boolean getScrollableTracksViewportHeight() {
             // Allow dynamic vertical enlarging of the panel but request the vertical scrollbar when needed
             Container parent = getParent();
-            if ((parent == null) || !(parent instanceof JViewport)) return false;
+            if (!(parent instanceof JViewport)) return false;
             return getPreferredSize().height < ((JViewport)parent).getHeight();
         }
 
         public boolean getScrollableTracksViewportWidth() {
             // Allow dynamic horizontal enlarging of the panel but request the vertical scrollbar when needed
             Container parent = getParent();
-            if ((parent == null) || !(parent instanceof JViewport)) return false;
+            if (!(parent instanceof JViewport)) return false;
             return getPreferredSize().width < ((JViewport)parent).getWidth();
         }
 

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/InstanceNode.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/InstanceNode.java
@@ -132,7 +132,7 @@ public abstract class InstanceNode extends AbstractHeapWalkerNode implements Hea
         if (hasInstance()) {
             HeapWalkerNode parent = getParent();
 
-            while ((parent != null) && parent instanceof HeapWalkerInstanceNode) {
+            while (parent instanceof HeapWalkerInstanceNode) {
                 if (((HeapWalkerInstanceNode) parent).getInstance().equals(instance)) {
                     return parent;
                 }

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectFieldNode.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectFieldNode.java
@@ -77,7 +77,7 @@ public class ObjectFieldNode extends ObjectNode implements HeapWalkerFieldNode {
         JavaClass declaringClass = fieldValue.getField().getDeclaringClass();
         HeapWalkerNode parent = getParent();
 
-        while ((parent != null) && parent instanceof HeapWalkerInstanceNode) {
+        while (parent instanceof HeapWalkerInstanceNode) {
             if (parent instanceof HeapWalkerFieldNode) {
                 HeapWalkerFieldNode parentF = (HeapWalkerFieldNode) parent;
 

--- a/profiler/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/GoToJavaSourceProvider.java
+++ b/profiler/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/providers/GoToJavaSourceProvider.java
@@ -102,7 +102,7 @@ public final class GoToJavaSourceProvider extends GoToSourceProvider {
                         
                         if (ElementOpen.open(controller.getClasspathInfo(), parentClass)) {
                             Document doc = controller.getDocument();
-                            if (doc != null && doc instanceof StyledDocument) {
+                            if (doc instanceof StyledDocument) {
                                 if (openAtLine(controller, doc, methodName, line)) {
                                     result.set(true);
                                     return;

--- a/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointWizard.java
+++ b/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ProfilingPointWizard.java
@@ -63,7 +63,7 @@ public class ProfilingPointWizard implements WizardDescriptor.Iterator {
         public HelpCtx getHelp() {
             Component customizer = getComponent();
 
-            if ((customizer == null) || !(customizer instanceof HelpCtx.Provider)) {
+            if (!(customizer instanceof HelpCtx.Provider)) {
                 return null;
             }
 
@@ -122,7 +122,7 @@ public class ProfilingPointWizard implements WizardDescriptor.Iterator {
         //~ Methods --------------------------------------------------------------------------------------------------------------
 
         public HelpCtx getHelp() {
-            if ((customizer == null) || !(customizer instanceof HelpCtx.Provider)) {
+            if (!(customizer instanceof HelpCtx.Provider)) {
                 return null;
             }
 

--- a/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/Utils.java
+++ b/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/Utils.java
@@ -197,7 +197,7 @@ public class Utils {
             renderer.setEnabled(rendererOrig.isEnabled());
             renderer.setBorder(rendererOrig.getBorder());
 
-            if ((value != null) && value instanceof Lookup.Provider) {
+            if (value instanceof Lookup.Provider) {
                 renderer.setText(ProjectUtilities.getDisplayName((Lookup.Provider)value));
                 renderer.setIcon(ProjectUtilities.getIcon((Lookup.Provider)value));
 

--- a/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ValidityAwarePanel.java
+++ b/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/ui/ValidityAwarePanel.java
@@ -82,7 +82,7 @@ public abstract class ValidityAwarePanel extends JPanel implements Scrollable {
     public boolean getScrollableTracksViewportWidth() {
         Container parent = getParent();
 
-        if ((parent == null) || !(parent instanceof JViewport)) {
+        if (!(parent instanceof JViewport)) {
             return false;
         }
 

--- a/profiler/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/ScrollableContainer.java
+++ b/profiler/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/swing/ScrollableContainer.java
@@ -99,7 +99,7 @@ public final class ScrollableContainer extends JScrollPane {
                 return true;
 
             Container parent = getParent();
-            if ((parent == null) || !(parent instanceof JViewport)) return false;
+            if (!(parent instanceof JViewport)) return false;
             return getMinimumSize().width < ((JViewport)parent).getWidth();
         }
 
@@ -108,7 +108,7 @@ public final class ScrollableContainer extends JScrollPane {
                 return true;
 
             Container parent = getParent();
-            if ((parent == null) || !(parent instanceof JViewport)) return false;
+            if (!(parent instanceof JViewport)) return false;
             return getMinimumSize().height < ((JViewport)parent).getHeight();
         }
 

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/model/AngularModuleInterceptor.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/model/AngularModuleInterceptor.java
@@ -116,14 +116,14 @@ public class AngularModuleInterceptor implements FunctionInterceptor{
                     functionName = fArgumentValue.isEmpty() ? null : fArgumentValue.get(0);
                     if (functionName != null) {
                         JsObject funcObj = globalObject.getProperty(functionName);
-                        JsFunction func = funcObj != null && (funcObj instanceof JsFunction) ? (JsFunction) funcObj : null;
+                        JsFunction func = funcObj instanceof JsFunction ? (JsFunction) funcObj : null;
                         if (func == null) {
                             // try to find it enclosed in IIFE
                             JsObject argumentObject = ModelUtils.findJsObject(globalObject, fArgument.getOffset());
-                            if (argumentObject != null && argumentObject instanceof JsFunction) {
+                            if (argumentObject instanceof JsFunction) {
                                 JsFunction iife = (JsFunction) argumentObject;
                                 funcObj = iife.getProperty(functionName);
-                                func = funcObj != null && (funcObj instanceof JsFunction) ? (JsFunction) iife.getProperty(functionName) : null;
+                                func = funcObj instanceof JsFunction ? (JsFunction) iife.getProperty(functionName) : null;
                             }
                         }
                         if (func != null && !func.isAnonymous()) {
@@ -170,7 +170,7 @@ public class AngularModuleInterceptor implements FunctionInterceptor{
                     controllerDecl = functProp;
                 }
             }
-            if (controllerDecl != null && controllerDecl instanceof JsFunction && controllerDecl.isDeclared()) {
+            if (controllerDecl instanceof JsFunction && controllerDecl.isDeclared()) {
                 fqnOfController = controllerDecl.getFullyQualifiedName();
                 FileObject fo = globalObject.getFileObject();
                 if (fo != null) {
@@ -183,7 +183,7 @@ public class AngularModuleInterceptor implements FunctionInterceptor{
         } else if (controllerName == null && controllersMap != null) {
             // we need to find an anonymous object, which contains the controller map
             JsObject controllerDecl = ModelUtils.findJsObject(globalObject, functionOffset);
-            if (controllerDecl != null && controllerDecl instanceof JsObject && controllerDecl.isDeclared()) {
+            if (controllerDecl instanceof JsObject && controllerDecl.isDeclared()) {
                 FileObject fo = globalObject.getFileObject();
                 for (Map.Entry<String, Integer> controller : controllersMap.entrySet()) {
                     fqnOfController = controllerDecl.getFullyQualifiedName() + "." + controller.getKey(); //NOI18N
@@ -207,7 +207,7 @@ public class AngularModuleInterceptor implements FunctionInterceptor{
      */
     private void indexComponents(Snapshot snapshot, FileObject fo, JsObject controllerDecl) {
         JsObject routerConfig = controllerDecl.getProperty(ROUTECONFIG_PROP);
-        if (routerConfig != null && routerConfig instanceof JsArray) {
+        if (routerConfig instanceof JsArray) {
             Collection<? extends TypeUsage> assignments = routerConfig.getAssignments();
             if (assignments.size() == 1 && assignments.iterator().next().getType().equals(TypeUsage.ARRAY)) {
                 int routerConfigOffset = routerConfig.getOffset();

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsCompletionItem.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsCompletionItem.java
@@ -198,7 +198,7 @@ public class JsCompletionItem implements CompletionProposal {
     @Override
     public int getSortPrioOverride() {
         int order = 100;
-        if (element != null && element instanceof JsElement) {
+        if (element instanceof JsElement) {
             if (((JsElement)element).isPlatform()) {
                 if (ModelUtils.PROTOTYPE.equals(element.getName())) { //NOI18N
                     order = 1;

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/doc/JsDocumentationCompleter.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/doc/JsDocumentationCompleter.java
@@ -92,7 +92,7 @@ public class JsDocumentationCompleter {
                     @Override
                     public void run(ResultIterator resultIterator) throws Exception {
                         ParserResult parserResult = (ParserResult) resultIterator.getParserResult(offset);
-                        if (parserResult != null && parserResult instanceof JsParserResult) {
+                        if (parserResult instanceof JsParserResult) {
                             final JsParserResult jsParserResult = (JsParserResult) parserResult;
                             if (jsParserResult.getRoot() == null) {
                                 // broken source

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/formatter/JsFormatVisitor.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/formatter/JsFormatVisitor.java
@@ -1482,7 +1482,7 @@ public class JsFormatVisitor extends NodeVisitor {
             }
         } else if (node instanceof VarNode) {
             VarNode var = (VarNode) node;
-            if (var.getInit() != null && (var.getInit() instanceof ClassNode)) {
+            if (var.getInit() instanceof ClassNode) {
                 return getFinish(var.getInit());
             }
             Token token = tokenUtils.getNextNonEmptyToken(getFinishFixed(node) - 1);

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/index/JsIndexer.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/index/JsIndexer.java
@@ -260,7 +260,7 @@ public class JsIndexer extends EmbeddingIndexer {
             if (parent != null && parent.getJSKind() == JsElement.Kind.FILE) {
                 return false;
             }
-            if (parent != null && parent instanceof JsFunction) {
+            if (parent instanceof JsFunction) {
                 Collection<? extends TypeUsage> returnTypes = ((JsFunction) parent).getReturnTypes();
                 String fqn = object.getFullyQualifiedName();
                 for (TypeUsage returnType : returnTypes) {

--- a/webcommon/javascript2.extjs/src/org/netbeans/modules/javascript2/extjs/ExtJsCodeCompletion.java
+++ b/webcommon/javascript2.extjs/src/org/netbeans/modules/javascript2/extjs/ExtJsCodeCompletion.java
@@ -134,7 +134,7 @@ public class ExtJsCodeCompletion implements CompletionProvider {
 
     @Override
     public String getHelpDocumentation(ParserResult info, ElementHandle element) {
-        if (element != null && element instanceof ExtJsElement) {
+        if (element instanceof ExtJsElement) {
             return ((ExtJsElement)element).getDocumentation();
         }
         return null;

--- a/webcommon/javascript2.jquery/src/org/netbeans/modules/javascript2/jquery/editor/JQueryCodeCompletion.java
+++ b/webcommon/javascript2.jquery/src/org/netbeans/modules/javascript2/jquery/editor/JQueryCodeCompletion.java
@@ -165,7 +165,7 @@ public class JQueryCodeCompletion implements CompletionProvider {
 
     @Override
     public String getHelpDocumentation(ParserResult info, ElementHandle element) {
-        if (element != null && element instanceof DocSimpleElement) {
+        if (element instanceof DocSimpleElement) {
             return ((DocSimpleElement)element).getDocumentation();
         }
         if (element != null && element.getKind() == ElementKind.CALL) {

--- a/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsonLexer.java
+++ b/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsonLexer.java
@@ -49,7 +49,7 @@ public class JsonLexer implements Lexer<JsTokenId> {
         FileObject fo = (FileObject) info.getAttributeValue(FileObject.class);
         boolean allowComments = fo != null ? JsonOptionsQuery.getOptions(fo).isCommentSupported() : false;
         scanner = new org.netbeans.modules.javascript2.json.parser.JsonLexer(charStream, allowComments, true);
-        if (info.state() != null && info.state() instanceof LexerState) {
+        if (info.state() instanceof LexerState) {
             scanner.setLexerState((LexerState) info.state());
         }
     }

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -919,7 +919,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
             if(!(property instanceof JsFunction)) {
                 property = fncParent.getProperty(modelBuilder.getGlobal().getName() + modelBuilder.getFunctionName(functionNode));
             }
-            if (property != null && property instanceof JsFunction) {
+            if (property instanceof JsFunction) {
                 if (property instanceof JsFunctionReference) {
                     fncScope = (JsFunctionImpl)((JsFunctionReference)property).getOriginal();
                 } else {
@@ -2491,7 +2491,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
                     for (int i = isPriviliged ? 1 : 0; parent != null && i < name.size(); i++) {
                         parent = parent.getProperty(name.get(i).getName());
                     }
-                    if (parent!= null && parent instanceof JsFunction) {
+                    if (parent instanceof JsFunction) {
                         Identifier propertyName = create(parserResult, varNode.getName());
                         Set<Modifier> modifiers;
                         if (isPriviliged) {

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/OccurrenceBuilder.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/OccurrenceBuilder.java
@@ -101,7 +101,7 @@ public class OccurrenceBuilder {
         JsObject parameter = null;
         DeclarationScope scope = item.scope;
         JsObject parent = item.currentParent;
-        if (!(parent instanceof JsWith || (parent.getParent() != null && parent.getParent() instanceof JsWith))) {
+        if (!(parent instanceof JsWith || parent.getParent() instanceof JsWith)) {
             while (scope != null && property == null && parameter == null) {
                 if (scope instanceof JsFunction) {
                     parameter = ((JsFunction) scope).getParameter(name);
@@ -119,7 +119,7 @@ public class OccurrenceBuilder {
                 }
             }
         } else {
-            if (!(parent instanceof JsWith) && (parent.getParent() != null && parent.getParent() instanceof JsWith)) {
+            if (!(parent instanceof JsWith) && parent.getParent() instanceof JsWith) {
                 parent = parent.getParent();
             }
             property = parent.getProperty(name);

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/ModelUtils.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/ModelUtils.java
@@ -273,7 +273,7 @@ public class ModelUtils {
         while (result.getParent() != null && !(result.getParent() instanceof DeclarationScope)) {
             result = result.getParent();
         }
-        if (result.getParent() != null && result.getParent() instanceof DeclarationScope) {
+        if (result.getParent() instanceof DeclarationScope) {
             result = result.getParent();
         }
         if (!(result instanceof DeclarationScope)) {

--- a/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsDataProvider.java
+++ b/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsDataProvider.java
@@ -345,12 +345,12 @@ public class NodeJsDataProvider {
         if (modules != null) {
             for (int i = 0; i < modules.size(); i++) {
                 jsonValue = modules.get(i);
-                if (jsonValue != null && jsonValue instanceof JSONObject) {
+                if (jsonValue instanceof JSONObject) {
                     JSONObject jsonModule = (JSONObject) jsonValue;
                     jsonValue = jsonModule.get(NAME);
-                    if (jsonValue != null && jsonValue instanceof String && moduleName.equals(((String) jsonValue).toLowerCase())) {
+                    if (jsonValue instanceof String && moduleName.equals(((String) jsonValue).toLowerCase())) {
                         jsonValue = jsonModule.get(DESCRIPTION);
-                        if (jsonValue != null && jsonValue instanceof String) {
+                        if (jsonValue instanceof String) {
                             return (String) jsonValue;
                         }
                     }
@@ -498,7 +498,7 @@ public class NodeJsDataProvider {
 
     private String getJSONStringProperty(final JSONObject object, final String property) {
         Object value = object.get(property);
-        if (value != null && value instanceof String) {
+        if (value instanceof String) {
             return (String) value;
         }
         return null;
@@ -506,7 +506,7 @@ public class NodeJsDataProvider {
 
     private JSONArray getJSONArrayProperty(final JSONObject object, final String property) {
         Object value = object.get(property);
-        if (value != null && value instanceof JSONArray) {
+        if (value instanceof JSONArray) {
             return (JSONArray) value;
         }
         return null;
@@ -553,7 +553,7 @@ public class NodeJsDataProvider {
             JSONObject root = (JSONObject) JSONValue.parse(content);
             if (root != null) {
                 Object jsonValue = root.get(MODULES);
-                if (jsonValue != null && jsonValue instanceof JSONArray) {
+                if (jsonValue instanceof JSONArray) {
                     return (JSONArray) jsonValue;
                 }
             }

--- a/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsUtils.java
+++ b/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsUtils.java
@@ -202,7 +202,7 @@ public class NodeJsUtils {
             JSONObject root = (JSONObject) JSONValue.parse(content);
             if (root != null) {
                 Object main = root.get(MAIN_FIELD);
-                if (main != null && main instanceof String) {
+                if (main instanceof String) {
                     value = (String)main;
                 }
             }

--- a/webcommon/javascript2.prototypejs/src/org/netbeans/modules/javascript2/prototypejs/model/CreateInterceptor.java
+++ b/webcommon/javascript2.prototypejs/src/org/netbeans/modules/javascript2/prototypejs/model/CreateInterceptor.java
@@ -74,7 +74,7 @@ public class CreateInterceptor implements FunctionInterceptor {
                 JsObject newObject = ((JsObject) scope).getProperty(objectName);
                 if (newObject != null) {
                     JsObject constructor = configObject.getProperty(INITIALIZE_METHOD_NAME);
-                    if (constructor != null && constructor instanceof JsFunction) {
+                    if (constructor instanceof JsFunction) {
                         // we need to replace the original object with this constructor
                         List<Identifier> paramNames = new ArrayList<>();
                         for (JsObject param : ((JsFunction) constructor).getParameters()) {

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/RequireJSCodeCompletion.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/RequireJSCodeCompletion.java
@@ -330,7 +330,7 @@ public class RequireJSCodeCompletion implements CompletionProvider {
     
     @Override
     public String getHelpDocumentation(ParserResult info, ElementHandle element) {
-        if (element != null && element instanceof FSCompletionItem.FSElementHandle) {
+        if (element instanceof FSCompletionItem.FSElementHandle) {
             Set<FileObject> representedFiles = ((FSCompletionItem.FSElementHandle)element).getRepresentedFiles();
             StringBuilder sb = new StringBuilder();
             for (Iterator<FileObject> iterator = representedFiles.iterator(); iterator.hasNext();) {
@@ -340,7 +340,7 @@ public class RequireJSCodeCompletion implements CompletionProvider {
             }
             return sb.toString();
         }
-        if (element != null && element instanceof SimpleHandle.DocumentationHandle) {
+        if (element instanceof SimpleHandle.DocumentationHandle) {
             return ((SimpleHandle.DocumentationHandle)element).getDocumentation();
         }
         return null;

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/model/ConfigInterceptor.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/model/ConfigInterceptor.java
@@ -145,7 +145,7 @@ public class ConfigInterceptor implements FunctionInterceptor {
                     }
                 }
 
-                if (packages != null && packages instanceof JsArray) {
+                if (packages instanceof JsArray) {
                     Map<String, String> packagesMap = loadPackages(th, packages.getOffset());
                     if (packagesMap != null) {
                         // save packages to the index

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/model/DefineInterceptor.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/model/DefineInterceptor.java
@@ -109,7 +109,7 @@ public class DefineInterceptor implements FunctionInterceptor {
                 List<String> fqn = (List<String>) fArg.getValue();
                 JsObject posibleFunc = findJsObjectByName(globalObject, fqn);
 
-                if (posibleFunc != null && posibleFunc instanceof JsFunction) {
+                if (posibleFunc instanceof JsFunction) {
                     JsFunction defFunc = (JsFunction) posibleFunc;
                     List<String> paths = new ArrayList<>();
                     if (modules != null && snapshot != null) {


### PR DESCRIPTION
Sometimes found usage of instance operator with variable superflous  check for null. But also there is not only variables. Additional null check performs with map.get() or method() and so on.