### PR TITLE
Include JS implementation for JDK16+ execution environment.

### DIFF
--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -67,7 +67,6 @@ disabled.modules=\
     org.netbeans.libs.cglib,\
     org.netbeans.libs.commons_net,\
     org.netbeans.libs.felix,\
-    org.netbeans.libs.graaljs,\
     org.netbeans.libs.ini4j,\
     org.netbeans.libs.jshell.compile,\
     org.netbeans.libs.jsr223,\


### PR DESCRIPTION
NBLS does not bundle GraalJS implementation. In JDK16+ Nashorn was removed from the JDK and without JS implementation NBLS is not able to process PAC proxy definitions. That affects all outbound connections from NBLS, such as JDBC or OCI ADM audit requests. 

It also affects Apache NB vscode extension: since PAC processing fails and no proxy is detected, NBLS gives misleading info to the user that maven/gradle proxy is misconfigured.