### PR TITLE
ci: add retry script to ide/options.editor tests and increase mac timeout.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -554,7 +554,7 @@ jobs:
         run: ant $OPTS -f ide/o.openidex.util test
 
       - name: ide/options.editor
-        run: ant $OPTS -f ide/options.editor test
+        run: .github/retry.sh ant $OPTS -f ide/options.editor test
 
 #      - name: ide/parsing.api
 #        run: ant $OPTS -f ide/parsing.api test
@@ -1731,7 +1731,7 @@ jobs:
     name: Tests on MacOS/JDK ${{ matrix.java }}
     needs: base-build
     runs-on: macos-11
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       matrix:
         java: [ '11' ]


### PR DESCRIPTION
checked the CI runs of the last 18 merges to master to see if we can reduce the whack-a-mole factor a bit.

Most had `java.mx.project` failing which is already wrapped in a retry script and `continue-on-error`is set to true for merges. I couldn't reproduce the failure locally, it always passed, so this one might be tricky to fix (previews attempt #4100).

But `ide/options.editor` did also fail often. Those are fairly short tests which could benefit from a retry script - which I added with this PR.

I did also increase the job timeout on mac since the mac runners can sometimes have really high latencies or artifact download speeds.

The other tests failing were in `java/refactoring.java` and `java.source.base` which would be mitigated by #5138 if it makes it in before freeze.