### PR TITLE
LSP client: Prevent NullPointerException when caret is not present on text component

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/GoToMarkOccurrencesAction.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/GoToMarkOccurrencesAction.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.lsp.client.bindings;
 
 import java.awt.event.ActionEvent;
+import javax.swing.text.Caret;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import org.netbeans.api.editor.EditorActionNames;
@@ -115,7 +116,11 @@ public class GoToMarkOccurrencesAction extends BaseAction {
     private static void navigateToOccurence(boolean next, JTextComponent txt) {
         if (txt != null && txt.getDocument() != null) {
             Document doc = txt.getDocument();
-            int position = txt.getCaretPosition();
+            Caret caret = txt.getCaret();
+            if(caret == null) {
+                return;
+            }
+            int position = caret.getDot();
             int goTo = findOccurrencePosition(next, doc, position);
             if (goTo > 0) {
                 txt.setCaretPosition(goTo);

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/RefactoringActionsProvider.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/RefactoringActionsProvider.java
@@ -24,6 +24,7 @@ import javax.swing.JEditorPane;
 import javax.swing.SwingUtilities;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.BadLocationException;
+import javax.swing.text.Caret;
 import javax.swing.text.Document;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.ReferenceContext;
@@ -70,7 +71,11 @@ public class RefactoringActionsProvider extends ActionsImplementationProvider{
                     AbstractDocument abstractDoc = (doc instanceof AbstractDocument) ? ((AbstractDocument) doc) : null;
                     FileObject file = NbEditorUtilities.getFileObject(doc);
                     LSPBindings bindings = LSPBindings.getBindings(file);
-                    int caretPos = c.getCaretPosition();
+                    Caret caret = c.getCaret();
+                    if(caret == null) {
+                        return;
+                    }
+                    int caretPos = caret.getDot();
                     Position pos = Utils.createPosition(doc, caretPos);
                     ReferenceParams params = new ReferenceParams();
                     params.setTextDocument(new TextDocumentIdentifier(Utils.toURI(file)));
@@ -118,7 +123,11 @@ public class RefactoringActionsProvider extends ActionsImplementationProvider{
                     AbstractDocument abstractDoc = (doc instanceof AbstractDocument) ? ((AbstractDocument) doc) : null;
                     FileObject file = NbEditorUtilities.getFileObject(doc);
                     LSPBindings bindings = LSPBindings.getBindings(file);
-                    int caretPos = c.getCaretPosition();
+                    Caret caret = c.getCaret();
+                    if(caret == null) {
+                        return;
+                    }
+                    int caretPos = caret.getDot();
                     Position pos = Utils.createPosition(doc, caretPos);
                     String name;
                     if(abstractDoc != null) {


### PR DESCRIPTION
Observed exception:

```
java.lang.NullPointerException: Cannot invoke "javax.swing.text.Caret.getDot()" because "this.caret" is null
            at java.desktop/javax.swing.text.JTextComponent.getCaretPosition(JTextComponent.java:1704)
            at org.netbeans.modules.lsp.client.bindings.MarkOccurrences.<init>(MarkOccurrences.java:71)
            at org.netbeans.modules.lsp.client.bindings.TextDocumentSyncServerCapabilityHandler.lambda$registerBackgroundTasks$6(TextDocumentSyncServerCapabilityHandler.java:330)
            at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
            at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:771)
            at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:722)
            at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:716)
            at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
            at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
            at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:741)
            at org.netbeans.core.TimableEventQueue.dispatchEvent(TimableEventQueue.java:136)
[catch] at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
            at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
            at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
            at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
            at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
            at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```

The fix is similar to this fix:
https://github.com/apache/netbeans/pull/2775/commits/22f5827525e281e1f4eb5d870026719d04de7655