### PR TITLE
PHP Debugger - show NULL values by default

### DIFF
--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/models/VariablesModelFilter.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/models/VariablesModelFilter.java
@@ -154,6 +154,7 @@ public class VariablesModelFilter extends ViewModelSupport
                 FilterType.SCALARS,
                 FilterType.SUPERGLOBALS,
                 FilterType.RESOURCE,
+                FilterType.NULL,
         };
         myShowFilters.set( filters );
     }


### PR DESCRIPTION
Changes default setting of filter for NULL values in PHP debugger.

Based on personal experience when I need to turn display of NULL values for almost every debugging session.