### PR TITLE
Remove unnessary build options from project definitions

### DIFF
--- a/ide/xml.axi/nbproject/project.properties
+++ b/ide/xml.axi/nbproject/project.properties
@@ -20,8 +20,6 @@
 is.autoload=true
 javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
-test.unit.jvmargs=-Xmx128m
-xtest.jvm.args=-Xmx128m
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/ide/xml.xdm/nbproject/project.properties
+++ b/ide/xml.xdm/nbproject/project.properties
@@ -21,7 +21,5 @@ is.autoload=true
 javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.54.0
-test.unit.jvmargs=-Xmx128m
-xtest.jvm.args=-Xmx128m
 
 test.config.stableBTD.includes=**/*Test.class

--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -16,9 +16,7 @@
 # under the License.
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-build.compiler=extJavac
 nbjavac.ignore.missing.enclosing=**/CUP$ASTPHP5Parser$actions.class
-javac.compilerargs=-J-Xmx512m
 nbm.needs.restart=true
 spec.version.base=2.23.0
 release.external/predefined_vars-1.0.zip=docs/predefined_vars.zip

--- a/webcommon/javascript2.editor/nbproject/project.properties
+++ b/webcommon/javascript2.editor/nbproject/project.properties
@@ -17,8 +17,6 @@
 
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-build.compiler=extJavac
-javac.compilerargs=-J-Xmx512m
 javadoc.arch=${basedir}/arch.xml
 nbm.needs.restart=true
 


### PR DESCRIPTION
This removes the last remaining "-Xmx" overrides from the project.properties. The option does not seem to be used and the property definition overrides a previous one.

In addition the "build.compiler=extJavac" option is removed as the build run correctly without this.
