### PR TITLE
Don't show the '+' separator in keyboard accelerators on MacOS

### DIFF
--- a/harness/jellytools.platform/src/org/netbeans/jellytools/actions/Action.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/actions/Action.java
@@ -23,7 +23,6 @@ import java.awt.Container;
 import java.awt.EventQueue;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
 import javax.swing.KeyStroke;
 import javax.swing.tree.TreePath;
 
@@ -44,6 +43,7 @@ import org.netbeans.jemmy.operators.Operator.ComponentVisualizer;
 import org.netbeans.jemmy.operators.Operator.DefaultStringComparator;
 import org.netbeans.jemmy.operators.Operator.StringComparator;
 import org.netbeans.jemmy.util.EmptyVisualizer;
+import org.openide.awt.Actions;
 import org.openide.cookies.InstanceCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -1281,8 +1281,8 @@ public class Action {
          */
         @Override
         public String toString() {
-            String s = KeyEvent.getKeyModifiersText(getKeyModifiers());
-            return s + (s.length() > 0 ? "+" : "") + KeyEvent.getKeyText(getKeyCode());
+            return Actions.keyStrokeToString(
+                    KeyStroke.getKeyStroke(getKeyCode(), getKeyModifiers()));
         }
     }
 }

--- a/ide/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/GotoLineOrBookmarkPanel.java
+++ b/ide/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/GotoLineOrBookmarkPanel.java
@@ -68,6 +68,7 @@ import org.netbeans.modules.editor.bookmarks.BookmarkInfo;
 import org.netbeans.modules.editor.bookmarks.BookmarkManager;
 import org.netbeans.modules.editor.bookmarks.BookmarkUtils;
 import org.openide.actions.GotoAction;
+import org.openide.awt.Actions;
 import org.openide.util.NbBundle;
 import org.openide.util.actions.SystemAction;
 
@@ -193,10 +194,8 @@ public class GotoLineOrBookmarkPanel extends JPanel implements ActionListener, F
                 JPanel southPanel = new JPanel();
                 southPanel.setLayout(new GridBagLayout());
                 JLabel keyChooserLabel = new JLabel();
-                String ksText = KeyEvent.getKeyModifiersText(ks.getModifiers()) + "+" + // NOI18N
-                        KeyEvent.getKeyText(ks.getKeyCode());
                 keyChooserLabel.setText(NbBundle.getMessage(GotoLineOrBookmarkPanel.class,
-                        "CTL_gotoDialogBookmarkKeyChooserLabel", ksText));
+                        "CTL_gotoDialogBookmarkKeyChooserLabel", Actions.keyStrokeToString(ks)));
                 InputMap inputMap = rootPane.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
                 inputMap.put(ks, "openKeyChooser");
                 rootPane.getActionMap().put("openKeyChooser", new AbstractAction() {

--- a/ide/editor.lib/src/org/netbeans/editor/MultiKeymap.java
+++ b/ide/editor.lib/src/org/netbeans/editor/MultiKeymap.java
@@ -35,6 +35,7 @@ import javax.swing.text.DefaultEditorKit;
 import javax.swing.KeyStroke;
 import javax.swing.Action;
 import javax.swing.AbstractAction;
+import org.openide.awt.Actions;
 import org.openide.awt.StatusDisplayer;
 import org.openide.util.Lookup;
 
@@ -134,7 +135,7 @@ public class MultiKeymap implements Keymap {
             
             StringBuffer text = new StringBuffer();
             for (Iterator it = globalContextList.iterator(); it.hasNext();) {
-                text.append(getKeyText((KeyStroke)it.next())).append(' ');
+                text.append(Actions.keyStrokeToString((KeyStroke) it.next())).append(' ');
             }
             StatusDisplayer.getDefault().setStatusText(text.toString());        
         }

--- a/ide/editor.lib/src/org/netbeans/editor/Utilities.java
+++ b/ide/editor.lib/src/org/netbeans/editor/Utilities.java
@@ -83,6 +83,7 @@ import org.netbeans.modules.editor.lib.BeforeSaveTasks;
 import org.netbeans.modules.editor.lib2.EditorPreferencesDefaults;
 import org.netbeans.modules.editor.lib2.view.DocumentView;
 import org.netbeans.modules.editor.lib2.view.EditorView;
+import org.openide.awt.Actions;
 import org.openide.util.Exceptions;
 import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
@@ -1292,47 +1293,14 @@ public class Utilities {
 
     /**
      * Creates nice textual representation of KeyStroke.
-     * Modifiers and an actual key label are concated by plus signs
+     * Modifiers and an actual key label are concated per the platform-specific convention
      * @param stroke the KeyStroke to get description of
      * @return String describing the KeyStroke
      */
     public static String keyStrokeToString( KeyStroke stroke ) {
-        String modifText = KeyEvent.getKeyModifiersText( stroke.getModifiers() );
-        String keyText = (stroke.getKeyCode() == KeyEvent.VK_UNDEFINED) ? 
-            String.valueOf(stroke.getKeyChar()) : getKeyText(stroke.getKeyCode());
-        if( modifText.length() > 0 ) return modifText + '+' + keyText;
-        else return keyText;
-    }
-    
-    /** @return slight modification of what KeyEvent.getKeyText() returns.
-     *  The numpad Left, Right, Down, Up get extra result.
-     */
-    private static String getKeyText(int keyCode) {
-        String ret = KeyEvent.getKeyText(keyCode);
-        if (ret != null) {
-            switch (keyCode) {
-                case KeyEvent.VK_KP_DOWN:
-                    ret = prefixNumpad(ret, KeyEvent.VK_DOWN);
-                    break;
-                case KeyEvent.VK_KP_LEFT:
-                    ret = prefixNumpad(ret, KeyEvent.VK_LEFT);
-                    break;
-                case KeyEvent.VK_KP_RIGHT:
-                    ret = prefixNumpad(ret, KeyEvent.VK_RIGHT);
-                    break;
-                case KeyEvent.VK_KP_UP:
-                    ret = prefixNumpad(ret, KeyEvent.VK_UP);
-                    break;
-            }
-        }
-        return ret;
-    }
-    
-    private static String prefixNumpad(String key, int testKeyCode) {
-        if (key.equals(KeyEvent.getKeyText(testKeyCode))) {
-            key = NbBundle.getBundle(BaseKit.class).getString("key-prefix-numpad") + key;
-        }
-        return key;
+        /* The related logic has now been moved into org.openide.awt.Actions, so that it can be used
+        by modules that do not depend on the editor infrastructure. */
+        return Actions.keyStrokeToString(stroke);
     }
 
     private static void checkOffsetValid(Document doc, int offset) throws BadLocationException {

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/EditorActionUtilities.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/EditorActionUtilities.java
@@ -47,6 +47,7 @@ import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.api.editor.settings.KeyBindingSettings;
 import org.netbeans.api.editor.settings.MultiKeyBinding;
 import org.netbeans.spi.editor.AbstractEditorAction;
+import org.openide.awt.Actions;
 import org.openide.filesystems.FileObject;
 import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
@@ -184,7 +185,7 @@ public final class EditorActionUtilities {
      * @return mnemonic of the keystroke.
      */
     public static String getKeyMnemonic(KeyStroke key) {
-        return appendKeyMnemonic(new StringBuilder(20), key).toString();
+        return Actions.keyStrokeToString(key);
     }
 
     public static String getKeyMnemonic(List<KeyStroke> keys) {
@@ -193,36 +194,10 @@ public final class EditorActionUtilities {
             if (sb.length() > 0) {
                 sb.append(' '); //NOI18N
             }
-            appendKeyMnemonic(sb, key);
+            sb.append(Actions.keyStrokeToString(key));
         }
         return sb.toString();
     }
-
-    public static String appendKeyMnemonic(StringBuilder sb, KeyStroke key) {
-        String sk = org.openide.util.Utilities.keyToString(key);
-        int mods = key.getModifiers();
-        if ((mods & KeyEvent.CTRL_MASK) != 0) {
-            sb.append("Ctrl+"); // NOI18N
-        }
-        if ((mods & KeyEvent.ALT_MASK) != 0) {
-            sb.append("Alt+"); // NOI18N
-        }
-        if ((mods & KeyEvent.SHIFT_MASK) != 0) {
-            sb.append("Shift+"); // NOI18N
-        }
-        if ((mods & KeyEvent.META_MASK) != 0) {
-            sb.append("Meta+"); // NOI18N
-        }
-
-        int i = sk.indexOf('-'); //NOI18N
-        if (i != -1) {
-            sk = sk.substring(i + 1);
-        }
-        sb.append(sk);
-
-        return sb.toString();
-    }
-
 
     public static SearchableEditorKit getGlobalActionsKit() {
         synchronized (EditorActionUtilities.class) {

--- a/java/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeAnnotations.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeAnnotations.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.java.editor.overridden;
 
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
-import java.awt.event.KeyEvent;
 import com.sun.source.tree.Tree;
 import java.util.Collection;
 import java.util.Collections;
@@ -49,6 +48,7 @@ import org.netbeans.api.java.source.JavaSource.Phase;
 import org.netbeans.modules.parsing.api.Snapshot;
 import org.netbeans.modules.parsing.spi.*;
 import org.netbeans.modules.parsing.spi.Parser.Result;
+import org.openide.awt.Actions;
 import org.openide.text.NbDocument;
 import org.openide.util.NbBundle;
 
@@ -245,7 +245,7 @@ public class ComputeAnnotations extends JavaParserResultTask<Result> {
         for (MultiKeyBinding mkb : kbs.getKeyBindings()) {
             if (actionName.equals(mkb.getActionName())) {
                 KeyStroke ks = mkb.getKeyStrokeCount() > 0 ? mkb.getKeyStroke(0) : null;
-                return ks != null ? KeyEvent.getKeyModifiersText(ks.getModifiers()) + '+' + KeyEvent.getKeyText(ks.getKeyCode()) : null;
+                return ks != null ? Actions.keyStrokeToString(ks) : null;
             }
         }
         return null;

--- a/java/java.navigation/src/org/netbeans/modules/java/navigation/ToolTipManagerEx.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/navigation/ToolTipManagerEx.java
@@ -35,6 +35,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
+import javax.swing.KeyStroke;
 import javax.swing.Popup;
 import javax.swing.PopupFactory;
 import javax.swing.SwingUtilities;
@@ -44,6 +45,7 @@ import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.api.editor.settings.SimpleValueNames;
+import org.openide.awt.Actions;
 import org.openide.nodes.Node;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
@@ -760,8 +762,10 @@ final class ToolTipManagerEx extends MouseAdapter implements MouseMotionListener
             JScrollPane scroll = new JScrollPane( content );
             scroll.setHorizontalScrollBarPolicy( JScrollPane.HORIZONTAL_SCROLLBAR_NEVER );
             add( scroll, new GridBagConstraints(0,0,1,1,1.0,1.0,GridBagConstraints.CENTER,GridBagConstraints.BOTH,new Insets(0,0,0,0),0,0) );
+            String shownKeyStroke = Actions.keyStrokeToString(KeyStroke.getKeyStroke(
+                KeyEvent.VK_F1, Utilities.isMac() ? KeyEvent.VK_META : KeyEvent.CTRL_DOWN_MASK));
             shortcut = new JLabel( NbBundle.getMessage( ToolTipManagerEx.class, "HINT_EnlargeJavaDocToolip", //NOI18N
-                    Utilities.isMac() ? KeyEvent.getKeyText(KeyEvent.VK_META)+"+F1" : "Ctrl+F1" ) ); //NOI18N //NOI18N
+                    shownKeyStroke ) );
             shortcut.setHorizontalAlignment( JLabel.CENTER );
             shortcut.setBorder( BorderFactory.createLineBorder(Color.black) );
             add( shortcut, new GridBagConstraints(0,1,1,1,0.0,0.0,GridBagConstraints.CENTER,GridBagConstraints.BOTH,new Insets(0,0,0,0),0,0) );

--- a/platform/o.n.core/src/org/netbeans/core/NbKeymap.java
+++ b/platform/o.n.core/src/org/netbeans/core/NbKeymap.java
@@ -39,6 +39,7 @@ import javax.swing.Action;
 import javax.swing.KeyStroke;
 import javax.swing.text.Keymap;
 import org.openide.awt.AcceleratorBinding;
+import org.openide.awt.Actions;
 import org.openide.awt.StatusDisplayer;
 import org.openide.cookies.InstanceCookie;
 import org.openide.filesystems.FileAttributeEvent;
@@ -281,19 +282,9 @@ public final class NbKeymap implements Keymap, Comparator<KeyStroke> {
 
         StringBuilder text = new StringBuilder();
         for (KeyStroke ks: context) {
-            text.append(getKeyText(ks)).append(' ');
+            text.append(Actions.keyStrokeToString(ks)).append(' ');
         }
         StatusDisplayer.getDefault().setStatusText(text.toString());        
-    }
-    
-    private static String getKeyText (KeyStroke keyStroke) {
-        if (keyStroke == null) return "";
-        String modifText = KeyEvent.getKeyModifiersText 
-            (keyStroke.getModifiers ());
-        if ("".equals (modifText))       
-            return KeyEvent.getKeyText (keyStroke.getKeyCode ());
-        return modifText + "+" +                                // NOI18N
-            KeyEvent.getKeyText (keyStroke.getKeyCode ()); 
     }
            
     private static final Logger LOG = Logger.getLogger(NbKeymap.class.getName());

--- a/platform/openide.awt/apichanges.xml
+++ b/platform/openide.awt/apichanges.xml
@@ -26,6 +26,23 @@
 <apidef name="awt">AWT API</apidef>
 </apidefs>
 <changes>
+    <change id="add-actions-keyStrokeToString">
+        <api name="awt"/>
+        <summary>Add Actions.keyStrokeToString utility method.</summary>
+        <version major="7" minor="88"/>
+        <date day="25" month="3" year="2023"/>
+        <author login="ebakke"/>
+        <compatibility binary="compatible" semantic="compatible" source="compatible" addition="yes" deprecation="no" deletion="no"/>
+        <description>
+            <p>The Actions.keyStrokeToString method has been added as a public API, to avoid
+               duplication of the same logic in the editor.lib module. This method has identical
+               semantics to the existing org.netbeans.editor.Utilities.Actions.keyStrokeToString
+               method (which now delegates to the new Actions.keyStrokeToString), but is available
+               without depending on the editor infrastructure.
+            </p>
+        </description>
+        <class name="Actions" package="org.openide.awt"/>
+    </change>
     <change id="configureDefaultRenderingHints">
         <api name="awt"/>
         <summary>Added GraphicsUtils.configureDefaultRenderingHints(Graphics).</summary>

--- a/platform/openide.awt/src/org/openide/awt/Bundle.properties
+++ b/platform/openide.awt/src/org/openide/awt/Bundle.properties
@@ -62,6 +62,9 @@ ACSD_SplittedPanel_EmptySplitter=N/A
 # {1} = shortcut
 FMT_ButtonHint={0} ({1})
 
+# Used by Actions.keyStrokeToString
+key-prefix-numpad=NumPad-
+
 # SwingBrowserImpl
 ACS_SwingBrowserImpl_SwingBrowser=N/A
 #Title while loading

--- a/profiler/profiler.api/src/org/netbeans/modules/profiler/api/ActionsSupport.java
+++ b/profiler/profiler.api/src/org/netbeans/modules/profiler/api/ActionsSupport.java
@@ -23,8 +23,8 @@ import javax.swing.Action;
 import javax.swing.ActionMap;
 import javax.swing.InputMap;
 import javax.swing.KeyStroke;
-import javax.swing.UIManager;
 import org.netbeans.modules.profiler.spi.ActionsSupportProvider;
+import org.openide.awt.Actions;
 import org.openide.util.Lookup;
 
 /**
@@ -35,22 +35,12 @@ import org.openide.util.Lookup;
 public final class ActionsSupport {
     
     public static final KeyStroke NO_KEYSTROKE = KeyStroke.getKeyStroke(KeyEvent.VK_UNDEFINED, 0);
-    
-    private static String ACC_DELIMITER;
+
     public static String keyAcceleratorString(KeyStroke keyStroke) {
-        if (keyStroke == null || NO_KEYSTROKE.equals(keyStroke)) return null;
-        
-        String keyText = KeyEvent.getKeyText(keyStroke.getKeyCode());
-        
-        int modifiers = keyStroke.getModifiers();
-        if (modifiers == 0) return keyText;
-        
-        if (ACC_DELIMITER == null) {
-            ACC_DELIMITER = UIManager.getString("MenuItem.acceleratorDelimiter"); // NOI18N
-            if (ACC_DELIMITER == null) ACC_DELIMITER = "+"; // NOI18N // Note: NetBeans default, Swing uses '-' by default
+        if (keyStroke == null || NO_KEYSTROKE.equals(keyStroke)) {
+            return null;
         }
-        
-        return KeyEvent.getKeyModifiersText(modifiers) + ACC_DELIMITER + keyText;
+        return Actions.keyStrokeToString(keyStroke);
     }
     
     public static KeyStroke registerAction(String actionKey, Action action, ActionMap actionMap, InputMap inputMap) {


### PR DESCRIPTION
Keyboard accelerator strings, such as "Ctrl+R", are shown to the user in various places throughout NetBeans, e.g. in editor toolbar tooltips. On MacOS, the traditional display format for these is to use a special single-character symbol for modifier keys, and no "+" symbol. E.g. "⌘R" for Command+R. On NetBeans, though, we currently show this as "⌘+R".

This PR gets rid of the plus symbol on MacOS, to match the native convention. This is already how shortcuts are displayed in the main menu (where the accelerator display strings are generated by the OS).