### PR TITLE
Wildfly server restart not possible

### DIFF
--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/common/api/SocketBinding.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/common/api/SocketBinding.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.j2ee.deployment.common.api;
+
+/**
+ * A socket from a server instance.
+ */
+public interface SocketBinding {
+
+    /**
+     * Retrieve the socket name.
+     *
+     * @return The name as defined in the configuration.
+     */
+    String getName();
+
+    /**
+     * Retrieve the port number.
+     *
+     * @return The port for the socket.
+     */
+    int getPort();
+
+    /**
+     * The interface name.
+     *
+     * @return The name as defined in the configuration.
+     */
+    String getInterfaceName();
+}

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
@@ -54,8 +54,7 @@ import org.netbeans.modules.javaee.wildfly.deploy.WildflyProgressObject;
 import org.netbeans.modules.javaee.wildfly.ide.commands.WildflyClient;
 import org.netbeans.modules.javaee.wildfly.ide.commands.WildflyModule;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties;
-import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_ADMIN_PORT;
-import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.PROPERTY_ADMIN_PORT;
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.PROPERTY_CONFIG_FILE;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils.Version;
 import org.netbeans.modules.javaee.wildfly.util.WildFlyProperties;
@@ -101,15 +100,15 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
         File serverPath = new File(this.instanceProperties.getProperty(WildflyPluginProperties.PROPERTY_ROOT_DIR));
         version = WildflyPluginUtils.getServerVersion(serverPath);
         isWildfly = WildflyPluginUtils.isWildFly(serverPath);
-        int controllerPort = DEFAULT_ADMIN_PORT;
-        String adminPort = this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT);
-        if (adminPort != null) {
-            controllerPort = Integer.parseInt(this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT));
+        String configFilePath = this.instanceProperties.getProperty(PROPERTY_CONFIG_FILE);
+        int adminPort = WildflyPluginProperties.DEFAULT_ADMIN_PORT;
+        if (configFilePath != null) {
+            adminPort = WildflyPluginUtils.getManagementConnectorPort(configFilePath);
         }
         if (username != null && password != null) {
-            this.client = new WildflyClient(instanceProperties, version, getHost(), controllerPort, username, password);
+            this.client = new WildflyClient(instanceProperties, version, getHost(), adminPort, username, password);
         } else {
-            this.client = new WildflyClient(instanceProperties, version, getHost(), controllerPort);
+            this.client = new WildflyClient(instanceProperties, version, getHost(), adminPort);
         }
         ChangelogWildflyPlugin.showChangelog();
     }

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
@@ -54,9 +54,8 @@ import org.netbeans.modules.javaee.wildfly.deploy.WildflyProgressObject;
 import org.netbeans.modules.javaee.wildfly.ide.commands.WildflyClient;
 import org.netbeans.modules.javaee.wildfly.ide.commands.WildflyModule;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties;
-
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_ADMIN_PORT;
 import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.PROPERTY_ADMIN_PORT;
-
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils.Version;
 import org.netbeans.modules.javaee.wildfly.util.WildFlyProperties;
@@ -70,18 +69,15 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
     private static final Logger LOGGER = Logger.getLogger(WildflyDeploymentManager.class.getName());
 
     private static final int DEBUGGING_PORT = 8787;
-    private static final int CONTROLLER_PORT = 9990;
 
     private final Version version;
     private final boolean isWildfly;
     private final WildflyClient client;
 
     /**
-     * Stores information about running instances. instance is represented by
-     * its InstanceProperties, running state by Boolean.TRUE, stopped state
-     * Boolean.FALSE. WeakHashMap should guarantee erasing of an unregistered
-     * server instance bcs instance properties are also removed along with
-     * instance.
+     * Stores information about running instances. instance is represented by its InstanceProperties, running
+     * state by Boolean.TRUE, stopped state Boolean.FALSE. WeakHashMap should guarantee erasing of an
+     * unregistered server instance bcs instance properties are also removed along with instance.
      */
     private static final Map<InstanceProperties, Boolean> PROPERTIES_TO_IS_RUNNING
             = Collections.synchronizedMap(new WeakHashMap());
@@ -105,9 +101,9 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
         File serverPath = new File(this.instanceProperties.getProperty(WildflyPluginProperties.PROPERTY_ROOT_DIR));
         version = WildflyPluginUtils.getServerVersion(serverPath);
         isWildfly = WildflyPluginUtils.isWildFly(serverPath);
-        int controllerPort = CONTROLLER_PORT;
+        int controllerPort = DEFAULT_ADMIN_PORT;
         String adminPort = this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT);
-        if(adminPort != null) {
+        if (adminPort != null) {
             controllerPort = Integer.parseInt(this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT));
         }
         if (username != null && password != null) {
@@ -119,8 +115,8 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
     }
 
     /**
-     * Returns true if the given instance properties are present in the map and
-     * value equals true. Otherwise return false.
+     * Returns true if the given instance properties are present in the map and value equals true. Otherwise
+     * return false.
      */
     public static boolean isRunningLastCheck(InstanceProperties ip) {
         return PROPERTIES_TO_IS_RUNNING.containsKey(ip) && PROPERTIES_TO_IS_RUNNING.get(ip).equals(Boolean.TRUE);
@@ -254,7 +250,7 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
             if (ModuleType.EJB.equals(mt)) {
                 for (WildflyModule module : modules) {
                     if (module.getArchiveName().endsWith("jar") && module.isRunning()) {
-                        result.add(new WildflyTargetModuleID(targets[0], module.getArchiveName(),  Type.fromJsrType(mt), false));
+                        result.add(new WildflyTargetModuleID(targets[0], module.getArchiveName(), Type.fromJsrType(mt), false));
                     }
                 }
             } else if (ModuleType.WAR.equals(mt)) {
@@ -392,17 +388,18 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
     public boolean isWildfly() {
         return isWildfly;
     }
+
     /**
-     * Mark the server with a needs restart flag. This may be needed for
-     * instance when JDBC driver is deployed to a running server.
+     * Mark the server with a needs restart flag. This may be needed for instance when JDBC driver is deployed
+     * to a running server.
      */
     public synchronized void setNeedsRestart(boolean needsRestart) {
         this.needsRestart = needsRestart;
     }
 
     /**
-     * Returns true if the server needs to be restarted. This may occur for
-     * instance when JDBC driver was deployed to a running server
+     * Returns true if the server needs to be restarted. This may occur for instance when JDBC driver was
+     * deployed to a running server
      */
     public synchronized boolean getNeedsRestart() {
         return needsRestart;

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/SocketContainer.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/SocketContainer.java
@@ -1,0 +1,68 @@
+package org.netbeans.modules.javaee.wildfly.config;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.netbeans.modules.j2ee.deployment.common.api.SocketBinding;
+
+/**
+ * A container for {@link SocketBindings}.
+ */
+public class SocketContainer {
+
+    private final String name;
+    private final String defaultInterface;
+    private final int portOffset;
+    private final Set<SocketBinding> socketBindings = new HashSet<>();
+
+    /**
+     * Creates a new container from the given configuration values.
+     *
+     * @param name The container name.
+     * @param defaultInterface The default interface.
+     * @param portOffset The port offset.
+     * @param socketBindings The {@link SocketBinding}s.
+     */
+    public SocketContainer(String name, String defaultInterface, int portOffset, Set<SocketBinding> socketBindings) {
+        this.name = name;
+        this.defaultInterface = defaultInterface;
+        this.portOffset = portOffset;
+        this.socketBindings.addAll(socketBindings);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDefaultInterface() {
+        return defaultInterface;
+    }
+
+    public int getPortOffset() {
+        return portOffset;
+    }
+
+    /**
+     * Retrieve all available {@link SocketBinding}s.
+     *
+     * @return The set of socket bindings.
+     */
+    public Set<SocketBinding> getSocketBindings() {
+        return Collections.unmodifiableSet(socketBindings);
+    }
+
+    /**
+     * Retrieve an {@link Optional} holding the {@link SocketBinding} with the given name.
+     *
+     * @param name The name of the socket binding.
+     * @return The optional.
+     */
+    public Optional<SocketBinding> getSocketByName(String name) {
+        return socketBindings.stream()
+                .filter(s -> name.equals(s.getName()))
+                .findFirst();
+
+    }
+}

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/SocketContainer.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/SocketContainer.java
@@ -1,10 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.netbeans.modules.javaee.wildfly.config;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-
 import org.netbeans.modules.j2ee.deployment.common.api.SocketBinding;
 
 /**

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/ds/WildflyDatasourcesHandler.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/ds/WildflyDatasourcesHandler.java
@@ -18,9 +18,11 @@
  */
 package org.netbeans.modules.javaee.wildfly.config.xml.ds;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
 import org.netbeans.modules.j2ee.deployment.common.api.Datasource;
 import org.netbeans.modules.javaee.wildfly.config.WildflyDatasource;
 import org.xml.sax.Attributes;
@@ -35,10 +37,10 @@ import org.xml.sax.helpers.DefaultHandler;
 public class WildflyDatasourcesHandler extends DefaultHandler {
 
     private final XMLReader parser;
-    private final Set<Datasource> datasources = new HashSet<Datasource>();
-    private final Set<WildflyDataSource> parsedDatasources = new HashSet<WildflyDataSource>();
+    private final Set<Datasource> datasources = new HashSet<>();
+    private final Set<WildflyDataSource> parsedDatasources = new HashSet<>();
 
-    boolean isDatasource = false;
+    private boolean isDatasource = false;
 
     private WildflyDatasourceHandler datasourceHandler;
     private WildflyDriversHandler driversHandler;
@@ -48,7 +50,7 @@ public class WildflyDatasourcesHandler extends DefaultHandler {
     }
 
     public Set<Datasource> getDatasources() {
-        return datasources;
+        return Collections.unmodifiableSet(datasources);
     }
 
     @Override

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBinding.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBinding.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.netbeans.modules.javaee.wildfly.config.xml.sockets;
 
 import org.netbeans.modules.j2ee.deployment.common.api.SocketBinding;

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBinding.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBinding.java
@@ -1,0 +1,41 @@
+package org.netbeans.modules.javaee.wildfly.config.xml.sockets;
+
+import org.netbeans.modules.j2ee.deployment.common.api.SocketBinding;
+
+/**
+ * A wildfly specific {@link SocketBinding}.
+ */
+public class WildflySocketBinding implements SocketBinding {
+
+    private String name;
+    private String interfaceName;
+    private int port;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getInterfaceName() {
+        return interfaceName;
+    }
+
+    public void setInterfaceName(String interfaceName) {
+        this.interfaceName = interfaceName;
+    }
+
+    @Override
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+}

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBindingsHandler.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBindingsHandler.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.netbeans.modules.javaee.wildfly.config.xml.sockets;
 
 import java.util.HashSet;

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBindingsHandler.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBindingsHandler.java
@@ -1,0 +1,87 @@
+package org.netbeans.modules.javaee.wildfly.config.xml.sockets;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+import org.netbeans.modules.j2ee.deployment.common.api.SocketBinding;
+import org.netbeans.modules.javaee.wildfly.config.SocketContainer;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.DEFAULT_INTERFACE;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.INTERFACE;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.NAME;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.PORT;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.PORT_OFFSET;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.SOCKET_BINDING;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.SOCKET_BINDING_GROUP;
+import org.netbeans.modules.javaee.wildfly.util.WildflyVariableResolver;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * A {@link DefaultHandler} for Wildfly socket bindings.
+ */
+public class WildflySocketBindingsHandler extends DefaultHandler {
+
+    private static final Logger LOG = Logger.getLogger(WildflySocketBindingsHandler.class.getName());
+
+    private static final int DEFAULT_PORT_OFFSET = 0;
+
+    private final Set<SocketBinding> socketBindings = new HashSet<>();
+
+    private boolean isSocketBinding = false;
+    private String name;
+    private String defaultInterface;
+    private int portOffset;
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+        isSocketBinding = isSocketBinding || SOCKET_BINDING_GROUP.equals(qName);
+        if (isSocketBinding) {
+            if (SOCKET_BINDING_GROUP.equals(qName)) {
+                name = attributes.getValue(uri, NAME);
+                defaultInterface = attributes.getValue(uri, DEFAULT_INTERFACE);
+                portOffset = parsePort(resolveExpression(attributes.getValue(uri, PORT_OFFSET)), DEFAULT_PORT_OFFSET);
+            } else if (SOCKET_BINDING.equals(qName)) {
+                WildflySocketBinding socketBinding = new WildflySocketBinding();
+                socketBinding.setName(attributes.getValue(uri, NAME));
+                socketBinding.setInterfaceName(valueOrDefaultInterface(attributes.getValue(uri, INTERFACE)));
+                int port = WildflySocketBindingsHandler.parsePort(resolveExpression(attributes.getValue(uri, PORT)), null);
+                socketBinding.setPort(port + portOffset);
+                socketBindings.add(socketBinding);
+            }
+        }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        // no need to track end of group
+    }
+
+    public SocketContainer getSocketContainer() {
+        return new SocketContainer(name, defaultInterface, portOffset, socketBindings);
+    }
+
+    private static int parsePort(String value, Integer fallback) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            if (fallback == null) {
+                throw e;
+            }
+            LOG.warning(String.format("The socket binding contained a non-parseable port: '%s', using fallback '%s'", value, fallback));
+        }
+        return fallback;
+    }
+
+    private static String resolveExpression(String expression) {
+        return WildflyVariableResolver.resolve(expression)
+                .orElse(null);
+    }
+
+    private String valueOrDefaultInterface(String parsedInterface) {
+        if (parsedInterface == null) {
+            return defaultInterface;
+        }
+        return parsedInterface;
+    }
+}

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/commands/Constants.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/commands/Constants.java
@@ -202,6 +202,7 @@ public class Constants {
     public static final String HOST_STATE = "host-state";// NOI18N
     public static final String HTTP_UPGRADE_ENABLED = "http-upgrade-enabled";// NOI18N
     public static final String HTTP_INTERFACE = "http-interface";// NOI18N
+    public static final String HOST_HTTP = "http";// NOI18N
     public static final String IGNORED = "ignored-by-unaffected-host-controller";// NOI18N
     public static final String IGNORED_RESOURCES = "ignored-resources";// NOI18N
     public static final String IGNORED_RESOURCE_TYPE = "ignored-resource-type";// NOI18N
@@ -220,6 +221,7 @@ public class Constants {
     public static final String INITIAL_SERVER_GROUPS = "initial-server-groups";// NOI18N
     public static final String INPUT_STREAM_INDEX = "input-stream-index";// NOI18N
     public static final String INTERFACE = "interface";// NOI18N
+    public static final String INTERFACES = "interfaces";// NOI18N
     public static final String ITERATIVE = "iterative";// NOI18N
     public static final String JAXRS_SUBSYSTEM = "jaxrs";// NOI18N
     public static final String JAXRS_RESOURCE = "jaxrs-resource";// NOI18N
@@ -239,6 +241,7 @@ public class Constants {
     public static final String LOG_BOOT = "log-boot";// NOI18N
     public static final String LOG_READ_ONLY = "log-read-only";// NOI18N
     public static final String MANAGEMENT = "management";// NOI18N
+    public static final String MANAGEMENT_HTTP = "management-http";// NOI18N
     public static final String MANAGEMENT_CLIENT_CONTENT = "management-client-content";// NOI18N
     public static final String MANAGEMENT_INTERFACE = "management-interface";// NOI18N
     public static final String MANAGEMENT_MAJOR_VERSION = "management-major-version";// NOI18N
@@ -512,5 +515,5 @@ public class Constants {
     public static final String WRITE = "write";// NOI18N
     public static final String WRITE_ATTRIBUTE_OPERATION = "write-attribute";// NOI18N
     public static final String XML_NAMESPACES = "xml-namespaces";// NOI18N
-
+    
 }

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesVisualPanel.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesVisualPanel.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-
 import javax.swing.AbstractListModel;
 import javax.swing.ComboBoxModel;
 import javax.swing.JComboBox;
@@ -38,7 +37,6 @@ import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-
 import org.openide.util.NbBundle;
 
 /**
@@ -138,8 +136,8 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         DomainComboModel model = (DomainComboModel) domainField.getModel();
         String path = model.getCurrentPath();
         domainPathField.setText(path);
-        portField.setText(WildflyPluginUtils.getHTTPConnectorPort(path));
-        managementPortField.setText(WildflyPluginUtils.getManagementConnectorPort(path));
+        portField.setText(String.valueOf(WildflyPluginUtils.getHTTPConnectorPort(path)));
+        managementPortField.setText(String.valueOf(WildflyPluginUtils.getManagementConnectorPort(path)));
         fireChangeEvent();
     }
 
@@ -410,7 +408,7 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         add(panel1, gridBagConstraints);
 
         hostField.setText("localhost");//NOI18N
-        portField.setText(WildflyPluginUtils.getHTTPConnectorPort(domainPathField.getText()));//NOI18N
+        portField.setText(String.valueOf(WildflyPluginUtils.getHTTPConnectorPort(domainPathField.getText())));//NOI18N
         domainChanged();
 
     }

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesVisualPanel.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesVisualPanel.java
@@ -28,18 +28,18 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+
 import javax.swing.AbstractListModel;
 import javax.swing.ComboBoxModel;
 import javax.swing.JComboBox;
-import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import org.openide.util.NbBundle;
 
+import org.openide.util.NbBundle;
 
 /**
  *
@@ -49,26 +49,27 @@ public class AddServerPropertiesVisualPanel extends JPanel {
 
     private final Set listeners = new HashSet();
 
-    private javax.swing.JComboBox  domainField;  // Domain name (list of registered domains) can be edited
+    private javax.swing.JComboBox domainField;  // Domain name (list of registered domains) can be edited
     private javax.swing.JTextField domainPathField;  //
-    private javax.swing.JLabel     domainLabel;
-    private javax.swing.JLabel     domainPathLabel;
-    private javax.swing.JLabel     label1;
-    private javax.swing.JPanel     panel1;
-    private javax.swing.JLabel     hostLabel;
+    private javax.swing.JLabel domainLabel;
+    private javax.swing.JLabel domainPathLabel;
+    private javax.swing.JLabel label1;
+    private javax.swing.JPanel panel1;
+    private javax.swing.JLabel hostLabel;
     private javax.swing.JTextField hostField;
-    private javax.swing.JLabel     portLabel;
+    private javax.swing.JLabel portLabel;
     private javax.swing.JTextField portField;
-    private javax.swing.JLabel     managementPortLabel;
+    private javax.swing.JLabel managementPortLabel;
     private javax.swing.JTextField managementPortField;
-    private javax.swing.JLabel     userLabel;
+    private javax.swing.JLabel userLabel;
     private javax.swing.JTextField userField;
-    private javax.swing.JLabel     passwordLabel;
+    private javax.swing.JLabel passwordLabel;
     private javax.swing.JPasswordField passwordField;
-    private javax.swing.JComboBox  serverType;  // Local or Remote
+    private javax.swing.JComboBox serverType;  // Local or Remote
 
-
-    /** Creates a new instance of AddServerPropertiesVisualPanel */
+    /**
+     * Creates a new instance of AddServerPropertiesVisualPanel
+     */
     public AddServerPropertiesVisualPanel() {
         init();
         setName(NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "TITLE_ServerProperties")); //NOI18N
@@ -80,7 +81,7 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         }
     }
 
-    public void removeChangeListener(ChangeListener l ) {
+    public void removeChangeListener(ChangeListener l) {
         synchronized (listeners) {
             listeners.remove(l);
         }
@@ -97,44 +98,44 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         }
         ChangeEvent ev = new ChangeEvent(this);
         while (it.hasNext()) {
-            ((ChangeListener)it.next()).stateChanged(ev);
+            ((ChangeListener) it.next()).stateChanged(ev);
         }
     }
 
-    public boolean isLocalServer(){
-        return  ("Local".equals(serverType.getSelectedItem()));
+    public boolean isLocalServer() {
+        return ("Local".equals(serverType.getSelectedItem()));
     }
 
-    public String getHost(){
+    public String getHost() {
         return hostField.getText().trim();
     }
 
-    public String getPort(){
+    public String getPort() {
         return portField.getText().trim();
     }
 
-    public String getManagementPort(){
+    public String getManagementPort() {
         return managementPortField.getText().trim();
     }
 
-    public String getUser(){
+    public String getUser() {
         return userField.getText();
     }
 
-    public String getPassword(){
+    public String getPassword() {
         return new String(passwordField.getPassword());
     }
 
-    public String getDomainPath(){
+    public String getDomainPath() {
         return domainPathField.getText();
     }
 
-    public String getDomain(){
-        return (String)domainField.getSelectedItem();
+    public String getDomain() {
+        return (String) domainField.getSelectedItem();
     }
 
-    private void domainChanged(){
-        DomainComboModel model = (DomainComboModel)domainField.getModel();
+    private void domainChanged() {
+        DomainComboModel model = (DomainComboModel) domainField.getModel();
         String path = model.getCurrentPath();
         domainPathField.setText(path);
         portField.setText(WildflyPluginUtils.getHTTPConnectorPort(path));
@@ -164,9 +165,9 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         domainChanged();
     }
 
-    private void serverTypeChanged(){
+    private void serverTypeChanged() {
 
-        if (isLocalServer()){  //NOI18N
+        if (isLocalServer()) {  //NOI18N
             domainLabel.setVisible(true);
             domainField.setVisible(true);
 
@@ -188,26 +189,24 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         somethingChanged();
     }
 
-    private void init(){
+    private void init() {
         java.awt.GridBagConstraints gridBagConstraints;
 
         label1 = new JLabel(NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "TXT_PROPERTY_TEXT")); //NOI18N
 
-        serverType = new JComboBox(new String[]{"Local","Remote"});//NOI18N
-        serverType.addActionListener(new ActionListener(){
+        serverType = new JComboBox(new String[]{"Local", "Remote"});//NOI18N
+        serverType.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 serverTypeChanged();
             }
         });
 
-
         domainPathLabel = new JLabel(NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "LBL_DomainPath"));//NOI18N
         domainPathField = new JTextField();
         domainPathField.setColumns(20);
         domainPathField.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "LBL_DomainPath"));
         domainPathField.getAccessibleContext().setAccessibleName(NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "LBL_DomainPath"));
-
 
         panel1 = new JPanel();
 
@@ -218,7 +217,8 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         domainField.getAccessibleContext().setAccessibleName(NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "LBL_Domain"));
         domainField.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "LBL_Domain"));
 
-        domainField.addActionListener(new ActionListener(){
+        domainField.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent e) {
                 domainChanged();
             }
@@ -269,7 +269,6 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         passwordField = new JPasswordField();
         passwordField.addKeyListener(new SomeChangesListener());
 
-
         setLayout(new java.awt.GridBagLayout());
 
         setFocusable(false);
@@ -283,15 +282,12 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 0);
         add(label1, gridBagConstraints);
 
-
-
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridy = 0;
         gridBagConstraints.gridx = 2;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 0);
 
         add(serverType, gridBagConstraints);
-
 
         //-------------- domain ---------------
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -300,16 +296,12 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         add(domainLabel, gridBagConstraints);
 
-
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridy = 1;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 0);
         add(domainField, gridBagConstraints);
-
-
-
 
         //-------------- domain path ---------------
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -334,7 +326,6 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         add(hostLabel, gridBagConstraints);
 
-
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridy = 3;
         gridBagConstraints.gridx = 1;
@@ -343,14 +334,12 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 0);
         add(hostField, gridBagConstraints);
 
-
         //-------------- port ---------------
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 6);
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         add(portLabel, gridBagConstraints);
-
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridy = 4;
@@ -366,14 +355,12 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         add(managementPortLabel, gridBagConstraints);
 
-
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridy = 5;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 0);
         add(managementPortField, gridBagConstraints);
-
 
         //-------------- User ---------------
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -382,7 +369,6 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         add(userLabel, gridBagConstraints);
 
-
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridy = 6;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
@@ -390,15 +376,12 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 0);
         add(userField, gridBagConstraints);
 
-
-
         //-------------- Password ---------------
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 6);
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         add(passwordLabel, gridBagConstraints);
-
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridy = 7;
@@ -415,14 +398,12 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
 
-
         domainPathField.setEnabled(false);
 
         userField.setVisible(true);
         userLabel.setVisible(true);
         passwordField.setVisible(true);
         passwordLabel.setVisible(true);
-
 
         serverType.setVisible(false);
 
@@ -434,158 +415,118 @@ public class AddServerPropertiesVisualPanel extends JPanel {
 
     }
 
-
-    class SomeChangesListener implements KeyListener{
-
-        @Override
-        public void keyTyped(KeyEvent e){}
+    private class SomeChangesListener implements KeyListener {
 
         @Override
-        public void keyPressed(KeyEvent e){}
-
-        @Override
-        public void keyReleased(KeyEvent e){ somethingChanged();}
-
-    }
-
-    private String browseDomainLocation(){
-        String insLocation = null;
-        JFileChooser chooser = getJFileChooser();
-        int returnValue = chooser.showDialog(this, NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "LBL_ChooseButton")); //NOI18N
-
-        if(returnValue == JFileChooser.APPROVE_OPTION){
-            insLocation = chooser.getSelectedFile().getAbsolutePath();
+        public void keyTyped(KeyEvent e) {
         }
-        return insLocation;
-    }
-
-    private JFileChooser getJFileChooser(){
-        JFileChooser chooser = new JFileChooser();
-
-        chooser.setDialogTitle("LBL_Chooser_Name"); //NOI18N
-        chooser.setDialogType(JFileChooser.CUSTOM_DIALOG);
-
-        chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-        chooser.setApproveButtonMnemonic("Choose_Button_Mnemonic".charAt(0)); //NOI18N
-        chooser.setMultiSelectionEnabled(false);
-        chooser.addChoosableFileFilter(new dirFilter());
-        chooser.setAcceptAllFileFilterUsed(false);
-        chooser.setApproveButtonToolTipText("LBL_Chooser_Name"); //NOI18N
-
-        chooser.getAccessibleContext().setAccessibleName("LBL_Chooser_Name"); //NOI18N
-        chooser.getAccessibleContext().setAccessibleDescription("LBL_Chooser_Name"); //NOI18N
-
-        return chooser;
-    }
-
-    private static class dirFilter extends javax.swing.filechooser.FileFilter {
 
         @Override
-        public boolean accept(File f) {
-            if(!f.exists() || !f.canRead() || !f.isDirectory() ) {
-                return false;
-            }else{
-                return true;
+        public void keyPressed(KeyEvent e) {
+        }
+
+        @Override
+        public void keyReleased(KeyEvent e) {
+            somethingChanged();
+        }
+
+    }
+
+    private class DomainComboModel extends AbstractListModel implements ComboBoxModel {
+
+        private int current = -1;
+        private String[][] domains = null;
+
+        public void addDomain(String domain, String path) {
+            String[][] newDomains = new String[domains.length + 1][2];
+            int i = 0;
+            for (; i < domains.length; i++) {
+                newDomains[i][0] = domains[i][0];
+                newDomains[i][1] = domains[i][1];
+            }
+            newDomains[i][0] = domain;
+            newDomains[i][1] = path;
+            domains = newDomains;
+
+        }
+
+        public DomainComboModel(Map domains) {
+            setDomains(domains);
+        }
+
+        public void setDomains(Map domains) {
+
+            current = -1;
+            this.domains = null;
+
+            int len = domains.size();
+            this.domains = new String[len][2];
+            Set en = domains.keySet();
+
+            if (len > 0) {
+                current = 0;
+            }
+
+            int i = 0;
+            for (Object key : en) {
+                this.domains[i][0] = (String) key;
+                this.domains[i][1] = (String) domains.get(this.domains[i][0]);
+                if (this.domains[i][0].equalsIgnoreCase("default")) //NOI18N
+                {
+                    current = i;
+                }
+                i++;
             }
         }
 
         @Override
-        public String getDescription() {
-            return NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "LBL_DirType"); //NOI18N
-        }
-
-    }
-
-}
-
-
-class DomainComboModel extends AbstractListModel implements ComboBoxModel{
-    private int current = -1;
-    private String[][] domains = null;
-
-
-    public void addDomain(String domain, String path){
-        String[][] newDomains = new String[domains.length+1][2];
-        int i = 0;
-        for(;i<domains.length; i++){
-            newDomains[i][0] = domains[i][0];
-            newDomains[i][1] = domains[i][1];
-        }
-        newDomains[i][0] = domain;
-        newDomains[i][1] = path;
-        domains = newDomains;
-
-    }
-
-    public DomainComboModel(Map domains){
-        setDomains(domains);
-    }
-
-    public void setDomains(Map domains) {
-
-        current = -1;
-        this.domains = null;
-
-        int len = domains.size();
-        this.domains = new String[len][2];
-        Set en = domains.keySet();
-
-        if (len > 0) current = 0;
-
-        int i = 0;
-        for(Object key : en) {
-            this.domains[i][0] = (String)key;
-            this.domains[i][1] = (String)domains.get(this.domains[i][0]);
-            if(this.domains[i][0].equalsIgnoreCase("default")) //NOI18N
-                current=i;
-            i++;
-        }
-    }
-
-    @Override
-    public Object  getSelectedItem() {
-        if (current ==-1 )
-            return "";
-        return domains[current][0];
-    }
-
-    @Override
-    public void setSelectedItem(Object anItem) {
-        for (int i = 0; i < getSize(); i++){
-            if (domains[i][0].equals(anItem)){
-                current = i;
-                fireContentsChanged(this, -1, -1);
-                return;
+        public Object getSelectedItem() {
+            if (current == -1) {
+                return "";
             }
+            return domains[current][0];
         }
-        current = -1;
-        //currentVal = (String)anItem;
-        fireContentsChanged(this, -1, -1);
-    }
 
-    @Override
-    public Object getElementAt(int index){
-        return domains[index][0];
-    }
-
-    @Override
-    public int 	getSize(){
-        return domains.length;
-    }
-    //----------------------------------------------------
-
-    public String getCurrentPath(){
-        if (current == -1) return "";
-        return domains[current][1];
-    }
-
-    public boolean hasDomain(String domain){
-        for (int i = 0; i < getSize(); i++){
-            if (domains[i][0].equals(domain)){
-                return true;
+        @Override
+        public void setSelectedItem(Object anItem) {
+            for (int i = 0; i < getSize(); i++) {
+                if (domains[i][0].equals(anItem)) {
+                    current = i;
+                    fireContentsChanged(this, -1, -1);
+                    return;
+                }
             }
+            current = -1;
+            //currentVal = (String)anItem;
+            fireContentsChanged(this, -1, -1);
         }
-        return false;
-    }
 
+        @Override
+        public Object getElementAt(int index) {
+            return domains[index][0];
+        }
+
+        @Override
+        public int getSize() {
+            return domains.length;
+        }
+        //----------------------------------------------------
+
+        public String getCurrentPath() {
+            if (current == -1) {
+                return "";
+            }
+            return domains[current][1];
+        }
+
+        public boolean hasDomain(String domain) {
+            for (int i = 0; i < getSize(); i++) {
+                if (domains[i][0].equals(domain)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+    }
 }

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginProperties.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginProperties.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils.Version;
 import org.openide.filesystems.FileLock;
 import org.openide.filesystems.FileObject;
@@ -29,11 +30,14 @@ import org.openide.filesystems.FileUtil;
 
 /**
  * Plugin Properties Singleton class
+ *
  * @author Ivan Sidorkin
  */
 public final class WildflyPluginProperties {
 
-    public static final String PROPERTY_DISPLAY_NAME ="displayName";//NOI18N
+    public static final int DEFAULT_HOST_PORT = 8080;
+    public static final int DEFAULT_ADMIN_PORT = 9990;
+    public static final String PROPERTY_DISPLAY_NAME = "displayName";//NOI18N
     public static final String PROPERTY_SERVER = "server";//NOI18N
     public static final String PROPERTY_DEPLOY_DIR = "deploy-dir";//NOI18N
     public static final String PROPERTY_SERVER_DIR = "server-dir";//NOI18N
@@ -50,17 +54,16 @@ public final class WildflyPluginProperties {
     private String configLocation;
     private Version serverVersion = WildflyPluginUtils.WILDFLY_8_0_0;
 
-
-    public static WildflyPluginProperties getInstance(){
-        if(pluginProperties==null){
+    public static WildflyPluginProperties getInstance() {
+        if (pluginProperties == null) {
             pluginProperties = new WildflyPluginProperties();
         }
         return pluginProperties;
     }
 
-
-
-    /** Creates a new instance of */
+    /**
+     * Creates a new instance of
+     */
     private WildflyPluginProperties() {
         java.io.InputStream inStream = null;
         try {
@@ -95,7 +98,7 @@ public final class WildflyPluginProperties {
             }
         }
         String loc = inProps.getProperty(INSTALL_ROOT_KEY);
-        if (loc!=null){// try to get the default value
+        if (loc != null) {// try to get the default value
             setInstallLocation(loc);
         }
     }
@@ -103,23 +106,21 @@ public final class WildflyPluginProperties {
     private static final String INSTALL_ROOT_KEY = "installRoot"; // NOI18N
     public static final String INSTALL_ROOT_PROP_NAME = "com.sun.aas.installRoot"; //NOI18N
 
-
-    private  FileObject propertiesFile = null;
+    private FileObject propertiesFile = null;
 
     private FileObject getPropertiesFile() throws java.io.IOException {
         FileObject dir = FileUtil.getConfigFile("J2EE");
         FileObject retVal = null;
         if (null != dir) {
-            retVal = dir.getFileObject("jb","properties"); // NOI18N
+            retVal = dir.getFileObject("jb", "properties"); // NOI18N
             if (null == retVal) {
-                retVal = dir.createData("jb","properties"); //NOI18N
+                retVal = dir.createData("jb", "properties"); //NOI18N
             }
         }
         return retVal;
     }
 
-
-    public void saveProperties(){
+    public void saveProperties() {
         Properties outProp = new Properties();
         String installRoot = getInstallLocation();
         if (installRoot != null) {
@@ -161,12 +162,11 @@ public final class WildflyPluginProperties {
     }
 
     public int getAdminPort() {
-        if(this.installLocation == null || WildflyPluginUtils.WILDFLY_8_0_0.compareTo(serverVersion) > 0){
+        if (this.installLocation == null || WildflyPluginUtils.WILDFLY_8_0_0.compareTo(serverVersion) > 0) {
             return 9999;
         }
-        return 9990;
+        return DEFAULT_ADMIN_PORT;
     }
-
 
     public void setInstallLocation(String installLocation) {
         if (installLocation.endsWith(File.separator)) {
@@ -187,16 +187,15 @@ public final class WildflyPluginProperties {
 
     public void setConfigLocation(String configLocation) {
         if (configLocation.endsWith(File.separator)) {
-            configLocation = configLocation.substring(0, configLocation.length() - 1);
+            this.configLocation = configLocation.substring(0, configLocation.length() - 1);
         }
         this.configLocation = configLocation;
     }
 
     public void setDomainLocation(String domainLocation) {
         if (domainLocation.endsWith(File.separator)) {
-            domainLocation = domainLocation.substring(0, domainLocation.length() - 1);
+            this.domainLocation = domainLocation.substring(0, domainLocation.length() - 1);
         }
-
         this.domainLocation = domainLocation;
     }
 

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
@@ -18,11 +18,10 @@
  */
 package org.netbeans.modules.javaee.wildfly.ide.ui;
 
-import java.io.File;
-
 import static java.io.File.separatorChar;
 
 import java.beans.PropertyVetoException;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.FilenameFilter;
@@ -34,11 +33,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.openide.filesystems.JarFileSystem;
@@ -188,7 +189,7 @@ public class WildflyPluginUtils {
     }
 
     public static boolean isGoodJBInstanceLocation(File serverDir, File candidate) {
-       return WildflyPluginUtils.isGoodJBInstanceLocation8x(serverDir, candidate);
+        return WildflyPluginUtils.isGoodJBInstanceLocation8x(serverDir, candidate);
     }
 
     private static boolean isGoodJBServerLocation(File candidate, List<String> requirements) {
@@ -211,12 +212,10 @@ public class WildflyPluginUtils {
     }
 
     /**
-     * Checks whether the given candidate has all required childrens. Children
-     * can be both files and directories. Method does not distinguish between
-     * them.
+     * Checks whether the given candidate has all required childrens. Children can be both files and
+     * directories. Method does not distinguish between them.
      *
-     * @return true if the candidate has all files/directories named in
-     * requiredChildren, false otherwise
+     * @return true if the candidate has all files/directories named in requiredChildren, false otherwise
      */
     private static boolean hasRequiredChildren(File candidate, List<String> requiredChildren) {
         if (null == candidate || null == candidate.list()) {
@@ -240,13 +239,11 @@ public class WildflyPluginUtils {
     }
 
     public static String getHTTPConnectorPort(String configFile) {
-        String defaultPort = "8080"; // NOI18N
-        return defaultPort;
+        return String.valueOf(WildflyPluginProperties.DEFAULT_HOST_PORT);
     }
 
-     public static String getManagementConnectorPort(String configFile) {
-        String defaultPort = "9990"; // NOI18N
-        return defaultPort;
+    public static String getManagementConnectorPort(String configFile) {
+        return String.valueOf(WildflyPluginProperties.DEFAULT_ADMIN_PORT);
     }
 
     /**
@@ -271,8 +268,8 @@ public class WildflyPluginUtils {
     }
 
     /**
-     * Return the version of the server located at the given path. If the server
-     * version can't be determined returns <code>null</code>.
+     * Return the version of the server located at the given path. If the server version can't be determined
+     * returns <code>null</code>.
      *
      * @param serverPath path to the server directory
      * @return specification version of the server
@@ -296,15 +293,15 @@ public class WildflyPluginUtils {
                 }
             }
         }
-        if(version == null) {
+        if (version == null) {
             return WILDFLY_8_0_0;
         }
         return version;
     }
 
     /**
-     * Return the version of the server located at the given path. If the server
-     * version can't be determined returns <code>null</code>.
+     * Return the version of the server located at the given path. If the server version can't be determined
+     * returns <code>null</code>.
      *
      * @param serverPath path to the server directory
      * @return specification version of the server using product.conf.
@@ -313,7 +310,7 @@ public class WildflyPluginUtils {
     public static Version getProductVersion(File serverPath) {
         assert serverPath != null : "Can't determine version with null server path"; // NOI18N
         String productConf = getProductConf(serverPath);
-        if(productConf != null) {
+        if (productConf != null) {
             try (FileReader reader = new FileReader(productConf)) {
                 Properties props = new Properties();
                 props.load(reader);
@@ -323,10 +320,10 @@ public class WildflyPluginUtils {
                     InputStream stream = new FileInputStream(manifestFile);
                     Manifest manifest = new Manifest(stream);
                     String productName = manifest.getMainAttributes().getValue("JBoss-Product-Release-Name");
-                    if(productName == null || productName.isEmpty()) {
+                    if (productName == null || productName.isEmpty()) {
                         productName = manifest.getMainAttributes().getValue("JBoss-Project-Release-Name");
                     }
-                    boolean wildfly =  productName == null || !productName.toLowerCase().contains("eap");
+                    boolean wildfly = productName == null || !productName.toLowerCase().contains("eap");
                     return new Version(manifest.getMainAttributes().getValue("JBoss-Product-Release-Version"), wildfly);
                 }
             } catch (Exception e) {
@@ -346,8 +343,8 @@ public class WildflyPluginUtils {
     }
 
     /**
-     * Check the product name of the server located at the given path. If the server
-     * version can't be determined returns <code>null</code>.
+     * Check the product name of the server located at the given path. If the server version can't be
+     * determined returns <code>null</code>.
      *
      * @param serverPath path to the server directory
      * @return specification version of the server using product.conf.
@@ -356,7 +353,7 @@ public class WildflyPluginUtils {
     public static boolean isWildFly(File serverPath) {
         assert serverPath != null : "Can't determine version with null server path"; // NOI18N
         String productConf = getProductConf(serverPath);
-        if(productConf != null) {
+        if (productConf != null) {
             try (FileReader reader = new FileReader(productConf)) {
                 Properties props = new Properties();
                 props.load(reader);
@@ -366,7 +363,7 @@ public class WildflyPluginUtils {
                     InputStream stream = new FileInputStream(manifestFile);
                     Manifest manifest = new Manifest(stream);
                     String productName = manifest.getMainAttributes().getValue("JBoss-Product-Release-Name");
-                    if(productName == null || productName.isEmpty()) {
+                    if (productName == null || productName.isEmpty()) {
                         productName = manifest.getMainAttributes().getValue("JBoss-Project-Release-Name");
                     }
                     return productName == null || !productName.toLowerCase().contains("eap");
@@ -379,8 +376,8 @@ public class WildflyPluginUtils {
     }
 
     /**
-     * Check the product name of the server located at the given path. If the server
-     * version can't be determined returns <code>null</code>.
+     * Check the product name of the server located at the given path. If the server version can't be
+     * determined returns <code>null</code>.
      *
      * @param serverPath path to the server directory
      * @return specification version of the server using product.conf.
@@ -389,9 +386,9 @@ public class WildflyPluginUtils {
     public static boolean isWildFlyServlet(File serverPath) {
         assert serverPath != null : "Can't determine version with null server path"; // NOI18N
         String productConf = getProductConf(serverPath);
-        if(productConf != null) {
+        if (productConf != null) {
             File productConfFile = new File(productConf);
-            if(productConfFile.exists() && productConfFile.canRead()) {
+            if (productConfFile.exists() && productConfFile.canRead()) {
                 try (FileReader reader = new FileReader(productConf)) {
                     Properties props = new Properties();
                     props.load(reader);
@@ -401,7 +398,7 @@ public class WildflyPluginUtils {
                         InputStream stream = new FileInputStream(manifestFile);
                         Manifest manifest = new Manifest(stream);
                         String productName = manifest.getMainAttributes().getValue("JBoss-Product-Release-Name");
-                        if(productName == null || productName.isEmpty()) {
+                        if (productName == null || productName.isEmpty()) {
                             productName = manifest.getMainAttributes().getValue("JBoss-Project-Release-Name");
                         }
                         return productName != null && (productName.contains("WildFly Web Lite") || productName.contains("WildFly Servlet"));
@@ -462,8 +459,8 @@ public class WildflyPluginUtils {
         private boolean wildfly = true;
 
         /**
-         * Constructs the version from the spec version string. Expected format
-         * is <code>MAJOR_NUMBER[.MINOR_NUMBER[.MICRO_NUMBER[.UPDATE]]]</code>.
+         * Constructs the version from the spec version string. Expected format is
+         * <code>MAJOR_NUMBER[.MINOR_NUMBER[.MICRO_NUMBER[.UPDATE]]]</code>.
          *
          * @param version spec version string with the following format:
          * <code>MAJOR_NUMBER[.MINOR_NUMBER[.MICRO_NUMBER[.UPDATE]]]</code>
@@ -524,12 +521,13 @@ public class WildflyPluginUtils {
         /**
          * {@inheritDoc}
          * <p>
-         * Two versions are equal if and only if they have same major, minor,
-         * micro number and update.
+         * Two versions are equal if and only if they have same major, minor, micro number and update.
          */
         @Override
         public boolean equals(Object obj) {
-            // XXX thiw want match compareTo contract in case there will be numbers like "1" and "01".
+            if (this == obj) {
+                return true;
+            }
             if (obj == null) {
                 return false;
             }
@@ -537,26 +535,16 @@ public class WildflyPluginUtils {
                 return false;
             }
             final Version other = (Version) obj;
-            if (this.majorNumber != other.majorNumber
-                    && (this.majorNumber == null || !this.majorNumber.equals(other.majorNumber))) {
+            if (!Objects.equals(this.majorNumber, other.getMajorNumber())) {
                 return false;
             }
-            if (this.minorNumber != other.minorNumber
-                    && (this.minorNumber == null || !this.minorNumber.equals(other.minorNumber))) {
+            if (!Objects.equals(this.minorNumber, other.getMinorNumber())) {
                 return false;
             }
-            if (this.microNumber != other.microNumber
-                    && (this.microNumber == null || !this.microNumber.equals(other.microNumber))) {
+            if (!Objects.equals(this.microNumber, other.getMicroNumber())) {
                 return false;
             }
-            if (this.update != other.update
-                    && (this.update == null || !this.update.equals(other.update))) {
-                return false;
-            }
-            if(this.wildfly != other.wildfly) {
-                return false;
-            }
-            return true;
+            return Objects.equals(this.update, other.getUpdate());
         }
 
         public boolean isWidlfy() {
@@ -581,9 +569,8 @@ public class WildflyPluginUtils {
         /**
          * {@inheritDoc}
          * <p>
-         * Compares the versions based on its major, minor, micro and update.
-         * Major number is the most significant. Implementation is consistent
-         * with {@link #equals(Object)}.
+         * Compares the versions based on its major, minor, micro and update. Major number is the most
+         * significant. Implementation is consistent with {@link #equals(Object)}.
          */
         @Override
         public int compareTo(Version o) {
@@ -591,12 +578,12 @@ public class WildflyPluginUtils {
             if (comparison != 0) {
                 return comparison;
             }
-            return update.compareTo(o.update);
+            return update.compareTo(o.getUpdate());
         }
 
         /**
-         * Compares the versions based on its major, minor, micro. Update field
-         * is ignored. Major number is the most significant.
+         * Compares the versions based on its major, minor, micro. Update field is ignored. Major number is
+         * the most significant.
          *
          * @param o version to compare with
          */
@@ -604,19 +591,19 @@ public class WildflyPluginUtils {
             if (o == null) {
                 return 1;
             }
-            if(this.wildfly != o.wildfly) {
-               return convertEAP(this).compareToIgnoreUpdate(convertEAP(o));
+            if (this.wildfly != o.isWidlfy()) {
+                return convertEAP(this).compareToIgnoreUpdate(convertEAP(o));
 
             }
-            int comparison = compare(majorNumber, o.majorNumber);
+            int comparison = compare(majorNumber, o.getMajorNumber());
             if (comparison != 0) {
                 return comparison;
             }
-            comparison = compare(minorNumber, o.minorNumber);
+            comparison = compare(minorNumber, o.getMinorNumber());
             if (comparison != 0) {
                 return comparison;
             }
-            return compare(microNumber, o.microNumber);
+            return compare(microNumber, o.getMicroNumber());
         }
 
         private Version convertEAP(Version version) {
@@ -632,8 +619,8 @@ public class WildflyPluginUtils {
         private int compare(String number1, String number2) {
             if (number1.length() != number2.length()) {
                 try {
-                    Integer i1 = Integer.parseInt(number1);
-                    Integer i2 = Integer.parseInt(number2);
+                    Integer i1 = Integer.valueOf(number1);
+                    Integer i2 = Integer.valueOf(number2);
                     return i1.compareTo(i2);
                 } catch (NumberFormatException ex) {
                     // compare as strings below

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/util/WildflyVariableResolver.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/util/WildflyVariableResolver.java
@@ -1,0 +1,59 @@
+package org.netbeans.modules.javaee.wildfly.util;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A resolver for variables from the wildfly configuration (standalone.xml).
+ */
+public class WildflyVariableResolver {
+
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("^\\$\\{([\\w|\\.|-]+)(?>:?)(\\S+)?\\}$");
+    private static final int VARIABLE_GROUP = 1;
+    private static final int FALLBACK_GROUP = 2;
+
+    /**
+     * Resolves the given (possibly variable) expression.
+     * <li>If the expression does not match the variable layout ("${}"), the expression itself is
+     * returned.</li>
+     * <li>If the expression matches the variable layout, an attempt to resolve the variable is made:</li>
+     * <ul>
+     * <li>If the variable could be resolved from a system property, the value of that property is
+     * assumed.</li>
+     * <li>If the variable could not be resolved from a system property, but from an environment variable, the
+     * value of that variable is assumed.</li>
+     * <li>If the variable could not be resolved from a system property or environment variable, the fallback
+     * value of the expression is assumed (the value after the ":" in the expression).</li>
+     * <li>If no fallback was defined in the expression, {@code null} is assumed.</li>
+     * </ul>
+     *
+     * @param expression The expression to resolve, might be a variable expression containing a fallback or
+     * not.
+     * @return An {@link Optional} containing the resolved value which might be {@code null},
+     */
+    public static Optional<String> resolve(String expression) {
+        Matcher matcher = VARIABLE_PATTERN.matcher(expression);
+        String result = expression;
+        if (matcher.matches()) {
+            String variableKey = matcher.group(VARIABLE_GROUP);
+            String variableValue = lookupProperty(variableKey);
+            if (variableValue == null) {
+                result = matcher.group(FALLBACK_GROUP);
+            } else {
+                result = variableValue;
+            }
+        }
+        return Optional.ofNullable(result);
+    }
+
+    private static String lookupProperty(String key) {
+        if (System.getProperty(key) != null) {
+            return System.getProperty(key);
+        }
+        if (System.getenv(key) != null) {
+            return System.getenv(key);
+        }
+        return null;
+    }
+}

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/util/WildflyVariableResolver.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/util/WildflyVariableResolver.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.netbeans.modules.javaee.wildfly.util;
 
 import java.util.Optional;

--- a/enterprise/javaee.wildfly/test/unit/src/org/netbeans/modules/javaee/wildfly/config/xml/ConfigurationParserTest.java
+++ b/enterprise/javaee.wildfly/test/unit/src/org/netbeans/modules/javaee/wildfly/config/xml/ConfigurationParserTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javaee.wildfly.config.xml;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.netbeans.modules.j2ee.deployment.common.api.SocketBinding;
+import org.netbeans.modules.javaee.wildfly.config.SocketContainer;
+import org.openide.filesystems.FileUtil;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+public class ConfigurationParserTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testSocketRetrieval() throws Exception {
+        File createdFile = folder.newFile("myfile.txt");
+        setupXml(createdFile);
+        ConfigurationParser parser = ConfigurationParser.INSTANCE;
+        Optional<SocketContainer> sockets = parser.getSockets(FileUtil.toFileObject(createdFile));
+        assertEquals(7, sockets.get().getSocketBindings().size());
+        Optional<SocketBinding> socketByName = sockets.get().getSocketByName("management-http");
+        assertTrue(socketByName.isPresent());
+        SocketBinding socketBinding = socketByName.get();
+        assertEquals(socketBinding.getInterfaceName(), "management");
+        assertEquals(socketBinding.getPort(), 19990);
+    }
+
+    private void setupXml(File file) throws Exception {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+            writer.write(getXml());
+        }
+    }
+
+    private String getXml() {
+        return "<server>\n"
+                + "<interfaces>\n"
+                + "        <interface name=\"management\">\n"
+                + "            <inet-address value=\"${jboss.bind.address.management:127.0.0.1}\"/>\n"
+                + "        </interface>\n"
+                + "        <interface name=\"public\">\n"
+                + "            <inet-address value=\"${jboss.bind.address:127.0.0.1}\"/>\n"
+                + "        </interface>\n"
+                + "    </interfaces>\n"
+                + "    <socket-binding-group name=\"standard-sockets\" default-interface=\"public\" port-offset=\"${jboss.socket.binding.port-offset:10000}\">\n"
+                + "        <socket-binding name=\"ajp\" port=\"${jboss.ajp.port:8009}\"/>\n"
+                + "        <socket-binding name=\"http\" port=\"${jboss.http.port:8080}\"/>\n"
+                + "        <socket-binding name=\"https\" port=\"${jboss.https.port:8443}\"/>\n"
+                + "        <socket-binding name=\"management-http\" interface=\"management\" port=\"${jboss.management.http.port:9990}\"/>\n"
+                + "        <socket-binding name=\"management-https\" interface=\"management\" port=\"${jboss.management.https.port:9993}\"/>\n"
+                + "        <socket-binding name=\"txn-recovery-environment\" port=\"4712\"/>\n"
+                + "        <socket-binding name=\"txn-status-manager\" port=\"4713\"/>\n"
+                + "        <outbound-socket-binding name=\"mail-smtp\">\n"
+                + "            <remote-destination host=\"${jboss.mail.server.host:localhost}\" port=\"${jboss.mail.server.port:25}\"/>\n"
+                + "        </outbound-socket-binding>\n"
+                + "    </socket-binding-group>"
+                + "</server>";
+
+    }
+
+}

--- a/enterprise/javaee.wildfly/test/unit/src/org/netbeans/modules/javaee/wildfly/util/WildflyVariableResolverTest.java
+++ b/enterprise/javaee.wildfly/test/unit/src/org/netbeans/modules/javaee/wildfly/util/WildflyVariableResolverTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javaee.wildfly.util;
+
+import static junit.framework.TestCase.*;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+public class WildflyVariableResolverTest {
+
+    @Test
+    public void testNoVariable() {
+        Optional<String> resolve = WildflyVariableResolver.resolve("1000");
+        assertEquals("1000", resolve.get());
+    }
+
+    @Test
+    public void testSystemVariableOnly() {
+        System.setProperty("jboss.management.http.port", "5050");
+        Optional<String> resolve = WildflyVariableResolver.resolve("${jboss.management.http.port}");
+        assertEquals("5050", resolve.get());
+    }
+
+    @Test
+    public void testSystemVariableWithFallback() {
+        System.setProperty("jboss.management.http.port", "9000");
+        Optional<String> resolve = WildflyVariableResolver.resolve("${jboss.management.http.port:3455}");
+        assertEquals("9000", resolve.get());
+    }
+
+    @Test
+    public void testUnavailableVariableWithFallback() {
+        System.clearProperty("jboss.management.http.port");
+        Optional<String> resolve = WildflyVariableResolver.resolve("${jboss.management.http.port:5050}");
+        assertEquals("5050", resolve.get());
+    }
+
+    @Test
+    public void testUnavailableVariableWithoutFallback() {
+        System.clearProperty("jboss.management.http.port");
+        Optional<String> resolve = WildflyVariableResolver.resolve("${jboss.management.http.port}");
+        assertFalse(resolve.isPresent());
+    }
+
+}


### PR DESCRIPTION
This PR fixes an issue with Wildfly servers. I noticed that, after successfully starting a Wildfly (JBoss) server, I was not able to restart or stop the instance in the `Services->Server->rightclick on server`-view. The respective menu items were grayed out, instead it was possible to start the server (although it was already running).
I investigated that and found out, that NetBeans did not take into account the port offset that can be specified in the `standalone.xml` server config file. Hence, in case a port offset is specified, NetBeans always checks against the wrong port and does not recognize a correctly started server.

What I did:
* I bundled hardcoded port numbers in a single place.
* I added a handler for port bindings from the config file, that also saves the port offset.
* When the server is set up, the config file is parsed and the offset added to the ports specified in the NetBeans server wizard.
* I refactored some code, mostly related to the files I touched anyway, hopefully not too much.

I tested this successfully on my machine, but I am not sure whether there are any side effects that I did not fathom.
Two things that I'd like to ask:
* Should NetBeans show a hint in the wizard when a port offset is detected, so the user knows the ports he enters are not the ones under which the running instance is reachable?
* While testing I got a bunch of warnings: `Parameter file was not normalized...` from `FileUtil#getFileObject`. After a clean build those warnings disappeared, they did not seem to do any harm. Why did that happen?