### PR TITLE
Display DB welcome only when no connections are defined.

### DIFF
--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -88,7 +88,8 @@
 		"viewsWelcome": [
 			{
 				"view": "database.connections",
-				"contents": "No database connections found.\n[Add Database Connection](command:db.add.connection)\n[Add Oracle Autonomous DB](command:nbls:Tools:org.netbeans.modules.cloud.oracle.actions.AddADBAction)"
+				"contents": "No database connections found.\n[Add Database Connection](command:db.add.connection)\n[Add Oracle Autonomous DB](command:nbls:Tools:org.netbeans.modules.cloud.oracle.actions.AddADBAction)",
+				"when": "nb.database.view.active"
 			}
 		],
 		"configuration": {

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -980,10 +980,18 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
     class Decorator implements TreeItemDecorator<Visualizer> {
         private provider : CustomizableTreeDataProvider<Visualizer>;
         private setCommand : vscode.Disposable;
+        private initialized: boolean = false;
 
         constructor(provider : CustomizableTreeDataProvider<Visualizer>, client : NbLanguageClient) {
             this.provider = provider;
             this.setCommand = vscode.commands.registerCommand('java.local.db.set.preferred.connection', (n) => this.setPreferred(n));
+        }
+
+        decorateChildren(element: Visualizer, children: Visualizer[]): Visualizer[] {
+            if (element.id == this.provider.getRoot().id) {
+                vscode.commands.executeCommand('setContext', 'nb.database.view.active', children.length == 0);
+            }
+            return children;
         }
 
         async decorateTreeItem(vis : Visualizer, item : vscode.TreeItem) : Promise<vscode.TreeItem> {


### PR DESCRIPTION
The DB view initializes asynchronously, and in the meantime, before the "Connections" node's children are fetched (possibly empty!), the area shows the Welcome view.

In this PR a new decorating wrapper/callback is defined, that allows to process children returned from the NBLS. The DB view uses that to enable the welcome view only if the number of connections (children of the root node) is 0.
