### PR TITLE
Catch IAE when Gradle error getLocation cannot be called.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
@@ -362,39 +362,29 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
         return Collections.singletonList(createReport(t.getCause()));
     }
     
-    /**
-     * Accessor for the 'location' property on LocationAwareException
-     */
-    private static Method locationAccessor;
-
-    /**
-     * Accessor for the 'lineNumber' property on LocationAwareException
-     */
-    private static Method lineNumberAccessor;
-    
     private static String getLocation(Throwable locationAwareEx) {
         try {
-            if (locationAccessor == null) {
-                locationAccessor = locationAwareEx.getClass().getMethod("getLocation"); // NOI18N
-            }
+            Method locationAccessor = locationAwareEx.getClass().getMethod("getLocation"); // NOI18N
             return (String)locationAccessor.invoke(locationAwareEx);
         } catch (ReflectiveOperationException ex) {
             LOG.log(Level.FINE,"Error getting location", ex);
-            return null;
+        } catch (IllegalArgumentException iae) {
+            LOG.log(Level.FINE, "This probably should not happen: " + locationAwareEx.getClass().getName(), iae);
         }
+        return null;
     }
 
     private static int getLineNumber(Throwable locationAwareEx) {
         try {
-            if (lineNumberAccessor == null) {
-                lineNumberAccessor = locationAwareEx.getClass().getMethod("getLineNumber"); // NOI18N
-            }
+            Method lineNumberAccessor = locationAwareEx.getClass().getMethod("getLineNumber"); // NOI18N
             Integer i = (Integer)lineNumberAccessor.invoke(locationAwareEx);
             return i != null ? i : -1;
         } catch (ReflectiveOperationException ex) {
             LOG.log(Level.FINE,"Error getting line number", ex);
-            return -1;
+        } catch (IllegalArgumentException iae) {
+            LOG.log(Level.FINE, "This probably should not happen: " + locationAwareEx.getClass().getName(), iae);
         }
+        return -1;
     }
 
     /**


### PR DESCRIPTION
I've bumped into this one today:

```
java.lang.IllegalArgumentException: object is not an instance of declaring class
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.netbeans.modules.gradle.loaders.LegacyProjectLoader.getLocation(LegacyProjectLoader.java:380)
```

Couldn't really know how to reproduce. I was fiddling with old Gradle versions with the new tooling.

The fix is trivial though...