### PR TITLE
Fix for Windows Maven parent.relativePath from Mark Herkrath

### DIFF
--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/PomModelUtils.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/PomModelUtils.java
@@ -183,7 +183,7 @@ public final class PomModelUtils {
 
         @Override
         public ModelSource2 getRelatedSource(String relative) {
-            return new M2S(new File(pomFile, relative), null);
+            return new M2S(new File(pomFile.getParentFile(), relative), null);
         }
 
         @Override


### PR DESCRIPTION
This is to address a parent.relativePath warning for Maven projects on the Windows platform. The fix was suggested by Mark Herkrath <herkrath@googlemail.com> and mentioned on the dev mailing list. This fixes #5281



---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
