### PR TITLE
Prevent NullPointerException when matching filenames in SourceUtils

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
@@ -683,7 +683,7 @@ public class SourceUtils {
         }
 
         final boolean apply(final FileObject fo) {
-            if (name.equals(fo.getNameExt())) {
+            if (fo.getNameExt().equals(name)) {
                 return true;
             }
             final String foName = fo.getName();


### PR DESCRIPTION
Closes: #5266
