### PR TITLE
Fix case when ANTLR getText() causes assertion in LexerInput.

### DIFF
--- a/ide/lexer.antlr4/src/org/netbeans/spi/lexer/antlr4/LexerInputCharStream.java
+++ b/ide/lexer.antlr4/src/org/netbeans/spi/lexer/antlr4/LexerInputCharStream.java
@@ -45,14 +45,14 @@ final class LexerInputCharStream implements CharStream {
         }
         int start = intrvl.a - tokenMark;
         int end = intrvl.b - tokenMark + 1;
-        int toread = end - start - input.readLength();
-        for (int i = 0; i < toread; i++) {
-            input.read();
+        int readCount = 0;
+        int next = 0;
+        while ((end > input.readLength()) && (next != EOF)) {
+            next = input.read();
+            readCount++;
         }
-        String ret = String.valueOf(input.readText(start, end));
-        if (toread > 0) {
-            input.backup(toread);
-        }
+        String ret = String.valueOf(input.readText(start, Math.min(end, input.readLength())));
+        input.backup(readCount);
         return ret;
     }
 


### PR DESCRIPTION
It seems getText() calls (only seen at error handling so far) from ANTLR could cause and assertion at [LexerInput.readText()](https://github.com/apache/netbeans/blob/5934827e80797ec9b93ff28635ce7fca12627a70/ide/lexer/src/org/netbeans/spi/lexer/LexerInput.java#L257)

This PR makes sure that we call the readText method with arguments that satisfy that condition.
