### PR TITLE
Added CompletionItem.shouldSingleClickInvokeDefaultAction to the Editor Completion API

### DIFF
--- a/ide/editor.completion/apichanges.xml
+++ b/ide/editor.completion/apichanges.xml
@@ -84,6 +84,24 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="CompletionItem.shouldSingleClickInvokeDefaultAction">
+            <api name="completion"/>
+            <summary>Addition of optional CompletionItem.shouldSingleClickInvokeDefaultAction() method</summary>
+            <version major="1" minor="65"/>
+            <date day="20" month="1" year="2023"/>
+            <author login="ebakke"/>
+            <compatibility addition="yes"/>
+            <description>
+            <p>
+                <code>CompletionItem.shouldSingleClickInvokeDefaultAction</code> method was added
+                to to indicate that a single mouse click on the <code>CompletionItem</code> in the
+                completion list, rather than only a double-click, will invoke its default action.
+                A default method is provided in the method which returns false, preserving the old
+                behavior by default.
+            </p>
+            </description>
+        </change>
+
         <change id="CompletionUtilities.newCompletionItemBuilder">
             <api name="completion"/>
             <summary>Addition of CompletionUtilities.newCompletionItemBuilder() method</summary>

--- a/ide/editor.completion/src/org/netbeans/spi/editor/completion/CompletionItem.java
+++ b/ide/editor.completion/src/org/netbeans/spi/editor/completion/CompletionItem.java
@@ -52,6 +52,14 @@ public interface CompletionItem {
     void defaultAction(JTextComponent component);
 
     /**
+     * Indicate if single-clicking the item in the completion list should invoke the default action.
+     * Normally a double-click is required.
+     */
+    default boolean shouldSingleClickInvokeDefaultAction() {
+        return false;
+    }
+
+    /**
      * Process the key pressed when this completion item was selected
      * in the completion popup window.
      * <br/>


### PR DESCRIPTION
This PR adds a method CompletionItem.shouldSingleClickInvokeDefaultAction() that can optionally be implemented by editor completion item implementations. If this method is overridden to return true, a completion item will be inserted after a single click, as opposed to the existing default behavior which is to require a double-click.

This allows platform applications to use the Editor Completion API to implement combobox-like behavior. E.g. in [Ultorg](https://www.ultorg.com/) below:

<img width="767" alt="ComboBox" src="https://user-images.githubusercontent.com/886243/213814455-bfc55777-69d3-4598-a371-734f6b57be71.png">

(The existing double-click behavior still makes sense as a default, because the user may be clicking the item once to show documentation.)