### PR TITLE
React on both build and compile goals.

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/maven/MicronautMavenConstants.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/maven/MicronautMavenConstants.java
@@ -52,9 +52,15 @@ public final class MicronautMavenConstants {
     public static final String CLASSIFIER_NATIVE = "native-image";
     
     /**
-     * Native image plugin's goal to compile image without fork.
+     * Native image plugin's goal to compile image without fork. Available from
+     * 0.9.14 version, DOES NOT exist on earlier versions.
      */
-    public static final String PLUGIN_GOAL_COMPILE_NOFORK = "build";
+    public static final String PLUGIN_GOAL_COMPILE_NOFORK = "compile-no-fork";
+
+    /**
+     * Now deprecated goal, which produces a warning starting from 0.9.14 .
+     */
+    public static final String PLUGIN_GOAL_COMPILE_NOFORK_OLD = "build";
 
     /**
      * Native image plugin's goal to compile image from commandline


### PR DESCRIPTION
Starting from Micronaut 3.8.x, micronaut plugins configure execution for `compile` goal rather than for the (now deprecated) `build` goal of the Graalvm native-image plugin.  

This PR allows to detect native compilation in older AND newer project setups. Instead of just `build` all the 'building' goals are checked: according to [the documentation](https://graalvm.github.io/native-build-tools/latest/maven-plugin.html) and `mvn help:describe`:
```
native:add-reachability-metadata
  Description: (no description available)

native:build
  Description: (no description available)

native:compile
  Description: (no description available)

native:compile-no-fork
  Description: (no description available)

native:generateResourceConfig
  Description: (no description available)

native:generateTestResourceConfig
  Description: (no description available)

native:merge-agent-files
  Description: (no description available)

native:test
  Description: (no description available)
```
the following should produce a binary:
* native:build
* native:compile
* native:compile-no-fork

Goals in execution config are unprefixed, while in actions, they can (or must?) carry plugin shortcut or prefix, so I check the configured goals against set of triggers that contains both unprefixed and prefixed goal names.

The default goal execution changed in plugin 0.9.14; before that, only `build` and `compile` were present. Now `build` is deprecated in favour of `compile-no-fork`