### PR TITLE
Improve TomEE support for JPA (Fix 4146)

### DIFF
--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
@@ -555,7 +555,6 @@ public class TomcatManager implements DeploymentManager {
         boolean fireListener = false;
         synchronized (this) {
             if (tomEEChecked) {
-                LOGGER.log(Level.INFO, "TomEE version {0}, type {1}", new Object[] {tomEEVersion, tomEEType});
                 return;
             }
             assert tomEEWarListener == null;

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
@@ -498,6 +498,38 @@ public class TomcatManager implements DeploymentManager {
                 return false;
         }
     }
+    
+    public boolean isTomEE9() {
+        return tomEEVersion == TomEEVersion.TOMEE_90;
+    }
+    
+    public boolean isTomEE8() {
+        return tomEEVersion == TomEEVersion.TOMEE_80;
+    }
+    
+    public boolean isTomEEplume() {
+        return tomEEType == TomEEType.TOMEE_PLUME;
+    }
+    
+    public boolean isJpa30() {
+        return isTomEE9();
+    }
+    
+    public boolean isJpa22() {
+        return isTomEE8();
+    }
+    
+    public boolean isJpa21() {
+        return tomEEVersion.isAtLeast(TomEEVersion.TOMEE_70) && !isTomEE9();
+    }
+    
+    public boolean isJpa20() {
+        return tomEEVersion.isAtLeast(TomEEVersion.TOMEE_15) && !isTomEE9();
+    }
+    
+    public boolean isJpa10() {
+        return isJpa20(); // All TomEE versions up to 8 support JPA 1.0
+    }
 
     /** Returns Tomcat lib folder: "lib" for  Tomcat 6.0 or greater and "common/lib" for Tomcat 5.x or less*/
     public String libFolder() {

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/JpaSupportImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/JpaSupportImpl.java
@@ -18,32 +18,58 @@
  */
 package org.netbeans.modules.tomcat5.j2ee;
 
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import org.netbeans.modules.javaee.specs.support.api.JpaProvider;
 import org.netbeans.modules.javaee.specs.support.spi.JpaProviderFactory;
 import org.netbeans.modules.javaee.specs.support.spi.JpaSupportImplementation;
+import org.netbeans.modules.tomcat5.deploy.TomcatManager;
 
 /**
- * This is TomEE only class.
- * @author Petr Hejl
+ * This is TomEE only class. TomEE PluME support two implementations: {@code OpenJPA}
+ * and {@code EclipseLink}, </p> every other TomEE flavor only support {@code OpenJPA}
+ * @author Petr Hejl, José Contreras
  */
-public class JpaSupportImpl implements JpaSupportImplementation {
+class JpaSupportImpl implements JpaSupportImplementation {
 
     private static final String OPENJPA_JPA_PROVIDER = "org.apache.openjpa.persistence.PersistenceProviderImpl"; // NOI18N
+    private static final String ECLIPSELINK_JPA_PROVIDER = "org.eclipse.persistence.jpa.PersistenceProvider"; // NOI18N
+    private final TomcatManager instance;
 
-    public JpaSupportImpl() {
-        super();
+    
+    JpaSupportImpl(TomcatManager instance) {
+        this.instance = instance;
     }
 
     @Override
     public JpaProvider getDefaultProvider() {
-        return JpaProviderFactory.createJpaProvider(OPENJPA_JPA_PROVIDER, true, true, true, false);
+        return JpaProviderFactory.createJpaProvider(
+                    OPENJPA_JPA_PROVIDER, 
+                    true, 
+                    instance.isJpa10(), 
+                    instance.isJpa20(), 
+                    instance.isJpa21());
     }
 
     @Override
     public Set<JpaProvider> getProviders() {
-        return Collections.singleton(getDefaultProvider());
+        Set<JpaProvider> providers = new HashSet<>();
+        providers.add(JpaProviderFactory.createJpaProvider(
+                OPENJPA_JPA_PROVIDER, 
+                true, 
+                instance.isJpa10(), 
+                instance.isJpa20(), 
+                instance.isJpa21()));
+        // TomEE PluME has Eclipselink and OpenJPA
+        if (instance.isTomEEplume()) {
+            providers.add(JpaProviderFactory.createJpaProvider(
+                    ECLIPSELINK_JPA_PROVIDER, 
+                    true, 
+                    instance.isJpa10(), 
+                    instance.isJpa20(), 
+                    instance.isJpa21()));
+        }
+        return providers;
     }
 
 }

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -614,7 +614,7 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
         Collections.addAll(content, tp.getCatalinaHome(),
                 new EjbSupportImpl(manager), wsStack);
         if (manager.isTomEE()) {
-            content.add(new JpaSupportImpl());
+            content.add(new JpaSupportImpl(manager));
             if (manager.isTomEEJaxRS()) {
                 content.add(new JaxRsStackSupportImpl(this));
             }


### PR DESCRIPTION
- Add logic to support two default provider for TomEE PluME
- Add logic to support up to JPA 2.1
- Add methods to support JPA 2.2 and 3.0; when available in NetBeans
- Fix [Issue-4146](https://github.com/apache/netbeans/issues/4146) 

Testing:
- Full build done
- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Sigtests
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Download every version of TomEE and successfully:
  - Register it
  - Create Web App Project
  - Check correct creation of persistence unit with JPA 1.0, 2.0 and 2.1
  - Deploy and run a servlet