### PR TITLE
LSP: Fix Delete action in context menu

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/DefaultDecorationsImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/DefaultDecorationsImpl.java
@@ -206,7 +206,7 @@ public class DefaultDecorationsImpl implements TreeDataProvider.Factory {
                 } else {
                     d.addContextValues(CTXVALUE_PROJECT_SUBPROJECT);
                 }
-            } else if (f == null || physFile != null) { 
+            } else if (n.canDestroy()) {
                 // TODO Hack: exclude projects from delete capability. The TreeItemData probably needs to support
                 // exclusion... Project delete UI is not suitable for LSP at the moment
                 d.addContextValues(CTXVALUE_CAP_DELETE);


### PR DESCRIPTION
Make sure CTXVALUE_CAP_DELETE is added to context value only for nodes, which can be deleted.