### PR TITLE
Bulk added some missing ElementKind.RECORD enums.

### DIFF
--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MarkOccurrencesHighlighterBase.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/MarkOccurrencesHighlighterBase.java
@@ -403,6 +403,7 @@ public abstract class MarkOccurrencesHighlighterBase extends JavaParserResultTas
             case CLASS:
             case ENUM:
             case INTERFACE:
+            case RECORD:
             case TYPE_PARAMETER: //???
                 return node.getBoolean(MarkOccurencesSettingsNames.TYPES, true);
             case CONSTRUCTOR:

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCodeTemplateProcessor.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCodeTemplateProcessor.java
@@ -359,6 +359,7 @@ public class JavaCodeTemplateProcessor implements CodeTemplateProcessor {
                                     switch (usedElement.getKind()) {
                                         case CLASS:
                                         case INTERFACE:
+                                        case RECORD:
                                         case ENUM:
                                         case ANNOTATION_TYPE:
                                             toRemove.remove(((TypeElement)usedElement).getQualifiedName().toString());

--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Tiny.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Tiny.java
@@ -39,7 +39,6 @@ import com.sun.source.tree.WhileLoopTree;
 import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
 import org.netbeans.api.java.source.support.ErrorAwareTreePathScanner;
-import org.netbeans.api.java.source.support.ErrorAwareTreeScanner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -443,8 +442,8 @@ public class Tiny {
                 } 
                 // attempt to resolve a simple-qualified identifier; assuming the user already has an import in the source
                 Element outer = el.getEnclosingElement();
-                if (outer != null && (outer.getKind() == ElementKind.CLASS || outer.getKind() == ElementKind.INTERFACE ||
-                        outer.getKind() == ElementKind.ENUM)) {
+                if (outer != null && (outer.getKind() == ElementKind.CLASS || outer.getKind() == ElementKind.INTERFACE
+                                   || outer.getKind() == ElementKind.RECORD || outer.getKind() == ElementKind.ENUM)) {
                     TypeElement tel = (TypeElement)outer;
                     String x =  tel.getSimpleName() + "." + l.toString();
                     if (tryResolveIdentifier(info, lPath, m, resolved, x)) {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElementUtilities.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElementUtilities.java
@@ -289,6 +289,7 @@ public final class CreateElementUtilities {
         if (mt.getReturnType() == error) {
             types.add(ElementKind.CLASS);
             types.add(ElementKind.INTERFACE);
+            types.add(ElementKind.RECORD);
             types.add(ElementKind.ENUM);
         }
 
@@ -637,6 +638,7 @@ public final class CreateElementUtilities {
             types.add(ElementKind.CLASS);
             types.add(ElementKind.ENUM);
             types.add(ElementKind.INTERFACE);
+            types.add(ElementKind.RECORD);
             
             return typeMirrorCollectionOrNull(info, "java.lang.Object");
         }
@@ -721,6 +723,7 @@ public final class CreateElementUtilities {
             } else {
                 types.add(ElementKind.CLASS);
                 types.add(ElementKind.INTERFACE);
+                types.add(ElementKind.RECORD);
             }
             
             if (numTypeParameters != null) {
@@ -785,6 +788,7 @@ public final class CreateElementUtilities {
             types.add(ElementKind.CLASS);
             types.add(ElementKind.ENUM);
             types.add(ElementKind.INTERFACE);
+            types.add(ElementKind.RECORD);
             
             return null;
         }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
@@ -1561,6 +1561,7 @@ public class Utilities {
                 case CLASS:
                 case ENUM:
                 case INTERFACE:
+                case RECORD:
                     tpes = ((TypeElement) target).getTypeParameters();
                     break;
                 case METHOD:

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/InstanceRefFinder.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/InstanceRefFinder.java
@@ -133,6 +133,7 @@ public class InstanceRefFinder extends ErrorAwareTreePathScanner {
                 case CLASS:
                 case ENUM:
                 case INTERFACE:
+                case RECORD:
                 case NEW_CLASS:
                     enclosingElementPath = path;
                     enclosingElement = ci.getTrees().getElement(enclosingElementPath);
@@ -364,6 +365,7 @@ public class InstanceRefFinder extends ErrorAwareTreePathScanner {
             case CLASS:
             case ENUM:
             case INTERFACE:
+            case RECORD:
                 if (node.getName().contentEquals("this") || node.getName().contentEquals("super")) {
                     addInstanceForType(enclosingType);
                 }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/suggestions/ExpectedTypeResolver.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/suggestions/ExpectedTypeResolver.java
@@ -1035,7 +1035,7 @@ public class ExpectedTypeResolver implements TreeVisitor<List<? extends TypeMirr
         } else if (el.getKind() == ElementKind.FIELD) {
             // access to a field
             Element parent = el.getEnclosingElement();
-            if (parent.getKind() == ElementKind.CLASS || parent.getKind() == ElementKind.INTERFACE || parent.getKind() == ElementKind.ENUM) {
+            if (parent.getKind() == ElementKind.CLASS || parent.getKind() == ElementKind.INTERFACE || parent.getKind() == ElementKind.ENUM || parent.getKind() == ElementKind.RECORD) {
                 return Collections.singletonList(parent.asType());
             }
         }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/suggestions/Lambda.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/suggestions/Lambda.java
@@ -452,6 +452,7 @@ public class Lambda {
                     case CLASS:
                     case ANNOTATION_TYPE:
                     case INTERFACE:
+                    case RECORD:
                         types.put(e.getSimpleName(), e);
                         break;
 
@@ -502,6 +503,7 @@ public class Lambda {
                                 case ANNOTATION_TYPE:
                                 case CLASS:
                                 case INTERFACE:
+                                case RECORD:
                                 case ENUM:
                                     rewrite = (other = types.get(e.getSimpleName())) != null;
                                     statRef = true;

--- a/java/java.navigation/src/org/netbeans/modules/java/navigation/CaretListeningTask.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/navigation/CaretListeningTask.java
@@ -180,6 +180,7 @@ public class CaretListeningTask implements CancellableTask<CompilationInfo> {
             case PACKAGE:
             case CLASS:
             case INTERFACE:
+            case RECORD:
             case ENUM:
             case ANNOTATION_TYPE:
             case METHOD:

--- a/java/java.navigation/src/org/netbeans/modules/java/navigation/ElementNode.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/navigation/ElementNode.java
@@ -686,6 +686,7 @@ public class ElementNode extends AbstractNode implements Iterable<ElementNode> {
                         return 3;
                     case CLASS:
                     case INTERFACE:
+                    case RECORD:
                     case ENUM:
                     case ANNOTATION_TYPE:
                     case MODULE:

--- a/java/java.source.base/src/org/netbeans/api/java/source/CodeStyle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/CodeStyle.java
@@ -1343,6 +1343,7 @@ public final class CodeStyle {
                 case CLASS:
                 case ENUM:
                 case INTERFACE:
+                case RECORD:
                     kind = ElementKind.CLASS;
                     modifiers = ((ClassTree)tree).getModifiers().getFlags();
                     break;

--- a/java/java.source.base/src/org/netbeans/api/java/source/DocTreePathHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/DocTreePathHandle.java
@@ -179,25 +179,6 @@ public final class DocTreePathHandle {
         Position pos = preferredPosition >= 0 ? createPositionRef(treePathHandle.getFileObject(), preferredPosition, Bias.Forward) : null;
         return new DocTreePathHandle(new DocTreeDelegate(pos, new DocTreeDelegate.KindPath(docTreePath), treePathHandle));
     }
-
-    private static boolean isSupported(Element el) {
-        switch (el.getKind()) {
-            case PACKAGE:
-            case CLASS:
-            case INTERFACE:
-            case ENUM:
-            case METHOD:
-            case CONSTRUCTOR:
-            case INSTANCE_INIT:
-            case STATIC_INIT:
-            case FIELD:
-            case ANNOTATION_TYPE:
-            case ENUM_CONSTANT:
-                return true;
-            default:
-                return false;
-        }
-    }
     
         private static List<DocTree> listChildren(@NonNull DocTree t) {
         final List<DocTree> result = new LinkedList<DocTree>();

--- a/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
@@ -1449,7 +1449,7 @@ public final class GeneratorUtilities {
                         break;
                     }
                    switch (p2.getLeaf().getKind()) {
-                       case CLASS: case INTERFACE: case ENUM:
+                       case CLASS: case INTERFACE: case ENUM: case RECORD:
                        case METHOD:
                        case BLOCK:
                        case VARIABLE:

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreePathHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreePathHandle.java
@@ -53,7 +53,6 @@ import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.modules.java.source.PositionRefProvider;
 import org.netbeans.modules.java.source.parsing.FileObjects;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileStateInvalidException;
 import org.openide.filesystems.FileUtil;                                                                                                                                                                                     
 import org.openide.filesystems.URLMapper;
 import org.openide.util.Exceptions;
@@ -401,6 +400,7 @@ public final class TreePathHandle {
                         case CLASS: kind = Tree.Kind.CLASS; break;
                         case ENUM: kind = Tree.Kind.ENUM; break;
                         case INTERFACE: kind = Tree.Kind.INTERFACE; break;
+                        case RECORD: kind = Tree.Kind.RECORD; break;
                         case ENUM_CONSTANT: case FIELD: kind = Tree.Kind.VARIABLE; break;
                         case METHOD: case CONSTRUCTOR: kind = Tree.Kind.METHOD; break;
                         default: kind = null; break;

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/CheckSums.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/CheckSums.java
@@ -119,6 +119,7 @@ public final class CheckSums {
                     case CLASS:
                     case INTERFACE:
                     case ENUM:
+                    case RECORD:
                     case ANNOTATION_TYPE:
                         if (!e.getModifiers().contains(Modifier.PRIVATE))
                             toHandle.offer((TypeElement) e);

--- a/java/java.source/src/org/netbeans/modules/java/classfile/AttachSourcePanel.java
+++ b/java/java.source/src/org/netbeans/modules/java/classfile/AttachSourcePanel.java
@@ -254,6 +254,7 @@ private void attachSources(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_at
             case PACKAGE:
             case CLASS:
             case INTERFACE:
+            case RECORD:
             case ENUM:
             case ANNOTATION_TYPE:
             case METHOD:

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameRefactoringPlugin.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameRefactoringPlugin.java
@@ -603,6 +603,7 @@ public class RenameRefactoringPlugin extends JavaRefactoringPlugin {
                     break;
                 case CLASS:
                 case INTERFACE:
+                case RECORD:
                 case ANNOTATION_TYPE:
                 case ENUM:
                     //TODO: any prechecks for JavaClass?

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveMembersPanel.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveMembersPanel.java
@@ -1037,6 +1037,7 @@ public class MoveMembersPanel extends javax.swing.JPanel implements CustomRefact
             switch (e.getKind()) {
                 case CLASS:
                 case INTERFACE:
+                case RECORD:
                 case ENUM:
                 case ANNOTATION_TYPE:
                     if(parent == null) {

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UIUtilities.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UIUtilities.java
@@ -57,22 +57,16 @@ public final class UIUtilities {
 
     // XXX: Remove "test_" when #211651 is fixed
     private static final String TEST_JAVA_MIME_TYPE = "test_text/x-java"; // NOI18N
-    private static final String RECORD = "RECORD"; // NOI18N
     /**
      * Element.Kind values allowed to be used when calling ElementHandle.create
      *
      * @see javax.lang.model.element.ElementKind
      * @see org.netbeans.api.java.source.ElementHandle
      */
-    public static EnumSet allowedElementKinds = EnumSet.of(ElementKind.PACKAGE, ElementKind.CLASS, ElementKind.INTERFACE, ElementKind.ENUM, ElementKind.ANNOTATION_TYPE, ElementKind.METHOD, ElementKind.CONSTRUCTOR, ElementKind.INSTANCE_INIT, ElementKind.STATIC_INIT, ElementKind.FIELD, ElementKind.ENUM_CONSTANT, ElementKind.TYPE_PARAMETER);
-    static {
-        ElementKind recKind = null;
-        try {
-            recKind = ElementKind.valueOf(RECORD);
-            allowedElementKinds.add(recKind);
-        } catch (IllegalArgumentException ex) {
-        }
-    }
+    public static final EnumSet allowedElementKinds = EnumSet.of(ElementKind.PACKAGE, ElementKind.CLASS, ElementKind.INTERFACE, ElementKind.RECORD,
+            ElementKind.ENUM, ElementKind.ANNOTATION_TYPE, ElementKind.METHOD, ElementKind.CONSTRUCTOR, ElementKind.INSTANCE_INIT,
+            ElementKind.STATIC_INIT, ElementKind.FIELD, ElementKind.ENUM_CONSTANT, ElementKind.TYPE_PARAMETER);
+
     // not to be instantiated
     private UIUtilities() {
     }
@@ -318,6 +312,7 @@ public final class UIUtilities {
 
         case CLASS:
         case INTERFACE:
+        case RECORD:
         case ENUM:
         case ANNOTATION_TYPE:
             if (forSignature) {

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedQueryUI.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedQueryUI.java
@@ -213,6 +213,7 @@ public class WhereUsedQueryUI implements RefactoringUI, Openable, JavaRefactorin
                 case CLASS:
                 case ENUM:
                 case INTERFACE:
+                case RECORD:
                 case ANNOTATION_TYPE: {
                     if (!panel.isClassFindUsages()) {
                         if (!panel.isClassSubTypesDirectOnly()) {

--- a/platform/openide.util/src/org/netbeans/modules/openide/util/NbBundleProcessor.java
+++ b/platform/openide.util/src/org/netbeans/modules/openide/util/NbBundleProcessor.java
@@ -55,6 +55,8 @@ import org.openide.util.NbBundle;
 import org.openide.util.NbCollections;
 import org.openide.util.lookup.ServiceProvider;
 
+import static javax.lang.model.element.ElementKind.PACKAGE;
+
 @ServiceProvider(service = Processor.class)
 public class NbBundleProcessor extends AbstractProcessor {
 
@@ -294,23 +296,27 @@ public class NbBundleProcessor extends AbstractProcessor {
 
     private String findPackage(Element e) {
         switch (e.getKind()) {
-        case PACKAGE:
-            return ((PackageElement) e).getQualifiedName().toString();
-        default:
-            return findPackage(e.getEnclosingElement());
+            case PACKAGE:
+                return ((PackageElement) e).getQualifiedName().toString();
+            default:
+                return findPackage(e.getEnclosingElement());
         }
     }
 
     private String findCompilationUnitName(Element e) {
         switch (e.getKind()) {
-        case PACKAGE:
-            return "package-info";
-        case CLASS:
-        case INTERFACE:
-        case ENUM:
-        case ANNOTATION_TYPE:
-            switch (e.getEnclosingElement().getKind()) {
             case PACKAGE:
+                return "package-info";
+            case CLASS:
+            case INTERFACE:
+            case ENUM:
+            case ANNOTATION_TYPE:
+                if (e.getEnclosingElement().getKind() == PACKAGE) {
+                    return e.getSimpleName().toString();
+                }
+        }
+        if ("RECORD".equals(e.getKind().name())) {  //TODO JDK 11 migration -> merge with switch above
+            if (e.getEnclosingElement().getKind() == PACKAGE) {
                 return e.getSimpleName().toString();
             }
         }


### PR DESCRIPTION
#5339 had the bits which were easily verifiable as bugs.

This PR is the bulk version of it. I searched for `ElementKind.CLASS` usage and tried to find out on a case by case basis if `RECORD` was missing based on what the code does. I didn't actually try to reproduce issues in the IDE for most of this since this would be too time consuming for all changes.

I am not sure if this is the right approach of doing this, but most changes here seemed fairly obvious/trivial so I hope this doesn't break anything.

This doesn't investigate missing `RECORD_COMPONENT` enums or add the record token to the lexer.