### PR TITLE
fixes a NPE in TestOutputListenerProvider (maven output handler).

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/output/TestOutputListenerProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/TestOutputListenerProvider.java
@@ -124,12 +124,18 @@ public class TestOutputListenerProvider implements OutputProcessor {
         match = runningPattern2.matcher(line);
         if (match.matches()) {
             try {
-                Object defaultValue = PluginPropertyUtils.createEvaluator(visitor.getContext().getCurrentProject())
-                        .evaluate("${project.build.directory}/surefire-reports");
-                if (defaultValue instanceof String) {
-                    outputDir = (String) defaultValue;
-                    // don't want to create link on the surefire line
-//                    visitor.setOutputListener(new TestOutputListener(runningTestClass, outputDir), true);
+                OutputVisitor.Context context = visitor.getContext();
+                if (context != null) {
+                    Project currentProject = context.getCurrentProject();
+                    if (currentProject != null) {
+                        Object defaultValue = PluginPropertyUtils.createEvaluator(currentProject)
+                                                                 .evaluate("${project.build.directory}/surefire-reports");
+                        if (defaultValue instanceof String) {
+                            outputDir = (String) defaultValue;
+                            // don't want to create link on the surefire line
+        //                    visitor.setOutputListener(new TestOutputListener(runningTestClass, outputDir), true);
+                        }
+                    }
                 }
                 return;
             } catch (ExpressionEvaluationException ex) {


### PR DESCRIPTION
```
java.lang.NullPointerException: Cannot invoke "org.netbeans.modules.maven.api.output.OutputVisitor$Context.getCurrentProject()" because the return value of "org.netbeans.modules.maven.api.output.OutputVisitor.getContext()" is null
	at org.netbeans.modules.maven.output.TestOutputListenerProvider.processLine(TestOutputListenerProvider.java:127)
	at org.netbeans.modules.maven.execute.AbstractOutputHandler.processLine(AbstractOutputHandler.java:293)
	at org.netbeans.modules.maven.execute.CommandLineOutputHandler$Output.run(CommandLineOutputHandler.java:338)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
```

This can be reproduced when building something while having the `-T 1` flag set. Which is a no-op for maven but makes NB think that the build is multithreaded and puts it into a fallback mode without the maven event spy active beside other things.