### PR TITLE
Various database fixes

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCINode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCINode.java
@@ -111,7 +111,9 @@ public class OCINode extends AbstractNode {
     }
     
     public void refresh() {
-        factory.refreshKeys();
+        if (factory != null) {
+            factory.refreshKeys();
+        }
     }
 
     @Override

--- a/ide/db/src/org/netbeans/modules/db/explorer/node/ConnectionNode.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/node/ConnectionNode.java
@@ -49,6 +49,7 @@ import org.netbeans.modules.db.metadata.model.api.MetadataModels;
 import org.netbeans.modules.db.util.PropertiesEditor;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
+import org.openide.awt.Actions;
 import org.openide.nodes.Sheet;
 import org.openide.util.Exceptions;
 import org.openide.util.HelpCtx;
@@ -504,7 +505,7 @@ public class ConnectionNode extends BaseNode implements PropertyChangeListener, 
     public Action getPreferredAction() {
         boolean disconnected = ! connection.isVitalConnection();
         if (disconnected) {
-            return SystemAction.get(ConnectAction.class);
+            return Actions.forID("Database", "netbeans.db.explorer.action.Connect"); // NOI18N
         } else {
             return null;
         }


### PR DESCRIPTION
"Refresh" action is available on OCI nodes including the leaves; but a leaf has no `factory` set, so refresh is likely to NPE. 

The `Connect` action implementation was written so that it blocked the UI thread with a modal dialog and/or sync with the background DB connection. It should have been rewritten probably more thoroughly, but at the least I've changed the action to `asynchronous=true` - I needed to restructure it to implement `ActionListener` + `ContextAwareAction` so that it properly reports DB connection changes through action's enable once instantiated. Asynchronous=true does not work well for `NodeActions` (default constructor must not be present).

Asynchronous processing is desirable in the headless mode, when the blocked "ui" thread is actually usually the message-processing one, which may block the client from all messages to/from the NBLS server. In particular progress messages are blocked, so if the connect operation takes some few seconds, the user is not given any feedback, although the connect action reports the progress.

As a result even Swing-bound parts now run asynchronously, so the UI parts were wrapped into `invokeLater`/`invokeAndWait`.

