### PR TITLE
Cleanup by removing do nothing replaceAll

### DIFF
--- a/enterprise/web.core.syntax/test/qa-functional/src/org/netbeans/test/syntax/EmbeddedSanityTest.java
+++ b/enterprise/web.core.syntax/test/qa-functional/src/org/netbeans/test/syntax/EmbeddedSanityTest.java
@@ -187,7 +187,7 @@ public class EmbeddedSanityTest extends GeneralJSP {
 
             evt.waitNoEvent(500);
             eo.pressKey(KeyEvent.VK_ENTER);
-            assertTrue("Wrong completion result", eo.getText(lineNumber).contains(config[6].replaceAll("|", "")));
+            assertTrue("Wrong completion result", eo.getText(lineNumber).contains(config[6]/*.replaceAll("|", "")*/));
 
         }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/ExtensionPropertiesExtractor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/ExtensionPropertiesExtractor.java
@@ -170,7 +170,7 @@ public class ExtensionPropertiesExtractor implements ProjectInfoExtractor {
             if (c == null) {
                 return null;
             }
-            return Arrays.asList(c.split(";;")).stream().map(s -> s.replaceAll("\\;", ";")).collect(Collectors.toList());
+            return Arrays.asList(c.split(";;"));
         }
 
         @Override

--- a/webcommon/html.angular/test/qa-functional/src/org/netbeans/modules/html/angular/GeneralAngular.java
+++ b/webcommon/html.angular/test/qa-functional/src/org/netbeans/modules/html/angular/GeneralAngular.java
@@ -374,7 +374,7 @@ public class GeneralAngular extends JellyTestCase {
             evt.waitNoEvent(500);
             cjo.clickOnItem(config[5]);
             eo.pressKey(KeyEvent.VK_ENTER);
-            assertTrue("Wrong completion result", eo.getText(lineNumber).contains(config[6].replaceAll("|", "")));
+            assertTrue("Wrong completion result", eo.getText(lineNumber).contains(config[6]/*.replaceAll("|", "")*/));
             completion.listItself.hideAll();
         }
 

--- a/webcommon/html.knockout/test/qa-functional/src/org/netbeans/modules/html/knockout/cc/CustomComponentTest.java
+++ b/webcommon/html.knockout/test/qa-functional/src/org/netbeans/modules/html/knockout/cc/CustomComponentTest.java
@@ -316,7 +316,7 @@ public class CustomComponentTest extends GeneralKnockout {
                 evt.waitNoEvent(500);
                 cjo.clickOnItem(config[5]);
                 eo.pressKey(KeyEvent.VK_ENTER);
-                assertTrue("Wrong completion result", eo.getText(lineNumber + 1).contains(config[6].replaceAll("|", "")));
+                assertTrue("Wrong completion result", eo.getText(lineNumber + 1).contains(config[6]/*.replaceAll("|", "")*/));
                 completion.listItself.hideAll();
             } catch (Exception ex) {
                 Logger.getLogger(CustomComponentTest.class.getName()).log(Level.INFO, "", ex);

--- a/webcommon/html.knockout/test/qa-functional/src/org/netbeans/modules/html/knockout/cc/PureComputedTest.java
+++ b/webcommon/html.knockout/test/qa-functional/src/org/netbeans/modules/html/knockout/cc/PureComputedTest.java
@@ -116,7 +116,7 @@ public class PureComputedTest extends GeneralKnockout {
                 evt.waitNoEvent(500);
                 cjo.clickOnItem(config[5]);
                 eo.pressKey(KeyEvent.VK_ENTER);
-                assertTrue("Wrong completion result", eo.getText(lineNumber + 1).contains(config[6].replaceAll("|", "")));
+                assertTrue("Wrong completion result", eo.getText(lineNumber + 1).contains(config[6]/*.replaceAll("|", "")*/));
                 completion.listItself.hideAll();
             } catch (Exception ex) {
                 Logger.getLogger(PureComputedTest.class.getName()).log(Level.INFO, "", ex);

--- a/webcommon/javascript2.requirejs/test/qa-functional/src/org/netbeans/modules/javascript2/requirejs/GeneralRequire.java
+++ b/webcommon/javascript2.requirejs/test/qa-functional/src/org/netbeans/modules/javascript2/requirejs/GeneralRequire.java
@@ -466,7 +466,7 @@ public class GeneralRequire extends JellyTestCase {
             evt.waitNoEvent(500);
             cjo.clickOnItem(config[5]);
             eo.pressKey(KeyEvent.VK_ENTER);
-            assertTrue("Wrong completion result", eo.getText(lineNumber).contains(config[6].replaceAll("|", "")));
+            assertTrue("Wrong completion result", eo.getText(lineNumber).contains(config[6]/*.replaceAll("|", "")*/));
             completion.listItself.hideAll();
         }
 


### PR DESCRIPTION
replaceAll("|", "") is do nothing code example
