### PR TITLE
Upgrade PostgreSQL JDBC driver to 42.5.4

### DIFF
--- a/ide/db.drivers/external/binaries-list
+++ b/ide/db.drivers/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-A9EE12F737BD5DC7D046E4C065E391D38D6A3CFC org.postgresql:postgresql:42.2.16
+015015A54F15E340A9A8A6A2C5457429CB1176B8 org.postgresql:postgresql:42.5.4

--- a/ide/db.drivers/external/postgresql-42.5.4-license.txt
+++ b/ide/db.drivers/external/postgresql-42.5.4-license.txt
@@ -1,9 +1,9 @@
 Name: PostgreSQL JDBC Driver
-Version: 42.2.16
+Version: 42.5.4
 Description: Allows Java programs to interact with a PostgreSQL database
 License: BSD-postgresql
 Origin: https://jdbc.postgresql.org/about/license.html
-Files: postgresql-42.2.16.jar
+Files: postgresql-42.5.4.jar
 Comment: Out-of-the-box support for Postgres Java database applications
 
 Copyright (c) 1997, PostgreSQL Global Development Group

--- a/ide/db.drivers/nbproject/project.properties
+++ b/ide/db.drivers/nbproject/project.properties
@@ -17,6 +17,6 @@
 
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
-release.external/postgresql-42.2.16.jar=modules/ext/postgresql-42.2.16.jar
+release.external/postgresql-42.5.4.jar=modules/ext/postgresql-42.5.4.jar
 jnlp.indirect.jars=\
-    modules/ext/postgresql-42.2.16.jar
+    modules/ext/postgresql-42.5.4.jar

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/Bundle.properties
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/Bundle.properties
@@ -20,6 +20,6 @@ OpenIDE-Module-Display-Category=Database
 OpenIDE-Module-Short-Description=JDBC database drivers
 OpenIDE-Module-Long-Description=\
     <html>This plugin provides JDBC database drivers for an improved out-of-the-box experience when developing database applications. \
-    <p>The following driver is included in this plugin: <ul> <li>PostgreSQL JDBC 4.2 Driver Version: 42.2.16</li> </ul> </p></html>
+    <p>The following driver is included in this plugin: <ul> <li>PostgreSQL JDBC 4.2 Driver Version: 42.5.4</li> </ul> </p></html>
 PostgreSQLDriver=PostgreSQL JDBC Driver
 MySQLDriver=MySQL JDBC Driver

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/PostgreSQLDriver.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/PostgreSQLDriver.xml
@@ -25,7 +25,7 @@
     <localizing-bundle>org.netbeans.modules.db.drivers.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.modules.db.drivers/modules/ext/postgresql-42.2.16.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.db.drivers/modules/ext/postgresql-42.5.4.jar!/</resource>
     </volume>
     <volume>
         <type>src</type>
@@ -38,7 +38,7 @@
     <properties>
         <property>
             <name>maven-dependencies</name>
-            <value>org.postgresql:postgresql:42.2.16:jar</value>
+            <value>org.postgresql:postgresql:42.5.4:jar</value>
         </property>
     </properties>
 </library>

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/db2.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/db2.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0'?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE driver PUBLIC '-//NetBeans//DTD JDBC Driver 1.1//EN' 'http://www.netbeans.org/dtds/jdbc-driver-1_1.dtd'>
+<driver>
+  <name value='IBMDb2'/>
+  <display-name value='IBM Db2'/>
+  <class value='com.ibm.db2.jcc.DB2Driver'/>
+</driver>

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/db2.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/db2.xml
@@ -22,6 +22,6 @@
 <!DOCTYPE driver PUBLIC '-//NetBeans//DTD JDBC Driver 1.1//EN' 'http://www.netbeans.org/dtds/jdbc-driver-1_1.dtd'>
 <driver>
   <name value='IBMDb2'/>
-  <display-name value='IBM Db2'/>
+  <display-name value='IBM DB2 Universal Driver'/>
   <class value='com.ibm.db2.jcc.DB2Driver'/>
 </driver>

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/informix.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/informix.xml
@@ -22,6 +22,6 @@
 <!DOCTYPE driver PUBLIC '-//NetBeans//DTD JDBC Driver 1.1//EN' 'http://www.netbeans.org/dtds/jdbc-driver-1_1.dtd'>
 <driver>
   <name value='IBMInformix'/>
-  <display-name value='IBM Informix'/>
+  <display-name value='Informix Dynamic Server'/>
   <class value='com.informix.jdbc.IfxDriver'/>
 </driver>

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/informix.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/informix.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0'?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE driver PUBLIC '-//NetBeans//DTD JDBC Driver 1.1//EN' 'http://www.netbeans.org/dtds/jdbc-driver-1_1.dtd'>
+<driver>
+  <name value='IBMInformix'/>
+  <display-name value='IBM Informix'/>
+  <class value='com.informix.jdbc.IfxDriver'/>
+</driver>

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/layer.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/layer.xml
@@ -23,9 +23,13 @@
 <filesystem>
     <folder name="Databases">
         <folder name="JDBCDrivers">
-            <file name="oracle_thin.xml" url="oracle_thin.xml"/>
-            <file name="oracle_oci.xml" url="oracle_oci.xml"/>
+            <file name="db2.xml" url="db2.xml"/>
+            <file name="informix.xml" url="informix.xml"/>
+            <file name="mariadb.xml" url="mariadb.xml"/>
+            <file name="mssql.xml" url="mssql.xml"/>
             <file name="mysql.xml" url="mysql.xml"/>
+            <file name="oracle_oci.xml" url="oracle_oci.xml"/>
+            <file name="oracle_thin.xml" url="oracle_thin.xml"/>
             <file name="postgresql.xml" url="postgresql.xml"/>
         </folder>
     </folder>

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/mariadb.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/mariadb.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0'?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE driver PUBLIC '-//NetBeans//DTD JDBC Driver 1.1//EN' 'http://www.netbeans.org/dtds/jdbc-driver-1_1.dtd'>
+<driver>
+  <name value='MariaDB'/>
+  <display-name value='MariaDB (Connector/J driver)'/>
+  <class value='org.mariadb.jdbc.Driver'/>
+</driver>

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/mariadb.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/mariadb.xml
@@ -22,6 +22,6 @@
 <!DOCTYPE driver PUBLIC '-//NetBeans//DTD JDBC Driver 1.1//EN' 'http://www.netbeans.org/dtds/jdbc-driver-1_1.dtd'>
 <driver>
   <name value='MariaDB'/>
-  <display-name value='MariaDB (Connector/J driver)'/>
+  <display-name value='MariaDB (MySQL-compatible)'/>
   <class value='org.mariadb.jdbc.Driver'/>
 </driver>

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/mssql.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/mssql.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0'?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE driver PUBLIC '-//NetBeans//DTD JDBC Driver 1.1//EN' 'http://www.netbeans.org/dtds/jdbc-driver-1_1.dtd'>
+<driver>
+  <name value='MSSQL'/>
+  <display-name value='MS SQL'/>
+  <class value='com.microsoft.jdbc.sqlserver.SQLServerDriver'/>
+</driver>

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/mssql.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/mssql.xml
@@ -22,6 +22,6 @@
 <!DOCTYPE driver PUBLIC '-//NetBeans//DTD JDBC Driver 1.1//EN' 'http://www.netbeans.org/dtds/jdbc-driver-1_1.dtd'>
 <driver>
   <name value='MSSQL'/>
-  <display-name value='MS SQL'/>
+  <display-name value='Microsoft SQL Server'/>
   <class value='com.microsoft.jdbc.sqlserver.SQLServerDriver'/>
 </driver>

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/postgresql.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/postgresql.xml
@@ -25,6 +25,6 @@
   <display-name value='PostgreSQL'/>
   <class value='org.postgresql.Driver'/>
   <urls>
-  	<url value="nbinst://org.netbeans.modules.db.drivers/modules/ext/postgresql-42.2.16.jar"/>
+  	<url value="nbinst://org.netbeans.modules.db.drivers/modules/ext/postgresql-42.5.4.jar"/>
   </urls>
 </driver>


### PR DESCRIPTION
This is mainly a maintenance release and contains bug fixes.
[Releases Notes](https://jdbc.postgresql.org/documentation/changelog.html)
- Include more database driver templates:
  - IBM DB2 
  - IBM Informix
  - Microsoft SQL
  - MariaDB

NetBeans Testing:

- Full build done
- Started NetBeans and ensure the log didn't have any errors or new warnings
- Checked that the file had been downloaded and referenced inside the Ant Library Manager
`jar:nbinst://org.netbeans.modules.db.drivers/modules/ext/postgresql-42.5.4.jar!/`
- Verify the new JDBC driver templates
![Screenshot from 2023-03-10 19-16-51](https://user-images.githubusercontent.com/9832133/224584223-c39e4893-e143-4d5d-8999-b904c3573ab4.png)
