### PR TITLE
yml to yaml

### DIFF
--- a/ide/languages.yaml/src/org/netbeans/modules/languages/yaml/layer.xml
+++ b/ide/languages.yaml/src/org/netbeans/modules/languages/yaml/layer.xml
@@ -72,7 +72,7 @@
     </folder>
     <folder name="Templates">
         <folder name="Other">
-            <file name="EmptyYAML.yml" url="EmptyYAML.yml">
+            <file name="EmptyYAML.yaml" url="EmptyYAML.yaml">
                 <attr name="position" intvalue="850"/>
                 <attr name="template" boolvalue="true"/>
                 <attr name="templateCategory" stringvalue="simple-files"/>


### PR DESCRIPTION
Correct extension for YAML is .yaml not .yml
'The official recommended filename extension for YAML files has been .yaml since 2006'