### PR TITLE
Remove JDK8 as minimum for build of VSNetBeans.

### DIFF
--- a/java/java.lsp.server/vscode/BUILD.md
+++ b/java/java.lsp.server/vscode/BUILD.md
@@ -23,14 +23,11 @@
 
 ## Prerequisities
 
-- JDK, version 11
+- JDK, version 11 or later
 - Ant, latest version
 - Maven, latest version
 - node.js, latest LTS (to build VSIX)
 
-It is currently possible to use JDK 8 for the build and execution.
-However, as the Apache NetBeans project is slowly moving towards JDK 11,
-using JDK 11 may be the safest bet.
 
 ## Getting the Code
 

--- a/java/java.lsp.server/vscode/README.md
+++ b/java/java.lsp.server/vscode/README.md
@@ -23,7 +23,7 @@
 
 This is a technology preview of [Apache NetBeans](http://netbeans.org)
 based extension for VS Code. Use it to get all the _goodies of NetBeans_
-via the VS Code user interface! Runs on __JDK8__[*] and all newer versions.
+via the VS Code user interface! Runs on __JDK11__ and all newer versions.
 
 Apache NetBeans Language Server brings full featured Java development (edit-compile-debug & test cycle) for Maven and Gradle projects to VSCode. As well as other features.
 ## Getting Started


### PR DESCRIPTION
Use JDK11+ for building VSNetBeans, removal of JDK8 mentions.