### PR TITLE
Report progress start when handle immediately switches to indeterminate.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/LspProgressUIWorker.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/LspProgressUIWorker.java
@@ -61,11 +61,11 @@ public class LspProgressUIWorker implements ProgressUIWorkerWithModel{
                 lsHandle.sendStartMessage(event);
                 break;
                 
+            case ProgressEvent.TYPE_SWITCH:
             case ProgressEvent.TYPE_PROGRESS:
                 lsHandle.sendProgress(event);
                 break;
                 
-            case ProgressEvent.TYPE_SWITCH:
             case ProgressEvent.TYPE_SILENT:
             case ProgressEvent.TYPE_REQUEST_STOP:
                 // ignore


### PR DESCRIPTION
During testing of #5361, I've found out that the `LspInternalHandle` receives SWITCH event as the first one (as a result of the switch to indeterminate status), and does not report start event to the LSP client at all. As a result the progress indicator is never created in LSP client and the progress for long-running operation may remain unreported.

`sendProgress` will first send `start` event to the client, if not already started.