### PR TITLE
Update FlatLaf from 2.6 to 3.0 and add macOS light and dark themes

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-4DD2BA228E3C57EB3D80E3927B5A6A33265EB69B com.formdev:flatlaf:2.6
+B5410F3F9137FEBC7D916CA4E0A7E9F6DDEB5B9A com.formdev:flatlaf:3.0

--- a/platform/libs.flatlaf/external/flatlaf-3.0-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-3.0-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 2.6
-Files: flatlaf-2.6.jar
+Version: 3.0
+Files: flatlaf-3.0.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/manifest.mf
+++ b/platform/libs.flatlaf/manifest.mf
@@ -4,4 +4,4 @@ OpenIDE-Module: org.netbeans.libs.flatlaf/1
 OpenIDE-Module-Install: org/netbeans/libs/flatlaf/Installer.class
 OpenIDE-Module-Specification-Version: 1.13
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Implementation-Version: 2.6
+OpenIDE-Module-Implementation-Version: 3.0

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -31,11 +31,11 @@ spec.version.base.fatal.warning=false
 #
 # So when FlatLaf is updated, the OpenIDE-Module-Implementation-Version entry
 # in manifest.mf needs to be updated to match the new FlatLaf version.
-release.external/flatlaf-2.6.jar=modules/ext/flatlaf-2.6.jar
+release.external/flatlaf-3.0.jar=modules/ext/flatlaf-3.0.jar
 
-release.external/flatlaf-2.6.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
-release.external/flatlaf-2.6.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
-release.external/flatlaf-2.6.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
+release.external/flatlaf-3.0.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
+release.external/flatlaf-3.0.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
+release.external/flatlaf-3.0.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
 jnlp.verify.excludes=\
     modules/lib/flatlaf-windows-x86.dll,\
     modules/lib/flatlaf-windows-x86_64.dll,\

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -44,11 +44,12 @@
             </module-dependencies>
             <public-packages>
                 <package>com.formdev.flatlaf</package>
+                <package>com.formdev.flatlaf.themes</package>
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-2.6.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-2.6.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-3.0.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-3.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -84,8 +84,8 @@ nb.completion.selectedForeground=@selectionForeground
 
 #---- TabControlIcon ----
 
-TabControlIcon.foreground=$ComboBox.buttonArrowColor
-TabControlIcon.disabledForeground=$ComboBox.buttonDisabledArrowColor
+TabControlIcon.foreground=tint(@foreground,40%)
+TabControlIcon.disabledForeground=lighten($TabControlIcon.foreground,25%)
 TabControlIcon.rolloverBackground=$Button.toolbar.hoverBackground
 TabControlIcon.pressedBackground=$Button.toolbar.pressedBackground
 TabControlIcon.close.rolloverBackground=#c74f50

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
@@ -21,6 +21,8 @@ package org.netbeans.swing.laf.flatlaf;
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.FlatDarkLaf;
 import com.formdev.flatlaf.FlatLightLaf;
+import com.formdev.flatlaf.themes.FlatMacDarkLaf;
+import com.formdev.flatlaf.themes.FlatMacLightLaf;
 import javax.swing.UIManager;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -29,7 +31,9 @@ import org.openide.util.*;
 
 @NbBundle.Messages({
     "LBL_FLATLAF_LIGHT=FlatLaf Light",
-    "LBL_FLATLAF_DARK=FlatLaf Dark"
+    "LBL_FLATLAF_DARK=FlatLaf Dark",
+    "LBL_FLATLAF_MACOS_LIGHT=FlatLaf macOS Light",
+    "LBL_FLATLAF_MACOS_DARK=FlatLaf macOS Dark"
 })
 public class Installer extends ModuleInstall {
 
@@ -37,6 +41,8 @@ public class Installer extends ModuleInstall {
     public void validate() throws IllegalStateException {
         UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_LIGHT(), FlatLightLaf.class.getName()));
         UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_DARK(), FlatDarkLaf.class.getName()));
+        UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_MACOS_LIGHT(), FlatMacLightLaf.class.getName()));
+        UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_MACOS_DARK(), FlatMacDarkLaf.class.getName()));
 
         // tell FlatLaf that it should look for .properties files in the given package
         FlatLaf.registerCustomDefaultsSource("org.netbeans.swing.laf.flatlaf", getClass().getClassLoader());

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
@@ -32,8 +32,8 @@ import org.openide.util.*;
 @NbBundle.Messages({
     "LBL_FLATLAF_LIGHT=FlatLaf Light",
     "LBL_FLATLAF_DARK=FlatLaf Dark",
-    "LBL_FLATLAF_MACOS_LIGHT=FlatLaf macOS Light",
-    "LBL_FLATLAF_MACOS_DARK=FlatLaf macOS Dark"
+    "LBL_FLATLAF_CUPERTINO_LIGHT=FlatLaf Cupertino Light",
+    "LBL_FLATLAF_CUPERTINO_DARK=FlatLaf Cupertino Dark"
 })
 public class Installer extends ModuleInstall {
 
@@ -41,8 +41,8 @@ public class Installer extends ModuleInstall {
     public void validate() throws IllegalStateException {
         UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_LIGHT(), FlatLightLaf.class.getName()));
         UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_DARK(), FlatDarkLaf.class.getName()));
-        UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_MACOS_LIGHT(), FlatMacLightLaf.class.getName()));
-        UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_MACOS_DARK(), FlatMacDarkLaf.class.getName()));
+        UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_CUPERTINO_LIGHT(), FlatMacLightLaf.class.getName()));
+        UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_CUPERTINO_DARK(), FlatMacDarkLaf.class.getName()));
 
         // tell FlatLaf that it should look for .properties files in the given package
         FlatLaf.registerCustomDefaultsSource("org.netbeans.swing.laf.flatlaf", getClass().getClassLoader());


### PR DESCRIPTION
Update FlatLaf to v3.0.

Changes: https://github.com/JFormDesigner/FlatLaf/releases/tag/3.0

### macOS themes

FlatLaf 3 comes with two new themes, which look similar to macOS:

![macOS themes](https://user-images.githubusercontent.com/5604048/208445599-9330287d-b019-42d7-99b0-46d8c66b7c1f.png)

I've added both to the list of look and feels (on all platforms, screenshots are from Windows 11):

![grafik](https://user-images.githubusercontent.com/5604048/212728364-a306990a-b338-42ca-b336-f3828bf3cdb6.png)

![grafik](https://user-images.githubusercontent.com/5604048/212727933-518e603d-0213-4ab7-a40f-99ea1a8d437b.png)

### Rounded outlined icons

FlatLaf 3 has new modern rounded outlined icons for `JFileChooser`, `JOptionPane`, `JPasswordField` and `JTree`:

![image](https://user-images.githubusercontent.com/5604048/208452543-797d3dd5-aedf-4a50-9405-d7c1c513be8d.png)

They are e.g. used in project/file trees and in file choosers (in all FlatLaf themes):

![grafik](https://user-images.githubusercontent.com/5604048/212730106-95b00eb9-463f-450e-8b55-3938c8bf0967.png)

