### PR TITLE
Fix possible NPE in Tiny.java

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/perf/Tiny.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/perf/Tiny.java
@@ -534,7 +534,7 @@ public class Tiny {
             List<? extends TypeMirror> type = CreateElementUtilities.resolveType(
                     EnumSet.noneOf(ElementKind.class), ctx.getInfo(), parent, leaf, pos, new TypeMirror[1], new int[1]);
 
-            if (!type.isEmpty()) {
+            if ((type != null) && !type.isEmpty()) {
                 return type.get(0);
             }
         }


### PR DESCRIPTION
Well, I've bumped into this one today:
```
java.lang.NullPointerException: Cannot invoke "java.util.List.isEmpty()" because "type" is null
	at org.netbeans.modules.java.hints.perf.Tiny.getDestinationType(Tiny.java:537)
	at org.netbeans.modules.java.hints.perf.Tiny.unnecessaryTempFromString(Tiny.java:488)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
```

This is a trivial patch for that. I've checked the invocations of `resolveType(...)` it seems that the return value is checked for `null` at other places.
