### PR TITLE
Replaced usage of String.to[U/L]Case() with String.equalsIgnoreCase()

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassFishSettings.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassFishSettings.java
@@ -144,7 +144,7 @@ public class GlassFishSettings {
         String showProperty
                 = System.getProperty("org.netbeans.core.WindowSystem.show");
         return showProperty == null
-                || !showProperty.toLowerCase().equals("false");
+                || !showProperty.equalsIgnoreCase("false");
     }
 
 }

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/PayaraSettings.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/PayaraSettings.java
@@ -144,7 +144,7 @@ public class PayaraSettings {
         String showProperty
                 = System.getProperty("org.netbeans.core.WindowSystem.show");
         return showProperty == null
-                || !showProperty.toLowerCase().equals("false");
+                || !showProperty.equalsIgnoreCase("false");
     }
 
 }

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatInstallUtil.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatInstallUtil.java
@@ -223,8 +223,8 @@ public class TomcatInstallUtil {
     
     private static boolean isHttpConnector(String protocol, String scheme, String secure) {
         return (protocol == null || protocol.length() == 0 || protocol.toLowerCase().startsWith(HTTP))
-                && (scheme == null || !scheme.toLowerCase().equals(HTTPS))
-                && (secure == null || !secure.toLowerCase().equals(TRUE));
+                && (scheme == null || !scheme.equalsIgnoreCase(HTTPS))
+                && (secure == null || !secure.equalsIgnoreCase(TRUE));
     }
     
     public static boolean setServerPort(int port, File tomcatConf) {

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/ManagedBeanIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/ManagedBeanIterator.java
@@ -181,7 +181,7 @@ public class ManagedBeanIterator implements TemplateWizard.Iterator {
                         break;
                 }
             } else {
-                if (targetName.equalsIgnoreCase(beanName) && targetName.substring(0, 1).toLowerCase().equals(beanName.substring(0, 1))) {
+                if (targetName.equalsIgnoreCase(beanName) && targetName.substring(0, 1).equalsIgnoreCase(beanName.substring(0, 1))) {
                     templateProperties.put("classAnnotation", "@ManagedBean");   //NOI18N
                 } else {
                     templateProperties.put("classAnnotation", "@ManagedBean(name=\"" + beanName + "\")");   //NOI18N

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/MethodCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/MethodCompletion.java
@@ -276,7 +276,7 @@ public class MethodCompletion extends BaseCompletion {
      */
     private boolean exactConstructorExists(List<? extends Element> typelist, String prefix) {
         for (Element element : typelist) {
-            if (prefix.toUpperCase().equals(element.getSimpleName().toString().toUpperCase())) {
+            if (prefix.equalsIgnoreCase(element.getSimpleName().toString())) {
                 return true;
             }
         }
@@ -294,7 +294,7 @@ public class MethodCompletion extends BaseCompletion {
                         // all the constructors are named <init>.
                         String constructorName = element.getSimpleName().toString();
 
-                        if (constructorName.toUpperCase().equals(context.getPrefix().toUpperCase())) {
+                        if (constructorName.equalsIgnoreCase(context.getPrefix())) {
                             addConstructorProposal(tel.getQualifiedName().toString(), (ExecutableElement) encl);
                         }
                     }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/TypesCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/TypesCompletion.java
@@ -311,7 +311,7 @@ public class TypesCompletion extends BaseCompletion {
         // If we are in situation: "String s = new String|" we don't want to show
         // String type as a option - we want to show String constructors + types
         // prefixed with String (e.g. StringBuffer)
-        if (constructorCompletion && typeName.toUpperCase().equals(request.getPrefix().toUpperCase())) {
+        if (constructorCompletion && typeName.equalsIgnoreCase(request.getPrefix())) {
             return;
         }
         

--- a/ide/bugzilla/src/org/netbeans/modules/bugzilla/issue/IssuePanel.java
+++ b/ide/bugzilla/src/org/netbeans/modules/bugzilla/issue/IssuePanel.java
@@ -489,7 +489,7 @@ public class IssuePanel extends javax.swing.JPanel {
         ComboBoxModel model = combo.getModel();
         for(int i = 0; i < model.getSize(); i++) {
             String element = model.getElementAt(i).toString();
-            if(value.toLowerCase().equals(element.toString().toLowerCase())) {
+            if(value.equalsIgnoreCase(element)) {
                 return element;
             }
         }
@@ -3011,7 +3011,7 @@ public class IssuePanel extends javax.swing.JPanel {
                 List<String> versions = repository.getConfiguration().getVersions(product);
                 String defaultVersion = getCurrentNetBeansVersion();
                 for (String v : versions) {
-                    if (v.trim().toLowerCase().equals(defaultVersion.toLowerCase())) {
+                    if (v.trim().equalsIgnoreCase(defaultVersion)) {
                         issue.setFieldValue(IssueField.VERSION, v);
                     }
                 }
@@ -3727,7 +3727,7 @@ private void workedFieldFocusLost(java.awt.event.FocusEvent evt) {//GEN-FIRST:ev
     private String getCurrentNetBeansVersion() {        
         String version = parseProductVersion(getProductVersionValue());        
         if(version != null) {
-            if(version.toLowerCase().equals("dev")) {                           // NOI18N
+            if(version.equalsIgnoreCase("dev")) {                           // NOI18N
                 return CURRENT_NB_VERSION;
             } else {                
                 return version;

--- a/ide/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryParameter.java
+++ b/ide/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryParameter.java
@@ -345,7 +345,7 @@ public abstract class QueryParameter {
                 // need case sensitive compare
                 for(int j = 0; j < model.getSize(); j++) {
                     ParameterValue pv = (ParameterValue) model.getElementAt(j);
-                    if(pv.getValue().toLowerCase().equals(values[i].getValue().toLowerCase())) {
+                    if(pv.getValue().equalsIgnoreCase(values[i].getValue())) {
                         selectionList.add(j);
                         break;
                     }

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/spi/CompletionContext.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/spi/CompletionContext.java
@@ -143,7 +143,7 @@ public class CompletionContext extends EditorFeatureContext {
                     //empty file
                     return getParseTreeRoot();
                 }
-                if(!CssTokenIdCategory.WHITESPACES.name().toLowerCase().equals(t.id().primaryCategory())) {
+                if(!CssTokenIdCategory.WHITESPACES.name().equalsIgnoreCase(t.id().primaryCategory())) {
                     return NodeUtil.findNonTokenNodeAtOffset(getParseTreeRoot(), ts.offset() + t.length());
                 } else {
                     if(!ts.movePrevious()) {
@@ -175,7 +175,7 @@ public class CompletionContext extends EditorFeatureContext {
                     //empty file
                     return null;
                 }
-                if(!CssTokenIdCategory.WHITESPACES.name().toLowerCase().equals(t.id().primaryCategory())) {
+                if(!CssTokenIdCategory.WHITESPACES.name().equalsIgnoreCase(t.id().primaryCategory())) {
                     return t.id();
                 } else {
                     if(!ts.movePrevious()) {

--- a/ide/db.core/src/org/netbeans/modules/db/sql/execute/SQLExecuteHelper.java
+++ b/ide/db.core/src/org/netbeans/modules/db/sql/execute/SQLExecuteHelper.java
@@ -578,7 +578,7 @@ public final class SQLExecuteHelper {
                 return false;
             }
             
-            if ( substr.toUpperCase().equals(token.toUpperCase())) { // NOI18N
+            if ( substr.equalsIgnoreCase(token)) { // NOI18N
                 return true;
             }
             

--- a/ide/db.core/src/org/netbeans/modules/db/sql/history/SQLHistoryEntry.java
+++ b/ide/db.core/src/org/netbeans/modules/db/sql/history/SQLHistoryEntry.java
@@ -105,10 +105,10 @@ public class SQLHistoryEntry {
             return false;
         }
         final SQLHistoryEntry other = (SQLHistoryEntry) obj;
-        if ((this.url == null) ? (other.url != null) : !this.url.toLowerCase().equals(other.url.toLowerCase())) {
+        if ((this.url == null) ? (other.url != null) : !this.url.equalsIgnoreCase(other.url)) {
             return false;
         }
-        if ((this.sql == null) ? (other.sql != null) : !this.sql.toLowerCase().equals(other.sql.toLowerCase())) {
+        if ((this.sql == null) ? (other.sql != null) : !this.sql.equalsIgnoreCase(other.sql)) {
             return false;
         }
         return true;

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/Log.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/Log.java
@@ -62,7 +62,7 @@ public class Log {
         if (logger == null) {
             String prop = System.getProperty(packageName, DEFAULT_NAME);
             for (int i = 1; i < LEVELS.length; i++) {
-                if (prop.toLowerCase().equals(LEVEL_NAMES[i].toLowerCase())) {
+                if (prop.equalsIgnoreCase(LEVEL_NAMES[i])) {
                     level = LEVELS[i];
                     break;
                 }

--- a/ide/db/src/org/netbeans/modules/db/explorer/DatabaseConnector.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/DatabaseConnector.java
@@ -214,7 +214,7 @@ public class DatabaseConnector {
                         col.setColumnSize(0);
                     }
 
-                    col.setNullAllowed((rset.get(Integer.valueOf(18))).toUpperCase().equals("YES")); //NOI18N
+                    col.setNullAllowed((rset.get(Integer.valueOf(18))).equalsIgnoreCase("YES")); //NOI18N
                     col.setDefaultValue(rset.get(Integer.valueOf(13)));
                     rset.clear();
                 } else {

--- a/ide/db/test/unit/src/org/netbeans/modules/db/test/DBTestBase.java
+++ b/ide/db/test/unit/src/org/netbeans/modules/db/test/DBTestBase.java
@@ -176,7 +176,7 @@ public abstract class DBTestBase extends TestBase {
                 // DatabaseNodeInfo.printChildren("tables", tables);
 
                 for (Node table : tables) {
-                    if (tablename.toLowerCase().equals(table.getDisplayName().toLowerCase())) {
+                    if (tablename.equalsIgnoreCase(table.getDisplayName())) {
                         return (TableNode)table;
                     }
                 }
@@ -189,7 +189,7 @@ public abstract class DBTestBase extends TestBase {
                         // DatabaseNodeInfo.printChildren("tables", tables);
 
                         for (Node table : tables) {
-                            if (tablename.toLowerCase().equals(table.getDisplayName().toLowerCase())) {
+                            if (tablename.equalsIgnoreCase(table.getDisplayName())) {
                                 return (TableNode)table;
                             }
                         }
@@ -224,7 +224,7 @@ public abstract class DBTestBase extends TestBase {
                 // DatabaseNodeInfo.printChildren("tables", tables);
 
                 for (Node view : views) {
-                    if (viewname.toLowerCase().equals(view.getDisplayName().toLowerCase())) {
+                    if (viewname.equalsIgnoreCase(view.getDisplayName())) {
                         return (ViewNode)view;
                     }
                 }
@@ -237,7 +237,7 @@ public abstract class DBTestBase extends TestBase {
                         // DatabaseNodeInfo.printChildren("tables", tables);
 
                         for (Node view : views) {
-                            if (viewname.toLowerCase().equals(view.getDisplayName().toLowerCase())) {
+                            if (viewname.equalsIgnoreCase(view.getDisplayName())) {
                                 return (ViewNode)view;
                             }
                         }

--- a/ide/db/test/unit/src/org/netbeans/modules/db/test/DefaultDBProvider.java
+++ b/ide/db/test/unit/src/org/netbeans/modules/db/test/DefaultDBProvider.java
@@ -80,7 +80,7 @@ public class DefaultDBProvider implements DBProvider {
         ResultSet rs  = md.getSchemas();
         
         while ( rs.next() ) {
-            if ( schemaName.toLowerCase().equals(rs.getString(1).toLowerCase())) {
+            if ( schemaName.equalsIgnoreCase(rs.getString(1))) {
                 return true;
             }
         }

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Path.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Path.java
@@ -100,7 +100,7 @@ public final class Path {
         if (pathName == null) {
             if (Utilities.isWindows()) {
                 for (String key : System.getenv().keySet()) {
-                    if (key.toLowerCase().equals("path")) { // NOI18N
+                    if (key.equalsIgnoreCase("path")) { // NOI18N
                         pathName = key.substring(0, 4);
                         return pathName;
                     }

--- a/ide/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/KeyMapOperator.java
+++ b/ide/editor/test/qa-functional/src/org/netbeans/jellytools/modules/editor/KeyMapOperator.java
@@ -164,7 +164,7 @@ public class KeyMapOperator extends JDialogOperator {
         String _scStr;
         for (int i = 0; i < tm.getRowCount(); i++) {
             _str = tm.getValueAt(i, 0).toString();
-            if (_str.toLowerCase().equals(actionName.toLowerCase()) || _str.toLowerCase().equals(actionName.toLowerCase() + " (alternative shortcut)")) {
+            if (_str.equalsIgnoreCase(actionName) || _str.equalsIgnoreCase(actionName + " (alternative shortcut)")) {
                 _scStr = tm.getValueAt(i, 1).toString().toLowerCase();
                 lstr.add(_scStr);
                 System.out.println("[TEST_DEBUG]  -> found action \"" + _str + "\" with shortcut " + _scStr);
@@ -192,7 +192,7 @@ public class KeyMapOperator extends JDialogOperator {
         for (int i = 0; i < tab.getRowCount(); i++) {
             _str = tm.getValueAt(i, 0).toString();
             System.out.println("[TEST_DEBUG]  Examining action \"" + _str + "\", which is no. " + (i + 1) + " in the table...");
-            if (_str.toLowerCase().equals(actionName.toLowerCase())) {
+            if (_str.equalsIgnoreCase(actionName)) {
                 System.out.println("[TEST_DEBUG]  -> action \"" + _str + "\" (" + actionName + ") was found");
                 sleep(100);
                 tab.clickForEdit(i, 1);
@@ -232,7 +232,7 @@ public class KeyMapOperator extends JDialogOperator {
         for (int i = 0; i < tab.getRowCount(); i++) {
             _str = tm.getValueAt(i, 0).toString();
             System.out.println("[TEST_DEBUG]  Examining action " + _str + ", which is no. " + (i + 1) + "in the table...");
-            if (_str.toLowerCase().equals(actionName.toLowerCase())) {
+            if (_str.equalsIgnoreCase(actionName)) {
                 System.out.println("[TEST_DEBUG]  Action " + actionName + "was found");
                 JListOperator jli = clickShortcutEllipsisButton(tab, i);
                 retval = true;
@@ -271,7 +271,7 @@ public class KeyMapOperator extends JDialogOperator {
         for (int i = 0; i < tab.getRowCount(); i++) {
             _str = tm.getValueAt(i, 0).toString();
             System.out.println("[TEST_DEBUG]  Examining action " + _str + ", which is no. " + (i + 1) + "in the table...");
-            if (_str.toLowerCase().startsWith(actionName.toLowerCase()) && tm.getValueAt(i, 1).toString().toLowerCase().equals(shortcutStr.toLowerCase())) {
+            if (_str.toLowerCase().startsWith(actionName.toLowerCase()) && tm.getValueAt(i, 1).toString().equalsIgnoreCase(shortcutStr)) {
                 System.out.println("[TEST_DEBUG]  Action " + actionName + "was found");
                 JListOperator jli = clickShortcutEllipsisButton(tab, i);
                 jli.clickOnItem("Clear");

--- a/ide/subversion/src/org/netbeans/modules/subversion/client/SvnClientInvocationHandler.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/client/SvnClientInvocationHandler.java
@@ -221,7 +221,7 @@ public class SvnClientInvocationHandler implements InvocationHandler {
             } catch (SSLKeyException ex) {
                 if(ex.getCause() instanceof InvalidKeyException) {
                     InvalidKeyException ike = (InvalidKeyException) ex.getCause();
-                    if(ike.getMessage().toLowerCase().equals("illegal key size or default parameters")) { // NOI18N
+                    if(ike.getMessage().equalsIgnoreCase("illegal key size or default parameters")) { // NOI18N
                         SvnClientExceptionHandler.handleInvalidKeyException(ike);
                     }
                     return null; 

--- a/ide/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Terminal.java
+++ b/ide/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Terminal.java
@@ -586,19 +586,19 @@ public final class Terminal extends JComponent {
 	StringTokenizer st = new StringTokenizer(value, ",");	// NOI18N
 	while (st.hasMoreTokens()) {
 	    String s = st.nextToken();
-	    if (s.toLowerCase().equals("ops"))			// NOI18N
+	    if (s.equalsIgnoreCase("ops"))			// NOI18N
 		flags |= Term.DEBUG_OPS;
-	    else if (s.toLowerCase().equals("keys"))		// NOI18N
+	    else if (s.equalsIgnoreCase("keys"))		// NOI18N
 		flags |= Term.DEBUG_KEYS;
-	    else if (s.toLowerCase().equals("input"))		// NOI18N
+	    else if (s.equalsIgnoreCase("input"))		// NOI18N
 		flags |= Term.DEBUG_INPUT;
-	    else if (s.toLowerCase().equals("output"))		// NOI18N
+	    else if (s.equalsIgnoreCase("output"))		// NOI18N
 		flags |= Term.DEBUG_OUTPUT;
-	    else if (s.toLowerCase().equals("wrap"))		// NOI18N
+	    else if (s.equalsIgnoreCase("wrap"))		// NOI18N
 		flags |= Term.DEBUG_WRAP;
-	    else if (s.toLowerCase().equals("margins"))		// NOI18N
+	    else if (s.equalsIgnoreCase("margins"))		// NOI18N
 		flags |= Term.DEBUG_MARGINS;
-	    else if (s.toLowerCase().equals("sequences"))	// NOI18N
+	    else if (s.equalsIgnoreCase("sequences"))	// NOI18N
 		term.setSequenceLogging(true);
 	    else
 		;

--- a/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
+++ b/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
@@ -875,7 +875,7 @@ public final class XMLSyntaxSupport extends ExtSyntaxSupport implements XMLToken
                 String tag = token.getImage().substring(2).trim().toLowerCase();
                 while ( token != null){
                     if (token.getTokenID() == XMLTokenIDs.TAG && !">".equals(token.getImage())) {
-                        if (token.getImage().substring(1).trim().toLowerCase().equals(tag)
+                        if (token.getImage().substring(1).trim().equalsIgnoreCase(tag)
                         && !isSingletonTag(token)) {
                             //it's an open tag
                             if (poss == 0){
@@ -911,7 +911,7 @@ public final class XMLSyntaxSupport extends ExtSyntaxSupport implements XMLToken
                 String tag = token.getImage().substring(1).toLowerCase();
                 while ( token != null){
                     if (token.getTokenID() == XMLTokenIDs.TAG && !">".equals(token.getImage())) {
-                        if (token.getImage().substring(2).trim().toLowerCase().equals(tag)) {
+                        if (token.getImage().substring(2).trim().equalsIgnoreCase(tag)) {
                             //it's a close tag
                             if (poss == 0) {
                                 //get offset of previous token: < or </
@@ -922,7 +922,7 @@ public final class XMLSyntaxSupport extends ExtSyntaxSupport implements XMLToken
                             } else
                                 poss--;
                         } else{
-                            if (token.getImage().substring(1).toLowerCase().equals(tag)
+                            if (token.getImage().substring(1).equalsIgnoreCase(tag)
                             && !isSingletonTag(token))
                                 poss++;
                         }

--- a/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/Source.java
+++ b/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/Source.java
@@ -199,7 +199,7 @@ public final class Source {
             name = name.substring(1, name.length() - 1);
         }
         int nl = name.length();
-        if (nl < 4 || !name.substring(nl - 3, nl).toLowerCase().equals(".js")) {
+        if (nl < 4 || !name.substring(nl - 3, nl).equalsIgnoreCase(".js")) {
             name = name + ".js";
         }
         // Check whether the file happens to exist

--- a/java/form/src/org/netbeans/modules/form/editors/PrimitiveTypeArrayEditor.java
+++ b/java/form/src/org/netbeans/modules/form/editors/PrimitiveTypeArrayEditor.java
@@ -175,7 +175,7 @@ public class PrimitiveTypeArrayEditor extends PropertyEditorSupport
         String[] parts;
         String trimText = text.trim();
         
-        if ((trimText.length() == 0) || trimText.toLowerCase().equals(NULL_STR)) {
+        if ((trimText.length() == 0) || trimText.equalsIgnoreCase(NULL_STR)) {
             return null;
         }
 

--- a/java/java.hints/src/org/netbeans/modules/java/hints/WrongPackageSuggestion.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/WrongPackageSuggestion.java
@@ -125,7 +125,7 @@ public class WrongPackageSuggestion extends AbstractHint {
         
         String packageLocation = cp.getResourceName(info.getFileObject().getParent(), '.', false);
         
-        if ((isCaseSensitive() && packageName.equals(packageLocation)) || (!isCaseSensitive() && packageName.toLowerCase().equals(packageLocation.toLowerCase()))) {
+        if ((isCaseSensitive() && packageName.equals(packageLocation)) || (!isCaseSensitive() && packageName.equalsIgnoreCase(packageLocation))) {
             return null;
         }
         

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/LatteVariableCompletionProvider.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/LatteVariableCompletionProvider.java
@@ -137,19 +137,19 @@ public class LatteVariableCompletionProvider implements CompletionProvider {
         }
 
         private static boolean isProperActionMethod(MethodDeclaration node, String actionName) {
-            return CodeUtils.extractMethodName(node).toLowerCase().equalsIgnoreCase(ACTION_METHOD_PREFIX + actionName);
+            return CodeUtils.extractMethodName(node).equalsIgnoreCase(ACTION_METHOD_PREFIX + actionName);
         }
 
         private static boolean isProperRenderMethod(MethodDeclaration node, String actionName) {
-            return CodeUtils.extractMethodName(node).toLowerCase().equalsIgnoreCase(RENDER_METHOD_PREFIX + actionName);
+            return CodeUtils.extractMethodName(node).equalsIgnoreCase(RENDER_METHOD_PREFIX + actionName);
         }
 
         private static boolean isStartupMethod(MethodDeclaration node) {
-            return CodeUtils.extractMethodName(node).toLowerCase().equalsIgnoreCase(STARTUP_METHOD);
+            return CodeUtils.extractMethodName(node).equalsIgnoreCase(STARTUP_METHOD);
         }
 
         private static boolean isBeforeRenderMethod(MethodDeclaration node) {
-            return CodeUtils.extractMethodName(node).toLowerCase().equalsIgnoreCase(BEFORE_RENDER_METHOD);
+            return CodeUtils.extractMethodName(node).equalsIgnoreCase(BEFORE_RENDER_METHOD);
         }
 
         public Set<MethodDeclaration> getMethodsToScan() {

--- a/php/php.zend2/src/org/netbeans/modules/php/zend2/editor/Zend2EditorExtender.java
+++ b/php/php.zend2/src/org/netbeans/modules/php/zend2/editor/Zend2EditorExtender.java
@@ -199,7 +199,7 @@ public class Zend2EditorExtender extends EditorExtender {
 
         @Override
         public void visit(MethodDeclaration node) {
-            if (CodeUtils.extractMethodName(node).toLowerCase().equalsIgnoreCase(action)) {
+            if (CodeUtils.extractMethodName(node).equalsIgnoreCase(action)) {
                 actionDeclarations.add(node);
             }
         }

--- a/platform/core.network/src/org/netbeans/core/network/proxy/NetworkProxyReloader.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/NetworkProxyReloader.java
@@ -207,12 +207,12 @@ public class NetworkProxyReloader extends ProxySettings.Reloader {
             if (Utilities.isUnix()){
                 String env = System.getProperty(RUNNING_ENV_SYS_PROPERTY);
                 if (env != null) {
-                    if (env.toLowerCase().equals(GNOME)) {
+                    if (env.equalsIgnoreCase(GNOME)) {
                         LOGGER.log(Level.INFO, "System network proxy resolver: Gnome"); //NOI18N
                         return new GnomeNetworkProxy();
                     }
                     
-                    if (env.toLowerCase().equals(KDE)) {
+                    if (env.equalsIgnoreCase(KDE)) {
                         LOGGER.log(Level.INFO, "System network proxy resolver: KDE"); //NOI18N
                         return new KdeNetworkProxy();
                     }

--- a/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
@@ -1325,7 +1325,7 @@ public final class FileUtil extends Object {
     @Deprecated
     public static String getMIMEType(String ext) {
         assert false : "FileUtil.getMIMEType(String extension) is deprecated. Please, use FileUtil.getMIMEType(FileObject).";  //NOI18N
-        if (ext.toLowerCase().equals("xml")) {  //NOI18N
+        if (ext.equalsIgnoreCase("xml")) {  //NOI18N
             return "text/xml"; // NOI18N
         }
         return null;

--- a/platform/openide.filesystems/src/org/openide/filesystems/MIMESupport.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/MIMESupport.java
@@ -287,7 +287,7 @@ final class MIMESupport extends Object {
                 resolvedMimeType = resolveMIME(withinMIMETypes);
                 if (resolvedMimeType == null) {
                     // fallback for xml files to be recognized e.g. in platform without any MIME resolver registered
-                    if (getExt().toLowerCase().equals("xml")) {  //NOI18N
+                    if (getExt().equalsIgnoreCase("xml")) {  //NOI18N
                         resolvedMimeType = "text/xml"; // NOI18N
                     } else {
                         // general fallback

--- a/platform/uihandler/src/org/netbeans/modules/uihandler/Installer.java
+++ b/platform/uihandler/src/org/netbeans/modules/uihandler/Installer.java
@@ -2679,7 +2679,7 @@ public class Installer extends ModuleInstall implements Runnable {
                 String rptr = null;
                 if (obj instanceof AbstractButton ) {
                     abut = (AbstractButton) obj;
-                    if(abut.getText().toLowerCase().equals("send")){
+                    if(abut.getText().equalsIgnoreCase("send")){
                         // disable sen button initialy, report panel can later enable it
                         abut.setEnabled(false);
                         abut.setToolTipText(NbBundle.getMessage(Installer.class, "ReportPanel.sendButton.tooltip"));//NOI18N

--- a/profiler/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/JavacClassInfo.java
+++ b/profiler/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/javac/JavacClassInfo.java
@@ -388,7 +388,7 @@ public class JavacClassInfo extends SourceClassInfo {
         JavaSource jSrc = sourceRef != null ? sourceRef.get() : null;
         if (jSrc == null || (!allowSourceLess && jSrc.getFileObjects().isEmpty())) {
             FileObject f = getFile();
-            if (f.getExt().toLowerCase().equals("java") || f.getExt().toLowerCase().equals("class")) { // NOI18N
+            if (f.getExt().equalsIgnoreCase("java") || f.getExt().equalsIgnoreCase("class")) { // NOI18N
                 jSrc = cpInfo != null ? JavaSource.create(cpInfo, f) : JavaSource.forFileObject(f);
             } else if (cpInfo != null) {
                 jSrc = JavaSource.create(cpInfo);

--- a/profiler/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLCompletionProvider.java
+++ b/profiler/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLCompletionProvider.java
@@ -149,7 +149,7 @@ public class OQLCompletionProvider implements CompletionProvider {
                         int backout = 0;
                         if (ts.movePrevious()) backout++;
                         if (ts.movePrevious()) backout++; // check for "heap.somet[...]"
-                        isHeap = ts.token().text().toString().trim().toLowerCase().equals("heap"); // NOI18N
+                        isHeap = ts.token().text().toString().trim().equalsIgnoreCase("heap"); // NOI18N
                         // get to the current token
                         for(int i=backout;i>0;i--) {
                             ts.moveNext();
@@ -199,7 +199,7 @@ public class OQLCompletionProvider implements CompletionProvider {
                     }
                     case DOT: {
                         ts.movePrevious();
-                        if (ts.token().text().toString().trim().toLowerCase().equals("heap")) { // NOI18N
+                        if (ts.token().text().toString().trim().equalsIgnoreCase("heap")) { // NOI18N
                             ts.moveNext();
 
                             for(String method : heapMethods) {

--- a/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/ui/SearchPanel.java
+++ b/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/ui/SearchPanel.java
@@ -182,9 +182,9 @@ class SearchPanel extends javax.swing.JPanel {
      */
     private void preSelectSearchedLibrary(Library[] libraries) {
         int index = 0;
-        String term = lastSearchTerm == null ? "" : lastSearchTerm.toLowerCase(); // NOI18N
+        String term = lastSearchTerm == null ? "" : lastSearchTerm; // NOI18N
         for (int i=0; i<libraries.length; i++) {
-            if (libraries[i].getName().toLowerCase().equals(term)) {
+            if (libraries[i].getName().equalsIgnoreCase(term)) {
                 index = i;
                 break;
             }

--- a/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/ui/DomPanel.java
+++ b/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/ui/DomPanel.java
@@ -429,11 +429,11 @@ public class DomPanel extends JPanel implements ExplorerManager.Provider {
         treeView.expandNode(root);
         for (Node node : root.getChildren().getNodes()) {
             String nodeName = node.getName();
-            if (nodeName != null && nodeName.trim().toLowerCase().equals("html")) { // NOI18N
+            if (nodeName != null && nodeName.trim().equalsIgnoreCase("html")) { // NOI18N
                 treeView.expandNode(node);
                 for (Node subNode : node.getChildren().getNodes()) {
                     nodeName = subNode.getName();
-                    if (nodeName != null && nodeName.trim().toLowerCase().equals("body")) { // NOI18N
+                    if (nodeName != null && nodeName.trim().equalsIgnoreCase("body")) { // NOI18N
                         treeView.expandNode(subNode);
                     }
                 }


### PR DESCRIPTION
No needed to convert case to compare strings in different case. The better in memory and cpu way is to use equalsIgnoreCase() method.

JMH  tests showing that String.equalsIgnoreCase() method faster then String.to[U/L]Case().equals() about several times.