### PR TITLE
Upgrade EclipseLink from 2.7.10 to 2.7.12

### DIFF
--- a/enterprise/websvc.restlib/src/org/netbeans/modules/websvc/swdp/swdp.xml
+++ b/enterprise/websvc.restlib/src/org/netbeans/modules/websvc/swdp/swdp.xml
@@ -47,12 +47,12 @@
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/aopalliance-repackaged-2.6.1.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/osgi.core-8.0.0.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/osgi-resource-locator-1.0.3.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.10.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-9.2.0.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.10.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.10.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.10.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.10.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.12.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-9.4.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.12.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.12.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.12.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.12.jar!/</resource>
     </volume>
     <properties>
         <!-- please check with mkleint@netbeans.org before/after updating this or "classpath" section -->

--- a/java/j2ee.eclipselink/external/binaries-list
+++ b/java/j2ee.eclipselink/external/binaries-list
@@ -14,11 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-4FCF93A34BAA5176E968498FAFB8B4E2C11D93F1 org.eclipse.persistence:org.eclipse.persistence.core:2.7.10
-40807FC4D91A3F827FB038369BD2C83009BEA3B8 org.eclipse.persistence:org.eclipse.persistence.asm:9.2.0
-78712ED5187194106A5563F3DE0539BED69ED8E5 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.10
-4E903136AB19889208E23C3C87B77DBBFD986DE5 org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.10
-EC685587096E9649AF3544010313992F188E3602 org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.10
-2652F3E9F0FA97B1AED3A2E512E6FA59CC243E18 org.eclipse.persistence:org.eclipse.persistence.moxy:2.7.10
+684CD163E2C2B3623B30A7C392783C12998B296E org.eclipse.persistence:org.eclipse.persistence.core:2.7.12
+BEECC6436A613956DBC9CAEED144C8CD50A9EB9C org.eclipse.persistence:org.eclipse.persistence.asm:9.4.0
+78712ED5187194106A5563F3DE0539BED69ED8E5 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.12
+E22A1DBFD01A4FD2FEECB4FC7B44496AF3DFEA17 org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.12
+1DBB819CF485816F70CA459A54FBC1BEBC92D8F2 org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.12
+CFA1D606E50143162E151E0D43C7B7BC36129016 org.eclipse.persistence:org.eclipse.persistence.moxy:2.7.12
 CCB72277523E79F81BBF74535BF6488443403BAE org.eclipse.persistence:jakarta.persistence:2.2.3
 0BE5F7D291047D13FDD4AA219AD755E431DAFECA org.eclipse.persistence:jakarta.persistence:2.2.3:sources

--- a/java/j2ee.eclipselink/external/eclipselink-2.7.12-license.txt
+++ b/java/j2ee.eclipselink/external/eclipselink-2.7.12-license.txt
@@ -1,12 +1,12 @@
 Name: EclipseLink
 Origin: Eclipse
-Version: 2.7.10
+Version: 2.7.12
 Description: The Eclipse Persistence Services Project (EclipseLink) project.
 License: EPL-v10-eclipselink
 Origin: http://www.eclipse.org/eclipselink/
-Files: jakarta.persistence-2.2.3-sources.jar, jakarta.persistence-2.2.3.jar, org.eclipse.persistence.core-2.7.10.jar, org.eclipse.persistence.asm-9.2.0.jar, org.eclipse.persistence.antlr-2.7.10.jar, org.eclipse.persistence.jpa-2.7.10.jar, org.eclipse.persistence.jpa.jpql-2.7.10.jar,org.eclipse.persistence.moxy-2.7.10.jar
+Files: jakarta.persistence-2.2.3-sources.jar, jakarta.persistence-2.2.3.jar, org.eclipse.persistence.core-2.7.12.jar, org.eclipse.persistence.asm-9.4.0.jar, org.eclipse.persistence.antlr-2.7.12.jar, org.eclipse.persistence.jpa-2.7.12.jar, org.eclipse.persistence.jpa.jpql-2.7.12.jar,org.eclipse.persistence.moxy-2.7.12.jar
 
-Use of EclipseLink version 2.7.10 is governed by the terms of the license below:
+Use of EclipseLink version 2.7.12 is governed by the terms of the license below:
 
 License
 

--- a/java/j2ee.eclipselink/nbproject/project.properties
+++ b/java/j2ee.eclipselink/nbproject/project.properties
@@ -19,21 +19,21 @@ is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 jnlp.indirect.jars=\
-    modules/ext/eclipselink/org.eclipse.persistence.core-2.7.10.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.asm-9.2.0.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.10.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.10.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.10.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.10.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.core-2.7.12.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.asm-9.4.0.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.12.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.12.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.12.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.12.jar,\
     modules/ext/eclipselink/jakarta.persistence-2.2.3.jar,\
     modules/ext/docs/jakarta.persistence-2.2.3-doc.zip
 
-release.external/org.eclipse.persistence.core-2.7.10.jar=modules/ext/eclipselink/org.eclipse.persistence.core-2.7.10.jar
-release.external/org.eclipse.persistence.asm-9.2.0.jar=modules/ext/eclipselink/org.eclipse.persistence.asm-9.2.0.jar
-release.external/org.eclipse.persistence.antlr-2.7.10.jar=modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.10.jar
-release.external/org.eclipse.persistence.jpa-2.7.10.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.10.jar
-release.external/org.eclipse.persistence.jpa.jpql-2.7.10.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.10.jar
-release.external/org.eclipse.persistence.moxy-2.7.10.jar=modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.10.jar
+release.external/org.eclipse.persistence.core-2.7.12.jar=modules/ext/eclipselink/org.eclipse.persistence.core-2.7.12.jar
+release.external/org.eclipse.persistence.asm-9.4.0.jar=modules/ext/eclipselink/org.eclipse.persistence.asm-9.4.0.jar
+release.external/org.eclipse.persistence.antlr-2.7.12.jar=modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.12.jar
+release.external/org.eclipse.persistence.jpa-2.7.12.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.12.jar
+release.external/org.eclipse.persistence.jpa.jpql-2.7.12.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.12.jar
+release.external/org.eclipse.persistence.moxy-2.7.12.jar=modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.12.jar
 release.external/jakarta.persistence-2.2.3.jar=modules/ext/eclipselink/jakarta.persistence-2.2.3.jar
 release.build/jakarta.persistence-2.2.3-doc.zip=modules/ext/docs/jakarta.persistence-2.2.3-doc.zip
 

--- a/java/j2ee.eclipselink/nbproject/project.xml
+++ b/java/j2ee.eclipselink/nbproject/project.xml
@@ -30,22 +30,22 @@
                 <subpackages>javax.persistence</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.core-2.7.10.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.core-2.7.12.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.asm-9.2.0.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.asm-9.4.0.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.antlr-2.7.10.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.antlr-2.7.12.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa-2.7.10.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa-2.7.12.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.10.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.12.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.moxy-2.7.10.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.moxy-2.7.12.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/eclipselink/jakarta.persistence-2.2.3.jar</runtime-relative-path>

--- a/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/eclipselink_lib.xml
+++ b/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/eclipselink_lib.xml
@@ -25,12 +25,12 @@
     <localizing-bundle>org.netbeans.modules.j2ee.eclipselink.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.10.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-9.2.0.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.10.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.10.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.10.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.10.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.12.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-9.4.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.12.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.12.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.12.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.12.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/jakarta.persistence-2.2.3.jar!/</resource>
     </volume>
     <volume>
@@ -42,12 +42,12 @@
         <property>
             <name>maven-dependencies</name>
             <value>
-                org.eclipse.persistence:org.eclipse.persistence.core:2.7.10:jar
-                org.eclipse.persistence:org.eclipse.persistence.asm:9.2.0:jar
-                org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.10:jar
-                org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.10:jar
-                org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.10:jar
-                org.eclipse.persistence:org.eclipse.persistence.moxy:2.7.10:jar
+                org.eclipse.persistence:org.eclipse.persistence.core:2.7.12:jar
+                org.eclipse.persistence:org.eclipse.persistence.asm:9.4.0:jar
+                org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.12:jar
+                org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.12:jar
+                org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.12:jar
+                org.eclipse.persistence:org.eclipse.persistence.moxy:2.7.12:jar
                 org.eclipse.persistence:jakarta.persistence:2.2.3:jar
             </value>
         </property>

--- a/java/j2ee.eclipselinkmodelgen/external/binaries-list
+++ b/java/j2ee.eclipselinkmodelgen/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-8166FE76CA693917A14717924947508612CD755A org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.10
+40A5550958D9AE12ADB285FACF69FC7CE1FFD707 org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.12

--- a/java/j2ee.eclipselinkmodelgen/external/eclipselink-2.7.12-license.txt
+++ b/java/j2ee.eclipselinkmodelgen/external/eclipselink-2.7.12-license.txt
@@ -1,12 +1,12 @@
 Name: EclipseLink
 Origin: Eclipse
-Version: 2.7.10
+Version: 2.7.12
 Description: The Eclipse Persistence Services Project ( EclipseLink) project.
 License: EPL-v10-eclipselink
 Origin: http://www.eclipse.org/eclipselink/
-Files: org.eclipse.persistence.jpa.modelgen.processor-2.7.10.jar
+Files: org.eclipse.persistence.jpa.modelgen.processor-2.7.12.jar
 
-Use of EclipseLink version 2.7.10 is governed by the terms of the license below:
+Use of EclipseLink version 2.7.12 is governed by the terms of the license below:
 
 License
 

--- a/java/j2ee.eclipselinkmodelgen/nbproject/project.properties
+++ b/java/j2ee.eclipselinkmodelgen/nbproject/project.properties
@@ -18,6 +18,6 @@
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 jnlp.indirect.jars=\
-    modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.10.jar
+    modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.12.jar
 
-release.external/org.eclipse.persistence.jpa.modelgen.processor-2.7.10.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.10.jar
+release.external/org.eclipse.persistence.jpa.modelgen.processor-2.7.12.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.12.jar

--- a/java/j2ee.eclipselinkmodelgen/src/org/netbeans/modules/j2ee/eclipselinkmodelgen/eclipselinkmodelgen_lib.xml
+++ b/java/j2ee.eclipselinkmodelgen/src/org/netbeans/modules/j2ee/eclipselinkmodelgen/eclipselinkmodelgen_lib.xml
@@ -25,7 +25,7 @@
     <localizing-bundle>org.netbeans.modules.j2ee.eclipselinkmodelgen.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselinkmodelgen/modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.10.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselinkmodelgen/modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.12.jar!/</resource>
     </volume>
     <volume>
         <type>javadoc</type>
@@ -37,7 +37,7 @@
         <!-- please check with mkleint@netbeans.org before/after updating this or "classpath" section -->
         <property>
             <name>maven-dependencies</name>
-            <value>org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.10:jar</value>
+            <value>org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.12:jar</value>
         </property>
     </properties> 
 </library>

--- a/java/j2ee.jpa.refactoring/nbproject/project.properties
+++ b/java/j2ee.jpa.refactoring/nbproject/project.properties
@@ -20,11 +20,11 @@ javac.source=1.8
 requires.nb.javac=true
 
 test.unit.run.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.2.0.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.10.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.4.0.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.12.jar:\
     ${j2ee.persistence.dir}/modules/ext/eclipselink/jakarta.persistence-2.2.3.jar:\
     ${j2eeserver.dir}/modules/ext/jsr88javax.jar:\
     ${masterfs.dir}/modules/org-netbeans-modules-masterfs.jar

--- a/java/j2ee.metadata.model.support/nbproject/project.properties
+++ b/java/j2ee.metadata.model.support/nbproject/project.properties
@@ -20,10 +20,10 @@ javac.source=1.8
 requires.nb.javac=true
 
 test.unit.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.2.0.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.10.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.4.0.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.12.jar:\
     ${j2ee.persistence.dir}/modules/ext/eclipselink/jakarta.persistence-2.2.3.jar:\
     ${j2ee.core.dir}/modules/ext/javaee6-endorsed/javax.annotation.jar

--- a/java/j2ee.persistence/nbproject/project.properties
+++ b/java/j2ee.persistence/nbproject/project.properties
@@ -20,11 +20,11 @@ javac.source=1.8
 spec.version.base=1.75.0
 
 test.unit.run.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.2.0.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.10.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.4.0.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.12.jar:\
     ${j2ee.persistence.dir}/modules/ext/eclipselink/jakarta.persistence-2.2.3.jar:\
     ${j2eeserver.dir}/modules/ext/jsr88javax.jar:\
     ${masterfs.dir}/modules/org-netbeans-modules-masterfs.jar

--- a/java/j2ee.persistenceapi/nbproject/project.properties
+++ b/java/j2ee.persistenceapi/nbproject/project.properties
@@ -24,11 +24,11 @@ requires.nb.javac=true
 
 spec.version.base=1.56.0
 test.unit.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.2.0.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.10.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.10.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.4.0.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.12.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.12.jar:\
     ${j2ee.persistence.dir}/modules/ext/eclipselink/jakarta.persistence-2.2.3.jar
 
 test.config.stableBTD.includes=**/*Test.class

--- a/nbbuild/licenses/EPL-v10-eclipselink
+++ b/nbbuild/licenses/EPL-v10-eclipselink
@@ -1,4 +1,4 @@
-Use of EclipseLink version 2.7.10 is governed by the terms of the license below:
+Use of EclipseLink version 2.7.12 is governed by the terms of the license below:
 
 License
 


### PR DESCRIPTION
Library Notes:

- This is mainly a maintenance release and contains bug fixes

NetBeans Testing:
- Full build done
- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of unit tests for modules `websvc.restlib`, `j2ee.eclipselink`, `j2ee.eclipselinkmodelgen`, `j2ee.jpa.refactoring`, `j2ee.metadata.model.support`, `j2ee.persistence` and `j2ee.persistenceapi`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Checked the files are in the Ant Library Manager
- Successfully create project as per [NetBeans Documentation](https://netbeans.apache.org/kb/docs/websvc/rest.html), with MariaDB, TomEE 8 plus and GlassFish 5.1.0


[EclipseLink Web Page](https://www.eclipse.org/eclipselink/)
[EclipseLink Release Notes](https://github.com/eclipse-ee4j/eclipselink/releases/tag/2.7.12)