### PR TITLE
[NETBEANS-5472] Bugfix: Updated maven archetype

### DIFF
--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/Bundle.properties
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/Bundle.properties
@@ -17,7 +17,7 @@
 
 # Maven Archetype Properties
 mvn.archetypeGroupId.JakartaEE10_0=io.github.juneau001
-mvn.archetypeVersion.JakartaEE10_0=1.0.0
+mvn.archetypeVersion.JakartaEE10_0=1.0.1
 mvn.archetypeArtifactId.JakartaEE10_0=webapp-jakartaee10
 mvn.archetypeGroupId.JakartaEE9_1=io.github.juneau001
 mvn.archetypeVersion.JakartaEE9_1=1.1.0


### PR DESCRIPTION
Updated maven archetype to build jakarta ee 10 webapp to latest bugfix version.

This version contains the correct java persistence version `3.1` (was `3.0`).

This fixes #5472 