### PR TITLE
Improve Dialog Placement

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/services/DialogDisplayerImpl.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/services/DialogDisplayerImpl.java
@@ -225,7 +225,7 @@ public class DialogDisplayerImpl extends DialogDisplayer {
             // if a modal dialog is active use it as parent
             // otherwise use the main window
 
-            NbPresenter presenter = null;
+            NbPresenter presenter;
             if (descriptor instanceof DialogDescriptor) {
                 if (NbPresenter.currentModalDialog != null) {
                     if (NbPresenter.currentModalDialog.isLeaf ()) {
@@ -252,11 +252,8 @@ public class DialogDisplayerImpl extends DialogDisplayer {
                         presenter = new NbPresenter(descriptor, NbPresenter.currentModalDialog, true);
                     }
                 } else {
-                    Frame f = KeyboardFocusManager.getCurrentKeyboardFocusManager().getActiveWindow() 
-                        instanceof Frame ? 
-                        (Frame) KeyboardFocusManager.getCurrentKeyboardFocusManager().getActiveWindow() 
-                        : WindowManager.getDefault().getMainWindow();
-
+                    Window w = KeyboardFocusManager.getCurrentKeyboardFocusManager ().getActiveWindow ();
+                    Frame f = w instanceof Frame ? (Frame) w : WindowManager.getDefault().getMainWindow();
                     if (noParent) {
                         f = null;
                     }

--- a/platform/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
@@ -1591,6 +1591,18 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
      */
     private Window findFocusedWindow() {
         Window w = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusedWindow();
+        if( w == null ) {
+            // PR#5280
+            LOG.fine( () -> "No focused window, find mainWindow" );
+            for( Frame f01 : Frame.getFrames() ) {
+                if( "NbMainWindow".equals(f01.getName())) { //NOI18N
+                    if(f01.getWidth() != 0 || f01.getHeight() != 0) {
+                        w = f01;
+                    }
+                    break;
+                }
+            }
+        }
         while( null != w && !w.isShowing() ) {
             w = w.getOwner();
         }

--- a/platform/openide.util.ui/src/org/openide/util/Utilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/Utilities.java
@@ -1157,11 +1157,9 @@ public final class Utilities {
                 return w.getGraphicsConfiguration();
             } else {
                 //#217737 - try to find the main window which could be placed in secondary screen
-                for( Frame f : Frame.getFrames() ) {
-                    if( "NbMainWindow".equals(f.getName())) { //NOI18N
-                        return f.getGraphicsConfiguration();
-                    }
-                }
+                Frame f = findMainWindow();
+                if(f != null)
+                    return f.getGraphicsConfiguration();
             }
         }
 
@@ -1326,6 +1324,25 @@ public final class Utilities {
     }
 
     /**
+     * Find the main NetBeans window; must have width or height.
+     * This is used locally to avoid dependency issues. 
+     * @return NetBeans' main window
+     */
+    private static Frame findMainWindow()
+    {
+        Frame f = null;
+        for( Frame f01 : Frame.getFrames() ) {
+            if( "NbMainWindow".equals(f01.getName())) { //NOI18N
+                if(f01.getWidth() != 0 || f01.getHeight() != 0) {
+                    f = f01;
+                }
+                break;
+            }
+        }
+        return f;
+    }
+
+    /**
      * This is for use in situations where a standard swing API,
      * such as {@linkplain JOptionPane.show*} or {@linkplain JFileChooser.show*},
      * is used to display a dialog. {@code null} should never be used
@@ -1345,8 +1362,8 @@ public final class Utilities {
             parent = KeyboardFocusManager.getCurrentKeyboardFocusManager().getActiveWindow();
         }
         if (parent == null) {
-            Frame[] f = Frame.getFrames();
-            parent = f.length == 0 ? null : f[f.length - 1];
+            // PR#5280
+            parent = findMainWindow();
         }
         return parent;
     }


### PR DESCRIPTION
When placing a dialog through NetBeans' API, if no focused component is found then use NbMainWindow. Change fallback for Utilities.findDialogParent to use NbMainWindow.

@matthiasblaesing , @neilcsmith-net , @mbien alerting since you made comments on previous PR.

This PR is a follow on to https://github.com/apache/netbeans/pull/4739. Wanted to open a bigger change earlier in the cycle, but... So this is a minimal change, hopefully more to come next cycle with detailed examination of cases from https://github.com/apache/netbeans/discussions/4887.

There are situations where
```
null == KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusedWindow();
```
And also related methods such as `getFocusOwner()`, `getActiveWindow()` are `null`.

What happens is `NbPresenter.findFocusedWindow()` returns null and the logic in `NbPresenter.initBounds()` ends up doing `Utilities.findCenterBounds(size)` which does `Utilities.getCurrentGraphicsConfiguration()` and ends up on the default screen instead of a screen that NetBeans is on. The bigger change I've been thinking about addresses some issues with `Utilities.getCurrentGraphicsConfiguration()` and would put the dialog on the same screen as NetBeans is on, but even better is to have the dialog *over the Window that NetBeans is in*. This PR does that with a hack to `NbPresenter.findFocusedWindow()`; taken from Utilities.

In `NbPresenter.initBounds()`, can consider `Utilities.findDialogParent()` instead of the local `findFocusedWindow()`, and then make sure that whatever's returned is a window. In any event, with this change the else clause is unlikely to ever be executed; just as well, notice the comment for the else clause:
```
//just center the dialog on the screen and let's hope it'll be
//the correct one in multi-monitor setup
```

### notes on Utilities.findDialogParent
There was some discussion in the dialog parent PR https://github.com/apache/netbeans/pull/4739#discussion_r997414384 from last release about the `Utilities.findDialogParent()` fallback. Investigation for this PR showed a situation where a fallback is needed, and the current fallback is not good.

Frame.getFrames() comes from a Vector<WeakReference<Window>>; doing garbage collection shortens the array. Here's an example I saw, the fallback
```
parent = f.length == 0 ? null : f[f.length - 1];
```
selects the last item and is choosing something ripe for garbage collection. Notice in this case the 2nd entry is the main window.

```
f	Frame[]	#16829(length=6)	#16829(length=6)	
[0]	Frame	#16831	java.awt.Frame[frame0,2640,390,480x300,invalid,hidden,
[1]	JFrame	#16832	javax.swing.JFrame[NbMainWindow,2566,544,1274x505,inva
[2]	Popup$DefaultFrame	#16833	javax.swing.Popup$DefaultFrame[frame3,
[3]	Popup$DefaultFrame	#16778	javax.swing.Popup$DefaultFrame[frame2,
[4]	Popup$DefaultFrame	#16834	javax.swing.Popup$DefaultFrame[frame4,
[5]	Popup$DefaultFrame	#16835	javax.swing.Popup$DefaultFrame[frame5,
```

These entries are like:
```
javax.swing.Popup$DefaultFrame[frame5,0,32,0x0,invalid,hidden
```

This PR makes the change to use the main window as fallback. This was previously proposed, but was deferred pending clarification on whether a fallback was needed at all.