### PR TITLE
Support port offset for wildfly server

### DIFF
--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
@@ -56,6 +56,7 @@ import org.netbeans.modules.javaee.wildfly.ide.commands.WildflyModule;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties;
 import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_ADMIN_PORT;
 import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.PROPERTY_ADMIN_PORT;
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.PROPERTY_CONFIG_FILE;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils.Version;
 import org.netbeans.modules.javaee.wildfly.util.WildFlyProperties;
@@ -104,10 +105,13 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
         version = WildflyPluginUtils.getServerVersion(serverPath);
         isWildfly = WildflyPluginUtils.isWildFly(serverPath);
         int controllerPort = DEFAULT_ADMIN_PORT;
+        String configFilePath = instanceProperties.getProperty(PROPERTY_CONFIG_FILE);
+        int portOffset = getPortOffsetOrDefault(configFilePath, WildflyPluginProperties.DEFAULT_PORT_OFFSET);
         String adminPort = this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT);
         if(adminPort != null) {
             controllerPort = Integer.parseInt(this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT));
         }
+        controllerPort += portOffset;
         if (username != null && password != null) {
             this.client = new WildflyClient(instanceProperties, version, getHost(), controllerPort, username, password);
         } else {
@@ -483,4 +487,10 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
         return progress;
     }
 
+    private int getPortOffsetOrDefault(String configFilePath, int defaultOffset) {
+        if (configFilePath != null) {
+            return WildflyPluginUtils.getStandardSocketsDefaultPortOffset(configFilePath);
+        }
+        return defaultOffset;
+    }
 }

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
@@ -54,9 +54,8 @@ import org.netbeans.modules.javaee.wildfly.deploy.WildflyProgressObject;
 import org.netbeans.modules.javaee.wildfly.ide.commands.WildflyClient;
 import org.netbeans.modules.javaee.wildfly.ide.commands.WildflyModule;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties;
-
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_ADMIN_PORT;
 import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.PROPERTY_ADMIN_PORT;
-
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils.Version;
 import org.netbeans.modules.javaee.wildfly.util.WildFlyProperties;
@@ -70,7 +69,6 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
     private static final Logger LOGGER = Logger.getLogger(WildflyDeploymentManager.class.getName());
 
     private static final int DEBUGGING_PORT = 8787;
-    private static final int CONTROLLER_PORT = 9990;
 
     private final Version version;
     private final boolean isWildfly;
@@ -105,7 +103,7 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
         File serverPath = new File(this.instanceProperties.getProperty(WildflyPluginProperties.PROPERTY_ROOT_DIR));
         version = WildflyPluginUtils.getServerVersion(serverPath);
         isWildfly = WildflyPluginUtils.isWildFly(serverPath);
-        int controllerPort = CONTROLLER_PORT;
+        int controllerPort = DEFAULT_ADMIN_PORT;
         String adminPort = this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT);
         if(adminPort != null) {
             controllerPort = Integer.parseInt(this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT));

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/ConfigurationParser.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/ConfigurationParser.java
@@ -22,12 +22,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import org.netbeans.modules.j2ee.deployment.common.api.Datasource;
 import org.netbeans.modules.javaee.wildfly.config.xml.ds.WildflyDatasourcesHandler;
+import org.netbeans.modules.javaee.wildfly.config.xml.sockets.WildflySocketBindingGroupHandler;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
 import org.xml.sax.SAXException;
@@ -73,5 +75,31 @@ public class ConfigurationParser {
             }
         }
         return null;
+    }
+
+    /**
+     * Retrieve the default port offset for the standard socket group from the given XML config file.
+     *
+     * @param xmlFile The XML config {@link FileObject}.
+     * @return An |@link Optional} containing the parsed default port offset or |@code null}, if none was
+     * defined.
+     */
+    public Optional<Integer> getStandardSocketsPortOffset(FileObject xmlFile) {
+        try (InputStream data = xmlFile.getInputStream()) {
+            SAXParser sp = getConfiguredParser();
+            WildflySocketBindingGroupHandler socketsHandler = new WildflySocketBindingGroupHandler();
+            sp.parse(data, socketsHandler);
+            return Optional.of(socketsHandler.getStandardSocketsPortOffset());
+        } catch (SAXException | ParserConfigurationException | IOException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        return Optional.empty();
+    }
+
+    private SAXParser getConfiguredParser() throws ParserConfigurationException, SAXException {
+        SAXParserFactory spf = SAXParserFactory.newInstance();
+        SAXParser sp = spf.newSAXParser();
+        sp.getXMLReader().setFeature(LOAD_EXTERNAL_DTD_FEATURE, false);
+        return sp;
     }
 }

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBindingGroupHandler.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBindingGroupHandler.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javaee.wildfly.config.xml.sockets;
+
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.NAME;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.PORT_OFFSET;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.SOCKET_BINDING_GROUP;
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_PORT_OFFSET;
+import org.netbeans.modules.javaee.wildfly.util.WildflyDefaultValueExtractor;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * A {@link DefaultHandler} for Wildfly socket binding groups.
+ * <p>
+ * Currently, only the port offset of the standard sockets section is read. In case more information from the
+ * socket binding group or the sockets defined there is needed, this class must be aádapted.
+ */
+public class WildflySocketBindingGroupHandler extends DefaultHandler {
+
+    private static final String STANDARD_SOCKETS = "standard-sockets";
+
+    private int portOffset = DEFAULT_PORT_OFFSET;
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+        if (SOCKET_BINDING_GROUP.equals(qName) && STANDARD_SOCKETS.equals(attributes.getValue(uri, NAME))) {
+            String portOffsetVariable = attributes.getValue(uri, PORT_OFFSET);
+            portOffset = WildflyDefaultValueExtractor.extract(portOffsetVariable)
+                    .map(WildflySocketBindingGroupHandler::parsePort)
+                    .orElse(DEFAULT_PORT_OFFSET);
+        }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        // no need to track end of group
+    }
+
+    /**
+     * Retrieve the port offset from the standard ports section of the configuration file.
+     *
+     * @return The offset.
+     */
+    public int getStandardSocketsPortOffset() {
+        return portOffset;
+    }
+
+    private static Integer parsePort(String value) {
+        try {
+            return Integer.valueOf(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+}

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/commands/Constants.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/commands/Constants.java
@@ -200,6 +200,7 @@ public class Constants {
     public static final String HOST_SCOPED_ROLE = "host-scoped-role";// NOI18N
     public static final String HOST_SCOPED_ROLES = "host-scoped-roles";// NOI18N
     public static final String HOST_STATE = "host-state";// NOI18N
+    public static final String MANAGEMENT_HTTP = "management-http";// NOI18N
     public static final String HTTP_UPGRADE_ENABLED = "http-upgrade-enabled";// NOI18N
     public static final String HTTP_INTERFACE = "http-interface";// NOI18N
     public static final String IGNORED = "ignored-by-unaffected-host-controller";// NOI18N

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginProperties.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginProperties.java
@@ -33,6 +33,8 @@ import org.openide.filesystems.FileUtil;
  */
 public final class WildflyPluginProperties {
 
+    public static final int DEFAULT_HTTP_PORT = 8080;
+    public static final int DEFAULT_ADMIN_PORT = 9990;
     public static final String PROPERTY_DISPLAY_NAME ="displayName";//NOI18N
     public static final String PROPERTY_SERVER = "server";//NOI18N
     public static final String PROPERTY_DEPLOY_DIR = "deploy-dir";//NOI18N
@@ -164,7 +166,7 @@ public final class WildflyPluginProperties {
         if(this.installLocation == null || WildflyPluginUtils.WILDFLY_8_0_0.compareTo(serverVersion) > 0){
             return 9999;
         }
-        return 9990;
+        return DEFAULT_ADMIN_PORT;
     }
 
 

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginProperties.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginProperties.java
@@ -35,6 +35,7 @@ public final class WildflyPluginProperties {
 
     public static final int DEFAULT_HTTP_PORT = 8080;
     public static final int DEFAULT_ADMIN_PORT = 9990;
+    public static final int DEFAULT_PORT_OFFSET = 0;
     public static final String PROPERTY_DISPLAY_NAME ="displayName";//NOI18N
     public static final String PROPERTY_SERVER = "server";//NOI18N
     public static final String PROPERTY_DEPLOY_DIR = "deploy-dir";//NOI18N

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
@@ -39,8 +39,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.modules.javaee.wildfly.config.xml.ConfigurationParser;
 import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_ADMIN_PORT;
 import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_HTTP_PORT;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.JarFileSystem;
 
 /**
@@ -245,6 +248,22 @@ public class WildflyPluginUtils {
 
      public static String getManagementConnectorPort(String configFile) {
         return String.valueOf(DEFAULT_ADMIN_PORT);
+    }
+
+     /**
+      * Retrieve the default port offset from the standard sockets group from the config file.
+      * If none was defined, {@link WildflyPluginProperties#DEFAULT_PORT_OFFSET} is returned.
+      * <p>
+      * Once NetBeans lets the user specify an offset themself, this method should be adapted to return
+      * the user offset with precedence.
+      * @param configFile The config file path as string.
+      * @return The offset.
+      */
+    public static int getStandardSocketsDefaultPortOffset(String configFile) {
+        File config = new File(configFile);
+        FileObject configFileObject = FileUtil.toFileObject(config);
+        return ConfigurationParser.INSTANCE.getStandardSocketsPortOffset(configFileObject)
+            .orElse(WildflyPluginProperties.DEFAULT_PORT_OFFSET);
     }
 
     /**

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
@@ -18,11 +18,9 @@
  */
 package org.netbeans.modules.javaee.wildfly.ide.ui;
 
-import java.io.File;
-
-import static java.io.File.separatorChar;
-
 import java.beans.PropertyVetoException;
+import java.io.File;
+import static java.io.File.separatorChar;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.FilenameFilter;
@@ -41,6 +39,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_ADMIN_PORT;
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_HTTP_PORT;
 import org.openide.filesystems.JarFileSystem;
 
 /**
@@ -240,13 +240,11 @@ public class WildflyPluginUtils {
     }
 
     public static String getHTTPConnectorPort(String configFile) {
-        String defaultPort = "8080"; // NOI18N
-        return defaultPort;
+        return String.valueOf(DEFAULT_HTTP_PORT);
     }
 
      public static String getManagementConnectorPort(String configFile) {
-        String defaultPort = "9990"; // NOI18N
-        return defaultPort;
+        return String.valueOf(DEFAULT_ADMIN_PORT);
     }
 
     /**

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/util/WildflyDefaultValueExtractor.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/util/WildflyDefaultValueExtractor.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javaee.wildfly.util;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A default value extractor for variables from the wildfly configuration (standalone.xml).
+ */
+public class WildflyDefaultValueExtractor {
+
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("^\\$\\{\\S+:(\\S+)\\}$");
+    private static final int DEFAULT_VALUE_GROUP = 1;
+
+    /**
+     * Retrieve default value from the given (possibly variable) expression.
+     * <p>
+     * If the expression matches the variable layout "${key:default}", an optional containing the default is
+     * returned. In all other cases, an empty optional is returned.
+     *
+     * @param expression The expression to extract the default value from, might be a variable expression
+     * containing a default or not.
+     * @return An {@link Optional} containing the default value or an empty optional.
+     */
+    public static Optional<String> extract(String expression) {
+        if (expression != null) {
+            Matcher matcher = VARIABLE_PATTERN.matcher(expression);
+            if (matcher.matches()) {
+                return Optional.of(matcher.group(DEFAULT_VALUE_GROUP));
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/enterprise/javaee.wildfly/test/unit/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBindingGroupHandlerTest.java
+++ b/enterprise/javaee.wildfly/test/unit/src/org/netbeans/modules/javaee/wildfly/config/xml/sockets/WildflySocketBindingGroupHandlerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javaee.wildfly.config.xml.sockets;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.NAME;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.PORT_OFFSET;
+import static org.netbeans.modules.javaee.wildfly.ide.commands.Constants.SOCKET_BINDING_GROUP;
+import org.xml.sax.Attributes;
+import static junit.framework.TestCase.assertEquals;
+
+public class WildflySocketBindingGroupHandlerTest {
+
+    @Test
+    public void testHandling() throws Exception {
+        WildflySocketBindingGroupHandler handler = new WildflySocketBindingGroupHandler();
+        final TestAttributes testAttributes = new TestAttributes();
+        testAttributes.addAttribute(NAME, "standard-sockets");
+        testAttributes.addAttribute(PORT_OFFSET, "${jboss.management.http.port:3455}");
+        handler.startElement("", "", SOCKET_BINDING_GROUP, testAttributes);
+        int standardSocketsPortOffset = handler.getStandardSocketsPortOffset();
+        assertEquals(3455, standardSocketsPortOffset);
+    }
+
+    private static final class TestAttributes implements Attributes {
+
+        private final Map<String, String> attributes = new HashMap<>();
+
+        void addAttribute(String localName, String value) {
+            attributes.put(localName, value);
+        }
+
+        @Override
+        public int getLength() {
+            throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        }
+
+        @Override
+        public String getURI(int index) {
+            throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        }
+
+        @Override
+        public String getLocalName(int index) {
+            throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        }
+
+        @Override
+        public String getQName(int index) {
+            throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        }
+
+        @Override
+        public String getType(int index) {
+            throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        }
+
+        @Override
+        public String getValue(int index) {
+            throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        }
+
+        @Override
+        public int getIndex(String uri, String localName) {
+            throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        }
+
+        @Override
+        public int getIndex(String qName) {
+            throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        }
+
+        @Override
+        public String getType(String uri, String localName) {
+            throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        }
+
+        @Override
+        public String getType(String qName) {
+            throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        }
+
+        @Override
+        public String getValue(String uri, String localName) {
+            return attributes.get(localName);
+        }
+
+        @Override
+        public String getValue(String qName) {
+            throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        }
+
+    }
+
+}

--- a/enterprise/javaee.wildfly/test/unit/src/org/netbeans/modules/javaee/wildfly/util/WildflyDefaultValueExtractorTest.java
+++ b/enterprise/javaee.wildfly/test/unit/src/org/netbeans/modules/javaee/wildfly/util/WildflyDefaultValueExtractorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javaee.wildfly.util;
+
+import java.util.Optional;
+import org.junit.Test;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+
+public class WildflyDefaultValueExtractorTest {
+
+    @Test
+    public void testNullInput() {
+        Optional<String> resolve = WildflyDefaultValueExtractor.extract(null);
+        assertFalse(resolve.isPresent());
+    }
+
+    @Test
+    public void testEmptyInput() {
+        Optional<String> resolve = WildflyDefaultValueExtractor.extract("");
+        assertFalse(resolve.isPresent());
+    }
+
+    @Test
+    public void testRandomInput() {
+        Optional<String> resolve = WildflyDefaultValueExtractor.extract("key=3344;value=12");
+        assertFalse(resolve.isPresent());
+    }
+
+    @Test
+    public void testVariableOnly() {
+        Optional<String> resolve = WildflyDefaultValueExtractor.extract("${jboss.management.http.port}");
+        assertFalse(resolve.isPresent());
+    }
+
+    @Test
+    public void testVariableWithDefault() {
+        Optional<String> resolve = WildflyDefaultValueExtractor.extract("${jboss.management.http.port:3455}");
+        assertEquals("3455", resolve.get());
+    }
+
+}


### PR DESCRIPTION
This solves the same issue as mentioned in #5453, but cleaner.
The problem: Wildfly servers are configured with XML files like `standalone.xml`. Those contain socket binding groups that comprise a bunch of ports and can have a port offset defined. One such group is the `standard-sockets` group in which for example the management port is defined. All variables in the config file can (must?) be written like `${jboss.socket.binding.port-offset:10000}`, that is, a variable and the fallback (or default) value separated by a `:`.
NetBeans does not set the port-offset variable, hence the default from the config file is used, but NetBeans does not parse it either so the Wildfly server runs on a different port as known by NetBeans. That leads to a correctly started server that can't be restarted, stopped or refreshed from the NetBeans server context view (but it is possible to start it regularly).

I fixed this by parsing the config and extracting the default port offset from the standard socket group. The offset is then added to the admin port value (which can be set in the add server wizard) in the deployment manager.

I did not add the offset to the regular port, because I have not yet found an issue with that (most likely I will, sooner or later) and that would mean touching a lot more files.