### PR TITLE
[NETBEANS-4054] Ensuring progress when javac crashes while batch evaluating hints.

### DIFF
--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBAttr.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBAttr.java
@@ -43,6 +43,8 @@ import java.lang.invoke.MethodType;
  */
 public class NBAttr extends Attr {
 
+    public static boolean TEST_DO_SINGLE_FAIL;
+
     public static void preRegister(Context context) {
         context.put(attrKey, new Context.Factory<Attr>() {
             public Attr make(Context c) {
@@ -58,6 +60,16 @@ public class NBAttr extends Attr {
         super(context);
         cancelService = CancelService.instance(context);
         tm = TreeMaker.instance(context);
+    }
+
+    @Override
+    public void attribClass(DiagnosticPosition pos, ClassSymbol c) {
+        cancelService.abortIfCanceled();
+        if (TEST_DO_SINGLE_FAIL) {
+            TEST_DO_SINGLE_FAIL = false;
+            throw new AssertionError("Test requested failure");
+        }
+        super.attribClass(pos, c);
     }
 
     @Override


### PR DESCRIPTION
If hints are run on save, `BatchSearch` is called on a single file. Normally, if javac would crash during `toPhase`, an exception would be thrown. But, it may happen the existing parser is reused, and `toPhase` does not throw the exception, and this may be mistaken for an out-of-memory situation, to which the response is to restart the processing. This may then lead to an infinite loop.

The proposed change here is to force progress in this situation. javac crash(es) need to be handled separately, of course.



---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
