### PR TITLE
When adding an Autonomous DB, present profiles instead of tenancies

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCIProfile.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCIProfile.java
@@ -178,7 +178,7 @@ public final class OCIProfile implements OCISessionInitiator {
      * Optional.empty() OCI configuration was not found
      */
     @NbBundle.Messages({
-        "LBL_HomeRegion=Home Region: {0}"
+        "LBL_HomeRegion=Region: {0}"
     })
     public Optional<TenancyItem> getTenancy() {
         if (configProvider == null) {

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/AddADBAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/AddADBAction.java
@@ -18,18 +18,21 @@
  */
 package org.netbeans.modules.cloud.oracle.actions;
 
+import com.oracle.bmc.identity.model.Tenancy;
 import com.oracle.bmc.model.BmcException;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.netbeans.api.progress.ProgressHandle;
 import org.netbeans.modules.cloud.oracle.OCIManager;
 import org.netbeans.modules.cloud.oracle.OCIProfile;
 import org.netbeans.modules.cloud.oracle.actions.DownloadWalletDialog.WalletInfo;
@@ -70,7 +73,10 @@ import org.openide.util.NbBundle;
 })
 @NbBundle.Messages({
     "AddADB=Add Oracle Autonomous DB",
-    "SelectTenancy=Select Tenancy",
+    "SelectProfile=Select OCI Profile",
+    "# {0} - tenancy name",
+    "# {1} - region id",
+    "SelectProfile_Description={0} (region: {1})",
     "SelectCompartment=Select Compartment",
     "SelectDatabase=Select Compartment or Database",
     "EnterUsername=Enter Username",
@@ -83,47 +89,82 @@ public class AddADBAction implements ActionListener {
     private static final String USERNAME = "username"; //NOI18N
     private static final String PASSWORD = "password"; //NOI18N
 
+    @NbBundle.Messages({
+        "MSG_CollectingProfiles=Searching for OCI Profiles",
+        "MSG_CollectingProfiles_Text=Loading OCI Profiles",
+        "MSG_CollectingItems=Loading OCI contents",
+        "MSG_CollectingItems_Text=Listing compartments and databases",
+    })
     @Override
     public void actionPerformed(ActionEvent e) {
         Map<String, Object> result = new HashMap<> ();
         
         NotifyDescriptor.ComposedInput ci = new NotifyDescriptor.ComposedInput(Bundle.AddADB(), 3, new Callback() {
-            Map<Integer, List> values = new HashMap<> ();
-            
+            Map<Integer, Map> values = new HashMap<> ();
+
             @Override
             public NotifyDescriptor createInput(NotifyDescriptor.ComposedInput input, int number) {
                 if (number == 1) {
-                    List<TenancyItem> tenancies = new ArrayList<>();
-                    for (OCIProfile p : OCIManager.getDefault().getConnectedProfiles()) {
-                        p.getTenancy().ifPresent(tenancies::add);
+                    ProgressHandle h = ProgressHandle.createHandle(Bundle.MSG_CollectingProfiles());
+                    h.start();
+                    h.progress(Bundle.MSG_CollectingProfiles_Text());
+        
+                    Map<OCIProfile, Tenancy> profiles = new LinkedHashMap<>();
+                    Map<String, TenancyItem> tenancyItems = new LinkedHashMap<>();
+                    try {
+                        for (OCIProfile p : OCIManager.getDefault().getConnectedProfiles()) {
+                            TenancyItem t = p.getTenancy().orElse(null);
+                            if (t != null) {
+                                Tenancy data = p.getTenancyData();
+                                profiles.put(p, data);
+                                tenancyItems.put(p.getId(), t);
+                            }
+                        }
+                    } finally {
+                        h.finish();
                     }
                     String title;
-                    if (tenancies.size() == 1) {
-                        values.put(1, getCompartmentsAndDbs(tenancies.get(0)));
+                    if (profiles.size() == 1) {
+                        values.put(1, getCompartmentsAndDbs(profiles.keySet().iterator().next().getTenancy().get()));
                         title = Bundle.SelectCompartment();
+                        return createQuickPick(values.get(1), title);
                     } else {
-                        values.put(1, tenancies);
-                        title = Bundle.SelectTenancy();
+                        title = Bundle.SelectProfile();
+                        List<Item> items = new ArrayList<>(profiles.size());
+                        for (OCIProfile p : profiles.keySet()) {
+                            Tenancy t = profiles.get(p);
+                            items.add(new Item(p.getId(), Bundle.SelectProfile_Description(t.getName(), t.getHomeRegionKey())));
+                        }
+                        values.put(1, tenancyItems);
+                        return new NotifyDescriptor.QuickPick(title, title, items, false);
                     }
-                    return createQuickPick(values.get(1), title);
                 } else {
                     NotifyDescriptor prev = input.getInputs()[number - 2];
                     OCIItem prevItem = null;
                     if (prev instanceof NotifyDescriptor.QuickPick) {
-                        Optional<String> selected = ((QuickPick) prev).getItems().stream().filter(item -> item.isSelected()).map(item -> item.getLabel()).findFirst();
-                        if (selected.isPresent()) {
-                            Optional<? extends OCIItem> ti = values.get(number - 1).stream().filter(t -> ((OCIItem) t).getName().equals(selected.get())).findFirst();
-                            if (ti.isPresent()) {
-                                prevItem = ti.get();
+                        for (QuickPick.Item item : ((QuickPick)prev).getItems()) {
+                            if (item.isSelected()) {
+                                prevItem = (OCIItem)values.get(number - 1).get(item.getLabel());
+                                break;
                             }
+                        }
+                        if (prevItem == null) {
+                            return null;
                         }
                         if (prevItem instanceof DatabaseItem) {
                             result.put(DB, prevItem);
                             return new NotifyDescriptor.InputLine(Bundle.EnterUsername(), Bundle.EnterUsername());
                         }
-                        values.put(number, getCompartmentsAndDbs(prevItem));
-                        input.setEstimatedNumberOfInputs(input.getEstimatedNumberOfInputs() + 1);
-                        return createQuickPick(values.get(number), Bundle.SelectDatabase());
+                        ProgressHandle h = ProgressHandle.createHandle(Bundle.MSG_CollectingItems());
+                        h.start();
+                        h.progress(Bundle.MSG_CollectingItems_Text());
+                        try {
+                            values.put(number, getCompartmentsAndDbs(prevItem));
+                            input.setEstimatedNumberOfInputs(input.getEstimatedNumberOfInputs() + 1);
+                            return createQuickPick(values.get(number), Bundle.SelectDatabase());
+                        } finally {
+                            h.finish();
+                        }
                     } else if (prev instanceof NotifyDescriptor.PasswordLine) {
                         result.put(PASSWORD, ((NotifyDescriptor.PasswordLine) prev).getInputText());
                         return null;
@@ -156,24 +197,24 @@ public class AddADBAction implements ActionListener {
         }
     }
     
-    private <T extends OCIItem> NotifyDescriptor.QuickPick createQuickPick(List<T> ociItems, String title) {
+    private <T extends OCIItem> NotifyDescriptor.QuickPick createQuickPick(Map<String, T> ociItems, String title) {
         
-        List<Item> items = ociItems.stream()
+        List<Item> items = ociItems.values().stream()
                 .map(tenancy -> new Item(tenancy.getName(), tenancy.getDescription()))
                 .collect(Collectors.toList());
         return new NotifyDescriptor.QuickPick(title, title, items, false);
     }
     
-    private List<OCIItem> getCompartmentsAndDbs(OCIItem parent) {
-        List<OCIItem> items = new ArrayList<> ();
+    private Map<String, OCIItem> getCompartmentsAndDbs(OCIItem parent) {
+        Map<String, OCIItem> items = new HashMap<> ();
         try {
             if (parent instanceof CompartmentItem) {
-                items.addAll(DatabaseNode.getDatabases().apply((CompartmentItem) parent));
+                DatabaseNode.getDatabases().apply((CompartmentItem) parent).forEach((db) -> items.put(db.getName(), db));
             }
         } catch (BmcException e) {
             LOGGER.log(Level.SEVERE, "Unable to load compartment list", e); // NOI18N
         }
-        items.addAll(CompartmentNode.getCompartments().apply(parent));
+        CompartmentNode.getCompartments().apply(parent).forEach(c -> items.put(c.getName(), c));
         return items;
     }
     

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/LspInternalHandle.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/LspInternalHandle.java
@@ -153,6 +153,7 @@ public final class LspInternalHandle extends InternalHandle {
         boolean determinate = getTotalUnits() > 0;
         start.setCancellable(isAllowCancel());
         start.setTitle(getDisplayName());
+        start.setMessage(e.getMessage());
         if (determinate) {
             double percent = e.getPercentageDone();
             if (percent != -1) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
@@ -48,6 +48,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.netbeans.modules.java.lsp.server.input.InputBoxStep;
 import org.netbeans.modules.java.lsp.server.input.InputCallbackParams;
 import org.netbeans.modules.java.lsp.server.input.InputService;
+import org.netbeans.modules.java.lsp.server.input.LspInputServiceImpl;
 import org.netbeans.modules.java.lsp.server.input.QuickPickItem;
 import org.netbeans.modules.java.lsp.server.input.QuickPickStep;
 import org.netbeans.modules.java.lsp.server.input.ShowInputBoxParams;
@@ -59,6 +60,7 @@ import org.openide.NotifyDescriptor;
 import org.openide.awt.Actions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
+import org.openide.util.RequestProcessor;
 
 /**
  * Adapts a {@link NotifyDescriptor} to a {@link ShowMessageRequestParams} call.
@@ -66,6 +68,11 @@ import org.openide.util.NbBundle;
  */
 class NotifyDescriptorAdapter {
     private static final Logger LOG = Logger.getLogger(NotifyDescriptorAdapter.class.getName());
+    
+    /**
+     * Processor that handles requests to create input steps, which might block
+     */
+    private static final RequestProcessor RP = new RequestProcessor(NotifyDescriptorAdapter.class.getName(), 20);
     
     private final UIContext client;
     private final NotifyDescriptor  descriptor;
@@ -405,27 +412,41 @@ class NotifyDescriptorAdapter {
                 public CompletableFuture<Either<QuickPickStep, InputBoxStep>> step(InputCallbackParams params) {
                     String stepId = "ID:" + params.getStep();
                     updateData(params.getData(), data);
-                    NotifyDescriptor input = ci.createInput(params.getStep());
-                    if (input instanceof NotifyDescriptor.InputLine) {
-                        data.put(stepId, input);
-                        InputBoxStep step = new InputBoxStep(ci.getEstimatedNumberOfInputs(), stepId,
-                                null, input.getTitle(), ((NotifyDescriptor.InputLine) input).getInputText(),
-                                input instanceof NotifyDescriptor.PasswordLine);
-                        return CompletableFuture.completedFuture(Either.forRight(step));
-                    } else if (input instanceof NotifyDescriptor.QuickPick) {
-                        data.put(stepId, input);
-                        List<NotifyDescriptor.QuickPick.Item> qpItems = ((NotifyDescriptor.QuickPick) input).getItems();
-                        List<QuickPickItem> items = new ArrayList<>();
-                        for (int i = 0; i < qpItems.size(); i++) {
-                            NotifyDescriptor.QuickPick.Item item = qpItems.get(i);
-                            items.add(new QuickPickItem(item.getLabel(), item.getDescription(), null, item.isSelected(), Integer.toString(i)));
+                    
+                    CompletableFuture<Either<QuickPickStep, InputBoxStep>> res = new CompletableFuture<>();
+                    // the ComposedInput.Callback may block gathering information for e.g. quickpick. Offload to a Requestprocessor, as 
+                    // the main LSP thread cannot be blocked by long operations.
+                    RP.post(() -> {
+                        try {
+                            NotifyDescriptor input = ci.createInput(params.getStep());
+                            if (input instanceof NotifyDescriptor.InputLine) {
+                                data.put(stepId, input);
+                                InputBoxStep step = new InputBoxStep(ci.getEstimatedNumberOfInputs(), stepId,
+                                        null, input.getTitle(), ((NotifyDescriptor.InputLine) input).getInputText(),
+                                        input instanceof NotifyDescriptor.PasswordLine);
+                                res.complete(Either.forRight(step));
+                            } else if (input instanceof NotifyDescriptor.QuickPick) {
+                                data.put(stepId, input);
+                                List<NotifyDescriptor.QuickPick.Item> qpItems = ((NotifyDescriptor.QuickPick) input).getItems();
+                                List<QuickPickItem> items = new ArrayList<>();
+                                for (int i = 0; i < qpItems.size(); i++) {
+                                    NotifyDescriptor.QuickPick.Item item = qpItems.get(i);
+                                    items.add(new QuickPickItem(item.getLabel(), item.getDescription(), null, item.isSelected(), Integer.toString(i)));
+                                }
+                                QuickPickStep step = new QuickPickStep(ci.getEstimatedNumberOfInputs(), stepId,
+                                        null, input.getTitle(), ((NotifyDescriptor.QuickPick) input).isMultipleSelection(),
+                                        items);
+                                res.complete(Either.forLeft(step));
+                            } else {
+                                res.complete(null);
+                            }
+                        } catch (ThreadDeath td) {
+                            throw td;
+                        } catch (Throwable t) {
+                            res.completeExceptionally(t);
                         }
-                        QuickPickStep step = new QuickPickStep(ci.getEstimatedNumberOfInputs(), stepId,
-                                null, input.getTitle(), ((NotifyDescriptor.QuickPick) input).isMultipleSelection(),
-                                items);
-                        return CompletableFuture.completedFuture(Either.forLeft(step));
-                    }
-                    return CompletableFuture.completedFuture(null);
+                    });
+                    return res;
                 }
 
                 @Override


### PR DESCRIPTION
The user was presented with a selector for tenancies when asked to locate an autonomous DB from the OCI. But tenancy is not that descriptive and it's better when the user gets a selector for profiles, which usually have names meaningful to the user. Tenancy name and its region are still interesting as detail info.
This PR changes the chooser to present profiles, with tenancy+region as detail of the presented choice.

 In addition, two bugs were fixed:
- a progress detail message may be coalesced into the start event, but [was not sent to the client](https://github.com/apache/netbeans/pull/5543/files#diff-1027bccfaaf5f4f1d222a283acbbd61d93bf25b5512b88a24ca1a423781af527R156)
- the creation of next `NotifyDescriptor` step in `NotifyDescriptor.ComposedInput` may block when gathering information. We need to leave the main LSP thread unblocked
