### PR TITLE
Replaced old style collections creating with new List.of()/Set.of()/Map.of()

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/java/hints/errors/SearchModuleDependency.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/java/hints/errors/SearchModuleDependency.java
@@ -97,14 +97,16 @@ public class SearchModuleDependency implements org.netbeans.modules.java.hints.s
     public SearchModuleDependency() {
     }
 
+    private static final Set<String> CODES = Set.of(
+            "compiler.err.cant.resolve",//NOI18N
+            "compiler.err.cant.resolve.location",//NOI18N
+            "compiler.err.doesnt.exist",//NOI18N
+            "compiler.err.not.stmt"
+    );//NOI18N
+
     @Override
     public Set<String> getCodes() {
-        return new HashSet<String>(Arrays.asList(
-                "compiler.err.cant.resolve",//NOI18N
-                "compiler.err.cant.resolve.location",//NOI18N
-                "compiler.err.doesnt.exist",//NOI18N
-                "compiler.err.not.stmt"));//NOI18N
-
+        return CODES;
     }
 
     private boolean isHintEnabled() {

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerLibraries.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SuiteCustomizerLibraries.java
@@ -250,7 +250,7 @@ public final class SuiteCustomizerLibraries extends NbPropertyPanel.Suite
     }
 
     private void addExtCluster(ClusterInfo ci) {
-        Set<String> disabledModuleCNB = new HashSet<String>(Arrays.asList(getProperties().getDisabledModules()));
+        Set<String> disabledModuleCNB = Set.of(getProperties().getDisabledModules());
         Children.SortedArray moduleCh = new Children.SortedArray();
         try {
             ModuleList ml = ModuleList.scanCluster(ci.getClusterDir(), null, false, ci);
@@ -274,7 +274,7 @@ public final class SuiteCustomizerLibraries extends NbPropertyPanel.Suite
         assert ci.getProject() != null;
         assert ci.getProject().getLookup().lookup(SuiteProvider.class) != null;
 
-        Set<String> disabledModuleCNB = new HashSet<String>(Arrays.asList(getProperties().getDisabledModules()));
+        Set<String> disabledModuleCNB = Set.of(getProperties().getDisabledModules());
         Children.SortedArray moduleCh = new Children.SortedArray();
         moduleCh.setComparator(MODULES_COMPARATOR);
         Set<NbModuleProject> modules = SuiteUtils.getSubProjects(ci.getProject());
@@ -313,8 +313,8 @@ public final class SuiteCustomizerLibraries extends NbPropertyPanel.Suite
         // create platform modules children first
         platformModules = plaf.getSortedModules();
         initNodes();
-        Set<String> disabledModuleCNB = new HashSet<String>(Arrays.asList(getProperties().getDisabledModules()));
-        Set<String> enabledClusters = new HashSet<String>(Arrays.asList(getProperties().getEnabledClusters()));
+        Set<String> disabledModuleCNB = Set.of(getProperties().getDisabledModules());
+        Set<String> enabledClusters = Set.of(getProperties().getEnabledClusters());
 
         Map<File, ClusterNode> clusterToNode = new HashMap<File, ClusterNode>();
         synchronized (libChildren.platformNodes) {

--- a/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/layers/LayerUtilsTest.java
+++ b/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/layers/LayerUtilsTest.java
@@ -631,10 +631,10 @@ public class LayerUtilsTest extends LayerTestBase {
             }
         }
         assertEquals("#63295: masks work",
-                new HashSet<String>(Arrays.asList(
-            "org-netbeans-modules-options-OptionsWindowAction.shadow"
-            // org-netbeans-core-actions-OptionsAction.instance should be masked
-        )), optionInstanceNames);
+                Set.of(
+                        "org-netbeans-modules-options-OptionsWindowAction.shadow"
+                        // org-netbeans-core-actions-OptionsAction.instance should be masked
+                ), optionInstanceNames);
 // catalogs registered by annotation
 //        assertNotNull("system FS has xml/catalog", fs.findResource("Services/Hidden/CatalogProvider/org-netbeans-modules-xml-catalog-impl-XCatalogProvider.instance"));
         assertNull("but one entry hidden by apisupport/project", fs.findResource("Services/Hidden/org-netbeans-modules-xml-catalog-impl-SystemCatalogProvider.instance"));

--- a/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/SuiteProjectTest.java
+++ b/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/SuiteProjectTest.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
+
 import org.netbeans.api.project.ProjectInformation;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ProjectUtils;
@@ -76,7 +78,7 @@ public class SuiteProjectTest extends NbTestCase {
         ep.setProperty("app.name", "sweetness");
         ep.setProperty("app.title", "Sweetness is Now!");
         p.getHelper().putProperties(AntProjectHelper.PROJECT_PROPERTIES_PATH, ep);
-        assertEquals(new HashSet<String>(Arrays.asList(ProjectInformation.PROP_NAME, ProjectInformation.PROP_DISPLAY_NAME)), l.changed);
+        assertEquals(Set.of(ProjectInformation.PROP_NAME, ProjectInformation.PROP_DISPLAY_NAME), l.changed);
         assertEquals("Sweet_Stuff", i.getName());
         assertEquals("Sweetness is Now!", i.getDisplayName());
         model = new SuiteBrandingModel(new SuiteProperties(p, p.getHelper(), p.getEvaluator(), Collections.<NbModuleProject>emptySet()));

--- a/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/SuiteLogicalViewTest.java
+++ b/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/SuiteLogicalViewTest.java
@@ -85,7 +85,7 @@ public class SuiteLogicalViewTest extends TestBase {
         ep.setProperty("app.title", "Sweetness is Now!");
         p.getHelper().putProperties(AntProjectHelper.PROJECT_PROPERTIES_PATH, ep);
         TestBase.waitForNodesUpdate();
-        assertEquals(new HashSet<String>(Arrays.asList(Node.PROP_NAME, Node.PROP_DISPLAY_NAME)), nl.changed);
+        assertEquals(Set.of(Node.PROP_NAME, Node.PROP_DISPLAY_NAME), nl.changed);
         assertEquals("Sweetness is Now!", n.getName());
         assertEquals("Sweetness is Now!", n.getDisplayName());
     }

--- a/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/AddModuleFilterTest.java
+++ b/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/ui/customizer/AddModuleFilterTest.java
@@ -100,7 +100,7 @@ public class AddModuleFilterTest extends TestBase {
         for (ModuleDependency dep : filter.getMatches(null, text, false)) {
             matchedCNBs.add(dep.getModuleEntry().getCodeNameBase());
         }
-        assertEquals("correct matches for '" + text + "'", new HashSet<String>(Arrays.asList(cnbs)), matchedCNBs);
+        assertEquals("correct matches for '" + text + "'", Set.of(cnbs), matchedCNBs);
     }
     
 }

--- a/apisupport/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/api/EditableManifestTest.java
+++ b/apisupport/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/api/EditableManifestTest.java
@@ -26,6 +26,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
+
 import org.netbeans.junit.NbTestCase;
 
 /**
@@ -125,21 +127,21 @@ public class EditableManifestTest extends NbTestCase {
         assertEquals(Collections.EMPTY_SET, m.getAttributeNames(null));
         assertEquals(Collections.EMPTY_SET, m.getSectionNames());
         m = string2Manifest("Foo: val1\nBar: val2");
-        assertEquals(new HashSet<String>(Arrays.asList("Foo", "Bar")), m.getAttributeNames(null));
+        assertEquals(Set.of("Foo", "Bar"), m.getAttributeNames(null));
         assertEquals("val1", m.getAttribute("Foo", null));
         assertEquals("val2", m.getAttribute("Bar", null));
         assertEquals(Collections.emptySet(), m.getSectionNames());
         m = string2Manifest("Foo: val1\nBar: val2\n\nName: something.class\nAttr: val\n\nName: other.class\nAttr: val2\n\n");
-        assertEquals(new HashSet<String>(Arrays.asList("Foo", "Bar")), m.getAttributeNames(null));
+        assertEquals(Set.of("Foo", "Bar"), m.getAttributeNames(null));
         assertEquals("val1", m.getAttribute("foo", null));
         assertEquals("val2", m.getAttribute("bar", null));
-        assertEquals(new HashSet<String>(Arrays.asList("something.class", "other.class")), m.getSectionNames());
+        assertEquals(Set.of("something.class", "other.class"), m.getSectionNames());
         assertEquals(Collections.singleton("Attr"), m.getAttributeNames("something.class"));
         assertEquals("val", m.getAttribute("Attr", "something.class"));
         assertEquals(Collections.singleton("Attr"), m.getAttributeNames("other.class"));
         assertEquals("val2", m.getAttribute("Attr", "other.class"));
         m = string2Manifest("Foo :  bar \nBaz:quux");
-        assertEquals(new HashSet<String>(Arrays.asList("Foo", "Baz")), m.getAttributeNames(null));
+        assertEquals(Set.of("Foo", "Baz"), m.getAttributeNames(null));
         assertEquals("bar ", m.getAttribute("Foo", null));
         assertEquals("quux", m.getAttribute("Baz", null));
     }

--- a/apisupport/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/layers/WritableXMLFileSystemTest.java
+++ b/apisupport/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/layers/WritableXMLFileSystemTest.java
@@ -146,7 +146,7 @@ public class WritableXMLFileSystemTest extends LayerTestBase {
         FileSystem fs = new Layer("<file name='x'><attr name='a' stringvalue='v'/> <attr name='b' urlvalue='file:/nothing'/></file> " +
                 "<folder name='y'> <file name='ignore'/><attr name='a' boolvalue='true'/><!--ignore--></folder>").read();
         FileObject x = fs.findResource("x");
-        assertEquals(new HashSet<String>(Arrays.asList("a", "b")), new HashSet<String>(Collections.list(x.getAttributes())));
+        assertEquals(Set.of("a", "b"), Set.of(Collections.list(x.getAttributes())));
         assertEquals("v", x.getAttribute("a"));
         assertEquals(new URL("file:/nothing"), x.getAttribute("b"));
         assertEquals(null, x.getAttribute("dummy"));
@@ -613,9 +613,7 @@ public class WritableXMLFileSystemTest extends LayerTestBase {
         FileUtil.createData(fs.getRoot(), "a");
         FileUtil.createData(fs.getRoot(), "f/b");
         fs.findResource("x").delete();
-        assertEquals("expected things fired",
-                new HashSet<String>(Arrays.asList("a", "f/b", "x")),
-                        fcl.changes());
+        assertEquals("expected things fired", Set.of("a", "f/b", "x"), fcl.changes());
     }
 
     @RandomlyFails // issue #237349

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/loader/FileRecognitionPanel.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/loader/FileRecognitionPanel.java
@@ -45,7 +45,7 @@ final class FileRecognitionPanel extends BasicWizardIterator.Panel {
     private static final Pattern EXTENSION_PATTERN = Pattern.compile("([.]?[a-zA-Z0-9_]+){1}([ ,]+[.]?[a-zA-Z0-9_]+)*[ ]*"); // NOI18N
     private static final Pattern ELEMENT_PATTERN = Pattern.compile("(application/([a-zA-Z0-9_.-])*\\+xml|text/([a-zA-Z0-9_.-])*\\+xml)"); // NOI18N
     private static final Pattern REG_NAME_PATTERN = Pattern.compile("^[[\\p{Alnum}][!#$&.+\\-^_]]{1,127}$"); //NOI18N
-    private static final Set<String> WELL_KNOWN_TYPES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> WELL_KNOWN_TYPES = Set.of(
         "application", //NOI18N
         "audio", //NOI18N
         "content", //NOI18N   for content/unknown mime type
@@ -55,7 +55,7 @@ final class FileRecognitionPanel extends BasicWizardIterator.Panel {
         "multipart", //NOI18N
         "text", //NOI18N
         "video" //NOI18N
-    ));
+    );
     
     private NewLoaderIterator.DataModel data;
     private ButtonGroup group;

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmActionGoalProvider.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmActionGoalProvider.java
@@ -79,12 +79,12 @@ public class NbmActionGoalProvider implements MavenActionsProvider {
         }
     };
 
+    private static final Set<String> SUPPORTED_ACTIONS = Set.of(NBMRELOAD, RELOAD_TARGET);
 
     public @Override Set<String> getSupportedDefaultActions() {
-        return new HashSet<String>(Arrays.asList(NBMRELOAD, RELOAD_TARGET));
+        return SUPPORTED_ACTIONS;
     }
-    
-    
+
     @ActionID(id = "org.netbeans.modules.maven.apisupport.NBMReload", category = "Project")
     @ActionRegistration(displayName = "#ACT_NBM_Reload", lazy=false)
     @ActionReference(position = 1250, path = "Projects/org-netbeans-modules-maven/Actions")

--- a/enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/serverplugin/AmazonJ2eePlatformImpl2.java
+++ b/enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/serverplugin/AmazonJ2eePlatformImpl2.java
@@ -143,9 +143,11 @@ public class AmazonJ2eePlatformImpl2 extends J2eePlatformImpl2 {
         return false;
     }
 
+    private static final Set<String> SUPPORTED_PLATFORMS = Set.of("1.6","1.5");
+
     @Override
     public Set getSupportedJavaPlatformVersions() {
-        return new HashSet<String>(Arrays.asList(new String[] {"1.6","1.5"}));
+        return SUPPORTED_PLATFORMS;
     }
 
     @Override

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/AppClientActionProvider.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/AppClientActionProvider.java
@@ -20,9 +20,6 @@
 package org.netbeans.modules.j2ee.clientproject;
 
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -46,9 +43,9 @@ import org.openide.util.Lookup;
  * Action provider of the Application Client project.
  */
 class AppClientActionProvider extends BaseActionProvider {
-    
+
     private static final String COMMAND_VERIFY = "verify"; //NOI18N
-    
+
     // Commands available from Application Client project
     private static final String[] supportedActions = {
         COMMAND_BUILD,
@@ -74,8 +71,8 @@ class AppClientActionProvider extends BaseActionProvider {
         COMMAND_MOVE,
         COMMAND_RENAME,
     };
-    
-    
+
+
     private static final String[] platformSensitiveActions = {
         COMMAND_BUILD,
         COMMAND_REBUILD,
@@ -93,51 +90,11 @@ class AppClientActionProvider extends BaseActionProvider {
         SingleMethod.COMMAND_RUN_SINGLE_METHOD,
         SingleMethod.COMMAND_DEBUG_SINGLE_METHOD,
     };
-    
-    /**Set of commands which are affected by background scanning*/
-    private Set<String> bkgScanSensitiveActions;
 
-    /**Set of commands which need java model up to date*/
-    private Set<String> needJavaModelActions;
-
-    private static final String[] actionsDisabledForQuickRun = {
-        COMMAND_COMPILE_SINGLE,
-        JavaProjectConstants.COMMAND_DEBUG_FIX,
-    };
-
-    /** Map from commands to ant targets */
-    Map<String,String[]> commands;
-    
-    public AppClientActionProvider( AppClientProject project, UpdateHelper updateHelper ) {
-        super(project, updateHelper, project.evaluator(), project.getSourceRoots(),
-                project.getTestSourceRoots(), project.getAntProjectHelper(), 
-                new BaseActionProvider.CallbackImpl(project.getClassPathProvider()));
-        commands = new HashMap<String, String[]>();
-        commands.put(COMMAND_BUILD, new String[] {"dist"}); // NOI18N
-        commands.put(COMMAND_CLEAN, new String[] {"clean"}); // NOI18N
-        commands.put(COMMAND_REBUILD, new String[] {"clean", "dist"}); // NOI18N
-        commands.put(COMMAND_COMPILE_SINGLE, new String[] {"compile-single"}); // NOI18N
-        commands.put(COMMAND_RUN, new String[] {"run"}); // NOI18N
-        commands.put(COMMAND_RUN_SINGLE, new String[] {"run-single"}); // NOI18N
-        commands.put(EjbProjectConstants.COMMAND_REDEPLOY, new String[] {"run-deploy"}); // NOI18N
-        commands.put(COMMAND_DEBUG, new String[] {"debug"}); // NOI18N
-        commands.put(COMMAND_DEBUG_SINGLE, new String[] {"debug-single"}); // NOI18N
-        commands.put(JavaProjectConstants.COMMAND_JAVADOC, new String[] {"javadoc"}); // NOI18N
-        commands.put(COMMAND_TEST, new String[] {"test"}); // NOI18N
-        commands.put(COMMAND_TEST_SINGLE, new String[] {"test-single"}); // NOI18N
-        commands.put(COMMAND_DEBUG_TEST_SINGLE, new String[] {"debug-test"}); // NOI18N
-        commands.put(JavaProjectConstants.COMMAND_DEBUG_FIX, new String[] {"debug-fix"}); // NOI18N
-        commands.put(COMMAND_DEBUG_STEP_INTO, new String[] {"debug-stepinto"}); // NOI18N
-        commands.put(COMMAND_VERIFY, new String[] {"verify"}); // NOI18N
-        commands.put(COMMAND_DEBUG_SINGLE, new String[] {"debug-single"}); // NOI18N
-        commands.put(SingleMethod.COMMAND_RUN_SINGLE_METHOD, new String[] {"test-single-method"}); // NOI18N
-        commands.put(SingleMethod.COMMAND_DEBUG_SINGLE_METHOD, new String[] {"debug-single-method"}); // NOI18N
-
-        this.needJavaModelActions = new HashSet<String>(Arrays.asList(
-            JavaProjectConstants.COMMAND_DEBUG_FIX
-        ));
-        
-        this.bkgScanSensitiveActions = new HashSet<String>(Arrays.asList(new String[] {
+    /**
+     * Set of commands which are affected by background scanning
+     */
+    private static final Set<String> BKG_SCAN_SENSITIVE_ACTIONS = Set.of(
             COMMAND_RUN,
             COMMAND_RUN_SINGLE,
             COMMAND_DEBUG,
@@ -145,7 +102,44 @@ class AppClientActionProvider extends BaseActionProvider {
             COMMAND_DEBUG_STEP_INTO,
             SingleMethod.COMMAND_RUN_SINGLE_METHOD,
             SingleMethod.COMMAND_DEBUG_SINGLE_METHOD
-        }));
+    );
+
+    /**Set of commands which need java model up to date*/
+    private static final Set<String> NEED_JAVA_MODEL_ACTIONS = Set.of(
+            JavaProjectConstants.COMMAND_DEBUG_FIX
+    );
+
+    private static final String[] actionsDisabledForQuickRun = {
+        COMMAND_COMPILE_SINGLE,
+        JavaProjectConstants.COMMAND_DEBUG_FIX,
+    };
+
+    /** Map from commands to ant targets */
+    private static final Map<String,String[]> COMMANDS = Map.ofEntries(
+            Map.entry(COMMAND_BUILD, new String[]{"dist"}), // NOI18N
+            Map.entry(COMMAND_CLEAN, new String[]{"clean"}), // NOI18N
+            Map.entry(COMMAND_REBUILD, new String[]{"clean", "dist"}), // NOI18N
+            Map.entry(COMMAND_COMPILE_SINGLE, new String[]{"compile-single"}), // NOI18N
+            Map.entry(COMMAND_RUN, new String[]{"run"}), // NOI18N
+            Map.entry(COMMAND_RUN_SINGLE, new String[]{"run-single"}), // NOI18N
+            Map.entry(EjbProjectConstants.COMMAND_REDEPLOY, new String[]{"run-deploy"}), // NOI18N
+            Map.entry(COMMAND_DEBUG, new String[]{"debug"}), // NOI18N
+            Map.entry(COMMAND_DEBUG_SINGLE, new String[]{"debug-single"}), // NOI18N
+            Map.entry(JavaProjectConstants.COMMAND_JAVADOC, new String[]{"javadoc"}), // NOI18N
+            Map.entry(COMMAND_TEST, new String[]{"test"}), // NOI18N
+            Map.entry(COMMAND_TEST_SINGLE, new String[]{"test-single"}), // NOI18N
+            Map.entry(COMMAND_DEBUG_TEST_SINGLE, new String[]{"debug-test"}), // NOI18N
+            Map.entry(JavaProjectConstants.COMMAND_DEBUG_FIX, new String[]{"debug-fix"}), // NOI18N
+            Map.entry(COMMAND_DEBUG_STEP_INTO, new String[]{"debug-stepinto"}), // NOI18N
+            Map.entry(COMMAND_VERIFY, new String[]{"verify"}), // NOI18N
+            Map.entry(SingleMethod.COMMAND_RUN_SINGLE_METHOD, new String[]{"test-single-method"}), // NOI18N
+            Map.entry(SingleMethod.COMMAND_DEBUG_SINGLE_METHOD, new String[]{"debug-single-method"}) // NOI18N
+    );
+
+    public AppClientActionProvider( AppClientProject project, UpdateHelper updateHelper ) {
+        super(project, updateHelper, project.evaluator(), project.getSourceRoots(),
+                project.getTestSourceRoots(), project.getAntProjectHelper(),
+                new BaseActionProvider.CallbackImpl(project.getClassPathProvider()));
     }
 
     @Override
@@ -160,17 +154,17 @@ class AppClientActionProvider extends BaseActionProvider {
 
     @Override
     public Map<String, String[]> getCommands() {
-        return commands;
+        return COMMANDS;
     }
 
     @Override
     protected Set<String> getScanSensitiveActions() {
-        return bkgScanSensitiveActions;
+        return BKG_SCAN_SENSITIVE_ACTIONS;
     }
 
     @Override
     protected Set<String> getJavaModelActions() {
-        return needJavaModelActions;
+        return NEED_JAVA_MODEL_ACTIONS;
     }
 
     @Override
@@ -185,7 +179,7 @@ class AppClientActionProvider extends BaseActionProvider {
 
     @Override
     public String[] getTargetNames(String command, Lookup context, Properties p, boolean doJavaChecks) throws IllegalArgumentException {
-        if (command.equals(COMMAND_RUN) || command.equals(EjbProjectConstants.COMMAND_REDEPLOY) || 
+        if (command.equals(COMMAND_RUN) || command.equals(EjbProjectConstants.COMMAND_REDEPLOY) ||
                 command.equals(COMMAND_DEBUG) || command.equals(COMMAND_DEBUG_SINGLE) || command.equals(COMMAND_RUN_SINGLE)) {
             if (!checkSelectedServer(command.equals(COMMAND_DEBUG) || command.equals(COMMAND_DEBUG_SINGLE), false, false)) {
                 return null;
@@ -201,7 +195,7 @@ class AppClientActionProvider extends BaseActionProvider {
         }
         return super.getTargetNames(command, context, p, doJavaChecks);
     }
-    
+
     @Override
     public boolean isActionEnabled( String command, Lookup context ) {
         boolean res = super.isActionEnabled(command, context);
@@ -215,7 +209,7 @@ class AppClientActionProvider extends BaseActionProvider {
         }
         return res;
     }
-    
+
     private boolean checkSelectedServer(boolean checkDebug, boolean checkProfile, boolean noMessages) {
         return J2EEProjectProperties.checkSelectedServer(getProject(), getAntProjectHelper(),
                 ((AppClientProject) getProject()).getAPICar().getJ2eeProfile(), J2eeModule.Type.CAR, new J2EEProjectProperties.SetServerInstanceCallback() {
@@ -226,11 +220,11 @@ class AppClientActionProvider extends BaseActionProvider {
             }
         }, checkDebug, checkProfile, false);
     }
-    
+
     private void setServerInstance(final String serverInstanceId) {
         AppClientProjectProperties.setServerInstance((AppClientProject)getProject(), getAntProjectHelper(), serverInstanceId);
     }
-    
+
    private boolean isDebugged() {
         J2eeModuleProvider jmp = getProject().getLookup().lookup(J2eeModuleProvider.class);
         ServerDebugInfo sdi = jmp.getServerDebugInfo();
@@ -238,7 +232,7 @@ class AppClientActionProvider extends BaseActionProvider {
             return false;
         }
         Session[] sessions = DebuggerManager.getDebuggerManager().getSessions();
-        
+
         for (int i=0; i < sessions.length; i++) {
             Session s = sessions[i];
             if (s != null) {
@@ -260,7 +254,7 @@ class AppClientActionProvider extends BaseActionProvider {
         }
         return false;
     }
-   
+
     private boolean isTargetServerRemote() {
         J2eeModuleProvider module = getProject().getLookup().lookup(J2eeModuleProvider.class);
         InstanceProperties props = module.getInstanceProperties();

--- a/enterprise/j2ee.dd/test/unit/src/org/netbeans/modules/j2ee/dd/impl/common/annotation/CommonAnnotationHelperTest.java
+++ b/enterprise/j2ee.dd/test/unit/src/org/netbeans/modules/j2ee/dd/impl/common/annotation/CommonAnnotationHelperTest.java
@@ -99,7 +99,7 @@ public class CommonAnnotationHelperTest extends CommonTestCase {
      */
     public void testGetResourceRefsOnClasspath() throws Exception {
         initClasses();
-        final Set<String> resourceNames = new HashSet<String>(Arrays.asList("myDS", "yourDataSource"));
+        final Set<String> resourceNames = Set.of("myDS", "yourDataSource");
         createWebAppModel(false).runReadAction(new MetadataModelAction<WebAppMetadata, Void>() {
             public Void run(WebAppMetadata metadata) throws VersionNotSupportedException {
                 List<ResourceRef> rs = metadata.getResourceRefs();
@@ -122,7 +122,7 @@ public class CommonAnnotationHelperTest extends CommonTestCase {
      */
     public void testGetResourceRefsInClass() throws Exception {
         initClass();
-        final Set<String> resourceNames = new HashSet<String>(Arrays.asList("myDS", "yourDataSource"));
+        final Set<String> resourceNames = Set.of("myDS", "yourDataSource");
 
         createEjbJarModel().runReadAction(new MetadataModelAction<EjbJarMetadata, Void>() {
             public Void run(EjbJarMetadata metadata) throws VersionNotSupportedException {
@@ -140,7 +140,7 @@ public class CommonAnnotationHelperTest extends CommonTestCase {
      */
     public void testGetResourceEnvRefsOnClasspath() throws Exception {
         initClasses();
-        final Set<String> resourceNames = new HashSet<String>(Arrays.asList("myInteractionSpec", "yourClass"));
+        final Set<String> resourceNames = Set.of("myInteractionSpec", "yourClass");
         createWebAppModel(false).runReadAction(new MetadataModelAction<WebAppMetadata, Void>() {
             public Void run(WebAppMetadata metadata) throws VersionNotSupportedException {
                 List<ResourceEnvRef> rs = metadata.getResourceEnvRefs();
@@ -163,7 +163,7 @@ public class CommonAnnotationHelperTest extends CommonTestCase {
      */
     public void testGetResourceEnvRefsInClass() throws Exception {
         initClass();
-        final Set<String> resourceNames = new HashSet<String>(Arrays.asList("myTransaction"));
+        final Set<String> resourceNames = Set.of("myTransaction");
 
         createEjbJarModel().runReadAction(new MetadataModelAction<EjbJarMetadata, Void>() {
             public Void run(EjbJarMetadata metadata) throws VersionNotSupportedException {
@@ -181,7 +181,7 @@ public class CommonAnnotationHelperTest extends CommonTestCase {
      */
     public void testGetEnvEntriesOnClasspath() throws Exception {
         initClasses();
-        final Set<String> resourceNames = new HashSet<String>(Arrays.asList("myString", "yourLong"));
+        final Set<String> resourceNames = Set.of("myString", "yourLong");
         createWebAppModel(false).runReadAction(new MetadataModelAction<WebAppMetadata, Void>() {
             public Void run(WebAppMetadata metadata) throws VersionNotSupportedException {
                 List<EnvEntry> rs = metadata.getEnvEntries();
@@ -204,7 +204,7 @@ public class CommonAnnotationHelperTest extends CommonTestCase {
      */
     public void testGetEnvEntriesInClass() throws Exception {
         initClass();
-        final Set<String> resourceNames = new HashSet<String>(Arrays.asList("myString", "yourLong"));
+        final Set<String> resourceNames = Set.of("myString", "yourLong");
 
         createEjbJarModel().runReadAction(new MetadataModelAction<EjbJarMetadata, Void>() {
             public Void run(EjbJarMetadata metadata) throws VersionNotSupportedException {
@@ -222,7 +222,7 @@ public class CommonAnnotationHelperTest extends CommonTestCase {
      */
     public void testGetMessageDestinationRefsOnClasspath() throws Exception {
         initClasses();
-        final Set<String> resourceNames = new HashSet<String>(Arrays.asList("myQueue"));
+        final Set<String> resourceNames = Set.of("myQueue");
         createWebAppModel(false).runReadAction(new MetadataModelAction<WebAppMetadata, Void>() {
             public Void run(WebAppMetadata metadata) throws VersionNotSupportedException {
                 List<MessageDestinationRef> rs = metadata.getMessageDestinationRefs();
@@ -245,7 +245,7 @@ public class CommonAnnotationHelperTest extends CommonTestCase {
      */
     public void testGetMessageDestinationRefsInClass() throws Exception {
         initClass();
-        final Set<String> resourceNames = new HashSet<String>(Arrays.asList("myTopic"));
+        final Set<String> resourceNames = Set.of("myTopic");
 
         createEjbJarModel().runReadAction(new MetadataModelAction<EjbJarMetadata, Void>() {
             public Void run(EjbJarMetadata metadata) throws VersionNotSupportedException {
@@ -263,7 +263,7 @@ public class CommonAnnotationHelperTest extends CommonTestCase {
      */
     public void testGetServiceRefsOnClasspath() throws Exception {
         initClasses();
-        final Set<String> resourceNames = new HashSet<String>(Arrays.asList("yourService"));
+        final Set<String> resourceNames = Set.of("yourService");
         createWebAppModel(false).runReadAction(new MetadataModelAction<WebAppMetadata, Void>() {
             public Void run(WebAppMetadata metadata) throws VersionNotSupportedException {
                 List<ServiceRef> rs = metadata.getServiceRefs();
@@ -286,7 +286,7 @@ public class CommonAnnotationHelperTest extends CommonTestCase {
      */
     public void testGetServiceRefsInClass() throws Exception {
         initClass();
-        final Set<String> resourceNames = new HashSet<String>(Arrays.asList("myService"));
+        final Set<String> resourceNames = Set.of("myService");
 
         createEjbJarModel().runReadAction(new MetadataModelAction<EjbJarMetadata, Void>() {
             public Void run(EjbJarMetadata metadata) throws VersionNotSupportedException {

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarActionProvider.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarActionProvider.java
@@ -108,10 +108,14 @@ public class EjbJarActionProvider extends BaseActionProvider {
     private final EjbJarProject project;
 
     /**Set of commands which are affected by background scanning*/
-    private Set<String> bkgScanSensitiveActions;
+    private static final Set<String> BKG_SCAN_SENSITIVE_ACTIONS = Set.of(
+            COMMAND_RUN_SINGLE
+    );
 
     /**Set of commands which need java model up to date*/
-    private Set<String> needJavaModelActions;
+    private static final Set<String> NEED_JAVA_MODEL_ACTIONS = Set.of(
+            JavaProjectConstants.COMMAND_DEBUG_FIX
+    );
 
     private static final String[] actionsDisabledForQuickRun = {
         COMMAND_COMPILE_SINGLE,
@@ -119,39 +123,32 @@ public class EjbJarActionProvider extends BaseActionProvider {
     };
     
     /** Map from commands to ant targets */
-    private Map<String,String[]> commands;
+    private static final Map<String,String[]> COMMANDS = Map.ofEntries(
+            Map.entry(COMMAND_BUILD, new String[] {"dist"}), // NOI18N
+            Map.entry(COMMAND_CLEAN, new String[] {"clean"}), // NOI18N
+            Map.entry(COMMAND_REBUILD, new String[] {"clean", "dist"}), // NOI18N
+            Map.entry(COMMAND_COMPILE_SINGLE, new String[] {"compile-single"}), // NOI18N
+            Map.entry(COMMAND_RUN, new String[] {"run"}), // NOI18N
+            Map.entry(COMMAND_RUN_SINGLE, new String[] {"run-main"}), // NOI18N
+            Map.entry(EjbProjectConstants.COMMAND_REDEPLOY, new String[] {"run"}), // NOI18N
+            Map.entry(COMMAND_DEBUG, new String[] {"debug"}), // NOI18N
+            Map.entry(COMMAND_PROFILE, new String[]{"profile"}), // NOI18N
+            Map.entry(JavaProjectConstants.COMMAND_JAVADOC, new String[] {"javadoc"}), // NOI18N
+            Map.entry(COMMAND_TEST, new String[] {"test"}), // NOI18N
+            Map.entry(COMMAND_TEST_SINGLE, new String[] {"test-single"}), // NOI18N
+            Map.entry(COMMAND_DEBUG_TEST_SINGLE, new String[] {"debug-test"}), // NOI18N
+            Map.entry(JavaProjectConstants.COMMAND_DEBUG_FIX, new String[] {"debug-fix"}), // NOI18N
+            Map.entry(COMMAND_VERIFY, new String[] {"verify"}), // NOI18N
+            Map.entry(COMMAND_DEBUG_SINGLE, new String[] {"debug-single"}), // NOI18N
+            Map.entry(COMMAND_PROFILE_SINGLE, new String[]{"profile-single"}), // NOI18N
+            Map.entry(SingleMethod.COMMAND_RUN_SINGLE_METHOD, new String[] {"test-single-method"}), // NOI18N
+            Map.entry(SingleMethod.COMMAND_DEBUG_SINGLE_METHOD, new String[] {"debug-single-method"}) // NOI18N
+    );
 
     public EjbJarActionProvider(EjbJarProject project, UpdateHelper updateHelper) {
         super(project, updateHelper, project.evaluator(), project.getSourceRoots(), project.getTestSourceRoots(), 
                 project.getAntProjectHelper(), new CallbackImpl(new BaseActionProvider.CallbackImpl(project.getClassPathProvider()), project.getEjbModule()));
         this.project = project;
-        commands = new HashMap<String,String[]>();
-        commands.put(COMMAND_BUILD, new String[] {"dist"}); // NOI18N
-        commands.put(COMMAND_CLEAN, new String[] {"clean"}); // NOI18N
-        commands.put(COMMAND_REBUILD, new String[] {"clean", "dist"}); // NOI18N
-        commands.put(COMMAND_COMPILE_SINGLE, new String[] {"compile-single"}); // NOI18N
-        commands.put(COMMAND_RUN, new String[] {"run"}); // NOI18N
-        commands.put(COMMAND_RUN_SINGLE, new String[] {"run-main"}); // NOI18N
-        commands.put(EjbProjectConstants.COMMAND_REDEPLOY, new String[] {"run"}); // NOI18N
-        commands.put(COMMAND_DEBUG, new String[] {"debug"}); // NOI18N
-        commands.put(COMMAND_PROFILE, new String[]{"profile"}); // NOI18N
-        commands.put(JavaProjectConstants.COMMAND_JAVADOC, new String[] {"javadoc"}); // NOI18N
-        commands.put(COMMAND_TEST, new String[] {"test"}); // NOI18N
-        commands.put(COMMAND_TEST_SINGLE, new String[] {"test-single"}); // NOI18N
-        commands.put(COMMAND_DEBUG_TEST_SINGLE, new String[] {"debug-test"}); // NOI18N
-        commands.put(JavaProjectConstants.COMMAND_DEBUG_FIX, new String[] {"debug-fix"}); // NOI18N
-        commands.put(COMMAND_VERIFY, new String[] {"verify"}); // NOI18N
-        commands.put(COMMAND_DEBUG_SINGLE, new String[] {"debug-single"}); // NOI18N
-        commands.put(COMMAND_PROFILE_SINGLE, new String[]{"profile-single"}); // NOI18N
-        commands.put(SingleMethod.COMMAND_RUN_SINGLE_METHOD, new String[] {"test-single-method"}); // NOI18N
-        commands.put(SingleMethod.COMMAND_DEBUG_SINGLE_METHOD, new String[] {"debug-single-method"}); // NOI18N
-        this.bkgScanSensitiveActions = new HashSet<String>(Arrays.asList(
-            COMMAND_RUN_SINGLE
-        ));
-
-        this.needJavaModelActions = new HashSet<String>(Arrays.asList(
-            JavaProjectConstants.COMMAND_DEBUG_FIX
-        ));
         setServerExecution(true);
     }
 
@@ -167,17 +164,17 @@ public class EjbJarActionProvider extends BaseActionProvider {
 
     @Override
     public Map<String, String[]> getCommands() {
-        return commands;
+        return COMMANDS;
     }
 
     @Override
     protected Set<String> getScanSensitiveActions() {
-        return bkgScanSensitiveActions;
+        return BKG_SCAN_SENSITIVE_ACTIONS;
     }
 
     @Override
     protected Set<String> getJavaModelActions() {
-        return needJavaModelActions;
+        return NEED_JAVA_MODEL_ACTIONS;
     }
 
     @Override
@@ -260,7 +257,7 @@ public class EjbJarActionProvider extends BaseActionProvider {
             } else {
                 p.setProperty("forceRedeploy", "false"); //NOI18N
             }
-            return commands.get(command);
+            return COMMANDS.get(command);
         } else {
             return super.getTargetNames(command, context, p, doJavaChecks);
         }

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautJavaConfigPropertiesCompletion.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautJavaConfigPropertiesCompletion.java
@@ -24,9 +24,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -54,7 +52,10 @@ import org.springframework.boot.configurationmetadata.ConfigurationMetadataPrope
  */
 public class MicronautJavaConfigPropertiesCompletion implements Processor {
 
-    private static final Set<String> supportedAnnotationTypes = new HashSet<String>(Arrays.asList("io.micronaut.context.annotation.Property", "io.micronaut.context.annotation.Value"));
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            "io.micronaut.context.annotation.Property",
+            "io.micronaut.context.annotation.Value"
+    );
     private Reference<ProcessingEnvironment> processingEnv;
 
     @Override
@@ -125,7 +126,7 @@ public class MicronautJavaConfigPropertiesCompletion implements Processor {
 
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return supportedAnnotationTypes;
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/hints/CreateQualifier.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/hints/CreateQualifier.java
@@ -104,15 +104,20 @@ public class CreateQualifier implements ErrorRule<Void> {
     public void cancel() {
     }
 
+    private static final Set<String> CODES = Set.of(
+            "compiler.err.cant.resolve.location",
+            "compiler.err.cant.resolve.location.args",
+            "compiler.err.cant.apply.symbol",
+            "compiler.err.cant.resolve",
+            "compiler.err.cant.resolve.args"
+    ); // NOI18N
+
     /* (non-Javadoc)
      * @see org.netbeans.modules.java.hints.spi.ErrorRule#getCodes()
      */
     @Override
     public Set<String> getCodes() {
-        return new HashSet<String>(Arrays.asList("compiler.err.cant.resolve.location", 
-                "compiler.err.cant.resolve.location.args", 
-                "compiler.err.cant.apply.symbol", "compiler.err.cant.resolve", 
-                "compiler.err.cant.resolve.args")); // NOI18N
+        return CODES;
     }
 
     /* (non-Javadoc)

--- a/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/JspSourceTask.java
+++ b/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/JspSourceTask.java
@@ -57,26 +57,14 @@ public final class JspSourceTask extends ParserResultTask<JspParserResult> {
     private boolean cancelled;
 
     //map of jsp syntax element kind -> element name -> attribute name
-    private static final Map<JspSyntaxElement.Kind, Map<String, Set<String>>> EMBEDDINGS =
-            new HashMap<JspSyntaxElement.Kind, Map<String, Set<String>>>();
-
-    static {
-        Map<String, Set<String>> tags = new HashMap<String, Set<String>>();
-        tags.put("jsp:useBean",
-                new HashSet<String>(Arrays.asList(new String[]{"class", "type", "id"}))); //NOI18N
-        
-        Map<String, Set<String>> dirs = new HashMap<String, Set<String>>();
-        dirs.put("page",
-                new HashSet<String>(Arrays.asList(new String[]{"extends", "import"}))); //NOI18N
-        dirs.put("tag",
-                new HashSet<String>(Collections.singletonList("import"))); //NOI18N
-        dirs.put("attribute",
-                new HashSet<String>(Collections.singletonList("type"))); //NOI18N
-
-        EMBEDDINGS.put(JspSyntaxElement.Kind.OPENTAG, tags);
-        EMBEDDINGS.put(JspSyntaxElement.Kind.DIRECTIVE, dirs);
-
-    }
+    private static final Map<JspSyntaxElement.Kind, Map<String, Set<String>>> EMBEDDINGS = Map.of(
+            JspSyntaxElement.Kind.OPENTAG, Map.of("jsp:useBean", Set.of("class", "type", "id")), //NOI18N
+            JspSyntaxElement.Kind.DIRECTIVE, Map.of(
+                    "page", Set.of("extends", "import"), //NOI18N
+                    "tag", Set.of("import"), //NOI18N
+                    "attribute", Set.of("type") //NOI18N
+            )
+    );
 
     public static class Factory extends TaskFactory {
 

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/JSFConfigurationPanelVisual.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/JSFConfigurationPanelVisual.java
@@ -145,8 +145,10 @@ public class JSFConfigurationPanelVisual extends javax.swing.JPanel implements H
     private final ChangeSupport changeSupport = new ChangeSupport(this);
 
     /** Libraries excluded from panel's {@link #jsfLibraries}. Libraries offered as registered in the IDE. */
-    private static final Set<String> EXCLUDE_FROM_REGISTERED_LIBS = new HashSet<String>(Arrays.asList(
-            "jsp-compilation", "jsp-compilation-syscp")); //NOI18N
+    private static final Set<String> EXCLUDE_FROM_REGISTERED_LIBS = Set.of(
+            "jsp-compilation",
+            "jsp-compilation-syscp"
+    ); //NOI18N
 
     /** Cached all JSF libraries */
     private static volatile boolean jsfLibrariesCacheDirty = true;

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/WebActionProvider.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/WebActionProvider.java
@@ -24,9 +24,7 @@ import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -155,10 +153,14 @@ public class WebActionProvider extends BaseActionProvider {
     };
 
     /**Set of commands which are affected by background scanning*/
-    private Set<String> bkgScanSensitiveActions;
+    private static final Set<String> BKG_SCAN_SENSITIVE_ACTIONS = Set.of(
+            COMMAND_RUN_SINGLE
+    );
 
     /**Set of commands which need java model up to date*/
-    private Set<String> needJavaModelActions;
+    private static final Set<String> NEED_JAVA_MODEL_ACTIONS = Set.of(
+            JavaProjectConstants.COMMAND_DEBUG_FIX
+    );
 
     private static final String[] actionsDisabledForQuickRun = {
         COMMAND_COMPILE_SINGLE,
@@ -166,42 +168,35 @@ public class WebActionProvider extends BaseActionProvider {
     };
 
     /** Map from commands to ant targets */
-    Map<String,String[]> commands;
+    private static final Map<String,String[]> COMMANDS = Map.ofEntries(
+            Map.entry(COMMAND_BUILD, new String[]{"dist"}), // NOI18N
+            Map.entry(COMMAND_CLEAN, new String[]{"clean"}), // NOI18N
+            Map.entry(COMMAND_REBUILD, new String[]{"clean", "dist"}), // NOI18N
+            // the target name is compile-single, except for JSPs, where it is compile-single-jsp
+            Map.entry(COMMAND_COMPILE_SINGLE, new String[]{"compile-single"}), // NOI18N
+            Map.entry(COMMAND_RUN, new String[]{"run"}), // NOI18N
+            // the target name is run, except for Java files with main method, where it is run-main
+            Map.entry(COMMAND_RUN_SINGLE, new String[]{"run-main"}), // NOI18N
+            Map.entry(WebProjectConstants.COMMAND_REDEPLOY, new String[]{"run-deploy"}), // NOI18N
+            Map.entry(COMMAND_DEBUG, new String[]{"debug"}), // NOI18N
+            // the target name is debug, except for Java files with main method, where it is debug-single-main
+            Map.entry(COMMAND_DEBUG_SINGLE, new String[]{"debug-single-main"}), // NOI18N
+            Map.entry(COMMAND_PROFILE, new String[]{"profile"}), // NOI18N
+            Map.entry(COMMAND_PROFILE_SINGLE, new String[]{"profile-single-main"}), // NOI18N
+            Map.entry(JavaProjectConstants.COMMAND_JAVADOC, new String[]{"javadoc"}), // NOI18N
+            Map.entry(COMMAND_TEST, new String[]{"test"}), // NOI18N
+            Map.entry(COMMAND_TEST_SINGLE, new String[]{"test-single"}), // NOI18N
+            Map.entry(COMMAND_DEBUG_TEST_SINGLE, new String[]{"debug-test"}), // NOI18N
+            Map.entry(COMMAND_PROFILE_TEST_SINGLE, new String[]{"profile-test"}), // NOI18N
+            Map.entry(JavaProjectConstants.COMMAND_DEBUG_FIX, new String[]{"debug-fix"}), // NOI18N
+            Map.entry(COMMAND_VERIFY, new String[]{"verify"}), // NOI18N
+            Map.entry(SingleMethod.COMMAND_RUN_SINGLE_METHOD, new String[]{"test-single-method"}), // NOI18N
+            Map.entry(SingleMethod.COMMAND_DEBUG_SINGLE_METHOD, new String[]{"debug-single-method"}) // NOI18N
+    );
 
     public WebActionProvider(WebProject project, UpdateHelper updateHelper, PropertyEvaluator evaluator) {
         super(project, updateHelper, evaluator, project.getSourceRoots(), project.getTestSourceRoots(), 
                 project.getAntProjectHelper(), new CallbackImpl(project.getClassPathProvider(), project.getWebModule()));
-        commands = new HashMap<String, String[]>();
-        commands.put(COMMAND_BUILD, new String[]{"dist"}); // NOI18N
-        commands.put(COMMAND_CLEAN, new String[]{"clean"}); // NOI18N
-        commands.put(COMMAND_REBUILD, new String[]{"clean", "dist"}); // NOI18N
-        // the target name is compile-single, except for JSPs, where it is compile-single-jsp
-        commands.put(COMMAND_COMPILE_SINGLE, new String[]{"compile-single"}); // NOI18N
-        commands.put(COMMAND_RUN, new String[]{"run"}); // NOI18N
-        // the target name is run, except for Java files with main method, where it is run-main
-        commands.put(COMMAND_RUN_SINGLE, new String[]{"run-main"}); // NOI18N
-        commands.put(WebProjectConstants.COMMAND_REDEPLOY, new String[]{"run-deploy"}); // NOI18N
-        commands.put(COMMAND_DEBUG, new String[]{"debug"}); // NOI18N
-        // the target name is debug, except for Java files with main method, where it is debug-single-main
-        commands.put(COMMAND_DEBUG_SINGLE, new String[]{"debug-single-main"}); // NOI18N
-        commands.put(COMMAND_PROFILE, new String[]{"profile"}); // NOI18N
-        commands.put(COMMAND_PROFILE_SINGLE, new String[]{"profile-single-main"}); // NOI18N
-        commands.put(JavaProjectConstants.COMMAND_JAVADOC, new String[]{"javadoc"}); // NOI18N
-        commands.put(COMMAND_TEST, new String[]{"test"}); // NOI18N
-        commands.put(COMMAND_TEST_SINGLE, new String[]{"test-single"}); // NOI18N
-        commands.put(COMMAND_DEBUG_TEST_SINGLE, new String[]{"debug-test"}); // NOI18N
-        commands.put(COMMAND_PROFILE_TEST_SINGLE, new String[]{"profile-test"}); // NOI18N
-        commands.put(JavaProjectConstants.COMMAND_DEBUG_FIX, new String[]{"debug-fix"}); // NOI18N
-        commands.put(COMMAND_VERIFY, new String[]{"verify"}); // NOI18N
-        commands.put(SingleMethod.COMMAND_RUN_SINGLE_METHOD, new String[] {"test-single-method"}); // NOI18N
-        commands.put(SingleMethod.COMMAND_DEBUG_SINGLE_METHOD, new String[] {"debug-single-method"}); // NOI18N
-        this.bkgScanSensitiveActions = new HashSet<String>(Arrays.asList(
-            COMMAND_RUN_SINGLE
-        ));
-
-        this.needJavaModelActions = new HashSet<String>(Arrays.asList(
-            JavaProjectConstants.COMMAND_DEBUG_FIX
-        ));
         setServerExecution(true);
     }
 
@@ -217,17 +212,17 @@ public class WebActionProvider extends BaseActionProvider {
 
     @Override
     public Map<String, String[]> getCommands() {
-        return commands;
+        return COMMANDS;
     }
 
     @Override
     protected Set<String> getScanSensitiveActions() {
-        return bkgScanSensitiveActions;
+        return BKG_SCAN_SENSITIVE_ACTIONS;
     }
 
     @Override
     protected Set<String> getJavaModelActions() {
-        return needJavaModelActions;
+        return NEED_JAVA_MODEL_ACTIONS;
     }
 
     @Override
@@ -367,7 +362,7 @@ public class WebActionProvider extends BaseActionProvider {
             if (WhiteListUpdater.isWhitelistViolated(getProject())) {
                 return null;
             }
-            return commands.get(command);
+            return COMMANDS.get(command);
         } else if (command.equals(COMMAND_PROFILE)) {
             if (!checkSelectedServer(false, true)) {
                 return null;

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/actions/ActionMappingPropertyReaderTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/actions/ActionMappingPropertyReaderTest.java
@@ -86,8 +86,8 @@ public class ActionMappingPropertyReaderTest {
         DefaultActionMapping mapping = (DefaultActionMapping) result.iterator().next();
         assertEquals("build", mapping.getName());
         assertEquals(100, mapping.priority);
-        assertTrue(mapping.isApplicable(new HashSet<String>(Arrays.asList("groovy", "root", "war"))));
-        assertFalse(mapping.isApplicable(new HashSet<String>(Arrays.asList("groovy"))));
+        assertTrue(mapping.isApplicable(Set.of("groovy", "root", "war")));
+        assertFalse(mapping.isApplicable(Set.of("groovy")));
     }
 
     @Test

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/execute/GradleCommandLineTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/execute/GradleCommandLineTest.java
@@ -89,7 +89,7 @@ public class GradleCommandLineTest {
         System.out.println("addTask");
         GradleCommandLine instance = new GradleCommandLine("-a", "clean");
         instance.addTask("build");
-        assertEquals(new HashSet<String>(Arrays.asList("clean", "build")), instance.getTasks());
+        assertEquals(Set.of("clean", "build"), instance.getTasks());
     }
 
     @Test

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/ApplyGroovyTransformationProcessor.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/ApplyGroovyTransformationProcessor.java
@@ -42,10 +42,12 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 public class ApplyGroovyTransformationProcessor extends LayerGeneratingProcessor {
-    private static final Set<String> APPLY_DEFAULT = new HashSet<>(Arrays.asList(new String[] { "parse" })); // NOI18N
+    private static final Set<String> APPLY_DEFAULT = Set.of("parse"); // NOI18N
+
+    private static final Set<String> ANNOTATION_TYPES = Set.of(ApplyGroovyTransformation.class.getCanonicalName());
 
     public @Override Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(ApplyGroovyTransformation.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/harness/nbjunit/src/org/netbeans/junit/Log.java
+++ b/harness/nbjunit/src/org/netbeans/junit/Log.java
@@ -404,7 +404,7 @@ public final class Log extends Handler {
             List<Reference> refs = new ArrayList<Reference>();
             List<String> txts = new ArrayList<String>();
             int count = 0;
-            Set<String> nameSet = names == null || names.length == 0 ? null : new HashSet<String>(Arrays.asList(names));
+            Set<String> nameSet = names == null || names.length == 0 ? null : Set.of(names);
             synchronized (instances) {
                 for (Iterator<Map.Entry<Object, String>> it = instances.entrySet().iterator(); it.hasNext();) {
                     Entry<Object, String> entry = it.next();

--- a/harness/nbjunit/src/org/netbeans/junit/NbModuleSuite.java
+++ b/harness/nbjunit/src/org/netbeans/junit/NbModuleSuite.java
@@ -1055,7 +1055,7 @@ public class NbModuleSuite {
 
             return cnbs;
         }
-        private static final Set<String> pseudoModules = new HashSet<String>(Arrays.asList(
+        private static final Set<String> PSEUDO_MODULES = Set.of(
                 "org.openide.util",
                 "org.openide.util.ui",
                 "org.openide.util.lookup",
@@ -1065,7 +1065,8 @@ public class NbModuleSuite {
                 "org.openide.filesystems.compat8",
                 "org.netbeans.core.startup",
                 "org.netbeans.core.startup.base",
-                "org.netbeans.libs.asm"));
+                "org.netbeans.libs.asm"
+        );
         static void turnClassPathModules(File ud, ClassLoader loader) throws IOException {
             Enumeration<URL> en = loader.getResources("META-INF/MANIFEST.MF");
             while (en.hasMoreElements()) {
@@ -1085,7 +1086,7 @@ public class NbModuleSuite {
                     if (jar == null) {
                         continue;
                     }
-                    if (pseudoModules.contains(cnb)) {
+                    if (PSEUDO_MODULES.contains(cnb)) {
                         // Otherwise will get DuplicateException.
                         continue;
                     }

--- a/harness/nbjunit/src/org/netbeans/junit/internal/RandomlyFailsProcessor.java
+++ b/harness/nbjunit/src/org/netbeans/junit/internal/RandomlyFailsProcessor.java
@@ -40,8 +40,10 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class RandomlyFailsProcessor extends AbstractProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(RandomlyFails.class.getCanonicalName());
+
     public @Override Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(RandomlyFails.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
+++ b/ide/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
@@ -63,8 +63,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class DebuggerProcessor extends LayerGeneratingProcessor {
 
-    public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
             ActionsProvider.Registration.class.getCanonicalName(),
             ActionsProvider.Registrations.class.getCanonicalName(),
             DebuggerEngineProvider.Registration.class.getCanonicalName(),
@@ -72,7 +71,10 @@ public class DebuggerProcessor extends LayerGeneratingProcessor {
             LazyActionsManagerListener.Registration.class.getCanonicalName(),
             DebuggerServiceRegistration.class.getCanonicalName(),
             DebuggerServiceRegistrations.class.getCanonicalName()
-        ));
+    );
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingRegistrationProcessor.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingRegistrationProcessor.java
@@ -38,9 +38,11 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class BugtrackingRegistrationProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(BugtrackingConnector.Registration.class.getCanonicalName());
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(BugtrackingConnector.Registration.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/core.ide/src/org/netbeans/core/ide/ServiceTabProcessor.java
+++ b/ide/core.ide/src/org/netbeans/core/ide/ServiceTabProcessor.java
@@ -53,8 +53,10 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class ServiceTabProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(ServicesTabNodeRegistration.class.getCanonicalName());
+
     public @Override Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(ServicesTabNodeRegistration.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/overridden/IsOverriddenAnnotationAction.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/overridden/IsOverriddenAnnotationAction.java
@@ -270,9 +270,9 @@ public final class IsOverriddenAnnotationAction extends AbstractAction {
         return caption;
     }
 
-    private static final Set<String> COMBINED_TYPES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> COMBINED_TYPES = Set.of(
             "org-netbeans-modules-editor-annotations-implements-has-implementations-combined",
             "org-netbeans-modules-editor-annotations-implements-is-overridden-combined",
             "org-netbeans-modules-editor-annotations-override-is-overridden-combined"
-    ));
+    );
 }

--- a/ide/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadataDerbyTest.java
+++ b/ide/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadataDerbyTest.java
@@ -25,6 +25,8 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
+
 import org.netbeans.modules.db.metadata.model.api.Catalog;
 import org.netbeans.modules.db.metadata.model.api.Column;
 import org.netbeans.modules.db.metadata.model.api.ForeignKey;
@@ -131,7 +133,7 @@ public class JDBCMetadataDerbyTest extends JDBCMetadataTestBase {
         assertEquals(IndexType.OTHER, index.getIndexType());
         assertEquals("JDBCIndex[name='BAR_INDEX', type=OTHER, unique=false]", index.toString());
         Collection<IndexColumn> columns = index.getColumns();
-        assertNames(new HashSet<String>(Arrays.asList("FOO_ID", "FOO_NAME")), columns);
+        assertNames(Set.of("FOO_ID", "FOO_NAME"), columns);
 
         IndexColumn col = index.getColumn("FOO_ID");
         assertNotNull(col);
@@ -155,7 +157,7 @@ public class JDBCMetadataDerbyTest extends JDBCMetadataTestBase {
         assertEquals(IndexType.OTHER, index.getIndexType());
         columns = index.getColumns();
         assertEquals(1, columns.size());
-        assertNames(new HashSet<String>(Arrays.asList("DEC_COL")), columns);
+        assertNames(Set.of("DEC_COL"), columns);
         col = index.getColumn("DEC_COL");
         assertNotNull(col);
         assertEquals(index, col.getParent());
@@ -191,7 +193,7 @@ public class JDBCMetadataDerbyTest extends JDBCMetadataTestBase {
         Schema schema = metadata.getDefaultSchema();
 
         Collection<View> views = schema.getViews();
-        assertNames(new HashSet<String>(Arrays.asList("BARVIEW")), views);
+        assertNames(Set.of("BARVIEW"), views);
         View barView = schema.getView("BARVIEW");
         assertTrue(views.contains(barView));
         assertSame(schema, barView.getParent());

--- a/ide/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadataMySQLTest.java
+++ b/ide/db.metadata.model/test/unit/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadataMySQLTest.java
@@ -24,6 +24,7 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Logger;
 import org.netbeans.modules.db.metadata.model.api.Catalog;
 import org.netbeans.modules.db.metadata.model.api.Column;
@@ -159,7 +160,7 @@ public class JDBCMetadataMySQLTest extends JDBCMetadataTestBase {
         assertSame(defaultCatalog, schema.getParent());
 
         Collection<Table> tables = schema.getTables();
-        assertNames(new HashSet<String>(Arrays.asList("foo", "bar", "groucho", "chico")), tables);
+        assertNames(Set.of("foo", "bar", "groucho", "chico"), tables);
         Table barTable = schema.getTable("bar");
         assertTrue(tables.contains(barTable));
         assertSame(schema, barTable.getParent());
@@ -186,7 +187,7 @@ public class JDBCMetadataMySQLTest extends JDBCMetadataTestBase {
     public void testSchemaRefresh() throws Exception {
         Schema schema = metadata.getDefaultSchema();
         Collection<Table> tables = schema.getTables();
-        assertNames(new HashSet<String>(Arrays.asList("foo", "bar", "groucho", "chico")), tables);
+        assertNames(Set.of("foo", "bar", "groucho", "chico"), tables);
 
         stmt.executeUpdate("CREATE TABLE testSchemaRefresh ("
                 + "id INT NOT NULL PRIMARY KEY AUTO_INCREMENT, "
@@ -195,7 +196,7 @@ public class JDBCMetadataMySQLTest extends JDBCMetadataTestBase {
         schema.refresh();
 
         tables = schema.getTables();
-        assertNames(new HashSet<String>(Arrays.asList("foo", "bar", "groucho", "chico", "testSchemaRefresh")), tables);
+        assertNames(Set.of("foo", "bar", "groucho", "chico", "testSchemaRefresh"), tables);
 
     }
 
@@ -203,7 +204,7 @@ public class JDBCMetadataMySQLTest extends JDBCMetadataTestBase {
         Schema schema = metadata.getDefaultSchema();
         Table table = schema.getTable("groucho");
         Collection<Index> indexes = table.getIndexes();
-        assertNames(new HashSet<String>(Arrays.asList("groucho_index", "PRIMARY")), indexes);
+        assertNames(Set.of("groucho_index", "PRIMARY"), indexes);
 
         Index index = table.getIndex("groucho_index");
         assertEquals(index.getParent(), table);
@@ -211,7 +212,7 @@ public class JDBCMetadataMySQLTest extends JDBCMetadataTestBase {
         assertEquals(IndexType.OTHER, index.getIndexType());
         Collection<IndexColumn> columns = index.getColumns();
         assertEquals(1, columns.size());
-        assertNames(new HashSet<String>(Arrays.asList("id2")), columns);
+        assertNames(Set.of("id2"), columns);
         IndexColumn col = index.getColumn("id2");
         assertNotNull(col);
         assertEquals(index, col.getParent());
@@ -224,7 +225,7 @@ public class JDBCMetadataMySQLTest extends JDBCMetadataTestBase {
         assertEquals(IndexType.OTHER, index.getIndexType());
         columns = index.getColumns();
         assertEquals(2, columns.size());
-        assertNames(new HashSet<String>(Arrays.asList("id2", "id")), columns);
+        assertNames(Set.of("id2", "id"), columns);
         col = index.getColumn("id2");
         assertNotNull(col);
         assertEquals(index, col.getParent());
@@ -239,13 +240,13 @@ public class JDBCMetadataMySQLTest extends JDBCMetadataTestBase {
 
         table = schema.getTable("bar");
         indexes = table.getIndexes();
-        assertNames(new HashSet<String>(Arrays.asList("bar_name_index", "bar_foo_index", "PRIMARY")), indexes);
+        assertNames(Set.of("bar_name_index", "bar_foo_index", "PRIMARY"), indexes);
 
         index = table.getIndex("bar_name_index");
         assertEquals(index.getParent(), table);
         assertFalse(index.isUnique());
         columns = index.getColumns();
-        assertNames(new HashSet<String>(Arrays.asList("bar_name", "bar_digit")), columns);
+        assertNames(Set.of("bar_name", "bar_digit"), columns);
         col = index.getColumn("bar_name");
         assertEquals(index, col.getParent());
         assertEquals(Ordering.ASCENDING, col.getOrdering());
@@ -258,18 +259,18 @@ public class JDBCMetadataMySQLTest extends JDBCMetadataTestBase {
         Table table = schema.getTable("chico");
 
         Collection<ForeignKey> fkeys = table.getForeignKeys();
-        assertNames(new HashSet<String>(Arrays.asList("groucho_fk", "foo_fk")), fkeys);
+        assertNames(Set.of("groucho_fk", "foo_fk"), fkeys);
 
         for (ForeignKey key : fkeys) {
             Collection<ForeignKeyColumn> cols = key.getColumns();
 
             if ("groucho_fk".equals(key.getName())) {
-                assertNames(new HashSet<String>(Arrays.asList("groucho_id2", "groucho_id")), cols);
+                assertNames(Set.of("groucho_id2", "groucho_id"), cols);
                 Table referredTable = schema.getTable("groucho");
                 checkForeignKeyColumn(key, referredTable, "groucho_id2", "id2", 1);
                 checkForeignKeyColumn(key, referredTable, "groucho_id", "id", 2);
             } else {
-                assertNames(new HashSet<String>(Arrays.asList("foo_id")), cols);
+                assertNames(Set.of("foo_id"), cols);
                 checkForeignKeyColumn(key, schema.getTable("foo"), "foo_id", "id", 1);
             }
         }
@@ -320,7 +321,7 @@ public class JDBCMetadataMySQLTest extends JDBCMetadataTestBase {
         Schema schema = metadata.getDefaultSchema();
 
         Collection<View> views = schema.getViews();
-        assertNames(new HashSet<String>(Arrays.asList("barview")), views);
+        assertNames(Set.of("barview"), views);
         View barView = schema.getView("barview");
         assertTrue(views.contains(barView));
         assertSame(schema, barView.getParent());

--- a/ide/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/TestMetadataTest.java
+++ b/ide/db.sql.editor/test/unit/src/org/netbeans/modules/db/sql/editor/completion/TestMetadataTest.java
@@ -22,6 +22,8 @@ package org.netbeans.modules.db.sql.editor.completion;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
+
 import org.netbeans.modules.db.metadata.model.api.Catalog;
 import org.netbeans.modules.db.metadata.model.api.Schema;
 import org.netbeans.modules.db.metadata.model.test.api.MetadataTestBase;
@@ -53,12 +55,12 @@ public class TestMetadataTest extends MetadataTestBase {
                 "      col35",
                 "catalog9"
         });
-        assertNames(new HashSet<String>(Arrays.asList("catalog0", "catalog9")), metadata.getCatalogs());
+        assertNames(Set.of("catalog0", "catalog9"), metadata.getCatalogs());
         Catalog defaultCatalog = metadata.getDefaultCatalog();
         assertEquals("catalog0", defaultCatalog.getName());
         assertSame(defaultCatalog, metadata.getCatalog("catalog0"));
         assertNotNull(metadata.getCatalog("catalog9"));
-        assertNames(new HashSet<String>(Arrays.asList("schema1", "schema5")), defaultCatalog.getSchemas());
+        assertNames(Set.of("schema1", "schema5"), defaultCatalog.getSchemas());
         Schema defaultSchema = metadata.getDefaultSchema();
         assertEquals("schema1", defaultSchema.getName());
         assertNames(Collections.singleton("table2"), defaultSchema.getTables());
@@ -82,7 +84,7 @@ public class TestMetadataTest extends MetadataTestBase {
                 "<unknown>",
                 "another"
         });
-        assertNames(new HashSet<String>(Arrays.asList(null, "another")), metadata.getCatalogs());
+        assertNames(Set.of(null, "another"), metadata.getCatalogs());
     }
 
     public void testNoSchema() throws Exception {

--- a/ide/db/src/org/netbeans/api/db/explorer/node/BaseNode.java
+++ b/ide/db/src/org/netbeans/api/db/explorer/node/BaseNode.java
@@ -22,10 +22,7 @@ package org.netbeans.api.db.explorer.node;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.*;
 import javax.swing.Action;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -313,7 +310,7 @@ public abstract class BaseNode extends AbstractNode {
 
     public synchronized Collection<Property> getProperties() {
         Property[] properties = getSheet().get(Sheet.PROPERTIES).getProperties();
-        return Collections.unmodifiableCollection(Arrays.asList(properties));
+        return List.of(properties);
     }
 
     @Override

--- a/ide/db/test/unit/src/org/netbeans/modules/db/util/DriverListUtilTest.java
+++ b/ide/db/test/unit/src/org/netbeans/modules/db/util/DriverListUtilTest.java
@@ -46,28 +46,26 @@ public class DriverListUtilTest extends TestCase {
     private static final String DSN = "mydsn";
     private static final String TNSNAME = "mytns";
     
-    private static final HashMap<String, String> ALLPROPS = new HashMap<>();
+    private static final Map<String, String> ALLPROPS = Map.of(
+            JdbcUrl.TOKEN_HOST, HOST,
+            JdbcUrl.TOKEN_DB, DB,
+            JdbcUrl.TOKEN_PORT, PORT,
+            JdbcUrl.TOKEN_SERVERNAME, SERVERNAME,
+            JdbcUrl.TOKEN_ADDITIONAL, ADDITIONAL,
+            JdbcUrl.TOKEN_DSN, DSN,
+            JdbcUrl.TOKEN_SERVICENAME, SERVICENAME,
+            JdbcUrl.TOKEN_SID, SID,
+            JdbcUrl.TOKEN_TNSNAME, TNSNAME,
+            JdbcUrl.TOKEN_INSTANCE, INSTANCE
+    );
     
-    private static final ArrayList<String> STD_SUPPORTED_PROPS = new ArrayList<>();
-    
-    static {
-        ALLPROPS.put(JdbcUrl.TOKEN_HOST, HOST);
-        ALLPROPS.put(JdbcUrl.TOKEN_DB, DB);
-        ALLPROPS.put(JdbcUrl.TOKEN_PORT, PORT);
-        ALLPROPS.put(JdbcUrl.TOKEN_SERVERNAME, SERVERNAME);
-        ALLPROPS.put(JdbcUrl.TOKEN_ADDITIONAL, ADDITIONAL);
-        ALLPROPS.put(JdbcUrl.TOKEN_DSN, DSN);
-        ALLPROPS.put(JdbcUrl.TOKEN_SERVICENAME, SERVICENAME);
-        ALLPROPS.put(JdbcUrl.TOKEN_SID, SID);
-        ALLPROPS.put(JdbcUrl.TOKEN_TNSNAME, TNSNAME);
-        ALLPROPS.put(JdbcUrl.TOKEN_INSTANCE, INSTANCE);
-        
-        STD_SUPPORTED_PROPS.add(JdbcUrl.TOKEN_HOST);
-        STD_SUPPORTED_PROPS.add(JdbcUrl.TOKEN_PORT);
-        STD_SUPPORTED_PROPS.add(JdbcUrl.TOKEN_DB);
-        STD_SUPPORTED_PROPS.add(JdbcUrl.TOKEN_ADDITIONAL);
-    }
-    
+    private static final List<String> STD_SUPPORTED_PROPS = List.of(
+            JdbcUrl.TOKEN_HOST,
+            JdbcUrl.TOKEN_PORT,
+            JdbcUrl.TOKEN_DB,
+            JdbcUrl.TOKEN_ADDITIONAL
+    );
+
     public DriverListUtilTest(String testName) {
         super(testName);
     }

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorActionRegistrationProcessor.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorActionRegistrationProcessor.java
@@ -49,11 +49,13 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public final class EditorActionRegistrationProcessor extends LayerGeneratingProcessor {
 
-    public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
             EditorActionRegistration.class.getCanonicalName(),
             EditorActionRegistrations.class.getCanonicalName()
-        ));
+    );
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/editor/src/org/netbeans/modules/editor/impl/KitsTrackerImpl.java
+++ b/ide/editor/src/org/netbeans/modules/editor/impl/KitsTrackerImpl.java
@@ -182,7 +182,7 @@ public final class KitsTrackerImpl extends KitsTracker {
     private boolean needsReloading = true;
     private boolean mimeType2kitClassLoaded = false;
 
-    private static final Set<String> WELL_KNOWN_PARENTS = new HashSet<String>(Arrays.asList(new String [] {
+    private static final Set<String> WELL_KNOWN_PARENTS = Set.of(
         "java.lang.Object", //NOI18N
         "javax.swing.text.EditorKit", //NOI18N
         "javax.swing.text.DefaultEditorKit", //NOI18N
@@ -190,14 +190,14 @@ public final class KitsTrackerImpl extends KitsTracker {
         "org.netbeans.editor.ext.ExtKit", //NOI18N
         "org.netbeans.modules.editor.NbEditorKit", //NOI18N
         // common superclass of some XML related kits
-        "org.netbeans.modules.xml.text.syntax.UniKit", //NOI18N
-    }));
+        "org.netbeans.modules.xml.text.syntax.UniKit" //NOI18N
+    );
 
-    private static final Set<String> DYNAMIC_LANGUAGES = new HashSet<String>(Arrays.asList(new String [] {
+    private static final Set<String> DYNAMIC_LANGUAGES = Set.of(
         // Schliemann and GSF kits are provided on the fly by the frameworks' MimeDataProvider
         "org.netbeans.modules.languages.dataobject.LanguagesEditorKit", //NOI18N
-        "org.netbeans.modules.gsf.GsfEditorKitFactory$GsfEditorKit", //NOI18N
-    }));
+        "org.netbeans.modules.gsf.GsfEditorKitFactory$GsfEditorKit" //NOI18N
+    );
 
     private final ThreadLocal<Stack<String>> contexts = new ThreadLocal<Stack<String>>();
     

--- a/ide/git/src/org/netbeans/modules/git/client/GitClient.java
+++ b/ide/git/src/org/netbeans/modules/git/client/GitClient.java
@@ -82,7 +82,7 @@ public final class GitClient {
     /**
      * Set of commands that do not need to run under repository lock
      */
-    private static final HashSet<String> PARALLELIZABLE_COMMANDS = new HashSet<String>(Arrays.asList("addNotificationListener", //NOI18N
+    private static final Set<String> PARALLELIZABLE_COMMANDS = Set.of("addNotificationListener", //NOI18N
             "blame", //NOI18N
             "catFile",  //NOI18N
             "catIndexEntry",  //NOI18N
@@ -107,12 +107,13 @@ public final class GitClient {
             "removeRemote", //NOI18N - i guess there's no need to mke this an exclusive command
             "setCallback", //NOI18N
             "setRemote", //NOI18N - i guess there's no need to mke this an exclusive command
-            "stashList")); //NOI18N
+            "stashList"); //NOI18N
     /**
      * Commands triggering last cached timestamp of the index file. This means that after every command that somehow modifies the index, we need to refresh the timestamp
      * otherwise a FS event will come to Interceptor and trigger the full scan.
      */
-    private static final HashSet<String> WORKING_TREE_READ_ONLY_COMMANDS = new HashSet<String>(Arrays.asList("addNotificationListener",  //NOI18N
+    private static final Set<String> WORKING_TREE_READ_ONLY_COMMANDS = Set.of(
+            "addNotificationListener",  //NOI18N
             "blame", //NOI18N
             "catFile",  //NOI18N
             "catIndexEntry",  //NOI18N
@@ -148,11 +149,11 @@ public final class GitClient {
             "setRemote", //NOI18N - does not update index or files in WT
             "stashDrop", //NOI18N
             "stashDropAll", //NOI18N
-            "stashList")); //NOI18N
+            "stashList"); //NOI18N
     /**
      * Commands that will trigger repository information refresh, i.e. those that change HEAD, current branch, etc.
      */
-    private static final HashSet<String> NEED_REPOSITORY_REFRESH_COMMANDS = new HashSet<String>(Arrays.asList("add",//NOI18N // may change state, e.g. MERGING->MERGED
+    private static final Set<String> NEED_REPOSITORY_REFRESH_COMMANDS = Set.of("add",//NOI18N // may change state, e.g. MERGING->MERGED
             "checkout", //NOI18N
             "checkoutRevision", //NOI18N // current head changes
             "cherryPick", //NOI18N
@@ -174,18 +175,18 @@ public final class GitClient {
             "setUpstreamBranch", //NOI18N - updates remotes
             "updateReference", //NOI18N - updates branches
             "updateSubmodules" //NOI18N - current head changes
-    ));
+    );
     /**
      * Commands accessing a remote repository. For these NbAuthenticator must be switched off
      */
-    private static final HashSet<String> NETWORK_COMMANDS = new HashSet<String>(Arrays.asList(
+    private static final Set<String> NETWORK_COMMANDS = Set.of(
             "fetch", //NOI18N
             "listRemoteBranches", //NOI18N
             "listRemoteTags", //NOI18N
             "pull", //NOI18N
             "push", //NOI18N
             "updateSubmodules" //NOI18N
-            ));
+            );
     private static final Logger LOG = Logger.getLogger(GitClient.class.getName());
     private final File repositoryRoot;
     private boolean released;

--- a/ide/git/test/unit/src/org/netbeans/modules/git/GitClientTest.java
+++ b/ide/git/test/unit/src/org/netbeans/modules/git/GitClientTest.java
@@ -80,7 +80,7 @@ public class GitClientTest extends AbstractGitTestCase {
      * @throws Exception
      */
     public void testIndexReadOnlyMethods () throws Exception {
-        Set<String> allTestedMethods = new HashSet<String>(Arrays.asList(
+        Set<String> allTestedMethods = Set.of(
                 "add",
                 "addNotificationListener",
                 "blame",
@@ -139,7 +139,7 @@ public class GitClientTest extends AbstractGitTestCase {
                 "unignore",
                 "updateReference",
                 "updateSubmodules"
-        ));
+        );
         Set<String> readOnlyMethods = new HashSet<String>(Arrays.asList(
                 "addNotificationListener",
                 "blame",
@@ -203,7 +203,7 @@ public class GitClientTest extends AbstractGitTestCase {
      * @throws Exception
      */
     public void testMethodsNeedingRepositoryInfoRefresh () throws Exception {
-        Set<String> allTestedMethods = new HashSet<String>(Arrays.asList(
+        Set<String> allTestedMethods = Set.of(
                 "add",
                 "addNotificationListener",
                 "blame",
@@ -262,7 +262,7 @@ public class GitClientTest extends AbstractGitTestCase {
                 "unignore",
                 "updateReference",
                 "updateSubmodules"
-        ));
+        );
         Set<String> expectedMethods = new HashSet<String>(Arrays.asList(
                 "checkout",
                 "checkoutRevision",

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/hints/FatalHtmlRule.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/hints/FatalHtmlRule.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.html.editor.hints;
 
-import java.util.Collections;
 import java.util.Set;
 import org.netbeans.modules.csl.api.HintSeverity;
 import org.netbeans.modules.csl.api.Rule.ErrorRule;
@@ -34,10 +33,12 @@ public class FatalHtmlRule implements ErrorRule {
     public enum Code {
         DEFAULT;
     }
+
+    private static final Set<?> CODES = Set.of(Code.DEFAULT);
     
     @Override
     public Set<?> getCodes() {
-        return Collections.singleton(Code.DEFAULT);
+        return CODES;
     }
 
     @Override

--- a/ide/html.parser/src/org/netbeans/modules/html/parser/model/ElementDescriptorRules.java
+++ b/ide/html.parser/src/org/netbeans/modules/html/parser/model/ElementDescriptorRules.java
@@ -18,13 +18,7 @@
  */
 package org.netbeans.modules.html.parser.model;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Some additional html5 metadata
@@ -56,7 +50,7 @@ public class ElementDescriptorRules {
             ElementDescriptor.TH, ElementDescriptor.TD);
 
     //manually regexped from http://www.w3.org/TR/MathML/appendixl.html#index.elem
-    public static final Collection<String> MATHML_TAG_NAMES = new HashSet<String>(Arrays.asList(new String[]{
+    public static final Set<String> MATHML_TAG_NAMES = Set.of(
         "abs", "and", "annotation", "annotation-xml", "apply", "approx", "arccos", "arccosh",
         "arccot", "arccoth", "arccsc", "arccsch", "arcsec", "arcsech", "arcsin", "arcsinh",
         "arctan", "arctanh", "arg", "bvar", "card", "cartesianproduct", "ceiling", "ci", "cn",
@@ -67,28 +61,28 @@ public class ElementDescriptorRules {
         "fn", "forall", "function", "gcd", "geq", "grad", "gt", "ident", "image", "imaginary",
         "imaginaryi", "implies", "in", "infinity", "int", "integers", "intersect", "interval",
         "inverse", "lambda", "laplacian", "lcm", "leq", "limit", "list", "ln", "log", "logbase",
-        "lowlimit", "lt", "apply", "mrow", "maction", "malign", "maligngroup", "malignmark",
+        "lowlimit", "lt", "mrow", "maction", "malign", "maligngroup", "malignmark",
         "malignscope", "math", "matrix", "matrixrow", "max", "mean", "median", "menclose", "merror",
         "mfenced", "mfrac", "mfraction", "mglyph", "mi", "min", "minus", "mlabeledtr", "mmultiscripts",
         "mn", "mo", "mode", "moment", "momentabout", "mover", "mpadded", "mphantom", "mprescripts",
-        "mroot", "mrow", "ms", "mspace", "msqrt", "mstyle", "msub", "msubsup", "msup", "mtable",
+        "mroot", "ms", "mspace", "msqrt", "mstyle", "msub", "msubsup", "msup", "mtable",
         "mtd", "mtext", "mtr", "munder", "munderover", "naturalnumbers", "neq", "none", "not",
         "notanumber", "notin", "notprsubset", "notsubset", "or", "otherwise", "outerproduct",
         "partialdiff", "pi", "piece", "piecewice", "piecewise", "plus", "power", "primes", "product",
         "prsubset", "quotient", "rationals", "real", "reals", "reln", "rem", "root", "scalarproduct",
         "sdev", "sec", "sech", "selector", "semantics", "sep", "set", "setdiff", "sin", "sinh", "subset",
         "sum", "tan", "tanh", "tendsto", "times", "transpose", "true", "union", "uplimit", "variance",
-        "vector", "vectorproduct", "xor"}));//NOI18N
+        "vector", "vectorproduct", "xor");//NOI18N
 
     //manually regexped from http://www.w3.org/TR/SVGTiny12/elementTable.html
-    public static final Collection<String> SVG_TAG_NAMES = new HashSet<String>(Arrays.asList(new String[]{
+    public static final Set<String> SVG_TAG_NAMES = Set.of(
         "a", "animate", "animateColor", "animateMotion", "animateTransform", "animation", "audio",
         "circle", "defs", "desc", "discard", "ellipse", "font", "font-face", "font-face-src",
         "font-face-uri", "foreignObject", "g", "glyph", "handler", "hkern", "image", "line",
         "linearGradient", "listener", "metadata", "missing-glyph", "mpath", "path", "polygon",
         "polyline", "prefetch", "radialGradient", "rect", "script", "set", "solidColor", "stop",
         "svg", "switch", "tbreak", "text", "textArea", "title", "tspan", "use", "video"
-    }));//NOI18N
+    );//NOI18N
 
     public static synchronized Collection<ElementDescriptor> getElementsByContentType(ContentType ctype) {
         //the mapping needs to be extracted from the reverse information element->ctype first

--- a/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchAction.java
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchAction.java
@@ -95,18 +95,16 @@ public class FileSearchAction extends AbstractAction implements FileSearchPanel.
     /* package */ static final String CAMEL_CASE_SEPARATOR = "\\p{javaUpperCase}|-|_|\\.";    //NOI18N
     /* package */ static final String CAMEL_CASE_PART_CASE_SENSITIVE = "\\p{javaLowerCase}|\\p{Digit}|\\$";         //NOI18N
     /* package */ static final String CAMEL_CASE_PART_CASE_INSENSITIVE = "\\p{javaLowerCase}|\\p{Digit}|\\p{javaUpperCase}|\\$";         //NOI18N
-    /* package */ static final Map<String,Object> SEARCH_OPTIONS_CASE_SENSITIVE;
-    /* package */ static final Map<String,Object> SEARCH_OPTIONS_CASE_INSENSITIVE;
-    static {
-        Map<String,Object> m = new HashMap<>();
-        m.put(Queries.OPTION_CAMEL_CASE_SEPARATOR, CAMEL_CASE_SEPARATOR);
-        m.put(Queries.OPTION_CAMEL_CASE_PART, CAMEL_CASE_PART_CASE_SENSITIVE);
-        SEARCH_OPTIONS_CASE_SENSITIVE = Collections.unmodifiableMap(m);
-        m = new HashMap<>();
-        m.put(Queries.OPTION_CAMEL_CASE_SEPARATOR, CAMEL_CASE_SEPARATOR);
-        m.put(Queries.OPTION_CAMEL_CASE_PART, CAMEL_CASE_PART_CASE_INSENSITIVE);
-        SEARCH_OPTIONS_CASE_INSENSITIVE = Collections.unmodifiableMap(m);
-    }
+    /* package */ static final Map<String,Object> SEARCH_OPTIONS_CASE_SENSITIVE = Map.of(
+            Queries.OPTION_CAMEL_CASE_SEPARATOR, CAMEL_CASE_SEPARATOR,
+            Queries.OPTION_CAMEL_CASE_PART, CAMEL_CASE_PART_CASE_SENSITIVE
+    );
+
+    /* package */ static final Map<String,Object> SEARCH_OPTIONS_CASE_INSENSITIVE = Map.of(
+            Queries.OPTION_CAMEL_CASE_SEPARATOR, CAMEL_CASE_SEPARATOR,
+            Queries.OPTION_CAMEL_CASE_PART, CAMEL_CASE_PART_CASE_INSENSITIVE
+    );
+
     private static final char LINE_NUMBER_SEPARATOR = ':';    //NOI18N
     private static final Pattern PATTERN_WITH_LINE_NUMBER = Pattern.compile("(.*)"+LINE_NUMBER_SEPARATOR+"(\\d*)");    //NOI18N
 

--- a/ide/jumpto/src/org/netbeans/modules/jumpto/type/GoToTypeAction.java
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/type/GoToTypeAction.java
@@ -125,7 +125,7 @@ public class GoToTypeAction extends AbstractAction implements GoToPanel.ContentP
         putValue("PopupMenuText", NbBundle.getBundle(GoToTypeAction.class).getString("editor-popup-TXT_GoToType")); // NOI18N
         this.title = title;
         this.typeFilter = typeFilter;
-        this.implicitTypeProviders = typeProviders.length == 0 ? null : Collections.unmodifiableCollection(Arrays.asList(typeProviders));
+        this.implicitTypeProviders = typeProviders.length == 0 ? null : List.of(typeProviders);
         this.multiSelection = multiSelection;
         this.currentSearch = new CurrentSearch(() -> new AbstractModelFilter<TypeDescriptor>() {
             @Override

--- a/ide/jumpto/src/org/netbeans/spi/jumpto/support/NameMatcherFactory.java
+++ b/ide/jumpto/src/org/netbeans/spi/jumpto/support/NameMatcherFactory.java
@@ -37,22 +37,19 @@ import org.openide.util.Parameters;
  */
 public final class NameMatcherFactory {
 
-    private static final Map<Character,String> RE_SPECIALS;
-    static {
-        final Map<Character,String> m = new HashMap<>();
-        m.put('{',"\\{");         //NOI18N
-        m.put('}',"\\}");         //NOI18N
-        m.put('[',"\\[");         //NOI18N
-        m.put(']',"\\]");         //NOI18N
-        m.put('(',"\\(");         //NOI18N
-        m.put(')',"\\)");         //NOI18N
-        m.put('\\',"\\\\");       //NOI18N
-        m.put('.', "\\.");        //NOI18N
-        m.put('+',"\\+");         //NOI18N
-        m.put('*', ".*" );        //NOI18N
-        m.put('?', ".");          //NOI18N
-        RE_SPECIALS = Collections.unmodifiableMap(m);
-    }
+    private static final Map<Character,String> RE_SPECIALS = Map.ofEntries( //NOI18N
+            Map.entry('{',"\\{"),
+            Map.entry('}',"\\}"),
+            Map.entry('[',"\\["),
+            Map.entry(']',"\\]"),
+            Map.entry('(',"\\("),
+            Map.entry(')',"\\)"),
+            Map.entry('\\',"\\\\"),
+            Map.entry('.', "\\."),
+            Map.entry('+',"\\+"),
+            Map.entry('*', ".*"),
+            Map.entry('?', ".")
+    );
 
     private NameMatcherFactory() {
     }

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/PullTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/PullTest.java
@@ -25,6 +25,8 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.RefSpec;
@@ -190,7 +192,7 @@ public class PullTest extends AbstractGitTestCase {
         assertEquals(1, updates.size());
         assertUpdate(updates.get("origin/master"), "origin/master", "master", commitId, masterInfo.getRevision(), new URIish(otherWT.toURI().toURL()).toString(), Type.BRANCH, GitRefUpdateResult.FAST_FORWARD);
         assertEquals(MergeStatus.MERGED, result.getMergeResult().getMergeStatus());
-        assertEquals(new HashSet<String>(Arrays.asList(commitId, localCommitId)), new HashSet<String>(Arrays.asList(result.getMergeResult().getMergedCommits())));
+        assertEquals(Set.of(commitId, localCommitId), Set.of(result.getMergeResult().getMergedCommits()));
         assertTrue(f.exists());
         assertTrue(f2.exists());
     }
@@ -241,7 +243,7 @@ public class PullTest extends AbstractGitTestCase {
         assertEquals(1, updates.size());
         assertUpdate(updates.get("origin/" + BRANCH_NAME), "origin/" + BRANCH_NAME, BRANCH_NAME, commitId, branch.getId(), new URIish(otherWT.toURI().toURL()).toString(), Type.BRANCH, GitRefUpdateResult.FAST_FORWARD);
         assertEquals(MergeStatus.MERGED, result.getMergeResult().getMergeStatus());
-        assertEquals(new HashSet<String>(Arrays.asList(commitId, localCommitId)), new HashSet<String>(Arrays.asList(result.getMergeResult().getMergedCommits())));
+        assertEquals(Set.of(Arrays.asList(commitId, localCommitId), Set.of(result.getMergeResult().getMergedCommits()));
         assertTrue(f.exists());
         assertTrue(f2.exists());
     }

--- a/ide/localhistory/test/unit/src/org/netbeans/modules/localhistory/InterceptorTest.java
+++ b/ide/localhistory/test/unit/src/org/netbeans/modules/localhistory/InterceptorTest.java
@@ -244,7 +244,7 @@ public class InterceptorTest extends NbTestCase {
     /**
      * methods that aren't implemented in {@link LocalHistoryVCSInterceptor}
      */
-    private static final Set<String> INTERCEPTOR_COMPLETE_WHITELIST = new HashSet<String>(Arrays.asList(
+    private static final Set<String> INTERCEPTOR_COMPLETE_WHITELIST = Set.of(
         "isMutable",
         "getAttribute",
         "doDelete",
@@ -252,18 +252,20 @@ public class InterceptorTest extends NbTestCase {
         "doCopy",
         "doCreate",
         "afterCopy",
-        "refreshRecursively"));
+        "refreshRecursively"
+    );
     
     /**
      * files that are implemented in LocalHistoryVCSInterceptor,
      * but do not have to call {@link LocalHistoryStore.waitForProcessedStoring}
      */
-    private static final Set<String> WAIT_FOR_STORING_WHITELIST = new HashSet<String>(Arrays.asList(
+    private static final Set<String> WAIT_FOR_STORING_WHITELIST = Set.of(
         "beforeEdit",
         "afterChange",
         "afterDelete",
         "afterMove",
-        "afterCreate"));
+        "afterCreate"
+    );
     
     /**
      * Test whether all important methods are overriden and 

--- a/ide/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/LHTestCase.java
+++ b/ide/localhistory/test/unit/src/org/netbeans/modules/localhistory/store/LHTestCase.java
@@ -86,7 +86,7 @@ public class LHTestCase extends NbTestCase {
         if (files == null || files.length == 0) {
             fail("no files in store folder for file " + file.getAbsolutePath() + " store folder " + storeFolder.getAbsolutePath());
         }
-        Set<String> filesSet = new HashSet<String>(Arrays.asList(files));
+        Set<String> filesSet = Set.of(files);
         if(!filesSet.contains("data")) {
             fail("no data file available for file file " + file.getAbsolutePath() + " store folder " + storeFolder.getAbsolutePath());
         }

--- a/ide/mercurial/src/org/netbeans/modules/mercurial/WorkingCopyInfo.java
+++ b/ide/mercurial/src/org/netbeans/modules/mercurial/WorkingCopyInfo.java
@@ -154,7 +154,7 @@ public class WorkingCopyInfo {
                 for (HgLogMessage oldParent : oldParents) {
                     if (oldParent.getCSetShortID().equals(newParent.getCSetShortID())
                             && oldParent.getTags().length == newParent.getTags().length
-                            && new HashSet<String>(Arrays.asList(oldParent.getTags())).equals(new HashSet<String>(Arrays.asList(newParent.getTags())))) {
+                            && Set.of(oldParent.getTags()).equals(Set.of(newParent.getTags()))) {
                         contains = true;
                         break;
                     }

--- a/ide/mercurial/src/org/netbeans/modules/mercurial/ui/repository/Repository.java
+++ b/ide/mercurial/src/org/netbeans/modules/mercurial/ui/repository/Repository.java
@@ -304,10 +304,12 @@ public class Repository implements ActionListener, FocusListener, ItemListener {
         urlComboEditor.selectAll();
     }
 
-    private static final Set<String> SKIPPED_PATHS = new HashSet<String>(Arrays.asList(HgConfigFiles.HG_DEFAULT_PULL, 
+    private static final Set<String> SKIPPED_PATHS = Set.of(
+            HgConfigFiles.HG_DEFAULT_PULL,
             HgConfigFiles.HG_DEFAULT_PULL_VALUE, 
             HgConfigFiles.HG_DEFAULT_PUSH, 
-            HgConfigFiles.HG_DEFAULT_PUSH_VALUE));
+            HgConfigFiles.HG_DEFAULT_PUSH_VALUE
+    );
     
     private Vector<?> createPresetComboEntries() {
         assert repositoryPanel.urlComboBox.isEditable();

--- a/ide/mercurial/src/org/netbeans/modules/mercurial/util/HgCommand.java
+++ b/ide/mercurial/src/org/netbeans/modules/mercurial/util/HgCommand.java
@@ -371,7 +371,7 @@ public abstract class HgCommand<T> implements Callable<T> {
         MAX_COMMANDLINE_SIZE = maxCmdSize;
     }
 
-    private static final HashSet<String> WORKING_COPY_PARENT_MODIFYING_COMMANDS = new HashSet<String>(Arrays.asList(
+    private static final Set<String> WORKING_COPY_PARENT_MODIFYING_COMMANDS = Set.of(
         HG_BACKOUT_CMD,
         HG_CLONE_CMD,
         HG_COMMIT_CMD,
@@ -392,9 +392,9 @@ public abstract class HgCommand<T> implements Callable<T> {
         HG_TAG_CMD,
         HG_UNBUNDLE_CMD,
         HG_UPDATE_ALL_CMD
-    ));
+    );
 
-    private static final HashSet<String> REPOSITORY_NOMODIFICATION_COMMANDS = new HashSet<String>(Arrays.asList(
+    private static final Set<String> REPOSITORY_NOMODIFICATION_COMMANDS = Set.of(
         HG_ANNOTATE_CMD,
         HG_BRANCH_CMD,
         HG_BRANCHES_CMD,
@@ -419,7 +419,7 @@ public abstract class HgCommand<T> implements Callable<T> {
         HG_VERIFY_CMD,
         HG_VERSION_CMD,
         HG_VIEW_CMD
-    ));
+    );
     private static final String HG_FLAG_TOPO = "--topo"; //NOI18N
     
     private static final String CMD_EXE = "cmd.exe"; //NOI18N
@@ -4610,7 +4610,7 @@ public abstract class HgCommand<T> implements Callable<T> {
     }
 
     private static final Set<File> loggedRepositories = new HashSet<File>();
-    private static final Set<String> noLogCommands = new HashSet<String>(Arrays.asList(
+    private static final Set<String> noLogCommands = Set.of(
         HG_BRANCH_CMD,
         HG_BRANCHES_CMD,
         HG_CAT_CMD,
@@ -4621,7 +4621,8 @@ public abstract class HgCommand<T> implements Callable<T> {
         HG_DIFF_CMD,
         HG_TAGS_CMD,
         HG_VERSION_CMD
-    ));
+    );
+
     private static void logExternalRepositories (File repository, String hgCommand) {
         if (!noLogCommands.contains(hgCommand) && loggedRepositories.add(repository)) {
             HgConfigFiles hgConfigFiles = new HgConfigFiles(repository);

--- a/ide/parsing.api/src/org/netbeans/modules/parsing/impl/EmbeddingProviderRegistrationProcessor.java
+++ b/ide/parsing.api/src/org/netbeans/modules/parsing/impl/EmbeddingProviderRegistrationProcessor.java
@@ -37,9 +37,11 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class EmbeddingProviderRegistrationProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(EmbeddingProvider.Registration.class.getCanonicalName());
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(EmbeddingProvider.Registration.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerRegistrationProcessor.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerRegistrationProcessor.java
@@ -41,9 +41,11 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public final class IndexerRegistrationProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(ConstrainedBinaryIndexer.Registration.class.getCanonicalName());
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(ConstrainedBinaryIndexer.Registration.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
     
     @Override

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ProxyBinaryIndexerFactory.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ProxyBinaryIndexerFactory.java
@@ -165,9 +165,7 @@ public final class ProxyBinaryIndexerFactory extends BinaryIndexerFactory {
             }
             if (mimeTypes != null || pattern != null) {
                 final Enumeration<? extends FileObject> fos = root.getChildren(true);
-                final Set<String> mimeTypesSet = mimeTypes == null ?
-                        null :
-                        new HashSet<String>(Arrays.asList(mimeTypes));
+                final Set<String> mimeTypesSet = mimeTypes == null ? null : Set.of(mimeTypes);
                 while (fos.hasMoreElements()) {
                     final FileObject f = fos.nextElement();
                     if (pattern != null) {

--- a/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RefreshWorkTest.java
+++ b/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RefreshWorkTest.java
@@ -172,10 +172,10 @@ public class RefreshWorkTest  extends IndexingTestBase {
         assertTrue("Expecting " + rootCUrl + " to be scanned", indexer.indexedFiles.containsKey(rootCUrl));
 
         Set<String> files = indexer.indexedFiles.get(rootCUrl);
-        assertEquals("Wrong files scanned", new HashSet<String>(Arrays.asList(new String [] {
+        assertEquals("Wrong files scanned", Set.of(
             "org/pckg1/pckg2/file1.txt",
             "org/pckg1/pckg2/file2.txt"
-        })), files);
+        ), files);
     }
 
     public void testInnerFiles() throws IOException {
@@ -204,9 +204,9 @@ public class RefreshWorkTest  extends IndexingTestBase {
         assertTrue("Expecting " + rootCUrl + " to be scanned", indexer.indexedFiles.containsKey(rootCUrl));
 
         Set<String> files = indexer.indexedFiles.get(rootCUrl);
-        assertEquals("Wrong files scanned", new HashSet<String>(Arrays.asList(new String [] {
+        assertEquals("Wrong files scanned", Set.of(
             "org/pckg1/pckg2/file1.txt"
-        })), files);
+        ), files);
     }
 
     private static final class Indexer extends CustomIndexer {

--- a/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater2Test.java
+++ b/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater2Test.java
@@ -775,9 +775,7 @@ public class RepositoryUpdater2Test extends IndexingTestBase {
 
         @Override
         public Set<String> getSourcePathIds() {
-            return new HashSet<String>(Arrays.asList(new String [] {
-                CP1, CP3
-            }));
+            return Set.of(CP1, CP3);
         }
 
         @Override

--- a/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/QuerySupportTest.java
+++ b/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/spi/indexing/support/QuerySupportTest.java
@@ -496,7 +496,7 @@ public class QuerySupportTest extends IndexingTestBase {
 
         @Override
         public Set<String> getBinaryLibraryPathIds() {
-            return new HashSet<String>(Arrays.asList(BOOT, COMPILE));
+            return Set.of(BOOT, COMPILE);
         }
 
         @Override

--- a/ide/project.ant/src/org/netbeans/modules/project/ant/AntBasedProcessor.java
+++ b/ide/project.ant/src/org/netbeans/modules/project/ant/AntBasedProcessor.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.project.ant;
 
-import java.util.Collections;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
@@ -45,8 +44,10 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class AntBasedProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(AntBasedProjectRegistration.class.getCanonicalName());
+
     public @Override Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(AntBasedProjectRegistration.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/projectapi/src/org/netbeans/modules/projectapi/LookupProviderAnnotationProcessor.java
+++ b/ide/projectapi/src/org/netbeans/modules/projectapi/LookupProviderAnnotationProcessor.java
@@ -57,12 +57,14 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class LookupProviderAnnotationProcessor extends LayerGeneratingProcessor {
 
-    public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
             LookupProvider.Registration.class.getCanonicalName(),
             ProjectServiceProvider.class.getCanonicalName(),
             LookupMerger.Registration.class.getCanonicalName()
-        ));
+    );
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return ANNOTATION_TYPES;
     }
 
     protected boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {

--- a/ide/projectui/src/org/netbeans/modules/project/ui/groups/Group.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/groups/Group.java
@@ -304,7 +304,7 @@ public abstract class Group {
         String sanitizedId = name.replaceAll("[^a-zA-Z0-9_.-]+", "_");
         Set<String> existing;
         try {
-            existing = new HashSet<String>(Arrays.asList(NODE.childrenNames()));
+            existing = Set.of(NODE.childrenNames());
         } catch (BackingStoreException x) {
             Exceptions.printStackTrace(x);
             return sanitizedId;

--- a/ide/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/ProjectConvertorProcessor.java
+++ b/ide/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/ProjectConvertorProcessor.java
@@ -40,9 +40,12 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 public class ProjectConvertorProcessor extends LayerGeneratingProcessor {
+
+    private static final Set<String> ANNOTATION_TYPES = Set.of(ProjectConvertor.Registration.class.getCanonicalName());
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(ProjectConvertor.Registration.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/CompositeCategoryProviderAnnotationProcessor.java
+++ b/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/CompositeCategoryProviderAnnotationProcessor.java
@@ -38,11 +38,13 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class CompositeCategoryProviderAnnotationProcessor extends LayerGeneratingProcessor {
 
-    public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
             Registration.class.getCanonicalName(),
             Registrations.class.getCanonicalName()
-        ));
+    );
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return ANNOTATION_TYPES;
     }
 
     protected boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {

--- a/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/NodeFactoryAnnotationProcessor.java
+++ b/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/NodeFactoryAnnotationProcessor.java
@@ -37,8 +37,10 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class NodeFactoryAnnotationProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(NodeFactory.Registration.class.getCanonicalName());
+
     public @Override Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(NodeFactory.Registration.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/properties/src/org/netbeans/modules/properties/MultiBundleStructure.java
+++ b/ide/properties/src/org/netbeans/modules/properties/MultiBundleStructure.java
@@ -20,8 +20,6 @@ package org.netbeans.modules.properties;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -284,6 +282,9 @@ class MultiBundleStructure extends BundleStructure implements Serializable {
                 "Resource Bundles: Entries not initialized");           //NOI18N
     }
 
+    private static final Set<String> KNOWN_LANGUAGES = Set.of(Locale.getISOLanguages());
+    private static final Set<String> KNOWN_COUNTRIES = Set.of(Locale.getISOCountries());
+
     private static boolean isValidLocaleSuffix(String s) {
         // first char is _
         int n = s.length();
@@ -306,14 +307,12 @@ class MultiBundleStructure extends BundleStructure implements Serializable {
             return false;
         }
 
-        Set<String> knownLanguages = new HashSet<String>(Arrays.asList(Locale.getISOLanguages()));
-        if (!knownLanguages.contains(s1)) {
+        if (!KNOWN_LANGUAGES.contains(s1)) {
             return false;
         }
 
         if (s2 != null) {
-            Set<String> knownCountries = new HashSet<String>(Arrays.asList(Locale.getISOCountries()));
-            if (!knownCountries.contains(s2)) {
+            if (!KNOWN_COUNTRIES.contains(s2)) {
                 return false;
             }
         }

--- a/ide/properties/src/org/netbeans/modules/properties/PropertiesDataLoader.java
+++ b/ide/properties/src/org/netbeans/modules/properties/PropertiesDataLoader.java
@@ -24,8 +24,6 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import org.openide.filesystems.FileObject;
@@ -64,9 +62,9 @@ public final class PropertiesDataLoader extends MultiFileLoader {
     private Reference<PropertiesEncoding> encodingRef;
     
     /** */
-    private static Set<String> knownLanguages;
+    private static final Set<String> KNOWN_LANGUAGES = Set.of(Locale.getISOLanguages());
     /** */
-    private static Set<String> knownCountries;
+    private static final Set<String> KNOWN_COUNTRIES = Set.of(Locale.getISOCountries());
 
     /** */
     private static boolean nestedView = false;
@@ -179,19 +177,13 @@ public final class PropertiesDataLoader extends MultiFileLoader {
         } else {
             return false;
         }
-        
-        if (knownLanguages == null) {
-            knownLanguages = new HashSet<String>(Arrays.asList(Locale.getISOLanguages()));
-        }
-        if (!knownLanguages.contains(s1)) {
+
+        if (!KNOWN_LANGUAGES.contains(s1)) {
             return false;
         }
 
         if (s2 != null) {
-            if (knownCountries == null) {
-                knownCountries = new HashSet<String>(Arrays.asList(Locale.getISOCountries()));
-            }
-            if (!knownCountries.contains(s2)) {
+            if (!KNOWN_COUNTRIES.contains(s2)) {
                 return false;
             }
         }

--- a/ide/properties/src/org/netbeans/modules/properties/Util.java
+++ b/ide/properties/src/org/netbeans/modules/properties/Util.java
@@ -23,9 +23,9 @@ package org.netbeans.modules.properties;
 
 import java.io.IOException;
 import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
+
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.cookies.SaveCookie;
@@ -138,6 +138,9 @@ public final class Util extends Object {
             return fName.substring(baseName.length());
     }
 
+    private static final Set<String> KNOWN_LANGUAGES = Set.of(Locale.getISOLanguages());
+    private static final Set<String> KNOWN_COUNTRIES = Set.of(Locale.getISOCountries());
+
     private static boolean isValidLocaleSuffix(String s) {
         // first char is _
         int n = s.length();
@@ -160,14 +163,12 @@ public final class Util extends Object {
             return false;
         }
 
-        HashSet<String> knownLanguages = new HashSet<String>(Arrays.asList(Locale.getISOLanguages()));
-        if (!knownLanguages.contains(s1)) {
+        if (!KNOWN_LANGUAGES.contains(s1)) {
             return false;
         }
 
         if (s2 != null) {
-            HashSet<String> knownCountries = new HashSet<String>(Arrays.asList(Locale.getISOCountries()));
-            if (!knownCountries.contains(s2)) {
+            if (!KNOWN_COUNTRIES.contains(s2)) {
                 return false;
             }
         }

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beansdev/Schema2BeansProcessor.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beansdev/Schema2BeansProcessor.java
@@ -49,10 +49,13 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class Schema2BeansProcessor extends AbstractProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            Schema2Beans.class.getCanonicalName(),
+            Multiple.class.getCanonicalName()
+    );
+
     public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
-                Schema2Beans.class.getCanonicalName(),
-                Multiple.class.getCanonicalName()));
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/DebuggerProcessor.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/DebuggerProcessor.java
@@ -56,19 +56,20 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class DebuggerProcessor extends LayerGeneratingProcessor {
 
-    public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
             AttachType.Registration.class.getCanonicalName(),
             BreakpointType.Registration.class.getCanonicalName(),
             ColumnModelRegistration.class.getCanonicalName(),
             ColumnModelRegistrations.class.getCanonicalName(),
             DebuggingView.DVSupport.Registration.class.getCanonicalName(),
             CodeEvaluator.EvaluatorService.Registration.class.getCanonicalName()
-        ));
+    );
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return ANNOTATION_TYPES;
     }
 
     public static final String SERVICE_NAME = "serviceName"; // NOI18N
-
 
     @Override
     protected boolean handleProcess(

--- a/ide/spi.navigator/src/org/netbeans/modules/navigator/NavigatorPanelRegistrationProcessor.java
+++ b/ide/spi.navigator/src/org/netbeans/modules/navigator/NavigatorPanelRegistrationProcessor.java
@@ -34,8 +34,13 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class NavigatorPanelRegistrationProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            NavigatorPanel.Registration.class.getCanonicalName(),
+            NavigatorPanel.Registrations.class.getCanonicalName()
+    );
+
     @Override public Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(NavigatorPanel.Registration.class.getCanonicalName(), NavigatorPanel.Registrations.class.getCanonicalName()));
+        return ANNOTATION_TYPES;
     }
 
     @Override protected boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {

--- a/ide/subversion/src/org/netbeans/modules/subversion/client/MissingClient.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/client/MissingClient.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Set;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JPanel;
@@ -47,8 +48,7 @@ import org.openide.util.NbBundle;
 public class MissingClient implements ActionListener, HyperlinkListener {
     
     private final MissingClientPanel panel;
-    private static final HashSet<String> ALLOWED_EXECUTABLES =
-            new HashSet<String>(Arrays.asList(new String[] {"svn", "svn.exe"} )); //NOI18N
+    private static final Set<String> ALLOWED_EXECUTABLES = Set.of("svn", "svn.exe"); //NOI18N
     
     /** Creates a new instance of MissingSvnClient */
     public MissingClient() {

--- a/ide/subversion/src/org/netbeans/modules/subversion/options/SvnOptionsController.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/options/SvnOptionsController.java
@@ -67,8 +67,8 @@ public final class SvnOptionsController extends OptionsPanelController implement
     private final SvnOptionsPanel panel;
     private Repository repository;
     private final AnnotationSettings annotationSettings;
-    private static final HashSet<String> allowedExecutables = new HashSet<String>(Arrays.asList(new String[] {"svn", "svn.exe"} )); //NOI18N
-    private static final HashSet<String> allowedLibs = new HashSet<String>(Arrays.asList(new String[] {"libsvnjavahl-1.dll", "libsvnjavahl-1.so"} )); //NOI18N
+    private static final Set<String> allowedExecutables = Set.of("svn", "svn.exe"); //NOI18N
+    private static final Set<String> allowedLibs = Set.of("libsvnjavahl-1.dll", "libsvnjavahl-1.so"); //NOI18N
     private Object currentClient;
         
     public SvnOptionsController() {        

--- a/ide/subversion/src/org/netbeans/modules/subversion/ui/properties/SvnProperties.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/ui/properties/SvnProperties.java
@@ -63,17 +63,19 @@ import org.tigris.subversion.svnclientadapter.SVNUrl;
 public final class SvnProperties implements ActionListener {
 
     /** Subversion properties that may be set only on directories */
-    private static final HashSet<String> DIR_ONLY_PROPERTIES = new HashSet<String>(Arrays.asList(new String[] {
-                                                            "svn:ignore",
-                                                            "svn:externals"}));
- 
+    private static final Set<String> DIR_ONLY_PROPERTIES = Set.of(
+            "svn:ignore",
+            "svn:externals"
+    );
+
     /** Subversion properties that may be set only on files (not directories) */
-    private static final HashSet<String> FILE_ONLY_PROPERTIES = new HashSet<String>(Arrays.asList(new String[] {
-                                                            "svn:eol-style",
-                                                            "svn:executable",
-                                                            "svn:keywords",
-                                                            "svn:needs-lock",
-                                                            "svn:mime-type"}));
+    private static final Set<String> FILE_ONLY_PROPERTIES = Set.of(
+            "svn:eol-style",
+            "svn:executable",
+            "svn:keywords",
+            "svn:needs-lock",
+            "svn:mime-type"
+    );
 
     private static final HashSet<String> MIXED_PROPERTIES = new HashSet<String>(DIR_ONLY_PROPERTIES.size() + FILE_ONLY_PROPERTIES.size());
     static {
@@ -518,7 +520,7 @@ public final class SvnProperties implements ActionListener {
                 private void removePropertyRecursively (SvnClient client, Set<File> toRefresh) throws SVNClientException {
                     String propName = getPropertyName();
                     if (!propName.trim().isEmpty()) {
-                        if (JOptionPane.showConfirmDialog(panel, 
+                        if (JOptionPane.showConfirmDialog(panel,
                                 Bundle.MSG_SvnProperties_RecursiveDelete_question(propName),
                                 Bundle.LBL_SvnProperties_RecursiveDelete_title(),
                                 JOptionPane.YES_NO_OPTION,

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/VCSRegistrationProcessor.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/VCSRegistrationProcessor.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.versioning.core;
 
-import java.util.Collections;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
@@ -38,9 +37,11 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class VCSRegistrationProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(VersioningSystem.Registration.class.getCanonicalName());
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(VersioningSystem.Registration.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/versioning/src/org/netbeans/modules/versioning/VCSRegistrationProcessor.java
+++ b/ide/versioning/src/org/netbeans/modules/versioning/VCSRegistrationProcessor.java
@@ -38,9 +38,11 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class VCSRegistrationProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(VersioningSystem.Registration.class.getCanonicalName());
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(VersioningSystem.Registration.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/ide/web.common/test/unit/src/org/netbeans/modules/web/common/api/WebUtilsTest.java
+++ b/ide/web.common/test/unit/src/org/netbeans/modules/web/common/api/WebUtilsTest.java
@@ -149,7 +149,7 @@ public class WebUtilsTest extends CslTestBase {
         final String mimeType = "text/x-tpl";
         final String embeddedPhpMimeType = "text/x-php5";
 
-        Set<String> embeddedMimeTypes = new HashSet<String>(Arrays.asList(embeddedPhpMimeType, HTML_MIME_TYPE));
+        Set<String> embeddedMimeTypes = Set.of(embeddedPhpMimeType, HTML_MIME_TYPE);
         setEmbeddingProviderIntoMockLookup(mimeType, embeddedMimeTypes);
         setEmbeddingProviderIntoMockLookup(embeddedPhpMimeType, Collections.singleton(HTML_MIME_TYPE));
 
@@ -164,7 +164,7 @@ public class WebUtilsTest extends CslTestBase {
         final String embeddedPhp4MimeType = "text/x-php4";
         final String embeddedPhp5MimeType = "text/x-php5";
 
-        Set<String> embeddedMimeTypes = new HashSet<String>(Arrays.asList(embeddedPhp4MimeType, embeddedPhp5MimeType));
+        Set<String> embeddedMimeTypes = Set.of(embeddedPhp4MimeType, embeddedPhp5MimeType);
         setEmbeddingProviderIntoMockLookup(mimeType, embeddedMimeTypes);
         setEmbeddingProviderIntoMockLookup(embeddedPhp4MimeType, Collections.singleton(HTML_MIME_TYPE));
         setEmbeddingProviderIntoMockLookup(embeddedPhp5MimeType, Collections.singleton(HTML_MIME_TYPE));

--- a/ide/xml.lexer/src/org/netbeans/lib/xml/lexer/DTDLexer.java
+++ b/ide/xml.lexer/src/org/netbeans/lib/xml/lexer/DTDLexer.java
@@ -412,20 +412,18 @@ public class DTDLexer implements Lexer<DTDTokenId> {
         }
         return error();
     }
-    
-    private static final Map<String, Integer>   DECLARATION_KEYWORDS = new HashMap<>();
 
     /**
      * Recognized declaration keywords. A declaration (&lt;!) followed by other name
      * will be reported as ERROR token.
      */
-    static {
-        DECLARATION_KEYWORDS.put("ELEMENT", ISI_ELEMENT);
-        DECLARATION_KEYWORDS.put("ATTLIST", ISI_ATTLIST);
-        DECLARATION_KEYWORDS.put("ENTITY", ISI_ENTITY);
-        DECLARATION_KEYWORDS.put("NOTATION", ISI_NOTATION);
-    }
-    
+    private static final Map<String, Integer> DECLARATION_KEYWORDS = Map.of(
+            "ELEMENT", ISI_ELEMENT,
+            "ATTLIST", ISI_ATTLIST,
+            "ENTITY", ISI_ENTITY,
+            "NOTATION", ISI_NOTATION
+    );
+
     private Token<DTDTokenId> nextDeclaration() {
         int ch = input.read();
         // process escapes:

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
@@ -40,43 +40,36 @@ import org.netbeans.modules.xml.tax.util.TAXUtil;
  */
 public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustomPropertyEditor {
     /** */
-    private static final long serialVersionUID = 1767193347881681541L;    
+    private static final long serialVersionUID = 1767193347881681541L;
 
-    
-    /** */
-    private static final Map<Class<?>, String> publicNodeTypeNamesMap = new HashMap<>();
+    /**
+     *
+     */
+    private static final Map<Class<?>, String> PUBLIC_NODE_TYPE_NAMES_MAP = Map.ofEntries(
+            Map.entry(TreeNode.class, Util.THIS.getString("NAME_Any_Node_Type")),
+            Map.entry(TreeParentNode.class, Util.THIS.getString("NAME_Any_Parent_Node_Type")),
+            Map.entry(TreeCharacterData.class, Util.THIS.getString("NAME_Any_Character_Data_Node_Type")),
+            Map.entry(TreeReference.class, Util.THIS.getString("NAME_Any_Reference_Node_Type")),
+//          Map.entry(TreeEntityReference.class, Util.THIS.getString ("NAME_Any_Entity_Reference_Node_Type")),
+            Map.entry(TreeNodeDecl.class, Util.THIS.getString("NAME_Any_Declaration_Node_Type")),
 
-
-    //
-    // Static initialization
-    //
-        
-    static {
-        publicNodeTypeNamesMap.put (TreeNode.class, Util.THIS.getString ("NAME_Any_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeParentNode.class, Util.THIS.getString ("NAME_Any_Parent_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeCharacterData.class, Util.THIS.getString ("NAME_Any_Character_Data_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeReference.class, Util.THIS.getString ("NAME_Any_Reference_Node_Type"));
-//          publicNodeTypeNamesMap.put (TreeEntityReference.class, Util.THIS.getString ("NAME_Any_Entity_Reference_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeNodeDecl.class, Util.THIS.getString ("NAME_Any_Declaration_Node_Type"));
-
-        publicNodeTypeNamesMap.put (TreeComment.class, Util.THIS.getString ("NAME_Comment_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeProcessingInstruction.class, Util.THIS.getString ("NAME_Processing_Instruction_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeText.class, Util.THIS.getString ("NAME_Text_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeCDATASection.class, Util.THIS.getString ("NAME_CDATA_Section_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeElement.class, Util.THIS.getString ("NAME_Element_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeAttribute.class, Util.THIS.getString ("NAME_Attribute_Node_Type"));
-//          publicNodeTypeNamesMap.put (TreeDocument.class, Util.THIS.getString ("NAME_Document_Node_Type"));
-//          publicNodeTypeNamesMap.put (TreeDTD.class, Util.THIS.getString ("NAME_DTD_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeConditionalSection.class, Util.THIS.getString ("NAME_Conditional_Section_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeDocumentType.class, Util.THIS.getString ("NAME_Document_Type_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeGeneralEntityReference.class, Util.THIS.getString ("NAME_General_Entity_Reference_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeParameterEntityReference.class, Util.THIS.getString ("NAME_Parameter_Entity_Reference_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeElementDecl.class, Util.THIS.getString ("NAME_Element_Declaration_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeEntityDecl.class, Util.THIS.getString ("NAME_Entity_Declaration_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeAttlistDecl.class, Util.THIS.getString ("NAME_Attlist_Declaration_Node_Type"));
-        publicNodeTypeNamesMap.put (TreeNotationDecl.class, Util.THIS.getString ("NAME_Notation_Declaration_Node_Type"));
-    }
-
+            Map.entry(TreeComment.class, Util.THIS.getString("NAME_Comment_Node_Type")),
+            Map.entry(TreeProcessingInstruction.class, Util.THIS.getString("NAME_Processing_Instruction_Node_Type")),
+            Map.entry(TreeText.class, Util.THIS.getString("NAME_Text_Node_Type")),
+            Map.entry(TreeCDATASection.class, Util.THIS.getString("NAME_CDATA_Section_Node_Type")),
+            Map.entry(TreeElement.class, Util.THIS.getString("NAME_Element_Node_Type")),
+            Map.entry(TreeAttribute.class, Util.THIS.getString("NAME_Attribute_Node_Type")),
+//          Map.entry(TreeDocument.class, Util.THIS.getString ("NAME_Document_Node_Type")),
+//          Map.entry(TreeDTD.class, Util.THIS.getString ("NAME_DTD_Node_Type")),
+            Map.entry(TreeConditionalSection.class, Util.THIS.getString("NAME_Conditional_Section_Node_Type")),
+            Map.entry(TreeDocumentType.class, Util.THIS.getString("NAME_Document_Type_Node_Type")),
+            Map.entry(TreeGeneralEntityReference.class, Util.THIS.getString("NAME_General_Entity_Reference_Node_Type")),
+            Map.entry(TreeParameterEntityReference.class, Util.THIS.getString("NAME_Parameter_Entity_Reference_Node_Type")),
+            Map.entry(TreeElementDecl.class, Util.THIS.getString("NAME_Element_Declaration_Node_Type")),
+            Map.entry(TreeEntityDecl.class, Util.THIS.getString("NAME_Entity_Declaration_Node_Type")),
+            Map.entry(TreeAttlistDecl.class, Util.THIS.getString("NAME_Attlist_Declaration_Node_Type")),
+            Map.entry(TreeNotationDecl.class, Util.THIS.getString("NAME_Notation_Declaration_Node_Type"))
+    );
 
     /** */
     private final TreeNodeFilter filter;
@@ -468,7 +461,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
         /**
          */
         public String toString () {
-            String name = publicNodeTypeNamesMap.get (clazz);
+            String name = PUBLIC_NODE_TYPE_NAMES_MAP.get (clazz);
 
             if ( name == null ) {
                 name = clazz.getName();
@@ -530,7 +523,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("Init Set"); // NOI18N
             
             Item rootItem = new Item();
-            Object[] array = publicNodeTypeNamesMap.keySet().toArray();
+            Object[] array = PUBLIC_NODE_TYPE_NAMES_MAP.keySet().toArray();
             for (int i = 0; i < array.length; i++) {
                 Class<?> clazz = (Class)array[i];
                 Item.insertItemIntoLayer (rootItem.layer, Item.getItem (clazz));

--- a/java/ant.freeform/src/org/netbeans/modules/ant/freeform/Actions.java
+++ b/java/ant.freeform/src/org/netbeans/modules/ant/freeform/Actions.java
@@ -90,20 +90,20 @@ public final class Actions implements ActionProvider {
      * Some routine global actions for which we can supply a display name.
      * These are IDE-specific.
      */
-    private static final Set<String> COMMON_IDE_GLOBAL_ACTIONS = new HashSet<String>(Arrays.asList(
+    private static final Set<String> COMMON_IDE_GLOBAL_ACTIONS = Set.of(
         ActionProvider.COMMAND_DEBUG,
         ActionProvider.COMMAND_PROFILE,
         ActionProvider.COMMAND_DELETE,
         ActionProvider.COMMAND_COPY,
         ActionProvider.COMMAND_MOVE,
-        ActionProvider.COMMAND_RENAME));
+        ActionProvider.COMMAND_RENAME);
     /**
      * Similar to {@link #COMMON_IDE_GLOBAL_ACTIONS}, but these are not IDE-specific.
      * We also mark all of these as bound in the project; if the user
      * does not really have a binding, they are prompted for one when
      * the action is "run".
      */
-    private static final Set<String> COMMON_NON_IDE_GLOBAL_ACTIONS = new HashSet<String>(Arrays.asList(
+    private static final Set<String> COMMON_NON_IDE_GLOBAL_ACTIONS = Set.of(
         ActionProvider.COMMAND_BUILD,
         ActionProvider.COMMAND_CLEAN,
         ActionProvider.COMMAND_REBUILD,
@@ -115,7 +115,7 @@ public final class Actions implements ActionProvider {
         // XXX should this really be here? perhaps not, once web part of #46886 is implemented...
         "redeploy",
         // XXX deploy action of EJB freeform project
-        "deploy")); // NOI18N
+        "deploy"); // NOI18N
     
     private final FreeformProject project;
     

--- a/java/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformEvaluatorTest.java
+++ b/java/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/FreeformEvaluatorTest.java
@@ -153,7 +153,7 @@ public class FreeformEvaluatorTest extends TestBase {
             });
         }
         // Check that the change took.
-        Set<String> exact = new HashSet<String>(Arrays.asList("src.dir", "build.properties"));
+        Set<String> exact = Set.of("src.dir", "build.properties");
         // OK to just return null for the property name instead.
         assertTrue("got a change from properties file in src.dir: " + l.changed, l.changed.contains(null) || l.changed.equals(exact));
         l.reset();

--- a/java/ant.hints/src/org/netbeans/modules/ant/hints/errors/EnablePreviewAntProj.java
+++ b/java/ant.hints/src/org/netbeans/modules/ant/hints/errors/EnablePreviewAntProj.java
@@ -53,16 +53,16 @@ import org.openide.util.MutexException;
  */
 public class EnablePreviewAntProj implements ErrorRule<Void> {
 
-    private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> ERROR_CODES = Set.of(
             "compiler.err.preview.feature.disabled",          // NOI18N
-            "compiler.err.preview.feature.disabled.plural")); // NOI18N
+            "compiler.err.preview.feature.disabled.plural"); // NOI18N
     private static final String ENABLE_PREVIEW_FLAG = "--enable-preview";   // NOI18N
     private static final String JAVAC_COMPILER_ARGS = "javac.compilerargs"; // NOI18N
     private static final String RUN_JVMARGS = "run.jvmargs"; // NOI18N
 
     @Override
     public Set<String> getCodes() {
-        return Collections.unmodifiableSet(ERROR_CODES);
+        return ERROR_CODES;
     }
 
     @Override

--- a/java/api.debugger.jpda/src/org/netbeans/modules/debugger/jpda/apiregistry/DebuggerProcessor.java
+++ b/java/api.debugger.jpda/src/org/netbeans/modules/debugger/jpda/apiregistry/DebuggerProcessor.java
@@ -56,15 +56,17 @@ public class DebuggerProcessor extends LayerGeneratingProcessor {
 
     public static final String SERVICE_NAME = "serviceName"; // NOI18N
 
-    public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
             JPDADebugger.Registration.class.getCanonicalName(),
             SmartSteppingCallback.Registration.class.getCanonicalName(),
             SourcePathProvider.Registration.class.getCanonicalName(),
             EditorContext.Registration.class.getCanonicalName(),
             Evaluator.Registration.class.getCanonicalName(),
             BreakpointsClassFilter.Registration.class.getCanonicalName()
-        ));
+    );
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/java/classfile/src/org/netbeans/modules/classfile/ClassFile.java
+++ b/java/classfile/src/org/netbeans/modules/classfile/ClassFile.java
@@ -59,8 +59,7 @@ public class ClassFile {
     /** size of buffer in buffered input streams */
     private static final int BUFFER_SIZE = 4096;
 
-     private static final Set<String> badNonJavaClassNames  =
-             new HashSet<String>(Arrays.asList(new String[] {";","[","."}));    //NOI18N
+     private static final Set<String> badNonJavaClassNames  = Set.of(";", "[", ".");    //NOI18N
     
     /**
      * Create a new ClassFile object.

--- a/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/SourcePathProviderImpl.java
+++ b/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/SourcePathProviderImpl.java
@@ -893,7 +893,7 @@ public class SourcePathProviderImpl extends SourcePathProvider {
             srcRoots = unorderedOriginalRoots;
         }
         projectSourceRoots = getSourceRoots(originalSourcePath);
-        Set<String> smartSteppingRoots = new HashSet<String>(Arrays.asList(getSourceRoots(smartSteppingSourcePath)));
+        Set<String> smartSteppingRoots = Set.of(getSourceRoots(smartSteppingSourcePath));
         String[] orderedSmartSteppingRoots = new String[smartSteppingRoots.size()];
         int i = 0;
         for (String root : projectSourceRoots) {

--- a/java/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/ToolTipAnnotation.java
+++ b/java/debugger.jpda.projectsui/src/org/netbeans/modules/debugger/jpda/projectsui/ToolTipAnnotation.java
@@ -96,7 +96,7 @@ import org.openide.util.WeakListeners;
 
 public class ToolTipAnnotation extends Annotation implements Runnable {
 
-    private static final Set<String> JAVA_KEYWORDS = new HashSet<String>(Arrays.asList(new String[] {
+    private static final Set<String> JAVA_KEYWORDS = Set.of(
         "abstract",     "continue",     "for",          "new",  	"switch",
         "assert", 	"default", 	"goto", 	"package", 	"synchronized",
         "boolean", 	"do",           "if",           "private", 	/*"this",*/
@@ -106,8 +106,8 @@ public class ToolTipAnnotation extends Annotation implements Runnable {
         "catch",        "extends", 	"int",          "short", 	"try",
         "char",         "final", 	"interface", 	"static", 	"void",
         /*"class",*/    "finally", 	"long", 	"strictfp", 	"volatile",
-        "const",        "float", 	"native", 	"super", 	"while",
-    }));
+        "const",        "float", 	"native", 	"super", 	"while"
+    );
 
     private static final int MAX_STRING_LENGTH;
 

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTreeModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTreeModel.java
@@ -80,18 +80,20 @@ public class DebuggingTreeModel extends CachedChildrenTreeModel {
     public static final String SHOW_SYSTEM_THREADS = "show.systemThreads";
     public static final String SHOW_THREAD_GROUPS = "show.threadGroups";
     public static final String SHOW_SUSPENDED_THREADS_ONLY = "show.suspendedThreadsOnly";
-    
-    private static final Set<String> SYSTEM_THREAD_NAMES = new HashSet<String>(Arrays.asList(new String[] {
-                                                           "Reference Handler",
-                                                           "Signal Dispatcher",
-                                                           "Finalizer",
-                                                           "Java2D Disposer",
-                                                           "TimerQueue",
-                                                           "Attach Listener"}));
-    private static final Set<String> SYSTEM_MAIN_THREAD_NAMES = new HashSet<String>(Arrays.asList(new String[] {
-                                                           "DestroyJavaVM",
-                                                           "AWT-XAWT",
-                                                           "AWT-Shutdown"}));
+
+    private static final Set<String> SYSTEM_THREAD_NAMES = Set.of(
+            "Reference Handler",
+            "Signal Dispatcher",
+            "Finalizer",
+            "Java2D Disposer",
+            "TimerQueue",
+            "Attach Listener"
+    );
+    private static final Set<String> SYSTEM_MAIN_THREAD_NAMES = Set.of(
+            "DestroyJavaVM",
+            "AWT-XAWT",
+            "AWT-Shutdown"
+    );
     
     private final JPDADebugger debugger;
     private Listener listener;

--- a/java/debugger.jpda/gensrc/org/netbeans/modules/debugger/jpda/jdi/Generate.java
+++ b/java/debugger.jpda/gensrc/org/netbeans/modules/debugger/jpda/jdi/Generate.java
@@ -73,15 +73,15 @@ public class Generate {
     private static final Set<Class> SILENT_EXCEPTIONS = Collections.unmodifiableSet(new LinkedHashSet<Class>(Arrays.asList(new Class[] {
            com.sun.jdi.InternalException.class, com.sun.jdi.ObjectCollectedException.class, com.sun.jdi.VMDisconnectedException.class })));
 
-    private static final Set<String> NOT_USED_CLASSES = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(new String[] {
+    private static final Set<String> NOT_USED_CLASSES = Set.of(
             com.sun.jdi.Accessible.class.getName(), com.sun.jdi.Bootstrap.class.getName(),
             com.sun.jdi.ClassLoaderReference.class.getName(),
             com.sun.jdi.PathSearchingVirtualMachine.class.getName(),
             com.sun.jdi.VoidValue.class.getName(),
             // Connectors are used in API and UI modules.
             // Classes starting with "com.sun.jdi.connect" are not generated
-            com.sun.jdi.event.EventIterator.class.getName(),
-    })));
+            com.sun.jdi.event.EventIterator.class.getName()
+    );
     
     private static final String METHODS_BY_JDK = "MethodsByJDK";
 

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
@@ -51,13 +51,13 @@ public class GradleJavaTokenProvider implements ReplaceTokenProvider {
     private static final String TEST_TASK_NAME       = "testTaskName";      //NOI18N
     private static final String CLEAN_TEST_TASK_NAME = "cleanTestTaskName"; //NOI18N
 
-    private static final Set<String> SUPPORTED = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
+    private static final Set<String> SUPPORTED = Set.of(
             SELECTED_CLASS,
             SELECTED_CLASS_NAME,
             SELECTED_METHOD,
             SELECTED_PACKAGE,
             AFFECTED_BUILD_TASK
-    )));
+    );
 
     final Project project;
 

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceUnitPanel.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceUnitPanel.java
@@ -1089,7 +1089,7 @@ public class PersistenceUnitPanel extends SectionInnerPanel {
             return;
         }
         String[] existingClassNames = persistenceUnit.getClass2();
-        Set<String> ignoreClassNames = new HashSet<String>(Arrays.asList(existingClassNames));
+        Set<String> ignoreClassNames = Set.of(existingClassNames);
         List<String> addedClassNames = AddEntityDialog.open(entityClassScope, ignoreClassNames);
         for (String entityClass : addedClassNames) {
             if (dObj.addClass(persistenceUnit, entityClass, true)){

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/Roots.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/Roots.java
@@ -139,7 +139,7 @@ public abstract class Roots {
 
         private NonSourceRoots(final String... rootPropNames) {
             super(false,false, null, null);
-            this.rootPropNames = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(rootPropNames)));
+            this.rootPropNames = Set.of(rootPropNames);
         }
 
         @Override

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathSupport.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ClassPathSupport.java
@@ -22,10 +22,7 @@ package org.netbeans.modules.java.api.common.classpath;
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +76,7 @@ public final class ClassPathSupport {
     private AntProjectHelper antProjectHelper;
     private UpdateHelper updateHelper;
     //@GuardedBy("ClassPathSupport.class")
-    private static Set<String> wellKnownPaths;
+    private static final Set<String> WELL_KNOWN_PATHS = Set.of(ProjectProperties.WELL_KNOWN_PATHS);
     private static String antArtifactPrefix = ANT_ARTIFACT_PREFIX;
         
     private Callback callback;
@@ -327,12 +324,8 @@ out:                for (int tmp = 0; tmp == 0; tmp++) {
     }
 
     @NonNull
-    private static synchronized Set<String> getWellKnownPaths() {
-        if (wellKnownPaths == null) {
-             wellKnownPaths = Collections.unmodifiableSet(
-                     new HashSet<String>(Arrays.asList(ProjectProperties.WELL_KNOWN_PATHS)));
-        }
-        return wellKnownPaths;
+    private static Set<String> getWellKnownPaths() {
+        return WELL_KNOWN_PATHS;
     }
 
     public static boolean isVariableBasedReference(String ref) {

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/queries/AnnotationProcessingQueryImpl.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/queries/AnnotationProcessingQueryImpl.java
@@ -73,7 +73,7 @@ final class AnnotationProcessingQueryImpl implements AnnotationProcessingQueryIm
         this.annotationProcessingEnabledInEditorProperty = annotationProcessingEnabledInEditorProperty;
         this.runAllAnnotationProcessorsProperty = runAllAnnotationProcessorsProperty;
         this.annotationProcessorsProperty = annotationProcessorsProperty;
-        this.properties = new HashSet<String>(Arrays.asList(annotationProcessingEnabledProperty, annotationProcessingEnabledInEditorProperty, runAllAnnotationProcessorsProperty, annotationProcessorsProperty, sourceOutputProperty, processorOptionsProperty));
+        this.properties = Set.of(annotationProcessingEnabledProperty, annotationProcessingEnabledInEditorProperty, runAllAnnotationProcessorsProperty, annotationProcessorsProperty, sourceOutputProperty, processorOptionsProperty);
         this.sourceOutputProperty = sourceOutputProperty;
         this.processorOptionsProperty = processorOptionsProperty;
     }
@@ -103,7 +103,7 @@ final class AnnotationProcessingQueryImpl implements AnnotationProcessingQueryIm
         }
     }
 
-    private static final Set<String> TRUE = new HashSet<String>(Arrays.asList("true", "on", "1"));
+    private static final Set<String> TRUE = Set.of("true", "on", "1");
     
     private final class ResultImpl implements Result, PropertyChangeListener, ChangeListener {
 

--- a/java/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/UnusedImportsTest.java
+++ b/java/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/UnusedImportsTest.java
@@ -383,7 +383,7 @@ public class UnusedImportsTest extends NbTestCase {
             out.add(h.resolve(ci).getLeaf().toString());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList(golden)), out);
+        assertEquals(Set.of(golden), out);
     }
 
     @Override

--- a/java/java.editor/src/org/netbeans/modules/editor/java/SupportedAnnotationTypesCompletion.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/SupportedAnnotationTypesCompletion.java
@@ -23,10 +23,8 @@ import com.sun.source.util.Trees;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -112,11 +110,11 @@ public class SupportedAnnotationTypesCompletion implements Processor {
         return Collections.emptySet();
     }
 
-    private static final Set<String> supportedAnnotationTypes = new HashSet<String>(Arrays.asList(SupportedAnnotationTypes.class.getName()));
+    private static final Set<String> ANNOTATION_TYPES = Set.of(SupportedAnnotationTypes.class.getName());
     
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return supportedAnnotationTypes;
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/java/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenAnnotationAction.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenAnnotationAction.java
@@ -261,9 +261,9 @@ public final class IsOverriddenAnnotationAction extends AbstractAction {
         return caption;
     }
 
-    private static final Set<String> COMBINED_TYPES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> COMBINED_TYPES = Set.of(
             "org-netbeans-modules-editor-annotations-implements-has-implementations-combined",
             "org-netbeans-modules-editor-annotations-implements-is-overridden-combined",
             "org-netbeans-modules-editor-annotations-override-is-overridden-combined"
-    ));
+    );
 }

--- a/java/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codetemplates/CustomizedLog.java
+++ b/java/java.editor/test/qa-functional/src/org/netbeans/test/java/editor/codetemplates/CustomizedLog.java
@@ -133,7 +133,7 @@ public class CustomizedLog extends Handler {
             List<Reference> refs = new ArrayList<Reference>();
             List<String> txts = new ArrayList<String>();
             int count = 0;
-            Set<String> nameSet = names == null || names.length == 0 ? null : new HashSet<String>(Arrays.asList(names));
+            Set<String> nameSet = names == null || names.length == 0 ? null : Set.of(names);
             synchronized (instances) {
                 for (Iterator<Map.Entry<Object, String>> it = instances.entrySet().iterator(); it.hasNext();) {
                     Entry<Object, String> entry = it.next();

--- a/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/ComputeImportsTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/ComputeImportsTest.java
@@ -71,7 +71,7 @@ import org.openide.loaders.DataObject;
  */
 public class ComputeImportsTest extends NbTestCase {
     
-    private static final Set<String> IGNORE_CLASSES = new HashSet<String>(Arrays.asList(new String[] {
+    private static final Set<String> IGNORE_CLASSES = Set.of(
         "com.sun.tools.javac.util.List",
         "com.sun.tools.javac.code.Attribute.RetentionPolicy",
         "com.sun.tools.classfile.Opcode.Set",
@@ -92,12 +92,12 @@ public class ComputeImportsTest extends NbTestCase {
         "sun.rmi.transport.Target",
         "com.sun.org.apache.xalan.internal.xsltc.compiler.util.Type.Element",
         "com.sun.xml.internal.ws.policy.privateutil.PolicyUtils.Collections"
-    }));
+    );
     
-    private static final List<Pattern> IGNORE_PATTERNS = Collections.unmodifiableList(Arrays.asList(
+    private static final List<Pattern> IGNORE_PATTERNS = List.of(
         Pattern.compile("jdk\\..*\\.internal\\..*"),
         Pattern.compile("org\\.graalvm\\..*")
-    ));
+    );
 
     private FileObject testSource;
     private JavaSource js;

--- a/java/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/ClasspathsTest.java
+++ b/java/java.freeform/test/unit/src/org/netbeans/modules/java/freeform/ClasspathsTest.java
@@ -284,9 +284,9 @@ public class ClasspathsTest extends TestBase {
         assertEquals("original classpath is empty now", 0, cpAnt.entries().size());
         assertEquals("classpath for src/ and antsrc/ are the same. " + cpAnt2 + " "+cpSrc2, cpAnt2, cpSrc2);
         
-        assertEquals("ROOTS fired", new HashSet<String>(Arrays.asList(ClassPath.PROP_ENTRIES, ClassPath.PROP_ROOTS)), srcL.changed);
+        assertEquals("ROOTS fired", Set.of(ClassPath.PROP_ENTRIES, ClassPath.PROP_ROOTS), srcL.changed);
         srcL.reset();
-        assertEquals("ROOTS fired", new HashSet<String>(Arrays.asList(ClassPath.PROP_ENTRIES, ClassPath.PROP_ROOTS)), antL.changed);
+        assertEquals("ROOTS fired", Set.of(ClassPath.PROP_ENTRIES, ClassPath.PROP_ROOTS), antL.changed);
         antL.reset();
         
         compile = gpr.getPaths(ClassPath.COMPILE);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/analyzer/AnalyzeFolder.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/analyzer/AnalyzeFolder.java
@@ -67,7 +67,7 @@ public final class AnalyzeFolder extends AbstractAction implements ContextAwareA
         putValue(NAME, NbBundle.getMessage(AnalyzeFolder.class, "CTL_AnalyzeFolder"));
     }
     
-    private static final Set<String> SUPPORTED_IDS = new HashSet<String>(Arrays.asList("create-javadoc", "error-in-javadoc"));
+    private static final Set<String> SUPPORTED_IDS = Set.of("create-javadoc", "error-in-javadoc");
     
     public void actionPerformed(ActionEvent e) {
         RequestProcessor.getDefault().post(new Runnable() {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/CheckReturnValueHint.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/CheckReturnValueHint.java
@@ -63,7 +63,7 @@ public class CheckReturnValueHint {
         return ErrorDescriptionFactory.forName(ctx, ctx.getPath(), displayName);
     }
 
-    private static final Set<String> JDK_IMMUTABLE_CLASSES = new HashSet<String>(Arrays.asList("java.lang.String"));
+    private static final Set<String> JDK_IMMUTABLE_CLASSES = Set.of("java.lang.String");
 
     private static boolean checkReturnValueForJDKMethods(ExecutableElement method) {
         Element owner = method.getEnclosingElement();

--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Tiny.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Tiny.java
@@ -253,24 +253,20 @@ public class Tiny {
         return ErrorDescriptionFactory.forName(ctx, columnIndex, displayName);
     }
     
-    private static final Set<String> METHOD_NAME = new HashSet<String>(Arrays.asList(
+    private static final Set<String> METHOD_NAME = Set.of(
             "getString", "getBoolean", "getByte", "getShort", "getInt", "getLong",
             "getFloat", "getDouble", "getBigDecimal", "getBytes", "getDate",
             "getTime", "getTimestamp", "getAsciiStream", "getUnicodeStream",
-            "getBinaryStream", "getObject", "getCharacterStream", "getBigDecimal",
+            "getBinaryStream", "getObject", "getCharacterStream",
             "updateNull", "updateBoolean", "updateByte", "updateShort", "updateInt",
             "updateLong", "updateFloat", "updateDouble", "updateBigDecimal", "updateString",
             "updateBytes", "updateDate", "updateTime", "updateTimestamp", "updateAsciiStream",
-            "updateBinaryStream", "updateCharacterStream", "updateObject", "updateObject",
-            "getObject", "getRef", "getBlob", "getClob", "getArray", "getDate", "getTime",
-            "getTimestamp", "getURL", "updateRef", "updateBlob", "updateClob", "updateArray",
+            "updateBinaryStream", "updateCharacterStream", "updateObject",
+            "getRef", "getBlob", "getClob", "getArray",
+            "getURL", "updateRef", "updateBlob", "updateClob", "updateArray",
             "getRowId", "updateRowId", "updateNString", "updateNClob", "getNClob", "getSQLXML",
-            "updateSQLXML", "getNString", "getNCharacterStream", "updateNCharacterStream",
-            "updateAsciiStream", "updateBinaryStream", "updateCharacterStream", "updateBlob",
-            "updateClob", "updateNClob", "updateNCharacterStream", "updateAsciiStream",
-            "updateBinaryStream", "updateCharacterStream", "updateBlob", "updateClob",
-            "updateNClob"
-    ));
+            "updateSQLXML", "getNString", "getNCharacterStream", "updateNCharacterStream"
+    );
     
     @Hint(displayName = "#DN_indentation", description = "#DESC_indentation", category="bugs", suppressWarnings="SuspiciousIndentAfterControlStatement", options=Options.QUERY)
     @TriggerTreeKind({Kind.IF, Kind.WHILE_LOOP, Kind.FOR_LOOP, Kind.ENHANCED_FOR_LOOP})

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/AccessError.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/AccessError.java
@@ -50,7 +50,7 @@ import org.openide.util.NbBundle.Messages;
  */
 public class AccessError implements ErrorRule<Void> {
 
-    private static final Set<String> CODES = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("compiler.err.report.access")));
+    private static final Set<String> CODES = Set.of("compiler.err.report.access");
     
     @Override
     public Set<String> getCodes() {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/AddCast.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/AddCast.java
@@ -57,13 +57,13 @@ import org.openide.util.NbBundle;
  */
 public final class AddCast implements ErrorRule<Void> {
 
-    private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> ERROR_CODES = Set.of(
             "compiler.err.prob.found.req", // NOI18N
             "compiler.err.cant.apply.symbol", // NOI18N
             "compiler.err.cant.apply.symbol.1", // NOI18N
             "compiler.err.cant.resolve.location.args", // NOI18N
             "compiler.err.cant.apply.symbols",
-            "compiler.err.prob.found.req/compiler.misc.incompatible.ret.type.in.lambda/compiler.misc.inconvertible.types")); // NOI18N
+            "compiler.err.prob.found.req/compiler.misc.incompatible.ret.type.in.lambda/compiler.misc.inconvertible.types"); // NOI18N
     
     static void computeType(CompilationInfo info, int offset, List<TypeMirror> targetType, TreePath[] typeTree, ExpressionTree[] expression, Tree[] leaf) {
         TreePath path = info.getTreeUtilities().pathFor(offset + 1);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/AddConstructor.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/AddConstructor.java
@@ -53,8 +53,10 @@ import org.openide.util.NbBundle;
  */
 public class AddConstructor implements ErrorRule<Void> {
 
-    private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
-            "compiler.err.cant.apply.symbol", "compiler.err.cant.apply.symbols")); // NOI18N
+    private static final Set<String> ERROR_CODES = Set.of(
+            "compiler.err.cant.apply.symbol",
+            "compiler.err.cant.apply.symbols"
+    ); // NOI18N
     
     @Override
     public Set<String> getCodes() {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/AddOrRemoveFinalModifier.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/AddOrRemoveFinalModifier.java
@@ -100,7 +100,7 @@ public class AddOrRemoveFinalModifier implements ErrorRule<Void> {
     }
 
     public Set<String> getCodes() {
-        return new HashSet<String>(Arrays.asList(errorCode));
+        return Set.of(errorCode);
      }
 
     public List<Fix> run(CompilationInfo compilationInfo, String diagnosticKey, int offset, TreePath treePath, Data<Void> data) {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeMethodParameters.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeMethodParameters.java
@@ -35,7 +35,6 @@ import org.netbeans.api.java.source.TreePathHandle;
 import org.netbeans.api.java.source.TreeUtilities;
 import org.netbeans.modules.java.hints.infrastructure.ErrorHintsProvider;
 import org.netbeans.modules.java.hints.spi.ErrorRule;
-import org.netbeans.modules.java.hints.spi.ErrorRule.Data;
 import org.netbeans.modules.refactoring.java.api.ChangeParametersRefactoring;
 import org.netbeans.modules.refactoring.java.api.ChangeParametersRefactoring.ParameterInfo;
 import org.netbeans.spi.editor.hints.Fix;
@@ -49,12 +48,16 @@ public class ChangeMethodParameters implements ErrorRule<Void> {
     private String DEFAULT_NAME = "par";
     private boolean cancel = false;
 
+    private static final Set<String> CODES = Set.of(
+            "compiler.err.cant.apply.symbol",
+            "compiler.err.cant.apply.symbol.1",
+            "compiler.err.cant.apply.symbols",
+            "compiler.err.prob.found.req"
+            ); // NOI18N
+
     @Override
     public Set<String> getCodes() {
-        return new HashSet<String>(Arrays.asList("compiler.err.cant.apply.symbol",
-                                                 "compiler.err.cant.apply.symbol.1",
-                                                 "compiler.err.cant.apply.symbols",
-                                                 "compiler.err.prob.found.req")); // NOI18N
+        return CODES;
     }
 
     @Override

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeMethodReturnType.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeMethodReturnType.java
@@ -49,10 +49,10 @@ import org.openide.util.NbBundle;
  */
 public class ChangeMethodReturnType implements ErrorRule<Void> {
 
-    private static final Set<String> CODES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> CODES = Set.of(
             "compiler.err.cant.ret.val.from.meth.decl.void",
             "compiler.err.prob.found.req"
-    ));
+    );
 
     @Override
     public Set<String> getCodes() {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElement.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElement.java
@@ -106,10 +106,25 @@ public final class CreateElement implements ErrorRule<Void> {
     public CreateElement() {
     }
 
-    public Set<String> getCodes() {
-        return new HashSet<String>(Arrays.asList("compiler.err.cant.resolve.location", "compiler.err.cant.resolve.location.args", "compiler.err.cant.apply.symbol", "compiler.err.cant.apply.symbol.1", "compiler.err.cant.apply.symbols", "compiler.err.cant.resolve", "compiler.err.cant.resolve.args", CAST_KEY, "compiler.err.try.with.resources.expr.needs.var", "compiler.err.invalid.mref", "compiler.err.bad.initializer")); // NOI18N
-    }
     public static final String CAST_KEY = "compiler.err.prob.found.req";
+
+    private static final Set<String> CODES = Set.of(
+            "compiler.err.cant.resolve.location",
+            "compiler.err.cant.resolve.location.args",
+            "compiler.err.cant.apply.symbol",
+            "compiler.err.cant.apply.symbol.1",
+            "compiler.err.cant.apply.symbols",
+            "compiler.err.cant.resolve",
+            "compiler.err.cant.resolve.args",
+            CAST_KEY,
+            "compiler.err.try.with.resources.expr.needs.var",
+            "compiler.err.invalid.mref",
+            "compiler.err.bad.initializer"
+    ); // NOI18N
+
+    public Set<String> getCodes() {
+        return CODES;
+    }
 
     public List<Fix> run(CompilationInfo info, String diagnosticKey, int offset, TreePath treePath, Data<Void> data) {
         try {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/DifferentCaseKindsFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/DifferentCaseKindsFix.java
@@ -47,12 +47,13 @@ public class DifferentCaseKindsFix implements ErrorRule<Void> {
 
     private static final int SWITCH_RULE_PREVIEW_JDK_VERSION = 13;
 
-    private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
-            "compiler.err.switch.mixing.case.types")); // NOI18N
+    private static final Set<String> ERROR_CODES = Set.of(
+            "compiler.err.switch.mixing.case.types"
+    ); // NOI18N
     
     @Override
     public Set<String> getCodes() {
-        return Collections.unmodifiableSet(ERROR_CODES);
+        return ERROR_CODES;
     }
 
     @Override

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/EnablePreviewSingleSourceFile.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/EnablePreviewSingleSourceFile.java
@@ -52,9 +52,10 @@ import org.openide.util.MutexException;
  */
 public class EnablePreviewSingleSourceFile implements ErrorRule<Void> {
 
-    private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> ERROR_CODES = Set.of(
             "compiler.err.preview.feature.disabled",           //NOI18N  
-            "compiler.err.preview.feature.disabled.plural")); // NOI18N
+            "compiler.err.preview.feature.disabled.plural"
+    ); // NOI18N
     private static final String ENABLE_PREVIEW_FLAG = "--enable-preview";   // NOI18N
     private static final String SOURCE_FLAG = "--source";   // NOI18N
 
@@ -62,7 +63,7 @@ public class EnablePreviewSingleSourceFile implements ErrorRule<Void> {
 
     @Override
     public Set<String> getCodes() {
-        return Collections.unmodifiableSet(ERROR_CODES);
+        return ERROR_CODES;
     }
 
     @Override

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ExtendsImplements.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ExtendsImplements.java
@@ -44,7 +44,7 @@ public class ExtendsImplements implements ErrorRule<Void> {
     
     private static final String KEY_EXTENDS_TO_IMPLEMENTS = "compiler.err.no.intf.expected.here";
     private static final String KEY_IMPLEMENTS_TO_EXTENDS = "compiler.err.intf.expected.here";
-    private static final Set<String> CODES = new HashSet<String>(Arrays.asList(KEY_EXTENDS_TO_IMPLEMENTS, KEY_IMPLEMENTS_TO_EXTENDS));
+    private static final Set<String> CODES = Set.of(KEY_EXTENDS_TO_IMPLEMENTS, KEY_IMPLEMENTS_TO_EXTENDS);
     
     @Override
     public Set<String> getCodes() {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ImplementAllAbstractMethods.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ImplementAllAbstractMethods.java
@@ -85,12 +85,13 @@ public final class ImplementAllAbstractMethods implements ErrorRule<Object>, Ove
     public ImplementAllAbstractMethods() {
     }
 
+    private static final Set<String> CODES = Set.of(
+            "compiler.err.abstract.cant.be.instantiated", // NOI18N
+            "compiler.err.does.not.override.abstract", // NOI18N
+            "compiler.err.enum.constant.does.not.override.abstract"); // NOI18N
+
     public Set<String> getCodes() {
-        return new HashSet<String>(Arrays.asList(
-                "compiler.err.abstract.cant.be.instantiated", // NOI18N
-                "compiler.err.does.not.override.abstract", // NOI18N
-                "compiler.err.abstract.cant.be.instantiated", // NOI18N
-                "compiler.err.enum.constant.does.not.override.abstract")); // NOI18N
+        return CODES;
     }
     
     /**

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ImportClass.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ImportClass.java
@@ -107,18 +107,20 @@ public final class ImportClass implements ErrorRule<Void>{
     
     public ImportClass() {
     }
-    
+
+    private static final Set<String> CODES = Set.of(
+            "compiler.err.cant.resolve",
+            "compiler.err.cant.resolve.location",
+            "compiler.err.cant.resolve.location.args",
+            "compiler.err.doesnt.exist",
+            "compiler.err.not.stmt",
+            "compiler.err.not.def.public.cant.access",
+            "compiler.err.expected"
+    );
+
     @Override
     public Set<String> getCodes() {
-        return new HashSet<>(Arrays.asList(
-                "compiler.err.cant.resolve",
-                "compiler.err.cant.resolve.location",
-                "compiler.err.cant.resolve.location.args",
-                "compiler.err.doesnt.exist",
-                "compiler.err.not.stmt", 
-                "compiler.err.not.def.public.cant.access",
-                "compiler.err.expected"
-        ));
+        return CODES;
     }
 
     @Override

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/MissingReturnStatement.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/MissingReturnStatement.java
@@ -58,11 +58,11 @@ import org.openide.util.NbBundle;
  */
 public class MissingReturnStatement implements ErrorRule<Void> {
 
-    private static final Set<String> CODES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> CODES = Set.of(
             "compiler.err.missing.ret.stmt",
             "compiler.err.prob.found.req/compiler.misc.incompatible.ret.type.in.lambda/compiler.misc.missing.ret.val",
             "compiler.err.prob.found.req/compiler.misc.incompatible.ret.type.in.lambda/compiler.misc.inconvertible.types"
-            ));
+    );
 
     @Override
     public Set<String> getCodes() {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/OverrideWeakerAccess.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/OverrideWeakerAccess.java
@@ -49,8 +49,9 @@ import org.openide.util.NbBundle.Messages;
 })
 public final class OverrideWeakerAccess implements ErrorRule<Void> {
 
-    private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
-            "compiler.err.override.weaker.access")); // NOI18N
+    private static final Set<String> ERROR_CODES = Set.of(
+            "compiler.err.override.weaker.access"
+    ); // NOI18N
     
     public Set<String> getCodes() {
         return ERROR_CODES;

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/RemoveOverride.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/RemoveOverride.java
@@ -45,7 +45,7 @@ import org.openide.util.NbBundle.Messages;
 })
 public class RemoveOverride implements ErrorRule<Void> {
 
-    private static final Set<String> CODES = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("compiler.err.method.does.not.override.superclass")));
+    private static final Set<String> CODES = Set.of("compiler.err.method.does.not.override.superclass");
     
     @Override
     public Set<String> getCodes() {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/RemoveUselessCast.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/RemoveUselessCast.java
@@ -42,9 +42,11 @@ public final class RemoveUselessCast implements ErrorRule<Void> {
     
     public RemoveUselessCast() {
     }
+
+    private static final Set<String> CODES = Set.of("compiler.warn.redundant.cast"); // NOI18N
     
     public Set<String> getCodes() {
-        return Collections.singleton("compiler.warn.redundant.cast"); // NOI18N
+        return CODES;
     }
     
     public List<Fix> run(CompilationInfo info, String diagnosticKey, int offset, TreePath treePath, Data<Void> data) {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/UncaughtException.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/UncaughtException.java
@@ -169,11 +169,10 @@ public final class UncaughtException implements ErrorRule<Void> {
     static final String ERR_IMPLICIT_CLOSE = "compiler.err.unreported.exception.implicit.close"; // NOI18N
     static final String ERR_UNREPORTED = "compiler.err.unreported.exception.need.to.catch.or.throw"; // NOI18N
     
-    private static final Set<String> ERRCODES = new HashSet<String>(Arrays.asList(
-        new String[]{
+    private static final Set<String> ERRCODES = Set.of(
             ERR_UNREPORTED,
             ERR_IMPLICIT_CLOSE
-        }));
+    );
     
     public Set<String> getCodes() {
         return ERRCODES;

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/VarArgsCast.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/VarArgsCast.java
@@ -48,7 +48,7 @@ import org.openide.util.NbBundle;
  */
 public class VarArgsCast implements ErrorRule<Void> {
 
-    private static final Set<String> CODES = new HashSet<String>(Arrays.asList("compiler.warn.inexact.non-varargs.call"));
+    private static final Set<String> CODES = Set.of("compiler.warn.inexact.non-varargs.call");
     
     @Override
     public Set<String> getCodes() {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/VarCompDeclaration.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/VarCompDeclaration.java
@@ -45,12 +45,14 @@ import org.openide.util.NbBundle;
  */
 public class VarCompDeclaration implements ErrorRule<Void> {
 
-    private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
-            "compiler.err.var.not.allowed.compound", "compiler.err.restricted.type.not.allowed.compound")); // NOI18N
+    private static final Set<String> ERROR_CODES = Set.of(
+            "compiler.err.var.not.allowed.compound",
+            "compiler.err.restricted.type.not.allowed.compound"
+    ); // NOI18N
 
     @Override
     public Set<String> getCodes() {
-        return Collections.unmodifiableSet(ERROR_CODES);
+        return ERROR_CODES;
     }
 
     @Override

--- a/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProvider.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProvider.java
@@ -382,23 +382,23 @@ public final class ErrorHintsProvider extends JavaParserResultTask {
         }
     }
     
-    private static final Set<String> INVALID_METHOD_INVOCATION = new HashSet<String>(Arrays.asList(
+    private static final Set<String> INVALID_METHOD_INVOCATION = Set.of(
         "compiler.err.prob.found.req",
         "compiler.err.cant.apply.symbol",
         "compiler.err.cant.apply.symbol.1",
 //        "compiler.err.cant.resolve.location",
         "compiler.err.cant.resolve.location.args"
-    ));
+    );
     
-    private static final Set<String> CANNOT_RESOLVE = new HashSet<String>(Arrays.asList(
+    private static final Set<String> CANNOT_RESOLVE = Set.of(
             "compiler.err.cant.resolve",
             "compiler.err.cant.resolve.location",
             "compiler.err.cant.resolve.location.args",
             "compiler.err.doesnt.exist",
             "compiler.err.type.error"
-    ));
+    );
     
-    private static final Set<String> UNDERLINE_IDENTIFIER = new HashSet<String>(Arrays.asList(
+    private static final Set<String> UNDERLINE_IDENTIFIER = Set.of(
             "compiler.err.local.var.accessed.from.icls.needs.final",
             "compiler.err.var.might.not.have.been.initialized",
             "compiler.err.report.access",
@@ -408,13 +408,13 @@ public final class ErrorHintsProvider extends JavaParserResultTask {
             "compiler.warn.has.been.deprecated",
             "compiler.warn.raw.class.use",
             "compiler.err.class.public.should.be.in.file"
-    ));
+    );
     
-    private static final Set<String> USE_PROVIDED_SPAN = new HashSet<String>(Arrays.asList(
+    private static final Set<String> USE_PROVIDED_SPAN = Set.of(
             "compiler.err.method.does.not.override.superclass",
             "compiler.err.illegal.unicode.esc",
             "compiler.err.unreported.exception.need.to.catch.or.throw"
-    ));
+    );
 
     private static final Set<JavaTokenId> WHITESPACE = EnumSet.of(JavaTokenId.BLOCK_COMMENT, JavaTokenId.JAVADOC_COMMENT, JavaTokenId.LINE_COMMENT, JavaTokenId.WHITESPACE);
     

--- a/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/SuppressWarningsCompletion.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/SuppressWarningsCompletion.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.java.hints.infrastructure;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -82,11 +81,11 @@ public class SuppressWarningsCompletion implements Processor {
         return Collections.emptySet();
     }
 
-    private static final Set<String> supportedAnnotationTypes = new HashSet<String>(Arrays.asList(SuppressWarnings.class.getName()));
+    private static final Set<String> ANNOTATION_TYPES = Set.of(SuppressWarnings.class.getName());
 
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return supportedAnnotationTypes;
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHint.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToDiamondBulkHint.java
@@ -68,7 +68,7 @@ import org.openide.util.NbBundle;
 public class ConvertToDiamondBulkHint {
 
     public static final String ID = "Javac_canUseDiamond";
-    public static final Set<String> CODES = new HashSet<String>(Arrays.asList("compiler.warn.diamond.redundant.args"));
+    public static final Set<String> CODES = Set.of("compiler.warn.diamond.redundant.args");
 
     //XXX: hack:
     public static boolean isHintEnabled() {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambda.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambda.java
@@ -56,7 +56,7 @@ import org.openide.util.NbBundle;
 public class ConvertToLambda {
 
     public static final String ID = "Javac_canUseLambda"; //NOI18N
-    public static final Set<String> CODES = new HashSet<String>(Arrays.asList("compiler.warn.potential.lambda.found")); //NOI18N
+    public static final Set<String> CODES = Set.of("compiler.warn.potential.lambda.found"); //NOI18N
 
     static final boolean DEF_PREFER_MEMBER_REFERENCES = true;
 

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ChangeMethodParametersTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ChangeMethodParametersTest.java
@@ -40,87 +40,87 @@ public class ChangeMethodParametersTest extends HintsTestBase {
     
     public void testConstructor() throws Exception {
         performTestAnalysisTest("org.netbeans.test.java.hints.Constructor",
-                    180,  new HashSet<String>(Arrays.asList(
-                "Change constructor from Constructor(int i) to Constructor(int i, String hello_World)"
-        )));
+                180,
+                Set.of("Change constructor from Constructor(int i) to Constructor(int i, String hello_World)")
+        );
         performTestAnalysisTest("org.netbeans.test.java.hints.Constructor",
-                    226,  new HashSet<String>(Arrays.asList(
-                "Change constructor from Constructor(int i) to Constructor(String hello_World, int i)"
-        )));
+                226,
+                Set.of("Change constructor from Constructor(int i) to Constructor(String hello_World, int i)")
+        );
         performTestAnalysisTest("org.netbeans.test.java.hints.Constructor",
-                    272,  new HashSet<String>(Arrays.asList(
-                "Change constructor from Constructor(int i) to Constructor(String hello_World, int i, String string)"
-        )));
+                272,
+                Set.of("Change constructor from Constructor(int i) to Constructor(String hello_World, int i, String string)")
+        );
         performTestAnalysisTest("org.netbeans.test.java.hints.Constructor",
-                    323,  new HashSet<String>(Arrays.asList(
-                "Change constructor from Constructor(int i) to Constructor(int i, int par1, int par2)"
-        )));
+                323,
+                Set.of("Change constructor from Constructor(int i) to Constructor(int i, int par1, int par2)")
+        );
     }
     
     public void testAddParameter() throws Exception {
         performTestAnalysisTest("org.netbeans.test.java.hints.AddParameter",
-                    180,  new HashSet<String>(Arrays.asList(
-                "Change method from method(int i) to method(int i, String hello_World)"
-        )));
+                180, Set.of(
+                        "Change method from method(int i) to method(int i, String hello_World)"
+                ));
         performTestAnalysisTest("org.netbeans.test.java.hints.AddParameter",
-                    215,  new HashSet<String>(Arrays.asList(
-                "Change method from method(int i) to method(String hello_World, int i)"
-        )));
+                215, Set.of(
+                        "Change method from method(int i) to method(String hello_World, int i)"
+                ));
         performTestAnalysisTest("org.netbeans.test.java.hints.AddParameter",
-                    250,  new HashSet<String>(Arrays.asList(
-                "Change method from method(int i) to method(String hello_World, int i, String string)"
-        )));
+                250, Set.of(
+                        "Change method from method(int i) to method(String hello_World, int i, String string)"
+                ));
         performTestAnalysisTest("org.netbeans.test.java.hints.AddParameter",
-                    290,  new HashSet<String>(Arrays.asList(
-                "Change method from method(int i) to method(int i, int par1, int par2)"
-        )));
+                290, Set.of(
+                        "Change method from method(int i) to method(int i, int par1, int par2)"
+                ));
     }
     
     public void test201360() throws Exception { // NullPointerException at org.netbeans.modules.java.hints.errors.ChangeMethodParameters.analyze
         performTestAnalysisTest("org.netbeans.test.java.hints.Test201360",
-                    205,  new HashSet<String>(Arrays.asList(
-                "Change method from getColor(int number) to getColor()", "Change method from getColor(int number, Color failedColor) to getColor()"
-        )));
+                205, Set.of(
+                        "Change method from getColor(int number) to getColor()", "Change method from getColor(int number, Color failedColor) to getColor()"
+                ));
     }
     
     public void test204556() throws Exception {
         performTestAnalysisTest("org.netbeans.test.java.hints.Test204556",
-                    130,  new HashSet<String>(Arrays.asList(
+                    130,  Set.of(
                 "Change method from getColor(boolean b) to getColor(T b)"
-        )));
+        ));
     }
     
     public void testReorderParameter() throws Exception {
         performTestAnalysisTest("org.netbeans.test.java.hints.ReorderParameter",
-                    312,  new HashSet<String>(Arrays.asList(
+                    312, Set.of(
                 "Change method from method(int i, String a, Object o, boolean b) to "
                 + "method(boolean b, String a, Object o, int i)"
         )));
         performTestAnalysisTest("org.netbeans.test.java.hints.ReorderParameter",
-                    345,  new HashSet<String>(Arrays.asList(
+                    345, Set.of(
                 "Change method from method(int i, String a, Object o, boolean b) to "
                 + "method(String a, Object o, boolean b, int i)"
-        )));
+        ));
     }
     
     public void testRemoveParameter() throws Exception {
         performTestAnalysisTest("org.netbeans.test.java.hints.RemoveParameter",
-                    312,  new HashSet<String>(Arrays.asList(
+                    312, Set.of(
                 "Change method from method(int i, String a, Object o, boolean b) to "
                 + "method(int i, String a, Object o)"
-        )));
+        ));
         performTestAnalysisTest("org.netbeans.test.java.hints.RemoveParameter",
-                    340,  new HashSet<String>(Arrays.asList(
+                    340, Set.of(
                 "Change method from method(int i, String a, Object o, boolean b) to "
                 + "method(String a)"
-        )));
+        ));
     }
     
     public void test200235() throws Exception {
         performTestAnalysisTest("org.netbeans.test.java.hints.AbstractMethod",
-                    195,  new HashSet<String>(Arrays.asList(
+                    195,  Set.of(
                 "Change method from method(int i) to method(int i, String hello_World)"
-        )));
+        ));
     }
 
     @Override

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateElementTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateElementTest.java
@@ -44,11 +44,11 @@ public class CreateElementTest extends HintsTestBase {
     }
 
     public void testBinaryOperator() throws Exception {
-        Set<String> golden = new HashSet<String>(Arrays.asList(
+        Set<String> golden = Set.of(
             "CreateFieldFix:p:org.netbeans.test.java.hints.BinaryOperator:int:[private, static]",
             "AddParameterOrLocalFix:p:int:PARAMETER",
             "AddParameterOrLocalFix:p:int:LOCAL_VARIABLE"
-        ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.BinaryOperator", 218, golden);
         performTestAnalysisTest("org.netbeans.test.java.hints.BinaryOperator", 255, golden);
@@ -57,11 +57,13 @@ public class CreateElementTest extends HintsTestBase {
     }
 
     public void testEnhancedForLoop() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.EnhancedForLoop", 186, new HashSet<String>(Arrays.asList(
-            "CreateFieldFix:u:org.netbeans.test.java.hints.EnhancedForLoop:java.lang.Iterable<java.lang.String>:[private, static]",
-            "AddParameterOrLocalFix:u:java.lang.Iterable<java.lang.String>:PARAMETER",
-            "AddParameterOrLocalFix:u:java.lang.Iterable<java.lang.String>:LOCAL_VARIABLE"
-        )));
+        performTestAnalysisTest("org.netbeans.test.java.hints.EnhancedForLoop", 186,
+                Set.of(
+                        "CreateFieldFix:u:org.netbeans.test.java.hints.EnhancedForLoop:java.lang.Iterable<java.lang.String>:[private, static]",
+                        "AddParameterOrLocalFix:u:java.lang.Iterable<java.lang.String>:PARAMETER",
+                        "AddParameterOrLocalFix:u:java.lang.Iterable<java.lang.String>:LOCAL_VARIABLE"
+                )
+        );
 
 //        performTestAnalysisTest("org.netbeans.test.java.hints.EnhancedForLoop", 244, new HashSet<String>(Arrays.asList(
 //                "CreateFieldFix:u:org.netbeans.test.java.hints.EnhancedForLoop:java.lang.Iterable<java.util.List<? extends java.lang.String>>:[private, static]",
@@ -71,104 +73,104 @@ public class CreateElementTest extends HintsTestBase {
     }
 
     public void testArrayAccess() throws Exception {
-        Set<String> simpleGoldenWithLocal = new HashSet<String>(Arrays.asList(
+        Set<String> simpleGoldenWithLocal = Set.of(
                 "CreateFieldFix:x:org.netbeans.test.java.hints.ArrayAccess:int[]:[private, static]",
                 "AddParameterOrLocalFix:x:int[]:PARAMETER",
                 "AddParameterOrLocalFix:x:int[]:LOCAL_VARIABLE"
-                ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.ArrayAccess", 170, simpleGoldenWithLocal);
         performTestAnalysisTest("org.netbeans.test.java.hints.ArrayAccess", 188, simpleGoldenWithLocal);
 
-        Set<String> simpleGoldenWithoutLocal = new HashSet<String>(Arrays.asList(
+        Set<String> simpleGoldenWithoutLocal = Set.of(
                 "CreateFieldFix:x:org.netbeans.test.java.hints.ArrayAccess:int[]:[private]"
-                ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.ArrayAccess", 262, simpleGoldenWithoutLocal);
         performTestAnalysisTest("org.netbeans.test.java.hints.ArrayAccess", 283, simpleGoldenWithoutLocal);
 
-        Set<String> indexGoldenWithLocal = new HashSet<String>(Arrays.asList(
+        Set<String> indexGoldenWithLocal = Set.of(
                 "CreateFieldFix:u:org.netbeans.test.java.hints.ArrayAccess:int:[private, static]",
                 "AddParameterOrLocalFix:u:int:PARAMETER",
                 "AddParameterOrLocalFix:u:int:LOCAL_VARIABLE"
-                ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.ArrayAccess", 335, indexGoldenWithLocal);
         performTestAnalysisTest("org.netbeans.test.java.hints.ArrayAccess", 377, indexGoldenWithLocal);
 
-        Set<String> indexGoldenWithoutLocal = new HashSet<String>(Arrays.asList(
+        Set<String> indexGoldenWithoutLocal = Set.of(
                 "CreateFieldFix:u:org.netbeans.test.java.hints.ArrayAccess:int:[private]"
-                ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.ArrayAccess", 359, indexGoldenWithoutLocal);
         performTestAnalysisTest("org.netbeans.test.java.hints.ArrayAccess", 401, indexGoldenWithoutLocal);
 
-        performTestAnalysisTest("org.netbeans.test.java.hints.ArrayAccess", 442, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.ArrayAccess", 442, Set.of(
                 "CreateFieldFix:s:org.netbeans.test.java.hints.ArrayAccess:java.lang.Object[][]:[private]"
-        )));
+        ));
     }
 
     public void testAssignment() throws Exception {
-        Set<String> golden = new HashSet<String>(Arrays.asList(
+        Set<String> golden = Set.of(
                 "CreateFieldFix:x:org.netbeans.test.java.hints.Assignment:int:[private, static]",
                 "AddParameterOrLocalFix:x:int:PARAMETER",
                 "AddParameterOrLocalFix:x:int:LOCAL_VARIABLE"
-                ));
+        );
         performTestAnalysisTest("org.netbeans.test.java.hints.Assignment", 174, golden);
         performTestAnalysisTest("org.netbeans.test.java.hints.Assignment", 186, golden);
     }
 
     public void testVariableDeclaration() throws Exception {
-        Set<String> golden = new HashSet<String>(Arrays.asList(
+        Set<String> golden = Set.of(
                 "CreateFieldFix:x:org.netbeans.test.java.hints.VariableDeclaration:int:[private, static]",
                 "AddParameterOrLocalFix:x:int:PARAMETER",
                 "AddParameterOrLocalFix:x:int:LOCAL_VARIABLE"
-                ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.VariableDeclaration", 186, golden);
     }
 
     public void testAssert() throws Exception {
-        Set<String> goldenC = new HashSet<String>(Arrays.asList(
+        Set<String> goldenC = Set.of(
                 "CreateFieldFix:c:org.netbeans.test.java.hints.Assert:boolean:[private, static]",
                 "AddParameterOrLocalFix:c:boolean:PARAMETER",
                 "AddParameterOrLocalFix:c:boolean:LOCAL_VARIABLE"
-                ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.Assert", 159, goldenC);
 
-        Set<String> goldenS = new HashSet<String>(Arrays.asList(
+        Set<String> goldenS = Set.of(
                 "CreateFieldFix:s:org.netbeans.test.java.hints.Assert:java.lang.Object:[private, static]",
                 "AddParameterOrLocalFix:s:java.lang.Object:PARAMETER",
                 "AddParameterOrLocalFix:s:java.lang.Object:LOCAL_VARIABLE"
-                ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.Assert", 163, goldenS);
     }
 
     public void testParenthesis() throws Exception {
-        Set<String> goldenC = new HashSet<String>(Arrays.asList(
+        Set<String> goldenC = Set.of(
                 "CreateFieldFix:x:org.netbeans.test.java.hints.Parenthesis:int[][]:[private]"
-        ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.Parenthesis", 203, goldenC);
     }
 
     public void testIfAndLoops() throws Exception {
-        Set<String> simple = new HashSet<String>(Arrays.asList(
+        Set<String> simple = Set.of(
                 "CreateFieldFix:a:org.netbeans.test.java.hints.IfAndLoops:boolean:[private, static]",
                 "AddParameterOrLocalFix:a:boolean:PARAMETER",
                 "AddParameterOrLocalFix:a:boolean:LOCAL_VARIABLE"
-        ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.IfAndLoops", 194, simple);
         performTestAnalysisTest("org.netbeans.test.java.hints.IfAndLoops", 247, simple);
         performTestAnalysisTest("org.netbeans.test.java.hints.IfAndLoops", 309, simple);
         performTestAnalysisTest("org.netbeans.test.java.hints.IfAndLoops", 368, simple);
 
-        Set<String> complex = new HashSet<String>(Arrays.asList(
+        Set<String> complex = Set.of(
                 "CreateFieldFix:a:org.netbeans.test.java.hints.IfAndLoops:boolean[]:[private]"
-        ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.IfAndLoops", 214, complex);
         performTestAnalysisTest("org.netbeans.test.java.hints.IfAndLoops", 270, complex);
@@ -177,17 +179,17 @@ public class CreateElementTest extends HintsTestBase {
     }
 
     public void testTarget() throws Exception {
-        Set<String> simple = new HashSet<String>(Arrays.asList(
+        Set<String> simple = Set.of(
                 "CreateFieldFix:a:org.netbeans.test.java.hints.Target:int:[private, static]",
                 "AddParameterOrLocalFix:a:int:PARAMETER",
                 "AddParameterOrLocalFix:a:int:LOCAL_VARIABLE"
-        ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.Target", 186, simple);
 
-        Set<String> complex = new HashSet<String>(Arrays.asList(
+        Set<String> complex = Set.of(
                 "CreateFieldFix:a:org.netbeans.test.java.hints.Target:int:[private]"
-        ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.Target", 203, complex);
         performTestAnalysisTest("org.netbeans.test.java.hints.Target", 224, complex);
@@ -195,12 +197,12 @@ public class CreateElementTest extends HintsTestBase {
     }
 
     public void testMemberSelect() throws Exception {
-        Set<String> simpleWithStatic = new HashSet<String>(Arrays.asList(
+        Set<String> simpleWithStatic = Set.of(
                 "CreateFieldFix:a:org.netbeans.test.java.hints.MemberSelect:int:[private, static]"
-        ));
-        Set<String> simple = new HashSet<String>(Arrays.asList(
+        );
+        Set<String> simple = Set.of(
                 "CreateFieldFix:a:org.netbeans.test.java.hints.MemberSelect:int:[private]"
-        ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.MemberSelect", 236, simpleWithStatic);
         performTestAnalysisTest("org.netbeans.test.java.hints.MemberSelect", 268, simpleWithStatic);
@@ -210,22 +212,22 @@ public class CreateElementTest extends HintsTestBase {
     }
 
     public void testSimple() throws Exception {
-        Set<String> simpleJLOWithLocal = new HashSet<String>(Arrays.asList(
+        Set<String> simpleJLOWithLocal = Set.of(
                 "CreateFieldFix:e:org.netbeans.test.java.hints.Simple:java.lang.Object:[private, static]",
                 "AddParameterOrLocalFix:e:java.lang.Object:PARAMETER",
                 "AddParameterOrLocalFix:e:java.lang.Object:LOCAL_VARIABLE"
-        ));
-        Set<String> simpleJLO = new HashSet<String>(Arrays.asList(
+        );
+        Set<String> simpleJLO = Set.of(
                 "CreateFieldFix:e:org.netbeans.test.java.hints.Simple:java.lang.Object:[private]"
-        ));
-        Set<String> simpleJLEWithLocal = new HashSet<String>(Arrays.asList(
+        );
+        Set<String> simpleJLEWithLocal = Set.of(
                 "CreateFieldFix:e:org.netbeans.test.java.hints.Simple:java.lang.Exception:[private, static]",
                 "AddParameterOrLocalFix:e:java.lang.Exception:PARAMETER",
                 "AddParameterOrLocalFix:e:java.lang.Exception:LOCAL_VARIABLE"
-        ));
-        Set<String> simpleJLE = new HashSet<String>(Arrays.asList(
+        );
+        Set<String> simpleJLE = Set.of(
                 "CreateFieldFix:e:org.netbeans.test.java.hints.Simple:java.lang.Exception:[private]"
-        ));
+        );
 
         performTestAnalysisTest("org.netbeans.test.java.hints.Simple", 192, simpleJLEWithLocal);
         performTestAnalysisTest("org.netbeans.test.java.hints.Simple", 211, simpleJLE);
@@ -247,81 +249,83 @@ public class CreateElementTest extends HintsTestBase {
     }
 
     public void testTypevarsAndEnums() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.TypevarsAndErrors", 221, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.TypevarsAndErrors", 221, Set.of(
                 "CreateFieldFix:c1:org.netbeans.test.java.hints.TypevarsAndErrors:T:[private]"
-        )));
-        performTestAnalysisTest("org.netbeans.test.java.hints.TypevarsAndErrors", 243, new HashSet<String>(Arrays.asList(
+        ));
+        performTestAnalysisTest("org.netbeans.test.java.hints.TypevarsAndErrors", 243, Set.of(
                 "CreateFieldFix:c2:org.netbeans.test.java.hints.TypevarsAndErrors:java.lang.Class<T>:[private]"
-        )));
+        ));
         performTestAnalysisTest("org.netbeans.test.java.hints.TypevarsAndErrors", 265, Collections.<String>emptySet());
         performTestAnalysisTest("org.netbeans.test.java.hints.TypevarsAndErrors", 287, Collections.<String>emptySet());
     }
 
     public void testReturn() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.Return", 164, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.Return", 164, Set.of(
                 "AddParameterOrLocalFix:l:int:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:l:int:PARAMETER",
                 "CreateFieldFix:l:org.netbeans.test.java.hints.Return:int:[private]"
-        )));
-        performTestAnalysisTest("org.netbeans.test.java.hints.Return", 220, new HashSet<String>(Arrays.asList(
+        ));
+        performTestAnalysisTest("org.netbeans.test.java.hints.Return", 220, Set.of(
                 "AddParameterOrLocalFix:l:java.util.List:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:l:java.util.List:PARAMETER",
                 "CreateFieldFix:l:org.netbeans.test.java.hints.Return:java.util.List:[private]"
-        )));
-        performTestAnalysisTest("org.netbeans.test.java.hints.Return", 284, new HashSet<String>(Arrays.asList(
+        ));
+        performTestAnalysisTest("org.netbeans.test.java.hints.Return", 284, Set.of(
                 "AddParameterOrLocalFix:l:java.util.List<java.lang.String>:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:l:java.util.List<java.lang.String>:PARAMETER",
                 "CreateFieldFix:l:org.netbeans.test.java.hints.Return:java.util.List<java.lang.String>:[private]"
-        )));
+        ));
         performTestAnalysisTest("org.netbeans.test.java.hints.Return", 340, Collections.<String>emptySet());
     }
 
     public void test92419() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.Bug92419", 123, new HashSet<String>(Arrays.asList(
-                "CreateClass:org.netbeans.test.java.hints.XXXX:[]:CLASS",
-		"CreateInnerClass:org.netbeans.test.java.hints.Bug92419.XXXX:[private, static]:CLASS"
-        )));
+        performTestAnalysisTest("org.netbeans.test.java.hints.Bug92419", 123,
+                Set.of(
+                        "CreateClass:org.netbeans.test.java.hints.XXXX:[]:CLASS",
+                        "CreateInnerClass:org.netbeans.test.java.hints.Bug92419.XXXX:[private, static]:CLASS"
+                )
+        );
     }
 
     public void testConditionalExpression() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.CondExpression", 203, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.CondExpression", 203, Set.of(
                 "AddParameterOrLocalFix:b:boolean:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:b:boolean:PARAMETER",
                 "CreateFieldFix:b:org.netbeans.test.java.hints.CondExpression:boolean:[private]"
-        )));
-        performTestAnalysisTest("org.netbeans.test.java.hints.CondExpression", 235, new HashSet<String>(Arrays.asList(
+        ));
+        performTestAnalysisTest("org.netbeans.test.java.hints.CondExpression", 235, Set.of(
                 "AddParameterOrLocalFix:b:boolean:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:b:boolean:PARAMETER",
                 "CreateFieldFix:b:org.netbeans.test.java.hints.CondExpression:boolean:[private]"
-        )));
-        performTestAnalysisTest("org.netbeans.test.java.hints.CondExpression", 207, new HashSet<String>(Arrays.asList(
+        ));
+        performTestAnalysisTest("org.netbeans.test.java.hints.CondExpression", 207, Set.of(
                 "AddParameterOrLocalFix:d:java.lang.CharSequence:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:d:java.lang.CharSequence:PARAMETER",
                 "CreateFieldFix:d:org.netbeans.test.java.hints.CondExpression:java.lang.CharSequence:[private]"
-        )));
-        performTestAnalysisTest("org.netbeans.test.java.hints.CondExpression", 243, new HashSet<String>(Arrays.asList(
+        ));
+        performTestAnalysisTest("org.netbeans.test.java.hints.CondExpression", 243, Set.of(
                 "AddParameterOrLocalFix:d:java.lang.CharSequence:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:d:java.lang.CharSequence:PARAMETER",
                 "CreateFieldFix:d:org.netbeans.test.java.hints.CondExpression:java.lang.CharSequence:[private]"
-        )));
+        ));
     }
 
     public void testArrayInitializer() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.ArrayInitializer", 210, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.ArrayInitializer", 210, Set.of(
                 "AddParameterOrLocalFix:f:java.io.File:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:f:java.io.File:PARAMETER",
                 "CreateFieldFix:f:org.netbeans.test.java.hints.ArrayInitializer:java.io.File:[private]"
-        )));
-        performTestAnalysisTest("org.netbeans.test.java.hints.ArrayInitializer", 248, new HashSet<String>(Arrays.asList(
+        ));
+        performTestAnalysisTest("org.netbeans.test.java.hints.ArrayInitializer", 248, Set.of(
                 "AddParameterOrLocalFix:f:java.io.File:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:f:java.io.File:PARAMETER",
                 "CreateFieldFix:f:org.netbeans.test.java.hints.ArrayInitializer:java.io.File:[private]"
-        )));
-        performTestAnalysisTest("org.netbeans.test.java.hints.ArrayInitializer", 281, new HashSet<String>(Arrays.asList(
+        ));
+        performTestAnalysisTest("org.netbeans.test.java.hints.ArrayInitializer", 281, Set.of(
                 "AddParameterOrLocalFix:i:int:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:i:int:PARAMETER",
                 "CreateFieldFix:i:org.netbeans.test.java.hints.ArrayInitializer:int:[private]"
-        )));
+        ));
     }
 
     public void test105415() throws Exception {
@@ -329,80 +333,80 @@ public class CreateElementTest extends HintsTestBase {
     }
 
     public void test112846() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.Bug112846", 152, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.Bug112846", 152, Set.of(
                 "AddParameterOrLocalFix:xxx:double[]:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:xxx:double[]:PARAMETER",
                 "CreateFieldFix:xxx:org.netbeans.test.java.hints.Bug112846:double[]:[private]"
-        )));
+        ));
     }
 
     public void test111048() throws Exception {
 	// do not offer to create method in non-writable file/class
 	performTestAnalysisTest("org.netbeans.test.java.hints.Bug111048", 202, Collections.<String>emptySet());
 	// but do it in writable
-	performTestAnalysisTest("org.netbeans.test.java.hints.Bug111048", 231, new HashSet<String>(Arrays.asList(
+	performTestAnalysisTest("org.netbeans.test.java.hints.Bug111048", 231, Set.of(
 		"CreateMethodFix:contains(java.lang.String string)boolean:org.netbeans.test.java.hints.Bug111048"
-        )));
+        ));
 	// do not offer to create field/inner class in non-writable file/class
 	performTestAnalysisTest("org.netbeans.test.java.hints.Bug111048", 261, Collections.<String>emptySet());
-	performTestAnalysisTest("org.netbeans.test.java.hints.Bug111048", 301, new HashSet<String>(Arrays.asList(
+	performTestAnalysisTest("org.netbeans.test.java.hints.Bug111048", 301, Set.of(
 		"CreateInnerClass:org.netbeans.test.java.hints.Bug111048.fieldOrClass:[private]:CLASS",
 		"CreateFieldFix:fieldOrClass:org.netbeans.test.java.hints.Bug111048:java.lang.Object:[private]"
-        )));
+        ));
     }
 
     public void test117431() throws Exception {
         //do not offer same hint more times for a same unknown variable
-        performTestAnalysisTest("org.netbeans.test.java.hints.Bug117431", 155, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.Bug117431", 155, Set.of(
 		"AddParameterOrLocalFix:ii:int:PARAMETER",
 		"CreateFieldFix:ii:org.netbeans.test.java.hints.Bug117431:int:[private, static]",
                 "AddParameterOrLocalFix:ii:int:LOCAL_VARIABLE"
-        )));
+        ));
         //but do offer for a different one
-        performTestAnalysisTest("org.netbeans.test.java.hints.Bug117431", 219, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.Bug117431", 219, Set.of(
                 "AddParameterOrLocalFix:kk:int:PARAMETER",
                 "CreateFieldFix:kk:org.netbeans.test.java.hints.Bug117431:int:[private, static]",
                 "AddParameterOrLocalFix:kk:int:LOCAL_VARIABLE"
-        )));
+        ));
     }
 
     public void testMethodArgument() throws Exception {
         //do not offer same hint more times for a same unknown variable
-        performTestAnalysisTest("org.netbeans.test.java.hints.MethodArgument", 217, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.MethodArgument", 217, Set.of(
 		"AddParameterOrLocalFix:xx:int:PARAMETER",
 		"CreateFieldFix:xx:org.netbeans.test.java.hints.MethodArgument:int:[private, static]",
                 "AddParameterOrLocalFix:xx:int:LOCAL_VARIABLE"
-        )));
+        ));
     }
 
     public void testConstructorArgument() throws Exception {
         //do not offer same hint more times for a same unknown variable
-        performTestAnalysisTest("org.netbeans.test.java.hints.ConstructorArgument", 181, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.ConstructorArgument", 181, Set.of(
 		"AddParameterOrLocalFix:xx:int:PARAMETER",
 		"CreateFieldFix:xx:org.netbeans.test.java.hints.ConstructorArgument:int:[private, static]",
                 "AddParameterOrLocalFix:xx:int:LOCAL_VARIABLE"
-        )));
+        ));
     }
 
     public void testEnumConstant() throws Exception {
         //test hint creating a new enum constant
-        performTestAnalysisTest("org.netbeans.test.java.hints.EnumConstant", 118, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.EnumConstant", 118, Set.of(
                 "CreateEnumConstant:D:org.netbeans.test.java.hints.EnumConstant.Name:org.netbeans.test.java.hints.EnumConstant.Name"
-                )));
+                ));
     }
 
     public void test180111() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.Bug180111", 163, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.Bug180111", 163, Set.of(
                 "CreateMethodFix:create()void:org.netbeans.test.java.hints.Bug180111"
-        )));
+        ));
     }
 
     public void test190447a() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.Bug190447", 107, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.Bug190447", 107, Set.of(
                 "CreateFieldFix:t:org.netbeans.test.java.hints.Bug190447:java.lang.Iterable<? extends java.lang.String>:[private]",
                 "AddParameterOrLocalFix:t:java.lang.Iterable<? extends java.lang.String>:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:t:java.lang.Iterable<? extends java.lang.String>:PARAMETER"
-        )));
+        ));
     }
 
     public void test190447b() throws Exception {
@@ -418,28 +422,28 @@ public class CreateElementTest extends HintsTestBase {
     }
 
     public void test190447d() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.Bug190447", 157, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.Bug190447", 157, Set.of(
                 "CreateFieldFix:t3:org.netbeans.test.java.hints.Bug190447:java.lang.Iterable<? extends E>:[private]",
                 "AddParameterOrLocalFix:t3:java.lang.Iterable<? extends E>:LOCAL_VARIABLE",
                 "AddParameterOrLocalFix:t3:java.lang.Iterable<? extends E>:PARAMETER"
-        )));
+        ));
     }
 
     public void test189687() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.Bug189687", 83, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.Bug189687", 83, Set.of(
                 "CreateFieldFix:ii:org.netbeans.test.java.hints.Bug189687:int:[private]",
                 "AddParameterOrLocalFix:ii:int:LOCAL_VARIABLE"
-        )));
-        performTestAnalysisTest("org.netbeans.test.java.hints.Bug189687", 119, new HashSet<String>(Arrays.asList(
+        ));
+        performTestAnalysisTest("org.netbeans.test.java.hints.Bug189687", 119, Set.of(
                 "CreateFieldFix:ii:org.netbeans.test.java.hints.Bug189687:int:[private, static]",
                 "AddParameterOrLocalFix:ii:int:LOCAL_VARIABLE"
-        )));
+        ));
     }
 
     public void test194625() throws Exception {
-        performTestAnalysisTest("org.netbeans.test.java.hints.CreateConstructor", 160, new HashSet<String>(Arrays.asList(
+        performTestAnalysisTest("org.netbeans.test.java.hints.CreateConstructor", 160, Set.of(
                 "CreateConstructorFix:(java.lang.String string):org.netbeans.test.java.hints.CreateConstructor"
-        )));
+        ));
     }
     
     protected void performTestAnalysisTest(String className, int offset, Set<String> golden) throws Exception {

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ImportClassTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ImportClassTest.java
@@ -102,7 +102,12 @@ public class ImportClassTest extends HintsTestBase {
         return "org/netbeans/modules/java/hints/errors/only-imports-layer.xml";
     }
 
-    private static final Set<String> IGNORED_IMPORTS = new HashSet<String>(Arrays.asList("com.sun.tools.javac.util.List", "com.sun.xml.internal.bind.v2.schemagen.xmlschema.List", "com.sun.xml.internal.ws.policy.privateutil.PolicyUtils.Collections"));
+    private static final Set<String> IGNORED_IMPORTS = Set.of(
+            "com.sun.tools.javac.util.List",
+            "com.sun.xml.internal.bind.v2.schemagen.xmlschema.List",
+            "com.sun.xml.internal.ws.policy.privateutil.PolicyUtils.Collections"
+    );
+
     @Override
     protected boolean includeFix(Fix f) {
         if (!(f instanceof FixImport)) {

--- a/java/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/Utilities.java
+++ b/java/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/project/Utilities.java
@@ -73,8 +73,7 @@ final class Utilities {
     private static final String BUILD_SCRIPT_BACK_UP = "remote-platform-impl_backup";   //NOI18N
     private static final String BUILD_SCRIPT_PROTOTYPE = "/org/netbeans/modules/java/j2seembedded/resources/remote-platform-impl.xml";  //NOI18N
     private static final Map<String,String> CONFIG_PROPERTIES;
-    private static final Set<String> REMOVE_CONFIG_PROPERTIES = Collections.unmodifiableSet(
-        new HashSet<String>(Arrays.asList(new String[] {TARGET_RUN, TARGET_DEBUG, TARGET_PROFILE})));
+    private static final Set<String> REMOVE_CONFIG_PROPERTIES = Set.of(TARGET_RUN, TARGET_DEBUG, TARGET_PROFILE);
 
     private static final String PLATFORM_RUNTIME = "platform.runtime"; //NOI18N
 

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibraryClassPathProvider.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibraryClassPathProvider.java
@@ -45,13 +45,12 @@ import org.openide.util.Exceptions;
 @org.openide.util.lookup.ServiceProvider(service=org.netbeans.spi.java.classpath.ClassPathProvider.class, position=150)
 public class J2SELibraryClassPathProvider implements ClassPathProvider {
     
-    private static final Set<? extends String> SUPPORTED_CLASS_PATH_TYPES =
-            new HashSet<String>(Arrays.asList(new String[]{
-                ClassPath.SOURCE,
-                ClassPath.BOOT,
-                ClassPath.COMPILE,
-                JavaClassPathConstants.MODULE_BOOT_PATH
-            }));
+    private static final Set<? extends String> SUPPORTED_CLASS_PATH_TYPES = Set.of(
+            ClassPath.SOURCE,
+            ClassPath.BOOT,
+            ClassPath.COMPILE,
+            JavaClassPathConstants.MODULE_BOOT_PATH
+    );
 
     public ClassPath findClassPath(
             @NonNull final FileObject file,

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibraryTypeProvider.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibraryTypeProvider.java
@@ -74,11 +74,11 @@ public final class J2SELibraryTypeProvider implements LibraryTypeProvider {
         VOLUME_TYPE_MAVEN_POM
     };
 
-    private static final Set<String> VOLUME_TYPES_REQUIRING_FOLDER = new HashSet<String>(Arrays.asList(new String[] {
+    private static final Set<String> VOLUME_TYPES_REQUIRING_FOLDER = Set.of(
         VOLUME_TYPE_CLASSPATH,
         VOLUME_TYPE_SRC,
-        VOLUME_TYPE_JAVADOC,
-    }));
+        VOLUME_TYPE_JAVADOC
+    );
 
     @Override
     public String getLibraryType() {

--- a/java/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEConfigurationProviderTest.java
+++ b/java/java.j2seproject/test/unit/src/org/netbeans/modules/java/j2seproject/J2SEConfigurationProviderTest.java
@@ -171,21 +171,21 @@ public class J2SEConfigurationProviderTest extends NbTestCase {
         ProjectConfiguration c = configs.get(1);
         assertEquals("debug", c.getDisplayName());
         setActiveConfiguration(pcp, c);
-        assertEquals(new HashSet<String>(Arrays.asList("config", "debug")), l.events());
+        assertEquals(Set.of("config", "debug"), l.events());
         assertEquals("debug", eval.getProperty("config"));
         assertEquals("true", eval.getProperty("debug"));
         assertEquals(null, eval.getProperty("more"));
         c = configs.get(2);
         assertEquals("release", c.getDisplayName());
         setActiveConfiguration(pcp, c);
-        assertEquals(new HashSet<String>(Arrays.asList("config", "debug", "more")), l.events());
+        assertEquals(Set.of("config", "debug", "more"), l.events());
         assertEquals("release", eval.getProperty("config"));
         assertEquals("false", eval.getProperty("debug"));
         assertEquals("stuff", eval.getProperty("more"));
         c = configs.get(0);
         assertEquals("<default config>", c.getDisplayName());
         setActiveConfiguration(pcp, c);
-        assertEquals(new HashSet<String>(Arrays.asList("config", "debug", "more")), l.events());
+        assertEquals(Set.of("config", "debug", "more"), l.events());
         assertEquals(null, eval.getProperty("config"));
         assertEquals(null, eval.getProperty("debug"));
         assertEquals(null, eval.getProperty("more"));
@@ -213,7 +213,7 @@ public class J2SEConfigurationProviderTest extends NbTestCase {
         });
         ProjectManager.mutex().readAccess(new Mutex.ExceptionAction<Void>() {
                 @Override public Void run () throws Exception {
-                    assertEquals(new HashSet<String>(Arrays.asList(ProjectConfigurationProvider.PROP_CONFIGURATIONS, ProjectConfigurationProvider.PROP_CONFIGURATION_ACTIVE)),
+                    assertEquals(Set.of(ProjectConfigurationProvider.PROP_CONFIGURATIONS, ProjectConfigurationProvider.PROP_CONFIGURATION_ACTIVE),
                         l.events());
                     assertEquals(2, pcp.getConfigurations().size());
                     assertEquals("X", pcp.getActiveConfiguration().getDisplayName());

--- a/java/java.platform/src/org/netbeans/modules/java/platform/classpath/PlatformClassPathProvider.java
+++ b/java/java.platform/src/org/netbeans/modules/java/platform/classpath/PlatformClassPathProvider.java
@@ -42,13 +42,12 @@ import org.openide.modules.SpecificationVersion;
 public class PlatformClassPathProvider implements ClassPathProvider {
     private static final SpecificationVersion JAVA_9 = new SpecificationVersion("9");   //NOI18N
 
-    private static final Set<? extends String> SUPPORTED_CLASS_PATH_TYPES =
-            new HashSet<String>(Arrays.asList(new String[]{
-                ClassPath.SOURCE,
-                ClassPath.BOOT,
-                ClassPath.COMPILE,
-                JavaClassPathConstants.MODULE_BOOT_PATH
-            }));
+    private static final Set<? extends String> SUPPORTED_CLASS_PATH_TYPES = Set.of(
+            ClassPath.SOURCE,
+            ClassPath.BOOT,
+            ClassPath.COMPILE,
+            JavaClassPathConstants.MODULE_BOOT_PATH
+    );
 
 
 

--- a/java/java.project.ui/src/org/netbeans/modules/java/project/ui/ProjectProblemsProviders.java
+++ b/java/java.project.ui/src/org/netbeans/modules/java/project/ui/ProjectProblemsProviders.java
@@ -1357,7 +1357,7 @@ public class ProjectProblemsProviders {
             this.platformType = platformType;
             this.minimalVersion = minimalVersion;
             this.platformProp = platformProp;
-            this.versionProps = new HashSet<String>(Arrays.asList(versionProps));
+            this.versionProps = Set.of(versionProps);
         }
 
         @Override

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
@@ -1348,10 +1348,11 @@ public class JavaCustomIndexer extends CustomIndexer {
         return JavaIndex.ensureAttributeValue(root.toURL(), SOURCE_PATH, srcPathStr);
     }
 
-    private static final Set<String> JDK7AndLaterWarnings = new HashSet<String>(Arrays.asList(
+    private static final Set<String> JDK_7_AND_LATER_WARNINGS = Set.of(
             "compiler.warn.diamond.redundant.args", 
             "compiler.warn.diamond.redundant.args.1",
-            "compiler.note.potential.lambda.found"));
+            "compiler.note.potential.lambda.found"
+    );
 
     @CheckForNull
     private static File dumpHeap(@NonNull final String path) {
@@ -1399,7 +1400,7 @@ public class JavaCustomIndexer extends CustomIndexer {
 
     private static class FilterOutJDK7AndLaterWarnings implements Comparable<Diagnostic<? extends JavaFileObject>> {
         @Override public int compareTo(Diagnostic<? extends JavaFileObject> o) {
-            return JDK7AndLaterWarnings.contains(o.getCode()) ? 0 : -1;
+            return JDK_7_AND_LATER_WARNINGS.contains(o.getCode()) ? 0 : -1;
         }
     }
     

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavaPathRecognizer.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavaPathRecognizer.java
@@ -37,10 +37,10 @@ public class JavaPathRecognizer extends PathRecognizer {
 
     private static final Set<String> SOURCES = Collections.singleton(ClassPath.SOURCE);
 
-    private static final Set<String> BINARIES = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(new String[] {
+    private static final Set<String> BINARIES = Set.of(
         ClassPath.BOOT,
         ClassPath.COMPILE
-    })));
+    );
 
     @Override
     public Set<String> getSourcePathIds() {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ProcessorGenerated.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ProcessorGenerated.java
@@ -248,7 +248,7 @@ public final class ProcessorGenerated extends TransactionContext.Service {
             @NonNull Set<? super String> currentResources) {
         if (cachedFile == null) {
             cachedValue = readFile(file);
-            cachedResources = new HashSet<String>(Arrays.asList(cachedValue.toString().split("\n")));  //NOI18N
+            cachedResources = Set.of(cachedValue.toString().split("\n");  //NOI18N
             cachedFile = file;
         }        
         assert cachedValue != null;

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/ClassIndexTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/ClassIndexTest.java
@@ -572,7 +572,7 @@ public class ClassIndexTest extends NbTestCase {
         for (Symbols s : result) {
             actualResult.add(s.getEnclosingType().getQualifiedName() + ":" + s.getSymbols().toString());
         }
-        assertEquals(new HashSet<String>(Arrays.asList("test.foo:[foo]", "test.Test:[foo]")), actualResult);
+        assertEquals(Set.of("test.foo:[foo]", "test.Test:[foo]"), actualResult);
     }
     
     private FileObject createJavaFile (

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/support/ReferencesCountTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/support/ReferencesCountTest.java
@@ -301,6 +301,9 @@ public class ReferencesCountTest extends NbTestCase {
     
     public static class PRImpl extends PathRecognizer {
 
+        private static final Set<String> CLASS_PATH_SET = Set.of(ClassPath.BOOT, ClassPath.COMPILE);
+        private static final Set<String> MIME_TYPES = Set.of(JavaDataLoader.JAVA_MIME_TYPE);
+
         @Override
         public Set<String> getSourcePathIds() {
             return Collections.<String>singleton(ClassPath.SOURCE);
@@ -313,13 +316,12 @@ public class ReferencesCountTest extends NbTestCase {
 
         @Override
         public Set<String> getBinaryLibraryPathIds() {
-            return Collections.unmodifiableSet(
-                    new HashSet<String>(Arrays.asList(ClassPath.BOOT, ClassPath.COMPILE)));
+            return CLASS_PATH_SET;
         }
 
         @Override
         public Set<String> getMimeTypes() {
-            return Collections.<String>singleton(JavaDataLoader.JAVA_MIME_TYPE);
+            return MIME_TYPES;
         }
         
     }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/PostFlowAnalysisTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/PostFlowAnalysisTest.java
@@ -80,7 +80,7 @@ public class PostFlowAnalysisTest extends NbTestCase {
             }
         }, true);
         
-        assertEquals(new HashSet<String>(Arrays.asList(errors)), actual);
+        assertEquals(Set.of(errors), actual);
     }
 
     private FileObject sourceRoot;

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/CompileWorkerTestBase.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/CompileWorkerTestBase.java
@@ -86,11 +86,11 @@ public abstract class CompileWorkerTestBase extends NbTestCase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
         
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test1.sig",
-                                                       "cache/s1/java/15/classes/test/Test1a.sig",
-                                                       "cache/s1/java/15/classes/test/Test2.sig",
-                                                       "cache/s1/java/15/classes/test/Test2a.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test1.sig",
+                        "cache/s1/java/15/classes/test/Test1a.sig",
+                        "cache/s1/java/15/classes/test/Test2.sig",
+                        "cache/s1/java/15/classes/test/Test2a.sig"),
+                createdFiles);
         assertFalse(ErrorsCache.isInError(getRoot(), true));
     }
 
@@ -108,8 +108,7 @@ public abstract class CompileWorkerTestBase extends NbTestCase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         assertFalse(ErrorsCache.isInError(getRoot(), false));
 
         JavaSource js = JavaSource.forFileObject(src.getFileObject("test/Test.java"));

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -89,8 +89,8 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test3.sig",
-                                                       "cache/s1/java/15/classes/test/Test4.sig")), createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test3.sig",
+                "cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         result = runIndexing(Arrays.asList(compileTuple("test/Test4.java", "package test; public class Test4 { void t() { Undef undef; } }")),
                              Collections.emptyList());
 
@@ -111,7 +111,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")), createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
     }
 
     public void testRepair2() throws Exception {
@@ -127,7 +127,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")), createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -144,7 +144,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")), createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -161,7 +161,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")), createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -178,9 +178,9 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig",
-                                                       "cache/s1/java/15/classes/test/Test4$1.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig",
+                        "cache/s1/java/15/classes/test/Test4$1.sig"),
+                createdFiles);
         //TODO: check file content!!!
     }
 
@@ -197,8 +197,8 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig",
-                                                       "cache/s1/java/15/classes/test/Test4$1.sig")),
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig",
+                        "cache/s1/java/15/classes/test/Test4$1.sig"),
                      createdFiles);
         //TODO: check file content!!!
     }
@@ -216,8 +216,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -234,8 +233,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -255,8 +253,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
     }
 
     public void testErroneousMethodClassNETBEANS_224() throws Exception {
@@ -275,10 +272,10 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test1.sig",
-                                                       "cache/s1/java/15/classes/test/Test2.sig",
-                                                       "cache/s1/java/15/classes/test/Test3.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test1.sig",
+                        "cache/s1/java/15/classes/test/Test2.sig",
+                        "cache/s1/java/15/classes/test/Test3.sig"),
+                createdFiles);
     }
 
     public void testRepairFieldBrokenGenerics() throws Exception {
@@ -294,7 +291,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")), createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -311,8 +308,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -332,8 +328,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -352,8 +347,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -370,8 +364,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -388,8 +381,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -406,8 +398,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/java/lang/Object.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/java/lang/Object.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -425,8 +416,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test4.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -445,9 +435,9 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Additional.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Additional.sig",
+                        "cache/s1/java/15/classes/test/Test.sig"),
+                createdFiles);
         //TODO: check file content!!!
     }
 
@@ -480,24 +470,26 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.put(getWorkDir().toURI().relativize(created.toURI()).getPath(), created);
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/AnnUse.sig",
-                                                       "cache/s1/java/15/classes/test/FirstAnnBroken.sig",
-                                                       "cache/s1/java/15/classes/test/FirstTwoAnnBroken.sig",
-                                                       "cache/s1/java/15/classes/test/FirstAnnOK.sig",
-                                                       "cache/s1/java/15/classes/test/Ann1.sig",
-                                                       "cache/s1/java/15/classes/test/Ann2.sig",
-                                                       "cache/s1/java/15/classes/test/Ann3.sig",
-                                                       "cache/s1/java/15/classes/test/Ann4.sig",
-                                                       "cache/s1/java/15/classes/test/Ann5.sig",
-                                                       "cache/s1/java/15/classes/test/Ann6.sig",
-                                                       "cache/s1/java/15/classes/test/AnnExtra.sig",
-                                                       "cache/s1/java/15/classes/test/EnumExtra.sig",
-                                                       "cache/s1/java/15/classes/test/MiddleBroken.sig",
-                                                       "cache/s1/java/15/classes/test/WrongType.sig",
-                                                       "cache/s1/java/15/classes/test/Additional.sig",
-                                                       "cache/s1/java/15/classes/test/WrongDefault.sig",
-                                                       "cache/s1/java/15/classes/test/ManyWrongTrailing.sig")),
-                     createdFiles.keySet());
+        assertEquals(Set.of(
+                        "cache/s1/java/15/classes/test/AnnUse.sig",
+                        "cache/s1/java/15/classes/test/FirstAnnBroken.sig",
+                        "cache/s1/java/15/classes/test/FirstTwoAnnBroken.sig",
+                        "cache/s1/java/15/classes/test/FirstAnnOK.sig",
+                        "cache/s1/java/15/classes/test/Ann1.sig",
+                        "cache/s1/java/15/classes/test/Ann2.sig",
+                        "cache/s1/java/15/classes/test/Ann3.sig",
+                        "cache/s1/java/15/classes/test/Ann4.sig",
+                        "cache/s1/java/15/classes/test/Ann5.sig",
+                        "cache/s1/java/15/classes/test/Ann6.sig",
+                        "cache/s1/java/15/classes/test/AnnExtra.sig",
+                        "cache/s1/java/15/classes/test/EnumExtra.sig",
+                        "cache/s1/java/15/classes/test/MiddleBroken.sig",
+                        "cache/s1/java/15/classes/test/WrongType.sig",
+                        "cache/s1/java/15/classes/test/Additional.sig",
+                        "cache/s1/java/15/classes/test/WrongDefault.sig",
+                        "cache/s1/java/15/classes/test/ManyWrongTrailing.sig"
+                ),
+                createdFiles.keySet());
         assertAnnotations("@test.Ann5 runtimeVisible=false",
                           createdFiles.get("cache/s1/java/15/classes/test/FirstAnnBroken.sig"));
         assertAnnotations("@test.Ann5 runtimeVisible=false",
@@ -527,8 +519,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/package-info.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/package-info.sig"), createdFiles);
         //TODO: check file content!!!
     }
 
@@ -545,9 +536,9 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig",
-                                                            "cache/s1/java/15/classes/test/Test$1.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig",
+                        "cache/s1/java/15/classes/test/Test$1.sig"),
+                createdFiles);
         ClasspathInfo cpInfo = ClasspathInfo.create(ClassPath.EMPTY, ClassPath.EMPTY, ClassPathSupport.createClassPath(getRoot()));
         Set<ElementHandle<TypeElement>> classIndexResult = cpInfo.getClassIndex().getElements(ElementHandle.createTypeElementHandle(ElementKind.ENUM, "test.Test"), EnumSet.of(SearchKind.IMPLEMENTORS), EnumSet.of(ClassIndex.SearchScope.SOURCE));
         assertEquals(1, classIndexResult.size());
@@ -574,12 +565,12 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig",
-                                                            "cache/s1/java/15/classes/test/Test$1.sig",
-                                                            "cache/s1/java/15/classes/test/Test$2.sig",
-                                                            "cache/s1/java/15/classes/test/Test$3.sig",
-                                                            "cache/s1/java/15/classes/test/Test$4.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig",
+                        "cache/s1/java/15/classes/test/Test$1.sig",
+                        "cache/s1/java/15/classes/test/Test$2.sig",
+                        "cache/s1/java/15/classes/test/Test$3.sig",
+                        "cache/s1/java/15/classes/test/Test$4.sig"),
+                createdFiles);
         ClasspathInfo cpInfo = ClasspathInfo.create(ClassPath.EMPTY, ClassPath.EMPTY, ClassPathSupport.createClassPath(getRoot()));
         Set<ElementHandle<TypeElement>> classIndexResult = cpInfo.getClassIndex().getElements(ElementHandle.createTypeElementHandle(ElementKind.INTERFACE, "java.lang.Runnable"), EnumSet.of(SearchKind.IMPLEMENTORS), EnumSet.of(ClassIndex.SearchScope.SOURCE));
         assertEquals(4, classIndexResult.size());
@@ -613,8 +604,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig")), createdFiles);
     }
 
     public void testBasedAnonymous() throws Exception {
@@ -638,10 +628,10 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig",
-                                                       "cache/s1/java/15/classes/test/Test$Inner.sig",
-                                                       "cache/s1/java/15/classes/test/Test$1.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig",
+                        "cache/s1/java/15/classes/test/Test$Inner.sig",
+                        "cache/s1/java/15/classes/test/Test$1.sig"),
+                createdFiles);
     }
 
     public void testPreserveValidMethods1() throws Exception {
@@ -670,8 +660,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -714,8 +703,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -763,8 +751,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -820,8 +807,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"),createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -865,8 +851,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -914,8 +899,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -964,8 +948,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1015,8 +998,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1078,10 +1060,10 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test$1.sig",
-                                                       "cache/s1/java/15/classes/test/Test$1$1.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test$1.sig",
+                        "cache/s1/java/15/classes/test/Test$1$1.sig",
+                        "cache/s1/java/15/classes/test/Test.sig"),
+                createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1147,8 +1129,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1200,10 +1181,10 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test$1.sig",
-                                                       "cache/s1/java/15/classes/test/Test$N.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test$1.sig",
+                        "cache/s1/java/15/classes/test/Test$N.sig",
+                        "cache/s1/java/15/classes/test/Test.sig"),
+                createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1270,8 +1251,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1318,8 +1298,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1370,10 +1349,10 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test$1.sig",
-                                                       "cache/s1/java/15/classes/test/Test$Prop.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test$1.sig",
+                        "cache/s1/java/15/classes/test/Test$Prop.sig",
+                        "cache/s1/java/15/classes/test/Test.sig"),
+                createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1442,9 +1421,9 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test$T.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test$T.sig",
+                        "cache/s1/java/15/classes/test/Test.sig"),
+                createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1521,11 +1500,11 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test$1.sig",
-                                                       "cache/s1/java/15/classes/test/Test$N.sig",
-                                                       "cache/s1/java/15/classes/test/Test$1$1.sig",
-                                                       "cache/s1/java/15/classes/test/Test$1$2.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")),
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test$1.sig",
+                        "cache/s1/java/15/classes/test/Test$N.sig",
+                        "cache/s1/java/15/classes/test/Test$1$1.sig",
+                        "cache/s1/java/15/classes/test/Test$1$2.sig",
+                        "cache/s1/java/15/classes/test/Test.sig"),
                      createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
@@ -1623,12 +1602,12 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test$1.sig",
-                                                       "cache/s1/java/15/classes/test/Test$2.sig",
-                                                       "cache/s1/java/15/classes/test/Test$2$1.sig",
-                                                       "cache/s1/java/15/classes/test/Test$1$1.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test$1.sig",
+                        "cache/s1/java/15/classes/test/Test$2.sig",
+                        "cache/s1/java/15/classes/test/Test$2$1.sig",
+                        "cache/s1/java/15/classes/test/Test$1$1.sig",
+                        "cache/s1/java/15/classes/test/Test.sig"),
+                createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1726,10 +1705,10 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test$1.sig",
-                                                       "cache/s1/java/15/classes/test/Test$N.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test$1.sig",
+                        "cache/s1/java/15/classes/test/Test$N.sig",
+                        "cache/s1/java/15/classes/test/Test.sig"),
+                createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1791,8 +1770,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1843,10 +1821,10 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/SuperIntf.sig",
-                                                       "cache/s1/java/15/classes/test/SuperClass.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/SuperIntf.sig",
+                        "cache/s1/java/15/classes/test/SuperClass.sig",
+                        "cache/s1/java/15/classes/test/Test.sig"),
+                createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1906,8 +1884,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
-                     createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Test.sig"), createdFiles);
         Map<String, String> expected = Collections.singletonMap("test/Test.java",
                 "package test;\n" +
                 "\n" +
@@ -1948,10 +1925,10 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Rect.sig",
-                                                       "cache/s1/java/15/classes/test/ColoredPoint.sig",
-                                                       "cache/s1/java/15/classes/test/Point.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")), createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Rect.sig",
+                "cache/s1/java/15/classes/test/ColoredPoint.sig",
+                "cache/s1/java/15/classes/test/Point.sig",
+                "cache/s1/java/15/classes/test/Test.sig"), createdFiles);
     }
 
     public void testEnhancedSwitch1() throws Exception {
@@ -1982,10 +1959,10 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Rect.sig",
-                                                       "cache/s1/java/15/classes/test/ColoredPoint.sig",
-                                                       "cache/s1/java/15/classes/test/Point.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")), createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Rect.sig",
+                "cache/s1/java/15/classes/test/ColoredPoint.sig",
+                "cache/s1/java/15/classes/test/Point.sig",
+                "cache/s1/java/15/classes/test/Test.sig"), createdFiles);
     }
 
     public void testEnhancedSwitch2() throws Exception {
@@ -2016,10 +1993,10 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Rect.sig",
-                                                       "cache/s1/java/15/classes/test/ColoredPoint.sig",
-                                                       "cache/s1/java/15/classes/test/Point.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")), createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Rect.sig",
+                "cache/s1/java/15/classes/test/ColoredPoint.sig",
+                "cache/s1/java/15/classes/test/Point.sig",
+                "cache/s1/java/15/classes/test/Test.sig"), createdFiles);
     }
 
     public void testEnhancedSwitch3() throws Exception {
@@ -2050,10 +2027,10 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
         }
 
-        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Rect.sig",
-                                                       "cache/s1/java/15/classes/test/ColoredPoint.sig",
-                                                       "cache/s1/java/15/classes/test/Point.sig",
-                                                       "cache/s1/java/15/classes/test/Test.sig")), createdFiles);
+        assertEquals(Set.of("cache/s1/java/15/classes/test/Rect.sig",
+                "cache/s1/java/15/classes/test/ColoredPoint.sig",
+                "cache/s1/java/15/classes/test/Point.sig",
+                "cache/s1/java/15/classes/test/Test.sig"), createdFiles);
     }
 
     public static void noop() {}

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
@@ -256,7 +256,7 @@ public class JavacParserTest extends NbTestCase {
                     codes.add(d.getCode());
                 }
 
-                assertEquals(new HashSet<String>(Arrays.asList("compiler.warn.missing.SVUID", "compiler.err.does.not.override.abstract")), codes);
+                assertEquals(Set.of("compiler.warn.missing.SVUID", "compiler.err.does.not.override.abstract"), codes);
             }
         }, true);
         

--- a/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBClassWriterTest.java
+++ b/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBClassWriterTest.java
@@ -120,7 +120,7 @@ public class NBClassWriterTest extends NbTestCase {
             actualClassNames.add(ct.getElements().getBinaryName(te).toString());
         }
 
-        if (!new HashSet<String>(Arrays.asList(expectedClassNames)).equals(actualClassNames)) {
+        if (!Set.of(expectedClassNames).equals(actualClassNames)) {
             throw new AssertionError(actualClassNames.toString());
         }
     }

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/errors/EnablePreviewMavenProj.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/errors/EnablePreviewMavenProj.java
@@ -61,14 +61,15 @@ import org.openide.filesystems.FileSystem;
  */
 public class EnablePreviewMavenProj implements ErrorRule<Void> {
 
-    private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> ERROR_CODES = Set.of(
             "compiler.err.preview.feature.disabled",
-            "compiler.err.preview.feature.disabled.plural")); // NOI18N
+            "compiler.err.preview.feature.disabled.plural"
+    ); // NOI18N
     private static final String ENABLE_PREVIEW_FLAG = "--enable-preview";   // NOI18N
 
     @Override
     public Set<String> getCodes() {
-        return Collections.unmodifiableSet(ERROR_CODES);
+        return ERROR_CODES;
     }
 
     @Override

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/errors/SearchClassDependencyInRepo.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/errors/SearchClassDependencyInRepo.java
@@ -92,15 +92,17 @@ public class SearchClassDependencyInRepo implements ErrorRule<Void> {
     public SearchClassDependencyInRepo() {
     }
 
+    private static final Set<String> CODES = Set.of(
+            MODULE_DOES_NOT_READ,
+            "compiler.err.cant.resolve",//NOI18N
+            "compiler.err.cant.resolve.location",//NOI18N
+            "compiler.err.doesnt.exist",//NOI18N
+            "compiler.err.not.stmt"
+    );//NOI18N
+
     @Override
     public Set<String> getCodes() {
-        return new HashSet<String>(Arrays.asList(
-                MODULE_DOES_NOT_READ, 
-                "compiler.err.cant.resolve",//NOI18N
-                "compiler.err.cant.resolve.location",//NOI18N
-                "compiler.err.doesnt.exist",//NOI18N
-                "compiler.err.not.stmt"));//NOI18N
-
+        return CODES;
     }
 
     @Override

--- a/java/spi.debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/apiregistry/DebuggerProcessor.java
+++ b/java/spi.debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/apiregistry/DebuggerProcessor.java
@@ -51,10 +51,12 @@ public class DebuggerProcessor extends LayerGeneratingProcessor {
 
     public static final String SERVICE_NAME = "serviceName"; // NOI18N
 
-    public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
             VariablesFilter.Registration.class.getCanonicalName()
-        ));
+    );
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/java/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchSearchTest.java
+++ b/java/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchSearchTest.java
@@ -160,7 +160,7 @@ public class BatchSearchTest extends NbTestCase {
             snipets.add(code.substring(span[0], span[1]));
         }
 
-        Set<String> golden = new HashSet<String>(Arrays.asList("c.i().getFileObject(\"\")"));
+        Set<String> golden = Set.of("c.i().getFileObject(\"\")");
         assertEquals(golden, snipets);
     }
 
@@ -233,7 +233,7 @@ public class BatchSearchTest extends NbTestCase {
 
         Map<String, Iterable<String>> golden = new HashMap<String, Iterable<String>>();
 
-        golden.put(data.toURL().toExternalForm(), new HashSet<String>(Arrays.asList("src1/test/Test1.java", "src2/test/Test1.java")));
+        golden.put(data.toURL().toExternalForm(), Set.of("src1/test/Test1.java", "src2/test/Test1.java"));
 
         assertEquals(golden, output);
 
@@ -288,7 +288,7 @@ public class BatchSearchTest extends NbTestCase {
         Map<String, Iterable<String>> output = toDebugOutput(result);
         Map<String, Iterable<String>> golden = new HashMap<String, Iterable<String>>();
 
-        golden.put(data.toURL().toExternalForm(), new HashSet<String>(Arrays.asList("src1/test/Test1.java", "src2/test/Test1.java")));
+        golden.put(data.toURL().toExternalForm(), Set.of("src1/test/Test1.java", "src2/test/Test1.java"));
 
         assertEquals(golden, output);
     }

--- a/java/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/BulkSearchTestPerformer.java
+++ b/java/spi.java.hints/test/unit/src/org/netbeans/modules/java/hints/spiimpl/pm/BulkSearchTestPerformer.java
@@ -530,7 +530,7 @@ public abstract class BulkSearchTestPerformer extends NbTestCase {
 
         BulkPattern bp = createSearch().create(info, new AtomicBoolean(), "$0.isDirectory()");
 
-        assertEquals(Arrays.asList(new HashSet<String>(Arrays.asList("isDirectory"))), bp.getIdentifiers());
+        assertEquals(List.of("isDirectory"), bp.getIdentifiers());
         //TODO: the actual code for kinds differs for NFABased search and REBased search:
 //        assertEquals(Arrays.asList(new HashSet<String>(Arrays.asList(Kind.METHOD_INVOCATION.name()))), bp.getKinds());
     }

--- a/java/spring.beans/src/org/netbeans/modules/spring/api/beans/SpringAnnotations.java
+++ b/java/spring.beans/src/org/netbeans/modules/spring/api/beans/SpringAnnotations.java
@@ -18,9 +18,6 @@
  */
 package org.netbeans.modules.spring.api.beans;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -30,11 +27,10 @@ import java.util.Set;
  */
 public final class SpringAnnotations {
 
-    public static final Set<String> SPRING_COMPONENTS = Collections.unmodifiableSet(
-            new HashSet<String>(Arrays.asList(
+    public static final Set<String> SPRING_COMPONENTS = Set.of(
             "org.springframework.stereotype.Component", //NOI18N
             "org.springframework.stereotype.Controller", //NOI18N
             "org.springframework.stereotype.Repository", //NOI18N
             "org.springframework.stereotype.Service" //NOI18N
-            )));
+    );
 }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeOSGi.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeOSGi.java
@@ -882,15 +882,15 @@ public class MakeOSGi extends Task {
         "org.xml.sax.helpers"
     ));
 
-    private static final Set<String> SKIPPED_PSEUDO_MODULES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> SKIPPED_PSEUDO_MODULES = Set.of(
             "org.eclipse.osgi",
             "org.netbeans.core.netigso",
             "org.netbeans.modules.netbinox",
             "org.netbeans.libs.osgi",
             "org.netbeans.libs.felix"
-    ));
+    );
 
-    private static final Set<String> STARTUP_PSEUDO_MODULES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> STARTUP_PSEUDO_MODULES = Set.of(
             "org.openide.util.lookup",
             "org.openide.util.ui",
             "org.openide.util",
@@ -902,6 +902,6 @@ public class MakeOSGi extends Task {
             "org.netbeans.core.startup.base",
             "org.netbeans.core.osgi",
             "org.eclipse.osgi"
-    ));
+    );
 
 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/HintErrorRule.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/HintErrorRule.java
@@ -28,9 +28,11 @@ import org.netbeans.modules.csl.api.Hint;
  */
 public abstract class HintErrorRule extends ErrorRule implements InvokableRule<Hint> {
 
+    private static final Set<?> CODES = Set.of(PHPHintsProvider.ErrorType.HINT_ERRORS);
+
     @Override
     public Set<?> getCodes() {
-        return Collections.singleton(PHPHintsProvider.ErrorType.HINT_ERRORS);
+        return CODES;
     }
 
 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/UnhandledErrorRule.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/UnhandledErrorRule.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.php.editor.verification;
 
-import java.util.Collections;
 import java.util.Set;
 import org.netbeans.modules.csl.api.Error;
 
@@ -28,9 +27,11 @@ import org.netbeans.modules.csl.api.Error;
  */
 public abstract class UnhandledErrorRule extends ErrorRule implements InvokableRule<Error> {
 
+    private static final Set<?> CODES = Set.of(PHPHintsProvider.ErrorType.UNHANDLED_ERRORS);
+
     @Override
     public Set<?> getCodes() {
-        return Collections.singleton(PHPHintsProvider.ErrorType.UNHANDLED_ERRORS);
+        return CODES;
     }
 
 }

--- a/php/php.smarty/src/org/netbeans/modules/php/smarty/editor/TplSyntax.java
+++ b/php/php.smarty/src/org/netbeans/modules/php/smarty/editor/TplSyntax.java
@@ -37,7 +37,7 @@ public class TplSyntax {
     /**
      * List of all tags which introduce block of code.
      */
-    public static final Set<String> BLOCK_TAGS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
+    public static final Set<String> BLOCK_TAGS = Set.of(
             "block", //NOI18N
             "capture", //NOI18N
             "for", //NOI18N
@@ -50,25 +50,25 @@ public class TplSyntax {
             "section", //NOI18N
             "setfilter", //NOI18N
             "strip", //NOI18N
-            "while"))); //NOI18N
+            "while"
+    ); //NOI18N
     /**
      * List of all tags which are else-typed.
      */
-    public static final Set<String> ELSE_TAGS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
+    public static final Set<String> ELSE_TAGS = Set.of(
             "foreachelse", //NOI18N
             "elseif", //NOI18N
             "else", //NOI18N
-            "sectionelse"))); //NOI18N
+            "sectionelse"
+    ); //NOI18N
     /**
      * Mapping of non-else tag to else-like tags. To every else tag must correspond at least one normal tag.
      */
-    public static final Map<String, Set<String>> RELATED_TAGS = Collections.unmodifiableMap(new HashMap<String, Set<String>>() {
-        {
-            put("if", new HashSet<String>(Arrays.asList("else", "elseif"))); //NOI18N
-            put("foreach", new HashSet<String>(Arrays.asList("foreachelse"))); //NOI18N
-            put("section", new HashSet<String>(Arrays.asList("sectionelse"))); //NOI18N
-        }
-    });
+    public static final Map<String, Set<String>> RELATED_TAGS = Map.of(
+            "if", Set.of("else", "elseif"), //NOI18N
+            "foreach", Set.of("foreachelse"), //NOI18N
+            "section", Set.of("sectionelse") //NOI18N
+    );
 
     /**
      * Gets information whether the given command is block command.

--- a/platform/api.annotations.common/src/org/netbeans/api/annotations/common/proc/StaticResourceProcessor.java
+++ b/platform/api.annotations.common/src/org/netbeans/api/annotations/common/proc/StaticResourceProcessor.java
@@ -45,22 +45,22 @@ import org.netbeans.api.annotations.common.StaticResource;
 
 public class StaticResourceProcessor extends AbstractProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            // org.netbeans.api.annotations.common annotations
+            CheckForNull.class.getCanonicalName(),
+            CheckReturnValue.class.getCanonicalName(),
+            NonNull.class.getCanonicalName(),
+            NullAllowed.class.getCanonicalName(),
+            NullUnknown.class.getCanonicalName(),
+            StaticResource.class.getCanonicalName(),
+            SuppressWarnings.class.getCanonicalName(),
+
+            // other well-known Java platform annotations
+            SupportedAnnotationTypes.class.getCanonicalName()
+    );
+
     public @Override Set<String> getSupportedAnnotationTypes() {
-        TreeSet<String> all = new TreeSet<>();
-
-        // org.netbeans.api.annotations.common annotations
-        all.add(CheckForNull.class.getCanonicalName());
-        all.add(CheckReturnValue.class.getCanonicalName());
-        all.add(NonNull.class.getCanonicalName());
-        all.add(NullAllowed.class.getCanonicalName());
-        all.add(NullUnknown.class.getCanonicalName());
-        all.add(StaticResource.class.getCanonicalName());
-        all.add(SuppressWarnings.class.getCanonicalName());
-
-        // other well-known Java platform annotations
-        all.add(SupportedAnnotationTypes.class.getCanonicalName());
-
-        return all;
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/platform/api.htmlui/src/org/netbeans/modules/htmlui/HTMLDialogProcessor.java
+++ b/platform/api.htmlui/src/org/netbeans/modules/htmlui/HTMLDialogProcessor.java
@@ -62,12 +62,15 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = Processor.class)
 public class HTMLDialogProcessor extends AbstractProcessor
 implements Comparator<ExecutableElement> {
+
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            HTMLDialog.class.getCanonicalName(),
+            HTMLComponent.class.getCanonicalName()
+    );
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        Set<String> hash = new HashSet<>();
-        hash.add(HTMLDialog.class.getCanonicalName());
-        hash.add(HTMLComponent.class.getCanonicalName());
-        return hash;
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/platform/api.htmlui/src/org/netbeans/modules/htmlui/HTMLViewProcessor.java
+++ b/platform/api.htmlui/src/org/netbeans/modules/htmlui/HTMLViewProcessor.java
@@ -41,11 +41,14 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service = Processor.class)
 public class HTMLViewProcessor extends LayerGeneratingProcessor {
+
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            OpenHTMLRegistration.class.getCanonicalName()
+    );
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        Set<String> hash = new HashSet<>();
-        hash.add(OpenHTMLRegistration.class.getCanonicalName());
-        return hash;
+        return ANNOTATION_TYPES;
     }
     
     @Override

--- a/platform/api.templates/src/org/netbeans/modules/templates/TemplateProcessor.java
+++ b/platform/api.templates/src/org/netbeans/modules/templates/TemplateProcessor.java
@@ -51,8 +51,13 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class TemplateProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            TemplateRegistration.class.getCanonicalName(),
+            TemplateRegistrations.class.getCanonicalName()
+    );
+
     @Override public Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<>(Arrays.asList(TemplateRegistration.class.getCanonicalName(), TemplateRegistrations.class.getCanonicalName()));
+        return ANNOTATION_TYPES;
     }
 
     @Override protected boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewProcessor.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewProcessor.java
@@ -49,10 +49,13 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 public class MultiViewProcessor extends LayerGeneratingProcessor {
-    public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
+
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
             MultiViewElement.Registration.class.getCanonicalName()
-        ));
+    );
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/platform/core.startup/src/org/netbeans/core/startup/InstalledFileLocatorImpl.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/InstalledFileLocatorImpl.java
@@ -375,7 +375,7 @@ public final class InstalledFileLocatorImpl extends InstalledFileLocator {
                 if (isDir) {
                     String[] kids = d.list();
                     if (kids != null) {
-                        fileCachePerPrefix.put(root, new HashSet<String>(Arrays.asList(kids)));
+                        fileCachePerPrefix.put(root, Set.of(kids));
                     } else {
                         Util.err.log(Level.WARNING, "could not read files in {0} at {1}", new Object[] {d, findCaller()});
                     }

--- a/platform/javahelp/src/org/netbeans/modules/javahelp/HelpSetRegistrationProcessor.java
+++ b/platform/javahelp/src/org/netbeans/modules/javahelp/HelpSetRegistrationProcessor.java
@@ -60,8 +60,10 @@ import org.xml.sax.SAXException;
 @ServiceProvider(service=Processor.class)
 public class HelpSetRegistrationProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(HelpSetRegistration.class.getCanonicalName());
+
     public @Override Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(HelpSetRegistration.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     protected @Override boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {
@@ -129,7 +131,7 @@ public class HelpSetRegistrationProcessor extends LayerGeneratingProcessor {
                             try {
                                 PrintWriter pw = new PrintWriter(os);
                                 pw.println("IndexRemove " + d + File.separator);
-                                scan(d, pw, cnt, new HashSet<String>(Arrays.asList(r.excludes())), "");
+                                scan(d, pw, cnt, Set.of(r.excludes()), "");
                                 pw.flush();
                             } finally {
                                 os.close();

--- a/platform/libs.junit4/src/org/netbeans/libs/junit4/NbJUnitProcessor.java
+++ b/platform/libs.junit4/src/org/netbeans/libs/junit4/NbJUnitProcessor.java
@@ -32,21 +32,20 @@ public final class NbJUnitProcessor extends AbstractProcessor {
         return true;
     }
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            org.junit.After.class.getCanonicalName(),
+            org.junit.AfterClass.class.getCanonicalName(),
+            org.junit.Before.class.getCanonicalName(),
+            org.junit.BeforeClass.class.getCanonicalName(),
+            org.junit.ClassRule.class.getCanonicalName(),
+            org.junit.FixMethodOrder.class.getCanonicalName(),
+            org.junit.Ignore.class.getCanonicalName(),
+            org.junit.Rule.class.getCanonicalName(),
+            org.junit.Test.class.getCanonicalName()
+    );
+
     public Set<String> getSupportedAnnotationTypes() {
-        TreeSet<String> all = new TreeSet<>();
-
-        // org.junit annotations
-        all.add(org.junit.After.class.getCanonicalName());
-        all.add(org.junit.AfterClass.class.getCanonicalName());
-        all.add(org.junit.Before.class.getCanonicalName());
-        all.add(org.junit.BeforeClass.class.getCanonicalName());
-        all.add(org.junit.ClassRule.class.getCanonicalName());
-        all.add(org.junit.FixMethodOrder.class.getCanonicalName());
-        all.add(org.junit.Ignore.class.getCanonicalName());
-        all.add(org.junit.Rule.class.getCanonicalName());
-        all.add(org.junit.Test.class.getCanonicalName());
-
-        return all;
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/BaseFileObjectTestHid.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/BaseFileObjectTestHid.java
@@ -63,9 +63,8 @@ import org.openide.util.io.NbMarshalledObject;
 
 
 public class BaseFileObjectTestHid extends TestBaseHid{
-    public static final HashSet<String> AUTOMOUNT_SET = new HashSet<String>(Arrays.asList("set", "shared", "net", "java", "share", "home", "ws", "ade_autofs"));
-    private static final Set<String> REMOTE_FSTYPES = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
-    "nfs", "nfs4","autofs")));  //NOI18N
+    public static final Set<String> AUTOMOUNT_SET = Set.of("set", "shared", "net", "java", "share", "home", "ws", "ade_autofs");
+    private static final Set<String> REMOTE_FSTYPES = Set.of("nfs", "nfs4","autofs");  //NOI18N
     private static final boolean CHECK_REMOTE_FSTYPES = true;
     private FileObject root;
     private Logger LOG;

--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -658,11 +658,13 @@ public final class ModuleManager extends Modules {
             return allPermissions;
         }
 
-        private final Set<String> JRE_PROVIDED_FACTORIES = new HashSet<String>(Arrays.asList(
+        private final Set<String> JRE_PROVIDED_FACTORIES = Set.of(
                 "META-INF/services/javax.xml.parsers.SAXParserFactory", // NOI18N
                 "META-INF/services/javax.xml.parsers.DocumentBuilderFactory", // NOI18N
                 "META-INF/services/javax.xml.transform.TransformerFactory", // NOI18N
-                "META-INF/services/javax.xml.validation.SchemaFactory")); // NOI18N
+                "META-INF/services/javax.xml.validation.SchemaFactory"
+        ); // NOI18N
+
         @Override
         public InputStream getResourceAsStream(String name) {
             if (JRE_PROVIDED_FACTORIES.contains(name)) {

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerTest.java
@@ -1634,12 +1634,12 @@ public class ModuleManagerTest extends SetupHid {
             "prov-foo-req-bar.jar",
         };
         // Never make any of the following eager:
-        Set<String> noDepsNames = new HashSet<String>(Arrays.asList(
+        Set<String> noDepsNames = Set.of(
             "simple-module.jar",
             "prov-foo.jar",
             "prov-baz.jar",
             "prov-foo-bar.jar"
-        ));
+        );
         List<String> freeModules = new ArrayList<String>(Arrays.asList(moduleNames));
         int count = 100; // # of things to do in order
         Random r = new Random(count * 17 + 113);

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ColumnSelectionPanel.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ColumnSelectionPanel.java
@@ -30,16 +30,7 @@ import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.Collator;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.ResourceBundle;
+import java.util.*;
 import javax.swing.JCheckBox;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JComponent;
@@ -386,11 +377,13 @@ class ColumnSelectionPanel extends JPanel {
      * changes to the visible column for the given table.
      */
     private static void makeVisibleColumns(ETable table, String[] visibleColumns) {
-        HashSet<String> visible = new HashSet<String>(Arrays.asList(visibleColumns));
         TableColumnModel columnModel = table.getColumnModel();
         if (! (columnModel instanceof ETableColumnModel)) {
             return;
         }
+
+        Set<String> visible = Set.of(visibleColumns);
+
         final ETableColumnModel etcm = (ETableColumnModel)columnModel;
         List<TableColumn> columns = etcm.getAllColumns();
         Collections.sort(columns, ETableColumnComparator.DEFAULT);

--- a/platform/openide.awt/src/org/netbeans/modules/openide/awt/ActionProcessor.java
+++ b/platform/openide.awt/src/org/netbeans/modules/openide/awt/ActionProcessor.java
@@ -78,15 +78,16 @@ public final class ActionProcessor extends LayerGeneratingProcessor {
     private static final String[] DEFAULT_COMPLETIONS = { "Menu", "Toolbars", "Shortcuts", "Loaders" }; // NOI18N
     private Processor COMPLETIONS;
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            ActionRegistration.class.getCanonicalName(),
+            ActionID.class.getCanonicalName(),
+            ActionReference.class.getCanonicalName(),
+            ActionReferences.class.getCanonicalName()
+    );
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        Set<String> hash = new HashSet<String>();
-        hash.add(ActionRegistration.class.getCanonicalName());
-        hash.add(ActionID.class.getCanonicalName());
-        hash.add(ActionReference.class.getCanonicalName());
-        hash.add(ActionReferences.class.getCanonicalName());
-//        hash.add(ActionState.class.getCanonicalName());
-        return hash;
+        return ANNOTATION_TYPES;
     }
     
     @Override

--- a/platform/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessor.java
+++ b/platform/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessor.java
@@ -49,13 +49,15 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class MIMEResolverProcessor extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            MIMEResolver.Registration.class.getCanonicalName(),
+            MIMEResolver.ExtensionRegistration.class.getCanonicalName(),
+            MIMEResolver.NamespaceRegistration.class.getCanonicalName()
+    );
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        Set<String> set = new HashSet<String>();
-        set.add(MIMEResolver.Registration.class.getCanonicalName());
-        set.add(MIMEResolver.ExtensionRegistration.class.getCanonicalName());
-        set.add(MIMEResolver.NamespaceRegistration.class.getCanonicalName());
-        return set;
+        return ANNOTATION_TYPES;
     }
     
     

--- a/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
@@ -773,7 +773,7 @@ final class MultiFileObject extends AbstractFolder implements FileObject.Priorit
     }
 
     /** Special attributes which should not be checked for weight. See RemoveWritablesTest. */
-    private static final Set<String> SPECIAL_ATTR_NAMES = new HashSet<String>(Arrays.asList(FileObject.REMOVE_WRITABLES_ATTR, WEIGHT_ATTRIBUTE, "java.io.File")); // NOI18N
+    private static final Set<String> SPECIAL_ATTR_NAMES = Set.of(FileObject.REMOVE_WRITABLES_ATTR, WEIGHT_ATTRIBUTE, "java.io.File"); // NOI18N
     private final Object getAttribute(String attrName, String path) {
         // Look for attribute in any file system starting at the front.
         // Additionally, look for attribute in root folder, where

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
@@ -1047,7 +1047,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
             return 0;
         }
 
-        private static final Set<String> NETWORK_PROTOCOLS = new HashSet<String>(Arrays.asList("http", "https", "ftp")); // NOI18N
+        private static final Set<String> NETWORK_PROTOCOLS = Set.of("http", "https", "ftp"); // NOI18N
         /** One item cache to eliminate File.lastModified queries (see #160390). */
         private static File lastFile = null;
         private static Date lastFileDate = null;

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerBuilderTest.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerBuilderTest.java
@@ -299,8 +299,10 @@ public class LayerBuilderTest extends NbTestCase {
 
     @ServiceProvider(service=Processor.class)
     public static class AP extends LayerGeneratingProcessor {
+        private static final Set<String> ANNOTATION_TYPES = Set.of(A.class.getCanonicalName());
+
         public @Override Set<String> getSupportedAnnotationTypes() {
-            return Collections.singleton(A.class.getCanonicalName());
+            return ANNOTATION_TYPES;
         }
         protected @Override boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {
             if (roundEnv.processingOver()) {
@@ -358,8 +360,11 @@ public class LayerBuilderTest extends NbTestCase {
     // this processor has deliberately @SupportedSourceVersion left and obsolete, a test checks this
     @SupportedSourceVersion(SourceVersion.RELEASE_7)
     public static class VP extends LayerGeneratingProcessor {
+
+        private static final Set<String> ANNOTATION_TYPES = Set.of(V.class.getCanonicalName());
+
         public @Override Set<String> getSupportedAnnotationTypes() {
-            return Collections.singleton(V.class.getCanonicalName());
+            return ANNOTATION_TYPES;
         }
         protected @Override boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {
             if (roundEnv.processingOver()) {
@@ -424,8 +429,11 @@ public class LayerBuilderTest extends NbTestCase {
     public @interface I {}
     @ServiceProvider(service=Processor.class)
     public static class IP extends LayerGeneratingProcessor {
+
+        private static final Set<String> ANNOTATION_TYPES = Set.of(I.class.getCanonicalName());
+
         public @Override Set<String> getSupportedAnnotationTypes() {
-            return Collections.singleton(I.class.getCanonicalName());
+            return ANNOTATION_TYPES;
         }
         protected @Override boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {
             if (roundEnv.processingOver()) {

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGeneratingProcessorTest.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGeneratingProcessorTest.java
@@ -82,8 +82,11 @@ public class LayerGeneratingProcessorTest extends NbTestCase {
     public @interface A {}
     static class P extends LayerGeneratingProcessor {
         ProcessingEnvironment env;
+
+        private static final Set<String> ANNOTATION_TYPES = Set.of(A.class.getCanonicalName());
+
         public @Override Set<String> getSupportedAnnotationTypes() {
-            return Collections.singleton(A.class.getCanonicalName());
+            return ANNOTATION_TYPES;
         }
         protected @Override boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {
             env = processingEnv;

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGenerationExceptionTest.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGenerationExceptionTest.java
@@ -78,9 +78,16 @@ public class LayerGenerationExceptionTest extends NbTestCase {
 
     @ServiceProvider(service=Processor.class)
     public static class AP extends LayerGeneratingProcessor {
+
+        private static final Set<String> ANNOTATION_TYPES = Set.of(
+                A.class.getCanonicalName(),
+                AS.class.getCanonicalName()
+        );
+
         public @Override Set<String> getSupportedAnnotationTypes() {
-            return new HashSet<String>(Arrays.asList(A.class.getCanonicalName(), AS.class.getCanonicalName()));
+            return ANNOTATION_TYPES;
         }
+
         protected @Override boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {
             if (roundEnv.processingOver()) {
                 return false;

--- a/platform/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesAnnotationProcessor.java
+++ b/platform/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesAnnotationProcessor.java
@@ -57,13 +57,15 @@ public class NodesAnnotationProcessor extends LayerGeneratingProcessor {
     public NodesAnnotationProcessor() {
     }
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            PropertyEditorSearchPath.class.getName(),
+            PropertyEditorRegistration.class.getName(),
+            BeanInfoSearchPath.class.getName()
+    );
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        Set<String> set = new HashSet<String>();
-        set.add(PropertyEditorSearchPath.class.getName());
-        set.add(PropertyEditorRegistration.class.getName());
-        set.add(BeanInfoSearchPath.class.getName());
-        return set;
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/platform/openide.nodes/test/unit/src/org/openide/nodes/BeanChildrenTest.java
+++ b/platform/openide.nodes/test/unit/src/org/openide/nodes/BeanChildrenTest.java
@@ -64,9 +64,7 @@ public class BeanChildrenTest extends NbTestCase {
         Children c = new BeanChildren(bc, new SimpleFactory());
         // Note that BeanContextSupport keeps a HashMap of children
         // so the order is not deterministic.
-        assertEquals("correct subnodes",
-            new HashSet<String>(Arrays.asList(new String[] {"one", "two", "three"})),
-            new HashSet<String>(Arrays.asList(nodes2Names(c.getNodes()))));
+        assertEquals("correct subnodes", Set.of("one", "two", "three"), Set.of(nodes2Names(c.getNodes())));
     }
     
     public void testRemoveBeanRemovesChild() throws Exception {
@@ -74,7 +72,7 @@ public class BeanChildrenTest extends NbTestCase {
         final Children c = new BeanChildren(bc, new SimpleFactory());
         bc.remove("two");
         assertEquals("correct beans",
-            new HashSet<String>(Arrays.asList(new String[] {"one", "three"})),
+            Set.of("one", "three"),
             new HashSet<Object>(Arrays.asList(bc.toArray())));
         // Make sure we let the children thread run to completion.
         // Check the result in the reader.
@@ -89,8 +87,8 @@ public class BeanChildrenTest extends NbTestCase {
             }
         });
         assertEquals("correct subnodes",
-            new HashSet<String>(Arrays.asList(new String[] {"one", "three"})),
-            new HashSet<String>(Arrays.asList(nodes2Names(nodes))));
+            Set.of("one", "three"),
+            Set.of(nodes2Names(nodes)));
     }
     
     // Cf. #7925.
@@ -108,8 +106,8 @@ public class BeanChildrenTest extends NbTestCase {
             }
         });
         assertEquals("correct beans",
-            new HashSet<String>(Arrays.asList(new String[] {"one", "three"})),
-            new HashSet<Object>(Arrays.asList(bc.toArray())));
+            Set.of("one", "three"),
+            Set.of(bc.toArray()));
     }
     
     private static final class SimpleFactory implements BeanChildren.Factory {

--- a/platform/openide.text/src/org/openide/text/QuietEditorPane.java
+++ b/platform/openide.text/src/org/openide/text/QuietEditorPane.java
@@ -190,11 +190,11 @@ final class QuietEditorPane extends JEditorPane {
     // on any measurements. Use -Dtryme.args="-J-Dorg.netbeans.QuietEditorPane.level=FINE" to
     // see in the log file what property chenges are swallowed.
     // If making changes to the list make sure to check on #132669.
-    private static final Set<String> EXPENSIVE_PROPERTIES = new HashSet<String>(Arrays.asList(
+    private static final Set<String> EXPENSIVE_PROPERTIES = Set.of(
             "document", //NOI18N
             "editorKit", //NOI18N
             "keymap" //NOI18N
-    ));
+    );
 
     public @Override void firePropertyChange(String s, Object val1, Object val2) {
         if ((working & FIRE) != 0 || s == null || !EXPENSIVE_PROPERTIES.contains(s)) {

--- a/platform/openide.util.lookup/src/org/netbeans/modules/openide/util/NamedServiceProcessor.java
+++ b/platform/openide.util.lookup/src/org/netbeans/modules/openide/util/NamedServiceProcessor.java
@@ -52,12 +52,16 @@ public final class NamedServiceProcessor extends AbstractServiceProviderProcesso
     private static final String PATH = "META-INF/namedservices.index"; // NOI18N
     private static Pattern reference = Pattern.compile("@([^/]+)\\(\\)"); // NOI18N
 
+    private static final Set<String> ANNOTATION_TYPES = new HashSet<String>();
+
+    static {
+        ANNOTATION_TYPES.add(NamedServiceDefinition.class.getName());
+        searchAnnotations(ANNOTATION_TYPES, true);
+    }
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        Set<String> all = new HashSet<String>();
-        all.add(NamedServiceDefinition.class.getName());
-        searchAnnotations(all, true);
-        return all;
+        return ANNOTATION_TYPES;
     }
     
 

--- a/platform/openide.util.lookup/src/org/netbeans/modules/openide/util/ServiceProviderProcessor.java
+++ b/platform/openide.util.lookup/src/org/netbeans/modules/openide/util/ServiceProviderProcessor.java
@@ -42,11 +42,13 @@ import org.openide.util.lookup.implspi.AbstractServiceProviderProcessor;
 
 public class ServiceProviderProcessor extends AbstractServiceProviderProcessor {
 
-    public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
             ServiceProvider.class.getCanonicalName(),
             ServiceProviders.class.getCanonicalName()
-        ));
+    );
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return ANNOTATION_TYPES;
     }
 
     /** public for ServiceLoader */

--- a/platform/openide.util.ui/test/unit/src/org/openide/util/test/MockPropertyChangeListener.java
+++ b/platform/openide.util.ui/test/unit/src/org/openide/util/test/MockPropertyChangeListener.java
@@ -48,7 +48,7 @@ public class MockPropertyChangeListener implements PropertyChangeListener {
      * @param whiteListedPropertyNames an optional list of property names; if any others are received, an assertion will be thrown
      */
     public MockPropertyChangeListener(String... whitelistedPropertyNames) {
-        whitelist = whitelistedPropertyNames.length > 0 ? new HashSet<String>(Arrays.asList(whitelistedPropertyNames)) : null;
+        whitelist = whitelistedPropertyNames.length > 0 ? Set.of(whitelistedPropertyNames) : null;
     }
 
     /**

--- a/platform/openide.util/src/org/netbeans/modules/openide/util/NbBundleProcessor.java
+++ b/platform/openide.util/src/org/netbeans/modules/openide/util/NbBundleProcessor.java
@@ -58,8 +58,10 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = Processor.class)
 public class NbBundleProcessor extends AbstractProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(NbBundle.Messages.class.getCanonicalName())
+
     public @Override Set<String> getSupportedAnnotationTypes() {
-        return Collections.singleton(NbBundle.Messages.class.getCanonicalName());
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/platform/openide.util/src/org/netbeans/modules/openide/util/ProxyURLStreamHandlerFactory.java
+++ b/platform/openide.util/src/org/netbeans/modules/openide/util/ProxyURLStreamHandlerFactory.java
@@ -42,7 +42,7 @@ public final class ProxyURLStreamHandlerFactory implements URLStreamHandlerFacto
     /** prevents GC only */
     private final Map<String, Lookup.Result<URLStreamHandler>> results = new HashMap<String, Lookup.Result<URLStreamHandler>>();
     private final Map<String, URLStreamHandler> handlers = new HashMap<String, URLStreamHandler>();
-    private static final Set<String> STANDARD_PROTOCOLS = new HashSet<String>(Arrays.asList("jar", "file", "http", "https", "resource")); // NOI18N
+    private static final Set<String> STANDARD_PROTOCOLS = Set.of("jar", "file", "http", "https", "resource"); // NOI18N
 
     public @Override synchronized URLStreamHandler createURLStreamHandler(final String protocol) {
         if (STANDARD_PROTOCOLS.contains(protocol)) {

--- a/platform/openide.util/test/unit/src/org/openide/util/test/MockPropertyChangeListener.java
+++ b/platform/openide.util/test/unit/src/org/openide/util/test/MockPropertyChangeListener.java
@@ -48,7 +48,7 @@ public class MockPropertyChangeListener implements PropertyChangeListener {
      * @param whiteListedPropertyNames an optional list of property names; if any others are received, an assertion will be thrown
      */
     public MockPropertyChangeListener(String... whitelistedPropertyNames) {
-        whitelist = whitelistedPropertyNames.length > 0 ? new HashSet<String>(Arrays.asList(whitelistedPropertyNames)) : null;
+        whitelist = whitelistedPropertyNames.length > 0 ? Set.of(whitelistedPropertyNames) : null;
     }
 
     /**

--- a/platform/openide.windows/src/org/netbeans/modules/openide/windows/TopComponentProcessor.java
+++ b/platform/openide.windows/src/org/netbeans/modules/openide/windows/TopComponentProcessor.java
@@ -42,13 +42,15 @@ public final class TopComponentProcessor extends LayerGeneratingProcessor {
     public TopComponentProcessor() {
     }
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            TopComponent.Registration.class.getCanonicalName(),
+            TopComponent.OpenActionRegistration.class.getCanonicalName(),
+            TopComponent.Description.class.getCanonicalName()
+    );
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        Set<String> hash = new HashSet<String>();
-        hash.add(TopComponent.Registration.class.getCanonicalName());
-        hash.add(TopComponent.OpenActionRegistration.class.getCanonicalName());
-        hash.add(TopComponent.Description.class.getCanonicalName());
-        return hash;
+        return ANNOTATION_TYPES;
     }
     
     @Override

--- a/platform/options.api/src/org/netbeans/modules/options/OptionsPanelControllerProcessor.java
+++ b/platform/options.api/src/org/netbeans/modules/options/OptionsPanelControllerProcessor.java
@@ -58,14 +58,16 @@ public class OptionsPanelControllerProcessor extends LayerGeneratingProcessor {
 
     private Element originatingElement;
 
-    public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
             TopLevelRegistration.class.getCanonicalName(),
             ContainerRegistration.class.getCanonicalName(),
             SubRegistration.class.getCanonicalName(),
             KeywordsRegistration.class.getCanonicalName(),
             Keywords.class.getCanonicalName()
-        ));
+    );
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return ANNOTATION_TYPES;
     }
 
     protected boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {

--- a/platform/options.keymap/test/unit/src/org/netbeans/modules/options/keymap/KeymapViewModelTest.java
+++ b/platform/options.keymap/test/unit/src/org/netbeans/modules/options/keymap/KeymapViewModelTest.java
@@ -193,7 +193,7 @@ public class KeymapViewModelTest extends NbTestCase {
             public void run (MutableShortcutsModel model, ShortcutAction action) {
                 String[] sh = model.getShortcuts (action);
                 if (sh.length == 0) return;
-                Set<String> shortcuts = new HashSet<String>(Arrays.asList(sh));
+                Set<String> shortcuts = Set.of(sh);
                 //System.out.println("sh: " + shortcuts + " : " + action);
                 assertFalse ("Same shortcuts assigned to two actions ", result.containsKey (shortcuts));
                 result.put (shortcuts, action);
@@ -217,7 +217,7 @@ public class KeymapViewModelTest extends NbTestCase {
             public void run (MutableShortcutsModel model, ShortcutAction action) {
                 String[] sh = model.getShortcuts (action);
                 if (sh.length == 0) return;
-                Set<String> s = new HashSet<String>(Arrays.asList(sh));
+                Set<String> s = Set.of(sh);
                 if (print)
                     System.out.println (s + " : " + action + " : " + localCopy.get (s));
                 assertEquals ("Shortcut changed: " + s + " : " + action, localCopy.get (s), action);

--- a/platform/sendopts/src/org/netbeans/modules/sendopts/OptionAnnotationProcessorImpl.java
+++ b/platform/sendopts/src/org/netbeans/modules/sendopts/OptionAnnotationProcessorImpl.java
@@ -41,11 +41,13 @@ import org.openide.filesystems.annotations.LayerGenerationException;
  */
 final class OptionAnnotationProcessorImpl extends LayerGeneratingProcessor {
 
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
+            Arg.class.getName()
+    );
+
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        Set<String> set = new HashSet<String>();
-        set.add(Arg.class.getName());
-        return set;
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/platform/settings/src/org/netbeans/modules/settings/convertors/ConvertorProcessor.java
+++ b/platform/settings/src/org/netbeans/modules/settings/convertors/ConvertorProcessor.java
@@ -49,12 +49,14 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=Processor.class)
 public class ConvertorProcessor extends LayerGeneratingProcessor {
 
-    public @Override Set<String> getSupportedAnnotationTypes() {
-        return new HashSet<String>(Arrays.asList(
+    private static final Set<String> ANNOTATION_TYPES = Set.of(
             ConvertAsProperties.class.getCanonicalName(),
             ConvertAsJavaBean.class.getCanonicalName(),
             FactoryMethod.class.getCanonicalName()
-        ));
+    );
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return ANNOTATION_TYPES;
     }
 
     @Override

--- a/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AndroidPlatform.java
+++ b/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AndroidPlatform.java
@@ -25,10 +25,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -135,7 +132,7 @@ public class AndroidPlatform implements MobilePlatform {
         return Target.parse(avdString);
     }
     
-    private final HashSet<String> targets = new HashSet<String>(Arrays.asList(new String[]{
+    private static final Set<String> TARGETS = Set.of(
             "android-14", //NOI18N
             "android-15", //NOI18N
             "android-16", //NOI18N
@@ -144,7 +141,8 @@ public class AndroidPlatform implements MobilePlatform {
             "android-19", //NOI18N
             "android-20", //NOI18N
             "android-21", //NOI18N
-            "android-22"})); //NOI18N
+            "android-22"
+    ); //NOI18N
     
     
     @Override
@@ -152,7 +150,7 @@ public class AndroidPlatform implements MobilePlatform {
         try {
             final Collection<SDK> targets1 = getSDKs();
             for (SDK t: targets1) {
-                if (targets.contains(t.getName())) {
+                if (TARGETS.contains(t.getName())) {
                     return t;
                 }
             }

--- a/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/api/sites/SiteHelper.java
+++ b/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/api/sites/SiteHelper.java
@@ -151,7 +151,7 @@ public final class SiteHelper {
             ZipEntry entry;
             Set<String> ignored = Collections.emptySet();
             if (ignoredFiles != null && ignoredFiles.length > 0) {
-                ignored = new HashSet<String>(Arrays.asList(ignoredFiles));
+                ignored = Set.of(ignoredFiles);
             }
             while ((entry = str.getNextEntry()) != null) {
                 String entryName = entry.getName();

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ClientSideProject.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ClientSideProject.java
@@ -898,9 +898,10 @@ public class ClientSideProject implements Project {
 
     private static final class ProjectSearchInfo extends SearchInfoDefinition {
 
-        private static final Set<String> WATCHED_PROPERTIES = new HashSet<String>(Arrays.asList(
+        private static final Set<String> WATCHED_PROPERTIES = Set.of(
                 ClientSideProjectConstants.PROJECT_SITE_ROOT_FOLDER,
-                ClientSideProjectConstants.PROJECT_TEST_FOLDER));
+                ClientSideProjectConstants.PROJECT_TEST_FOLDER
+        );
 
         private final ClientSideProject project;
         // @GuardedBy("this")


### PR DESCRIPTION
WARNING: this type of changes was made and can be made only on unmodifiable collections BENEFITS:
1. Internal protected data. Example: LayerGeneratingProcessor.getSupportedAnnotationTypes() and similar return unmodifiable collections to protect content
2. IDE side visual highlighting for values duplicates (for set/map)
3. Less required imports
4. Less mem usage
5. Shortest form, for example: Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(new String[] {... this line might be replaced by Set.of()
