### PR TITLE
Save/restore the ANTLR RustLexer specific internals.

### DIFF
--- a/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/RustLanguageLexer.java
+++ b/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/RustLanguageLexer.java
@@ -74,7 +74,7 @@ public class RustLanguageLexer extends AbstractAntlrLexerBridge<RustLexer, RustT
 
     }
 
-    private static final RustLexer createLexer(CharStream input) {
+    private static RustLexer createLexer(CharStream input) {
         RustLexer lexer = new RustLexer(input);
         lexer.removeErrorListeners();
         lexer.addErrorListener(new RustLanguageLexerErrorListener());
@@ -96,8 +96,8 @@ public class RustLanguageLexer extends AbstractAntlrLexerBridge<RustLexer, RustT
     }
 
     private static final class LexerState extends AbstractAntlrLexerBridge.LexerState<RustLexer> {
-        final org.antlr.v4.runtime.Token lt1;
-        final org.antlr.v4.runtime.Token lt2;
+        final Integer lt1;
+        final Integer lt2;
 
         LexerState(RustLexer lexer) {
             super(lexer);

--- a/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/RustLanguageLexer.java
+++ b/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/RustLanguageLexer.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.rust.grammar;
 import java.util.BitSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.Parser;
@@ -91,4 +90,28 @@ public class RustLanguageLexer extends AbstractAntlrLexerBridge<RustLexer, RustT
         return token(RustTokenID.from(antlrToken));
     }
 
+    @Override
+    public Object state() {
+        return new LexerState(lexer);
+    }
+
+    private static final class LexerState extends AbstractAntlrLexerBridge.LexerState<RustLexer> {
+        final org.antlr.v4.runtime.Token lt1;
+        final org.antlr.v4.runtime.Token lt2;
+
+        LexerState(RustLexer lexer) {
+            super(lexer);
+
+            this.lt1 = lexer.lt1;
+            this.lt2 = lexer.lt2;
+        }
+
+        @Override
+        public void restore(RustLexer lexer) {
+            super.restore(lexer);
+
+            lexer.lt1 = lt1;
+            lexer.lt2 = lt2;
+        }
+    }
 }

--- a/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/antlr4/RustLexerBase.java
+++ b/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/antlr4/RustLexerBase.java
@@ -54,8 +54,8 @@ public abstract class RustLexerBase extends Lexer {
         super(input);
     }
 
-    public Token lt1;
-    public Token lt2;
+    public Integer lt1;
+    public Integer lt2;
 
     @Override
     public Token nextToken() {
@@ -85,7 +85,7 @@ public abstract class RustLexerBase extends Lexer {
         if (next.getChannel() == Token.DEFAULT_CHANNEL) {
             // Keep track of the last token on the default channel.
             this.lt2 = this.lt1;
-            this.lt1 = next;
+            this.lt1 = next.getType();
         }
 
         return next;
@@ -130,10 +130,10 @@ public abstract class RustLexerBase extends Lexer {
         if (this.lt1 == null || this.lt2 == null) {
             return true;
         }
-        if (this.lt1.getType() != RustLexer.DOT) {
+        if (this.lt1 != RustLexer.DOT) {
             return true;
         }
-        switch (this.lt2.getType()) {
+        switch (this.lt2) {
             case RustLexer.CHAR_LITERAL:
             case RustLexer.STRING_LITERAL:
             case RustLexer.RAW_STRING_LITERAL:

--- a/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/antlr4/RustLexerBase.java
+++ b/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/antlr4/RustLexerBase.java
@@ -54,8 +54,8 @@ public abstract class RustLexerBase extends Lexer {
         super(input);
     }
 
-    Token lt1;
-    Token lt2;
+    public Token lt1;
+    public Token lt2;
 
     @Override
     public Token nextToken() {


### PR DESCRIPTION
@vieiro You might this one. I have not tested this trough, it just compiles.
The NB lexer saves/restores the lexer input at some wierd positions, and if the ANTLR lexer state is not fully saved/restored it can cause wide range of issues.
