### PR TITLE
Proposal to change  `==` comparing constants with `equals`

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ModuleDependency.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ModuleDependency.java
@@ -146,7 +146,7 @@ public final class ModuleDependency implements Comparable<ModuleDependency> {
         if (result != 0) { return result; }
         
         // do not force resolution of SPEC_VERSION_LAZY for comparisons, unnecessary
-        if (specVersion != SPEC_VERSION_LAZY || other.specVersion != SPEC_VERSION_LAZY) {
+        if (!SPEC_VERSION_LAZY.equals(specVersion) || !SPEC_VERSION_LAZY.equals(other.specVersion)) {
             String otherSpec = other.getSpecificationVersion();
             String spec = getSpecificationVersion();
             result = spec == null // spec versions may be null
@@ -167,7 +167,7 @@ public final class ModuleDependency implements Comparable<ModuleDependency> {
             ModuleDependency other = (ModuleDependency) o;
             return getCodeNameBase().equals(other.getCodeNameBase()) &&
                     Utilities.compareObjects(getReleaseVersion(), other.getReleaseVersion()) &&
-                    ((specVersion == SPEC_VERSION_LAZY && other.specVersion == SPEC_VERSION_LAZY) ||
+                    ((SPEC_VERSION_LAZY.equals(specVersion) && SPEC_VERSION_LAZY.equals(other.specVersion)) ||
                     Utilities.compareObjects(getSpecificationVersion(), other.getSpecificationVersion())) &&
                     (hasImplementationDependency() == other.hasImplementationDependency()) &&
                     (hasCompileDependency() == other.hasCompileDependency());

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ImportantFilesNodeFactory.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ImportantFilesNodeFactory.java
@@ -103,7 +103,7 @@ public class ImportantFilesNodeFactory implements NodeFactory {
 
         @Override
         public Node node(String key) {
-            assert key == IMPORTANT_FILES_NAME;
+            assert IMPORTANT_FILES_NAME.equals(key);
             return new ImportantFilesNode(project);
         }
 

--- a/contrib/j2ee.jboss4/src/org/netbeans/modules/j2ee/jboss4/customizer/CustomizerSupport.java
+++ b/contrib/j2ee.jboss4/src/org/netbeans/modules/j2ee/jboss4/customizer/CustomizerSupport.java
@@ -446,11 +446,11 @@ public final class CustomizerSupport {
             c.weighty = 1.0;
             ((GridBagLayout)this.getLayout()).setConstraints(spane,c);
             add(spane);
-            if (type == SOURCES || type == JAVADOC) {
+            if (SOURCES.equals(type) || JAVADOC.equals(type)) {
                 this.addButton = new JButton ();
                 String text;
                 char mne;
-                if (type == SOURCES) {
+                if (SOURCES.equals(type)) {
                     text = NbBundle.getMessage(CustomizerSupport.class, "CTL_Add");
                     mne = NbBundle.getMessage(CustomizerSupport.class, "MNE_Add").charAt(0);
                     ad = NbBundle.getMessage(CustomizerSupport.class, "AD_Add");
@@ -709,7 +709,7 @@ public final class CustomizerSupport {
         }
 
         private void selectionChanged () {
-            if (this.type == CLASSPATH) {
+            if (CLASSPATH.equals(this.type)) {
                 return;
             }
             int indices[] = this.resources.getSelectedIndices();

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/LibrariesNodeFactory.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/LibrariesNodeFactory.java
@@ -118,7 +118,7 @@ public final class LibrariesNodeFactory implements NodeFactory {
         }
 
         public Node node(String key) {
-            if (key == LIBRARIES) {
+            if (LIBRARIES.equals(key)) {
                 //Libraries Node
                 return  
                     new LibrariesNode(
@@ -141,7 +141,7 @@ public final class LibrariesNodeFactory implements NodeFactory {
                         cs,
                         new ExtraLibrariesNode(project, evaluator, AppClientProjectProperties.J2EE_SERVER_INSTANCE, cs)
                     );
-            } else if (key == TEST_LIBRARIES) {
+            } else if (TEST_LIBRARIES.equals(key)) {
                 return  
                     new LibrariesNode(
                         NbBundle.getMessage(LibrariesNodeFactory.class,"CTL_TestLibrariesNode"),

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/SetupDirNodeFactory.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/SetupDirNodeFactory.java
@@ -77,7 +77,7 @@ public final class SetupDirNodeFactory implements NodeFactory {
         }
 
         public Node node(String key) {
-            if (key == SETUP_DIR) {
+            if (SETUP_DIR.equals(key)) {
                 return J2eeProjectView.createServerResourcesNode(project);
             }
             assert false: "No node for key: " + key;

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EntityOverviewPanel.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EntityOverviewPanel.java
@@ -104,7 +104,7 @@ public class EntityOverviewPanel extends EntityOverviewForm {
 
                 public void setItemValue(String value) {
                     try {
-                        entityHelper.setPrimkeyField(value == PK_COMPOUND ? null : value);
+                        entityHelper.setPrimkeyField(PK_COMPOUND.equals(value) ? null : value);
                     } catch (ClassNotFoundException e) {
                         Utils.notifyError(e);
                     }

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/TextItemEditorModel.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/TextItemEditorModel.java
@@ -22,6 +22,8 @@ package org.netbeans.modules.j2ee.ddloaders.multiview;
 import org.netbeans.modules.xml.multiview.ItemEditorHelper;
 import org.netbeans.modules.xml.multiview.XmlMultiViewDataSynchronizer;
 
+import java.util.Objects;
+
 /**
  * @author pfiala
  */
@@ -62,7 +64,7 @@ public abstract class TextItemEditorModel extends ItemEditorHelper.ItemEditorMod
         }
         if (validate(value)) {
             String currentValue = getValue();
-            if (!(value == currentValue || value != null && value.equals(currentValue))) {
+            if (!Objects.equals(value, currentValue)) {
                 setValue(value);
                 synchronizer.requestUpdateData();
             }

--- a/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/ddloaders/multiview/TextItemEditorModel.java
+++ b/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/ddloaders/multiview/TextItemEditorModel.java
@@ -22,6 +22,8 @@ package org.netbeans.modules.j2ee.sun.ddloaders.multiview;
 import org.netbeans.modules.xml.multiview.ItemEditorHelper;
 import org.netbeans.modules.xml.multiview.XmlMultiViewDataSynchronizer;
 
+import java.util.Objects;
+
 /**
  * @author pfiala,pcw
  */
@@ -60,7 +62,7 @@ public abstract class TextItemEditorModel extends ItemEditorHelper.ItemEditorMod
         }
         if (validate(value)) {
             String currentValue = getValue();
-            if (!(value == currentValue || value != null && value.equals(currentValue))) {
+            if (!Objects.equals(value, currentValue)) {
                 setValue(value);
                 synchronizer.requestUpdateData();
             }

--- a/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/share/CharsetMapping.java
+++ b/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/share/CharsetMapping.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.Objects;
 
 import java.text.MessageFormat;
 
@@ -344,7 +345,7 @@ public class CharsetMapping implements Comparable {
 	public static void setDisplayOption(Integer option) {
 		Integer newDisplayOption = getDisplayOptionEnum(option);
 		
-		if(newDisplayOption != null && newDisplayOption != displayOption) {
+		if(!Objects.equals(newDisplayOption, displayOption)) {
 			Integer oldDisplayOption = displayOption;
 			displayOption = newDisplayOption;
 			updateInternalState();
@@ -354,7 +355,7 @@ public class CharsetMapping implements Comparable {
 	}
 	
 	private static void updateInternalState() {
-		if(displayOption == CHARSET_CANONICAL) {
+		if(CHARSET_CANONICAL.equals(displayOption)) {
 			useAliases = false;
                         if(sortedCanonicalCharsetMappings == null){
                             sortedCanonicalCharsetMappings = getSortedCanonicalCharsetMappings();
@@ -365,7 +366,7 @@ public class CharsetMapping implements Comparable {
 				mapping.showAliases = false;
 				mapping.updateDisplayText();
 			}
-		} else if(displayOption == CHARSET_ALIAS_ASIDE) {
+		} else if(CHARSET_ALIAS_ASIDE.equals(displayOption)) {
 			useAliases = false;
                         if(sortedCanonicalCharsetMappings == null){
                             sortedCanonicalCharsetMappings = getSortedCanonicalCharsetMappings();
@@ -376,7 +377,7 @@ public class CharsetMapping implements Comparable {
 				mapping.showAliases = true;
 				mapping.updateDisplayText();
 			}
-		} else if(displayOption == CHARSET_ALIAS_SELECTION) {
+		} else if(CHARSET_ALIAS_SELECTION.equals(displayOption)) {
 			useAliases = true;
 		}
 	}

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/customizer/CustomizerSupport.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/customizer/CustomizerSupport.java
@@ -448,11 +448,11 @@ public final class CustomizerSupport {
             c.weighty = 1.0;
             ((GridBagLayout)this.getLayout()).setConstraints(spane,c);
             add(spane);
-            if (type == SOURCES || type == JAVADOC) {
+            if (SOURCES.equals(type) || JAVADOC.equals(type)) {
                 this.addButton = new JButton ();
                 String text;
                 char mne;
-                if (type == SOURCES) {
+                if (SOURCES.equals(type)) {
                     text = NbBundle.getMessage(CustomizerSupport.class, "CTL_Add");
                     mne = NbBundle.getMessage(CustomizerSupport.class, "MNE_Add").charAt(0);
                     ad = NbBundle.getMessage(CustomizerSupport.class, "AD_Add");
@@ -711,7 +711,7 @@ public final class CustomizerSupport {
         }
 
         private void selectionChanged () {
-            if (this.type == CLASSPATH) {
+            if (CLASSPATH.equals(this.type)) {
                 return;
             }
             int indices[] = this.resources.getSelectedIndices();

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/customizer/CustomizerSupport.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/customizer/CustomizerSupport.java
@@ -441,10 +441,10 @@ public final class CustomizerSupport {
             c.weighty = 1.0;
             ((GridBagLayout)this.getLayout()).setConstraints(spane,c);
             add(spane);
-            if (type == SOURCES || type == JAVADOC) {
+            if (SOURCES.equals(type) || JAVADOC.equals(type)) {
                 this.addButton = new JButton ();
                 String text;
-                if (type == SOURCES) {
+                if (SOURCES.equals(type)) {
                     text = NbBundle.getMessage(CustomizerSupport.class, "CTL_Add");
                     ad = NbBundle.getMessage(CustomizerSupport.class, "AD_Add");
                 }
@@ -692,7 +692,7 @@ public final class CustomizerSupport {
         }
 
         private void selectionChanged () {
-            if (this.type == CLASSPATH) {
+            if (CLASSPATH.equals(this.type)) {
                 return;
             }
             int indices[] = this.resources.getSelectedIndices();

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/InitParamPanel.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/InitParamPanel.java
@@ -187,17 +187,17 @@ class InitParamPanel extends JPanel implements ActionListener,
     public void actionPerformed(ActionEvent evt) {
         int row = -1;
         if (evt.getSource() instanceof JButton) {
-            if (evt.getActionCommand() == ADD) {
+            if (ADD.equals(evt.getActionCommand())) {
                 String[] values = {
                     NbBundle.getMessage(InitParamPanel.class, "LBL_paramname"),
                     NbBundle.getMessage(InitParamPanel.class, "LBL_paramvalue"),};
                 row = table.addRow(values);
                 table.setRowSelectionInterval(row, row);
-            } else if (evt.getActionCommand() == REMOVE) {
+            } else if (REMOVE.equals(evt.getActionCommand())) {
                 row = table.getSelectedRow();
                 table.removeRow(row);
                 setEnabled();
-            } else if (evt.getActionCommand() == EDIT) {
+            } else if (EDIT.equals(evt.getActionCommand())) {
                 row = table.getSelectedRow();
                 String name = (String) (table.getValueAt(row, 0));
                 String value = (String) (table.getValueAt(row, 1));

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/MappingEditor.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/MappingEditor.java
@@ -258,14 +258,14 @@ public class MappingEditor extends JPanel implements ActionListener {
     }
 
     public void actionPerformed(ActionEvent evt) {
-        if (evt.getActionCommand() == URL) {
+        if (URL.equals(evt.getActionCommand())) {
             fmd.setType(FilterMappingData.Type.URL);
             fmd.setPattern(mappingField.getText().trim());
             mappingField.requestFocus();
             return;
         }
 
-        if (evt.getActionCommand() == SERVLET) {
+        if (SERVLET.equals(evt.getActionCommand())) {
             if (!haveNames) {
                 return;
             }
@@ -275,7 +275,7 @@ public class MappingEditor extends JPanel implements ActionListener {
             return;
         }
 
-        if (evt.getActionCommand() == SELECT_SERVLET) {
+        if (SELECT_SERVLET.equals(evt.getActionCommand())) {
             if (!haveNames) {
                 return;
             }

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/MappingPanel.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/MappingPanel.java
@@ -201,14 +201,14 @@ class MappingPanel extends JPanel implements ActionListener,
 
     public void actionPerformed(ActionEvent evt) {
         if (evt.getSource() instanceof JButton) {
-            if (evt.getActionCommand() == ADD) {
+            if (ADD.equals(evt.getActionCommand())) {
                 FilterMappingData fmd = new FilterMappingData(deployData.getName());
                 MappingEditor editor = new MappingEditor(fmd, deployData.getServletNames());
                 editor.showEditor();
                 if (editor.isOK()) {
                     table.addRow(0, fmd);
                 }
-            } else if (evt.getActionCommand() == EDIT) {
+            } else if (EDIT.equals(evt.getActionCommand())) {
                 int index = table.getSelectedRow();
                 FilterMappingData fmd, fmd2;
                 fmd = table.getRow(index);
@@ -218,16 +218,16 @@ class MappingPanel extends JPanel implements ActionListener,
                 if (editor.isOK()) {
                     table.setRow(index, fmd2);
                 }
-            } else if (evt.getActionCommand() == REMOVE) {
+            } else if (REMOVE.equals(evt.getActionCommand())) {
                 int index = table.getSelectedRow();
                 table.removeRow(index);
                 table.clearSelection();
-            } else if (evt.getActionCommand() == UP) {
+            } else if (UP.equals(evt.getActionCommand())) {
                 int index = table.getSelectedRow();
                 table.moveRowUp(index);
                 table.setRowSelectionInterval(index - 1, index - 1);
 
-            } else if (evt.getActionCommand() == DOWN) {
+            } else if (DOWN.equals(evt.getActionCommand())) {
                 int index = table.getSelectedRow();
                 table.moveRowDown(index);
                 table.setRowSelectionInterval(index + 1, index + 1);

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/ServletData.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/ServletData.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -72,7 +73,7 @@ class ServletData extends DeployData {
     }
 
     void setName(String name) {
-        if (name != this.name) {
+        if (!Objects.equals(name, this.name)) {
             if (fileType == FileType.FILTER) {
                 updateFilterMappings(getName(), name);
             }

--- a/enterprise/web.debug/src/org/netbeans/modules/web/debug/breakpoints/JspLineBreakpoint.java
+++ b/enterprise/web.debug/src/org/netbeans/modules/web/debug/breakpoints/JspLineBreakpoint.java
@@ -26,6 +26,8 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.Objects;
+
 import org.netbeans.api.debugger.*;
 import org.netbeans.api.debugger.jpda.*;
 import org.netbeans.api.debugger.jpda.event.JPDABreakpointEvent;
@@ -231,7 +233,7 @@ public class JspLineBreakpoint extends Breakpoint {
      * @param printText a new value of print text property
      */
     public void setPrintText (String printText) {
-        if (this.printText == printText) return;
+        if (Objects.equals(this.printText, printText)) return;
         String old = this.printText;
         this.printText = printText;
         if (javalb != null) {
@@ -291,9 +293,7 @@ public class JspLineBreakpoint extends Breakpoint {
      * @param cn a new name of class to stop on
      */
     public void setURL (String url) {
-        if ( (url == this.url) ||
-             ((url != null) && (this.url != null) && url.equals (this.url))
-        ) return;
+        if (Objects.equals(url, this.url)) return;
         String old = this.url;
         this.url = url;
         addFileURLListener(url);
@@ -340,9 +340,7 @@ public class JspLineBreakpoint extends Breakpoint {
      */
     public void setCondition (String c) {
         if (c != null) c = c.trim ();
-        if ( (c == condition) ||
-             ((c != null) && (condition != null) && condition.equals (c))
-        ) return;
+        if (Objects.equals(c, condition)) return;
         String old = condition;
         condition = c;
         if (javalb != null) {

--- a/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/model/impl/RestServiceDescriptionImpl.java
+++ b/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/model/impl/RestServiceDescriptionImpl.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
@@ -125,14 +126,14 @@ public class RestServiceDescriptionImpl extends PersistentObject implements Rest
         
         
         // Refresh the resource name.
-        if (this.name != newValue) {
+        if (!Objects.equals(this.name, newValue)) {
             this.name = newValue;
             isModified = true;
         }
         
         // Refresh the class name.
         newValue = typeElement.getQualifiedName().toString();
-        if (this.className != newValue) {
+        if (!Objects.equals(this.className, newValue)) {
             this.className = newValue;
             isModified = true;
         }

--- a/enterprise/websvc.utilities/src/org/netbeans/modules/websvc/utilities/ui/SelectHandlerPanel.java
+++ b/enterprise/websvc.utilities/src/org/netbeans/modules/websvc/utilities/ui/SelectHandlerPanel.java
@@ -117,7 +117,7 @@ public class SelectHandlerPanel extends JPanel implements ExplorerManager.Provid
         protected Node[] createNodes(String key) {
             Node n = null;
             List<Node> sourceNodes = new LinkedList<Node>();
-            if (key == KEY_SOURCES) {
+            if (KEY_SOURCES.equals(key)) {
                 Sources sources = ProjectUtils.getSources(project);
                 SourceGroup[] groups = sources.getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA);
                 for(int i = 0; i < groups.length; i++){

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
@@ -55,6 +55,7 @@ import java.util.MissingResourceException;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.function.Function;
+import java.util.Objects;
 import org.netbeans.api.project.ProjectInformation;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ProjectUtils;
@@ -490,7 +491,7 @@ public final class RunUtils {
         Map<Object, Integer>  options = new HashMap<>();
         Object def = null;
         for (String opt : TRUST_DIALOG_OPTION_IDS) {
-            if (opt == TRUST_DIALOG_OPTION_IDS.get(2) && !allowPermanent) {
+            if (Objects.equals(opt, TRUST_DIALOG_OPTION_IDS.get(2)) && !allowPermanent) {
                 continue;
             }
             String key = BRANDING_API_PREFIX + opt;

--- a/extide/gradle/src/org/netbeans/modules/gradle/customizer/BuildActionsCustomizer.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/customizer/BuildActionsCustomizer.java
@@ -569,7 +569,7 @@ public class BuildActionsCustomizer extends javax.swing.JPanel {
     private void cbAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cbAddActionPerformed
         if (!comboReady) return;
         String action = availableActionsModel.getElementAt(cbAdd.getSelectedIndex());
-        if (action != CUSTOM_ACTION) {
+        if (!CUSTOM_ACTION.equals(action)) {
             availableActionsModel.removeElement(action);
         } else {
             action = actionRegistry.findNewCustonActionId();

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/wizard/impl/AntProjectTypeStrategy.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/wizard/impl/AntProjectTypeStrategy.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -251,8 +252,8 @@ public class AntProjectTypeStrategy extends ProjectTypeStrategy {
             }
             String verNumToRemove = (jUnit == JUnit.JUNIT3) ? "4" : "3"; //NOI18N
             if (name.equals("junit")) {                                  //NOI18N
-                add    = (verNumToAdd    == "3");                        //NOI18N
-                remove = (verNumToRemove == "3");                        //NOI18N
+                add    = (Objects.equals(verNumToAdd, "3"));                        //NOI18N
+                remove = (verNumToRemove.equals("3"));                        //NOI18N
             } else if ((matcher = pattern.matcher(name)).matches()) {
                 String verNum = matcher.group(1);
                 add    = verNum.equals(verNumToAdd);

--- a/ide/api.debugger/src/org/netbeans/api/debugger/Properties.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/Properties.java
@@ -1093,7 +1093,7 @@ public abstract class Properties {
                 if (!typeID.startsWith ("# ")) { // NOI18N
                     if (typeID.startsWith ("\"")) { // NOI18N
                         String s = getString (propertyName, BAD_STRING);
-                        if (s == BAD_STRING) {
+                        if (BAD_STRING.equals(s)) {
                             return defaultValue;
                         }
                         return s;

--- a/ide/api.debugger/src/org/netbeans/api/debugger/Session.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/Session.java
@@ -24,6 +24,8 @@ import java.beans.PropertyChangeSupport;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 import org.netbeans.spi.debugger.ContextProvider;
 
 
@@ -422,7 +424,7 @@ public final class Session implements ContextProvider {
             oldL,
             newL
         );
-        if (oldCurrentL != newCurrentL) {
+        if (!Objects.equals(oldCurrentL, newCurrentL)) {
             pcs.firePropertyChange (
                 PROP_CURRENT_LANGUAGE,
                 oldCurrentL,

--- a/ide/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsPanelLogic.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsPanelLogic.java
@@ -31,6 +31,7 @@ import java.awt.event.MouseListener;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.AbstractPreferences;
@@ -188,7 +189,7 @@ class HintsPanelLogic implements MouseListener, KeyListener, TreeSelectionListen
 
             Boolean currentEnabled = mn.getBoolean(HintsSettings.ENABLED_KEY, hint.getDefaultEnabled());
             Boolean savedEnabled = HintsSettings.isEnabled(manager, hint);
-            isChanged |= currentEnabled != savedEnabled;
+            isChanged |= !Objects.equals(currentEnabled, savedEnabled);
             if (isChanged) {
                 return true;
             }

--- a/ide/db/src/org/netbeans/modules/db/explorer/node/ProcedureNode.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/node/ProcedureNode.java
@@ -376,7 +376,7 @@ public class ProcedureNode extends BaseNode {
                                 source = getTypeName(getType()) + " " + parent + getName() + "(" + params + ")" + "\n" // NOI18N
                                        + (function ? "RETURNS " + rs.getString("dtd_identifier") + "\n" : "") // NOI18N
                                        + sql_data_access + "\n" // NOI18N
-                                       + (is_deterministic == "YES" ? "" : "NOT ") + "DETERMINISTIC\n" // NOI18N
+                                       + ("YES".equals(is_deterministic) ? "" : "NOT ") + "DETERMINISTIC\n" // NOI18N
                                        + (comment.length() > 0 ? "COMMENT '" + comment +"'\n" : "") // NOI18N
                                        + rs.getString("routine_definition"); // NOI18N
                             }

--- a/ide/diff/src/org/netbeans/modules/diff/PatchAction.java
+++ b/ide/diff/src/org/netbeans/modules/diff/PatchAction.java
@@ -375,7 +375,7 @@ public class PatchAction extends NodeAction {
         @Override
         public void actionPerformed(ActionEvent e){
             String command  = e.getActionCommand();
-            if(command == JFileChooser.APPROVE_SELECTION){
+            if (JFileChooser.APPROVE_SELECTION.equals(command)) {
                 if(dialog != null) {
                     file = chooser.getSelectedFile();
                     dialog.setVisible(false);

--- a/ide/editor.lib2/src/org/netbeans/spi/editor/AbstractEditorAction.java
+++ b/ide/editor.lib2/src/org/netbeans/spi/editor/AbstractEditorAction.java
@@ -522,7 +522,7 @@ public abstract class AbstractEditorAction extends TextAction implements
     }
 
     private Object getValueLocal(String key) {
-        if ("enabled" == key) { // Same == in AbstractAction
+        if ("enabled".equals(key)) { // Same == in AbstractAction
             return enabled;
         }
         synchronized (properties) {
@@ -589,7 +589,7 @@ public abstract class AbstractEditorAction extends TextAction implements
             return;
         }
         Object oldValue;
-        if ("enabled" == key) { // Same == in AbstractAction
+        if ("enabled".equals(key)) { // Same == in AbstractAction
             oldValue = enabled;
             enabled = Boolean.TRUE.equals(value);
         } else {

--- a/ide/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesImpl.java
+++ b/ide/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/preferences/PreferencesImpl.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -268,7 +269,7 @@ public final class PreferencesImpl extends AbstractPreferences implements Prefer
         // This hack is here for refiring preferenceChange events from 'inherited'.
         // Comparing the key strings by == is ok here. Please see firePreferenceChange()
         // for details.
-        if (refiringChangeKey.get() != key) {
+        if (!Objects.equals(refiringChangeKey.get(), key)) {
             if (!key.startsWith(JAVATYPE_KEY_PREFIX)) {
                 getLocal().put(key, new TypedValue(value, putValueJavaType.get()));
                 asyncInvocationOfFlushSpi();

--- a/ide/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/annotation/LineBreakpointAnnotation.java
+++ b/ide/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/annotation/LineBreakpointAnnotation.java
@@ -72,16 +72,16 @@ public final class LineBreakpointAnnotation extends BreakpointAnnotation {
             }
             return Bundle.TOOLTIP_BREAKPOINT_BROKEN();
         }
-        if (type == BREAKPOINT_ANNOTATION_TYPE) {
+        if (BREAKPOINT_ANNOTATION_TYPE.equals(type)) {
             return Bundle.TOOLTIP_BREAKPOINT();
         }
-        if (type == DISABLED_BREAKPOINT_ANNOTATION_TYPE) {
+        if (DISABLED_BREAKPOINT_ANNOTATION_TYPE.equals(type)) {
             return Bundle.TOOLTIP_DISABLED_BREAKPOINT();
         }
-        if (type == CONDITIONAL_BREAKPOINT_ANNOTATION_TYPE) {
+        if (CONDITIONAL_BREAKPOINT_ANNOTATION_TYPE.equals(type)) {
             return Bundle.TOOLTIP_CONDITIONAL_BREAKPOINT();
         }
-        if (type == DISABLED_CONDITIONAL_BREAKPOINT_ANNOTATION_TYPE) {
+        if (DISABLED_CONDITIONAL_BREAKPOINT_ANNOTATION_TYPE.equals(type)) {
             return Bundle.TOOLTIP_DISABLED_CONDITIONAL_BREAKPOINT();
         }
         if (type.endsWith(DEACTIVATED_BREAKPOINT_SUFFIX)) {

--- a/ide/mercurial/src/org/netbeans/modules/mercurial/MercurialInterceptor.java
+++ b/ide/mercurial/src/org/netbeans/modules/mercurial/MercurialInterceptor.java
@@ -36,6 +36,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Set;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import org.netbeans.modules.mercurial.util.HgUtils;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -753,7 +754,8 @@ public class MercurialInterceptor extends VCSInterceptor {
                 for (Map.Entry<String, Long> e : interestingTimestamps.entrySet()) {
                     // has a newer (higher) ts or the file is deleted
                     if (e.getValue() > other.interestingTimestamps.get(e.getKey())
-                            || e.getValue() == 0 && other.interestingTimestamps.get(e.getKey()) != e.getValue()) {
+                        || e.getValue() == 0
+                           && !Objects.equals(other.interestingTimestamps.get(e.getKey()), e.getValue())) {
                         newer = true;
                         break;
                     }

--- a/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryChooserUI.java
+++ b/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryChooserUI.java
@@ -2058,10 +2058,10 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         @Override
         public void propertyChange(PropertyChangeEvent e) {
             String prop = e.getPropertyName();
-            if(prop == JFileChooser.CHOOSABLE_FILE_FILTER_CHANGED_PROPERTY) {
+            if (JFileChooser.CHOOSABLE_FILE_FILTER_CHANGED_PROPERTY.equals(prop)) {
                 filters = (FileFilter[]) e.getNewValue();
                 fireContentsChanged(this, -1, -1);
-            } else if (prop == JFileChooser.FILE_FILTER_CHANGED_PROPERTY) {
+            } else if (JFileChooser.FILE_FILTER_CHANGED_PROPERTY.equals(prop)) {
                 fireContentsChanged(this, -1, -1);
             }
         }

--- a/ide/projectui/src/org/netbeans/modules/project/ui/groups/CheckBoxRenderrer.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/groups/CheckBoxRenderrer.java
@@ -161,7 +161,7 @@ public class CheckBoxRenderrer extends JCheckBox implements ListCellRenderer, Se
     @Override
     protected void firePropertyChange (String propertyName, Object oldValue, Object newValue) {
         // Strings get interned...
-        if (propertyName == "text" || ((propertyName == "font" || propertyName == "foreground") &&
+        if ("text".equals(propertyName) || (("font".equals(propertyName) || "foreground".equals(propertyName)) &&
             oldValue != newValue &&
             getClientProperty (javax.swing.plaf.basic.BasicHTML.propertyKey) != null)
         ) {

--- a/ide/properties/src/org/netbeans/modules/properties/PropertiesDataObject.java
+++ b/ide/properties/src/org/netbeans/modules/properties/PropertiesDataObject.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.TreeSet;
+import java.util.Objects;
 import java.util.logging.Logger;
 import org.openide.cookies.OpenCookie;
 import org.openide.cookies.SaveCookie;
@@ -442,7 +443,7 @@ public final class PropertiesDataObject extends MultiDataObject implements Cooki
         protected void mySetKeys() {
             TreeSet<String> newKeys = new TreeSet<String>(new Comparator<String>() {
                 public int compare(String o1, String o2) {
-                    if (o1 == o2) {
+                    if (Objects.equals(o1, o2)) {
                         return 0;
                     }
                     if (o1 == null) {

--- a/ide/properties/src/org/netbeans/modules/properties/Util.java
+++ b/ide/properties/src/org/netbeans/modules/properties/Util.java
@@ -308,14 +308,14 @@ public final class Util extends Object {
         }
 
         String defaultLangName = null;
-        if (language == "") {                                           //NOI18N
+        if (language.isEmpty()) {                                           //NOI18N
             defaultLangName = NbBundle.getMessage(
                     Util.class,
                     "LAB_defaultLanguage");                             //NOI18N
         }
 
         /* Simple case #1 - the default locale */
-        if (language == "" && country == "" && variant == "") {         //NOI18N
+        if (language.isEmpty() && country.isEmpty() && variant.isEmpty()) {         //NOI18N
             return defaultLangName;
         }
 
@@ -324,7 +324,7 @@ public final class Util extends Object {
 
         /* - language name: */
         String langName;
-        if (language == "") {                                           //NOI18N
+        if (language.isEmpty()) {                                           //NOI18N
             langName = defaultLangName;
         } else {
             langName = locale.getDisplayLanguage();
@@ -336,7 +336,7 @@ public final class Util extends Object {
         }
 
         /* Simple case #2 - language specification only */
-        if (country == "" && variant == "") {                           //NOI18N
+        if (country.isEmpty() && variant.isEmpty()) {                           //NOI18N
             return NbBundle.getMessage(Util.class,
                                        "LAB_localeSpecLang",            //NOI18N
                                        localeSpec,
@@ -345,7 +345,7 @@ public final class Util extends Object {
 
         /* - country name: */
         String countryName = "";                                        //NOI18N
-        if (country != "") {                                            //NOI18N
+        if (!country.isEmpty()) {                                            //NOI18N
             countryName = locale.getDisplayCountry();
             if (countryName.equals(country)) {
                 countryName = NbBundle.getMessage(Util.class,
@@ -355,14 +355,14 @@ public final class Util extends Object {
         }
 
         /* - variant name: */
-        String variantName = variant == "" ? ""                         //NOI18N
+        String variantName = variant.isEmpty() ? ""                         //NOI18N
                                            : locale.getDisplayVariant();
 
         /* Last case - country and/or variant specification */
         String countryAndVariant;
-        if (variantName == "") {                                        //NOI18N
+        if (variantName.isEmpty()) {                                        //NOI18N
             countryAndVariant = countryName;
-        } else if (countryName == "") {                                 //NOI18N
+        } else if (countryName.isEmpty()) {                                 //NOI18N
             countryAndVariant = variantName;
         } else {
             countryAndVariant = countryName + ", " + variantName;       //NOI18N

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/BaseBean.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/BaseBean.java
@@ -1248,7 +1248,7 @@ public abstract class BaseBean implements Cloneable, Bean {
                 String a = attrs[j];
                 if (!this.beanProp().getAttrProp(a).isFixed()) {
                     String v = this.getAttributeValue(a);
-                    if (bean.getAttributeValue(a) != v)
+                    if (!Objects.equals(bean.getAttributeValue(a), v))
                         bean.setAttributeValue(a, v);
                 }
             }
@@ -1288,7 +1288,7 @@ public abstract class BaseBean implements Cloneable, Bean {
                         if (!prop.getAttrProp(a).isFixed()) {
                             for(int i=0; i<size; i++) {
                                 String v = prop.getAttributeValue(i, a);
-                                if (bean.getAttributeValue(name, i, a) != v)
+                                if (!Objects.equals(bean.getAttributeValue(name, i, a), v))
                                     bean.setAttributeValue(name, i, a, v);
                                 
                             }
@@ -1310,7 +1310,7 @@ public abstract class BaseBean implements Cloneable, Bean {
                         String a = attrs[j];
                         if (!prop.getAttrProp(a).isFixed()) {
                             String v = prop.getAttributeValue(0, a);
-                            if (bean.getAttributeValue(name, 0, a) != v)
+                            if (!Objects.equals(bean.getAttributeValue(name, 0, a), v))
                                 bean.setAttributeValue(name, a, v);
                         }
                     }
@@ -1469,15 +1469,13 @@ public abstract class BaseBean implements Cloneable, Bean {
                     String curValue = this.getAttributeValue(attrName);
                     String otherValue = bean.getAttributeValue(attrName);
 
-                    if (curValue != otherValue) {
+                    if (!Objects.equals(curValue, otherValue)) {
                         // Might have one of the two null, not both
-                        if (curValue == null || otherValue == null || !curValue.equals(otherValue)) {
-                            if ((mode & MERGE_COMPARE) == MERGE_COMPARE) {
-                                return false;
-                            }
-                            if ((mode & MERGE_UNION) == MERGE_UNION) {
-                                this.setAttributeValue(attrName, otherValue);
-                            }
+                        if ((mode & MERGE_COMPARE) == MERGE_COMPARE) {
+                            return false;
+                        }
+                        if ((mode & MERGE_UNION) == MERGE_UNION) {
+                            this.setAttributeValue(attrName, otherValue);
                         }
                     }
                 }

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/BeanComparator.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/BeanComparator.java
@@ -88,13 +88,9 @@ public class BeanComparator {
 			String curValue = curBean.getAttributeValue(attrName);
 			String otherValue = newBean.getAttributeValue(attrName);
 
-			if (curValue != otherValue) {
-			    if (curValue == null || otherValue == null ||
-				!curValue.equals(otherValue)) {
-			
+			if (!Objects.equals(curValue, otherValue)) {
 				//  Diffenrence found - not the same bean
 				return newBean;
-			    }
 			}
 		    }
 		}
@@ -208,7 +204,7 @@ public class BeanComparator {
                         ret = newValue;
                         break;
                     }
-                } else if (v2 != v1) {
+                } else if (!Objects.equals(v2, v1)) {
                     ret = newValue;
                     break;
                 }

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/XMLUtil.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/XMLUtil.java
@@ -565,7 +565,7 @@ public class XMLUtil {
                         textNode = (Text) childNode;
                         // Need to make sure it has the correct whitespace
                         if (i == length-1) {
-                            if (idealFinalWhitespace != childNodeValue) {
+                            if (!idealFinalWhitespace.equals(childNodeValue)) {
                                 //System.out.println("!Incorrect whitespace on final!");
                                 if (textNode.getLength() > 0)
                                     textNode.deleteData(0, textNode.getLength());
@@ -573,7 +573,7 @@ public class XMLUtil {
                             }
                             
                         } else {
-                            if (idealChildWhitespace != childNodeValue) {
+                            if (!idealChildWhitespace.equals(childNodeValue)) {
                                 //System.out.println("!Incorrect whitespace: '"+childNodeValue+"' versus ideal of '"+idealChildWhitespace+"'");
                                 textNode.deleteData(0, textNode.getLength());
                                 textNode.appendData(idealChildWhitespace);
@@ -613,7 +613,7 @@ public class XMLUtil {
                             // Go back and fix up the last node.
                             childNode = children.item(i);
                             String childNodeValue = childNode.getNodeValue().intern();
-                            if (idealFinalWhitespace != childNodeValue) {
+                            if (!idealFinalWhitespace.equals(childNodeValue)) {
                                 textNode = (Text) childNode;
                                 //System.out.println("!Incorrect whitespace on final!");
                                 if (textNode.getLength() > 0)

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beansdev/AbstractCodeGeneratorClass.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beansdev/AbstractCodeGeneratorClass.java
@@ -541,7 +541,7 @@ public abstract class AbstractCodeGeneratorClass {
             mutable = false;
             needToCallClone = false;
         }
-        if (type == "java.io.File") {
+        if ("java.io.File".equals(type)) {
             return true;
         } else if (needToCallClone) {
             return true;

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beansdev/SchemaRep.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beansdev/SchemaRep.java
@@ -86,7 +86,7 @@ public class SchemaRep implements PrefixGuesser {
                     String parentFullContentName = parentExpr.getFullContentName();
                     if (contentName == null)
                         fullContentName = parentFullContentName;
-                    else if (parentFullContentName == "/")
+                    else if ("/".equals(parentFullContentName))
                         fullContentName = (parentFullContentName + contentName).intern();
                     else
                         fullContentName = (parentFullContentName + "/" + contentName).intern();
@@ -123,7 +123,7 @@ public class SchemaRep implements PrefixGuesser {
                     while (it.hasNext()) {
                         ElementExpr otherElement = (ElementExpr) it.next();
                         String otherElementFullContentName = otherElement.getFullContentName();
-                        if (subElementFullContentName == otherElementFullContentName) {
+                        if (Objects.equals(subElementFullContentName, otherElementFullContentName)) {
                             if (debug)
                                 System.out.println("Found duplicate fullContentName for "+otherElement.getName()+" : "+subElementFullContentName);
                             subElement.uniquifyFullContentName();

--- a/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/CheckBoxRenderrer.java
+++ b/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/CheckBoxRenderrer.java
@@ -161,7 +161,7 @@ public class CheckBoxRenderrer extends JCheckBox implements ListCellRenderer, Se
     @Override
     protected void firePropertyChange (String propertyName, Object oldValue, Object newValue) {
         // Strings get interned...
-        if (propertyName == "text" || ((propertyName == "font" || propertyName == "foreground") &&
+        if ("text".equals(propertyName) || (("font".equals(propertyName) || "foreground".equals(propertyName)) &&
             oldValue != newValue &&
             getClientProperty (javax.swing.plaf.basic.BasicHTML.propertyKey) != null)
         ) {

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/DebuggerAction.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/DebuggerAction.java
@@ -67,7 +67,7 @@ public class DebuggerAction extends AbstractAction {
     
     @Override
     public Object getValue(String key) {
-        if (key == Action.NAME && nameInBundle) {
+        if (Action.NAME.equals(key) && nameInBundle) {
             return NbBundle.getMessage (DebuggerAction.class, (String) super.getValue(key));
         }
         return super.getValue(key);

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ViewActions.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ViewActions.java
@@ -44,7 +44,7 @@ public class ViewActions extends AbstractAction {
     }
 
     public Object getValue(String key) {
-        if (key == Action.NAME) {
+        if (Action.NAME.equals(key)) {
             return NbBundle.getMessage (ViewActions.class, (String) super.getValue(key));
         }
         Object value = super.getValue(key);

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/annotations/DebuggerAnnotation.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/annotations/DebuggerAnnotation.java
@@ -80,7 +80,7 @@ public class DebuggerAnnotation extends Annotation implements Lookup.Provider {
     @NbBundle.Messages("TOOLTIP_WATCH_PIN=Watch")
     @Override
     public String getShortDescription () {
-        if (type == WATCH_ANNOTATION_TYPE) {
+        if (WATCH_ANNOTATION_TYPE.equals(type)) {
             return Bundle.TOOLTIP_WATCH_PIN();
         }
         ErrorManager.getDefault().notify(ErrorManager.INFORMATIONAL, new IllegalStateException("Unknown annotation type '"+type+"'."));

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/annotations/WatchAnnotationProvider.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/annotations/WatchAnnotationProvider.java
@@ -46,6 +46,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
@@ -729,7 +730,7 @@ public class WatchAnnotationProvider implements AnnotationProvider, LazyDebugger
         private String getWatchValueText(Watch watch, ValueProvider vp, boolean[] isEvaluating) {
             String value = vp.getValue(watch);
             //System.err.println("WatchAnnotationProvider.getWatchText("+watch.getExpression()+"): value = "+value+", lastValue = "+lastValue);
-            if (value == evaluatingValue) {
+            if (Objects.equals(value, evaluatingValue)) {
                 if (isEvaluating != null) {
                     isEvaluating[0] = true;
                 }

--- a/ide/subversion/src/org/netbeans/modules/subversion/ui/repository/Repository.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/ui/repository/Repository.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Objects;
 import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -452,19 +453,19 @@ public class Repository implements ActionListener, DocumentListener, ItemListene
     private void updateVisibility(String connPanelTypeId,
                                   String selectedUrlString) {
 
-        if (connPanelTypeId == HTTP_PANEL) {
+        if (HTTP_PANEL.equals(connPanelTypeId)) {
             currentPanel = http;
-        } else if (connPanelTypeId == SSH_PANEL) {
+        } else if (SSH_PANEL.equals(connPanelTypeId)) {
             currentPanel = svnSSH;
-        } else if (connPanelTypeId == FILE_PANEL) {
+        } else if (FILE_PANEL.equals(connPanelTypeId)) {
             currentPanel = file;
-        } else if (connPanelTypeId == INVALID_URL_PANEL) {
+        } else if (INVALID_URL_PANEL.equals(connPanelTypeId)) {
             currentPanel = invalidUrlPanel;
         } else {
             assert false;
         }
 
-        if (connPanelTypeId != currentConnPanelType) {
+        if (!Objects.equals(connPanelTypeId, currentConnPanelType)) {
             ((CardLayout) repositoryPanel.connPanel.getLayout()).show(repositoryPanel.connPanel, connPanelTypeId);
             currentConnPanelType = connPanelTypeId;
         }

--- a/ide/subversion/src/org/netbeans/modules/subversion/ui/status/VersioningPanel.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/ui/status/VersioningPanel.java
@@ -281,7 +281,7 @@ class VersioningPanel extends JPanel implements ExplorerManager.Provider, Prefer
                                 return;
                             }
                             String sticky = nodes[i].getCopy(); // copy must be initialized on all nodes
-                            if (stickyCommon && sticky != currentSticky && (sticky == null || currentSticky == null || !sticky.equals(currentSticky))) {
+                            if (stickyCommon && !Objects.equals(sticky, currentSticky)) {
                                 stickyCommon = false;
                             }
                         }

--- a/ide/xml.core/src/org/netbeans/modules/xml/api/EncodingUtil.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/api/EncodingUtil.java
@@ -162,7 +162,7 @@ public class EncodingUtil {
             
             String detectedEnc = detectDeclaredEncoding(bytes, enc, size);
             if (detectedEnc == null) {
-                return enc == UTF8_DEFAULT ? null : enc;
+                return UTF8_DEFAULT.equals(enc) ? null : enc;
             }
             
             return getIANA2JavaMapping(detectedEnc);
@@ -188,7 +188,7 @@ public class EncodingUtil {
      * canonicalization with other UTF8 constants.
      */
     @SuppressWarnings("")
-    static final String UTF8_DEFAULT = new String("UTF8"); // NOI18N
+    static final String UTF8_DEFAULT = "UTF8"; // NOI18N
     
     private static String autoDetectEncoding(byte[] buf, int len) throws IOException {
         if (len >= 4) {

--- a/ide/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/Utilities.java
+++ b/ide/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/Utilities.java
@@ -283,7 +283,7 @@ public class Utilities {
             List<String> targetNSList = null;
             try {
                 targetNSList = runXPathQuery(file, xpathQuery);
-                String targetNS = null;
+                String targetNS;
                 FileObject fobj = FileUtil.toFileObject(file);
                 if(targetNSList.size() > 0){
                     //just take the first and ignore rest
@@ -291,7 +291,7 @@ public class Utilities {
                 } else{
                     targetNS = NO_NAME_SPACE;
                 }
-                if((docType == docType.wsdl) && (targetNS == NO_NAME_SPACE))
+                if((docType == docType.wsdl) && NO_NAME_SPACE.equals(targetNS))
                     //this is wsdl and it must have NS so ignore this file
                     continue;
                 result.put(fobj, targetNS);

--- a/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionUtil.java
+++ b/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/util/CompletionUtil.java
@@ -512,7 +512,7 @@ public class CompletionUtil {
             ae = findOriginal(ae);
             String defaultNS = context.getDefaultNamespace();
             String targetNS = ae.getTargetNamespace();
-            if((defaultNS != targetNS) &&  // in case both are null, go away
+            if (!Objects.equals(defaultNS, targetNS) &&  // in case both are null, go away
                (defaultNS == null || targetNS == null ||
                 !context.getDefaultNamespace().equals(ae.getTargetNamespace()))) {
                 prefixes = getPrefixesAgainstNamespace(context, ae.getTargetNamespace());

--- a/ide/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaImpl.java
+++ b/ide/xml.schema.model/src/org/netbeans/modules/xml/schema/model/impl/SchemaImpl.java
@@ -408,7 +408,7 @@ public class SchemaImpl extends SchemaComponentImpl implements Schema {
         
        private static String translateNamespace(String s) {
             // == comparison is deliberate
-            return s == NO_NAMESPACE_PLACEHOLDER ? null : s;
+            return NO_NAMESPACE_PLACEHOLDER.equals(s) ? null : s;
         }
 
         public String getTargetNamespace() {

--- a/ide/xml/src/org/netbeans/modules/xml/util/Util.java
+++ b/ide/xml/src/org/netbeans/modules/xml/util/Util.java
@@ -163,7 +163,7 @@ public class Util extends AbstractUtil {
             List targetNSList = null;
             try {
                 targetNSList = runXPathQuery(file, xpathQuery);
-                String targetNS = null;
+                String targetNS;
                 FileObject fobj = FileUtil.toFileObject(file);
                 if(targetNSList.size() > 0){
                     //just take the first and ignore rest
@@ -171,7 +171,7 @@ public class Util extends AbstractUtil {
                 } else{
                     targetNS = NO_NAME_SPACE;
                 }
-                if( (targetNS == NO_NAME_SPACE))
+                if (NO_NAME_SPACE.equals(targetNS))
                     //this is wsdl and it must have NS so ignore this file
                     continue;
                 result.put(fobj, targetNS);

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAnnotation.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAnnotation.java
@@ -59,16 +59,16 @@ public class DebuggerAnnotation extends Annotation {
     
     @Override
     public String getShortDescription () {
-        if (type == CURRENT_LINE_ANNOTATION_TYPE)
+        if (CURRENT_LINE_ANNOTATION_TYPE.equals(type))
             return NbBundle.getMessage(DebuggerAnnotation.class, "TOOLTIP_CURRENT_PC");
         else
-        if (type == CURRENT_LINE_ANNOTATION_TYPE2)
+        if (CURRENT_LINE_ANNOTATION_TYPE2.equals(type))
             return NbBundle.getMessage(DebuggerAnnotation.class, "TOOLTIP_CURRENT_PC_2");
         else
-        if (type == CURRENT_LINE_PART_ANNOTATION_TYPE)
+        if (CURRENT_LINE_PART_ANNOTATION_TYPE.equals(type))
             return NbBundle.getMessage(DebuggerAnnotation.class, "TOOLTIP_CURRENT_PC");
         else
-        if (type == CALL_STACK_FRAME_ANNOTATION_TYPE)
+        if (CALL_STACK_FRAME_ANNOTATION_TYPE.equals(type))
             return NbBundle.getMessage(DebuggerAnnotation.class, "TOOLTIP_CALLSITE");
         return null;
     }

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerBreakpointAnnotation.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerBreakpointAnnotation.java
@@ -61,19 +61,19 @@ public class DebuggerBreakpointAnnotation extends BreakpointAnnotation {
     
     @Override
     public String getShortDescription () {
-        if (type == BREAKPOINT_ANNOTATION_TYPE)
+        if (BREAKPOINT_ANNOTATION_TYPE.equals(type))
             return NbBundle.getMessage 
                 (DebuggerBreakpointAnnotation.class, "TOOLTIP_BREAKPOINT");
         else 
-        if (type == DISABLED_BREAKPOINT_ANNOTATION_TYPE)
+        if (DISABLED_BREAKPOINT_ANNOTATION_TYPE.equals(type))
             return NbBundle.getMessage 
                 (DebuggerBreakpointAnnotation.class, "TOOLTIP_DISABLED_BREAKPOINT");
         else 
-        if (type == CONDITIONAL_BREAKPOINT_ANNOTATION_TYPE)
+        if (CONDITIONAL_BREAKPOINT_ANNOTATION_TYPE.equals(type))
             return NbBundle.getMessage 
                 (DebuggerBreakpointAnnotation.class, "TOOLTIP_CONDITIONAL_BREAKPOINT");
         else
-        if (type == DISABLED_CONDITIONAL_BREAKPOINT_ANNOTATION_TYPE)
+        if (DISABLED_CONDITIONAL_BREAKPOINT_ANNOTATION_TYPE.equals(type))
             return NbBundle.getMessage 
                 (DebuggerBreakpointAnnotation.class, "TOOLTIP_DISABLED_CONDITIONAL_BREAKPOINT");
         return null;

--- a/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ExceptionBreakpoint.java
+++ b/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ExceptionBreakpoint.java
@@ -24,6 +24,8 @@ import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
 import org.netbeans.api.debugger.DebuggerEngine;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
@@ -133,9 +135,7 @@ public class ExceptionBreakpoint extends JPDABreakpoint {
         if (cn != null) {
             cn = cn.trim();
         }
-        if ( (cn == exceptionClassName) ||
-             ((cn != null) && (exceptionClassName != null) && exceptionClassName.equals (cn))
-        ) return;
+        if (Objects.equals(cn, exceptionClassName)) return;
         Object old = exceptionClassName;
         exceptionClassName = cn;
         firePropertyChange (PROP_EXCEPTION_CLASS_NAME, old, exceptionClassName);

--- a/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/FieldBreakpoint.java
+++ b/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/FieldBreakpoint.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.WeakHashMap;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -117,12 +118,7 @@ public class FieldBreakpoint extends JPDABreakpoint {
      * @param className a new name of class the field is defined in
      */
     public void setClassName (String className) {
-        if ( (className == this.className) ||
-             ( (className != null) && 
-               (this.className != null) && 
-               this.className.equals (className)
-             )
-        ) return;
+        if (Objects.equals(className, this.className)) return;
         Object old = this.className;
         this.className = className;
         firePropertyChange (PROP_CLASS_NAME, old, className);
@@ -146,9 +142,7 @@ public class FieldBreakpoint extends JPDABreakpoint {
         if (name != null) {
             name = name.trim();
         }
-        if ( (name == fieldName) ||
-             ((name != null) && (fieldName != null) && fieldName.equals (name))
-        ) return;
+        if (Objects.equals(name, fieldName)) return;
         String old = fieldName;
         fieldName = name;
         firePropertyChange (PROP_FIELD_NAME, old, fieldName);

--- a/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/MethodBreakpoint.java
+++ b/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/MethodBreakpoint.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.WeakHashMap;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -134,9 +135,7 @@ public class MethodBreakpoint extends JPDABreakpoint {
         if (mn != null) {
             mn = mn.trim();
         }
-        if ( (mn == methodName) ||
-             ((mn != null) && (methodName != null) && methodName.equals (mn))
-        ) return;
+        if (Objects.equals(mn, methodName)) return;
         String old = methodName;
         methodName = mn;
         firePropertyChange (PROP_METHOD_NAME, old, mn);
@@ -162,9 +161,7 @@ public class MethodBreakpoint extends JPDABreakpoint {
         if (signature != null) {
             signature = signature.trim();
         }
-        if ((signature == methodSignature) ||
-            ((signature != null) && signature.equals (methodSignature))) {
-            
+        if (Objects.equals(signature, methodSignature)) {
             return;
         }
         String old = methodSignature;

--- a/java/beans/src/org/netbeans/modules/beans/ModePropertyEditor.java
+++ b/java/beans/src/org/netbeans/modules/beans/ModePropertyEditor.java
@@ -20,6 +20,8 @@
 package org.netbeans.modules.beans;
 
 import java.beans.*;
+import java.util.Objects;
+
 import static org.netbeans.modules.beans.BeanUtils.*;
 
 /** property editor for mode property of Prperty patterns
@@ -62,7 +64,7 @@ public class ModePropertyEditor extends PropertyEditorSupport {
     /** @param text A text for the current value. */
     public void setAsText (String text) {
         for (int i = 0; i < getTags().length ; i++)
-            if (getTags()[i] == text) {
+            if (Objects.equals(getTags()[i], text)) {
                 setValue(values[i]);
                 return;
             }

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -362,7 +362,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                         
                         pkSchema = rset.get(new Integer(2));
                         fkSchema = rset.get(new Integer(6));
-                        if ((pkSchema == fkSchema) || (pkSchema.equals(fkSchema))) {
+                        if ((Objects.equals(pkSchema, fkSchema)) || (pkSchema.equals(fkSchema))) {
                             refTable = rset.get(new Integer(3));
                             if (! tables.contains(refTable))
                                 tables.add(refTable);
@@ -389,7 +389,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                         if (fkSchema != null) {
                             fkSchema = fkSchema.trim();
                         }
-                        if ((pkSchema == fkSchema) || (pkSchema.equals(fkSchema))) {
+                        if (Objects.equals(pkSchema, fkSchema)) {
                             refTable = rs.getString("PKTABLE_NAME").trim(); //NOI18N
                             if (! tables.contains(refTable))
                                 tables.add(refTable);

--- a/java/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/XMLGraphDeserializer.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/migration/archiver/deserializer/XMLGraphDeserializer.java
@@ -526,7 +526,7 @@ public  class XMLGraphDeserializer extends BaseSpecificXMLDeserializer implement
     public   void readAttributeHeader(java.lang.String name, org.xml.sax.AttributeList atts)
     {
         //@olsen+MBO: intended to compare strings by '==' instead of equals()?
-        if (name == "_.METHOD"  || name == "_.CALLBACK")
+        if ("_.METHOD".equals(name) || "_.CALLBACK".equals(name))
         {
             this.pushAttrName(atts.getValue("NAME"));
             this.pushAttrName(name);

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/ToggleMethodFieldBreakpointAction.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/actions/ToggleMethodFieldBreakpointAction.java
@@ -87,7 +87,7 @@ public class ToggleMethodFieldBreakpointAction extends AbstractAction {//impleme
     
     @Override
     public Object getValue(String key) {
-        if (key == Action.NAME) {
+        if (Action.NAME.equals(key)) {
             return NbBundle.getMessage (ToggleMethodFieldBreakpointAction.class, "CTL_ToggleMethodFieldBreakpointAction");
         }
         return super.getValue(key);

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BoldVariablesTableModelFilter.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BoldVariablesTableModelFilter.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.debugger.jpda.ui.models;
 
 import java.awt.Color;
 import java.util.Map;
+import java.util.Objects;
 import java.util.WeakHashMap;
 import javax.swing.JTable;
 import javax.swing.UIManager;
@@ -183,9 +184,7 @@ Constants {
     private String bold (Object variable, String value, Map<Object, String> map) {
         if (map.containsKey (variable)) {
             String oldValue = (String) map.get (variable);
-            if (oldValue == value ||
-                oldValue != null && oldValue.equals (value)) {
-                
+            if (Objects.equals(oldValue, value)) {
                 return toHTML (value, false, false, null);
             }
             map.put (variable, value);

--- a/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpoint.java
+++ b/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpoint.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.debugger.jpda.visual.breakpoints;
 import com.sun.jdi.ObjectReference;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.WeakHashMap;
 import org.netbeans.api.debugger.Breakpoint;
 import org.netbeans.api.debugger.jpda.JPDABreakpoint;
@@ -144,7 +145,7 @@ public abstract class ComponentBreakpoint extends Breakpoint {
     void setPrintText(String printText) {
         String old;
         synchronized (this) {
-            if (printText == this.printText || (printText != null && printText.equals(this.printText))) {
+            if (Objects.equals(printText, this.printText)) {
                 return;
             }
             old = this.printText;

--- a/java/form/src/org/netbeans/modules/form/layoutsupport/delegates/JSplitPaneSupport.java
+++ b/java/form/src/org/netbeans/modules/form/layoutsupport/delegates/JSplitPaneSupport.java
@@ -162,7 +162,7 @@ public class JSplitPaneSupport extends AbstractLayoutSupport {
             Component left = splitPane.getLeftComponent();
             Component right = splitPane.getRightComponent();
             
-            if (position == JSplitPane.LEFT) {
+            if (JSplitPane.LEFT.equals(position)) {
                 if ((right == null) || (right == component)) {
                     rect.width = sz.width / 2;
                 }
@@ -185,7 +185,7 @@ public class JSplitPaneSupport extends AbstractLayoutSupport {
             Component top = splitPane.getTopComponent();
             Component bottom = splitPane.getBottomComponent();
             
-            if (position == JSplitPane.TOP) {
+            if (JSplitPane.TOP.equals(position)) {
                 if ((bottom == null) || (bottom == component)) {
                     rect.height /= 2;
                 }

--- a/java/i18n.form/src/org/netbeans/modules/i18n/form/I18nServiceImpl.java
+++ b/java/i18n.form/src/org/netbeans/modules/i18n/form/I18nServiceImpl.java
@@ -273,8 +273,7 @@ public class I18nServiceImpl implements I18nService {
         String newComment = i18nString.getComment();
         if ("".equals(newComment)) // NOI18N
             newComment = null;
-        return (storedValue == newValue || (storedValue != null && storedValue.equals(newValue)))
-            && (storedComment == newComment || (storedComment != null && storedComment.equals(newComment)));
+        return Objects.equals(storedValue, newValue) && Objects.equals(storedComment, newComment);
     }
 
     private static void updateAllData(FormI18nString newI18nString, String localeSuffix) {

--- a/java/i18n/src/org/netbeans/modules/i18n/I18nString.java
+++ b/java/i18n/src/org/netbeans/modules/i18n/I18nString.java
@@ -23,6 +23,8 @@ package org.netbeans.modules.i18n;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import org.netbeans.api.java.classpath.ClassPath;
 import org.openide.filesystems.FileObject;
 
@@ -124,7 +126,7 @@ public class I18nString {
 
     /** Setter for <code>key</code>. */
     public void setKey(String key) {
-        if ((this.key == key) || ((this.key != null) && this.key.equals(key))) {
+        if (Objects.equals(this.key, key)) {
             return;
         }
 
@@ -138,7 +140,7 @@ public class I18nString {
 
     /** Setter for <code>value</code>. */
     public void setValue(String value) {
-        if ((this.value == value) || ((this.value != null) && (this.value.equals(value)))) {
+        if (Objects.equals(this.value, value)) {
             return;
         }
 
@@ -152,7 +154,7 @@ public class I18nString {
 
     /** Setter for <code>comment</code>. */
     public void setComment(String comment) {
-        if ((this.comment == comment) || ((this.comment != null) && (this.comment.equals(comment)))) {
+        if (Objects.equals(this.comment, comment)) {
             return;
         }
 

--- a/java/i18n/src/org/netbeans/modules/i18n/java/JavaI18nSupport.java
+++ b/java/i18n/src/org/netbeans/modules/i18n/java/JavaI18nSupport.java
@@ -391,7 +391,7 @@ public class JavaI18nSupport extends I18nSupport {
 
     /** Getter for identifier. */    
     public String getIdentifier() {
-        if ((identifier == null) || (identifier == "")) {               //NOI18N
+        if ((identifier == null) || identifier.isEmpty()) {               //NOI18N
             createIdentifier();
         }
         return identifier;

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/ReflectionInfo.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/ui/ReflectionInfo.java
@@ -54,7 +54,7 @@ public class ReflectionInfo implements Comparable<ReflectionInfo> {
 
     @Override
     public int compareTo(ReflectionInfo o) {
-        if (index != o.index) {
+        if (!Objects.equals(index, o.index)) {
             if (index == null) {
                 return -1;
             }
@@ -67,7 +67,7 @@ public class ReflectionInfo implements Comparable<ReflectionInfo> {
             }
         }
 
-        if (propertyName != o.propertyName) {
+        if (!Objects.equals(propertyName, o.propertyName)) {
             if (propertyName == null) {
                 return -1;
             }

--- a/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionTask.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionTask.java
@@ -41,6 +41,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -629,7 +630,7 @@ public class JavadocCompletionTask<T> extends UserTask {
                 if (typeElement == null) {
                     continue;
                 }
-                items.add(factory.createJavaTypeItem(jdctx.javac, typeElement, (DeclaredType) typeElement.asType(), substitutionOffset, /*XXX:*/ typeName != qualTypeName ? jdctx.getReferencesCount() : null, elements.isDeprecated(typeElement), true));
+                items.add(factory.createJavaTypeItem(jdctx.javac, typeElement, (DeclaredType) typeElement.asType(), substitutionOffset, /*XXX:*/ !Objects.equals(typeName, qualTypeName) ? jdctx.getReferencesCount() : null, elements.isDeprecated(typeElement), true));
                 excludes.add(typeElement);
             }
         }

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanelLogic.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanelLogic.java
@@ -37,6 +37,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.prefs.AbstractPreferences;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
@@ -764,7 +765,7 @@ public class HintsPanelLogic implements MouseListener, KeyListener, TreeSelectio
                 if (e.enabledOverride != null) {
                     Boolean currentEnabled = e.enabledOverride;
                     Boolean savedEnabled = delegate.isEnabled(hint);
-                    isChanged |= currentEnabled != savedEnabled;
+                    isChanged |= !Objects.equals(currentEnabled, savedEnabled);
                     if(isChanged) {
                         return true;
                     }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/Flow.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/Flow.java
@@ -90,6 +90,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.lang.model.element.Element;
@@ -804,8 +805,8 @@ public class Flow {
             switch (node.getKind()) {
                 case AND: case CONDITIONAL_AND: return left && right;
                 case OR: case CONDITIONAL_OR: return left || right;
-                case EQUAL_TO: return left == right;
-                case NOT_EQUAL_TO: return left != right;
+                case EQUAL_TO: return Objects.equals(left, right);
+                case NOT_EQUAL_TO: return !Objects.equals(left, right);
             }
             
             return null;

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
@@ -821,10 +821,10 @@ public class J2SEModularProjectProperties {
     //Hotfix of the issue #70058
     //Should be removed when the StoreGroup SPI will be extended to allow false default value in ToggleButtonModel
     private static String encodeBoolean (boolean value, Integer kind) {
-        if ( kind == BOOLEAN_KIND_ED ) {
+        if (BOOLEAN_KIND_ED.equals(kind)) {
             return value ? "on" : "off"; // NOI18N
         }
-        else if ( kind == BOOLEAN_KIND_YN ) { // NOI18N
+        else if (BOOLEAN_KIND_YN.equals(kind)) { // NOI18N
             return value ? "yes" : "no";
         }
         else {

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceJavadocAttacher.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceJavadocAttacher.java
@@ -107,7 +107,7 @@ public class J2SELibrarySourceJavadocAttacher implements SourceJavadocAttacherIm
                         final Map<String,List<URI>> volumes = new HashMap<String, List<URI>>();
                         for (String currentVolume : J2SELibraryTypeProvider.VOLUME_TYPES) {
                             List<URI> content = lib.getURIContent(currentVolume);
-                            if (volume == currentVolume) {
+                            if (Objects.equals(volume, currentVolume)) {
                                 final List<URI> newContent = new ArrayList<>(selected);
                                 content = newContent;
                             }

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceLevelQueryImpl.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceLevelQueryImpl.java
@@ -105,7 +105,7 @@ public class J2SELibrarySourceLevelQueryImpl implements SourceLevelQueryImplemen
             slevel = getSourceLevel(lib.getContent(J2SELibraryTypeProvider.VOLUME_TYPE_CLASSPATH));
             this.sourceLevelCache.put (lib,slevel);
         }
-        return slevel == JDK_UNKNOWN ? null : slevel;                
+        return JDK_UNKNOWN.equals(slevel) ? null : slevel;
     }
     
     private String getSourceLevel (List cpRoots) {

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/LibrariesNodeFactory.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/LibrariesNodeFactory.java
@@ -116,7 +116,7 @@ public final class LibrariesNodeFactory implements NodeFactory {
         }
 
         public Node node(String key) {
-            if (key == LIBRARIES) {
+            if (LIBRARIES.equals(key)) {
                 //Libraries Node
                 return new LibrariesNode.Builder(project,evaluator, helper, resolver, cs).
                     setName(NbBundle.getMessage(LibrariesNodeFactory.class,"CTL_LibrariesNode")).
@@ -135,7 +135,7 @@ public final class LibrariesNodeFactory implements NodeFactory {
                     setModuleInfoBasedPath(project.getClassPathProvider().getProjectClassPaths(ClassPath.EXECUTE)[0]).
                     setSourcePath(project.getClassPathProvider().getProjectClassPaths(ClassPath.SOURCE)[0]).
                     build();
-            } else if (key == TEST_LIBRARIES) {
+            } else if (TEST_LIBRARIES.equals(key)) {
                 return new LibrariesNode.Builder(project,evaluator, helper, resolver, cs).
                     setName(NbBundle.getMessage(LibrariesNodeFactory.class,"CTL_TestLibrariesNode")).
                     addClassPathProperties(ProjectProperties.RUN_TEST_CLASSPATH).

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectProperties.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectProperties.java
@@ -822,10 +822,10 @@ public class J2SEProjectProperties {
     //Hotfix of the issue #70058
     //Should be removed when the StoreGroup SPI will be extended to allow false default value in ToggleButtonModel
     private static String encodeBoolean (boolean value, Integer kind) {
-        if ( kind == BOOLEAN_KIND_ED ) {
+        if (BOOLEAN_KIND_ED.equals(kind)) {
             return value ? "on" : "off"; // NOI18N
         }
-        else if ( kind == BOOLEAN_KIND_YN ) { // NOI18N
+        else if (BOOLEAN_KIND_YN.equals(kind)) { // NOI18N
             return value ? "yes" : "no";
         }
         else {

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaTypeDescription.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/JavaTypeDescription.java
@@ -368,7 +368,7 @@ public class JavaTypeDescription extends TypeDescriptor {
             }
             cachedRelPath = relativePath;
         }
-        if (relativePath == PATH_FROM_HANDLE) {
+        if (PATH_FROM_HANDLE.equals(relativePath)) {
                 relativePath = binaryName;
                 int lastDot = relativePath.lastIndexOf('.');    //NOI18N
                 int csIndex = relativePath.indexOf('$', lastDot);     //NOI18N

--- a/java/junit/src/org/netbeans/modules/junit/DefaultPlugin.java
+++ b/java/junit/src/org/netbeans/modules/junit/DefaultPlugin.java
@@ -1590,8 +1590,8 @@ public final class DefaultPlugin extends JUnitPlugin {
             // style. This means only junit-3.x can be removed no matter what.
             String verNumToRemove = "3";                        //NOI18N
             if (name.equals("junit")) {                                 //NOI18N
-                add    = (verNumToAdd    == "3");                       //NOI18N
-                remove = (verNumToRemove == "3");                       //NOI18N
+                add    = "3".equals(verNumToAdd);                       //NOI18N
+                remove = true;
             } else if ((matcher = pattern.matcher(name)).matches()) {
                 String verNum = matcher.group(1);
                 add    = verNum.equals(verNumToAdd   );

--- a/java/maven/src/org/netbeans/modules/maven/runjar/MavenExecuteUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/runjar/MavenExecuteUtils.java
@@ -517,7 +517,7 @@ public final class MavenExecuteUtils {
     }
     
     public static boolean isEnvRemovedValue(String value) {
-        return value == ENV_REMOVED; // It's crutial to test the instance identity
+        return ENV_REMOVED.equals(value); // It's crutial to test the instance identity
     }
     
     /**

--- a/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Binding.java
+++ b/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Binding.java
@@ -209,7 +209,7 @@ public class Binding {
 	public String nameChild(Object childObj, boolean returnConstName, boolean returnSchemaName, boolean returnXPathName) {
 		if (childObj instanceof java.lang.String) {
 			java.lang.String child = (java.lang.String) childObj;
-			if (child == _OrigLocation) {
+			if (child.equals(_OrigLocation)) {
 				if (returnConstName) {
 					return ORIGLOCATION;
 				} else if (returnSchemaName) {
@@ -220,7 +220,7 @@ public class Binding {
 					return "OrigLocation";
 				}
 			}
-			if (child == _Location) {
+			if (child.equals(_Location)) {
 				if (returnConstName) {
 					return LOCATION;
 				} else if (returnSchemaName) {

--- a/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Catalog.java
+++ b/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Catalog.java
@@ -208,7 +208,7 @@ public class Catalog {
 	public String nameChild(Object childObj, boolean returnConstName, boolean returnSchemaName, boolean returnXPathName) {
 		if (childObj instanceof java.lang.String) {
 			java.lang.String child = (java.lang.String) childObj;
-			if (child == _Location) {
+			if (child.equals(_Location)) {
 				if (returnConstName) {
 					return LOCATION;
 				} else if (returnSchemaName) {
@@ -219,7 +219,7 @@ public class Catalog {
 					return "Location";
 				}
 			}
-			if (child == _OrigLocation) {
+			if (child.equals(_OrigLocation)) {
 				if (returnConstName) {
 					return ORIGLOCATION;
 				} else if (returnSchemaName) {

--- a/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Schema.java
+++ b/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Schema.java
@@ -448,7 +448,7 @@ public class Schema {
 		}
 		if (childObj instanceof java.lang.String) {
 			java.lang.String child = (java.lang.String) childObj;
-			if (child == _Type) {
+			if (child.equals(_Type)) {
 				if (returnConstName) {
 					return TYPE;
 				} else if (returnSchemaName) {
@@ -459,7 +459,7 @@ public class Schema {
 					return "Type";
 				}
 			}
-			if (child == _Package) {
+			if (child.equals(_Package)) {
 				if (returnConstName) {
 					return PACKAGE;
 				} else if (returnSchemaName) {
@@ -470,7 +470,7 @@ public class Schema {
 					return "Package";
 				}
 			}
-			if (child == _Name) {
+			if (child.equals(_Name)) {
 				if (returnConstName) {
 					return NAME;
 				} else if (returnSchemaName) {

--- a/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/SchemaSource.java
+++ b/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/SchemaSource.java
@@ -27,6 +27,8 @@
 
 package org.netbeans.modules.xml.jaxb.cfg.schema;
 
+import java.util.Objects;
+
 public class SchemaSource {
 	public static final String LOCATION = "Location";	// NOI18N
 	public static final String ORIGLOCATION = "OrigLocation";	// NOI18N
@@ -235,7 +237,7 @@ public class SchemaSource {
 	public String nameChild(Object childObj, boolean returnConstName, boolean returnSchemaName, boolean returnXPathName) {
 		if (childObj instanceof java.lang.String) {
 			java.lang.String child = (java.lang.String) childObj;
-			if (child == _Location) {
+			if (child.equals(_Location)) {
 				if (returnConstName) {
 					return LOCATION;
 				} else if (returnSchemaName) {
@@ -246,7 +248,7 @@ public class SchemaSource {
 					return "Location";
 				}
 			}
-			if (child == _OrigLocation) {
+			if (Objects.equals(child, _OrigLocation)) {
 				if (returnConstName) {
 					return ORIGLOCATION;
 				} else if (returnSchemaName) {
@@ -257,7 +259,7 @@ public class SchemaSource {
 					return "OrigLocation";
 				}
 			}
-			if (child == _OrigLocationType) {
+			if (child.equals(_OrigLocationType)) {
 				if (returnConstName) {
 					return ORIGLOCATIONTYPE;
 				} else if (returnSchemaName) {

--- a/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Schemas.java
+++ b/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/Schemas.java
@@ -583,7 +583,7 @@ public class Schemas {
 		}
 		if (childObj instanceof java.lang.String) {
 			java.lang.String child = (java.lang.String) childObj;
-			if (child == _Destdir) {
+			if (child.equals(_Destdir)) {
 				if (returnConstName) {
 					return DESTDIR;
 				} else if (returnSchemaName) {
@@ -594,7 +594,7 @@ public class Schemas {
 					return "Destdir";
 				}
 			}
-			if (child == _ProjectName) {
+			if (child.equals(_ProjectName)) {
 				if (returnConstName) {
 					return PROJECTNAME;
 				} else if (returnSchemaName) {
@@ -608,7 +608,7 @@ public class Schemas {
 		}
 		if (childObj instanceof java.math.BigDecimal) {
 			java.math.BigDecimal child = (java.math.BigDecimal) childObj;
-			if (child == _Version) {
+			if (child.equals(_Version)) {
 				if (returnConstName) {
 					return VERSION;
 				} else if (returnSchemaName) {

--- a/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/XjcOption.java
+++ b/java/xml.jaxb/src/org/netbeans/modules/xml/jaxb/cfg/schema/XjcOption.java
@@ -208,7 +208,7 @@ public class XjcOption {
 	public String nameChild(Object childObj, boolean returnConstName, boolean returnSchemaName, boolean returnXPathName) {
 		if (childObj instanceof java.lang.String) {
 			java.lang.String child = (java.lang.String) childObj;
-			if (child == _Name) {
+			if (child.equals(_Name)) {
 				if (returnConstName) {
 					return NAME;
 				} else if (returnSchemaName) {
@@ -219,7 +219,7 @@ public class XjcOption {
 					return "Name";
 				}
 			}
-			if (child == _Value) {
+			if (child.equals(_Value)) {
 				if (returnConstName) {
 					return VALUE;
 				} else if (returnSchemaName) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ConvertImport.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ConvertImport.java
@@ -90,7 +90,7 @@ public class ConvertImport extends Task {
                 } 
                 
             } // while 
-            if (oldXml != xml) {
+            if (!oldXml.equals(xml)) {
                 // changed file
                 try ( PrintStream ps = new PrintStream(file)) {
                     ps.print(xml);

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/CodeSnifferStandardsComboBoxModel.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/CodeSnifferStandardsComboBoxModel.java
@@ -106,8 +106,7 @@ public final class CodeSnifferStandardsComboBoxModel extends AbstractListModel<S
 
     @CheckForNull
     public String getSelectedStandard() {
-        if (selectedStandard == NO_STANDARDS_AVAILABLE
-                || selectedStandard == FETCHING_STANDARDS ) {
+        if (NO_STANDARDS_AVAILABLE.equals(selectedStandard) || FETCHING_STANDARDS.equals(selectedStandard)) {
             return null;
         }
         return selectedStandard;

--- a/php/php.project/src/org/netbeans/modules/php/project/connections/transfer/TransferFile.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/connections/transfer/TransferFile.java
@@ -290,7 +290,7 @@ public abstract class TransferFile {
 
     public final String getRemoteAbsolutePath() {
         String remotePath = getRemotePath();
-        if (remotePath == REMOTE_PROJECT_ROOT) {
+        if (REMOTE_PROJECT_ROOT.equals(remotePath)) {
             return getBaseRemoteDirectoryPath();
         }
         String baseRemotePath = getBaseRemoteDirectoryPath();
@@ -318,7 +318,7 @@ public abstract class TransferFile {
      * @return {@code true} if the remote file is the project root
      */
     public boolean isProjectRoot() {
-        return REMOTE_PROJECT_ROOT == getRemotePath();
+        return REMOTE_PROJECT_ROOT.equals(getRemotePath());
     }
 
     /**

--- a/platform/api.search/src/org/netbeans/modules/search/ContextView.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ContextView.java
@@ -262,7 +262,7 @@ public final class ContextView extends JPanel {
      */
     private void displayMessage(String message) {
         lblMessage.setText(message);
-        if (displayedCard != MESSAGE_VIEW) {
+        if (!MESSAGE_VIEW.equals(displayedCard)) {
             cardLayout.show(this, displayedCard = MESSAGE_VIEW);
         }
     }
@@ -456,7 +456,7 @@ public final class ContextView extends JPanel {
             }
             editorPane.setText(text);
             
-            if (displayedCard != FILE_VIEW) {
+            if (!FILE_VIEW.equals(displayedCard)) {
                 cardLayout.show(ContextView.this, displayedCard = FILE_VIEW);
             }
             

--- a/platform/api.visual/src/org/netbeans/api/visual/widget/LabelWidget.java
+++ b/platform/api.visual/src/org/netbeans/api/visual/widget/LabelWidget.java
@@ -25,6 +25,7 @@ import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphVector;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
+import java.util.Objects;
 
 /**
  * A widget representing a text. The widget is not opaque and is checking clipping for by default.
@@ -214,7 +215,7 @@ public class LabelWidget extends Widget {
     private void assureGlyphVector () {
         Font font = getFont ();
         FontRenderContext fontRenderContext = getGraphics ().getFontRenderContext ();
-        if (cacheGlyphVector != null  &&  cacheFont == font  &&  cacheLabel == label)
+        if (cacheGlyphVector != null &&  cacheFont == font && Objects.equals(cacheLabel, label))
             return;
         cacheFont = font;
         cacheLabel = label;

--- a/platform/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
+++ b/platform/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
@@ -29,6 +29,8 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.UnknownServiceException;
+import java.util.Objects;
+
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
@@ -69,14 +71,13 @@ public class NbinstURLStreamHandler extends URLStreamHandler {
     @Override
     protected boolean sameFile(URL u1, URL u2) {
         // Compare the protocols.
-        if (!((u1.getProtocol() == u2.getProtocol()) ||
+        if (!(Objects.equals(u1.getProtocol(), u2.getProtocol()) ||
               (u1.getProtocol() != null &&
                u1.getProtocol().equalsIgnoreCase(u2.getProtocol()))))
             return false;
 
         // Compare the files.
-        if (!(u1.getFile() == u2.getFile() ||
-              (u1.getFile() != null && u1.getFile().equals(u2.getFile()))))
+        if (!Objects.equals(u1.getFile(), u2.getFile()))
             return false;
 
         // Compare the hosts.

--- a/platform/core.startup/src/org/netbeans/core/startup/ModuleList.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/ModuleList.java
@@ -415,14 +415,14 @@ final class ModuleList implements Stamps.Updater {
      * @return some parsed value suitable for the status map
      */
     private Object processStatusParam(String k, String v) throws NumberFormatException {
-        if (k == "enabled" // NOI18N
-                   || k == "autoload" // NOI18N
-                   || k == "eager" // NOI18N
-                   || k == "reloadable" // NOI18N
+        if ("enabled".equals(k) // NOI18N
+            || "autoload".equals(k) // NOI18N
+            || "eager".equals(k) // NOI18N
+            || "reloadable".equals(k) // NOI18N
                    ) {
             return Boolean.valueOf(v);
         } else {
-            if (k == "startlevel") { // NOI18N 
+            if ("startlevel".equals(k)) { // NOI18N
                 return Integer.valueOf(v);
             }
             // Other properties are of type String.

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/NamingFactory.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/NamingFactory.java
@@ -261,7 +261,7 @@ public final class NamingFactory {
                     return null;
                 }
                 fileIsDirectory = file.isDirectory();
-                if (cachedIsDirectory != fileIsDirectory) {
+                if (!Objects.equals(cachedIsDirectory, fileIsDirectory)) {
                     cachedElement = null;
                 }
             }

--- a/platform/o.n.bootstrap/src/org/netbeans/Events.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Events.java
@@ -133,8 +133,8 @@ public abstract class Events {
      * listed as the constant in this class, not a copy.
      */
     public final void log(String message, Object ... args) {
-        if (Util.err.isLoggable(Level.FINE) &&
-                message != PERF_START && message != PERF_TICK && message != PERF_END) {
+        if (Util.err.isLoggable(Level.FINE)
+            && !PERF_START.equals(message) && !PERF_TICK.equals(message) && !PERF_END.equals(message)) {
             Util.err.fine("EVENT -> " + message + " " + Arrays.asList(args));
         }
         try {

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicSlidingTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicSlidingTabDisplayerUI.java
@@ -32,6 +32,8 @@ import java.awt.image.BufferedImage;
 import java.beans.PropertyChangeEvent;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Objects;
+
 import org.netbeans.swing.tabcontrol.TabData;
 
 /** Common UI for sliding tabs.  Simply uses JToggleButtons for displayers,
@@ -398,7 +400,7 @@ public final class BasicSlidingTabDisplayerUI extends AbstractTabDisplayerUI {
             }
             String txt = lastKnownText;
             String nu = getText();
-            if (nu != txt) { //Equality compare probably not needed
+            if (!Objects.equals(nu, txt)) { //Equality compare probably not needed
                 firePropertyChange ("text", lastKnownText, getText()); //NOI18N
                 result = true;
             }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ToolbarTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ToolbarTabDisplayerUI.java
@@ -29,6 +29,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseListener;
 import java.util.Arrays;
+import java.util.Objects;
 import javax.swing.*;
 import javax.swing.border.Border;
 import javax.swing.event.ChangeEvent;
@@ -359,7 +360,7 @@ public class ToolbarTabDisplayerUI extends AbstractTabDisplayerUI {
             boolean result = false;
             String txt = lastKnownText;
             String nu = doGetText();
-            if (nu != txt) { //Equality compare probably not needed
+            if (!Objects.equals(nu, txt)) { //Equality compare probably not needed
                 firePropertyChange ("text", lastKnownText, doGetText()); //NOI18N
                 result = true;
             }

--- a/platform/openide.awt/src/org/openide/awt/GeneralAction.java
+++ b/platform/openide.awt/src/org/openide/awt/GeneralAction.java
@@ -26,6 +26,7 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Action;
@@ -267,7 +268,7 @@ final class GeneralAction {
             } else {
                 ns = Boolean.TRUE.equals(fallback.getValue(SELECTED_KEY));
             }
-            if (os != ns) {
+            if (!Objects.equals(os, ns)) {
                 putValue(SELECTED_KEY, ns);
             }
         }

--- a/platform/openide.awt/src/org/openide/awt/HtmlRendererImpl.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlRendererImpl.java
@@ -31,6 +31,7 @@ import java.beans.VetoableChangeListener;
 
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -262,7 +263,7 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
         String txt = getText();
         html = val ? Boolean.TRUE : Boolean.FALSE;
 
-        if ((html != wasHtml) || (swingRendering || !cellRenderer)) {
+        if (!Objects.equals(html, wasHtml) || (swingRendering || !cellRenderer)) {
             //Ensure label UI gets updated and builds its little document tree...
             firePropertyChange("text", txt, getText()); //NOI18N
         }

--- a/platform/openide.awt/src/org/openide/awt/StatusDisplayer.java
+++ b/platform/openide.awt/src/org/openide/awt/StatusDisplayer.java
@@ -23,6 +23,8 @@ import org.openide.util.Lookup;
 import org.openide.util.ChangeSupport;
 import org.openide.util.RequestProcessor;
 
+import java.util.Objects;
+
 
 /** Permits control of a status line.
  * The default instance may correspond to the NetBeans status line in the main window.
@@ -120,7 +122,7 @@ public abstract class StatusDisplayer {
             public void clear(int timeInMillis) {
                 RequestProcessor.getDefault().post(new Runnable() {
                     public void run() {
-                        if( text == getStatusText() )
+                        if(Objects.equals(text, getStatusText()))
                             setStatusText("");
                     }
                 }, timeInMillis);
@@ -128,7 +130,7 @@ public abstract class StatusDisplayer {
 
             @Override
             protected void finalize() throws Throwable {
-                if( text == getStatusText() )
+                if(Objects.equals(text, getStatusText()))
                     setStatusText("");
             }
         };

--- a/platform/openide.compat/src/org/openide/util/WeakListener.java
+++ b/platform/openide.compat/src/org/openide/util/WeakListener.java
@@ -18,6 +18,7 @@
  */
 package org.openide.util;
 
+import java.util.Objects;
 import java.util.logging.Logger;
 import org.openide.filesystems.*;
 import org.openide.nodes.*;
@@ -949,7 +950,7 @@ public abstract class WeakListener implements java.util.EventListener {
             String methodName = ref.removeMethodName();
 
             synchronized (LOCK) {
-                if ((lastClass == methodClass) && (lastMethodName == methodName) && (lastRemove != null)) {
+                if ((lastClass == methodClass) && Objects.equals(lastMethodName, methodName) && (lastRemove != null)) {
                     remove = lastRemove;
                 }
             }

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropUtils.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropUtils.java
@@ -641,7 +641,7 @@ final class PropUtils {
         String locMsg = Exceptions.findLocalizedMessage(throwable);
 
         if (locMsg != null
-            && (throwable.getLocalizedMessage() != throwable.getMessage())) { //XXX See issue 34569
+            && !Objects.equals(throwable.getLocalizedMessage(), throwable.getMessage())) { //XXX See issue 34569
 
             String msg = NbBundle.getMessage(
                     PropUtils.class, "FMT_ErrorSettingProperty", newValue, title); //NOI18N
@@ -672,7 +672,7 @@ final class PropUtils {
                 return null;
             }
 
-            if (throwable.getLocalizedMessage() != throwable.getMessage()) {
+            if (!Objects.equals(throwable.getLocalizedMessage(), throwable.getMessage())) {
                 return throwable.getLocalizedMessage();
             }
 
@@ -1834,7 +1834,7 @@ final class PropUtils {
             String s1 = (String) o1;
             String s2 = (String) o2;
 
-            if (s1 == s2) {
+            if (Objects.equals(s1, s2)) {
                 return 0;
             }
 

--- a/platform/openide.explorer/src/org/openide/explorer/view/PropertiesRowModel.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/PropertiesRowModel.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.WeakHashMap;
 import javax.swing.JLabel;
+import java.util.Objects;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.event.TableModelEvent;
@@ -348,7 +349,7 @@ class PropertiesRowModel implements RowModel {
         String locMsg = Exceptions.findLocalizedMessage(throwable);
 
         if (locMsg != null
-            && (throwable.getLocalizedMessage() != throwable.getMessage())) { //XXX See issue 34569
+            && !Objects.equals(throwable.getLocalizedMessage(), throwable.getMessage())) { //XXX See issue 34569
 
             String msg = NbBundle.getMessage(
                     PropertiesRowModel.class, "FMT_ErrorSettingValue", newValue, title); //NOI18N

--- a/platform/openide.explorer/src/org/openide/explorer/view/VisualizerNode.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/VisualizerNode.java
@@ -182,7 +182,7 @@ final class VisualizerNode extends EventListenerList implements NodeListener, Tr
     public String getShortDescription() {
         String desc = shortDescription;
 
-        if (desc == UNKNOWN) {
+        if (UNKNOWN.equals(desc)) {
             shortDescription = desc = node.getShortDescription();
         }
         String toolTip = ImageUtilities.getImageToolTip(ImageUtilities.icon2Image(icon != null ? icon : getIcon(false, false)));
@@ -199,7 +199,7 @@ final class VisualizerNode extends EventListenerList implements NodeListener, Tr
      * @return display name of represented node
      */
     public String getDisplayName() {
-        if (displayName == UNKNOWN) {
+        if (UNKNOWN.equals(displayName)) {
             displayName = (node == null) ? null : node.getDisplayName();
         }
 
@@ -210,7 +210,7 @@ final class VisualizerNode extends EventListenerList implements NodeListener, Tr
      * @return name of represented node
      */
     public String getName() {
-        if (name == UNKNOWN) {
+        if (UNKNOWN.equals(name)) {
             name = (node == null) ? null : node.getName();
         }
 
@@ -399,7 +399,7 @@ final class VisualizerNode extends EventListenerList implements NodeListener, Tr
         }
 
         // bugfix #37748, VisualizerNode ignores change of short desc if it is not read yet (set to UNKNOWN)
-        if (Node.PROP_SHORT_DESCRIPTION.equals(name) && (shortDescription != UNKNOWN)) {
+        if (Node.PROP_SHORT_DESCRIPTION.equals(name) && !UNKNOWN.equals(shortDescription)) {
             QUEUE.runSafe(this);
             return;
         }
@@ -519,7 +519,7 @@ final class VisualizerNode extends EventListenerList implements NodeListener, Tr
             }
         }
 
-        return (htmlDisplayName == NO_HTML_DISPLAYNAME) ? null : htmlDisplayName;
+        return NO_HTML_DISPLAYNAME.equals(htmlDisplayName) ? null : htmlDisplayName;
     }
 
     Icon getIcon(boolean opened, boolean large) {

--- a/platform/openide.util/src/org/openide/util/io/NbObjectInputStream.java
+++ b/platform/openide.util/src/org/openide/util/io/NbObjectInputStream.java
@@ -29,6 +29,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
+
 import org.openide.util.Exceptions;
 
 
@@ -117,7 +119,7 @@ public class NbObjectInputStream extends ObjectInputStream {
         String name = ose.getName();
         String newN = BaseUtilities.translate(name);
 
-        if (name == newN) {
+        if (Objects.equals(name, newN)) {
             // no translation
             return ose;
         }

--- a/platform/openide.windows/src/org/openide/windows/TopComponent.java
+++ b/platform/openide.windows/src/org/openide/windows/TopComponent.java
@@ -49,6 +49,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -959,7 +960,7 @@ public class TopComponent extends JComponent implements Externalizable, Accessib
     public void setDisplayName(String displayName) {
         String old = this.displayName;
 
-        if ((displayName == old) || ((displayName != null) && displayName.equals(old))) {
+        if (Objects.equals(displayName, old)) {
             return;
         }
 
@@ -1007,7 +1008,7 @@ public class TopComponent extends JComponent implements Externalizable, Accessib
     public void setHtmlDisplayName(String htmlDisplayName) {
         String old = this.htmlDisplayName;
 
-        if ((htmlDisplayName == old) || ((htmlDisplayName != null) && htmlDisplayName.equals(old))) {
+        if (Objects.equals(htmlDisplayName, old)) {
             return;
         }
 

--- a/platform/settings/src/org/netbeans/modules/settings/convertors/SerialDataConvertor.java
+++ b/platform/settings/src/org/netbeans/modules/settings/convertors/SerialDataConvertor.java
@@ -239,10 +239,10 @@ implements PropertyChangeListener, FileSystem.AtomicAction {
         if (name == null)
             return;
         // setting was changed
-        else if (name == SaveSupport.PROP_SAVE)
+        else if (SaveSupport.PROP_SAVE.equals(name))
             provideSaveCookie();
         // .settings file was changed
-        else if (name == SaveSupport.PROP_FILE_CHANGED) {
+        else if (SaveSupport.PROP_FILE_CHANGED.equals(name)) {
             miUnInitialized = true;
             if (moduleCodeBase != null) {
                 ModuleInfo mi = ModuleInfoManager.getDefault().getModule(moduleCodeBase);

--- a/platform/settings/src/org/netbeans/modules/settings/convertors/XMLSettingsSupport.java
+++ b/platform/settings/src/org/netbeans/modules/settings/convertors/XMLSettingsSupport.java
@@ -220,7 +220,7 @@ final class XMLSettingsSupport {
             String name = ose.getName();
             String newN = org.openide.util.Utilities.translate(name);
 
-            if (name == newN) {
+            if (Objects.equals(name, newN)) {
                 // no translation
                 return ose;
             }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassFileCache.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassFileCache.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -196,7 +197,7 @@ public class ClassFileCache {
     private byte[] get(String nameAndLocation) {
         int pos = (nameAndLocation.hashCode() & 0x7FFFFFFF) % capacity;
 
-        while ((classNameAndLocation[pos] != null) && (classNameAndLocation[pos] != nameAndLocation)) {
+        while (!Objects.equals(classNameAndLocation[pos], nameAndLocation)) {
             pos = (pos + 1) % capacity;
         }
 

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassInfo.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassInfo.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
 import org.netbeans.lib.profiler.classfile.ClassInfo.StackMapFrame.FrameType;
 import org.netbeans.lib.profiler.global.CommonConstants;
 import org.netbeans.lib.profiler.instrumentation.JavaClassConstants;
@@ -924,7 +926,7 @@ public abstract class ClassInfo extends BaseClassInfo implements JavaClassConsta
             return -1;
         }
         for (int i = 0; i < methodNames.length; i++) {
-            if ((methodNames[i] == name) && (methodSignatures[i] == sig)) {
+            if (Objects.equals(methodNames[i], name) && Objects.equals(methodSignatures[i], sig)) {
                 return i;
             }
         }
@@ -1160,7 +1162,7 @@ public abstract class ClassInfo extends BaseClassInfo implements JavaClassConsta
         // initializers, we may well get a constructor as the "best match" for the given line. Thus, we first
         // search normal methods, and only if this fails - constructors and class initializer.
         for (int i = 0; i < nMethods; i++) {
-            if ((methodNames[i] == "<init>") || (methodNames[i] == "<clinit>")) { // NOI18N
+            if ("<init>".equals(methodNames[i]) || "<clinit>".equals(methodNames[i])) { // NOI18N
                 continue;
             }
 
@@ -1173,7 +1175,7 @@ public abstract class ClassInfo extends BaseClassInfo implements JavaClassConsta
 
         // No success with ordinary methods - try constructors now
         for (int i = 0; i < nMethods; i++) {
-            if ((methodNames[i] != "<init>") && (methodNames[i] != "<clinit>")) { // NOI18N
+            if (!"<init>".equals(methodNames[i]) && !"<clinit>".equals(methodNames[i])) { // NOI18N
                 continue;
             }
 
@@ -1199,7 +1201,7 @@ public abstract class ClassInfo extends BaseClassInfo implements JavaClassConsta
 
         if (superClass.isMethodPublic(superMethodIdx) || superClass.isMethodProtected(superMethodIdx)) {
             return idx;
-        } else if (superClass.packageName == this.packageName) {
+        } else if (Objects.equals(superClass.packageName, this.packageName)) {
             return idx;
         } else {
             return -1;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassRepository.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/classfile/ClassRepository.java
@@ -208,7 +208,7 @@ public abstract class ClassRepository implements CommonConstants {
         if (methodIdx >= 0) {
             String methodName = clazz.getMethodNames()[methodIdx];
 
-            if ((methodName == "<init>") || (methodName == "<clinit>")) { // NOI18N
+            if ("<init>".equals(methodName) || "<clinit>".equals(methodName)) { // NOI18N
                                                                           // See the comment in ClassInfo.methodIdxAndBestBCIForLineNo() regarding initializers scattered about the class text.
                                                                           // Check if a method in a nested class matches the same spot in the source code.
 

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/classfile/DynamicClassInfo.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/classfile/DynamicClassInfo.java
@@ -21,6 +21,7 @@ package org.netbeans.lib.profiler.classfile;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Objects;
 
 
 /**
@@ -459,7 +460,7 @@ public class DynamicClassInfo extends ClassInfo {
 
         if (intfs != null) {
             for (int i = 0; i < intfs.length; i++) {
-                if (intfName == intfs[i]) {
+                if (Objects.equals(intfName, intfs[i])) {
                     return true;
                 }
             }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/CodeRegionMethodInstrumentor.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/CodeRegionMethodInstrumentor.java
@@ -29,6 +29,7 @@ import org.netbeans.lib.profiler.global.ProfilingSessionStatus;
 import org.netbeans.lib.profiler.utils.MiscUtils;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Objects;
 
 
 /**
@@ -82,7 +83,7 @@ public class CodeRegionMethodInstrumentor extends ClassManager {
         for (int i = 0; i < loadedClasses.length; i++) {
             String loadedClassName = loadedClasses[i];
 
-            if (className == loadedClassName) {
+            if (Objects.equals(className, loadedClassName)) {
                 clazz = javaClassForName(loadedClasses[i], loadedClassLoaderIds[i]);
 
                 if (clazz != null) {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ObjLivenessInstrCallsInjector.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/ObjLivenessInstrCallsInjector.java
@@ -315,7 +315,7 @@ class ObjLivenessInstrCallsInjector extends Injector implements CommonConstants 
                 String refClassName = cms[0];
                 String refMethodName = cms[1];
 
-                if (refMethodName == "<init>") { // NOI18N  // It's really a constructor call, not e.g. a call to a private method of 'this'
+                if ("<init>".equals(refMethodName)) { // NOI18N  // It's really a constructor call, not e.g. a call to a private method of 'this'
                     if (nestedNewOps == 0) {
                         bci += opcodeLength(bci);
                         return bci;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor1.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor1.java
@@ -21,6 +21,8 @@ package org.netbeans.lib.profiler.instrumentation;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
+
 import org.netbeans.lib.profiler.ProfilerEngineSettings;
 import org.netbeans.lib.profiler.classfile.BaseClassInfo;
 import org.netbeans.lib.profiler.classfile.DynamicClassInfo;
@@ -95,7 +97,7 @@ public class RecursiveMethodInstrumentor1 extends RecursiveMethodInstrumentor {
                         isMatch = true;
                     }
                 } else {
-                    if (className == rootClassName) { // precise match
+                    if (Objects.equals(className, rootClassName)) { // precise match
                         isMatch = true;
                     }
                 }
@@ -154,7 +156,7 @@ public class RecursiveMethodInstrumentor1 extends RecursiveMethodInstrumentor {
                     break;
                 }
             } else {
-                if (className == rootClassName) {
+                if (className.equals(rootClassName)) {
                     isRootClass = true;
 
                     break;
@@ -195,7 +197,7 @@ public class RecursiveMethodInstrumentor1 extends RecursiveMethodInstrumentor {
                         isMatch = true;
                     }
                 } else {
-                    if (className == rootClassName) { // precise match
+                    if (className.equals(rootClassName)) { // precise match
                         isMatch = true;
                     }
                 }
@@ -414,15 +416,15 @@ public class RecursiveMethodInstrumentor1 extends RecursiveMethodInstrumentor {
             clazz.setMethodReachable(idx);
 
             if (!clazz.isMethodStatic(idx) && !clazz.isMethodPrivate(idx) && !clazz.isMethodFinal(idx)
-                    && (methodName != "<init>")) {  // NOI18N
+                    && !"<init>".equals(methodName)) {  // NOI18N
                 clazz.setMethodVirtual(idx);
             }
 
             if (clazz.isMethodNative(idx) || clazz.isMethodAbstract(idx)
                     || (!clazz.isMethodRoot(idx) && !clazz.isMethodMarker(idx) && !instrFilter.passes(className))
-                    || (className == OBJECT_SLASHED_CLASS_NAME)) {  // Actually, just the Object.<init> method?
+                    || OBJECT_SLASHED_CLASS_NAME.equals(className)) {  // Actually, just the Object.<init> method?
                 clazz.setMethodUnscannable(idx);
-            } else if (methodName == "<init>" && !status.canInstrumentConstructor && clazz.getMajorVersion()>50) {
+            } else if ("<init>".equals(methodName) && !status.canInstrumentConstructor && clazz.getMajorVersion() > 50) {
                 clazz.setMethodUnscannable(idx);
                 constructorNotInstrumented = true;
             } else {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor2.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/RecursiveMethodInstrumentor2.java
@@ -224,7 +224,7 @@ public class RecursiveMethodInstrumentor2 extends RecursiveMethodInstrumentor {
 
                 for (int i = 0; i < methodNames.length; i++) {
                     if (clazz.isMethodReachable(i)
-                            || (!normallyFilteredOut && instrumentClinit && (methodNames[i] == "<clinit>"))) { // NOI18N
+                            || (!normallyFilteredOut && instrumentClinit && "<clinit>".equals(methodNames[i]))) { // NOI18N
                         checkAndScanMethod(clazz, methodNames[i], methodSignatures[i], false, false, false);
                     }
                 }
@@ -357,15 +357,15 @@ public class RecursiveMethodInstrumentor2 extends RecursiveMethodInstrumentor {
                 clazz.setMethodReachable(idx);
 
                 if (!clazz.isMethodStatic(idx) && !clazz.isMethodPrivate(idx) && !clazz.isMethodFinal(idx)
-                        && (methodName != "<init>")) { //NOI18N
+                        && !"<init>".equals(methodName)) { //NOI18N
                     clazz.setMethodVirtual(idx);
                 }
 
                 if (clazz.isMethodNative(idx) || clazz.isMethodAbstract(idx)
                         || (!clazz.isMethodRoot(idx) && !clazz.isMethodMarker(idx) && !instrFilter.passes(className))
-                        || (className == OBJECT_SLASHED_CLASS_NAME)) {  // Actually, just the Object.<init> method?
+                        || OBJECT_SLASHED_CLASS_NAME.equals(className)) {  // Actually, just the Object.<init> method?
                     clazz.setMethodUnscannable(idx);
-                } else if (methodName == "<init>" && !status.canInstrumentConstructor && clazz.getMajorVersion()>50) {
+                } else if ("<init>".equals(methodName) && !status.canInstrumentConstructor && clazz.getMajorVersion() > 50) {
                     clazz.setMethodUnscannable(idx);
                     constructorNotInstrumented = true;
                 } else {

--- a/profiler/profiler.attach/src/org/netbeans/modules/profiler/attach/steps/BasicAttachStepsProvider.java
+++ b/profiler/profiler.attach/src/org/netbeans/modules/profiler/attach/steps/BasicAttachStepsProvider.java
@@ -348,7 +348,7 @@ public class BasicAttachStepsProvider extends AttachStepsProvider {
     protected static String getOS(AttachSettings settings, String arch) {
 //        if (!settings.isRemote()) return settings.getHostOS();
         if (!settings.isRemote()) {
-            return IntegrationUtils.getLocalPlatform(arch == LINK_64ARCH ? 64 : 32);
+            return IntegrationUtils.getLocalPlatform(LINK_64ARCH.equals(arch) ? 64 : 32);
         } else {
             String hostOS = settings.getHostOS();
             if (IntegrationUtils.PLATFORM_WINDOWS_CVM.equals(hostOS))

--- a/profiler/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineSupport.java
+++ b/profiler/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/impl/timeline/TimelineSupport.java
@@ -355,7 +355,7 @@ public final class TimelineSupport {
                                     sameFactorUnits = false;
                                 lastDataFactor = dataFactor;
                                 
-                                if (lastUnitsString == LAST_UNITS_STRING)
+                                if (LAST_UNITS_STRING.equals(lastUnitsString))
                                     lastUnitsString = unitsString;
                                 else if (!equals(lastUnitsString, unitsString))
                                     sameFactorUnits = false;

--- a/profiler/profiler/src/org/netbeans/modules/profiler/actions/HeapDumpAction.java
+++ b/profiler/profiler/src/org/netbeans/modules/profiler/actions/HeapDumpAction.java
@@ -453,7 +453,7 @@ public final class HeapDumpAction extends ProfilingAwareAction {
                         String dumpFileName = askForDestination ? selectTargetDirectory() : getCurrentHeapDumpFilename(null);
 
                         // Selecting destination cancelled by the user
-                        if (dumpFileName == SELECTING_TARGET_CANCELLED) {
+                        if (SELECTING_TARGET_CANCELLED.equals(dumpFileName)) {
                             return;
                         }
 


### PR DESCRIPTION
Fixed erroneous direct form of comparison ("==") for these object types: String, Integer, Boolean, BigDecimal

Direct comparsion with == operator may cause unpredictable effects for business logic because its skip content check. Single exclusion is using method intern() for String. Replaced with Objects.equals() where left side might be a null and equals() otherwise. No any test directory was changed.
This change covers occurrences of the == operator except intern() Also expressions like (== "") changed to IsEmpty()