### PR TITLE
Fix increment on maven and java.editor.lib module for NB18

### DIFF
--- a/java/java.editor.lib/nbproject/project.properties
+++ b/java/java.editor.lib/nbproject/project.properties
@@ -21,6 +21,6 @@ javadoc.apichanges=${basedir}/apichanges.xml
 
 javac.source=1.8
 
-spec.version.base: 1.49.0
+spec.version.base=1.50.0
 is.autoload=true
 

--- a/java/maven/nbproject/project.properties
+++ b/java/maven/nbproject/project.properties
@@ -22,7 +22,7 @@ javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 javahelp.hs=maven.hs
 extra.module.files=maven-nblib/
-spec.version.base=2.157.0
+spec.version.base=2.158.0
 
 # The CPExtender test fails in library processing (not randomly) since NetBeans 8.2; disabling.
 test.excludes=**/CPExtenderTest.class


### PR DESCRIPTION
Fixes increment on `maven` and `java.editor.lib` modules for NB18. Both were missed by the increment Ant task used for #5312  due to use of a colon to separate key and value. Maven module syntax was fixed in later PR for 17, but needs an additional increment for NB18.

See https://github.com/apache/netbeans/pull/5352#discussion_r1087643842

Code that doesn't work with colon is at https://github.com/apache/netbeans/blob/master/nbbuild/antsrc/org/netbeans/nbbuild/IncrementSpecificationVersions.java#L96  Of course, that could also be used as a deliberate way of bypassing increment?!