### PR TITLE
LSP: Database connection context menu cleanup

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBDecorationProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBDecorationProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.db;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.netbeans.api.db.explorer.DatabaseConnection;
+import org.netbeans.modules.java.lsp.server.explorer.api.TreeDataListener;
+import org.netbeans.modules.java.lsp.server.explorer.api.TreeDataProvider;
+import org.netbeans.modules.java.lsp.server.explorer.api.TreeItemData;
+import org.openide.nodes.Node;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Provides decorations (connection status) for the Database node.
+ *
+ * @author Tomas Hurka
+ */
+@ServiceProvider(service = TreeDataProvider.Factory.class, path = "Explorers/database.connections")
+public class DBDecorationProvider implements TreeDataProvider.Factory {
+
+    private static final String CONNECTED = "is:connected";             // NOI18N
+    private static final String DISCONNECTED = "is:disconnected";       // NOI18N
+    private static final Logger LOG = Logger.getLogger(DBDecorationProvider.class.getName());
+
+    @Override
+    public TreeDataProvider createProvider(String treeId) {
+        LOG.log(Level.FINE, "Creating default DBDecorationProvider for {0}", treeId);   // NOI18N
+        return new DBDataProvider();
+    }
+
+    private static class DBDataProvider implements TreeDataProvider {
+
+        @Override
+        public TreeItemData createDecorations(Node n, boolean expanded) {
+            DatabaseConnection conn = n.getLookup().lookup(DatabaseConnection.class);
+
+            if (conn != null) {
+                String status = conn.getJDBCConnection() != null ? CONNECTED : DISCONNECTED;
+                TreeItemData data = new TreeItemData();
+                data.setContextValues(status);
+                return data;
+            }
+            LOG.log(Level.WARNING, "Could not get DatabaseConnection for node: {0}", n);  // NOI18N
+            return null;
+        }
+
+        @Override
+        public void addTreeItemDataListener(TreeDataListener l) {
+        }
+
+        @Override
+        public void removeTreeItemDataListener(TreeDataListener l) {
+        }
+
+        @Override
+        public void nodeReleased(Node n) {
+        }
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBDecorationProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBDecorationProvider.java
@@ -57,7 +57,6 @@ public class DBDecorationProvider implements TreeDataProvider.Factory {
                 data.setContextValues(status);
                 return data;
             }
-            LOG.log(Level.WARNING, "Could not get DatabaseConnection for node: {0}", n);  // NOI18N
             return null;
         }
 

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -498,7 +498,7 @@
 			},
 			{
 				"command": "nbls:Database:netbeans.db.explorer.action.Disconnect",
-				"title": "Disconnect"
+				"title": "Disconnect from Database"
 			},
 			{
 				"command": "nbls:Database:netbeans.db.explorer.action.Refresh",
@@ -568,7 +568,7 @@
 			},
 			{
 				"command": "java.local.db.set.preferred.connection",
-				"title": "Make Default Connection"
+				"title": "Set as Default Connection"
 			},
 			{
 				"command": "java.workspace.configureRunSettings",
@@ -758,19 +758,23 @@
 				},
 				{
 					"command": "nbls:Database:netbeans.db.explorer.action.Connect",
-					"when": "viewItem =~ /class:org.netbeans.api.db.explorer.DatabaseConnection/"
+					"when": "viewItem =~ /class:org.netbeans.api.db.explorer.DatabaseConnection/ && viewItem =~ /is:disconnected/",
+					"group": "db@10"
 				},
 				{
 					"command": "nbls:Database:netbeans.db.explorer.action.Disconnect",
-					"when": "viewItem =~ /class:org.netbeans.api.db.explorer.DatabaseConnection/"
+					"when": "viewItem =~ /class:org.netbeans.api.db.explorer.DatabaseConnection/ && viewItem =~ /is:connected/",
+					"group": "db@20"
 				},
 				{
 					"command": "nbls:Database:netbeans.db.explorer.action.Refresh",
-					"when": "viewItem =~ /class:ddl.DBConnection/"
+					"when": "viewItem =~ /class:org.netbeans.api.db.explorer.DatabaseConnection/",
+					"group": "db@30"
 				},
 				{
 					"command": "nbls:Edit:org.openide.actions.DeleteAction",
-					"when": "viewItem =~ /cap:delete/"
+					"when": "viewItem =~ /cap:delete/",
+					"group": "db@50"
 				},
 				{
 					"command": "java.workspace.new",
@@ -804,7 +808,8 @@
 				},
 				{
 					"command": "java.local.db.set.preferred.connection",
-					"when": "viewItem =~ /class:org.netbeans.api.db.explorer.DatabaseConnection/"
+					"when": "viewItem =~ /class:org.netbeans.api.db.explorer.DatabaseConnection/",
+					"group": "db@40"
 				},
 				{
 					"command": "nbls:Tools:org.netbeans.modules.cloud.oracle.actions.DownloadWalletAction",


### PR DESCRIPTION
This is Database connection context menu cleanup GCN-1406

- Action names were renamed and reordered
- Database connect/disconnect actions are displayed based on connection status. 
- Database connection status is exported via TreeItem.contextValue and available in VS Code 'viewItem'



