### PR TITLE
Cleanup: dead/unused private methods: [webcommon + websvccommon]

### DIFF
--- a/webcommon/cordova/src/org/netbeans/modules/cordova/project/PluginsPanel.java
+++ b/webcommon/cordova/src/org/netbeans/modules/cordova/project/PluginsPanel.java
@@ -132,14 +132,6 @@ public final class PluginsPanel extends JPanel {
         selectedPluginsList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
     }
 
-    private boolean isUpdateRunning() {
-        return !panelEnabled;
-    }
-
-    private void startUpdate() {
-        lockPanel();
-    }
-
     void finishUpdate() {
         unlockPanel();
     }

--- a/webcommon/cordova/src/org/netbeans/modules/cordova/wizard/CordovaTemplate.java
+++ b/webcommon/cordova/src/org/netbeans/modules/cordova/wizard/CordovaTemplate.java
@@ -254,10 +254,6 @@ public class CordovaTemplate implements SiteTemplateImplementation {
             return true;
         }
 
-        private void setErrorMessage(String message) {
-            wizardDescriptor.putProperty(WizardDescriptor.PROP_ERROR_MESSAGE, message);
-        }
-
         @Override
         public void propertyChange(PropertyChangeEvent evt) {
             changeSupport.fireChange();

--- a/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/chrome/WebStorePanel.java
+++ b/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/chrome/WebStorePanel.java
@@ -91,10 +91,6 @@ class WebStorePanel extends javax.swing.JPanel {
         }
     }
     
-    private Dimension getDescriptionSize(){
-        return new Dimension(350, (int)getAdjustedHeight());
-    }
-    
     private void init(){
         initComponents();
         // ui tweaks
@@ -148,21 +144,6 @@ class WebStorePanel extends javax.swing.JPanel {
                 "font-size: " + font.getSize() + "pt; }";
         ((HTMLDocument)fakePane.getDocument()).getStyleSheet().addRule(bodyRule);
         return fakePane.getPreferredSize().getHeight();
-    }
-    
-    private int getRows() {
-        int count = 0;
-        try {
-            int offs=description.getCaretPosition();
-            while( offs>0) {
-                offs=Utilities.getRowStart(description, offs)-1;
-                count++;
-            }
-        } 
-        catch (BadLocationException e) {
-            assert false;
-        }
-        return count+1;
     }
     
     private void attachActions(final Runnable runnable){

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/index/AngularJsIndexer.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/index/AngularJsIndexer.java
@@ -113,40 +113,6 @@ public class AngularJsIndexer extends EmbeddingIndexer{
         }
 
     }
-
-    private static void removeControllers(@NonNull final URI uri) {
-        final Map<URI, Collection<AngularJsController>> map = controllers.get();
-        
-        if (map == null) {
-            throw new IllegalStateException("AngularJsIndexer.addControllers can be called only from scanner thread.");  //NOI18N
-        }
-        map.remove(uri);
-    }
-    
-    private static void removeTemplateControllers(@NonNull final URI uri) {
-        final Map<URI, Map<String, AngularJsController.ModuleConfigRegistration>> map = templateControllers.get();
-        
-        if (map == null) {
-            throw new IllegalStateException("AngularJsIndexer.addControllers can be called only from scanner thread.");  //NOI18N
-        }
-        map.remove(uri);
-    }
-    
-    private static Collection<AngularJsController> getControllers(@NonNull final URI uri) {
-        final Map<URI, Collection<AngularJsController>> map = controllers.get();
-        if (map == null) {
-            throw new IllegalStateException("AngularJsIndexer.getControllers can be called only from scanner thread.");  //NOI18N
-        }
-        return map.get(uri);
-    }
-    
-    private static Map<String, AngularJsController.ModuleConfigRegistration> getTemplateControllers(@NonNull final URI uri) {
-        final Map<URI, Map<String, AngularJsController.ModuleConfigRegistration>> map = templateControllers.get();
-        if (map == null) {
-            throw new IllegalStateException("AngularJsIndexer.getControllers can be called only from scanner thread.");  //NOI18N
-        }
-        return map.get(uri);
-    }
     
     public static boolean isScannerThread() {
         return controllers.get() != null;

--- a/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/model/KOModel.java
+++ b/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/model/KOModel.java
@@ -111,31 +111,6 @@ public class KOModel {
         return LexerUtils.equals(KOUtils.KO_PARAMS_ATTR_NAME, attribute.unqualifiedName(), true, true);
     }
     
-    private static boolean containsKODirective(Snapshot snapshot, Attribute attribute) {
-        TokenHierarchy<?> tokenHierarchy = snapshot.getTokenHierarchy();
-        TokenSequence<HTMLTokenId> tokenSequence = tokenHierarchy.tokenSequence(HTMLTokenId.language());
-        if(tokenSequence != null) {
-            tokenSequence.move(attribute.valueOffset() + (attribute.isValueQuoted() ? 1 : 0));
-            if(tokenSequence.moveNext()) {
-                TokenSequence<KODataBindTokenId> embedded = tokenSequence.embedded(KODataBindTokenId.language());
-                if(embedded != null) {
-                    embedded.moveStart();
-                    while(embedded.moveNext()) {
-                        switch(embedded.token().id()) {
-                            case KEY:
-                                String img = embedded.token().text().toString();
-                                if(Binding.getBinding(img) != null) {
-                                    return true;
-                                }
-                                break;
-                        }
-                    }
-                }
-            }
-        }
-        return false;
-    }
-    
     /**
      * Gets a list of all angular attributes in the page.
      */

--- a/webcommon/javascript.karma/src/org/netbeans/modules/javascript/karma/mapping/ServerMapping.java
+++ b/webcommon/javascript.karma/src/org/netbeans/modules/javascript/karma/mapping/ServerMapping.java
@@ -139,9 +139,4 @@ public final class ServerMapping {
         return directoriesProvider.getTestDirectory(false);
     }
 
-    private boolean isUnderneath(FileObject root, FileObject folder) {
-        return root.equals(folder)
-                || FileUtil.isParentOf(root, folder);
-    }
-
 }

--- a/webcommon/javascript.karma/src/org/netbeans/modules/javascript/karma/run/TestRunner.java
+++ b/webcommon/javascript.karma/src/org/netbeans/modules/javascript/karma/run/TestRunner.java
@@ -374,20 +374,6 @@ public final class TestRunner {
                 .split(NEW_LINE_REGEX);
     }
 
-    private void testIgnore(String line) {
-        Matcher matcher = NAME_PATTERN.matcher(line);
-        if (matcher.find()) {
-            String name = matcher.group(1);
-            if (!StringUtils.hasText(name)) {
-                name = Bundle.TestRunner_noName();
-            }
-            addTestCase(name, Status.IGNORED);
-        } else {
-            LOGGER.log(Level.FINE, "Unexpected test IGNORE line: {0}", line);
-            assert false : line;
-        }
-    }
-
     private void addTestCase(String name, Status status) {
         addTestCase(name, status, 0L);
     }

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/hint/JsConventionHintTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/hint/JsConventionHintTest.java
@@ -37,10 +37,6 @@ public class JsConventionHintTest extends HintTestBase {
         super(testName);
     }
     
-    private Rule createRule() {
-        return new JsConventionRule();
-    }
-    
     private Rule createSemicolonHint() {
         return new MissingSemicolonHint();
     }

--- a/webcommon/javascript2.extdoc/test/unit/src/org/netbeans/modules/javascript2/extdoc/ExtDocDocumentationProviderTest.java
+++ b/webcommon/javascript2.extdoc/test/unit/src/org/netbeans/modules/javascript2/extdoc/ExtDocDocumentationProviderTest.java
@@ -66,16 +66,6 @@ public class ExtDocDocumentationProviderTest extends JsDocumentationTestBase {
         });
     }
 
-    private void checkReturnType(Source source, final int offset, final List<? extends Type> expected) throws Exception {
-        initializeDocumentationHolder(source);
-        if (expected == null) {
-            assertNull(documentationHolder.getReturnType(getNodeForOffset(parserResult, offset)));
-        } else {
-            for (int i = 0; i < expected.size(); i++) {
-                assertEquals(expected.get(i), documentationHolder.getReturnType(getNodeForOffset(parserResult, offset)).get(i));
-            }
-        }
-    }
 
     private void checkParameter(Source source, final int offset, final FakeDocParameter expectedParam) throws Exception {
         initializeDocumentationHolder(source);
@@ -93,40 +83,8 @@ public class ExtDocDocumentationProviderTest extends JsDocumentationTestBase {
         }
     }
 
-    private void checkExtend(Source source, final int offset, final List<? extends Type> expected) throws Exception {
-        initializeDocumentationHolder(source);
-        if (expected == null) {
-            assertTrue(documentationHolder.getExtends(getNodeForOffset(parserResult, offset)).isEmpty());
-        } else {
-            for (int i = 0; i < expected.size(); i++) {
-                assertEquals(expected.get(i), documentationHolder.getExtends(getNodeForOffset(parserResult, offset)).get(i));
-            }
-        }
-    }
 
-    private void checkDocumentation(Source source, final int offset, final String expected) throws Exception {
-        initializeDocumentationHolder(source);
-        assertEquals(expected, documentationHolder.getDocumentation(getNodeForOffset(parserResult, offset)));
-    }
 
-    private void checkModifiers(Source source, final int offset, final String expectedModifiers) throws Exception {
-        initializeDocumentationHolder(source);
-        Set<JsModifier> realModifiers = documentationHolder.getModifiers(getNodeForOffset(parserResult, offset));
-        if (expectedModifiers == null) {
-            assertEquals(0, realModifiers.size());
-        } else {
-            String[] expModifiers = expectedModifiers.split("[|]");
-            assertEquals(expModifiers.length, realModifiers.size());
-            for (int i = 0; i < expModifiers.length; i++) {
-                assertTrue(realModifiers.contains(JsModifier.fromString(expModifiers[i])));
-            }
-        }
-    }
-
-    private void checkFirstSummary(Source source, int offset, String summary) throws ParseException {
-        initializeDocumentationHolder(source);
-        assertEquals(summary, documentationHolder.getCommentForOffset(offset, documentationHolder.getCommentBlocks()).getSummary().get(0));
-    }
 
     public void testGetParametersForNameAndTypeParam() throws Exception {
         Source testSource = getTestSource(getTestFile(FILE_NAME_PARAMETERS));

--- a/webcommon/javascript2.jade/src/org/netbeans/modules/javascript2/jade/editor/lexer/JadeColoringLexer.java
+++ b/webcommon/javascript2.jade/src/org/netbeans/modules/javascript2/jade/editor/lexer/JadeColoringLexer.java
@@ -959,60 +959,6 @@ public final class JadeColoringLexer {
     return map;
   }
 
-
-  /**
-   * Refills the input buffer.
-   *
-   * @return      <code>false</code>, iff there was new input.
-   * 
-   * @exception   java.io.IOException  if any I/O-Error occurs
-   */
-  private boolean zzRefill() throws java.io.IOException {
-
-    /* first: make room (if you can) */
-    if (zzStartRead > 0) {
-      System.arraycopy(zzBuffer, zzStartRead,
-                       zzBuffer, 0,
-                       zzEndRead-zzStartRead);
-
-      /* translate stored positions */
-      zzEndRead-= zzStartRead;
-      zzCurrentPos-= zzStartRead;
-      zzMarkedPos-= zzStartRead;
-      zzStartRead = 0;
-    }
-
-    /* is the buffer big enough? */
-    if (zzCurrentPos >= zzBuffer.length) {
-      /* if not: blow it up */
-      char newBuffer[] = new char[zzCurrentPos*2];
-      System.arraycopy(zzBuffer, 0, newBuffer, 0, zzBuffer.length);
-      zzBuffer = newBuffer;
-    }
-
-    /* finally: fill the buffer with new input */
-    int numRead = zzReader.read(zzBuffer, zzEndRead,
-                                            zzBuffer.length-zzEndRead);
-
-    if (numRead > 0) {
-      zzEndRead+= numRead;
-      return false;
-    }
-    // unlikely but not impossible: read 0 characters, but not at end of stream    
-    if (numRead == 0) {
-      int c = zzReader.read();
-      if (c == -1) {
-        return true;
-      } else {
-        zzBuffer[zzEndRead++] = (char) c;
-        return false;
-      }     
-    }
-
-	// numRead < 0
-    return true;
-  }
-
     
   /**
    * Closes the input stream.

--- a/webcommon/javascript2.jquery/src/org/netbeans/modules/javascript2/jquery/editor/JQueryCodeCompletion.java
+++ b/webcommon/javascript2.jquery/src/org/netbeans/modules/javascript2/jquery/editor/JQueryCodeCompletion.java
@@ -108,61 +108,6 @@ public class JQueryCodeCompletion implements CompletionProvider {
         return result;
     }
 
-    private int findParamIndex(ParserResult parserResult, int offset) {
-        TokenSequence<? extends JsTokenId> ts = LexUtilities.getJsTokenSequence(parserResult.getSnapshot().getTokenHierarchy(), offset);
-        if (ts == null) {
-            return -1;
-        }
-        ts.move(offset);
-        if (!(ts.moveNext() && ts.movePrevious())) {
-            return -1;
-        }
-        Token<? extends JsTokenId> token = LexUtilities.findNext(ts, Arrays.asList(JsTokenId.WHITESPACE));
-        // count index of parameters
-        int paramIndex = 0;
-        while(token.id() != JsTokenId.EOL && token.id() != JsTokenId.BRACKET_LEFT_PAREN) {
-            if (token.id() == JsTokenId.OPERATOR_COMMA) {
-                paramIndex ++;
-            } else if (token.id() == JsTokenId.OPERATOR_DOT) {
-                // we are not inside ()
-                return -1;
-            }
-            token = LexUtilities.findNext(ts, Arrays.asList(JsTokenId.WHITESPACE));
-        }
-        if (token.id() == JsTokenId.BRACKET_LEFT_PAREN) {
-            return paramIndex;
-        }
-        return -1;
-    }
-    
-    private String findFunctionName(ParserResult parserResult, int offset) {
-        TokenSequence<? extends JsTokenId> ts = LexUtilities.getJsTokenSequence(parserResult.getSnapshot().getTokenHierarchy(), offset);
-        if (ts == null) {
-            return null;
-        }
-        ts.move(offset);
-        if (!(ts.moveNext() && ts.movePrevious())) {
-            return null;
-        }
-        Token<? extends JsTokenId> token = LexUtilities.findNext(ts, Arrays.asList(JsTokenId.WHITESPACE));
-        while(token.id() != JsTokenId.EOL && token.id() != JsTokenId.BRACKET_LEFT_PAREN) {
-            if (token.id() == JsTokenId.OPERATOR_DOT) {
-                // we are not inside ()
-                return null;
-            }
-            token = LexUtilities.findNext(ts, Arrays.asList(JsTokenId.WHITESPACE));
-        }
-        if (token.id() == JsTokenId.BRACKET_LEFT_PAREN && ts.movePrevious()) {
-            token = LexUtilities.findNext(ts, Arrays.asList(JsTokenId.WHITESPACE));
-            if (token.id() == JsTokenId.IDENTIFIER){
-                return token.text().toString();
-            }
-        }
-        return null;
-    }
-    
-    
-
     @Override
     public String getHelpDocumentation(ParserResult info, ElementHandle element) {
         if (element instanceof DocSimpleElement) {

--- a/webcommon/javascript2.jquery/src/org/netbeans/modules/javascript2/jquery/model/JQueryUtils.java
+++ b/webcommon/javascript2.jquery/src/org/netbeans/modules/javascript2/jquery/model/JQueryUtils.java
@@ -98,9 +98,6 @@ public class JQueryUtils {
         return false;
     }
 
-    private static boolean isEndToken(JsTokenId token) {
-        return token == JsTokenId.EOL || token == JsTokenId.OPERATOR_SEMICOLON;
-    }
 //
 //    public String getPrefix(ParserResult info, int caretOffset) {
 //        BaseDocument doc = (BaseDocument) info.getSnapshot().getSource().getDocument(false);

--- a/webcommon/javascript2.jsdoc/test/unit/src/org/netbeans/modules/javascript2/jsdoc/JsDocDocumentationProviderTest.java
+++ b/webcommon/javascript2.jsdoc/test/unit/src/org/netbeans/modules/javascript2/jsdoc/JsDocDocumentationProviderTest.java
@@ -109,10 +109,6 @@ public class JsDocDocumentationProviderTest extends JsDocumentationTestBase {
         }
     }
 
-    private void checkDocumentation(Source source, final int offset, final String expected) throws Exception {
-        initializeDocumentationHolder(source);
-        assertEquals(expected, documentationHolder.getDocumentation(getNodeForOffset(parserResult, offset)));
-    }
 
     private void checkDeprecated(Source source, final int offset, final boolean expected) throws Exception {
         initializeDocumentationHolder(source);

--- a/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsColoringLexer.java
+++ b/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsColoringLexer.java
@@ -1035,61 +1035,6 @@ public final class JsColoringLexer {
     }
     return map;
   }
-
-
-  /**
-   * Refills the input buffer.
-   *
-   * @return      <code>false</code>, iff there was new input.
-   * 
-   * @exception   java.io.IOException  if any I/O-Error occurs
-   */
-  private boolean zzRefill() throws java.io.IOException {
-
-    /* first: make room (if you can) */
-    if (zzStartRead > 0) {
-      System.arraycopy(zzBuffer, zzStartRead,
-                       zzBuffer, 0,
-                       zzEndRead-zzStartRead);
-
-      /* translate stored positions */
-      zzEndRead-= zzStartRead;
-      zzCurrentPos-= zzStartRead;
-      zzMarkedPos-= zzStartRead;
-      zzStartRead = 0;
-    }
-
-    /* is the buffer big enough? */
-    if (zzCurrentPos >= zzBuffer.length) {
-      /* if not: blow it up */
-      char newBuffer[] = new char[zzCurrentPos*2];
-      System.arraycopy(zzBuffer, 0, newBuffer, 0, zzBuffer.length);
-      zzBuffer = newBuffer;
-    }
-
-    /* finally: fill the buffer with new input */
-    int numRead = zzReader.read(zzBuffer, zzEndRead,
-                                            zzBuffer.length-zzEndRead);
-
-    if (numRead > 0) {
-      zzEndRead+= numRead;
-      return false;
-    }
-    // unlikely but not impossible: read 0 characters, but not at end of stream    
-    if (numRead == 0) {
-      int c = zzReader.read();
-      if (c == -1) {
-        return true;
-      } else {
-        zzBuffer[zzEndRead++] = (char) c;
-        return false;
-      }     
-    }
-
-	// numRead < 0
-    return true;
-  }
-
     
   /**
    * Closes the input stream.

--- a/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsDocumentationColoringLexer.java
+++ b/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsDocumentationColoringLexer.java
@@ -461,61 +461,6 @@ public final class JsDocumentationColoringLexer {
     }
     return map;
   }
-
-
-  /**
-   * Refills the input buffer.
-   *
-   * @return      <code>false</code>, iff there was new input.
-   * 
-   * @exception   java.io.IOException  if any I/O-Error occurs
-   */
-  private boolean zzRefill() throws java.io.IOException {
-
-    /* first: make room (if you can) */
-    if (zzStartRead > 0) {
-      System.arraycopy(zzBuffer, zzStartRead,
-                       zzBuffer, 0,
-                       zzEndRead-zzStartRead);
-
-      /* translate stored positions */
-      zzEndRead-= zzStartRead;
-      zzCurrentPos-= zzStartRead;
-      zzMarkedPos-= zzStartRead;
-      zzStartRead = 0;
-    }
-
-    /* is the buffer big enough? */
-    if (zzCurrentPos >= zzBuffer.length) {
-      /* if not: blow it up */
-      char newBuffer[] = new char[zzCurrentPos*2];
-      System.arraycopy(zzBuffer, 0, newBuffer, 0, zzBuffer.length);
-      zzBuffer = newBuffer;
-    }
-
-    /* finally: fill the buffer with new input */
-    int numRead = zzReader.read(zzBuffer, zzEndRead,
-                                            zzBuffer.length-zzEndRead);
-
-    if (numRead > 0) {
-      zzEndRead+= numRead;
-      return false;
-    }
-    // unlikely but not impossible: read 0 characters, but not at end of stream    
-    if (numRead == 0) {
-      int c = zzReader.read();
-      if (c == -1) {
-        return true;
-      } else {
-        zzBuffer[zzEndRead++] = (char) c;
-        return false;
-      }     
-    }
-
-	// numRead < 0
-    return true;
-  }
-
     
   /**
    * Closes the input stream.

--- a/webcommon/javascript2.sdoc/test/unit/src/org/netbeans/modules/javascript2/sdoc/SDocDocumentationProviderTest.java
+++ b/webcommon/javascript2.sdoc/test/unit/src/org/netbeans/modules/javascript2/sdoc/SDocDocumentationProviderTest.java
@@ -104,11 +104,6 @@ public class SDocDocumentationProviderTest extends JsDocumentationTestBase {
         }
     }
 
-    private void checkDocumentation(Source source, final int offset, final String expected) throws Exception {
-        initializeDocumentationHolder(source);
-        assertEquals(expected, documentationHolder.getDocumentation(getNodeForOffset(parserResult, offset)));
-    }
-
     private void checkDeprecated(Source source, final int offset, final boolean expected) throws Exception {
         initializeDocumentationHolder(source);
         assertEquals(expected, documentationHolder.isDeprecated(getNodeForOffset(parserResult, offset)));

--- a/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/connection/ClientConnection.java
+++ b/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/connection/ClientConnection.java
@@ -187,19 +187,6 @@ public final class ClientConnection {
         
     }
     
-    private static Map<String, String> readPropertiesScan(String properties) {
-        Scanner sp = new Scanner(properties);
-        Map<String, String> map = new HashMap<>();
-        try {
-            while (sp.hasNext()) {
-                String key = sp.next(": ");
-                String value = sp.next("\r\n");
-                map.put(key, value);
-            }
-        } catch (NoSuchElementException ex) {}
-        return map;
-    }
-    
     private static Map<String, String> readProperties(String properties) {
         Map<String, String> map = new HashMap<>();
         int l = properties.length();

--- a/webcommon/web.clientproject/test/qa-functional/src/org/netbeans/test/html5/EmbeddedBrowserOperator.java
+++ b/webcommon/web.clientproject/test/qa-functional/src/org/netbeans/test/html5/EmbeddedBrowserOperator.java
@@ -125,12 +125,6 @@ public class EmbeddedBrowserOperator extends TopComponentOperator {
         return _tbFitToScreenResize;
     }
 
-    private JToggleButtonOperator tbOption() {
-        if (_tbOption == null) {
-            _tbOption = new JToggleButtonOperator(this, 6);
-        }
-        return _tbOption;
-    }
 
     private JComboBoxOperator cboZoom() {
         if (_cboZoom == null) {

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/SaasClientCodeGenerator.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/SaasClientCodeGenerator.java
@@ -247,24 +247,6 @@ public abstract class SaasClientCodeGenerator implements SaasClientCodeGeneratio
     public void setBean(SaasBean bean) {
         this.bean = bean;
     }
-    
-    private String getParamList() {
-        List<ParameterInfo> inputParams = bean.filterParametersByAuth
-                (bean.filterParameters(new ParamFilter[]{ParamFilter.FIXED}));
-        String text = ""; //NOI18N
-        for (int i = 0; i < inputParams.size(); i++) {
-            ParameterInfo param = inputParams.get(i);
-
-            if (i == 0) {
-                text += getParameterName(param, true, true, true);
-            } else {
-                text += ", " + getParameterName(param, true, true, true); //NOI18N
-            }
-        }
-
-        return text;
-    }
-
   
     protected void insert(String s, boolean reformat)
             throws BadLocationException {

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SaasBean.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SaasBean.java
@@ -730,10 +730,6 @@ public abstract class SaasBean extends GenericResourceBean {
                     this.prompt = prompt;
                 }
 
-                private Prompt createPrompt() {
-                    return new Prompt();
-                }
-
                 public class Prompt {
 
                     private String deskTopUrl;


### PR DESCRIPTION
Target directories:
- webcommon
- websvccommon

Methods excluded throught commenting, no other types of changing are made. After was excluded unused methods layer 1 there is next level unused methods was found that also exluded. This type of changing is simple to review therefore contains a lot of diffs. Its not automated change!

Profits:
- less IDE indexer load
- resulting version size
- JVM method search speed and memory usage
- less compile time
- improved code navigation if parent methods will searching (unused parents excluded)
- less overall % of methods without tests coverage
- less Strings pool size of literals

UPD: BUILD SUCCESSFUL