### PR TITLE
Copy FlatLAF label positioning improvements into the Windows LAF

### DIFF
--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabDisplayerUI.java
@@ -66,15 +66,12 @@ public class WinFlatEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
 
     @Override
     public Dimension getPreferredSize(JComponent c) {
-        int prefHeight;
-        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics();
-        if (g != null) {
-            FontMetrics fm = g.getFontMetrics(displayer.getFont());
-            Insets ins = getTabAreaInsets();
-            prefHeight = fm.getHeight() + ins.top + ins.bottom
-                    + tabInsets.top + tabInsets.bottom;
-        } else
-            prefHeight = UIScale.scale(28);
+        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics(c);
+        FontMetrics fm = g.getFontMetrics(displayer.getFont());
+        Insets ins = getTabAreaInsets();
+        // Standard icons are 16 pixels tall, so always allocate space for them.
+        int prefHeight = Math.max(fm.getHeight(), 16) + ins.top + ins.bottom
+                + tabInsets.top + tabInsets.bottom;
         return new Dimension(displayer.getWidth(), prefHeight);
     }
 

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatViewTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatViewTabDisplayerUI.java
@@ -188,16 +188,19 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
 
         // paint text
         int txtX = x + txtLeftPad;
-        int txtY = y + tabInsets.top + fm.getAscent();
         int availH = height - tabInsets.top - tabInsets.bottom;
-        if (availH > fm.getHeight()) {
-            txtY += (availH - fm.getHeight()) / 2;
-        }
         int style = HtmlRenderer.STYLE_TRUNCATE;
         if (!isSelected(index)) {
             // center text of unselected tabs
             txtX = Math.max(x + 1, x + ((width - realTxtWidth) / 2));
         }
+
+        /* Keep the txtY calculation the same as for WinFlatEditorTabCellRenderer, with an offset that
+        makes the text in view tabs and editor tabs always line up. */
+        double txtVisualAscent = getTxtFont().createGlyphVector(fm.getFontRenderContext(), "H")
+            .getVisualBounds().getHeight();
+        int txtY = tabInsets.top + (int) Math.round((availH + txtVisualAscent) / 2) + 1;
+
         HtmlRenderer.renderString(text, g, txtX, txtY, availTxtWidth, height,
                 getTxtFont(), c, style, true);
     }


### PR DESCRIPTION
This PR copies the previously merged [text alignment improvements](https://github.com/apache/netbeans/pull/4349) in FlatLAF window system tabs back to the older Windows LAF.

This completes the tab component saga originally started in https://github.com/apache/netbeans/pull/3115 ; this PR corresponds to the last commit of the latter.

At some point we might want to move the FlatLAF tab control implementations into o.n.swing.tabcontrol so the code can be shared, but they have some dependencies on FlatLAF-specific UI scaling utilities and so on. But the Windows LAF will probably be obsoleted by FlatLAF soon anyway.