### PR TITLE
Fix double initialization of comboHelper in Persistence Provider

### DIFF
--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardPanelDS.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardPanelDS.java
@@ -79,8 +79,6 @@ public class PersistenceUnitWizardPanelDS extends PersistenceUnitWizardPanel imp
             checkValidity(); 
         });
         
-        PersistenceProviderComboboxHelper comboHelper = new PersistenceProviderComboboxHelper(project);
-        comboHelper.connect(providerCombo);
         unitNameTextField.setText(Util.getCandidateName(project));
         unitNameTextField.selectAll();
 

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardPanelJdbc.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/unit/PersistenceUnitWizardPanelJdbc.java
@@ -85,7 +85,7 @@ public class PersistenceUnitWizardPanelJdbc extends PersistenceUnitWizardPanel{
         
         unitNameTextField.getDocument().addDocumentListener(new ValidationListener());
         errorMessage.setForeground(Color.RED);
-                updateWarning();
+        updateWarning();
     }
     
     


### PR DESCRIPTION
The ComboboxHelper is already initialized in an asyc task a few statements before. See sister class `PersistenceUnitWizardPanelJdbc.java`

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of unit tests for module j2ee.persistence
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS

![Fix-double-provider-combobox](https://user-images.githubusercontent.com/9832133/218343253-89a21dc5-a09f-4359-9999-e1b3a3bb2d49.png)
![before-fix](https://user-images.githubusercontent.com/9832133/218343263-5efcd74b-a432-4c05-afa7-4ca607cb0a66.png)



