### PR TITLE
Avoid ConcurrentMod exception, tolerate broken project dependencies

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -168,10 +168,7 @@ public class VulnerabilityWorker implements ErrorProvider{
         
         private void buildDependecyMap(Dependency dependency, Map<String, Dependency> result) {
             String gav = createGAV(dependency.getArtifact());
-            if (gav == null) {
-                return;
-            }
-            if (result.putIfAbsent(gav, dependency) == null) {
+            if (gav != null && result.putIfAbsent(gav, dependency) == null) {
                 dependency.getChildren().forEach((childDependency) -> {
                     buildDependecyMap(childDependency, result);
                 });
@@ -588,7 +585,8 @@ public class VulnerabilityWorker implements ErrorProvider{
         if (artifact == null) {
             return null;
         }
-        StringBuffer sb = new StringBuffer();
+        // use a random constant that could be sufficient to hold gav text (micronaut-core has max 86)
+        StringBuilder sb = new StringBuilder(120); 
         sb.append(artifact.getGroupId()).append(':');
         sb.append(artifact.getArtifactId()).append(':');
         sb.append(artifact.getVersionSpec());

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -168,6 +168,9 @@ public class VulnerabilityWorker implements ErrorProvider{
         
         private void buildDependecyMap(Dependency dependency, Map<String, Dependency> result) {
             String gav = createGAV(dependency.getArtifact());
+            if (gav == null) {
+                return;
+            }
             if (result.putIfAbsent(gav, dependency) == null) {
                 dependency.getChildren().forEach((childDependency) -> {
                     buildDependecyMap(childDependency, result);
@@ -557,6 +560,9 @@ public class VulnerabilityWorker implements ErrorProvider{
     
     private int convert(Dependency dependency, Map<String, Integer> gavIndex, List<ApplicationDependency> result) {
         String gav = createGAV(dependency.getArtifact());
+        if (gav == null) {
+            return -1;
+        }
         Integer n = gavIndex.get(gav);
         if (n != null) {
             return n;
@@ -569,7 +575,9 @@ public class VulnerabilityWorker implements ErrorProvider{
         List<String> childrenNodeIds = new ArrayList<>(dependency.getChildren().size());
         for (Dependency childDependency : dependency.getChildren()) {
             int cid = convert(childDependency, gavIndex, result);
-            childrenNodeIds.add(Integer.toString(cid));
+            if (cid != -1) {
+                childrenNodeIds.add(Integer.toString(cid));
+            }
         }
         builder.applicationDependencyNodeIds(childrenNodeIds);
         result.add(builder.build());
@@ -577,6 +585,9 @@ public class VulnerabilityWorker implements ErrorProvider{
     }
 
     private static String createGAV(ArtifactSpec artifact) {
+        if (artifact == null) {
+            return null;
+        }
         StringBuffer sb = new StringBuffer();
         sb.append(artifact.getGroupId()).append(':');
         sb.append(artifact.getArtifactId()).append(':');

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -290,7 +290,8 @@ class NbProjectInfoBuilder {
         Map<String, Object> taskProperties = new HashMap<>();
         Map<String, String> taskPropertyTypes = new HashMap<>();
         
-        for (Task task : project.getTasks().getAsMap().values()) {
+        // make a copy of the task map; may mutate.
+        for (Task task : new ArrayList<>(project.getTasks().getAsMap().values())) {
             Class taskClass = task.getClass();
             Class nonDecorated = findNonDecoratedClass(taskClass);
             
@@ -305,7 +306,8 @@ class NbProjectInfoBuilder {
     private void detectTaskDependencies(NbProjectInfoModel model) {
         Map<String, Object> tasks = new HashMap<>();
         
-        for (Task task : project.getTasks().getAsMap().values()) {
+        // make a copy of the task map; may mutate.
+        for (Task task : new ArrayList<>(project.getTasks().getAsMap().values())) {
             Map<String, String> taskInfo = new HashMap<>();
             taskInfo.put("name", task.getPath()); // NOI18N
             taskInfo.put("enabled", Boolean.toString(task.getEnabled())); // NOI18N


### PR DESCRIPTION
An exception was thrown when the NB was trying to load `micronaut-core:aop` project during OCI ADM audit. The project was broken and its dependency root reported `null` artifact. ADM Vulnerability implementation then throws NPE as this is not handled well.

The PR fixes the root cause in Gradle tooling by eagerly copying the task list before iterating through it, as the task definition Map is not copied by Gradle library and may mutate during the iteration.

The a simple null check is done in vulnerability audit launcher.