### PR TITLE
Autoload default config profiles into ServerInstances.

### DIFF
--- a/enterprise/cloud.oracle/manifest.mf
+++ b/enterprise/cloud.oracle/manifest.mf
@@ -4,6 +4,6 @@ OpenIDE-Module: org.netbeans.modules.cloud.oracle
 OpenIDE-Module-Layer: org/netbeans/modules/cloud/oracle/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/cloud/oracle/Bundle.properties
 OpenIDE-Module-Provides: org.netbeans.modules.serverplugins.javaee
-OpenIDE-Module-Specification-Version: 1.4
+OpenIDE-Module-Specification-Version: 1.5
 OpenIDE-Module-Display-Category: Cloud
 

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/Bundle.properties
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/Bundle.properties
@@ -22,3 +22,6 @@ ConnectProfilePanel.lblConfig.text=Configuration file:
 ConnectProfilePanel.txConfigPath.text=(default configuration)
 ConnectProfilePanel.lblMessageIcon.text=\ 
 ConnectProfilePanel.textMessage.text=Checking Oracle Cloud setup...
+
+# Branding API
+OCIManager_Autoload_DefaultConfig=false

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCITenancyProvider.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCITenancyProvider.java
@@ -129,11 +129,16 @@ public class OCITenancyProvider implements ServerInstanceProvider, ChangeListene
         List<ProfileKey> currentKeys = new ArrayList<>();
         for (OCIProfile p : OCIManager.getDefault().getConnectedProfiles()) {
             ProfileKey k = new ProfileKey(p.getConfigPath(), p.getId(), p.getTenantId());
-            if (!newInstances.containsKey(k)) {
-                ServerInstance si = ServerInstanceFactory.createServerInstance(new TenancyInstance(
-                        p.getTenancy().orElse(null), p));
-                newInstances.put(k, si);
+            ServerInstance prev = newInstances.get(k);
+            if (prev != null) {
+                OCIProfile prevProf = prev.getLookup().lookup(OCIProfile.class);
+                if (prevProf == null || (prevProf.isValid() != p.isValid())) {
+                    continue;
+                }
             }
+            ServerInstance si = ServerInstanceFactory.createServerInstance(new TenancyInstance(
+                    p.getTenancy().orElse(null), p));
+            newInstances.put(k, si);
             currentKeys.add(k);
         }
         newInstances.keySet().retainAll(currentKeys);

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OracleCloudWizardProvider.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OracleCloudWizardProvider.java
@@ -18,6 +18,10 @@
  */
 package org.netbeans.modules.cloud.oracle;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import javax.swing.event.ChangeListener;
 import org.netbeans.spi.server.ServerWizardProvider;
 import org.openide.WizardDescriptor;
 import org.openide.util.NbBundle;
@@ -38,7 +42,62 @@ public class OracleCloudWizardProvider implements ServerWizardProvider {
 
     @Override
     public WizardDescriptor.InstantiatingIterator getInstantiatingIterator() {
-        return new OracleCloudWizardIterator();
+        return OCIManager.loadDefaultConfigProfiles() ? 
+                new SimpleIterator() :
+                new OracleCloudWizardIterator();
     }
     
+    private static class SimpleIterator implements WizardDescriptor.InstantiatingIterator {
+
+        @Override
+        public Set instantiate() throws IOException {
+            // force profiles collection
+            OCIManager.getDefault().getConnectedProfiles();
+            return Collections.emptySet();
+        }
+
+        @Override
+        public void initialize(WizardDescriptor wizard) {
+        }
+
+        @Override
+        public void uninitialize(WizardDescriptor wizard) {
+        }
+
+        @Override
+        public WizardDescriptor.Panel current() {
+            return null;
+        }
+
+        @Override
+        public String name() {
+            return Bundle.LBL_OC();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return false;
+        }
+
+        @Override
+        public void nextPanel() {
+        }
+
+        @Override
+        public void previousPanel() {
+        }
+
+        @Override
+        public void addChangeListener(ChangeListener l) {
+        }
+
+        @Override
+        public void removeChangeListener(ChangeListener l) {
+        }
+    }
 }

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/TenancyInstance.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/TenancyInstance.java
@@ -22,20 +22,24 @@ import org.netbeans.modules.cloud.oracle.items.OCIItem;
 import javax.swing.JComponent;
 import org.netbeans.spi.server.ServerInstanceImplementation;
 import org.openide.nodes.Node;
+import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
+import org.openide.util.lookup.Lookups;
 
 /**
  *
  * @author Jan Horvath
  */
-public class TenancyInstance implements ServerInstanceImplementation {
+public class TenancyInstance implements ServerInstanceImplementation, Lookup.Provider {
 
     private final OCIItem tenancy;
+    private final Lookup lkp;
     final OCIProfile profile;
     
     public TenancyInstance(OCIItem tenancy, OCIProfile profile) {
         this.tenancy = tenancy;
         this.profile = profile;
+        lkp = tenancy != null ? Lookups.fixed(profile, tenancy) : Lookups.fixed(profile);
     }
     
     @NbBundle.Messages({
@@ -57,6 +61,11 @@ public class TenancyInstance implements ServerInstanceImplementation {
         } else {
             return Bundle.MSG_BrokenProfile(profile.getId());
         }
+    }
+
+    @Override
+    public Lookup getLookup() {
+        return lkp;
     }
 
     @Override

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/TenancyNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/TenancyNode.java
@@ -82,7 +82,7 @@ public class TenancyNode extends OCINode implements PropertyChangeListener {
 
     @Override
     public boolean canDestroy() {
-        return OCIManager.getDefault().getConnectedProfiles().contains(session);
+        return OCIManager.getDefault().isConfiguredProfile((OCIProfile)session);
     }
 
     @Override

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/RemoveProfileAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/RemoveProfileAction.java
@@ -22,7 +22,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import org.netbeans.modules.cloud.oracle.OCIManager;
 import org.netbeans.modules.cloud.oracle.OCIProfile;
-import org.netbeans.modules.cloud.oracle.items.OCIItem;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
@@ -43,8 +42,8 @@ import org.openide.util.NbBundle;
 )
 
 @ActionReferences(value = {
-    @ActionReference(path = "Cloud/Oracle/Tenancy/Actions", position = 250),
-    @ActionReference(path = "Cloud/Oracle/BrokenProfile/Actions", position = 250)
+    @ActionReference(path = "Cloud/Oracle/Tenancy/Actions", position = 230),
+    @ActionReference(path = "Cloud/Oracle/BrokenProfile/Actions", position = 230)
 })
 @NbBundle.Messages({
     "RemoveProfileAction=Remove Profile"

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/SetDefaultProfileAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/SetDefaultProfileAction.java
@@ -44,7 +44,7 @@ import org.openide.util.NbBundle;
 )
 
 @ActionReferences(value = {
-    @ActionReference(path = "Cloud/Oracle/Tenancy/Actions", position = 250)
+    @ActionReference(path = "Cloud/Oracle/Tenancy/Actions", position = 200)
 })
 @NbBundle.Messages({
     "CTL_SetDefaultProfileAction=Set As Default",

--- a/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-cloud-oracle.jar/org/netbeans/modules/cloud/oracle/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-cloud-oracle.jar/org/netbeans/modules/cloud/oracle/Bundle.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Autoload default OCI config profiles.
+OCIManager_Autoload_DefaultConfig=true


### PR DESCRIPTION
The recent commit #5118  introduced the ability to select and add OCI profiles, but damaged the Cloud Explorer for Apache Netbeans VSCode extension - it relied on the (default) OCI profile to be automatically converted into `ServerInstance`.

This PR adds an alternative mode, which can be enabled using Branding API, that automatically loads all profiles from the default OCI configuration into the Cloud explorer (in NB IDE or vscode). In the future additional profiles from custom configuration can be added when the Add Cloud / Oracle wizard is enhanced to support custom configs.

NetBeans IDE behaves as in #5118, for the user convenience, vscode extension loads profiles from the default config.