### PR TITLE
Fix spurious messages printed to the console.

### DIFF
--- a/enterprise/micronaut/test/unit/data/gradle/artifacts/multi/gradle.properties
+++ b/enterprise/micronaut/test/unit/data/gradle/artifacts/multi/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=3.7.0-SNAPSHOT
+micronautVersion=3.7.0

--- a/java/jshell.support/src/org/netbeans/modules/jshell/editor/ConsoleEditor.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/editor/ConsoleEditor.java
@@ -78,6 +78,10 @@ public class ConsoleEditor extends CloneableEditor {
     private CL cl;
     private Lookup lookup;
 
+    public ConsoleEditor() {
+        this.lookup = Lookup.EMPTY;
+    }
+
     public ConsoleEditor(CloneableEditorSupport support, Lookup lookup) {
         super(support);
         this.lookup = lookup;

--- a/java/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
+++ b/java/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
@@ -355,7 +355,7 @@ public final class MavenProjectCache {
         "LBL_Incomplete_Project_Desc=Partially loaded Maven project; try building it."
     })
     public static MavenProject getFallbackProject(File projectFile) throws AssertionError {
-        LOG.log(Level.INFO, "Creating fallback project for " + projectFile, new Throwable());
+        LOG.log(Level.FINE, "Creating fallback project for " + projectFile, new Throwable());
         MavenProject newproject = new MavenProject();
         newproject.setGroupId("error");
         newproject.setArtifactId("error");


### PR DESCRIPTION
During testing of NB17, I've seen some messages printed to the console that should not be there.

1/ Maven creates a fallback project, if the pom.xml cannot be read into the model. This is a fairly common, either because of malformed XML, inaccessible basic build plugin (i.e. empty repository) etc. Should be logged, but not at INFO level - that is likely a leftover after debugging maven actions.
```
Reload broken project (clean repository): diagnostic message
INFO [org.netbeans.modules.maven.modelcache.MavenProjectCache]: Creating fallback project for /space/tmp/vsc2/src/microtest/pom.xml
java.lang.Throwable
        at org.netbeans.modules.maven.modelcache.MavenProjectCache.getFallbackProject(MavenProjectCache.java:358)
        at org.netbeans.modules.maven.modelcache.MavenProjectCache.loadOriginalMavenProject(MavenProjectCache.java:332)
        at org.netbeans.modules.maven.modelcache.MavenProjectCache.loadOriginalMavenProject(MavenProjectCache.java:157)
        at org.netbeans.modules.maven.modelcache.MavenProjectCache.access$200(MavenProjectCache.java:64)
```

2/ After a clean startup with Ergonomics, when Java SE feature is activated, a stacktrace prints to the console from unsuccessful JShell console deserialization:
```
Class: class org.netbeans.modules.jshell.editor.ConsoleEditor
Source: MultiFileObject@7a679502[Windows2Local/Components/JShellEditor.settings]
Caused: java.lang.NoSuchMethodException: org.netbeans.modules.jshell.editor.ConsoleEditor.<init>()
        at java.base/java.lang.Class.getConstructor0(Class.java:3349)
        at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2553)
        at org.netbeans.modules.settings.convertors.XMLSettingsSupport.newInstance(XMLSettingsSupport.java:73)
        at org.netbeans.modules.settings.convertors.XMLSettingsSupport$SettingsRecognizer.instanceCreate(XMLSettingsSupport.java:603)
```
The window is marked as `PERSISTENCE_NEVER` but the .settings file is there because of `@TopComponent.Registration`. Other similar windows use a default constructor with limited initialization and features - this patch addds the same.