### PR TITLE
Use default wpad.dat if autoproxy without explicit pacfile location.

### DIFF
--- a/platform/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxy.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxy.java
@@ -56,12 +56,12 @@ public class WindowsNetworkProxy implements NetworkProxyResolver {
             }
 
             Pointer pacFilePointer = prxCnf.pacFile;
-            if (pacFilePointer != null) {
-                String pacFileUrl = pacFilePointer.getWideString(0);
+            if (pacFilePointer != null || prxCnf.autoDetect) {
+                String pacFileUrl = pacFilePointer != null ? pacFilePointer.getWideString(0) : "http://wpad/wpad.dat"; // NOI18N
                 
                 LOGGER.log(Level.INFO, "Windows system proxy resolver: auto - PAC ({0})", pacFileUrl); //NOI18N                
                 return new NetworkProxySettings(pacFileUrl);
-            }
+            } 
 
             Pointer proxyPointer = prxCnf.proxy;
             Pointer proxyBypassPointer = prxCnf.proxyBypass;


### PR DESCRIPTION
On Windows it is possible to enable 'automatic proxy configuration', but leave PAC file location unset - this is even the Windows' default setting. NetBeans in 'system proxy' mode rely on pacfile location to be set, if it is blank, NB defaults to 'direct' connection, which may be wrong.
This PR just defaults to the standard `http://wpad/wpad.dat` if autoproxy is enabled in the system, but no pacfile location is set.