### PR TITLE
Cleanup by simplifying strings comparsion with JDK7 Objects.equals()

### DIFF
--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/TextItemEditorModel.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/TextItemEditorModel.java
@@ -22,6 +22,8 @@ package org.netbeans.modules.j2ee.ddloaders.multiview;
 import org.netbeans.modules.xml.multiview.ItemEditorHelper;
 import org.netbeans.modules.xml.multiview.XmlMultiViewDataSynchronizer;
 
+import java.util.Objects;
+
 /**
  * @author pfiala
  */
@@ -62,7 +64,7 @@ public abstract class TextItemEditorModel extends ItemEditorHelper.ItemEditorMod
         }
         if (validate(value)) {
             String currentValue = getValue();
-            if (!(value == currentValue || value != null && value.equals(currentValue))) {
+            if (!Objects.equals(value, currentValue)) {
                 setValue(value);
                 synchronizer.requestUpdateData();
             }

--- a/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/ddloaders/multiview/TextItemEditorModel.java
+++ b/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/ddloaders/multiview/TextItemEditorModel.java
@@ -22,6 +22,8 @@ package org.netbeans.modules.j2ee.sun.ddloaders.multiview;
 import org.netbeans.modules.xml.multiview.ItemEditorHelper;
 import org.netbeans.modules.xml.multiview.XmlMultiViewDataSynchronizer;
 
+import java.util.Objects;
+
 /**
  * @author pfiala,pcw
  */
@@ -60,7 +62,7 @@ public abstract class TextItemEditorModel extends ItemEditorHelper.ItemEditorMod
         }
         if (validate(value)) {
             String currentValue = getValue();
-            if (!(value == currentValue || value != null && value.equals(currentValue))) {
+            if (!Objects.equals(value, currentValue)) {
                 setValue(value);
                 synchronizer.requestUpdateData();
             }

--- a/enterprise/web.debug/src/org/netbeans/modules/web/debug/breakpoints/JspLineBreakpoint.java
+++ b/enterprise/web.debug/src/org/netbeans/modules/web/debug/breakpoints/JspLineBreakpoint.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.Objects;
 import org.netbeans.api.debugger.*;
 import org.netbeans.api.debugger.jpda.*;
 import org.netbeans.api.debugger.jpda.event.JPDABreakpointEvent;
@@ -291,9 +292,7 @@ public class JspLineBreakpoint extends Breakpoint {
      * @param cn a new name of class to stop on
      */
     public void setURL (String url) {
-        if ( (url == this.url) ||
-             ((url != null) && (this.url != null) && url.equals (this.url))
-        ) return;
+        if (Objects.equals(url, this.url)) return;
         String old = this.url;
         this.url = url;
         addFileURLListener(url);
@@ -340,9 +339,7 @@ public class JspLineBreakpoint extends Breakpoint {
      */
     public void setCondition (String c) {
         if (c != null) c = c.trim ();
-        if ( (c == condition) ||
-             ((c != null) && (condition != null) && condition.equals (c))
-        ) return;
+        if (Objects.equals(c, condition)) return;
         String old = condition;
         condition = c;
         if (javalb != null) {

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/BaseBean.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/BaseBean.java
@@ -1469,15 +1469,13 @@ public abstract class BaseBean implements Cloneable, Bean {
                     String curValue = this.getAttributeValue(attrName);
                     String otherValue = bean.getAttributeValue(attrName);
 
-                    if (curValue != otherValue) {
+                    if (!Objects.equals(curValue, otherValue)) {
                         // Might have one of the two null, not both
-                        if (curValue == null || otherValue == null || !curValue.equals(otherValue)) {
-                            if ((mode & MERGE_COMPARE) == MERGE_COMPARE) {
-                                return false;
-                            }
-                            if ((mode & MERGE_UNION) == MERGE_UNION) {
-                                this.setAttributeValue(attrName, otherValue);
-                            }
+                        if ((mode & MERGE_COMPARE) == MERGE_COMPARE) {
+                            return false;
+                        }
+                        if ((mode & MERGE_UNION) == MERGE_UNION) {
+                            this.setAttributeValue(attrName, otherValue);
                         }
                     }
                 }

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/BeanComparator.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/BeanComparator.java
@@ -88,13 +88,9 @@ public class BeanComparator {
 			String curValue = curBean.getAttributeValue(attrName);
 			String otherValue = newBean.getAttributeValue(attrName);
 
-			if (curValue != otherValue) {
-			    if (curValue == null || otherValue == null ||
-				!curValue.equals(otherValue)) {
-			
+			if (!Objects.equals(curValue, otherValue)) {
 				//  Diffenrence found - not the same bean
 				return newBean;
-			    }
 			}
 		    }
 		}

--- a/ide/subversion/src/org/netbeans/modules/subversion/ui/status/VersioningPanel.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/ui/status/VersioningPanel.java
@@ -281,7 +281,7 @@ class VersioningPanel extends JPanel implements ExplorerManager.Provider, Prefer
                                 return;
                             }
                             String sticky = nodes[i].getCopy(); // copy must be initialized on all nodes
-                            if (stickyCommon && sticky != currentSticky && (sticky == null || currentSticky == null || !sticky.equals(currentSticky))) {
+                            if (stickyCommon && !Objects.equals(sticky, currentSticky)) {
                                 stickyCommon = false;
                             }
                         }

--- a/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ExceptionBreakpoint.java
+++ b/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ExceptionBreakpoint.java
@@ -24,6 +24,8 @@ import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
 import org.netbeans.api.debugger.DebuggerEngine;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
@@ -133,9 +135,7 @@ public class ExceptionBreakpoint extends JPDABreakpoint {
         if (cn != null) {
             cn = cn.trim();
         }
-        if ( (cn == exceptionClassName) ||
-             ((cn != null) && (exceptionClassName != null) && exceptionClassName.equals (cn))
-        ) return;
+        if (Objects.equals(cn, exceptionClassName)) return;
         Object old = exceptionClassName;
         exceptionClassName = cn;
         firePropertyChange (PROP_EXCEPTION_CLASS_NAME, old, exceptionClassName);

--- a/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/FieldBreakpoint.java
+++ b/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/FieldBreakpoint.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.WeakHashMap;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -117,12 +118,7 @@ public class FieldBreakpoint extends JPDABreakpoint {
      * @param className a new name of class the field is defined in
      */
     public void setClassName (String className) {
-        if ( (className == this.className) ||
-             ( (className != null) && 
-               (this.className != null) && 
-               this.className.equals (className)
-             )
-        ) return;
+        if (Objects.equals(className, this.className)) return;
         Object old = this.className;
         this.className = className;
         firePropertyChange (PROP_CLASS_NAME, old, className);
@@ -146,9 +142,7 @@ public class FieldBreakpoint extends JPDABreakpoint {
         if (name != null) {
             name = name.trim();
         }
-        if ( (name == fieldName) ||
-             ((name != null) && (fieldName != null) && fieldName.equals (name))
-        ) return;
+        if (Objects.equals(name, fieldName)) return;
         String old = fieldName;
         fieldName = name;
         firePropertyChange (PROP_FIELD_NAME, old, fieldName);

--- a/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/MethodBreakpoint.java
+++ b/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/MethodBreakpoint.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.WeakHashMap;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -134,9 +135,7 @@ public class MethodBreakpoint extends JPDABreakpoint {
         if (mn != null) {
             mn = mn.trim();
         }
-        if ( (mn == methodName) ||
-             ((mn != null) && (methodName != null) && methodName.equals (mn))
-        ) return;
+        if (Objects.equals(mn, methodName)) return;
         String old = methodName;
         methodName = mn;
         firePropertyChange (PROP_METHOD_NAME, old, mn);
@@ -162,9 +161,7 @@ public class MethodBreakpoint extends JPDABreakpoint {
         if (signature != null) {
             signature = signature.trim();
         }
-        if ((signature == methodSignature) ||
-            ((signature != null) && signature.equals (methodSignature))) {
-            
+        if (Objects.equals(signature, methodSignature)) {
             return;
         }
         String old = methodSignature;

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -362,7 +362,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                         
                         pkSchema = rset.get(new Integer(2));
                         fkSchema = rset.get(new Integer(6));
-                        if ((pkSchema == fkSchema) || (pkSchema.equals(fkSchema))) {
+                        if (Objects.equals(pkSchema, fkSchema)) {
                             refTable = rset.get(new Integer(3));
                             if (! tables.contains(refTable))
                                 tables.add(refTable);
@@ -389,7 +389,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                         if (fkSchema != null) {
                             fkSchema = fkSchema.trim();
                         }
-                        if ((pkSchema == fkSchema) || (pkSchema.equals(fkSchema))) {
+                        if (Objects.equals(pkSchema, fkSchema)) {
                             refTable = rs.getString("PKTABLE_NAME").trim(); //NOI18N
                             if (! tables.contains(refTable))
                                 tables.add(refTable);

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BoldVariablesTableModelFilter.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BoldVariablesTableModelFilter.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.debugger.jpda.ui.models;
 
 import java.awt.Color;
 import java.util.Map;
+import java.util.Objects;
 import java.util.WeakHashMap;
 import javax.swing.JTable;
 import javax.swing.UIManager;
@@ -183,9 +184,7 @@ Constants {
     private String bold (Object variable, String value, Map<Object, String> map) {
         if (map.containsKey (variable)) {
             String oldValue = (String) map.get (variable);
-            if (oldValue == value ||
-                oldValue != null && oldValue.equals (value)) {
-                
+            if (Objects.equals(oldValue, value)) {
                 return toHTML (value, false, false, null);
             }
             map.put (variable, value);

--- a/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpoint.java
+++ b/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/breakpoints/ComponentBreakpoint.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.debugger.jpda.visual.breakpoints;
 import com.sun.jdi.ObjectReference;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.WeakHashMap;
 import org.netbeans.api.debugger.Breakpoint;
 import org.netbeans.api.debugger.jpda.JPDABreakpoint;
@@ -144,7 +145,7 @@ public abstract class ComponentBreakpoint extends Breakpoint {
     void setPrintText(String printText) {
         String old;
         synchronized (this) {
-            if (printText == this.printText || (printText != null && printText.equals(this.printText))) {
+            if (Objects.equals(printText, this.printText)) {
                 return;
             }
             old = this.printText;

--- a/java/i18n.form/src/org/netbeans/modules/i18n/form/I18nServiceImpl.java
+++ b/java/i18n.form/src/org/netbeans/modules/i18n/form/I18nServiceImpl.java
@@ -273,8 +273,7 @@ public class I18nServiceImpl implements I18nService {
         String newComment = i18nString.getComment();
         if ("".equals(newComment)) // NOI18N
             newComment = null;
-        return (storedValue == newValue || (storedValue != null && storedValue.equals(newValue)))
-            && (storedComment == newComment || (storedComment != null && storedComment.equals(newComment)));
+        return Objects.equals(storedValue, newValue) && Objects.equals(storedComment, newComment);
     }
 
     private static void updateAllData(FormI18nString newI18nString, String localeSuffix) {

--- a/java/i18n/src/org/netbeans/modules/i18n/I18nString.java
+++ b/java/i18n/src/org/netbeans/modules/i18n/I18nString.java
@@ -23,6 +23,8 @@ package org.netbeans.modules.i18n;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import org.netbeans.api.java.classpath.ClassPath;
 import org.openide.filesystems.FileObject;
 
@@ -124,7 +126,7 @@ public class I18nString {
 
     /** Setter for <code>key</code>. */
     public void setKey(String key) {
-        if ((this.key == key) || ((this.key != null) && this.key.equals(key))) {
+        if (Objects.equals(this.key, key)) {
             return;
         }
 
@@ -138,7 +140,7 @@ public class I18nString {
 
     /** Setter for <code>value</code>. */
     public void setValue(String value) {
-        if ((this.value == value) || ((this.value != null) && (this.value.equals(value)))) {
+        if (Objects.equals(this.value, value)) {
             return;
         }
 
@@ -152,7 +154,7 @@ public class I18nString {
 
     /** Setter for <code>comment</code>. */
     public void setComment(String comment) {
-        if ((this.comment == comment) || ((this.comment != null) && (this.comment.equals(comment)))) {
+        if (Objects.equals(this.comment, comment)) {
             return;
         }
 

--- a/platform/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
+++ b/platform/core.startup.base/src/org/netbeans/core/startup/layers/NbinstURLStreamHandler.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.core.startup.layers;
 
+import java.util.Objects;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -75,8 +76,7 @@ public class NbinstURLStreamHandler extends URLStreamHandler {
             return false;
 
         // Compare the files.
-        if (!(u1.getFile() == u2.getFile() ||
-              (u1.getFile() != null && u1.getFile().equals(u2.getFile()))))
+        if (!Objects.equals(u1.getFile(), u2.getFile()))
             return false;
 
         // Compare the hosts.

--- a/platform/openide.windows/src/org/openide/windows/TopComponent.java
+++ b/platform/openide.windows/src/org/openide/windows/TopComponent.java
@@ -49,6 +49,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -959,7 +960,7 @@ public class TopComponent extends JComponent implements Externalizable, Accessib
     public void setDisplayName(String displayName) {
         String old = this.displayName;
 
-        if ((displayName == old) || ((displayName != null) && displayName.equals(old))) {
+        if (Objects.equals(displayName, old)) {
             return;
         }
 
@@ -1007,7 +1008,7 @@ public class TopComponent extends JComponent implements Externalizable, Accessib
     public void setHtmlDisplayName(String htmlDisplayName) {
         String old = this.htmlDisplayName;
 
-        if ((htmlDisplayName == old) || ((htmlDisplayName != null) && htmlDisplayName.equals(old))) {
+        if (Objects.equals(htmlDisplayName, old)) {
             return;
         }
 


### PR DESCRIPTION
Objects.equals() implements normalized comparsion operations for two objects.

Different forms of comparison are reduced to the normalized.
No any changes for references check are made.