### PR TITLE
Springboot artifacts fix

### DIFF
--- a/enterprise/micronaut/nbproject/project.xml
+++ b/enterprise/micronaut/nbproject/project.xml
@@ -74,7 +74,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.156</specification-version>
+                        <specification-version>2.157</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/maven/MicronautPackagingArtifactsImpl.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/maven/MicronautPackagingArtifactsImpl.java
@@ -40,6 +40,8 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectActionContext;
 import org.netbeans.modules.maven.api.NbMavenProject;
+import org.netbeans.modules.maven.api.execute.RunConfig;
+import org.netbeans.modules.maven.api.execute.RunUtils;
 import org.netbeans.modules.micronaut.AbstractMicronautArtifacts;
 import org.netbeans.modules.project.dependency.ArtifactSpec;
 import org.netbeans.modules.project.dependency.ProjectArtifactsQuery;
@@ -62,8 +64,13 @@ public class MicronautPackagingArtifactsImpl implements ProjectArtifactsImplemen
     /**
      * sharedLibrary plugin parameter. Will build a DLL or .so 
      */
-    public static final String PLUGIN_PARAM_SHAREDLIBRARY = "sharedLibrary";
+    public static final String PLUGIN_PARAM_SHAREDLIBRARY = "sharedLibrary"; // NOI18N
     
+    /**
+     * Maven goal that does the native-image compilation.
+     */
+    private static final String GOAL_NATIVE_COMPILE = "native:compile"; // NOI18N
+
     private static final Set<String> SUPPORTED_ARTIFACT_TYPES = new HashSet<>(Arrays.asList(
             MicronautMavenConstants.TYPE_DYNAMIC_LIBRARY, MicronautMavenConstants.TYPE_EXECUTABLE
     ));
@@ -116,7 +123,8 @@ public class MicronautPackagingArtifactsImpl implements ProjectArtifactsImplemen
         return true;
     }
 
-   static class R extends AbstractMicronautArtifacts {
+    static class R extends AbstractMicronautArtifacts {
+
         private final NbMavenProject mavenProject;
 
         public R(Project project, NbMavenProject mavenProject, ProjectArtifactsQuery.Filter query) {
@@ -137,11 +145,11 @@ public class MicronautPackagingArtifactsImpl implements ProjectArtifactsImplemen
         protected boolean accept(PropertyChangeEvent e) {
             return NbMavenProject.PROP_PROJECT.equals(e.getPropertyName());
         }
-        
+
         @Override
         protected List<ArtifactSpec> compute() {
             ProjectActionContext buildCtx;
-            
+
             if (query.getBuildContext() != null) {
                 if (query.getBuildContext().getProjectAction() == null) {
                     buildCtx = query.getBuildContext().newDerivedBuilder().forProjectAction(ActionProvider.COMMAND_BUILD).context();
@@ -152,7 +160,7 @@ public class MicronautPackagingArtifactsImpl implements ProjectArtifactsImplemen
                 buildCtx = ProjectActionContext.newBuilder(getProject()).forProjectAction(ActionProvider.COMMAND_BUILD).context();
             }
             if (query.getArtifactType() != null && 
-                !SUPPORTED_ARTIFACT_TYPES.contains(query.getArtifactType()) &&
+                !SUPPORTED_ARTIFACT_TYPES.contains(query.getArtifactType()) && 
                 !ProjectArtifactsQuery.Filter.TYPE_ALL.equals(query.getArtifactType())) {
                 LOG.log(Level.FINE, "Unsupported type: {0}", query.getArtifactType());
                 return Collections.emptyList();
@@ -162,7 +170,15 @@ public class MicronautPackagingArtifactsImpl implements ProjectArtifactsImplemen
                 return Collections.emptyList();
             }
             MavenProject model = mavenProject.getEvaluatedProject(buildCtx);
-            if (!MicronautMavenConstants.PACKAGING_NATIVE.equals(model.getPackaging())) {
+            boolean explicitGraalvmGoal = false;
+            if (buildCtx.getProjectAction() != null) {
+                RunConfig cfg = RunUtils.createRunConfig(buildCtx.getProjectAction(), getProject(), null, Lookup.EMPTY);
+                if (cfg != null && cfg.getGoals().contains(GOAL_NATIVE_COMPILE)) {
+                    LOG.log(Level.FINE, "Go explicit native compilation goal from the action");
+                    explicitGraalvmGoal = true;
+                }
+            }
+            if (!explicitGraalvmGoal && !MicronautMavenConstants.PACKAGING_NATIVE.equals(model.getPackaging())) {
                 LOG.log(Level.FINE, "Unsupported packaging: {0}", model.getPackaging());
                 return Collections.emptyList();
             }
@@ -170,6 +186,8 @@ public class MicronautPackagingArtifactsImpl implements ProjectArtifactsImplemen
             if (LOG.isLoggable(Level.FINE)) {
                 LOG.log(Level.FINE, "Configured build plugins: {0}", model.getBuild().getPlugins());
             }
+            boolean foundExecution = false;
+
             for (Plugin p : model.getBuild().getPlugins()) {
                 if (!(MicronautMavenConstants.NATIVE_BUILD_PLUGIN_GROUP.equals(p.getGroupId()) && MicronautMavenConstants.NATIVE_BUILD_PLUGIN_ID.equals(p.getArtifactId()))) {
                     continue;
@@ -179,32 +197,49 @@ public class MicronautPackagingArtifactsImpl implements ProjectArtifactsImplemen
                     if (pe.getGoals().contains(MicronautMavenConstants.PLUGIN_GOAL_COMPILE_NOFORK)) { // NOI18N
                         Xpp3Dom dom = model.getGoalConfiguration(MicronautMavenConstants.NATIVE_BUILD_PLUGIN_GROUP, MicronautMavenConstants.NATIVE_BUILD_PLUGIN_ID, pe.getId(), MicronautMavenConstants.PLUGIN_GOAL_COMPILE_NOFORK); // NOI18N
                         if (dom != null) {
-                            Xpp3Dom imageName = dom.getChild(PLUGIN_PARAM_IMAGENAME); // NOI18N
-                            Xpp3Dom sharedLib = dom.getChild(PLUGIN_PARAM_SHAREDLIBRARY); // NOI18N
-
-                            String name;
-                            if (imageName == null) {
-                                // project default, but should be injected / interpolated by Maven already.
-                                name = model.getArtifactId();
-                            } else {
-                                name = imageName.getValue();
-                            }
-                            
-                            Path full = Paths.get(model.getBuild().getDirectory()).resolve(name);
-                            nativeStuff.add(ArtifactSpec.builder(model.getGroupId(), model.getArtifactId(), model.getVersion(), pe)
-                                    .type(sharedLib != null && Boolean.parseBoolean(sharedLib.getValue()) ? MicronautMavenConstants.TYPE_DYNAMIC_LIBRARY : MicronautMavenConstants.TYPE_EXECUTABLE)
-                                    .location(full.toUri())
-                                    .forceLocalFile(FileUtil.toFileObject(full.toFile()))
-                                    .build()
-                            );
+                            LOG.log(Level.FINE, "Found bound execution for goals {0}", pe.getGoals());
+                            addNativeExecutable(nativeStuff, model, dom, pe);
+                            foundExecution = true;
                         }
                     }
                 }
             }
+
+            if (!foundExecution && explicitGraalvmGoal) {
+                LOG.log(Level.FINE, "No bound execution found, but explicit native compilation requested, trying to search for plugin base config");
+                // try to get the configuration from PluginManagement, since the plugin is not directly in the build sequence.
+                Plugin p = model.getPluginManagement().getPluginsAsMap().get(MicronautMavenConstants.NATIVE_BUILD_PLUGIN_GROUP + ":" + MicronautMavenConstants.NATIVE_BUILD_PLUGIN_ID);
+                if (p != null && p.getConfiguration() != null) {
+                    LOG.log(Level.FINE, "Found plugin configuration");
+                    Xpp3Dom dom = (Xpp3Dom) p.getConfiguration();
+                    addNativeExecutable(nativeStuff, model, dom, p);
+                }
+            }
             return nativeStuff;
         }
+
+        private void addNativeExecutable(List<ArtifactSpec> nativeStuff, MavenProject model, Xpp3Dom dom, Object data) {
+           Xpp3Dom imageName = dom.getChild(PLUGIN_PARAM_IMAGENAME); // NOI18N
+           Xpp3Dom sharedLib = dom.getChild(PLUGIN_PARAM_SHAREDLIBRARY); // NOI18N
+
+           String name;
+           if (imageName == null) {
+               // project default, but should be injected / interpolated by Maven already.
+               name = model.getArtifactId();
+           } else {
+               name = imageName.getValue();
+           }
+
+           Path full = Paths.get(model.getBuild().getDirectory()).resolve(name);
+           nativeStuff.add(ArtifactSpec.builder(model.getGroupId(), model.getArtifactId(), model.getVersion(), data)
+                   .type(sharedLib != null && Boolean.parseBoolean(sharedLib.getValue()) ? MicronautMavenConstants.TYPE_DYNAMIC_LIBRARY : MicronautMavenConstants.TYPE_EXECUTABLE)
+                   .location(full.toUri())
+                   .forceLocalFile(FileUtil.toFileObject(full.toFile()))
+                   .build()
+           );
+       }
     }
-    
+   
     @NbBundle.Messages({
         "DN_MicronautArtifacts=Micronaut artifact support"
     })

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
@@ -80,6 +80,19 @@
                     </file>
                 </folder>
             </folder>
+            <folder name="org.springframework.boot:spring-boot-maven-plugin">
+                <folder name="Lookup">
+                    <file name="maven-project-actions.instance">
+                        <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                        <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
+                        <attr name="resource" stringvalue="nbres:/org/netbeans/modules/micronaut/resources/spring-actions-maven.xml"/>
+                    </file>
+                    <file name="native-image-artifacts.instance">
+                        <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                        <attr name="instanceCreate" methodvalue="org.netbeans.modules.micronaut.maven.MicronautPackagingArtifactsImpl.projectLookup"/>
+                    </file>
+                </folder>
+            </folder>
             <folder name="LifecycleParticipants">
                 <folder name="org.graalvm.buildtools.maven.NativeExtension">
                     <attr name="ignoreOnModelLoad" boolvalue="true"/>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/spring-actions-maven.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/spring-actions-maven.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<actions>
+    <action>
+        <actionName>native-build</actionName>
+        <packagings>
+            <packaging>*</packaging>
+        </packagings>
+        <goals>
+            <goal>native:compile</goal>
+        </goals>
+        <activatedProfiles>
+            <activatedProfile>native</activatedProfile>
+        </activatedProfiles>
+    </action>
+</actions>

--- a/java/maven/apichanges.xml
+++ b/java/maven/apichanges.xml
@@ -83,6 +83,21 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="runutils-createconfig-action">
+            <api name="general"/>
+            <summary></summary>
+            <version major="2" minor="157"/>
+            <date day="23" month="1" year="2023"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes" semantic="compatible"/>
+            <description>
+                Added a <a href="@TOP@/org/netbeans/modules/maven/api/execute/RunUtils.html#createRunConfig-java.lang.String-org.netbeans.api.project.Project-org.netbeans.spi.project.ProjectConfiguration-org.openide.util.Lookup-">
+                RunUtils.createRunConfig()</a> variant that allows to create a <a href="@TOP@/org/netbeans/modules/maven/api/execute/RunConfig.html">RunConfig</a> for a project-defined action. 
+                Clients can use this function to use all user customizations that may have been configured for the project action before executing it using 
+                <a href="@TOP@/org/netbeans/modules/maven/api/execute/RunUtils.html#run-org.netbeans.modules.maven.api.execute.RunConfig-">RunUtils.run</a>.
+            </description>
+            <class package="org.netbeans.modules.maven.api.execute" name="RunUtils"/>
+        </change>
         <change id="lifecycle-white-list">
             <api name="general"/>
             <summary>LifecycleParticipants can be ignored</summary>

--- a/java/maven/nbproject/project.properties
+++ b/java/maven/nbproject/project.properties
@@ -22,7 +22,7 @@ javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 javahelp.hs=maven.hs
 extra.module.files=maven-nblib/
-spec.version.base: 2.156
+spec.version.base=2.157.0
 
 # The CPExtender test fails in library processing (not randomly) since NetBeans 8.2; disabling.
 test.excludes=**/CPExtenderTest.class

--- a/java/maven/src/org/netbeans/modules/maven/api/execute/RunUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/execute/RunUtils.java
@@ -28,11 +28,15 @@ import javax.swing.JFrame;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.java.source.BuildArtifactMapper;
 import org.netbeans.api.project.Project;
+import org.netbeans.modules.maven.NbMavenProjectImpl;
 import org.netbeans.modules.maven.api.Constants;
+import org.netbeans.modules.maven.execute.ActionToGoalUtils;
 import org.netbeans.modules.maven.execute.BeanRunConfig;
 import org.netbeans.modules.maven.execute.MavenCommandLineExecutor;
 import org.netbeans.spi.project.AuxiliaryProperties;
+import org.netbeans.spi.project.ProjectConfiguration;
 import org.openide.execution.ExecutorTask;
+import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.windows.WindowManager;
 
@@ -97,6 +101,27 @@ public final class RunUtils {
      */
     public static ExecutorTask executeMaven(final RunConfig config) {
         return MavenCommandLineExecutor.executeMaven(config, null, null);
+    }
+    
+    /**
+     * Creates a {@link RunConfig} for the specified project action. Project configuration to be used can be also specified, which 
+     * affects potentially the action's mapping and/or properties. If {@code null} is passed, the current/active configuration is used.
+     * If applied on non-Maven project, the method returns {@code null}, as well as if the requested action does not exist in the project
+     * or its requested (or active) configuration.
+     * 
+     * @param action project action name
+     * @param prj the project
+     * @param c the configuration to use, use {@code null} for the active one.
+     * @param lookup lookup that becomes available to the action provider for possible further data / options
+     * @return configured {@link RunConfig} suitable for execution or {@code null} if the project is not maven, or action is unavailable.
+     * @since 2.157
+     */
+    public static RunConfig createRunConfig(String action, Project prj, ProjectConfiguration c, Lookup lookup) {
+        NbMavenProjectImpl impl = prj.getLookup().lookup(NbMavenProjectImpl.class);
+        if (impl == null) {
+            return null;
+        }
+        return ActionToGoalUtils.createRunConfig(action, impl, c, lookup);
     }
 
     public static RunConfig createRunConfig(File execDir, Project prj, String displayName, List<String> goals)


### PR DESCRIPTION
There's a springboot module on the Plugin portal, but that one does not handle native-image compilation. Longer term, I'd like to create a dedicated native-image supporting module(s) and move the gradle+maven plugin support there. But for NBLS immediate release and NB17 release, I'd like to include a very trivial springboot support - Micronaut module is a good enterprise cluster candidate to make homeplace for it.

The PR adds ability to run native compilation from the NetBeans IDE based on springboot plugin support. In addition, springboot projects are configured differently to micronaut projects - the changes in `MicronautPackagingArtifactsImpl`  make the impl more compatible with various setups, as it now reacts on the plugin's goal regardless of whether the plugin is bound to the buildchain.

The maven module part is a necessary subtle API change - the friend API did allow to create `RunConfig`s for an explicit goal, but not for an (abstract) project action  which is needed here, and uses possible user's customizations for the action (and therefore the goal). It fits well to the `RunUtils` API function set.

I'd like to include this PR into NB17 release.