### PR TITLE
Removed a lot of compiler warnings. Part 2

### DIFF
--- a/contrib/j2ee.jboss4/src/org/netbeans/modules/j2ee/jboss4/JBDeploymentManager.java
+++ b/contrib/j2ee.jboss4/src/org/netbeans/modules/j2ee/jboss4/JBDeploymentManager.java
@@ -104,7 +104,7 @@ public class JBDeploymentManager implements DeploymentManager {
      *  running state by Boolean.TRUE, stopped state Boolean.FALSE.
      * WeakHashMap should guarantee erasing of an unregistered server instance bcs instance properties are also removed along with instance.
      */
-    private static final Map<InstanceProperties, Boolean> propertiesToIsRunning = Collections.synchronizedMap(new WeakHashMap());
+    private static final Map<InstanceProperties, Boolean> propertiesToIsRunning = Collections.synchronizedMap(new WeakHashMap<>());
 
     /** Creates a new instance of JBDeploymentManager */
     public JBDeploymentManager(DeploymentFactory df, String realUri,

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
@@ -84,7 +84,7 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
      * instance.
      */
     private static final Map<InstanceProperties, Boolean> PROPERTIES_TO_IS_RUNNING
-            = Collections.synchronizedMap(new WeakHashMap());
+            = Collections.synchronizedMap(new WeakHashMap<>());
 
     private final DeploymentFactory df;
 

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/optional/StartTomcat.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/optional/StartTomcat.java
@@ -929,7 +929,7 @@ public final class StartTomcat extends StartServer implements ProgressObject {
         private static final long serialVersionUID = 992972967554321415L;
         
         public TomcatFormat(File startupScript, File homeDir) {
-            super(new HashMap());
+            super(new HashMap<>());
             Map<String, String> map = getMap();
             String scriptPath = startupScript.getAbsolutePath();
             map.put(TAG_EXEC_CMD,       scriptPath);

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogManager.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogManager.java
@@ -45,8 +45,8 @@ public class LogManager {
     private ServerLog serverLog;    
     private LogViewer sharedContextLogViewer;
     private LogViewer juliLogViewer;
-    private Map<TomcatModule, TomcatModuleConfig> tomcatModuleConfigs = Collections.synchronizedMap(new WeakHashMap());
-    private Map<String, LogViewer> contextLogViewers = Collections.synchronizedMap(new HashMap());
+    private Map<TomcatModule, TomcatModuleConfig> tomcatModuleConfigs = Collections.synchronizedMap(new WeakHashMap<>());
+    private Map<String, LogViewer> contextLogViewers = Collections.synchronizedMap(new HashMap<>());
     private TomcatManager manager;
     
     private final Object serverLogLock = new Object();

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogSupport.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogSupport.java
@@ -44,7 +44,7 @@ import org.openide.windows.*;
  * @author  Stepan Herold
  */
 public class LogSupport {
-    private Map<Link, Link> links = Collections.synchronizedMap(new HashMap());
+    private Map<Link, Link> links = Collections.synchronizedMap(new HashMap<>());
     private Annotation errAnnot;
     
     /**

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/wizard/fromdb/EjbFacadeGenerator.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/wizard/fromdb/EjbFacadeGenerator.java
@@ -217,7 +217,7 @@ public class EjbFacadeGenerator implements FacadeGenerator {
                             maker.Modifiers(EnumSet.of(Modifier.PUBLIC, 
                                     Modifier.ABSTRACT)),
                             classTree.getSimpleName(),
-                            Arrays.asList(maker.TypeParameter(genericsTypeName, 
+                            Arrays.asList(maker.TypeParameter(genericsTypeName,
                                     Collections.EMPTY_LIST)),
                             null,
                             Collections.EMPTY_LIST,

--- a/ide/extbrowser/src/org/netbeans/modules/extbrowser/ExtWebBrowser.java
+++ b/ide/extbrowser/src/org/netbeans/modules/extbrowser/ExtWebBrowser.java
@@ -489,7 +489,7 @@ public class ExtWebBrowser implements HtmlBrowser.Factory, java.io.Serializable,
          * @param url to specify URL
          */
         public UnixBrowserFormat (String url) {
-            super(new java.util.HashMap ());
+            super(new java.util.HashMap<>());
             java.util.Map map = getMap ();        
             map.put (TAG_URL, url);
         }

--- a/ide/extbrowser/src/org/netbeans/modules/extbrowser/SimpleExtBrowser.java
+++ b/ide/extbrowser/src/org/netbeans/modules/extbrowser/SimpleExtBrowser.java
@@ -108,7 +108,7 @@ public class SimpleExtBrowser extends ExtWebBrowser {
          * @param library library path
          */
         public BrowserFormat (String url) {
-            super(new HashMap());
+            super(new HashMap<>());
             java.util.Map map = getMap ();
             
             map.put (TAG_URL, url);

--- a/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ScanStartedTest.java
+++ b/ide/parsing.indexing/test/unit/src/org/netbeans/modules/parsing/impl/indexing/ScanStartedTest.java
@@ -120,7 +120,7 @@ public class ScanStartedTest extends IndexingTestBase {
         cp1 = ClassPathSupport.createClassPath(src1);
         bcp1 = ClassPathSupport.createClassPath(bin1);
         FooCPP.roots2cps = Collections.unmodifiableMap(
-                new HashMap() {
+                new HashMap<>() {
                     {
                         put(src1, Collections.singletonMap(FOO_SOURCES, cp1));
                         put(bin1, Collections.singletonMap(FOO_BINARY, bcp1));

--- a/ide/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/WSDLInlineSchemaValidator.java
+++ b/ide/xml.wsdl.model/src/org/netbeans/modules/xml/wsdl/validator/WSDLInlineSchemaValidator.java
@@ -78,7 +78,7 @@ public class WSDLInlineSchemaValidator extends XsdBasedValidator {
     
     @SuppressWarnings("unchecked")
     public static final ValidationResult EMPTY_RESULT = 
-        new ValidationResult( Collections.EMPTY_SET, 
+        new ValidationResult( Collections.EMPTY_SET,
                 Collections.EMPTY_SET);
 
     public String getName() {

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Catalog.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Catalog.java
@@ -46,7 +46,7 @@ public class Catalog {
     
     public synchronized Schema[] getSchemas() throws SQLException {
         if (schemas == null) {
-            schemas = new TreeMap();
+            schemas = new TreeMap<>();
 
             // (if name == null)
             //      assuming the current catalog when the catalog name is null

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataProvider.java
@@ -48,7 +48,7 @@ public class DBMetaDataProvider {
     // instead of List in order to be consistent with dbschema.
     
     // Maps java.sql.Connection-s to DB metadata providers.
-    private static final Map<Connection, DBMetaDataProvider> CONN_TO_PROVIDER = new WeakHashMap();
+    private static final Map<Connection, DBMetaDataProvider> CONN_TO_PROVIDER = new WeakHashMap<>();
     
     // must be a weak reference -- we don't want to prevent the connection from being GCd
     // it is OK to be a weak reference -- the connection is hold strongly by the DB Explorer

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbSourceProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbSourceProvider.java
@@ -48,8 +48,8 @@ public final class NbSourceProvider {
 
     private static final Logger LOG = Logger.getLogger(NbSourceProvider.class.getName());
 
-    private final Map<String, String> fqnToURI = Collections.synchronizedMap(new CacheMap());
-    private final Map<String, Source> uriToSource = Collections.synchronizedMap(new CacheMap());
+    private final Map<String, String> fqnToURI = Collections.synchronizedMap(new CacheMap<>());
+    private final Map<String, Source> uriToSource = Collections.synchronizedMap(new CacheMap<>());
     private final DebugAdapterContext context;
     private ClassPath sources = ClassPath.EMPTY;
 

--- a/java/java.source/test/qa-functional/src/org/netbeans/test/java/generating/InnerClasses.java
+++ b/java/java.source/test/qa-functional/src/org/netbeans/test/java/generating/InnerClasses.java
@@ -185,10 +185,10 @@ public class InnerClasses extends org.netbeans.test.java.XRunner {
                         Collections.EMPTY_LIST,
                         extendsTree,
                         implementsList,
-                        Collections.EMPTY_LIST);                
+                        Collections.EMPTY_LIST);
                 innerClass = make.addClassMember(innerClass, mt);
                 innerClass = make.addClassMember(innerClass, vt);
-                innerClass = make.addClassMember(innerClass, make.Block(Collections.EMPTY_LIST, false));                
+                innerClass = make.addClassMember(innerClass, make.Block(Collections.EMPTY_LIST, false));
                 ClassTree modifiedClazz = make.addClassMember(clazz, innerClass);
                 workingCopy.rewrite(clazz, modifiedClazz);
             }

--- a/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupBaseHid.java
+++ b/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/AbstractLookupBaseHid.java
@@ -1871,7 +1871,7 @@ public class AbstractLookupBaseHid extends NbTestCase {
         
         this.ic.addPair(l);
         
-        Collection c = lookup.lookup(new Lookup.Template(String.class)).allInstances();
+        Collection c = lookup.lookup(new Lookup.Template<>(String.class)).allInstances();
         assertTrue("It is empty: " + c, c.isEmpty());
     }
 

--- a/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/SerialDataConvertorTest.java
+++ b/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/SerialDataConvertorTest.java
@@ -96,7 +96,7 @@ public class SerialDataConvertorTest extends NbTestCase {
          LocalFileSystem lfs = new LocalFileSystem();
          InstanceDataObject i = InstanceDataObject.create (folder, null, lfs, null);
          assertNull(i.getCookie(SaveCookie.class));
-         Lookup.Result<SaveCookie> scr =  i.getLookup().lookup(new Lookup.Template(SaveCookie.class));        
+         Lookup.Result<SaveCookie> scr =  i.getLookup().lookup(new Lookup.Template(SaveCookie.class));
          scr.addLookupListener(ml);
          Collection<? extends SaveCookie>  saveCookies = scr.allInstances();
          assertFalse(saveCookies.contains(lfs));

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/UIUtils.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/UIUtils.java
@@ -119,7 +119,7 @@ public final class UIUtils {
 
     private static Map<Integer, Color> DARKER_CACHE;
     public static Color getDarker(Color c) {
-        if (DARKER_CACHE == null) DARKER_CACHE = new HashMap();
+        if (DARKER_CACHE == null) DARKER_CACHE = new HashMap<>();
         
         int rgb = c.getRGB();
         Color d = DARKER_CACHE.get(rgb);

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerColumnModel.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerColumnModel.java
@@ -105,7 +105,7 @@ class ProfilerColumnModel extends DefaultTableColumnModel {
     private Map<Integer, Integer> columnPreferredWidths;
     
     boolean setColumnOffset(int column, int offset) {
-        if (columnOffsets == null) columnOffsets = new HashMap();
+        if (columnOffsets == null) columnOffsets = new HashMap<>();
         Integer previousOffset = columnOffsets.put(column, offset);
         int _previousOffset = previousOffset == null ? 0 : previousOffset.intValue();
         boolean change = _previousOffset != offset;
@@ -124,7 +124,7 @@ class ProfilerColumnModel extends DefaultTableColumnModel {
     }
     
     boolean setColumnPreferredWidth(int column, int width) {
-        if (columnPreferredWidths == null) columnPreferredWidths = new HashMap();
+        if (columnPreferredWidths == null) columnPreferredWidths = new HashMap<>();
         Integer previousWidth = columnPreferredWidths.put(column, width);
         int _previousWidth = previousWidth == null ? 0 : previousWidth.intValue();
         boolean change = _previousWidth != width;
@@ -157,7 +157,7 @@ class ProfilerColumnModel extends DefaultTableColumnModel {
     }
     
     void setDefaultColumnWidth(int column, int width) {
-        if (defaultColumnWidths == null) defaultColumnWidths = new HashMap();
+        if (defaultColumnWidths == null) defaultColumnWidths = new HashMap<>();
         defaultColumnWidths.put(column, width);
         if (isColumnVisible(column)) {
             TableColumn c = getModelColumn(column);

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerRowSorter.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerRowSorter.java
@@ -160,7 +160,7 @@ class ProfilerRowSorter extends TableRowSorter {
     }
     
     void setDefaultSortOrder(int column, SortOrder sortOrder) {
-        if (defaultSortOrders == null) defaultSortOrders = new HashMap();
+        if (defaultSortOrders == null) defaultSortOrders = new HashMap<>();
         defaultSortOrders.put(column, sortOrder);
     }
     

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTreeTable.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/swing/ProfilerTreeTable.java
@@ -949,7 +949,7 @@ public class ProfilerTreeTable extends ProfilerTable {
         
         
         private List filteredChildren(Object parent) {
-            if (cache == null) cache = new HashMap();
+            if (cache == null) cache = new HashMap<>();
             
             TreeNode tParent = (TreeNode)parent;
             TreePathKey parentKey = new TreePathKey(getPathToRoot(tParent));
@@ -1067,7 +1067,7 @@ public class ProfilerTreeTable extends ProfilerTable {
         
         
         private int[] viewToModel(Object parent) {
-            if (viewToModel == null) viewToModel = new HashMap();
+            if (viewToModel == null) viewToModel = new HashMap<>();
             
             TreePathKey parentKey = new TreePathKey(getPathToRoot((TreeNode)parent));
             int[] indexes = viewToModel.get(parentKey);

--- a/profiler/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/logs/LogReader.java
+++ b/profiler/profiler.snaptracer/src/org/netbeans/modules/profiler/snaptracer/logs/LogReader.java
@@ -45,7 +45,7 @@ public final class LogReader {
 
     public LogReader(FileObject f) {
         logFile = f;
-        recordList = new TreeMap();
+        recordList = new TreeMap<>();
     }
 
 


### PR DESCRIPTION
Inserted diamond in constructions like this:
`ArrayList<Strings> = new ArrayList();`
No any interfaces was changed

Part 2:
Replaced on already defined generics:
```
Collections.EMPTY_SET -> Collections.emptySet()
Collections.EMPTY_LIST -> Collections.emptyList()
Collections.EMPTY_MAP -> Collections.emptyMap()
```

Previos part 1: #5487