### PR TITLE
Minor / typo fixes

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletDialog.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletDialog.java
@@ -55,7 +55,7 @@ import org.openide.windows.WindowManager;
     "OneLetter=The wallet download password should contain at least 1 letter.",
     "WalletPassword=Enter the wallet password",
     "WalletReEnterPassword=Re-enter the wallet password",
-    "JDBCUsername=Enter the conenction username",
+    "JDBCUsername=Enter the connection username",
     "JDBCPassword=Enter the conenction password"
 })
 final class DownloadWalletDialog extends AbstractPasswordPanel {

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -861,7 +861,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
             c.onRequest(ExecInHtmlPageRequest.type, execInHtmlPage);
             c.onNotification(LogMessageNotification.type, (param) => handleLog(log, param.message));
             c.onRequest(QuickPickRequest.type, async param => {
-                const selected = await window.showQuickPick(param.items, { title: param.title, placeHolder: param.placeHolder, canPickMany: param.canPickMany });
+                const selected = await window.showQuickPick(param.items, { title: param.title, placeHolder: param.placeHolder, canPickMany: param.canPickMany, ignoreFocusOut: true });
                 return selected ? Array.isArray(selected) ? selected : [selected] : undefined;
             });
             c.onRequest(UpdateConfigurationRequest.type, async (param) => {


### PR DESCRIPTION
1/ typo fix in DB password prompt
2/ make QuickPicks displayed by LSP client `ignoreFocusOut` by default. In NetBeans, revelevant dialogs are typically modal, so this is a better LSP metaphore.