### PR TITLE
GoToType dialog checks source attribute before disassembling bytecode

### DIFF
--- a/java/java.source/src/org/netbeans/modules/java/classfile/BinaryElementOpenImpl.java
+++ b/java/java.source/src/org/netbeans/modules/java/classfile/BinaryElementOpenImpl.java
@@ -41,8 +41,13 @@ public class BinaryElementOpenImpl implements BinaryElementOpen {
 
     @Override
     public boolean open(ClasspathInfo cpInfo, final ElementHandle<? extends Element> toOpen, final AtomicBoolean cancel) {
-        FileObject source = CodeGenerator.generateCode(cpInfo, toOpen);
+        boolean[] sourceAttrApplied = { false };
+        FileObject source = CodeGenerator.generateCode(cpInfo, toOpen, sourceAttrApplied);
         if (source != null) {
+            if (sourceAttrApplied[0]) {
+              return open(source, 0);
+            }
+
             final int[] pos = new int[] {-1};
 
             try {

--- a/java/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
+++ b/java/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
@@ -55,7 +55,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URL;
 import java.security.MessageDigest;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -131,9 +130,13 @@ public class CodeGenerator {
     static final String CLASSFILE_SOURCEFILE = "classfile-sourcefile";    //NOI18N
 
     public static FileObject generateCode(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> toOpenHandle) {
-	if (UNUSABLE_KINDS.contains(toOpenHandle.getKind())) {
-	    return null;
-	}
+      return generateCode(cpInfo, toOpenHandle, null);
+    }
+
+    public static FileObject generateCode(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> toOpenHandle, boolean[] trySourceAttr) {
+        if (UNUSABLE_KINDS.contains(toOpenHandle.getKind())) {
+          return null;
+        }
 
         try {
             FileObject file = FileUtil.createMemoryFileSystem().getRoot().createData(toOpenHandle.getKind() == ElementKind.MODULE ? "module-info.java" : "test.java");  //NOI18N
@@ -171,11 +174,23 @@ public class CodeGenerator {
                         }
                         root = resource.getParent();
                     } else {
+
                         final ClassPath cp = ClassPathSupport.createProxyClassPath(
                                 cpInfo.getClassPath(PathKind.BOOT),
                                 cpInfo.getClassPath(PathKind.COMPILE),
                                 cpInfo.getClassPath(PathKind.SOURCE));
                         final TypeElement te = toOpen != null ? wc.getElementUtilities().outermostTypeElement(toOpen) : null;
+                        if (trySourceAttr != null) {
+                            String name = SourceUtils.findSourceFileName(toOpen);
+                            if (name != null) {
+                                FileObject found = SourceUtils.getFile(toOpenHandle, cpInfo, name);
+                                if (found != null) {
+                                    result[0] = found;
+                                    trySourceAttr[0] = true;
+                                    return;
+                                }
+                            }
+                        }
 
                         if (te == null) {
                             LOG.info("Cannot resolve element: " + toOpenHandle.toString() + " on classpath: " + cp.toString()); //NOI18N
@@ -225,7 +240,7 @@ public class CodeGenerator {
                         result[0] = source;
 
                         String existingHash = (String) source.getAttribute(HASH_ATTRIBUTE_NAME);
-                        
+
                         if (hash.equals(existingHash)) {
                             LOG.fine(FileUtil.getFileDisplayName(source) + " is up to date, reusing from cache.");  //NOI18N
                             return;
@@ -245,7 +260,7 @@ public class CodeGenerator {
                     if (betterName[0] != null) {
                         result[0].setAttribute(CLASSFILE_SOURCEFILE, betterName[0]);
                     }
-                    
+
                     sourceGenerated[0] = true;
                 }
             });
@@ -354,7 +369,7 @@ public class CodeGenerator {
 
                     if (classfile != null && classfile.getKind() == Kind.CLASS) {
                         InputStream in = classfile.openInputStream();
-                        
+
                         try {
                             cf = ClassFile.read(in);
                             Attribute sfaRaw = cf.getAttribute(Attribute.SourceFile);
@@ -607,7 +622,7 @@ public class CodeGenerator {
                         ctx.put(CodeWriter.class, new ConvenientCodeWriter(ctx));
 
                         CodeWriter codeWriter = CodeWriter.instance(ctx);
-                        
+
                         codeWriter.writeInstrs((Code_attribute) code);
                         codeWriter.writeExceptionTable((Code_attribute) code);
 
@@ -623,7 +638,7 @@ public class CodeGenerator {
                 if (!set.hasComments()) {
                     set.addComment(RelativePosition.INNER, Comment.create(Style.LINE, "compiled code"));
                 }
-                
+
                 return addDeprecated(e, method);
             }
         }
@@ -723,7 +738,7 @@ public class CodeGenerator {
                             LOG.log(Level.WARNING, "Cannot create annotation for: {0}", v);
                             continue;
                         }
-                        
+
                         values.add(val);
                     }
 
@@ -738,29 +753,29 @@ public class CodeGenerator {
         }
 
     }
-    
+
     private static final class ConvenientCodeWriter extends CodeWriter {
 
         private final ConstantWriter constantWriter;
-        
+
         public ConvenientCodeWriter(Context context) {
             super(context);
             constantWriter = ConstantWriter.instance(context);
         }
 
-        private static final Set<Opcode> INSTRUCTION_WITH_REFERENCE = 
+        private static final Set<Opcode> INSTRUCTION_WITH_REFERENCE =
                 EnumSet.of(Opcode.LDC, Opcode.LDC_W, Opcode.LDC2_W,
                            Opcode.GETSTATIC, Opcode.PUTSTATIC, Opcode.GETFIELD,
                            Opcode.PUTFIELD, Opcode.INVOKEVIRTUAL, Opcode.INVOKESPECIAL,
                            Opcode.INVOKESTATIC, Opcode.INVOKEINTERFACE, Opcode.NEW,
                            Opcode.ANEWARRAY, Opcode.CHECKCAST, Opcode.INSTANCEOF);
-        
+
         @Override
         public void writeInstr(Instruction instr) {
             super.writeInstr(instr);
         }
     }
-    
+
     private static final Map<List<ElementKind>, Set<Modifier>> IMPLICIT_MODIFIERS;
 
     static {

--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
@@ -421,7 +421,7 @@ public final class ElementOpen {
                             @Override
                             public void attachmentFailed() {
                                 try {
-                                    FileObject generated = CodeGenerator.generateCode(cpInfo, el);
+                                    FileObject generated = CodeGenerator.generateCode(cpInfo, el, new boolean[1]);
                                     future.complete(generated != null ? getOpenInfo(generated, el, cancel) : null);
                                 } catch (Throwable t) {
                                     future.completeExceptionally(t);
@@ -436,7 +436,7 @@ public final class ElementOpen {
             }
         }
         // try to generate source from class file
-        FileObject generated = CodeGenerator.generateCode(cpInfo, el);
+        FileObject generated = CodeGenerator.generateCode(cpInfo, el, new boolean[1]);
         return CompletableFuture.completedFuture(generated != null ? getOpenInfo(generated, el, cancel) : null);
     }
 


### PR DESCRIPTION
I am still improving support for [Enso sbt projects](https://github.com/enso-org/enso/tree/develop/tools/enso4igv) in NetBeans and [GraalVM's IGV](https://github.com/oracle/graal/tree/master/visualizer). This time I'd like to improve support for _"Go to type"_.

The idea is to check _source attribute_ of parsed `.class` file as soon as _binary open_ parses the file. If the attribute is present and `FileObject` of such name can be find in provided classpaths, open it instead of disassembling the class file.