### PR TITLE
PreconditionsChecker: fixed NPE when path is null.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/PreconditionsChecker.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/PreconditionsChecker.java
@@ -223,11 +223,15 @@ public class PreconditionsChecker {
         }
 
         private boolean isLocalVariable(IdentifierTree id, Trees trees) {
-            Element el = trees.getElement(TreePath.getPath(treePath, id));
-            if (el != null) {
-                return el.getKind() == ElementKind.LOCAL_VARIABLE || el.getKind() == ElementKind.PARAMETER;
+            TreePath path = TreePath.getPath(treePath, id);
+            if (path == null) {
+                return false;
             }
-            return false;
+            Element el = trees.getElement(path);
+            if (el == null) {
+                return false;
+            }
+            return el.getKind() == ElementKind.LOCAL_VARIABLE || el.getKind() == ElementKind.PARAMETER;
         }
     }
 


### PR DESCRIPTION
fixes #5202, targets delivery

```
java.lang.NullPointerException: Cannot invoke "com.sun.source.util.TreePath.getLeaf()" because "path" is null
	at org.netbeans.lib.nbjavac.services.NBJavacTrees.getElement(NBJavacTrees.java:66)
	at org.netbeans.lib.nbjavac.services.NBJavacTrees.getElement(NBJavacTrees.java:40)
	at org.netbeans.modules.java.hints.jdk.mapreduce.PreconditionsChecker$VariablesVisitor.isLocalVariable(PreconditionsChecker.java:226)
```
`JavacTrees` and `NBJavacTrees` don't accept null as path parameters in the `getElement` method, so we guard against it and return `false`.