### PR TITLE
Proper escaping of TNS_ADMIN path. Select JDBC driver with defined implementation.

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
@@ -19,14 +19,16 @@
 package org.netbeans.modules.cloud.oracle.actions;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -45,6 +47,8 @@ import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionRegistration;
 import org.openide.awt.StatusDisplayer;
+import org.openide.filesystems.URLMapper;
+import org.openide.util.BaseUtilities;
 import org.openide.util.ContextAwareAction;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
@@ -75,8 +79,9 @@ import org.openide.util.NbBundle;
     "MSG_WalletNoConnection=Wallet doesn't contain any connection"
 })
 public class DownloadWalletAction extends AbstractAction implements ContextAwareAction {
+    private static final Logger LOG = Logger.getLogger(DownloadWalletAction.class.getName());
     
-    private static final String URL_TEMPLATE = "jdbc:oracle:thin:@{0}?TNS_ADMIN=\"{1}\""; //NOI18N
+    private static final String URL_TEMPLATE = "jdbc:oracle:thin:@{0}?TNS_ADMIN={1}"; //NOI18N
     private final DatabaseItem context;
     private OCIProfile session;
 
@@ -105,7 +110,22 @@ public class DownloadWalletAction extends AbstractAction implements ContextAware
                 if (p.getDbUser() != null && p.getDbPassword() != null) {
                     
                     JDBCDriver[] drivers = JDBCDriverManager.getDefault().getDrivers("oracle.jdbc.OracleDriver"); //NOI18N
+                    JDBCDriver jarsPresent = null;
+                    
                     if (drivers.length > 0) {
+                        
+                        // prefer a driver that actually defines some JARs.
+                        for (JDBCDriver d : drivers) {
+                            if (isAvailable(d)) {
+                                jarsPresent = d;
+                                break;
+                            }
+                        }
+                        if (jarsPresent == null) {
+                            jarsPresent = drivers[0];
+                            // PENDING: should be shown to the user ?
+                            LOG.log(Level.WARNING, "Unable to find driver JARs for wallet {0}, using fallback driver: {1}", new Object[] { walletPath, jarsPresent.getName() });
+                        }
                         String connectionName = context.getConnectionName();
                         if (connectionName == null) {
                             Optional<String> n = parseConnectionNames(walletPath).stream().findFirst();
@@ -116,7 +136,7 @@ public class DownloadWalletAction extends AbstractAction implements ContextAware
                                 return;
                             }
                         }
-                        String dbUrl = MessageFormat.format(URL_TEMPLATE, connectionName, walletPath);
+                        String dbUrl = MessageFormat.format(URL_TEMPLATE, connectionName, BaseUtilities.escapeParameters(new String[] { walletPath.toString() }));
                         DatabaseConnection dbConn = DatabaseConnection.create(
                                 drivers[0], 
                                 dbUrl, 
@@ -127,6 +147,9 @@ public class DownloadWalletAction extends AbstractAction implements ContextAware
                                 context.getName());
                         ConnectionManager.getDefault().addConnection(dbConn);
                     }
+                    
+                    // PENDING: what should happen, if the driver is not found at all - display an info message ?
+                    
                     DialogDisplayer.getDefault().notifyLater(
                             new NotifyDescriptor.Message(
                                     Bundle.MSG_WalletDownloadedPassword(
@@ -140,6 +163,29 @@ public class DownloadWalletAction extends AbstractAction implements ContextAware
         });
     }
     
+    static boolean isAvailable(JDBCDriver driver) {
+        URL[] urls = driver.getURLs();
+        for (URL u : urls) {
+            if (URLMapper.findFileObject(u) == null) {
+                return false;
+            }
+        }
+        if (urls.length > 0) {
+            // true, some jar is defined && exists.
+            return true;
+        } else {
+            // if the JDBC drive does not list jars, its class must be reachable. DbDriverManager uses no-arg classloader constructor, so it is
+            // using systemClassLoader as a parent for no-URL URLClassloader.
+            try {
+                Class.forName(driver.getClassName(), true, ClassLoader.getSystemClassLoader());
+                return true;
+            } catch (ClassNotFoundException | SecurityException | LinkageError ex) {
+                // expected, class is not avaialble
+                return false;
+            }
+        }
+    }
+
     protected List<String> parseConnectionNames(Path wallet) {
         Path tns = wallet.resolve("tnsnames.ora"); //NOI18N
         try {

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
@@ -76,7 +76,10 @@ import org.openide.util.NbBundle;
     "CTL_DownloadWalletAction=Download Wallet",
     "MSG_WalletDownloaded=Database Wallet was downloaded to {0}",
     "MSG_WalletDownloadedPassword=Database Wallet was downloaded. \nGenerated wallet password is: {0}",
-    "MSG_WalletNoConnection=Wallet doesn't contain any connection"
+    "MSG_WalletNoConnection=Wallet doesn't contain any connection",
+    "WARN_DriverWithoutJars=No matching JDBC drivers are configured with code location(s). Driver {0} will be associated with the connection, but the " +
+            "connection may fail because driver's code is not loadable. Continue ?"
+    
 })
 public class DownloadWalletAction extends AbstractAction implements ContextAwareAction {
     private static final Logger LOG = Logger.getLogger(DownloadWalletAction.class.getName());
@@ -123,8 +126,13 @@ public class DownloadWalletAction extends AbstractAction implements ContextAware
                         }
                         if (jarsPresent == null) {
                             jarsPresent = drivers[0];
-                            // PENDING: should be shown to the user ?
                             LOG.log(Level.WARNING, "Unable to find driver JARs for wallet {0}, using fallback driver: {1}", new Object[] { walletPath, jarsPresent.getName() });
+                            NotifyDescriptor.Confirmation msg = new NotifyDescriptor.Confirmation(Bundle.WARN_DriverWithoutJars(jarsPresent.getName()), 
+                                NotifyDescriptor.WARNING_MESSAGE, NotifyDescriptor.YES_NO_OPTION);
+                            Object choice = DialogDisplayer.getDefault().notify(msg);
+                            if (choice != NotifyDescriptor.YES_OPTION && choice != NotifyDescriptor.OK_OPTION) {
+                                return;
+                            }
                         }
                         String connectionName = context.getConnectionName();
                         if (connectionName == null) {


### PR DESCRIPTION
This PR fixes two issues with OCI database support:

 The `Download Wallet` action writes a JDBC connection string with a pathname in it, but the pathname is not properly escaped. This is not an issue on MacOS / Linux, but on Windows that uses backslashes as dir separators, the backslashes in string content are interpreted as escapes by the JDBC driver, and the resulting path will be broken.

Second, the action tries to find the appropriate JDBC driver, but `JDBCDriverManager.getDefault().getDrivers()` call may reeturn half-configured drivers, that have no JAR files associated with them. This PR makes the action to prefer such drivers that define jars with the actual driver code.
The original behaviour had the effect of selecting a wrong driver, i.e. OracleThin driver (without JARs) was persisted while there was full Oracle jdbc driver present (that was configured with appropriate code jars).