### PR TITLE
Allow to realy NEVER check for updates, even on first start.

### DIFF
--- a/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-autoupdate-ui.jar/org/netbeans/modules/autoupdate/ui/api/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-autoupdate-ui.jar/org/netbeans/modules/autoupdate/ui/api/Bundle.properties
@@ -1,2 +1,18 @@
-API_AutoupdateCheckScheduler_InitialCheckForced=false
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
+API_AutoupdateCheckScheduler_InitialCheckForced=false

--- a/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-autoupdate-ui.jar/org/netbeans/modules/autoupdate/ui/api/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-autoupdate-ui.jar/org/netbeans/modules/autoupdate/ui/api/Bundle.properties
@@ -1,0 +1,2 @@
+API_AutoupdateCheckScheduler_InitialCheckForced=false
+

--- a/platform/autoupdate.ui/apichanges.xml
+++ b/platform/autoupdate.ui/apichanges.xml
@@ -32,6 +32,22 @@
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="AutoupdateScheduler.InitialCheck">
+            <api name="ui"/>
+            <summary>Force initial AU check</summary>
+            <version major="1" minor="67"/>
+            <date day="7" month="3" year="2023"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes" binary="compatible" deletion="no"
+                deprecation="no" semantic="compatible" source="compatible"
+            />
+            <description>
+                <p>
+                    <a href="@TOP@/index.html#group-property">Branding API</a> to force or skip initial check was added. If branded to false, the check on first startup is skipped
+                    in NEVER mode. By default the check is done initially even if mode is set to NEVER.
+                </p>
+            </description>
+        </change>
         <change id="PluginManager.installPlugins">
             <api name="ui"/>
             <summary>PluginManager.install</summary>

--- a/platform/autoupdate.ui/arch.xml
+++ b/platform/autoupdate.ui/arch.xml
@@ -525,6 +525,14 @@
    include <code>{ "update", "available", "local", "installed" }</code>.
    </api>
   </p>
+  <p>
+   <api category="devel" group="property" name="org.netbeans.modules.autoupdate.ui.api.AutoupdateCheckScheduler_InitialCheckForced" type="export">
+       Determines if an initial autoupdate check is forced at the first startup. By default (set to <code>true</code>), the check is performed always, regardless 
+       of actual AutoUpdate settings in the distribution. Once the check was done (last check is recorded), the configured settings applied. If
+       <code>false</code>, the check is done according to settings, even for the first time. This affects mainly NEVER setting, as the other are
+       time-based and the last-check time is missing on 1st startup.
+   </api>
+  </p>
  </answer>
 
 

--- a/platform/autoupdate.ui/manifest.mf
+++ b/platform/autoupdate.ui/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.autoupdate.ui
 OpenIDE-Module-Install: org/netbeans/modules/autoupdate/ui/actions/Installer.class
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/autoupdate/ui/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.66
+OpenIDE-Module-Specification-Version: 1.67
 AutoUpdate-Show-In-Client: false
 AutoUpdate-Essential-Module: true

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/AutoupdateCheckScheduler.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/actions/AutoupdateCheckScheduler.java
@@ -69,12 +69,6 @@ import org.openide.windows.WindowManager;
  * @author Jiri Rechtacek
  */
 public class AutoupdateCheckScheduler {
-    /**
-     * System property that allows to skip forced initial check. If set to true, the check is not forced, if a check was never
-     * was performed - the scheduling is always driven by AU settings.
-     */
-    private static final String INITIAL_CHECK_SKIP_OPT = "autoupdate.initial.check.skip"; // NOI18N
-
     private static RequestProcessor.Task regularlyCheck = null;    
     private static final RequestProcessor REGULARLY_CHECK_TIMER = 
         new RequestProcessor("auto-checker-reqularly-timer", 1, true); // NOI18N

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/api/Bundle.properties
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/api/Bundle.properties
@@ -1,0 +1,5 @@
+# Branding API:
+# If set to true or missing, an initial check will be forced if no check was done at all, regardless the
+# AU settings. This is the default; if se to false, the AU settings will be always honoured - this changes
+# just the NEVER option, as time-based checks always expire when there's no last time recorded.
+AutoupdateCheckScheduler_InitialCheckForced=true


### PR DESCRIPTION
AutoUpdate can be configured to check never for updates, but regardless of that setting, the check happens on 1st startup. For vscode distribution, I would like to ensure the autoupdate really never connects to AU center. At the same time I did not want to affect the NB operation - so I've added a 'branding API' that can be used to disable the first forced check. nbls distribution then contains the appropriate branding that disables it.

Maybe a command will be added later to faciliate with AU to install updates, but given how the vscode Marketplace works, it may not be necessary.
