### PR TITLE
Pass buildnumber into NBM sub-ant target.

### DIFF
--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -326,6 +326,7 @@ metabuild.hash=${metabuild.hash}</echo>
           <buildpath path="${modules.sorted}"/>
           <property name="base.nbm.target.dir" value="${base.nbm.target.dir}"/>
           <property name="nbm.always.create" value="true" />
+          <property name="buildnumber" value="${buildnumber}" />
       </subant-junit>
   </target>
 
@@ -336,6 +337,7 @@ metabuild.hash=${metabuild.hash}</echo>
       <subant-junit target="nbm-nosignature" failonerror="${nbms.fail.on.error}" report="${nb.build.dir}/build-nbms.xml" inheritall="false">
           <buildpath path="${modules.sorted}"/>
           <property name="base.nbm.target.dir" value="${base.nbm.target.dir}"/>
+          <property name="buildnumber" value="${buildnumber}" />
       </subant-junit>
   </target>
 


### PR DESCRIPTION
Make sure that the minority of modules that get rebuilt during make-nbms get the required implementation version. This patches over the issue - it does not address why these modules are being marked stale and rebuilt.

(Partial!) Fix for #5253 