### PR TITLE
UnsupportedOperationException in maven dependency graph "Exclude dependency" and "Fix Version Conflict" actions

### DIFF
--- a/java/java.graph/manifest.mf
+++ b/java/java.graph/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.java.graph/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/graph/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.20
+OpenIDE-Module-Specification-Version: 1.21
 

--- a/java/java.graph/src/org/netbeans/modules/java/graph/DependencyGraphScene.java
+++ b/java/java.graph/src/org/netbeans/modules/java/graph/DependencyGraphScene.java
@@ -482,8 +482,7 @@ public class DependencyGraphScene<I extends GraphNodeImplementation> extends Gra
 
         if(supportsVersions()) {
             // other important paths
-            ArrayList<I> representants = new ArrayList<>(node.getDuplicatesOrConflicts());
-            for (GraphNodeImplementation curRep : representants) {
+            for (GraphNodeImplementation curRep : node.getDuplicatesOrConflicts()) {
                 addPathToRoot(curRep, curRep.getParent(), otherPathsEdges, importantNodes);
             }
         }

--- a/java/java.graph/src/org/netbeans/modules/java/graph/GraphNode.java
+++ b/java/java.graph/src/org/netbeans/modules/java/graph/GraphNode.java
@@ -42,7 +42,7 @@ public final class GraphNode<I extends GraphNodeImplementation> {
 
     private I impl, parentAfterFix;
     
-    private final  HashSet<I> duplicates;
+    private final Set<I> duplicates;
     private int level; 
     private int managedState = UNMANAGED;
 
@@ -70,6 +70,10 @@ public final class GraphNode<I extends GraphNodeImplementation> {
     
     public void addDuplicateOrConflict(I i) {
         duplicates.add(i);
+    }
+
+    public void removeDuplicateOrConflict(I i) {
+        duplicates.remove(i);
     }
 
     public Set<I> getDuplicatesOrConflicts() {

--- a/java/maven.graph/nbproject/project.xml
+++ b/java/maven.graph/nbproject/project.xml
@@ -57,7 +57,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.1</specification-version>
+                        <specification-version>1.21</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven.graph/src/org/netbeans/modules/maven/graph/MavenAction.java
+++ b/java/maven.graph/src/org/netbeans/modules/maven/graph/MavenAction.java
@@ -164,7 +164,9 @@ public abstract class MavenAction extends AbstractAction {
             }
         }
         // note, must be called before node removing edges to work correctly
-        node.getDuplicatesOrConflicts().removeAll(toExclude);
+        for(MavenDependencyNode mdn: toExclude) {
+            node.removeDuplicateOrConflict(mdn);
+        }
         for (GraphEdge<MavenDependencyNode> age : edges2Exclude) {
             scene.removeEdge(age);
             age.getSource().removeChild(age.getTarget());
@@ -210,7 +212,7 @@ public abstract class MavenAction extends AbstractAction {
             children.add(childNode);
             scene.removeEdge(age);
             age.getSource().removeChild(dn);
-            childNode.getDuplicatesOrConflicts().remove(dn);
+            childNode.removeDuplicateOrConflict(dn);
         }
         // recurse to children
         for (GraphNode age : children) {


### PR DESCRIPTION
The two actions:

org.netbeans.modules.maven.graph.FixVersionConflictAction
org.netbeans.modules.maven.graph.ExcludeDepAction

need to manipulate the duplicate or conflict list. The returned set is read-only, so a companion method to addDuplicateOrConflict removeDuplicateOrConflict is added to remove a node from the list.

Closes: #5402