### PR TITLE
LSP: Fix too many invocation of 'java.db.preferred.connection'

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -1033,7 +1033,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
         }
 
         async decorateTreeItem(vis : Visualizer, item : vscode.TreeItem) : Promise<vscode.TreeItem> {
-            if (!(item.contextValue && item.contextValue.match(/class:ddl.DBConnection/))) {
+            if (!(item.contextValue && item.contextValue.match(/class:org.netbeans.api.db.explorer.DatabaseConnection/))) {
                 return item;
             }
             return vscode.commands.executeCommand('java.db.preferred.connection').then((id) => {


### PR DESCRIPTION
Invoke 'java.db.preferred.connection' command only for database connection node and not for all database nodes, which are marked with `class:ddl.DBConnection` context value.