### PR TITLE
Fixed condition check in BugzillaExecutor.java: getLoginError()

### DIFF
--- a/ide/bugzilla/src/org/netbeans/modules/bugzilla/commands/BugzillaExecutor.java
+++ b/ide/bugzilla/src/org/netbeans/modules/bugzilla/commands/BugzillaExecutor.java
@@ -61,8 +61,8 @@ import org.openide.util.NbBundle;
 public class BugzillaExecutor {
 
     private static final String HTTP_ERROR_NOT_FOUND         = "http error: not found";         // NOI18N
-    private static final String EMPTY_PASSWORD               = "Empty password not allowed to login"; // NOI18N
-    private static final String USERNAME_CONFIRM_MATCH       = "Confirm Match"; // NOI18N
+    private static final String EMPTY_PASSWORD               = "empty password not allowed to login"; // NOI18N
+    private static final String USERNAME_CONFIRM_MATCH       = "confirm match"; // NOI18N
     private static final String INVALID_USERNAME_OR_PASSWORD = "invalid username or password";  // NOI18N
     private static final String REPOSITORY_LOGIN_FAILURE     = "unable to login to";            // NOI18N
     private static final String KENAI_LOGIN_REDIRECT         = "/people/login?original_uri=";   // NOI18N


### PR DESCRIPTION
Method String.contains() called on upper case strings and not work sometimes properly. Changing case to lower case fixing this.

Because BugzillaExecutor.java:
> msg = msg.trim().toLowerCase(); // <<<<<<
> if(INVALID_USERNAME_OR_PASSWORD.equals(msg) ||
>    msg.contains(INVALID_USERNAME_OR_PASSWORD) ||
>    msg.contains(EMPTY_PASSWORD) || 
>    msg.contains(USERNAME_CONFIRM_MATCH))
> {