### PR TITLE
Test PHP cluster on JDK 11 and fix tests where needed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2069,7 +2069,7 @@ jobs:
       DISPLAY: ":99.0"
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '11' ]
         os: [ 'windows-2022', 'ubuntu-20.04' ]
       fail-fast: false
     steps:

--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -2145,6 +2145,14 @@ public abstract class CslTestBase extends NbTestCase {
 
         ParserManager.parse(Collections.singleton(testSource), new UserTask() {
             public @Override void run(ResultIterator resultIterator) throws Exception {
+
+                // FoldingScanner#folds calls source.getDocument(false) and receive non null values on JDK 8.
+                // On JDK 11+ however the document is null which leads to test failures in FoldingTest#testPHPTags.
+                // This is likely a race condition which is more likely to occur on JDK 11+ since the test can be
+                // brute forced to passing on linux if restarted often enough. 
+                // This fixes it by making sure the document is open before folds are computed
+                assertNotNull(resultIterator.getSnapshot().getSource().getDocument(true));
+                
                 StructureScanner analyzer = getStructureScanner();
                 assertNotNull("getStructureScanner must be implemented", analyzer);
 


### PR DESCRIPTION
fix php folding test on JDK 11+ by opening the document in advance.
    
`FoldingScanner#folds` calls `source.getDocument(false)` and receives non
null values on JDK 8. On JDK 11+ however the document is null, which
leads to test failures in `FoldingTest#testPHPTags` it is not known why
this happens but this fixes it by making sure the document is open
before folds are computed

note: this was likely a race condition since the php job was observed to be green on linux if restarted often enough (https://github.com/apache/netbeans/issues/4904#issuecomment-1383155575).

lets see if something else fails (edit: everything green on first attempt)

meta issue: #4904

failure was:
```
Testcase: testPHPTags(org.netbeans.modules.php.editor.csl.FoldingTest):	FAILED
Not matching goldenfile: /home/mbien/NetBeansProjects/netbeans/php/php.editor/build/test/unit/data/testfiles/parser/foldingPHPTags.php

Expected content is:

<html>
      <body>
          <h2>Test</h2>
          <?= "test" ?>
+         <?php echo "test" ?>
          <?= "test" ?>
  
          <h2>Test</h2>
+         <?php
+         /**
|          * Get date.
|          *
|          * Description.
-          */
|         $date = getdate();
|         echo $date; // comment
-         ?>
      </body>
  </html>

but actual is:

<html>
      <body>
          <h2>Test</h2>
          <?= "test" ?>
          <?php echo "test" ?>
          <?= "test" ?>
  
          <h2>Test</h2>
          <?php
+         /**
|          * Get date.
|          *
|          * Description.
-          */
          $date = getdate();
          echo $date; // comment
          ?>
      </body>
  </html>

It differs in the following things:

Actual content contains following lines which are missing in expected content: 
	          <?php echo "test" ?>
	          <?php
	          $date = getdate();
	          echo $date; // comment
	          ?>
Expected content contains following lines which are missing in actual content: 
	+         <?php echo "test" ?>
	+         <?php
	|         $date = getdate();
	|         echo $date; // comment
	-         ?>
```
