### PR TITLE
NETBEANS-1935: Add common shortcus to the empty editor view

### DIFF
--- a/platform/core.windows/nbproject/project.xml
+++ b/platform/core.windows/nbproject/project.xml
@@ -35,12 +35,37 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.editor.settings</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.76</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.editor.settings.lib</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.70.0.1</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.options.api</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
                         <specification-version>1.29</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.options.keymap</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.56</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/core.windows/src/org/netbeans/core/windows/view/Bundle.properties
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/Bundle.properties
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+LBL_NewProject=New Project
+LBL_OpenProject=Open Project
+LBL_QuickSearch=Quick Search
+LBL_NewFile=New File
+LBL_OpenRecentFile=Open Recent File
+LBL_GoToFile=Go To File
+LBL_DropFilesHere=Drop files here to open
+LBL_DropFolderHere=Drop folder here to open
+LBL_NoShortcutAssigned=No shortcut assigned

--- a/platform/options.keymap/nbproject/project.xml
+++ b/platform/options.keymap/nbproject/project.xml
@@ -148,6 +148,7 @@
             </test-dependencies>
             <friend-packages>
                 <friend>org.netbeans.core.output2</friend>
+                <friend>org.netbeans.core.windows</friend>
                 <friend>org.netbeans.modules.editor.macros</friend>
                 <friend>org.netbeans.modules.jumpto</friend>
                 <friend>org.netbeans.modules.jvi</friend>


### PR DESCRIPTION
for new users to NetBeans to help onboarding them to their first use

How it looks
<img width="817" alt="image" src="https://user-images.githubusercontent.com/795658/222572386-b41d3584-d922-40d2-aeb5-1ed17be9e45c.png">

How it reacts to keybinding and profile changes
![netbeans-shortcuts-update](https://user-images.githubusercontent.com/795658/222573199-f2a545b8-ba1a-441d-aefb-687b4d1f3b16.gif)


Original Ticket: https://issues.apache.org/jira/browse/NETBEANS-1935