### PR TITLE
switch CI from release to full cluster config.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,9 @@ env:
     -Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json
     -Dtest-unit-sys-prop.ignore.random.failures=true
 
+  # what to build and test, see nbbuild/cluster.properties
+  CLUSTER_CONFIG: 'full'
+
   # flags for conditional, long running steps or jobs configurable with labels. If this is not a PR, everything will run.
   # 'Java' label
   test_java: ${{ contains(github.event.pull_request.labels.*.name, 'Java') || contains(github.event.pull_request.labels.*.name, 'ci:all-tests') || github.event_name != 'pull_request' }}
@@ -122,7 +125,7 @@ jobs:
           echo "org.gradle.java.home=$JAVA_HOME_11_X64" >> ~/.gradle/gradle.properties
 
       - name: Build NetBeans
-        run: ant -quiet -Dcluster.config=release build-nozip
+        run: ant -quiet -Dcluster.config=$CLUSTER_CONFIG build-nozip
 
       - name: Prepare Artifact
         if: ${{ matrix.java == '11' }}
@@ -139,7 +142,7 @@ jobs:
           
       - name: Create Dev Build
         if: ${{ matrix.java == '11' && contains(github.event.pull_request.labels.*.name, 'ci:dev-build') && success() }}
-        run: ant -quiet zip-cluster-config -Dcluster.config=release
+        run: ant -quiet zip-cluster-config -Dcluster.config=$CLUSTER_CONFIG
 
       - name: Upload Dev Build
         if: ${{ matrix.java == '11' && contains(github.event.pull_request.labels.*.name, 'ci:dev-build') && success() }}
@@ -183,7 +186,7 @@ jobs:
         run: tar --zstd -xf build.tar.zst
 
       - name: Commit Validation tests
-        run: ant $OPTS -Dcluster.config=release commit-validation
+        run: ant $OPTS -Dcluster.config=$CLUSTER_CONFIG commit-validation
 
       - name: Create Test Summary
         uses: test-summary/action@v2
@@ -285,12 +288,12 @@ jobs:
         run: tar --zstd -xf build.tar.zst
 
       - name: Test Netbeans Build System
-        run: ant $OPTS -Dcluster.config=release localtest
+        run: ant $OPTS -Dcluster.config=$CLUSTER_CONFIG localtest
 
       - name: Build all Tests
         # runs only in PRs if requested, nowhere else (~18 min)
         if: env.test_tests == 'true' && github.event_name == 'pull_request' && success()
-        run: ant -quiet -Dcluster.config=release test -Dtest.includes=NoTestsJustBuild
+        run: ant -quiet -Dcluster.config=$CLUSTER_CONFIG test -Dtest.includes=NoTestsJustBuild
 
 
   build-nbms:
@@ -1719,7 +1722,7 @@ jobs:
         run: ant $OPTS -f platform/core.network test
 
       - name: Commit Validation tests
-        run: ant $OPTS -Dcluster.config=release commit-validation
+        run: ant $OPTS -Dcluster.config=$CLUSTER_CONFIG commit-validation
 
       - name: Create Test Summary
         uses: test-summary/action@v2

--- a/README.md
+++ b/README.md
@@ -48,21 +48,21 @@ Apache NetBeans is an open source development environment, tooling platform, and
 
 ### Building NetBeans
 
-Build with the default config (See the [cluster.config](https://github.com/apache/netbeans/blob/ab66c7fdfdcbf0bde67b96ddb075c83451cdd1a6/nbbuild/cluster.properties#L19) property.)
+Build the default `release` config (See the [cluster.config](https://github.com/apache/netbeans/blob/ab66c7fdfdcbf0bde67b96ddb075c83451cdd1a6/nbbuild/cluster.properties#L19) property.)
 ```
-$ ant
+$ ant build
 ```
 Build the basic project (mainly Java features):
 ```
-$ ant -Dcluster.config=basic
+$ ant -Dcluster.config=basic build
 ```
-Build the full project (including Groovy, PHP, JavaEE/JakartaEE and JavaScript features):
+Build the full project (may include clusters which are not be in the release):
 ```
-$ ant -Dcluster.config=full
+$ ant -Dcluster.config=full build
 ```
 Build the NetBeans Platform:
 ```
-$ ant -Dcluster.config=platform
+$ ant -Dcluster.config=platform build
 ```
 Cleanup:
 ```

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckModuleConfigs.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckModuleConfigs.java
@@ -57,10 +57,7 @@ public final class CheckModuleConfigs extends Task {
         File clusterPropertiesFile = new File(nbroot, "nbbuild" + File.separatorChar + "cluster.properties");
         Map<String,Object> properties = getProject().getProperties();
         Map<String,Set<String>> clusters = loadModuleClusters(properties, clusterPropertiesFile);
-        Set<String> allClusterModules = new TreeSet<>();
-        for (Set<String> s : clusters.values()) {
-            allClusterModules.addAll(s);
-        }
+
         // Check that javadoc <= full cluster config:
         Set<String> javadoc = splitToSet(getProject().getProperty("config.javadoc.all"), "config.javadoc.all");
         for (Set<String> modules : clusters.values()) {
@@ -80,8 +77,7 @@ public final class CheckModuleConfigs extends Task {
             }
             allClusters.put(m.group(1), splitToList((String) clusterDef.getValue(), clusterDef.getKey()));
         }
-        allClusters.get("experimental").removeAll(allClusters.get("betauc")); // intentionally a superset
-        allClusters.get("betauc").removeAll(allClusters.get("stableuc")); // ditto
+
         for (Map.Entry<String,List<String>> entry : allClusters.entrySet()) {
             String name = entry.getKey();
             List<String> modules = entry.getValue();

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -19,6 +19,7 @@
 cluster.config=release
 clusters.prefix=libnb
 
+# clusters of the Apache NetBeans release, can be a subset of the 'full' config
 clusters.config.release.list=\
         ${clusters.config.java.list},\
         nb.cluster.apisupport,\
@@ -30,6 +31,10 @@ clusters.config.release.list=\
         nb.cluster.ergonomics
 # ergonomics must be last
 
+# full config must contain all clusters
+clusters.config.full.list=\
+        ${clusters.config.release.list}
+
 clusters.config.platform.list=\
         nb.cluster.harness,\
         nb.cluster.bootstrap,\
@@ -38,20 +43,6 @@ clusters.config.platform.list=\
 clusters.config.basic.list=\
         ${clusters.config.java.list},\
         nb.cluster.apisupport,\
-        nb.cluster.ergonomics
-# ergonomics must be last
-
-clusters.config.standard.list=\
-        ${clusters.config.java.list},\
-        nb.cluster.apisupport,\
-        nb.cluster.webcommon,\
-        nb.cluster.enterprise
-
-clusters.config.full.list=\
-        nb.cluster.cpplite,\
-        nb.cluster.groovy,\
-        nb.cluster.php,\
-        ${clusters.config.standard.list},\
         nb.cluster.ergonomics
 # ergonomics must be last
 
@@ -77,8 +68,8 @@ clusters.config.cnd.list=\
 
 clusters.config.cndext.list=\
         ${clusters.config.cnd.list},\
-	nb.cluster.cndext,\
-	nb.cluster.extide,\
+        nb.cluster.cndext,\
+        nb.cluster.extide,\
         nb.cluster.java
 
 clusters.config.cpplite.list=\
@@ -114,65 +105,12 @@ clusters.config.identity.list=\
         ${clusters.config.enterprise.list},\
         nb.cluster.identity
 
-clusters.config.mobility.list=\
-        ${clusters.config.enterprise.list},\
-        nb.cluster.mobility
-
-clusters.config.jdev.list=\
-        ${clusters.config.platform.list},\
-        nb.cluster.ide,\
-        nb.cluster.extide,\
-        nb.cluster.websvccommon,\
-        nb.cluster.java,\
-        nb.cluster.profiler,\
-        nb.cluster.jira,\
-        nb.cluster.odcs
-
-clusters.config.bloated.list=\
-        nb.cluster.identity,\
-        ${clusters.config.full.list}
-# ergonomics must be last
-
-# For technical reasons, nb.cluster.experimental is a superset of nb.cluster.betauc and nb.cluster.stableuc, so cannot list at once:
-clusters.config.experimental.list=\
-        ${clusters.config.bloated.list},\
-        nb.cluster.jira,\
-        nb.cluster.team,\
-        nb.cluster.experimental
-
 clusters.config.stableuc.list=\
         ${clusters.config.full.list},\
         nb.cluster.jira,\
         nb.cluster.team,\
         nb.cluster.stableuc
 # could put ergonomics last, but undesirable to also do so for clusters.config.experimental.list, so exclude stableuc from ergonomics processing
-
-clusters.config.betauc.list=\
-        ${clusters.config.full.list},\
-        nb.cluster.jira,\
-        nb.cluster.team,\
-        nb.cluster.betauc
-
-clusters.config.minimal.list=\
-        ${clusters.config.platform.list},\
-        nb.cluster.ide,\
-        nb.cluster.nb
-
-clusters.config.javacard.list=\
-        ${clusters.config.java.list},\
-        nb.cluster.javacard
-
-clusters.config.remote.list=\
-        ${clusters.config.java.list},\
-        nb.cluster.remote
-
-clusters.config.python.list=\
-        ${clusters.config.minimal.list},\
-        nb.cluster.python
-
-clusters.config.odcs.list=\
-        ${clusters.config.minimal.list},\
-        nb.cluster.odcs
 
 clusters.list=\
         ${clusters.config.full.list}
@@ -418,7 +356,7 @@ nb.cluster.ide=\
         hudson.mercurial,\
         hudson.subversion,\
         hudson.tasklist,\
-	hudson.ui,\
+        hudson.ui,\
         ide.kit,\
         image,\
         javascript2.debug,\
@@ -448,7 +386,7 @@ nb.cluster.ide=\
         libs.jaxb,\
         libs.jcodings,\
         libs.jsch.agentproxy,\
-	libs.json_simple,\
+        libs.json_simple,\
         libs.lucene,\
         libs.snakeyaml_engine,\
         libs.svnClientAdapter,\
@@ -559,7 +497,7 @@ nb.cluster.ide=\
         versioning.system.cvss.installer,\
         versioning.ui,\
         versioning.util,\
-	web.browser.api,\
+        web.browser.api,\
         web.common,\
         web.common.ui,\
         web.indent,\
@@ -877,7 +815,7 @@ nb.cluster.enterprise=\
         web.refactoring,\
         web.struts,\
         weblogic.common,\
-	websocket,\
+        websocket,\
         websvc.clientapi,\
         websvc.core,\
         websvc.customization,\
@@ -1044,28 +982,6 @@ nb.cluster.groovy=\
         groovy.support,\
         libs.groovy,\
         maven.groovy
-
-nb.cluster.mobility.dir=mobility
-nb.cluster.mobility.depends=\
-        nb.cluster.platform,\
-        nb.cluster.java,\
-        nb.cluster.websvccommon,\
-        nb.cluster.apisupport,\
-        nb.cluster.ide,\
-        nb.cluster.enterprise,\
-        nb.cluster.extide
-nb.cluster.mobility=\
-        api.mobility,\
-        j2me.common.ant,\
-        j2me.keystore,\
-        j2me.kit,\
-        j2me.project,\
-        mobility.cldcplatform,\
-        mobility.databindingme,\
-        mobility.end2end,\
-        mobility.jsr172,\
-        mobility.licensing,\
-        mobility.project.ant
 
 nb.cluster.identity.dir=identity
 nb.cluster.identity.depends=\
@@ -1249,31 +1165,6 @@ nb.cluster.team=\
         versioning.kenai,\
         versioning.system.cvss
 
-nb.cluster.odcs.dir=extra
-nb.cluster.odcs.depends=
-nb.cluster.odcs=\
-        c.tasktop.c2c.server.cloud.api,\
-        c.tasktop.c2c.server.common.api,\
-        c.tasktop.c2c.server.profile.api,\
-        c.tasktop.c2c.server.scm.api,\
-        c.tasktop.c2c.server.tasks.api,\
-        c.tasktop.c2c.server.wiki.api,\
-        o.codehaus.jackson.core,\
-        o.codehaus.jackson.mapper,\
-        odcs,\
-        odcs.git,\
-        odcs.hudson,\
-        odcs.kit,\
-        odcs.tasks,\
-        odcs.tasks.bridge,\
-        odcs.ui,\
-        odcs.versioning,\
-        oracle.clouddev.server.profile.activity.client.api,\
-        oracle.clouddev.server.profile.activity.client.rest,\
-        oracle.eclipse.tools.cloud.dev.tasks,\
-        team.server,\
-        team.server.nb
-
 nb.cluster.stableuc.dir=extra
 nb.cluster.stableuc.depends=${clusters.config.full.list}
 nb.cluster.stableuc=\
@@ -1302,24 +1193,9 @@ nb.cluster.stableuc=\
         libs.oracle.cloud,\
         libs.ppawtlayout,\
         loadgenerator,\
-	maven.util,\
-        mobility.antext,\
-        mobility.cldcplatform.catalog,\
-        mobility.deployment.ftpscp,\
-        mobility.deployment.nokia,\
-        mobility.deployment.sonyericsson,\
-        mobility.deployment.webdav,\
-        mobility.editor,\
-        mobility.j2meunit,\
-        mobility.kit,\
-        mobility.plugins.mpowerplayer,\
-        mobility.project,\
-        mobility.project.bridge,\
-        mobility.project.bridge.impl,\
-        mobility.svgcore,\
+        maven.util,\
         mvd,\
         o.apache.tools.ant.module.docs,\
-        otherlicenses/mobility.proguard,\
         profiler.commandrunner,\
         profiler.loadgen,\
         svg.perseus,\
@@ -1347,152 +1223,6 @@ nb.cluster.stableuc=\
         vmd.screen,\
         vmd.structure
 
-nb.cluster.betauc.dir=extra
-nb.cluster.betauc.depends=${clusters.config.full.list}
-nb.cluster.betauc=\
-        ${nb.cluster.stableuc},\
-        clearcase,\
-        coherence,\
-        contrib/ant.freeform.samples,\
-        contrib/api.workqueues,\
-        contrib/apisupport.projectinspector,\
-        contrib/autoproject.core,\
-        contrib/autoproject.java,\
-        contrib/autoproject.profiler,\
-        contrib/autoproject.web,\
-        contrib/cnd.debugger.gdbserver,\
-        contrib/docbook,\
-        contrib/docbook.project,\
-        contrib/imagepaste,\
-        contrib/insertunicode,\
-        contrib/j2ee.geronimo2,\
-        contrib/j2ee.jetty,\
-        contrib/libs.selenium,\
-        contrib/libs.selenium.server,\
-        contrib/logmanagement,\
-        contrib/masterfs.suspend,\
-        contrib/modulemanager,\
-        contrib/quickfilechooser,\
-        contrib/selenium,\
-        contrib/selenium.maven,\
-        contrib/selenium.php,\
-        contrib/selenium.server,\
-        o.apache.jmeter.module,\
-        websvc.rest.wadl.design,\
-        websvc.rest.wadl.model
-
-nb.cluster.experimental.dir=extra
-nb.cluster.experimental.depends=${clusters.config.full.list}
-nb.cluster.experimental=\
-        ${nb.cluster.betauc},\
-        avatar_js.project,\
-        c.s.collablet,\
-        c.s.collablet.moxc,\
-        collab.channel.chat,\
-        collab.channel.chat.html,\
-        collab.channel.chat.java,\
-        collab.channel.chat.text,\
-        collab.channel.chat.xml,\
-        collab.channel.filesharing,\
-        collab.channel.output,\
-        collab.kit,\
-        collab.provider.im,\
-        collab.ui,\
-        contrib/a11y,\
-        contrib/accelerators.terminal,\
-        contrib/apisupport.beanbrowser,\
-        contrib/apisupport.tc.cobertura,\
-        contrib/archiver,\
-        contrib/autosave,\
-        contrib/c.ericsson.otp.erlang,\
-        contrib/codetemplatetools,\
-        contrib/de.hunsicker.jalopy.plugin.netbeans,\
-        contrib/editor.deprecated.pre61completion,\
-        contrib/editor.deprecated.pre61settings,\
-        contrib/editor.fold.support,\
-        contrib/editor.hints.i18n,\
-        contrib/editor.nexterror,\
-        contrib/encoding,\
-        contrib/explorefromhere,\
-        contrib/fisheye,\
-        contrib/folder2html,\
-        contrib/formatmany,\
-        contrib/genericnavigator,\
-        contrib/graphicclassview,\
-        contrib/group,\
-        contrib/gsf,\
-        contrib/gsf.api,\
-        contrib/gsfpath.api,\
-        contrib/hexeditor,\
-        contrib/htmlprojects,\
-        contrib/j2ee.oc4j,\
-        contrib/j2ee.sun.ws7,\
-        contrib/java.debugjavac,\
-        contrib/java.ext.editor,\
-        contrib/javahints,\
-        contrib/javanavigators,\
-        contrib/jemmysupport,\
-        contrib/languages.execution,\
-        contrib/languages.prolog,\
-        contrib/languages.tcl,\
-        contrib/languages.velocity,\
-        contrib/libs.commons_lang,\
-        contrib/libs.ical4j,\
-        contrib/libs.jcalendar,\
-        contrib/licensechanger,\
-        contrib/loaderswitcher,\
-        contrib/moduleresolver,\
-        contrib/mount,\
-        contrib/nbignore,\
-        contrib/nborgsourcebrowse,\
-        contrib/o.jython,\
-        contrib/o.jython.distro,\
-        contrib/o.n.contrib.debuggerretry,\
-        contrib/o.n.erdbeans,\
-        contrib/o.n.misc.diff,\
-        contrib/performance.insane,\
-        contrib/perspective,\
-        contrib/python.console,\
-        contrib/python.core,\
-        contrib/python.debugger,\
-        contrib/python.editor,\
-        contrib/python.help,\
-        contrib/python.hints,\
-        contrib/python.kit,\
-        contrib/python.options,\
-        contrib/python.platform,\
-        contrib/python.project,\
-        contrib/python.project2,\
-        contrib/python.samples,\
-        contrib/python.source,\
-        contrib/python.testrunner,\
-        contrib/showtodos,\
-        contrib/sysprops,\
-        contrib/tanui,\
-        contrib/websvc.saas.services.rtm,\
-        contrib/whichproject,\
-        j2ee.websphere6,\
-        j2me.cdc.platform.bdj,\
-        j2me.cdc.project.bdj,\
-        keyring.jps,\
-        languages.refactoring,\
-        libs.xmlbeans,\
-        mercurial.search,\
-        o.n.bluej,\
-        o.n.bluej.ui,\
-        projectimport.jbuilder,\
-        traceio,\
-        uihandler.interactive,\
-        web.domdiff,\
-        web.facelets010114,\
-        web.jsf.extensions,\
-        web.livehtml,\
-        websvc.axis2,\
-        websvc.jaxrpc,\
-        websvc.jaxrpc16,\
-        websvc.jaxrpckit,\
-        websvc.registry
-
 nb.cluster.extide.dir=extide
 nb.cluster.extide.depends=\
         nb.cluster.ide,\
@@ -1504,10 +1234,6 @@ nb.cluster.extide=\
         libs.gradle,\
         o.apache.tools.ant.module,\
         options.java
-
-# XXX needs updates to build:
-#        contrib/c.s.fortress,\
-#        contrib/fortress.editing,\
 
 nb.cluster.webcommon.dir=webcommon
 nb.cluster.webcommon.depends=\
@@ -1536,7 +1262,7 @@ nb.cluster.webcommon=\
         javascript2.extdoc,\
         javascript2.extjs,\
         javascript2.html,\
-	javascript2.jade,\
+        javascript2.jade,\
         javascript2.jquery,\
         javascript2.jsdoc,\
         javascript2.json,\
@@ -1544,10 +1270,10 @@ nb.cluster.webcommon=\
         javascript2.knockout,\
         javascript2.lexer,\
         javascript2.model,\
-	javascript2.nodejs,\
+        javascript2.nodejs,\
         javascript2.prototypejs,\
         javascript2.react,\
-	javascript2.requirejs,\
+        javascript2.requirejs,\
         javascript2.sdoc,\
         javascript2.source.query,\
         javascript2.types,\
@@ -1582,29 +1308,6 @@ nb.cluster.websvccommon=\
         websvc.saas.kit,\
         websvc.saas.ui
 
-nb.cluster.javacard.dir=javacard
-nb.cluster.javacard.depends=\
-        nb.cluster.ide,\
-        nb.cluster.extide,\
-        nb.cluster.platform,\
-        nb.cluster.java
-nb.cluster.javacard=\
-        javacard.apdu.io,\
-        javacard.apdufile,\
-        javacard.common,\
-        javacard.console,\
-        javacard.filemodels,\
-        javacard.kit,\
-        javacard.oberthur,\
-        javacard.platform.ui,\
-        javacard.project,\
-        javacard.ri.bundle,\
-        javacard.ri.platform,\
-        javacard.spi,\
-        properties.based.dataobjects,\
-        simple.project.templates,\
-        swing.customizerlayout
-
 nb.cluster.javafx.dir=javafx
 nb.cluster.javafx.depends=\
         nb.cluster.ide,\
@@ -1621,36 +1324,3 @@ nb.cluster.javafx=\
         javafx2.samples,\
         javafx2.scenebuilder,\
         maven.htmlui
-
-nb.cluster.remote.dir=extra
-nb.cluster.remote.depends=\
-        nb.cluster.java,\
-        nb.cluster.ide,\
-        nb.cluster.extide,\
-        nb.cluster.platform,\
-        nb.cluster.harness
-nb.cluster.remote=\
-       contrib/dew4nb,\
-       contrib/json,\
-       contrib/remote.project.finder,\
-       contrib/remote.server
-
-nb.cluster.python.depends=\
-        nb.cluster.ide
-nb.cluster.python=\
-        contrib/o.jython,\
-        contrib/o.jython.distro,\
-        contrib/python.console,\
-        contrib/python.core,\
-        contrib/python.debugger,\
-        contrib/python.editor,\
-        contrib/python.help,\
-        contrib/python.hints,\
-        contrib/python.kit,\
-        contrib/python.options,\
-        contrib/python.platform,\
-        contrib/python.project,\
-        contrib/python.project2,\
-        contrib/python.samples,\
-        contrib/python.source,\
-        contrib/python.testrunner


### PR DESCRIPTION
both configs have the same set of clusters at the moment

This would allow us to test more clusters than those which are in the release config.

My only concern is that the order is different:
```
release:
        nb.cluster.cpplite,\
        nb.cluster.groovy,\
        nb.cluster.php,\
        ${clusters.config.java.list},\
        nb.cluster.apisupport,\
        nb.cluster.webcommon,\
        nb.cluster.enterprise
        nb.cluster.ergonomics

full:
        ${clusters.config.java.list},\
        nb.cluster.apisupport,\
        nb.cluster.webcommon,\
        nb.cluster.php,\
        nb.cluster.groovy,\
        nb.cluster.enterprise,\
        nb.cluster.cpplite,\
        nb.cluster.ergonomics 
```
we have to make sure that this won't cause any issues, since we would notice those issues super late. Best option would be to make sure both have the same order, but allow slightly different content.

edit: cleaned up the cluster file a bit