### PR TITLE
Add javadoc for JDK 21 early access

### DIFF
--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
@@ -69,6 +69,7 @@ public final class J2SEPlatformDefaultJavadocImpl implements J2SEPlatformDefault
         OFFICIAL_JAVADOC.put("18", "https://docs.oracle.com/en/java/javase/18/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("19", "https://docs.oracle.com/en/java/javase/19/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("20", "https://download.java.net/java/early_access/jdk20/docs/api/"); // NOI18N Early access
+        OFFICIAL_JAVADOC.put("21", "https://download.java.net/java/early_access/jdk21/docs/api/"); // NOI18N Early access
     }
 
     @Override


### PR DESCRIPTION
Add entry to the `OFFICIAL_JAVADOC` Map for Java 21

- https://download.java.net/java/early_access/jdk21/docs/api/

Hopefully this will be the last manual update thanks to [PR-4837](https://github.com/apache/netbeans/pull/4837)