### PR TITLE
Improve vertical alignment of DialogDisplayer icon (question mark, warning symbol etc.)

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
@@ -76,6 +76,7 @@ import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.MenuElement;
 import javax.swing.MenuSelectionManager;
+import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.WindowConstants;
@@ -507,6 +508,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             null // value
             );
         }
+        tweakIconLabelVerticalAlignment(optionPane);
 
         if (UIManager.getLookAndFeel().getClass() == MetalLookAndFeel.class ||
             UIManager.getLookAndFeel().getClass() == BasicLookAndFeel.class) {
@@ -583,6 +585,18 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
 
             getContentPane().remove(currentButtonsPanel);
             currentButtonsPanel = null;
+        }
+    }
+
+    private static void tweakIconLabelVerticalAlignment(Component component) {
+        if (component instanceof JLabel) {
+            if ("OptionPane.iconLabel".equals(component.getName())) {
+                ((JLabel) component).setVerticalAlignment(SwingConstants.CENTER);
+            }
+        } else if (component instanceof JComponent) {
+            for (Component childComponent : ((JComponent) component).getComponents()) {
+                tweakIconLabelVerticalAlignment(childComponent);
+            }
         }
     }
 


### PR DESCRIPTION
In DialogDisplayer dialogs, there's typically an "information", "question mark" or "warning" type icon next to the text. It shows up top-aligned by default, which makes it look mis-aligned relative to the message text. This PR centers the icon vertically. See below:

<img width="1071" alt="220930 Dialog Centering Screenshot" src="https://user-images.githubusercontent.com/886243/213815846-e33bfbc2-3954-451e-a596-1c9a895fba5b.png">

As the dialog is constructed by JOptionPane, the tweakIconLabelVerticalAlignment method applies the fix by descending into the child components and finding the one conveniently named "OptionPane.iconLabel".

This is purely a cosmetic UI improvement.