### PR TITLE
Audits should not automatically change persistent project settings.

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
@@ -129,7 +129,8 @@ public final class ProjectVulnerability {
     })
     public CompletableFuture<String> runProjectAudit(KnowledgeBaseItem item, AuditOptions options) {
         if (item != null) {
-            setProjectKnowledgeBase(item);
+            // make transient setting, so that change handler may work against the same knowledgebase.
+            setProjectKnowledgeBase0(item);
         }
         CompletableFuture<String> result = new CompletableFuture<>();
         AUDIT_PROCESSOR.post(() -> {
@@ -215,7 +216,7 @@ public final class ProjectVulnerability {
         return item;
     }
     
-    public KnowledgeBaseItem setProjectKnowledgeBase0(KnowledgeBaseItem item) {
+    private KnowledgeBaseItem setProjectKnowledgeBase0(KnowledgeBaseItem item) {
         synchronized (this) {
             lastProfile = OCIManager.getDefault().getActiveProfile();
             return knowledgeBaseItem = item;


### PR DESCRIPTION
Simple fix: during refactoring of the `ProjectVulnerability`, I have made `setKnowledgeBase` to persist the value in project setting, but did not adapt the runAudit to call `setKnowledgeBase0`.