### PR TITLE
New rt and rf abbrevations for return true; and return false;

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultAbbrevs.xml
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultAbbrevs.xml
@@ -380,6 +380,8 @@ ${cursor}]]></code></codetemplate>
 
      <!-- Miscellaneous common code patterns -->
      <codetemplate abbreviation="rn"><code><![CDATA[${no-indent}return null;]]></code></codetemplate>
+     <codetemplate abbreviation="rt"><code><![CDATA[${no-indent}return true;]]></code></codetemplate>
+     <codetemplate abbreviation="rf"><code><![CDATA[${no-indent}return false;]]></code></codetemplate>
      <codetemplate abbreviation="f"><code><![CDATA[${no-indent}final ]]></code></codetemplate>
      <codetemplate abbreviation="ps"><code><![CDATA[${no-format}private static ]]></code></codetemplate>
      <codetemplate abbreviation="Ps"><code><![CDATA[${no-format}public static ]]></code></codetemplate>

--- a/java/java.editor/test/qa-functional/data/goldenfiles/org/netbeans/test/java/editor/codetemplates/CodeTemplatesTest/testDumpTemplates.pass
+++ b/java/java.editor/test/qa-functional/data/goldenfiles/org/netbeans/test/java/editor/codetemplates/CodeTemplatesTest/testDumpTemplates.pass
@@ -664,6 +664,14 @@ rn
 ${no-indent}return null;
 null
 -----------------------
+rt
+${no-indent}return true;
+null
+-----------------------
+rf
+${no-indent}return false;
+null
+-----------------------
 rp
 ${rp type="org.openide.util.RequestProcessor" default="RequestProcessor" editable="false"}.getDefault().post(${toRun instanceof="java.lang.Runnable" default="new Runnable() {
         public void run() {


### PR DESCRIPTION
This is a pull request for 2 new code templates in NetBeans:

- rt for "return true;"
- rf for "return false;"

Reasons:

- Both are used quite often. For example NetBeans source code has more than 14,000 "return true;" and more than 20,000 "return false;"
- They are consistent with the following existing code template in NetBeans: "re" for "return" and "rn" for "return null;"
- Easy to remember: just like rn for return null; 't' for true and 'f' for false
- Easy to use: rt and rf are next each other on the keyboard
- I've been using these code templates for at least 2 years and they remain ones of the main code templates I use

