### PR TITLE
turn github PR squash feature off.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,7 +30,7 @@ github:
     issues: true
     projects: true
   enabled_merge_buttons:
-    squash:  true
+    squash:  false
     merge:   true
     rebase:  true
   protected_branches:


### PR DESCRIPTION
see discussion @ [dev list](https://lists.apache.org/thread/lps7q24bcl9d2hg1rhhy68qc5fn22r3t)

reasons:
 - not transparent how exactly github is squashing a PR, this can lead to noreply email commit headers etc
 - squashing locally as last post-review step before merge is probably the better workflow anyway and makes it less likely to merge with the wrong setting