### PR TITLE
Update issue forms for NB17 and fix for some GitHub changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
@@ -27,8 +27,8 @@ body:
         Latest releases are always available from https://netbeans.apache.org/download/
       multiple: false
       options:
-        - "Apache NetBeans 16"
-        - "Apache NetBeans 17 release candidate"
+        - "Apache NetBeans 17"
+#        - "Apache NetBeans 18 release candidate"
         - "Apache NetBeans latest daily build"
     validations:
       required: true
@@ -91,7 +91,7 @@ body:
       description: >
         Please select the Apache NetBeans package you're using. Provide additional details
         below if necessary.
-      multiple: false
+      multiple: true
       options:
         - "Apache NetBeans provided installer"
         - "Apache NetBeans binary zip"
@@ -122,21 +122,32 @@ body:
         especially if you already have a good understanding of how to implement the fix. <br>
         Apache NetBeans is a community-managed project and we love to bring new contributors in.
       options:
-        - "Yes"
         - "No"
-    validations:
-        required: true
-  - type: dropdown
-    attributes:
-      label: Code of Conduct
-      description: > 
-         The Code of Conduct helps create a safe space for everyone.
-         I agree to follow the Apache Software Foundation's
-         [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)
-      options:
         - "Yes"
     validations:
         required: true
+#  - type: dropdown
+#    attributes:
+#      label: Code of Conduct
+#      description: > 
+#         The Code of Conduct helps create a safe space for everyone.
+#         I agree to follow the Apache Software Foundation's
+#         [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)
+#      options:
+#        - "Yes"
+#    validations:
+#        required: true
+#  - type: markdown
+#    attributes:
+#      value: "Thank you for completing our form!"
   - type: markdown
     attributes:
-      value: "Thank you for completing our form!"
+      value: "###Code of Conduct
+        
+        
+        **By submitting this form you agree to follow the Apache Software Foundation's
+         [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)**.
+         The Code of Conduct helps create a safe space for everyone.
+        
+        
+        Thank you for completing our form!"

--- a/.github/ISSUE_TEMPLATE/netbeans_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/netbeans_feature_request.yml
@@ -42,21 +42,32 @@ body:
         especially if you already have a good understanding of how to implement the fix. <br>
         Apache NetBeans is a community-managed project and we love to bring new contributors in.
       options:
-        - "Yes"
         - "No"
-    validations:
-        required: true
-  - type: dropdown
-    attributes:
-      label: Code of Conduct
-      description: > 
-         The Code of Conduct helps create a safe space for everyone.
-         I agree to follow the Apache Software Foundation's
-         [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)
-      options:
         - "Yes"
     validations:
         required: true
+#  - type: dropdown
+#    attributes:
+#      label: Code of Conduct
+#      description: > 
+#         The Code of Conduct helps create a safe space for everyone.
+#         I agree to follow the Apache Software Foundation's
+#         [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)
+#      options:
+#        - "Yes"
+#    validations:
+#        required: true
+#  - type: markdown
+#    attributes:
+#      value: "Thank you for completing our form!"
   - type: markdown
     attributes:
-      value: "Thank you for completing our form!"
+      value: "###Code of Conduct
+        
+        
+        **By submitting this form you agree to follow the Apache Software Foundation's
+         [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)**.
+         The Code of Conduct helps create a safe space for everyone.
+        
+        
+        Thank you for completing our form!"


### PR DESCRIPTION
Update issue forms for NetBeans 17 release, and try and work around some GitHub form changes.

In particular, GitHub have changed required dropdowns to pre-select the first option.  This means a lot more people are volunteering pull requests! :smile:  It also makes the code of conduct dropdown pointless.

Swapped the pull request values, made the package selection multiple choice (will hopefully help with this issue and possible people are using multiple), and made the code of conduct section just markdown.  Left old settings commented in the hope GitHub reverse this daft choice.