### PR TITLE
Open projects that correspond to workspace folders. Prevents "do you want to open project ?" questions.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -71,12 +70,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ShowDocumentParams;
 import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolLocation;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
@@ -129,10 +130,12 @@ import org.netbeans.spi.project.ProjectConfigurationProvider;
 import org.netbeans.spi.project.ui.ProjectProblemsProvider;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
+import org.openide.awt.StatusDisplayer;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
 import org.openide.util.Pair;
 import org.openide.util.RequestProcessor;
@@ -1167,6 +1170,54 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
             prefs.putInt("countForUsingStarImport", configuration.getAsJsonPrimitive("countForUsingStarImport").getAsInt());
             prefs.putBoolean("allowConvertToStaticStarImport", true);
             prefs.putInt("countForUsingStaticStarImport", configuration.getAsJsonPrimitive("countForUsingStaticStarImport").getAsInt());
+        }
+    }
+
+    @NbBundle.Messages({
+        "# {0} - project name",
+        "MSG_ProjectFolderInitializationComplete=Completed initialization of project {0}",
+        "# {0} - some project name",
+        "# {1} - number of other projects loaded",
+        "MSG_ProjectFolderInitializationComplete2=Completed initialization of {0} and {1} other projectss"
+    })
+    @Override
+    public void didChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams params) {
+        List<FileObject> refreshProjectFolders = new ArrayList<>();
+        for (WorkspaceFolder wkspFolder : params.getEvent().getAdded()) {
+            String uri = wkspFolder.getUri();
+            try {
+                FileObject f = Utils.fromUri(uri);
+                if (f != null) {
+                    refreshProjectFolders.add(f);
+                }
+            } catch (MalformedURLException ex) {
+                // expected, perhaps some client-specific URL scheme ?
+                LOG.fine("Workspace folder URI could not be converted into fileobject: {0}");
+            }
+        }
+        if (!refreshProjectFolders.isEmpty()) {
+            server.asyncOpenSelectedProjects(refreshProjectFolders, true).thenAccept((projects) -> {
+                // report initialization of a project / projects
+                String msg;
+                if (projects.length == 0) {
+                    // this should happen immediately
+                    return;
+                } 
+                ProjectInformation pi = ProjectUtils.getInformation(projects[0]);
+                String n = pi.getDisplayName();
+                if (n == null) {
+                    n = pi.getName();
+                }
+                if (n == null) {
+                    n = projects[0].getProjectDirectory().getName();
+                }
+                if (projects.length == 1) {
+                    msg = Bundle.MSG_ProjectFolderInitializationComplete(n);
+                } else {
+                    msg = Bundle.MSG_ProjectFolderInitializationComplete2(n, projects.length);
+                }
+                StatusDisplayer.getDefault().setStatusText(msg, StatusDisplayer.IMPORTANCE_ANNOTATION);
+            });
         }
     }
 


### PR DESCRIPTION
If the LSP client added a folder to a workspace, then opened a file, NBLS would ask a question "File XXX is part of project Foo, do you want to open ... ?".  Since the containing folder **was** explicitly adeded the lsp client's user, this question is ... silly. 

It was caused by NBLS did not receive/process `didChangeWorkspaceFolders` notification from the LSP client. On the startup, workspace folders were 'registered' as known and NBLS does not ask "project open question" for files beneath those folders - but when the folders change during NBLS run, the added folders were not 'registered' in the same way.
