### PR TITLE
Fixed detection of duplicate types

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/UnusableTypesHintError.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/UnusableTypesHintError.java
@@ -430,18 +430,15 @@ public class UnusableTypesHintError extends HintErrorRule {
                 }
                 if (checkedTypes.contains(name)) {
                     createDuplicateTypeError(type, typeName);
-                    return;
                 } else if (checkedTypes.contains(Type.BOOL)) {
                     // bool|false bool|true
                     if (Type.FALSE.equals(name) || Type.TRUE.equals(name)) {
                         createDuplicateTypeError(type, typeName);
-                        return;
                     }
                 } else if (checkedTypes.contains(Type.FALSE) || checkedTypes.contains(Type.TRUE)) {
                     // false|bool true|bool
                     if (Type.BOOL.equals(name)) {
                         createDuplicateTypeError(type, typeName);
-                        return;
                     }
                 }
                 checkedTypes.add(name);

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testDuplicateTypes_01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testDuplicateTypes_01.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class DuplicateTypes {
+
+    private First|First $union;
+    private First&First $intersection;
+    private First|Second|First|Second $twoUnions;
+    private First&Second&First&Second $twoIntersections;
+
+    private bool|true|bool $unionBoolAndTrue;
+    private bool|false|bool $unionBoolAndFalse;
+
+    private bool|true|First|First $unionAfterBoolAndTrue;
+    private bool|false|First|First $unionAfterBoolAndFalse;
+    private true|bool|First|First $unionAfterTrueAndBool;
+    private false|bool|First|First $unionAfterFalseAndBool;
+
+    public function returnUnion(): First|First {
+    }
+
+    public function returnIntersection(): First&First {
+    }
+
+    public function returnTwoUnions(): First|Second|First|Second {
+    }
+
+    public function returnTwoIntersections(): First&Second&First&Second {
+    }
+
+    public function returnUnionBoolAndTrue(): bool|true|bool {
+    }
+
+    public function returnUnionBoolAndFalse(): bool|false|bool {
+    }
+
+    public function returnUnionAfterBoolAndTrue(): bool|true|First|First {
+    }
+
+    public function returnUnionAfterBoolAndFalse(): bool|false|First|First {
+    }
+
+    public function returnUnionAfterTrueAndBool(): true|bool|First|First {
+    }
+
+    public function returnUnionAfterFalseAndBool(): false|bool|First|First {
+    }
+
+    public function parameterUnion(First|First $union) {
+    }
+
+    public function parameterIntersection(First&First $intersection) {
+    }
+
+    public function parameterTwoUnions(First|Second|First|Second $twoUnions) {
+    }
+
+    public function parameterTwoIntersections(First&Second&First&Second $twoIntersections) {
+    }
+    
+    public function parameterUnionBoolAndTrue(bool|true|bool $union) {
+    }
+
+    public function parameterUnionBoolAndFalse(bool|false|bool $union) {
+    }
+
+    public function parameterUnionAfterBoolAndTrue(bool|true|First|First $union) {
+    }
+
+    public function parameterUnionAfterBoolAndFalse(bool|false|First|First $union) {
+    }
+
+    public function parameterUnionAfterTrueAndBool(true|bool|First|First $union) {
+    }
+
+    public function parameterUnionAfterFalseAndBool(false|bool|First|First $union) {
+    }
+}
+
+class First {}
+
+class Second {}

--- a/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testDuplicateTypes_01.php.testDuplicateTypes_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/UnusableTypesHintError/testDuplicateTypes_01.php.testDuplicateTypes_01.hints
@@ -1,0 +1,114 @@
+    private First|First $union;
+                  -----
+HINT:Type "First" is duplicated.
+    private First&First $intersection;
+                  -----
+HINT:Type "First" is duplicated.
+    private First|Second|First|Second $twoUnions;
+                               ------
+HINT:Type "First" is duplicated.
+HINT:Type "Second" is duplicated.
+    private First&Second&First&Second $twoIntersections;
+                               ------
+HINT:Type "First" is duplicated.
+HINT:Type "Second" is duplicated.
+    private bool|true|bool $unionBoolAndTrue;
+                      ----
+HINT:Type "bool" is duplicated.
+HINT:Type "true" is duplicated.
+    private bool|false|bool $unionBoolAndFalse;
+                       ----
+HINT:Type "bool" is duplicated.
+HINT:Type "false" is duplicated.
+    private bool|true|First|First $unionAfterBoolAndTrue;
+                            -----
+HINT:Type "First" is duplicated.
+HINT:Type "true" is duplicated.
+    private bool|false|First|First $unionAfterBoolAndFalse;
+                             -----
+HINT:Type "First" is duplicated.
+HINT:Type "false" is duplicated.
+    private true|bool|First|First $unionAfterTrueAndBool;
+                            -----
+HINT:Type "First" is duplicated.
+HINT:Type "bool" is duplicated.
+    private false|bool|First|First $unionAfterFalseAndBool;
+                             -----
+HINT:Type "First" is duplicated.
+HINT:Type "bool" is duplicated.
+    public function returnUnion(): First|First {
+                                         -----
+HINT:Type "First" is duplicated.
+    public function returnIntersection(): First&First {
+                                                -----
+HINT:Type "First" is duplicated.
+    public function returnTwoUnions(): First|Second|First|Second {
+                                                          ------
+HINT:Type "First" is duplicated.
+HINT:Type "Second" is duplicated.
+    public function returnTwoIntersections(): First&Second&First&Second {
+                                                                 ------
+HINT:Type "First" is duplicated.
+HINT:Type "Second" is duplicated.
+    public function returnUnionBoolAndTrue(): bool|true|bool {
+                                                        ----
+HINT:Type "bool" is duplicated.
+HINT:Type "true" is duplicated.
+    public function returnUnionBoolAndFalse(): bool|false|bool {
+                                                          ----
+HINT:Type "bool" is duplicated.
+HINT:Type "false" is duplicated.
+    public function returnUnionAfterBoolAndTrue(): bool|true|First|First {
+                                                                   -----
+HINT:Type "First" is duplicated.
+HINT:Type "true" is duplicated.
+    public function returnUnionAfterBoolAndFalse(): bool|false|First|First {
+                                                                     -----
+HINT:Type "First" is duplicated.
+HINT:Type "false" is duplicated.
+    public function returnUnionAfterTrueAndBool(): true|bool|First|First {
+                                                                   -----
+HINT:Type "First" is duplicated.
+HINT:Type "bool" is duplicated.
+    public function returnUnionAfterFalseAndBool(): false|bool|First|First {
+                                                                     -----
+HINT:Type "First" is duplicated.
+HINT:Type "bool" is duplicated.
+    public function parameterUnion(First|First $union) {
+                                         -----
+HINT:Type "First" is duplicated.
+    public function parameterIntersection(First&First $intersection) {
+                                                -----
+HINT:Type "First" is duplicated.
+    public function parameterTwoUnions(First|Second|First|Second $twoUnions) {
+                                                          ------
+HINT:Type "First" is duplicated.
+HINT:Type "Second" is duplicated.
+    public function parameterTwoIntersections(First&Second&First&Second $twoIntersections) {
+                                                                 ------
+HINT:Type "First" is duplicated.
+HINT:Type "Second" is duplicated.
+    public function parameterUnionBoolAndTrue(bool|true|bool $union) {
+                                                        ----
+HINT:Type "bool" is duplicated.
+HINT:Type "true" is duplicated.
+    public function parameterUnionBoolAndFalse(bool|false|bool $union) {
+                                                          ----
+HINT:Type "bool" is duplicated.
+HINT:Type "false" is duplicated.
+    public function parameterUnionAfterBoolAndTrue(bool|true|First|First $union) {
+                                                                   -----
+HINT:Type "First" is duplicated.
+HINT:Type "true" is duplicated.
+    public function parameterUnionAfterBoolAndFalse(bool|false|First|First $union) {
+                                                                     -----
+HINT:Type "First" is duplicated.
+HINT:Type "false" is duplicated.
+    public function parameterUnionAfterTrueAndBool(true|bool|First|First $union) {
+                                                                   -----
+HINT:Type "First" is duplicated.
+HINT:Type "bool" is duplicated.
+    public function parameterUnionAfterFalseAndBool(false|bool|First|First $union) {
+                                                                     -----
+HINT:Type "First" is duplicated.
+HINT:Type "bool" is duplicated.

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/UnusableTypesHintErrorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/UnusableTypesHintErrorTest.java
@@ -71,6 +71,10 @@ public class UnusableTypesHintErrorTest extends PHPHintsTestBase {
         checkHints(new UnusableTypesHintError(), "testDnfTypes_01.php");
     }
 
+    public void testDuplicateTypes_01() throws Exception {
+        checkHints(new UnusableTypesHintError(), "testDuplicateTypes_01.php");
+    }
+
     @Override
     protected String getTestDirectory() {
         return TEST_DIRECTORY + "UnusableTypesHintError/";


### PR DESCRIPTION
Goes through all types and does not return on first error.
Partial fix for #5072

