### PR TITLE
VSCode: Security vulnerabilities found in dependent libraries fixed.

### DIFF
--- a/java/java.lsp.server/vscode/package-lock.json
+++ b/java/java.lsp.server/vscode/package-lock.json
@@ -653,8 +653,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.0.4",
-			"license": "ISC",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -663,9 +664,10 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "9.2.0",
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
@@ -680,9 +682,9 @@
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
-				"minimatch": "3.0.4",
+				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.2.0",
+				"nanoid": "3.3.1",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -704,6 +706,18 @@
 				"url": "https://opencollective.com/mochajs"
 			}
 		},
+		"node_modules/mocha/node_modules/minimatch": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+			"integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/mocha/node_modules/ms": {
 			"version": "2.1.3",
 			"dev": true,
@@ -715,9 +729,10 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.2.0",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
 			"dev": true,
-			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -1510,13 +1525,17 @@
 			}
 		},
 		"minimatch": {
-			"version": "3.0.4",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
 		},
 		"mocha": {
-			"version": "9.2.0",
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
 			"dev": true,
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
@@ -1532,9 +1551,9 @@
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
-				"minimatch": "3.0.4",
+				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.2.0",
+				"nanoid": "3.3.1",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -1545,6 +1564,15 @@
 				"yargs-unparser": "2.0.0"
 			},
 			"dependencies": {
+				"minimatch": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+					"integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
 				"ms": {
 					"version": "2.1.3",
 					"dev": true
@@ -1556,7 +1584,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.2.0",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
 			"dev": true
 		},
 		"normalize-path": {


### PR DESCRIPTION
Fixing security vulnerabilities reported for dependent libraries:
```
minimatch  <3.0.5
Severity: high
minimatch ReDoS vulnerability - https://github.com/advisories/GHSA-f8q6-p94x-37v3
  mocha  5.1.0 - 9.2.1
  Depends on vulnerable versions of minimatch
```
