### PR TITLE
Made ANTLR Token LexerInputCharStream Friendly

### DIFF
--- a/ide/languages.toml/src/org/netbeans/modules/languages/toml/TomlLexer.java
+++ b/ide/languages.toml/src/org/netbeans/modules/languages/toml/TomlLexer.java
@@ -37,8 +37,8 @@ public final class TomlLexer extends AbstractAntlrLexerBridge<org.tomlj.internal
     }
 
     @Override
-    protected Token<TomlTokenId> mapToken(int antlrTokenType) {
-        switch (antlrTokenType) {
+    protected Token<TomlTokenId> mapToken(org.antlr.v4.runtime.Token antlrToken) {
+        switch (antlrToken.getType()) {
             case EOF:
                 return null;
 

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3Lexer.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v3/Antlr3Lexer.java
@@ -44,8 +44,8 @@ public final class Antlr3Lexer extends AbstractAntlrLexerBridge<ANTLRv3Lexer, An
     }
 
     @Override
-    protected Token<AntlrTokenId> mapToken(int antlrTokenType) {
-        switch (antlrTokenType) {
+    protected Token<AntlrTokenId> mapToken(org.antlr.v4.runtime.Token antlrToken) {
+        switch (antlrToken.getType()) {
             case TOKEN_REF:
                 return token(AntlrTokenId.TOKEN);
             case RULE_REF:

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4Lexer.java
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/v4/Antlr4Lexer.java
@@ -44,8 +44,8 @@ public final class Antlr4Lexer extends AbstractAntlrLexerBridge<ANTLRv4Lexer, An
     }
 
     @Override
-    protected Token<AntlrTokenId> mapToken(int antlrTokenType) {
-        switch (antlrTokenType) {
+    protected Token<AntlrTokenId> mapToken(org.antlr.v4.runtime.Token antlrToken) {
+        switch (antlrToken.getType()) {
             case TOKEN_REF:
                 return token(TOKEN);
             case RULE_REF:


### PR DESCRIPTION

This fix makes ANTLR Token `getText()` and `toString()` methods usable when the lexer is backed by `LexerInputCharStream`. Unfortunately it seems that ANTLR does not really honor their contract when saying some methods can throw `UnsupportedOperationException`. I may file a PR for ANTLR as well, till then, this one makes debugging easier.

I also dared to change the `AbstractAntlrLexerBridge.mapToken(int antlrTokenType)` -> `AbstractAntlrLexerBridge.mapToken(org.antlr.v4.runtime.Token antlrToken)` till it's in this phase. Mappers could take advantage on the full token info as  the `getText()` method is working.
