### PR TITLE
Remove non-working header from GitHub issues markdown.

### DIFF
--- a/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
@@ -142,12 +142,10 @@ body:
 #      value: "Thank you for completing our form!"
   - type: markdown
     attributes:
-      value: "###Code of Conduct
-        
-        
-        **By submitting this form you agree to follow the Apache Software Foundation's
-         [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)**.
-         The Code of Conduct helps create a safe space for everyone.
+      value: "**By submitting this form you agree to follow the Apache Software Foundation's
+        [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)**.
+         
+        The Code of Conduct helps create a safe space for everyone.
         
         
         Thank you for completing our form!"

--- a/.github/ISSUE_TEMPLATE/netbeans_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/netbeans_feature_request.yml
@@ -62,12 +62,10 @@ body:
 #      value: "Thank you for completing our form!"
   - type: markdown
     attributes:
-      value: "###Code of Conduct
-        
-        
-        **By submitting this form you agree to follow the Apache Software Foundation's
-         [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)**.
-         The Code of Conduct helps create a safe space for everyone.
+      value: "**By submitting this form you agree to follow the Apache Software Foundation's
+        [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)**.
+         
+        The Code of Conduct helps create a safe space for everyone.
         
         
         Thank you for completing our form!"


### PR DESCRIPTION
It appears that, despite the issue form documentation, markdown headers aren't working.  Apologies for the noise!