### PR TITLE
Annotated record reformatting fix

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -1279,11 +1279,10 @@ public class Reformatter implements ReformatTask {
             boolean old = continuationIndent;
             int oldIndent = indent;
             try {
-                continuationIndent = true;
                 ModifiersTree mods = node.getModifiers();
                 if (mods != null) {
                     if (scan(mods, p)) {
-
+                        continuationIndent = true;
                         if (cs.placeNewLineAfterModifiers()) {
                             newline();
                         } else {
@@ -1295,6 +1294,7 @@ public class Reformatter implements ReformatTask {
                     afterAnnotation = false;
                 }
                 accept(IDENTIFIER);
+                continuationIndent = true;
                 space();
 
                 if (!ERROR.contentEquals(node.getSimpleName())) {
@@ -1826,6 +1826,7 @@ public class Reformatter implements ReformatTask {
                 case CLASS:
                 case ENUM:
                 case INTERFACE:
+                case RECORD:
                     bracePlacement = cs.getOtherBracePlacement();
                     if (node.isStatic())
                         spaceBeforeLeftBrace = cs.spaceBeforeStaticInitLeftBrace();
@@ -5512,6 +5513,7 @@ public class Reformatter implements ReformatTask {
                 case CLASS:
                 case ENUM:
                 case INTERFACE:
+                case RECORD:
                     for (Tree tree : ((ClassTree)path.getLeaf()).getMembers()) {
                         if (tree == lastTree) {
                             indent += tabSize;

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -3498,7 +3498,44 @@ public class FormatingTest extends NbTestCase {
                 + "\n";
         reformat(doc, content, golden);
     }
-    
+
+    public void testAnnotatedRecord() throws Exception {
+        try {
+            SourceVersion.valueOf("RELEASE_19"); //NOI18N
+        } catch (IllegalArgumentException ex) {
+            //OK, no RELEASE_19, skip test
+            return;
+        }
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie) testSourceDO.getLookup().lookup(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        String content =
+                  "package test;\n"
+                + "\n"
+                + "/**\n"
+                + " * @author duke\n"
+                + " */\n"
+                + "@Deprecated public record DeprecatedRecord(int a) {}"
+                + "\n";
+
+        String golden =
+                  "package test;\n"
+                + "\n"
+                + "/**\n"
+                + " * @author duke\n"
+                + " */\n"
+                + "@Deprecated\n"
+                + "public record DeprecatedRecord(int a) {\n"
+                + "\n"
+                + "}"
+                + "\n";
+        reformat(doc, content, golden);
+    }
+
     public void testDoWhile() throws Exception {
         testFile = new File(getWorkDir(), "Test.java");
         TestUtilities.copyStringToFile(testFile,


### PR DESCRIPTION
fixes #4399 targets delivery

had a hard time figuring out how the `Reformatter` works since not much is documented there, But the fix turned out to be only a small change. Comparing `scanRecord` with other methods helped a bit.