### PR TITLE
Temporary fix: Support extra cluster directories.

### DIFF
--- a/java/java.lsp.server/vscode/src/nbcode.ts
+++ b/java/java.lsp.server/vscode/src/nbcode.ts
@@ -69,6 +69,7 @@ export function launch(
     if (info.verbose) {
         ideArgs.push('-J-Dnetbeans.logger.console=true');
     }
+    ideArgs.push(`-J-Dnetbeans.extra.dirs="${clusterPath}"`)
     if (env['netbeans.extra.options']) {
         ideArgs.push(env['netbeans.extra.options']);
     }
@@ -81,9 +82,6 @@ export function launch(
     let process: ChildProcessByStdio<any, Readable, Readable> = spawn(nbcodePath, ideArgs, {
         cwd : userDir,
         stdio : ["ignore", "pipe", "pipe"],
-        env : Object.assign({
-            'extra_clusters' : clusterPath
-        }, global.process.env)
     });
     return process;
 }

--- a/platform/o.n.bootstrap/src/org/netbeans/MainImpl.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/MainImpl.java
@@ -119,6 +119,19 @@ final class MainImpl extends Object {
         }
         // #34069: need to do the same for nbdirs.
         String nbdirs = System.getProperty("netbeans.dirs"); // NOI18N
+        String extNbDirs = System.getProperty("netbeans.extra.dirs"); // NOI18N
+        if (extNbDirs != null) {
+            // support for potential spaces in the cluster path:
+            if (extNbDirs.startsWith("\"")) {
+                extNbDirs = extNbDirs.substring(1, extNbDirs.lastIndexOf('"'));
+            }
+            if (nbdirs == null) {
+                nbdirs = extNbDirs;
+            } else {
+                nbdirs = nbdirs + File.pathSeparator + extNbDirs;
+            }
+            System.setProperty("netbeans.dirs", nbdirs); // NOI18N
+        }
         if (nbdirs != null) {
             StringTokenizer tok = new StringTokenizer(nbdirs, File.pathSeparator);
             while (tok.hasMoreTokens()) {


### PR DESCRIPTION
This PR patches just the vsnetbeans branch before Apache Language Server for Java  extension release; it could be then picked up by `master` and NB17 - or other solution can be applied.

The Apache Language Server  supposes that **other extensions** can contribute modules (clusters) into Apache Netbeans language server (part of vscode extension). For example we (Oracle) deliver jdbc drivers that cannot be distributed through Apache (e.g. licensing issues).

The original code uses a misfeature that if a `extra_clusters` env variable is defined, and the application's config file (`conf/nbcode.conf` in this case)  **does not** provide a value in its [`conf/app.conf`](https://github.com/apache/netbeans/blob/master/harness/apisupport.harness/release/etc/app.conf#L68) (which is the vscode extension case), the launcher shell script [reads it](https://github.com/apache/netbeans/blob/master/harness/apisupport.harness/release/launchers/app.sh#L56) as a local variable. But if the variable is not defined at all, the `$extra_clusters` [will pick](https://github.com/apache/netbeans/blob/master/harness/apisupport.harness/release/launchers/app.sh#L120)  environment variable value, if defined

This approach however does not work on Windows, where the native launcher itself parses `conf/app.conf` into variables and does not do the fallback to the env vars. The bug seems to be present from NBLS inception, at least from 10/2020.

This patch changes the way how extra clusters can be configured and adds support for that through a new System property in the NB core.

**NOTE**: originally I thought this is suitable as a temporary solution, and launchers ought to be updated in the `master` (and NB17 release). But as I am thinking about it, I am somewhat inclined to define this as the official NB core API in `arch.xml` as it would not require changes to the native launcher(s) ... although setting back the system property is not clean at all.