### PR TITLE
Improved method checks in enum declaration

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/PredefinedSymbols.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/PredefinedSymbols.java
@@ -101,6 +101,8 @@ public final class PredefinedSymbols {
                 "__sleep", // NOI18N
                 "__wakeup", // NOI18N
                 "__toString", // NOI18N
+                "__invoke", // NOI18N
+                "__debugInfo", // NOI18N
                 "__serialize", // NOI18N PHP 7.4
                 "__unserialize", // NOI18N PHP 7.4
             })));

--- a/php/php.editor/test/unit/data/testfiles/verification/IncorrectEnumHintError/testIncorrectEnums.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/IncorrectEnumHintError/testIncorrectEnums.php
@@ -40,6 +40,52 @@ enum IncorrectConstructor {
     }
 }
 
+enum IncorrectMethods {
+    public function cases():array {}
+    public function __get($name) {}
+    public function __set($name,$value) {}
+    public function __isset($name) {}
+    public function __unset($name) {}
+    public function __sleep() {}
+    public function __wakeup() {}
+    public function __serialize() {}
+    public function __unserialize($array) {}
+    public function __toString() {}
+    public static function __set_state($state) {}
+    public function __clone() {}
+    public function __debugInfo() {}
+}
+
+enum IncorrectMethodsBacked: string {
+    public function cases():array {}
+    public function from(string|int $value):self {}
+    public function tryFrom(string|int $value):self {}
+}
+
+enum IncorrectMethodsCorrectCaseInMessage {
+    public function Cases():array {}
+    public function __GET($name) {}
+    public function __seT($name,$value) {}
+    public function __ISset($name) {}
+    public function __unSET($name) {}
+    public function __sleeP() {}
+    public function __wAkeup() {}
+    public function __Serialize() {}
+    public function __Unserialize($array) {}
+    public function __ToString() {}
+    public static function __Set_State($state) {}
+    public function __clONe() {}
+    public function __DebugInfo() {}
+}
+
+enum CorrectMethods {
+    public function from(string|int $value):self {}
+    public function tryFrom(string|int $value):self {}
+    public function __call($name,$args) {}
+    public static function __callStatic($name,$args) {}
+    public function __invoke() {}
+}
+
 enum CorrectBackingTypeString: string {
     case CASE_NAME;
 }

--- a/php/php.editor/test/unit/data/testfiles/verification/IncorrectEnumHintError/testIncorrectEnums.php.testIncorrectEnums.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/IncorrectEnumHintError/testIncorrectEnums.php.testIncorrectEnums.hints
@@ -20,6 +20,93 @@ HINT:Enum cannot have properties
     public function __construct() {
                     -----------
 HINT:Enum cannot have a constructor
+    public function cases():array {}
+                    -----
+HINT:Enum cannot redeclare method "cases"
+    public function __get($name) {}
+                    -----
+HINT:Enum cannot contain magic method method "__get"
+    public function __set($name,$value) {}
+                    -----
+HINT:Enum cannot contain magic method method "__set"
+    public function __isset($name) {}
+                    -------
+HINT:Enum cannot contain magic method method "__isset"
+    public function __unset($name) {}
+                    -------
+HINT:Enum cannot contain magic method method "__unset"
+    public function __sleep() {}
+                    -------
+HINT:Enum cannot contain magic method method "__sleep"
+    public function __wakeup() {}
+                    --------
+HINT:Enum cannot contain magic method method "__wakeup"
+    public function __serialize() {}
+                    -----------
+HINT:Enum cannot contain magic method method "__serialize"
+    public function __unserialize($array) {}
+                    -------------
+HINT:Enum cannot contain magic method method "__unserialize"
+    public function __toString() {}
+                    ----------
+HINT:Enum cannot contain magic method method "__toString"
+    public static function __set_state($state) {}
+                           -----------
+HINT:Enum cannot contain magic method method "__set_state"
+    public function __clone() {}
+                    -------
+HINT:Enum cannot contain magic method method "__clone"
+    public function __debugInfo() {}
+                    -----------
+HINT:Enum cannot contain magic method method "__debugInfo"
+    public function cases():array {}
+                    -----
+HINT:Enum cannot redeclare method "cases"
+    public function from(string|int $value):self {}
+                    ----
+HINT:Backed enum cannot redeclare method "from"
+    public function tryFrom(string|int $value):self {}
+                    -------
+HINT:Backed enum cannot redeclare method "tryFrom"
+    public function Cases():array {}
+                    -----
+HINT:Enum cannot redeclare method "cases"
+    public function __GET($name) {}
+                    -----
+HINT:Enum cannot contain magic method method "__get"
+    public function __seT($name,$value) {}
+                    -----
+HINT:Enum cannot contain magic method method "__set"
+    public function __ISset($name) {}
+                    -------
+HINT:Enum cannot contain magic method method "__isset"
+    public function __unSET($name) {}
+                    -------
+HINT:Enum cannot contain magic method method "__unset"
+    public function __sleeP() {}
+                    -------
+HINT:Enum cannot contain magic method method "__sleep"
+    public function __wAkeup() {}
+                    --------
+HINT:Enum cannot contain magic method method "__wakeup"
+    public function __Serialize() {}
+                    -----------
+HINT:Enum cannot contain magic method method "__serialize"
+    public function __Unserialize($array) {}
+                    -------------
+HINT:Enum cannot contain magic method method "__unserialize"
+    public function __ToString() {}
+                    ----------
+HINT:Enum cannot contain magic method method "__toString"
+    public static function __Set_State($state) {}
+                           -----------
+HINT:Enum cannot contain magic method method "__set_state"
+    public function __clONe() {}
+                    -------
+HINT:Enum cannot contain magic method method "__clone"
+    public function __DebugInfo() {}
+                    -----------
+HINT:Enum cannot contain magic method method "__debugInfo"
     case C;
     -------
 HINT:"case" can only be in enums


### PR DESCRIPTION
- Checks declaration of forbidden methods.
- Adds __invoke and __debugInfo to list of magic methods.

Docs:
- https://www.php.net/manual/en/language.enumerations.listing.php
- https://www.php.net/manual/en/class.backedenum.php
- https://www.php.net/manual/en/language.enumerations.object-differences.php
- https://www.php.net/manual/en/language.oop5.magic.php

Closes  #5086, closes  #5094