### PR TITLE
PHP: removed built-in type boolean

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/actions/UsedNamesCollector.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/actions/UsedNamesCollector.java
@@ -186,7 +186,7 @@ public class UsedNamesCollector {
         @Override
         public void visit(PHPDocTypeNode node) {
             UsedNamespaceName usedName = new UsedNamespaceName(node);
-            if (isValidTypeName(usedName.getName())) {
+            if (isValidTypeName(usedName.getName()) && isValidAliasTypeName(usedName.getName())) {
                 processUsedName(usedName);
             }
         }
@@ -194,6 +194,10 @@ public class UsedNamesCollector {
         private boolean isValidTypeName(final String typeName) {
             return !SPECIAL_NAMES.contains(typeName) && !Type.isPrimitive(typeName);
         }
+        
+        private boolean isValidAliasTypeName(final String typeName) {
+            return !SPECIAL_NAMES.contains(typeName) && !Type.isPrimitiveAlias(typeName);
+        }        
 
         private void processUsedName(final UsedNamespaceName usedName) {
             List<UsedNamespaceName> usedNames = existingNames.get(usedName.getName());

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/Type.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/Type.java
@@ -108,7 +108,7 @@ public final class Type {
 
     public static boolean isPrimitive(String typeName) {
         boolean retval = false;
-        if (BOOL.equals(typeName) || BOOLEAN.equals(typeName) || INT.equals(typeName)
+        if (BOOL.equals(typeName) || INT.equals(typeName)
                 || INTEGER.equals(typeName) || FLOAT.equals(typeName) || REAL.equals(typeName)
                 || ARRAY.equals(typeName) || OBJECT.equals(typeName) || MIXED.equals(typeName)
                 || NUMBER.equals(typeName) || CALLBACK.equals(typeName) || RESOURCE.equals(typeName)
@@ -119,6 +119,14 @@ public final class Type {
             retval = true;
         }
         return retval;
+    }
+    
+    public static boolean isPrimitiveAlias(String typeName) {
+        boolean retval = false;
+        if (BOOLEAN.equals(typeName)) {
+            retval = true;
+        }
+        return retval;        
     }
 
     public static boolean isArray(String typeName) {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
@@ -435,7 +435,7 @@ public final class VariousUtils {
             if (scalarType.equals(Scalar.Type.STRING)) {
                 String stringValue = scalar.getStringValue().toLowerCase();
                 if (stringValue.equals("false") || stringValue.equals("true")) { //NOI18N
-                    return Type.BOOLEAN;
+                    return Type.BOOL;
                 }
                 if (stringValue.equals(Type.NULL)) {
                     return Type.NULL;

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/IdenticalComparisonSuggestion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/IdenticalComparisonSuggestion.java
@@ -197,7 +197,6 @@ public class IdenticalComparisonSuggestion extends SuggestionRule {
                 case Type.DOUBLE:
                 case Type.FLOAT:
                 case Type.BOOL:
-                case Type.BOOLEAN:
                 case Type.STRING:
                 case Type.ARRAY:
                     retval = typeName;

--- a/php/php.editor/test/unit/data/testfiles/actions/useCase_09.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/useCase_09.php
@@ -1,0 +1,11 @@
+<?php
+
+class ClassName {
+
+    function functionName(): boolean {
+        return true;
+    }
+
+}
+
+?>

--- a/php/php.editor/test/unit/data/testfiles/actions/useCase_09.php.usedNames
+++ b/php/php.editor/test/unit/data/testfiles/actions/useCase_09.php.usedNames
@@ -1,0 +1,2 @@
+Name: boolean
+ boolean --> boolean:55

--- a/php/php.editor/test/unit/data/testfiles/actions/useCase_10.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/useCase_10.php
@@ -1,0 +1,11 @@
+<?php
+
+class ClassName {
+
+    function functionName(boolean $a) {
+        return true;
+    }
+
+}
+
+?>

--- a/php/php.editor/test/unit/data/testfiles/actions/useCase_10.php.usedNames
+++ b/php/php.editor/test/unit/data/testfiles/actions/useCase_10.php.usedNames
@@ -1,0 +1,2 @@
+Name: boolean
+ boolean --> boolean:52

--- a/php/php.editor/test/unit/data/testfiles/codegen/testInstanceOverrideMethodWithGuessingBoolType/testInstanceOverrideMethodWithGuessingBoolType.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testInstanceOverrideMethodWithGuessingBoolType/testInstanceOverrideMethodWithGuessingBoolType.php
@@ -1,0 +1,11 @@
+<?php
+
+class Foo {
+    function myFoo(?string $string, int $int){
+        return true;
+    }
+}
+
+class Bar extends Foo {
+
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testInstanceOverrideMethodWithGuessingBoolType/testInstanceOverrideMethodWithGuessingBoolType.php.testInstanceOverrideMethodWithGuessingBoolType_01.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testInstanceOverrideMethodWithGuessingBoolType/testInstanceOverrideMethodWithGuessingBoolType.php.testInstanceOverrideMethodWithGuessingBoolType_01.codegen
@@ -1,0 +1,3 @@
+public function myFoo(?string $string, int $int): bool{
+return parent::myFoo($string, $int);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testInstanceOverrideMethodWithGuessingBoolType/testInstanceOverrideMethodWithGuessingBoolType.php.testInstanceOverrideMethodWithGuessingBoolType_02.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testInstanceOverrideMethodWithGuessingBoolType/testInstanceOverrideMethodWithGuessingBoolType.php.testInstanceOverrideMethodWithGuessingBoolType_02.codegen
@@ -1,0 +1,3 @@
+public function myFoo(?string $string, int $int){
+return parent::myFoo($string, $int);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests235450/issue235450.php.testLowercase_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests235450/issue235450.php.testLowercase_01.completion
@@ -2,7 +2,7 @@ Code completion result for source line:
 $a = |true;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 CLASS      ConstantClass                   [PUBLIC]   issue235450.php
-VARIABLE   boolean $a                      [PUBLIC]   issue235450.php
+VARIABLE   bool $a                         [PUBLIC]   issue235450.php
 ------------------------------------
 VARIABLE   $GLOBALS                                   PHP Platform
 VARIABLE   $HTTP_RAW_POST_DATA                        PHP Platform

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/UsedNamesCollectorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/UsedNamesCollectorTest.java
@@ -75,6 +75,14 @@ public class UsedNamesCollectorTest extends PHPTestBase {
     public void testUseCase_08() throws Exception {
         performTest("useCase_08", "class Class^Name {");
     }
+    
+    public void testUseCase_09() throws Exception {
+        performTest("useCase_09", "class Class^Name {");
+    }    
+    
+    public void testUseCase_10() throws Exception {
+        performTest("useCase_10", "class Class^Name {");
+    }       
 
     public void testIssue209755() throws Exception {
         performTest("issue209755", "class Class^Name {");

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
@@ -209,6 +209,18 @@ public class SelectedPropertyMethodsCreatorTest extends PHPTestBase {
         checkResult(new SelectedPropertyMethodsCreator().create(
                 selectProperties(cgsInfo.getPossibleMethods(), "myFoo"), new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)));
     }
+    
+    public void testInstanceOverrideMethodWithGuessingBoolType_01() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Bar extends Foo {^", PhpVersion.PHP_70);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "myFoo"), new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)));
+    }
+
+    public void testInstanceOverrideMethodWithGuessingBoolType_02() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Bar extends Foo {^", PhpVersion.PHP_56);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "myFoo"), new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)));
+    }    
 
     public void testGetterWithType_01() throws Exception {
         CGSInfo cgsInfo = getCgsInfo("class Foo {^", PhpVersion.PHP_70);

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGeneratorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGeneratorTest.java
@@ -827,6 +827,24 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                 + "class Class2 {}"
         );
     }
+    
+    public void testFunctionGuessingBoolReturnType() throws Exception {
+        insertBreak( "<?php\n" +
+                            "/**^\n" +
+                            "function foo() {\n" +
+                            "    return true;\n" +
+                            "}\n" +
+                            "?>\n",
+                            "<?php\n" +
+                            "/**\n" +
+                            " * \n" +
+                            " * @return bool^\n" +
+                            " */\n" +
+                            "function foo() {\n" +
+                            "    return true;\n" +
+                            "}\n" +
+                            "?>\n");
+    }    
 
     @Override
     public void insertNewline(String source, String reformatted, IndentPrefs preferences) throws Exception {


### PR DESCRIPTION
What was done in this PR:
 - deleted the built-in type `boolean`
 ( php does not have a built-in `boolean` type: https://www.php.net/manual/en/language.types.intro.php
Also see the warning under "Scalar Types": https://www.php.net/manual/en/language.types.declarations.php)
 - fixed broken tests
 - fixed issues: 
   - #5283, 
   - #5284
 - new tests for fixed issues have been added


