### PR TITLE
Display additional options prior to the standard ones.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
@@ -223,6 +223,12 @@ class NotifyDescriptorAdapter {
                     break;
             }
         }
+        Object[] add = descriptor.getAdditionalOptions();
+        if (add != null && add.length > 0) {
+            Object[] addOpts = Arrays.copyOf(add, add.length + options.length);
+            System.arraycopy(options, 0, addOpts, add.length, options.length);
+            options = addOpts;
+        }
         for (Object o : options) {
             String text;
             


### PR DESCRIPTION
The LSP implementation of `DialogDisplayer` ignored [`NotifyDescriptoir.getAdditionalOptions()`](https://bits.netbeans.org/dev/javadoc/org-openide-dialogs/org/openide/NotifyDescriptor.html#getAdditionalOptions--) completely. This PR merges the additional options with the standard ones, similar to the original DialogDescriptor implementation (actually `NbPresenter`).