### PR TITLE
Contributor insists in imposing his readability concerns.

### DIFF
--- a/ide/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/JavaHudsonLogger.java
+++ b/ide/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/JavaHudsonLogger.java
@@ -50,8 +50,11 @@ public class JavaHudsonLogger implements HudsonLogger {
 
     // derived from org.netbeans.modules.java.project.JavaAntLogger.STACK_TRACE
     // (would be nicer to have a utility API to parse stack traces, but unclear where this would go)
+    // Regexp description:
+    // 1. \\w is equals to [a-zA-Z0-9_] but have a much better performance
+    // 2. [:alpha:] is equals to [a-zA-Z] but have a better performance
     private static final Pattern STACK_TRACE = Pattern.compile(
-    "(?:\t|\\[catch\\] )at ((?:[a-zA-Z_$][a-zA-Z0-9_$]*\\.)*)[a-zA-Z_$][a-zA-Z0-9_$]*\\.[a-zA-Z_$<][a-zA-Z0-9_$>]*\\(([a-zA-Z_$][a-zA-Z0-9_$]*\\.java):([0-9]+)\\)"); // NOI18N
+    "(?:\t|\\[catch] )at ((?:[[:alpha:]_$][\\w$]*\\.)*)[[:alpha:]_$][\\w$]*\\.[[:alpha:]_$<][\\w$>]*\\(([[:alpha:]_$][\\w$]*\\.java):([0-9]+)\\)"); // NOI18N
 
     private static class Session implements HudsonLogSession {
 


### PR DESCRIPTION
A performance proof:
1. \w: https://gist.github.com/tbw777/8ce56d2cc3a0216012362d18b7262eb2
2. [:alpha:] https://gist.github.com/tbw777/cd1c7eeb85972b849190244af36c146a

Also unnecassary escaping was removed