### PR TITLE
Add port offset to wildfly server wizard

### DIFF
--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
@@ -56,6 +56,7 @@ import org.netbeans.modules.javaee.wildfly.ide.commands.WildflyModule;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties;
 import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_ADMIN_PORT;
 import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.PROPERTY_ADMIN_PORT;
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.PROPERTY_PORT_OFFSET;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils.Version;
 import org.netbeans.modules.javaee.wildfly.util.WildFlyProperties;
@@ -90,6 +91,8 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
 
     private final InstanceProperties instanceProperties;
 
+    private final int portOffset;
+
     /**
      * <i>GuardedBy("this")</i>
      */
@@ -105,9 +108,12 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
         isWildfly = WildflyPluginUtils.isWildFly(serverPath);
         int controllerPort = DEFAULT_ADMIN_PORT;
         String adminPort = this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT);
+        String portOffsetString = this.instanceProperties.getProperty(PROPERTY_PORT_OFFSET);
+        portOffset = Integer.parseInt(portOffsetString);
         if(adminPort != null) {
-            controllerPort = Integer.parseInt(this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT));
+            controllerPort = Integer.parseInt(adminPort);
         }
+        controllerPort += portOffset;
         if (username != null && password != null) {
             this.client = new WildflyClient(instanceProperties, version, getHost(), controllerPort, username, password);
         } else {
@@ -361,10 +367,14 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
         return host;
     }
 
+    public int getPortOffset() {
+        return portOffset;
+    }
+
     public int getPort() {
         String port = InstanceProperties.getInstanceProperties(realUri).
                 getProperty(WildflyPluginProperties.PROPERTY_PORT);
-        return Integer.parseInt(port);
+        return Integer.parseInt(port) + portOffset;
     }
 
     public Version getServerVersion() {

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
@@ -54,9 +54,8 @@ import org.netbeans.modules.javaee.wildfly.deploy.WildflyProgressObject;
 import org.netbeans.modules.javaee.wildfly.ide.commands.WildflyClient;
 import org.netbeans.modules.javaee.wildfly.ide.commands.WildflyModule;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties;
-
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_ADMIN_PORT;
 import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.PROPERTY_ADMIN_PORT;
-
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils.Version;
 import org.netbeans.modules.javaee.wildfly.util.WildFlyProperties;
@@ -70,7 +69,6 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
     private static final Logger LOGGER = Logger.getLogger(WildflyDeploymentManager.class.getName());
 
     private static final int DEBUGGING_PORT = 8787;
-    private static final int CONTROLLER_PORT = 9990;
 
     private final Version version;
     private final boolean isWildfly;
@@ -105,7 +103,7 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
         File serverPath = new File(this.instanceProperties.getProperty(WildflyPluginProperties.PROPERTY_ROOT_DIR));
         version = WildflyPluginUtils.getServerVersion(serverPath);
         isWildfly = WildflyPluginUtils.isWildFly(serverPath);
-        int controllerPort = CONTROLLER_PORT;
+        int controllerPort = DEFAULT_ADMIN_PORT;
         String adminPort = this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT);
         if(adminPort != null) {
             controllerPort = Integer.parseInt(this.instanceProperties.getProperty(PROPERTY_ADMIN_PORT));

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyStartRunnable.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyStartRunnable.java
@@ -229,6 +229,7 @@ class WildflyStartRunnable implements Runnable {
             } catch (NumberFormatException ex) {
             }
         }
+        javaOptsBuilder.append(" -Djboss.socket.binding.port-offset=").append(dm.getPortOffset());
         for (StartupExtender args : StartupExtender.getExtenders(
                 Lookups.singleton(CommonServerBridge.getCommonInstance(ip.getProperty("url"))), getMode(startServer.getMode()))) {
             for (String singleArg : args.getArguments()) {
@@ -266,7 +267,7 @@ class WildflyStartRunnable implements Runnable {
 
     private boolean checkPorts(final InstanceProperties ip) {
         try {
-            String strHTTPConnectorPort = ip.getProperty(WildflyPluginProperties.PROPERTY_PORT);
+            String strHTTPConnectorPort = String.valueOf(Integer.parseInt(ip.getProperty(WildflyPluginProperties.PROPERTY_ADMIN_PORT)) + dm.getPortOffset());
             int httpConnectorPort = Integer.parseInt(strHTTPConnectorPort);
             if (httpConnectorPort <= 0) {
                 // server will complain hopefully

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/commands/WildflyClient.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/commands/WildflyClient.java
@@ -72,7 +72,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.security.auth.callback.CallbackHandler;
 import org.netbeans.modules.j2ee.deployment.common.api.Datasource;
-import org.netbeans.modules.j2ee.deployment.common.api.MessageDestination;
 import org.netbeans.modules.j2ee.deployment.common.api.MessageDestination.Type;
 import org.netbeans.modules.j2ee.deployment.plugins.api.InstanceProperties;
 import org.netbeans.modules.j2ee.deployment.plugins.spi.DeploymentContext;
@@ -165,6 +164,7 @@ public class WildflyClient {
 
     private final String serverAddress;
     private final int serverPort;
+    private final String httpPort;
     private final CallbackHandler handler;
     private final InstanceProperties ip;
     private Object client;
@@ -224,6 +224,7 @@ public class WildflyClient {
         this.serverPort = serverPort;
         this.ip = ip;
         this.version = version;
+        this.httpPort = resolveHttpPort(this.ip);
         handler = new Authentication().getCallbackHandler();
     }
 
@@ -233,7 +234,15 @@ public class WildflyClient {
         this.serverPort = serverPort;
         this.ip = ip;
         this.version = version;
+        this.httpPort = resolveHttpPort(this.ip);
         handler = new Authentication(login, password.toCharArray()).getCallbackHandler();
+    }
+
+    private String resolveHttpPort(InstanceProperties ip) {
+        String httpPort = ip.getProperty(WildflyPluginProperties.PROPERTY_PORT);
+        String portOffset = ip.getProperty(WildflyPluginProperties.PROPERTY_PORT_OFFSET);
+        return String.valueOf(
+                Integer.parseInt(httpPort) + Integer.parseInt(portOffset));
     }
 
     // ModelControllerClient
@@ -357,7 +366,6 @@ public class WildflyClient {
             Object readDeployments = createReadResourceOperation(cl, deploymentAddressModelNode, true, true);
             // ModelNode
             Object response = executeOnModelNode(cl, readDeployments);
-            String httpPort = ip.getProperty(WildflyPluginProperties.PROPERTY_PORT);
             if (isSuccessfulOutcome(cl, response)) {
                 // ModelNode
                 Object result = readResult(cl, response);
@@ -391,7 +399,6 @@ public class WildflyClient {
             Object readDeployments = createReadResourceOperation(cl, deploymentAddressModelNode, true, true);
             // ModelNode
             Object response = executeOnModelNode(cl, readDeployments);
-            String httpPort = ip.getProperty(WildflyPluginProperties.PROPERTY_PORT);
             if (isSuccessfulOutcome(cl, response)) {
                 // ModelNode
                 Object result = readResult(cl, response);
@@ -426,7 +433,6 @@ public class WildflyClient {
             Object readDeployments = createReadResourceOperation(cl, deploymentAddressModelNode, true, true);
             // ModelNode
             Object response = executeOnModelNode(cl, readDeployments);
-            String httpPort = ip.getProperty(WildflyPluginProperties.PROPERTY_PORT);
             if (isSuccessfulOutcome(cl, response)) {
                 // ModelNode
                 Object result = readResult(cl, response);
@@ -968,7 +974,7 @@ public class WildflyClient {
             // ModelNode
             Object response = executeOnModelNode(cl, readJaxrsResources);
             if (isSuccessfulOutcome(cl, response)) {
-                String serverUrl = "http://" + serverAddress + ':' + ip.getProperty(WildflyPluginProperties.PROPERTY_PORT);
+                String serverUrl = "http://" + serverAddress + ':' + httpPort;
                 // List<ModelNode>
                 Object result = readResult(cl, response);
                 if (modelNodeIsDefined(cl, result)) {
@@ -1053,7 +1059,6 @@ public class WildflyClient {
             Object readDeployments = createReadResourceOperation(cl, deploymentAddressModelNode, true, true);
             Object response = executeOnModelNode(cl, readDeployments);
             if (isSuccessfulOutcome(cl, response)) {
-                String httpPort = ip.getProperty(WildflyPluginProperties.PROPERTY_PORT);
                 Object result = readResult(cl, response);
                 List subDeployments = modelNodeAsList(cl, getModelNodeChild(cl, result, "subdeployment"));
                 for (Object subDeployment : subDeployments) {

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesPanel.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesPanel.java
@@ -52,6 +52,7 @@ public class AddServerPropertiesPanel implements WizardDescriptor.Panel, ChangeL
         String host = panel.getHost();
         String port = panel.getPort();
         String adminPort = panel.getManagementPort();
+        String portOffset = panel.getPortOffset();
 
         if(panel.isLocalServer()){
             // wrong domain path
@@ -122,6 +123,13 @@ public class AddServerPropertiesPanel implements WizardDescriptor.Panel, ChangeL
                 return false;
             }
 
+            try{
+                Integer.valueOf(portOffset);
+            } catch(NumberFormatException e) {
+                wizard.putProperty(WizardDescriptor.PROP_ERROR_MESSAGE,
+                        NbBundle.getMessage(AddServerPropertiesPanel.class, "MSG_InvalidPortOffset"));  //NOI18N
+                return false;
+            }
 
         } else { //remote
             if (host.length() < 1){
@@ -142,6 +150,7 @@ public class AddServerPropertiesPanel implements WizardDescriptor.Panel, ChangeL
         instantiatingIterator.setHost(host);
         instantiatingIterator.setPort(port);
         instantiatingIterator.setAdminPort(adminPort);
+        instantiatingIterator.setPortOffset(portOffset);
         instantiatingIterator.setServer(panel.getDomain());
         instantiatingIterator.setServerPath(panel.getDomainPath());
         instantiatingIterator.setDeployDir(WildflyPluginUtils.getDeployDir( panel.getDomainPath()));

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesVisualPanel.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesVisualPanel.java
@@ -61,6 +61,8 @@ public class AddServerPropertiesVisualPanel extends JPanel {
     private javax.swing.JTextField portField;
     private javax.swing.JLabel     managementPortLabel;
     private javax.swing.JTextField managementPortField;
+    private javax.swing.JLabel     portOffsetLabel;
+    private javax.swing.JTextField portOffsetField;
     private javax.swing.JLabel     userLabel;
     private javax.swing.JTextField userField;
     private javax.swing.JLabel     passwordLabel;
@@ -117,6 +119,10 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         return managementPortField.getText().trim();
     }
 
+    public String getPortOffset(){
+        return portOffsetField.getText().trim();
+    }
+
     public String getUser(){
         return userField.getText();
     }
@@ -139,6 +145,7 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         domainPathField.setText(path);
         portField.setText(WildflyPluginUtils.getHTTPConnectorPort(path));
         managementPortField.setText(WildflyPluginUtils.getManagementConnectorPort(path));
+        portOffsetField.setText(WildflyPluginUtils.getPortOffset(path));
         fireChangeEvent();
     }
 
@@ -261,6 +268,17 @@ public class AddServerPropertiesVisualPanel extends JPanel {
 
         managementPortLabel.setLabelFor(managementPortField);
 
+        portOffsetLabel = new JLabel();
+        org.openide.awt.Mnemonics.setLocalizedText(portOffsetLabel, NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "LBL_Port_Offset")); // NOI18N
+
+        portOffsetField = new JTextField();
+        portOffsetField.setColumns(20);
+        portOffsetField.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "LBL_Port_Offset"));
+        portOffsetField.getAccessibleContext().setAccessibleName(NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "LBL_Port_Offset"));
+        portOffsetField.addKeyListener(new SomeChangesListener());
+
+        portOffsetLabel.setLabelFor(portOffsetField);
+
         userLabel = new JLabel(NbBundle.getMessage(AddServerPropertiesVisualPanel.class, "LBL_User"));//NOI18N
         userField = new JTextField();
         userField.addKeyListener(new SomeChangesListener());
@@ -375,6 +393,22 @@ public class AddServerPropertiesVisualPanel extends JPanel {
         add(managementPortField, gridBagConstraints);
 
 
+        //-------------- port offset ---------------
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 6);
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        add(portOffsetLabel, gridBagConstraints);
+
+
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 0);
+        add(portOffsetField, gridBagConstraints);
+
+
         //-------------- User ---------------
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -384,7 +418,7 @@ public class AddServerPropertiesVisualPanel extends JPanel {
 
 
         gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridy = 6;
+        gridBagConstraints.gridy = 7;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 0);
@@ -401,7 +435,7 @@ public class AddServerPropertiesVisualPanel extends JPanel {
 
 
         gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridy = 7;
+        gridBagConstraints.gridy = 8;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 12, 0);

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/Bundle.properties
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/Bundle.properties
@@ -57,6 +57,8 @@ LBL_Port=&Port:
 
 LBL_Management_Port=&Management Port:
 
+LBL_Port_Offset=&Port Offset:
+
 LBL_User=User
 
 LBL_Password=Password
@@ -82,6 +84,8 @@ MSG_INSTANCE_REGISTRATION_FAILED=Registration Failed
 TXT_PROPERTY_TEXT=Select Server Configuration
 
 MSG_InvalidPort=Enter a valid port number
+
+MSG_InvalidPortOffset=Enter a valid port offset
 
 MSG_InstanceExists=The domain instance you want to add already exists.
 

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyInstantiatingIterator.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyInstantiatingIterator.java
@@ -148,6 +148,7 @@ public class WildflyInstantiatingIterator implements WizardDescriptor.Instantiat
             initialProperties.put(WildflyPluginProperties.PROPERTY_PORT, port);
             initialProperties.put(WildflyPluginProperties.PROPERTY_CONFIG_FILE, configFile);
             initialProperties.put(WildflyPluginProperties.PROPERTY_ADMIN_PORT, adminPort);
+            initialProperties.put(WildflyPluginProperties.PROPERTY_PORT_OFFSET, portOffset);
             initialProperties.put(WildflyPluginProperties.PROPERTY_JAVA_OPTS, WILDFLY_JAVA_OPTS);
 
             InstanceProperties ip = InstanceProperties.createInstanceProperties(url,
@@ -261,6 +262,7 @@ public class WildflyInstantiatingIterator implements WizardDescriptor.Instantiat
     private String host;
     private String port;
     private String adminPort;
+    private String portOffset;
     private String userName="";
     private String password="";
     private String server;
@@ -291,6 +293,10 @@ public class WildflyInstantiatingIterator implements WizardDescriptor.Instantiat
 
     public void setAdminPort(String port){
         this.adminPort = port.trim();
+    }
+
+    public void setPortOffset(String portOffset) {
+        this.portOffset = portOffset.trim();
     }
 
     public void setServer(String server){

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginProperties.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginProperties.java
@@ -33,6 +33,8 @@ import org.openide.filesystems.FileUtil;
  */
 public final class WildflyPluginProperties {
 
+    public static final int DEFAULT_HTTP_PORT = 8080;
+    public static final int DEFAULT_ADMIN_PORT = 9990;
     public static final String PROPERTY_DISPLAY_NAME ="displayName";//NOI18N
     public static final String PROPERTY_SERVER = "server";//NOI18N
     public static final String PROPERTY_DEPLOY_DIR = "deploy-dir";//NOI18N
@@ -164,7 +166,7 @@ public final class WildflyPluginProperties {
         if(this.installLocation == null || WildflyPluginUtils.WILDFLY_8_0_0.compareTo(serverVersion) > 0){
             return 9999;
         }
-        return 9990;
+        return DEFAULT_ADMIN_PORT;
     }
 
 

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginProperties.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginProperties.java
@@ -33,6 +33,7 @@ import org.openide.filesystems.FileUtil;
  */
 public final class WildflyPluginProperties {
 
+    public static final int DEFAULT_PORT_OFFSET = 0;
     public static final int DEFAULT_HTTP_PORT = 8080;
     public static final int DEFAULT_ADMIN_PORT = 9990;
     public static final String PROPERTY_DISPLAY_NAME ="displayName";//NOI18N
@@ -43,6 +44,7 @@ public final class WildflyPluginProperties {
     public static final String PROPERTY_HOST = "host";//NOI18N
     public static final String PROPERTY_PORT = "port";//NOI18N
     public static final String PROPERTY_ADMIN_PORT = "admin-port";//NOI18N
+    public static final String PROPERTY_PORT_OFFSET = "port-offset";//NOI18N
     public static final String PROPERTY_JAVA_OPTS = "java_opts"; // NOI18N
     public static final String PROPERTY_CONFIG_FILE = "config_file"; // NOI18N
 

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
@@ -41,6 +41,7 @@ import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_ADMIN_PORT;
 import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_HTTP_PORT;
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_PORT_OFFSET;
 import org.openide.filesystems.JarFileSystem;
 
 /**
@@ -245,6 +246,10 @@ public class WildflyPluginUtils {
 
      public static String getManagementConnectorPort(String configFile) {
         return String.valueOf(DEFAULT_ADMIN_PORT);
+    }
+
+    public static String getPortOffset(String configFile) {
+        return String.valueOf(DEFAULT_PORT_OFFSET);
     }
 
     /**

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
@@ -18,11 +18,9 @@
  */
 package org.netbeans.modules.javaee.wildfly.ide.ui;
 
-import java.io.File;
-
-import static java.io.File.separatorChar;
-
 import java.beans.PropertyVetoException;
+import java.io.File;
+import static java.io.File.separatorChar;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.FilenameFilter;
@@ -41,6 +39,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_ADMIN_PORT;
+import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties.DEFAULT_HTTP_PORT;
 import org.openide.filesystems.JarFileSystem;
 
 /**
@@ -240,13 +240,11 @@ public class WildflyPluginUtils {
     }
 
     public static String getHTTPConnectorPort(String configFile) {
-        String defaultPort = "8080"; // NOI18N
-        return defaultPort;
+        return String.valueOf(DEFAULT_HTTP_PORT);
     }
 
      public static String getManagementConnectorPort(String configFile) {
-        String defaultPort = "9990"; // NOI18N
-        return defaultPort;
+        return String.valueOf(DEFAULT_ADMIN_PORT);
     }
 
     /**

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/nodes/WildflyManagerNode.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/nodes/WildflyManagerNode.java
@@ -171,7 +171,8 @@ public class WildflyManagerNode extends AbstractNode implements Node.Cookie {
                 NbBundle.getMessage(WildflyManagerNode.class, "LBL_PORT"), NbBundle.getMessage(WildflyManagerNode.class, "HINT_PORT")) {
             @Override
                     public Object getValue() {
-                        return new Integer(ip.getProperty(WildflyPluginProperties.PROPERTY_PORT));
+                        return Integer.valueOf(ip.getProperty(WildflyPluginProperties.PROPERTY_PORT))
+                                + Integer.valueOf(ip.getProperty(WildflyPluginProperties.PROPERTY_PORT_OFFSET));
                     }
                 };
         properties.put(property);
@@ -200,7 +201,9 @@ public class WildflyManagerNode extends AbstractNode implements Node.Cookie {
         InstanceProperties ip = InstanceProperties.getInstanceProperties(getDeploymentManager().getUrl());
         String host = ip.getProperty(WildflyPluginProperties.PROPERTY_HOST);
         String port = ip.getProperty(WildflyPluginProperties.PROPERTY_PORT);
-        return HTTP_HEADER + host + ":" + port + "/"; // NOI18N
+        String portOffset = ip.getProperty(WildflyPluginProperties.PROPERTY_PORT_OFFSET);
+        String httpPort = String.valueOf(Integer.parseInt(port) + Integer.parseInt(portOffset));
+        return HTTP_HEADER + host + ":" + httpPort + "/"; // NOI18N
     }
 
     public final WildflyDeploymentManager getDeploymentManager() {


### PR DESCRIPTION
This is a replacement for #5478. 
Instead of parsing the default port offset from the configuration file, it is now possible to set the offset in the Wildfly server creation wizard. The offset is then passed to Wildfly via `-Djboss.socket.binding.port-offset`. That approach is more transparent to the user and NetBeans keeps track of the correct ports used. I tested this successfully. 
Anyway, I made this a draft because of a bunch of questions I have, where I hope @ehsavoie (and/or others) can help me out:

1. Should we validate that port + port offset is in the valid port range? Or just let Wildfly fail and report that?
2. Does it make sense to add a tooltip to the port offset label and explain what is going on?
3. I don't understand exactly how my changes will affect the connection to an already running server. I guess the port offset should be ignored then?
4. The ports are queried from the `InstanceProperties` in various places, maybe they should be regular class members? There is a lot of overhead at the moment for adding offset, parsing to int and to string.

Looking forward to getting input on these points!

Alex