### PR TITLE
Import local schema to avoid DNS lookup in build

### DIFF
--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/jakartaee_10.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/jakartaee_10.xsd
@@ -39,7 +39,7 @@
 
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:include schemaLocation="jakartaee_web_services_client_2_0.xsd"/>
 


### PR DESCRIPTION
This is the same fix as the one made to `jakartaee_9.xsd` in NetBeans 16 for #4920, but to the new file `jakartaee_10.xsd` in NetBeans 17. It allows NetBeans to be built in environments with very strict firewalls, such as Launchpad, by removing the only DNS lookup during the build.

I'd like to make sure NetBeans can build on Launchpad because that's the easiest way to publish Snap packages of NetBeans for all supported Linux architectures: amd64, arm64, armhf, and i386.
