### PR TITLE
OCI Audit project command LSP API

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditOptions.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditOptions.java
@@ -25,11 +25,14 @@ import org.netbeans.modules.cloud.oracle.OCISessionInitiator;
  *
  * @author sdedic
  */
-public class AuditOptions {
+public final class AuditOptions {
     private boolean forceAuditExecution;
     private boolean runIfNotExists;
     private String auditName;
     private OCISessionInitiator session;
+    private boolean returnData;
+    private boolean displaySummary = true;
+    private boolean supressErrors = false;
     
     public static AuditOptions makeNewAudit() {
         return new AuditOptions().setForceAuditExecution(true).setRunIfNotExists(true);
@@ -70,4 +73,36 @@ public class AuditOptions {
     public OCISessionInitiator getSession() {
         return session != null ? session : OCIManager.getDefault().getActiveSession();
     }
+
+    /**
+     * @return true, if data structure should be returned instead of just error/OK
+     */
+    public boolean isReturnData() {
+        return returnData;
+    }
+
+    public void setReturnData(boolean returnData) {
+        this.returnData = returnData;
+    }
+
+    /**
+     * @return True if the audit code should notify the user with a summary message.
+     * False otherwise.
+     */
+    public boolean isDisplaySummary() {
+        return displaySummary;
+    }
+
+    public void setDisplaySummary(boolean displaySummary) {
+        this.displaySummary = displaySummary;
+    }
+
+    public boolean isSupressErrors() {
+        return supressErrors;
+    }
+
+    public void setSupressErrors(boolean supressErrors) {
+        this.supressErrors = supressErrors;
+    }
 }
+

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditResult.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditResult.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.cloud.oracle.adm;
+
+import java.util.List;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+
+/**
+ *
+ * @author sdedic
+ */
+public final class AuditResult {
+    private String errorMessage;
+    private Throwable error;
+    private int dependencyCount;
+    private int vulnerableCount;
+    private String auditId;
+    private List<ArtifactSpec> vulnerabilities;
+    private String projectName;
+    private Project project;
+
+    public AuditResult() {
+    }
+
+    public AuditResult(Project project, String projectName, String errorMessage, Exception error) {
+        this.project = project;
+        this.projectName = projectName;
+        this.errorMessage = errorMessage;
+        this.error = error;
+    }
+
+    public AuditResult(Project project, String projectName, String auditId, int dependencyCount, int vulnerableCount, List<ArtifactSpec> vulnerabilities) {
+        this.project = project;
+        this.projectName = projectName;
+        this.auditId = auditId;
+        this.dependencyCount = dependencyCount;
+        this.vulnerableCount = vulnerableCount;
+        this.vulnerabilities = vulnerabilities;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public String getAuditId() {
+        return auditId;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public int getDependencyCount() {
+        return dependencyCount;
+    }
+
+    public void setDependencyCount(int dependencyCount) {
+        this.dependencyCount = dependencyCount;
+    }
+
+    public int getVulnerableCount() {
+        return vulnerableCount;
+    }
+
+    public void setVulnerableCount(int vulnerableCount) {
+        this.vulnerableCount = vulnerableCount;
+    }
+
+    public List<ArtifactSpec> getVulnerabilities() {
+        return vulnerabilities;
+    }
+
+    public void setVulnerabilities(List<ArtifactSpec> vulnerabilities) {
+        this.vulnerabilities = vulnerabilities;
+    }
+
+    public Throwable getError() {
+        return error;
+    }
+
+    public void setError(Throwable error) {
+        this.error = error;
+    }
+}

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
@@ -127,20 +127,22 @@ public final class ProjectVulnerability {
         "# {0} - project name",
         "MSG_CreatingAuditFailed=Creating Vulnerablity audit for project {0} failed.",
     })
-    public CompletableFuture<String> runProjectAudit(KnowledgeBaseItem item, AuditOptions options) {
+    public CompletableFuture<AuditResult> runProjectAudit(KnowledgeBaseItem item, AuditOptions options) {
         if (item != null) {
             // make transient setting, so that change handler may work against the same knowledgebase.
             setProjectKnowledgeBase0(item);
         }
-        CompletableFuture<String> result = new CompletableFuture<>();
+        CompletableFuture<AuditResult> result = new CompletableFuture<>();
         AUDIT_PROCESSOR.post(() -> {
             try {
-                result.complete(VulnerabilityWorker.getInstance().findVulnerability(project, options));
+                result.complete(VulnerabilityWorker.getInstance().vulnerabilityAudit(project, options));
             } catch (ThreadDeath x) {
                 throw x;
             } catch (AuditException ex) {
                 final String projectDisplayName = ProjectUtils.getInformation(project).getDisplayName();
-                ErrorUtils.processError(ex, Bundle.MSG_CreatingAuditFailed(projectDisplayName));
+                if (!options.isSupressErrors()) {
+                    ErrorUtils.processError(ex, Bundle.MSG_CreatingAuditFailed(projectDisplayName));
+                }
                 result.completeExceptionally(ex);
             } catch (Exception | Error e) {
                 result.completeExceptionally(e);

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -372,6 +372,11 @@ public class VulnerabilityWorker implements ErrorProvider{
      * @return Returns the audit ID, or {@code null} if no audit is present.
      */
     public String findVulnerability(Project project, AuditOptions auditOptions) throws AuditException {
+        AuditResult r = vulnerabilityAudit(project, auditOptions);
+        return r.getAuditId();
+    }
+    
+    public AuditResult vulnerabilityAudit(Project project, AuditOptions auditOptions) throws AuditException {
         if (auditOptions == null) {
             auditOptions = new AuditOptions();
         }
@@ -399,7 +404,7 @@ public class VulnerabilityWorker implements ErrorProvider{
         }
     }
 
-    private String doFindVulnerability(Project project, String compartmentId, String knowledgeBaseId, String projectDisplayName, AuditOptions auditOptions,
+    private AuditResult doFindVulnerability(Project project, String compartmentId, String knowledgeBaseId, String projectDisplayName, AuditOptions auditOptions,
             ProgressHandle progressHandle, AtomicBoolean remoteCall) throws AuditException {
         List<ApplicationDependency> result = new ArrayList<>();
         
@@ -516,16 +521,32 @@ public class VulnerabilityWorker implements ErrorProvider{
             } else {
                 message = Bundle.MSG_Audit_Failed_More(projectDisplayName, cacheItem.getAudit().getVulnerableArtifactsCount());
             }
-            if (auditDone) {
+            if (auditDone && auditOptions.isDisplaySummary()) {
                 DialogDisplayer.getDefault().notifyLater(
                                 new NotifyDescriptor.Message(message, cacheItem.getAudit().getIsSuccess() ? NotifyDescriptor.INFORMATION_MESSAGE : NotifyDescriptor.WARNING_MESSAGE));
             }
             Diagnostic.ReporterControl reporter = Diagnostic.findReporterControl(Lookup.getDefault(), project.getProjectDirectory());
             reporter.diagnosticChanged(problematicFiles, null);
-            return cacheItem.report.summary.getId();
+            
+            List<ArtifactSpec> arts = new ArrayList<>();
+            for (ApplicationDependencyVulnerabilitySummary s : cacheItem.getVulnerabilities()) {
+                Dependency d = cacheItem.getDependencyMap().get(s.getGav());
+                if (d == null) {
+                    continue;
+                }
+                ArtifactSpec spec = d.getArtifact();
+                if (spec != null) {
+                    arts.add(spec);
+                }
+            }
+            AuditResult res = new AuditResult(project, projectDisplayName, cacheItem.report.summary.getId(), 
+                    cacheItem.getDependencyMap().size(), cacheItem.getAudit().getVulnerableArtifactsCount(), 
+                    arts);
+            return res;
         } else {
             // indicate somehow the KB exists, but empty
-            return "";
+            return new AuditResult(project, projectDisplayName, "",  // NOI18N
+                    0, 0, Collections.emptyList());
         }
     }
     

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/ExtraGsonSetup.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/ExtraGsonSetup.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.nbcode.integration;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.GsonBuilder;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.netbeans.modules.java.lsp.server.LspGsonSetup;
+import org.netbeans.modules.project.dependency.ArtifactSpec;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Adds some more type adapters for ArtifactSpec.
+ * 
+ * @author sdedic
+ */
+@ServiceProvider(service = LspGsonSetup.class)
+public class ExtraGsonSetup implements LspGsonSetup{
+
+    private static final Set<String> ARTIFACT_BLOCK_FIELDS = new HashSet<>(Arrays.asList(
+            "data" // NOI18N
+    ));
+
+    @Override
+    public void configureBuilder(GsonBuilder b) {
+        b.addSerializationExclusionStrategy(new ExclusionStrategy() {
+            @Override
+            public boolean shouldSkipField(FieldAttributes fa) {
+                // this is hacky, but avoids dependency on project artifacts. An alternative is to place
+                //this part into VSNetbeans integration module that contains the relevant commands.
+                if (fa.getDeclaringClass() == ArtifactSpec.class) {
+                    return ARTIFACT_BLOCK_FIELDS.contains(fa.getName());
+                } else if (Throwable.class.isAssignableFrom(fa.getDeclaredClass())) {
+
+                }
+                return false;
+            }
+
+            @Override
+            public boolean shouldSkipClass(Class<?> type) {
+                return false;
+            }
+        });
+    }
+    
+}

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
@@ -40,6 +40,7 @@ import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.cloud.oracle.OCIManager;
 import org.netbeans.modules.cloud.oracle.OCIProfile;
 import org.netbeans.modules.cloud.oracle.adm.AuditOptions;
+import org.netbeans.modules.cloud.oracle.adm.AuditResult;
 import org.netbeans.modules.cloud.oracle.adm.ProjectVulnerability;
 import org.netbeans.modules.java.lsp.server.protocol.CodeActionsProvider;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
@@ -80,7 +81,11 @@ public class ProjectAuditCommand extends CodeActionsProvider {
         return Collections.emptyList();
     }
     
-    private final Gson gson = new Gson();
+    private final Gson gson;
+
+    public ProjectAuditCommand() {
+        gson = NbGsonBuilderUtils.createGsonBuilder().create();
+    }
 
     @NbBundle.Messages({
         "# {0} - project name",
@@ -94,7 +99,7 @@ public class ProjectAuditCommand extends CodeActionsProvider {
         }
         
         FileObject f = Utils.extractFileObject(arguments.get(0), gson);
-        Project p = FileOwnerQuery.getOwner(f);
+        final Project p = FileOwnerQuery.getOwner(f);
         if (p == null) {
             throw new IllegalArgumentException("Not part of a project " + f);
         }
@@ -146,31 +151,68 @@ public class ProjectAuditCommand extends CodeActionsProvider {
             auditWithProfile = OCIManager.getDefault().getActiveProfile();
         }
         
+        AuditOptions auditOpts = AuditOptions.makeNewAudit().useSession(auditWithProfile).setAuditName(preferredName);
+        
+        if (options.has("returnData") && options.get("returnData").isJsonPrimitive()) {
+            auditOpts.setReturnData(options.getAsJsonPrimitive("returnData").getAsBoolean());
+        }
+        if (options.has("displaySummary") && options.get("displaySummary").isJsonPrimitive()) {
+            auditOpts.setDisplaySummary(options.getAsJsonPrimitive("displaySummary").getAsBoolean());
+        }
+        
+        if (options.has("suppressErrors") && options.get("suppressErrors").isJsonPrimitive()) {
+            auditOpts.setSupressErrors(options.getAsJsonPrimitive("suppressErrors").getAsBoolean());
+        }
+        
+        AuditResult[] refR = { null };
+        Throwable[] exc = { null };
         return OCIManager.usingSession(auditWithProfile, () -> v.findKnowledgeBase(knowledgeBase).
                 exceptionally(th -> {
-                    DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(Bundle.ERR_KnowledgeBaseSearchFailed(fn, th.getMessage()),
-                            NotifyDescriptor.ERROR_MESSAGE));
+                    if (!auditOpts.isSupressErrors()) {
+                        DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(Bundle.ERR_KnowledgeBaseSearchFailed(fn, th.getMessage()),
+                                NotifyDescriptor.ERROR_MESSAGE));
+                    } else {
+                        exc[0] = th;
+                    }
                     return null;
+                    /*
+                    if (auditOpts.isReturnData()) {
+                        
+                        //refR[0] = new AuditResult(p, fn, th.getMessage(), (Exception)th);
+                    }
+                    return null;
+                    */
                 }).thenCompose((kb) -> {
-            if (kb == null) {
-                return CompletableFuture.completedFuture(null);
+            if (exc[0] != null) {
+                CompletableFuture r = new CompletableFuture();
+                r.completeExceptionally(exc[0]);
+                return r;
             }
-            CompletableFuture<String> exec;
+            if (kb == null) {
+                return CompletableFuture.completedFuture(/* gson.toJsonTree( */ refR[0] /* ) */);
+            }
+            CompletableFuture<AuditResult> exec;
             
             switch (command) {
                 case COMMAND_EXECUTE_AUDIT:
-                    exec = v.runProjectAudit(kb, AuditOptions.makeNewAudit().useSession(auditWithProfile).setAuditName(preferredName));
+                    exec = v.runProjectAudit(kb, auditOpts);
                     break;
                 case COMMAND_LOAD_AUDIT: {
-                    exec = v.runProjectAudit(kb, new AuditOptions().useSession(auditWithProfile).setRunIfNotExists(forceAudit).setAuditName(preferredName));
+                    exec = v.runProjectAudit(kb, auditOpts.setRunIfNotExists(forceAudit).setAuditName(preferredName));
+                    break;
                 }
                 default:
                     return CompletableFuture.completedFuture(null);
-                    
             }
-            return (CompletableFuture<Object>)(CompletableFuture)exec;
+            if (auditOpts.isReturnData()) {
+                return (CompletableFuture<Object>)(CompletableFuture)/* exec.thenApply((r) -> gson.toJsonTree(r)) */exec.thenApply(r -> {
+                   return r; 
+                });
+            } else {
+                return exec.thenApply(r -> r.getAuditId());
+            }
         }));
-    } 
+    }
 
     @Override
     public Set<String> getCommands() {

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
@@ -84,7 +84,7 @@ public class ProjectAuditCommand extends CodeActionsProvider {
     private final Gson gson;
 
     public ProjectAuditCommand() {
-        gson = NbGsonBuilderUtils.createGsonBuilder().create();
+        gson = new Gson();
     }
 
     @NbBundle.Messages({

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectMetadataCommand.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectMetadataCommand.java
@@ -18,21 +18,11 @@
  */
 package org.netbeans.modules.nbcode.integration.commands;
 
-import com.google.gson.ExclusionStrategy;
-import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.google.gson.TypeAdapter;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
-import com.google.gson.stream.JsonWriter;
-import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -47,13 +37,10 @@ import org.netbeans.api.project.ProjectActionContext;
 import org.netbeans.modules.java.lsp.server.LspServerState;
 import org.netbeans.modules.java.lsp.server.protocol.CodeActionsProvider;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
-import org.netbeans.modules.java.lsp.server.protocol.Server;
 import org.netbeans.modules.parsing.api.ResultIterator;
-import org.netbeans.modules.project.dependency.ArtifactSpec;
 import org.netbeans.modules.project.dependency.ProjectArtifactsQuery;
 import org.netbeans.modules.project.dependency.ProjectArtifactsQuery.ArtifactsResult;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
 import org.openide.util.RequestProcessor;
 import org.openide.util.lookup.ServiceProvider;
@@ -78,54 +65,7 @@ public class ProjectMetadataCommand extends CodeActionsProvider {
     private final Gson gson;
     
     public ProjectMetadataCommand() {
-        gson = new GsonBuilder()
-             // block the opaque 'data' field 
-            .addSerializationExclusionStrategy(new ExclusionStrategy() {
-                    @Override
-                    public boolean shouldSkipField(FieldAttributes fa) {
-                        if (fa.getDeclaringClass() == ArtifactSpec.class) {
-                          return ARTIFACT_BLOCK_FIELDS.contains(fa.getName());
-                        }
-                        return false;
-                    }
-
-                    @Override
-                    public boolean shouldSkipClass(Class<?> type) {
-                        return false;
-                    }
-            })
-            // serialize FileObject as null|path
-            .registerTypeAdapterFactory(new TypeAdapterFactory() {
-                @Override
-                public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> tt) {
-                    if (!FileObject.class.isAssignableFrom(tt.getRawType())) {
-                        return null;
-                    }
-                    return new TypeAdapter<T>() {
-                        @Override
-                        public void write(JsonWriter writer, T t) throws IOException {
-                            FileObject f = (FileObject)t;
-                            writer.value(f == null ? null : f.getPath());
-                        }
-
-                        @Override
-                        public T read(JsonReader reader) throws IOException {
-                            if (reader.peek() == JsonToken.NULL) {
-                                reader.nextNull();
-                                return null;
-                            } else {
-                                String s = reader.nextString();
-                                if (s == null) {
-                                    return null;
-                                }
-                                FileObject fo = FileUtil.toFileObject(Paths.get(s).toFile());
-                                return (T)fo;
-                            }
-                        }
-                    };
-                }
-            })
-            .create();
+        gson = new GsonBuilder().create();
     }
     
     @Override
@@ -221,8 +161,7 @@ public class ProjectMetadataCommand extends CodeActionsProvider {
         return Lookup.getDefault().lookup(LspServerState.class).asyncOpenFileOwner(f).thenApplyAsync((project) -> {
             ArtifactsResult arts = ProjectArtifactsQuery.findArtifacts(p, filter);
             // must serialize in advance, since we cannot configure gson instance in lsp4j
-            Object o = gson.toJsonTree(arts.getArtifacts());
-            return o;
+            return arts.getArtifacts();
         }, METADATA_PROCESSOR);
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspGsonSetup.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspGsonSetup.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server;
+
+import com.google.gson.GsonBuilder;
+
+/**
+ * Configure the GSON serializer that serializes messages to / from the
+ * LSP server. Allows to export NetBeans complex objects, such as FileObject,
+ * block unwanted fields from objects, or recreate complex objects by 
+ * finding them based on the received wire data (i.e. recreate a Project
+ * if a string directory path is given).
+ * <p/>
+ * An instance should be registered in the Lookup, using {@link ServiceProvider}
+ * annotation.
+ * 
+ * @author sdedic
+ */
+public interface LspGsonSetup {
+    /**
+     * Configures GSon builder and returns the configured instance
+     * @param b the builder, partially configured
+     * @return the configured instance
+     */
+    public void configureBuilder(GsonBuilder b);
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbGsonAdapter.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbGsonAdapter.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.api.project.ProjectUtils;
+import org.netbeans.modules.java.lsp.server.LspGsonSetup;
+import org.netbeans.modules.java.lsp.server.Utils;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * A default serialization helper. It handles the following cases:
+ * <ul>
+ * <li>{@link Throwable}s: excludes some internal fields, and attempts to serialize everything else. Should allow to export error details to vscode.
+ * <li>{@link FileObject}: serialized as path, FileObject is looked up on deserialization; both path and URI is supported on deserialization, null if not found + log.
+ * <li>{@link Project}: serialized as structure with directory+name, deserialized from the structure (just path/uri is used) or path/uri string
+ * </ul>
+ * Note: for Exceptions, the serializer does not transmit the class name - which could be useful. In order to do so + serialize the <i>data fields</i> of
+ * the exception, some clever delegating would have to be used. The reflective adapter is final / not
+ * customizable, so some weird JsonWriter man-in-the-middle could eventually inject a classname property : not implemented yet
+ * @author sdedic
+ */
+@ServiceProvider(service = LspGsonSetup.class)
+public class NbGsonAdapter implements LspGsonSetup {
+    private static final Logger LOG = Logger.getLogger(NbGsonAdapter.class.getName());
+    
+    /**
+     * Fields from Throwable that will not be serialized.
+     */
+    private static final Set<String> EXCEPTION_BLOCK_FIELDS = new HashSet<>(Arrays.asList(
+        "backtrace", // NOI18N
+        "depth", // NOI18N
+        "stackTrace", // NOI18N
+        "suppressedExceptions" // NOI18N
+    ));
+    
+    private static FileObject deserializeFile(String s) {
+        if (s == null || "".equals(s.trim())) {
+            return null;
+        }
+        FileObject fo = FileUtil.toFileObject(Paths.get(s).toFile());
+        if (fo == null) {
+            try {
+                fo = Utils.fromUri(s);
+            } catch (IllegalArgumentException | FileSystemNotFoundException | MalformedURLException ex) {
+                // will be logged later, along with URI ok but file-not-found case
+            }
+        }
+        if (fo == null) {
+            LOG.log(Level.FINE, "Could not deserialize path {0} to a file");
+        }
+        return fo;
+    }
+    
+    @Override
+    public void configureBuilder(GsonBuilder b) {
+        
+        // block the opaque 'data' field
+        b.addSerializationExclusionStrategy(new ExclusionStrategy() {
+            @Override
+            public boolean shouldSkipField(FieldAttributes fa) {
+                if (Throwable.class.isAssignableFrom(fa.getDeclaredClass())) {
+                    return EXCEPTION_BLOCK_FIELDS.contains(fa.getName());
+                }
+                return false;
+            }
+
+            @Override
+            public boolean shouldSkipClass(Class<?> type) {
+                return false;
+            }
+        }).registerTypeAdapterFactory(new TypeAdapterFactory() {
+            @Override
+            public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> tt) {
+                if (FileObject.class.isAssignableFrom(tt.getRawType())) {
+                    return new TypeAdapter<T>() {
+                        @Override
+                        public void write(JsonWriter writer, T t) throws IOException {
+                            FileObject f = (FileObject) t;
+                            writer.value(f == null ? null : f.getPath());
+                        }
+
+                        @Override
+                        public T read(JsonReader reader) throws IOException {
+                            if (reader.peek() == JsonToken.NULL) {
+                                reader.nextNull();
+                                return null;
+                            } else {
+                                return (T)deserializeFile(reader.nextString());
+                            }
+                        }
+                    };
+                } else if (Project.class.isAssignableFrom(tt.getRawType())) {
+                    // custom serialize Project as structure
+                    return new TypeAdapter<T>() {
+                        @Override
+                        public void write(JsonWriter writer, T t) throws IOException {
+                            Project p = (Project) t;
+                            if (p == null) {
+                                writer.nullValue();
+                            } else {
+                                writer.beginObject();
+                                writer.name("path").value(p.getProjectDirectory().getPath()); // NOI18N
+                                writer.name("name").value(ProjectUtils.getInformation(p).getDisplayName()); // NOI18N
+                                writer.endObject();
+                            }
+                        }
+
+                        @Override
+                        public T read(JsonReader reader) throws IOException {
+                            if (reader.peek() == JsonToken.NULL) {
+                                reader.nextNull();
+                                return null;
+                            } else if (reader.peek() == JsonToken.BEGIN_OBJECT) {
+                                reader.beginObject();
+                                Project p = null;
+                                while (reader.hasNext()) {
+                                    String n = reader.nextName();
+                                    if (n == null) {
+                                        continue;
+                                    }
+                                    String s = reader.nextString();
+                                    if ("path".equals(n) || "uri".equals(n)) { // NOI18N
+                                        // NOI18N
+                                        FileObject fo = deserializeFile(s);
+                                        if (fo != null) {
+                                            p = ProjectManager.getDefault().findProject(fo);
+                                        }
+                                    }
+                                }
+                                reader.endObject();
+                                return (T) p;
+                            } else if (reader.peek() == JsonToken.STRING) {
+                                String s = reader.nextString();
+                                if (s == null || s.isEmpty()) {
+                                    return null;
+                                }
+                                FileObject fo = deserializeFile(s);
+                                return (T)(fo == null ? null : ProjectManager.getDefault().findProject(fo));
+                            } else {
+                                return null;
+                            }
+                        }
+                    };
+                } else {
+                    return null;
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR extends the LSP command 'project.audit.execue/display' with several options that customize UI behaviour. In addition, the command can return the data back to the vscode for custom presentation of the result.

In the supplemental commit, I have moved  GSON (de)serialization helpers from integration module to the base LSP one and configured the server's GSON, so now some NetBeans objects can be used as results from LSP functions and will be serialized in some sane way to the JSON returned to the LSP client.