### PR TITLE
added missing record enums to editor module.

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionTask.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionTask.java
@@ -102,7 +102,10 @@ public class JavadocCompletionTask<T> extends UserTask {
         T createPackageItem(String pkgFQN, int startOffset);
     }
 
-    private static final Set<ElementKind> EXECUTABLE = EnumSet.of(ElementKind.METHOD, ElementKind.CONSTRUCTOR);
+    private static final EnumSet<ElementKind> EXECUTABLE = EnumSet.of(ElementKind.METHOD, ElementKind.CONSTRUCTOR);
+    private static final EnumSet<ElementKind> TYPE_KINDS = EnumSet.of(
+            ElementKind.CLASS, ElementKind.INTERFACE, ElementKind.ENUM, ElementKind.RECORD, ElementKind.ANNOTATION_TYPE);
+
     private static final String CLASS_KEYWORD = "class"; //NOI18N
 
     private final List<T> items = new ArrayList<>();
@@ -588,17 +591,17 @@ public class JavadocCompletionTask<T> extends UserTask {
         String pkgPrefix;
         if (fqn == null) {
             pkgPrefix = prefix;
-            addTypes(EnumSet.<ElementKind>of(ElementKind.CLASS, ElementKind.INTERFACE, ElementKind.ENUM, ElementKind.ANNOTATION_TYPE), null, null, prefix, substitutionOffset, jdctx);
+            addTypes(TYPE_KINDS, null, null, prefix, substitutionOffset, jdctx);
         } else {
             pkgPrefix = fqn + '.' + prefix;
             PackageElement pkgElm = jdctx.javac.getElements().getPackageElement(fqn);
             if (pkgElm != null) {
-                addPackageContent(pkgElm, EnumSet.<ElementKind>of(ElementKind.CLASS, ElementKind.INTERFACE, ElementKind.ENUM, ElementKind.ANNOTATION_TYPE), null, null, prefix, substitutionOffset, jdctx);
+                addPackageContent(pkgElm, TYPE_KINDS, null, null, prefix, substitutionOffset, jdctx);
             }
             TypeElement typeElm = jdctx.javac.getElements().getTypeElement(fqn);
             if (typeElm != null) {
                 // inner classes
-                addInnerClasses(typeElm, EnumSet.<ElementKind>of(ElementKind.CLASS, ElementKind.INTERFACE, ElementKind.ENUM, ElementKind.ANNOTATION_TYPE), null, null, prefix, substitutionOffset, jdctx);
+                addInnerClasses(typeElm, TYPE_KINDS, null, null, prefix, substitutionOffset, jdctx);
             }
         }
         for (String pkgName : jdctx.javac.getClasspathInfo().getClassIndex().getPackageNames(pkgPrefix, true, EnumSet.allOf(ClassIndex.SearchScope.class))) {

--- a/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/TagRegistery.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/TagRegistery.java
@@ -31,11 +31,11 @@ import javax.lang.model.element.ElementKind;
  */
 final class TagRegistery {
     
-    private static final Set<ElementKind> ALL_KINDS = EnumSet.<ElementKind>of(
+    private static final Set<ElementKind> ALL_KINDS = EnumSet.of(
             ElementKind.ANNOTATION_TYPE, ElementKind.CLASS,
             ElementKind.CONSTRUCTOR, ElementKind.ENUM,
             ElementKind.ENUM_CONSTANT, ElementKind.FIELD,
-            ElementKind.INTERFACE, ElementKind.METHOD,
+            ElementKind.INTERFACE, ElementKind.RECORD, ElementKind.METHOD,
             // OTHER stands for Overview here
             ElementKind.OTHER, ElementKind.MODULE,
             ElementKind.PACKAGE);
@@ -62,27 +62,27 @@ final class TagRegistery {
         this.tags = new ArrayList<TagEntry>(20);
         addTag("@author", false, EnumSet.of(
                 ElementKind.ANNOTATION_TYPE, ElementKind.CLASS,
-                ElementKind.ENUM, ElementKind.INTERFACE,
+                ElementKind.ENUM, ElementKind.INTERFACE, ElementKind.RECORD,
                 ElementKind.OTHER, ElementKind.MODULE,
                 ElementKind.PACKAGE));
         addTag("@exception", false, EnumSet.of(ElementKind.METHOD, ElementKind.CONSTRUCTOR));
         // deprecated: not in PACKAGE and OVERVIEW!
-        addTag("@deprecated", false, EnumSet.<ElementKind>of(
+        addTag("@deprecated", false, EnumSet.of(
                 ElementKind.ANNOTATION_TYPE, ElementKind.CLASS,
                 ElementKind.CONSTRUCTOR, ElementKind.ENUM,
                 ElementKind.ENUM_CONSTANT, ElementKind.FIELD,
-                ElementKind.INTERFACE, ElementKind.METHOD));
+                ElementKind.INTERFACE, ElementKind.METHOD, ElementKind.RECORD));
 
         addTag("@param", false, EnumSet.of(
                 ElementKind.METHOD, ElementKind.CONSTRUCTOR, ElementKind.CLASS,
-                ElementKind.INTERFACE));
+                ElementKind.INTERFACE, ElementKind.RECORD));
         addTag("@return", false, EnumSet.of(ElementKind.METHOD));
         addTag("@see", false, ALL_KINDS);
-        addTag("@serial", false, EnumSet.<ElementKind>of(
+        addTag("@serial", false, EnumSet.of(
                 ElementKind.ANNOTATION_TYPE, ElementKind.CLASS,
                 ElementKind.ENUM,
                 ElementKind.ENUM_CONSTANT, ElementKind.FIELD,
-                ElementKind.INTERFACE,
+                ElementKind.INTERFACE, ElementKind.RECORD,
                 ElementKind.PACKAGE));
 
         // serialData can be used just for writeObject, readObject, writeExternal, readExternal, writeReplace, and readResolve methods
@@ -90,10 +90,10 @@ final class TagRegistery {
         addTag("@serialField", false, EnumSet.of(ElementKind.FIELD));
         addTag("@since", false, ALL_KINDS);
         addTag("@throws", false, EnumSet.of(ElementKind.METHOD, ElementKind.CONSTRUCTOR));
-        addTag("@version", false, EnumSet.<ElementKind>of(
+        addTag("@version", false, EnumSet.of(
                 ElementKind.ANNOTATION_TYPE, ElementKind.CLASS,
                 ElementKind.ENUM,
-                ElementKind.INTERFACE,
+                ElementKind.INTERFACE, ElementKind.RECORD,
                 ElementKind.OTHER, ElementKind.PACKAGE));
         addTag("@hidden", false, ALL_KINDS);
         addTag("@provides", false, EnumSet.of(ElementKind.MODULE));
@@ -102,11 +102,11 @@ final class TagRegistery {
         addTag("@code", true, ALL_KINDS);
         addTag("@snippet", true, ALL_KINDS);
         addTag("@summary", true, ALL_KINDS);
-        addTag("@systemProperty", true, EnumSet.<ElementKind>of(
+        addTag("@systemProperty", true, EnumSet.of(
             ElementKind.ANNOTATION_TYPE, ElementKind.CLASS,
             ElementKind.CONSTRUCTOR, ElementKind.ENUM,
             ElementKind.ENUM_CONSTANT, ElementKind.FIELD,
-            ElementKind.INTERFACE, ElementKind.METHOD,
+            ElementKind.INTERFACE, ElementKind.METHOD, ElementKind.RECORD,
             ElementKind.MODULE, ElementKind.PACKAGE));
         addTag("@docRoot", true, ALL_KINDS);
         addTag("@index", true, ALL_KINDS);

--- a/java/java.editor/src/org/netbeans/modules/java/editor/overridden/GoToImplementation.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/overridden/GoToImplementation.java
@@ -165,6 +165,7 @@ public final class GoToImplementation extends BaseAction {
             case CLASS:
             case ENUM:
             case INTERFACE:
+            case RECORD:
                 elementNameSpan = info.getTreeUtilities().findNameSpan((ClassTree) tp.getLeaf());
                 onDeclaration.set(true);
                 break;
@@ -186,6 +187,7 @@ public final class GoToImplementation extends BaseAction {
         }
     }
 
-    private static Set<ElementKind> SUPPORTED_ELEMENTS = EnumSet.of(ElementKind.METHOD, ElementKind.ANNOTATION_TYPE, ElementKind.CLASS, ElementKind.ENUM, ElementKind.INTERFACE);
+    private static final Set<ElementKind> SUPPORTED_ELEMENTS = EnumSet.of(
+            ElementKind.METHOD, ElementKind.ANNOTATION_TYPE, ElementKind.CLASS, ElementKind.ENUM, ElementKind.INTERFACE, ElementKind.RECORD);
     
 }

--- a/java/java.editor/src/org/netbeans/modules/java/editor/semantic/Bundle.properties
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/semantic/Bundle.properties
@@ -27,6 +27,7 @@ LBL_UnusedMethod=Method {0} is not used
 LBL_UnusedConstructor=Constructor {0} is not used
 LBL_UnusedClass=Class {0} is not used
 LBL_UnusedInterface=Interface {0} is not used
+LBL_UnusedRecord=Record {0} is not used
 LBL_UnusedAnnotationType=Annotation Type {0} is not used
 LBL_UnusedEnum=Enum {0} is not used
 

--- a/java/java.editor/src/org/netbeans/modules/java/editor/semantic/UnusedTooltipResolver.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/semantic/UnusedTooltipResolver.java
@@ -128,6 +128,10 @@ final class UnusedTooltipResolver implements HighlightAttributeValue<String> {
                             key = "LBL_UnusedInterface"; // NOI18N
                             elementDisplayName = e.getSimpleName().toString();
                             break;
+                        case RECORD:
+                            key = "LBL_UnusedRecord"; // NOI18N
+                            elementDisplayName = e.getSimpleName().toString();
+                            break;
                         case ANNOTATION_TYPE:
                             key = "LBL_UnusedAnnotationType"; // NOI18N
                             elementDisplayName = e.getSimpleName().toString();


### PR DESCRIPTION
based on delivery

checks for `ElementKind.RECORD` are missing all over the codebase. The lexer isn't even record aware. This PR only covers `java.editor`. I had a larger changeset which checked all usages of the CLASS enum and added RECORD on a case by case basis. But it is probably not a good idea to do this blindly without being able to validate it properly.

this PR fixes three small bugs which are easily verifiable:

 - tooltip on unused records will use the right bundle msg
 - javadoc completion for records
 - goto impl is now working for records


test code:

```java
package bugs;

public class RecordEnums {

    /**
     * @see bugs.RecordEnums.
     *      check completion ^^^ should have records
     */
    record ARecord() { }
    
    record UnusedRecord() { }
    // mouse over ^^^ should have tooltip
    
    class AClass { }
    
    public static void main(String[] args) {
        ARecord r = new ARecord();
    //  ^^^ use navigate -> goto implementation
    }
}
```

took me a while to get to this. Wanted to enable the lexer tests first which required other CI related tasks, but its all done now :)