### PR TITLE
Improve image display tool (antialias, improved dragging, optimize menu and fix warnings)

### DIFF
--- a/ide/image/src/org/netbeans/modules/image/CustomZoomAction.java
+++ b/ide/image/src/org/netbeans/modules/image/CustomZoomAction.java
@@ -27,7 +27,6 @@ import java.awt.event.ActionListener;
 
 import org.openide.DialogDescriptor;
 import org.openide.NotifyDescriptor;
-import org.openide.NotifyDescriptor.Message;
 import org.openide.DialogDisplayer;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionRegistration;
@@ -45,30 +44,33 @@ import org.openide.windows.TopComponent;
 @ActionRegistration(lazy = false, displayName = "#LBL_CustomZoom")
 public class CustomZoomAction extends CallableSystemAction {
 
-    
+
     /** Generated serial version UID. */
     static final long serialVersionUID = 8247068408606777895L;
-    
-    
+
+
     /** Actually performs action. */
+    @Override
     public void performAction () {
         final Dialog[] dialogs = new Dialog[1];
         final CustomZoomPanel zoomPanel = new CustomZoomPanel();
 
         zoomPanel.setEnlargeFactor(1);
         zoomPanel.setDecreaseFactor(1);
-        
+
         DialogDescriptor dd = new DialogDescriptor(
             zoomPanel,
-            NbBundle.getBundle(CustomZoomAction.class).getString("LBL_CustomZoomAction"),
+            NbBundle.getMessage(CustomZoomAction.class, "LBL_CustomZoomAction"),
             true,
             DialogDescriptor.OK_CANCEL_OPTION,
             DialogDescriptor.OK_OPTION,
             new ActionListener() {
+                @Override
                 public void actionPerformed(ActionEvent ev) {
                     if (ev.getSource() == DialogDescriptor.OK_OPTION) {
-                        int enlargeFactor = 1, decreaseFactor = 1;
-                        
+                        int enlargeFactor;
+                        int decreaseFactor;
+
                         try {
                             enlargeFactor = zoomPanel.getEnlargeFactor();
                             decreaseFactor = zoomPanel.getDecreaseFactor();
@@ -76,35 +78,35 @@ public class CustomZoomAction extends CallableSystemAction {
                             notifyInvalidInput();
                             return;
                         }
-                        
+
                         // Invalid values.
                         if(enlargeFactor == 0 || decreaseFactor == 0) {
                             notifyInvalidInput();
                             return;
                         }
-                        
+
                         performZoom(enlargeFactor, decreaseFactor);
-                        
+
                         dialogs[0].setVisible(false);
                         dialogs[0].dispose();
                     } else {
                         dialogs[0].setVisible(false);
                         dialogs[0].dispose();
                     }
-                }        
-                
+                }
+
                 private void notifyInvalidInput() {
                     DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(
-                        NbBundle.getBundle(CustomZoomAction.class).getString("MSG_InvalidValues"),
+                        NbBundle.getMessage(CustomZoomAction.class, "MSG_InvalidValues"),
                         NotifyDescriptor.ERROR_MESSAGE
                     ));
                 }
-                
+
             } // End of annonymnous ActionListener.
         );
         dialogs[0] = DialogDisplayer.getDefault().createDialog(dd);
         dialogs[0].setVisible(true);
-        
+
     }
 
     /** Performs customized zoom. */
@@ -115,16 +117,19 @@ public class CustomZoomAction extends CallableSystemAction {
     }
 
     /** Gets action name. Implements superclass abstract method. */
+    @Override
     public String getName () {
-        return NbBundle.getBundle(CustomZoomAction.class).getString("LBL_CustomZoom");
+        return NbBundle.getMessage(CustomZoomAction.class, "LBL_CustomZoom");
     }
-    
+
     /** Gets action help context. Implemenets superclass abstract method.*/
+    @Override
     public HelpCtx getHelpCtx () {
-        return new HelpCtx(CustomZoomAction.class);
+        return new HelpCtx("org.netbeans.modules.image.CustomZoomAction");
     }
-    
+
     /** Gets icon resource. Overrides superclass method. */
+    @Override
     protected String iconResource() {
         return "org/netbeans/modules/image/customZoom.gif"; // NOI18N
     }

--- a/ide/image/src/org/netbeans/modules/image/ImageDataLoader.java
+++ b/ide/image/src/org/netbeans/modules/image/ImageDataLoader.java
@@ -67,7 +67,7 @@ public class ImageDataLoader extends UniFileLoader {
 
     /** Generated serial version UID. */
     static final long serialVersionUID =-8188309025795898449L;
-    
+
     public static final String GIF_MIME_TYPE = "image/gif";
     public static final String BMP_MIME_TYPE = "image/bmp";
     public static final String PNG_MIME_TYPE = "image/png";
@@ -75,24 +75,25 @@ public class ImageDataLoader extends UniFileLoader {
     /** is BMP format support status known? */
     private static boolean bmpSupportStatusKnown = false;
     static final String ACTIONS = "Loaders/image/png-gif-jpeg-bmp/Actions";
-    
+
     /** Creates new image loader. */
     public ImageDataLoader() {
         // Set the representation class.
         super("org.netbeans.modules.image.ImageDataObject"); // NOI18N
-        
+
         ExtensionList ext = new ExtensionList();
         ext.addMimeType(GIF_MIME_TYPE);
         ext.addMimeType(JPEG_MIME_TYPE);
         ext.addMimeType(PNG_MIME_TYPE);
         setExtensions(ext);
     }
-    
+
+    @Override
     protected FileObject findPrimaryFile(FileObject fo){
         FileObject primFile = super.findPrimaryFile(fo);
-        
+
         if ((primFile == null)
-                && !bmpSupportStatusKnown 
+                && !bmpSupportStatusKnown
                 && !fo.isFolder()
                 && fo.getMIMEType().equals(BMP_MIME_TYPE)) {
             try {
@@ -104,32 +105,35 @@ public class ImageDataLoader extends UniFileLoader {
                 bmpSupportStatusKnown = true;
             }
         }
-        
+
         return primFile;
     }
-    
+
     /** Gets default display name. Overrides superclass method. */
     @Messages("PROP_ImageLoader_Name=Image Objects")
+    @Override
     protected String defaultDisplayName() {
         return PROP_ImageLoader_Name();
     }
-    
+
     /**
      * This methods uses the layer action context so it returns
      * a non-<code>null</code> value.
      *
      * @return  name of the context on layer files to read/write actions to
      */
+    @Override
     protected String actionsContext () {
         return ACTIONS;
     }
-    
+
     /** Create the image data object.
      * @param primaryFile the primary file (e.g. <code>*.gif</code>)
      * @return the data object for this file
      * @exception DataObjectExistsException if the primary file already has a data object
      * @exception java.io.IOException should not be thrown
      */
+    @Override
     protected MultiDataObject createMultiObject (FileObject primaryFile)
     throws DataObjectExistsException, java.io.IOException {
         return new ImageDataObject(primaryFile, this);

--- a/ide/image/src/org/netbeans/modules/image/ImageDataLoaderBeanInfo.java
+++ b/ide/image/src/org/netbeans/modules/image/ImageDataLoaderBeanInfo.java
@@ -25,7 +25,6 @@ import java.awt.Image;
 import org.openide.ErrorManager;
 import org.openide.loaders.UniFileLoader;
 import org.openide.util.ImageUtilities;
-import org.openide.util.Utilities;
 
 /** Image data loader bean info.
 *
@@ -33,6 +32,7 @@ import org.openide.util.Utilities;
 */
 public class ImageDataLoaderBeanInfo extends SimpleBeanInfo {
 
+    @Override
     public BeanInfo[] getAdditionalBeanInfo () {
         try {
             return new BeanInfo[] { Introspector.getBeanInfo (UniFileLoader.class) };
@@ -42,6 +42,7 @@ public class ImageDataLoaderBeanInfo extends SimpleBeanInfo {
         }
     }
 
+    @Override
     public Image getIcon(final int type) {
         if ((type == java.beans.BeanInfo.ICON_COLOR_16x16) ||
                 (type == java.beans.BeanInfo.ICON_MONO_16x16)) {

--- a/ide/image/src/org/netbeans/modules/image/ImagePrintSupport.java
+++ b/ide/image/src/org/netbeans/modules/image/ImagePrintSupport.java
@@ -43,19 +43,19 @@ import org.openide.util.NbBundle;
  */
 public class ImagePrintSupport implements PrintCookie, Printable, ImageObserver {
     /* associated dataObject */
-    protected ImageDataObject dataObject;
+    private final ImageDataObject dataObject;
     /* image to print */
-    protected Image image;
+    private Image image;
     /* image to print */
-    protected RenderedImage renderedImage;
-    
+    private RenderedImage renderedImage;
+
     /** Creates new ImagePrintSupport */
     public ImagePrintSupport( ImageDataObject ido ) {
         dataObject = ido;
     }
-    
-    /** Prepare the image to fit on the given page, within the given margins. 
-     * Returns null if it were unable to prepare the image for the given page. 
+
+    /** Prepare the image to fit on the given page, within the given margins.
+     * Returns null if it were unable to prepare the image for the given page.
      * Throws a IllegalArgumentException if the page were too small for the image.
      **/
     protected static RenderedImage transformImage(RenderedImage image,
@@ -67,26 +67,27 @@ public class ImagePrintSupport implements PrintCookie, Printable, ImageObserver 
             }else{
                 af.translate(pf.getImageableX(), pf.getImageableY());
             }
-            
+
             /** notify if too big for page **/
             if( pf.getImageableWidth() - pf.getImageableX() < image.getWidth()
                 || pf.getImageableHeight() - pf.getImageableY() < image.getHeight() )
                     throw new IllegalArgumentException("Page too small for image");            //NOI18N
-            
+
             /* Translate image */
             AffineTransformOp afo = new AffineTransformOp( af, AffineTransformOp.TYPE_NEAREST_NEIGHBOR );
             BufferedImage o = (BufferedImage)image;
             BufferedImage i = new BufferedImage( o.getWidth()+(int)pf.getImageableX(), o.getHeight()+(int)pf.getImageableY(), o.getType() );
             return afo.filter( (BufferedImage)image, i );
-        }catch(Exception ex){
+        }catch(RuntimeException ex){
             ex.printStackTrace();
         }
         return null;
     }
-    
+
     /** Print the content of the object.  */
+    @Override
     public void print() {
-        
+
         /* Try to load the image from the ImageDataObject: */
         String errMsgKey;
         try {
@@ -97,13 +98,13 @@ public class ImagePrintSupport implements PrintCookie, Printable, ImageObserver 
             errMsgKey = "MSG_ErrorWhileLoading";                        //NOI18N
         }
         assert (image == null) != (errMsgKey == null);
-        
+
         /* If an error occured during loading, display a message and quit: */
         if (errMsgKey != null) {
             displayMessage(errMsgKey, NotifyDescriptor.WARNING_MESSAGE);
             return;
         }
-        
+
         PrinterJob job = PrinterJob.getPrinterJob();
         Book book = new Book();
         PageFormat pf = PrintPreferences.getPageFormat(job);
@@ -122,14 +123,14 @@ public class ImagePrintSupport implements PrintCookie, Printable, ImageObserver 
         } catch (PrinterAbortException e) { // user exception
             displayMessage("CTL_Printer_Abort",                         //NOI18N
                            NotifyDescriptor.INFORMATION_MESSAGE);
-        } catch (Exception e) {
+        } catch (RuntimeException | PrinterException e) {
             ErrorManager.getDefault().notify(e);
         } finally {
             renderedImage = null;
             image = null;
         }
     }
-    
+
     /**
      * Displays a localized user message.
      * It is guaranteed that the displaying routine is called from
@@ -140,18 +141,17 @@ public class ImagePrintSupport implements PrintCookie, Printable, ImageObserver 
      */
     private void displayMessage(String msgKey, final int msgType) {
         final String msg = NbBundle.getMessage(ImagePrintSupport.class, msgKey);
-        java.awt.EventQueue.invokeLater(new Runnable() { // display in the awt thread
-            public void run() {
-                DialogDisplayer.getDefault().notify(
-                        new NotifyDescriptor.Message(msg, msgType));
-            }
+        // display in the awt thread
+        java.awt.EventQueue.invokeLater(() -> {
+            DialogDisplayer.getDefault().notify(
+                    new NotifyDescriptor.Message(msg, msgType));
         });
     }
-    
+
     /* Implements Printable */
     public int print(Graphics graphics, PageFormat pageFormat, int page) throws PrinterException {
         if( page != 0 ) return Printable.NO_SUCH_PAGE;
-        
+
         Graphics2D g2 = (Graphics2D)graphics;
         if( renderedImage == null ){
             /**
@@ -164,9 +164,10 @@ public class ImagePrintSupport implements PrintCookie, Printable, ImageObserver 
         }
         return Printable.PAGE_EXISTS;
     }
-    
+
+    @Override
     public boolean imageUpdate(java.awt.Image image, int flags, int param2, int param3, int param4, int param5) {
         return false;
     }
-    
+
 }

--- a/ide/image/src/org/netbeans/modules/image/ImageViewer.java
+++ b/ide/image/src/org/netbeans/modules/image/ImageViewer.java
@@ -286,7 +286,7 @@ public class ImageViewer extends CloneableTopComponent {
             @Override
             public void mousePressed(MouseEvent e) {
                 if(e.getButton() == 2) {
-                    startDragPos = e.getPoint();
+                    startDragPos = e.getLocationOnScreen();
                     scrollPaneStartPos = scrollPane.getViewport().getViewPosition();
                     panel.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
                 }
@@ -312,7 +312,7 @@ public class ImageViewer extends CloneableTopComponent {
             @Override
             public void mouseDragged(MouseEvent e) {
                 if(startDragPos != null) {
-                    Point newPos = e.getPoint();
+                    Point newPos = e.getLocationOnScreen();
                     int delta_x = newPos.x - startDragPos.x;
                     int delta_y = newPos.y - startDragPos.y;
                     

--- a/ide/image/src/org/netbeans/modules/image/ImageViewer.java
+++ b/ide/image/src/org/netbeans/modules/image/ImageViewer.java
@@ -28,7 +28,6 @@ import java.awt.Graphics;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.event.ActionListener;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -42,8 +41,10 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
+import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -51,10 +52,10 @@ import javax.swing.JScrollPane;
 import javax.swing.JToolBar;
 import javax.swing.SwingUtilities;
 import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.progress.ProgressHandleFactory;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
+import org.openide.nodes.Node;
 import org.openide.util.*;
 import org.openide.util.actions.SystemAction;
 import org.openide.windows.CloneableTopComponent;
@@ -69,98 +70,93 @@ public class ImageViewer extends CloneableTopComponent {
 
     /** Serialized version UID. */
     static final long serialVersionUID =6960127954234034486L;
-    
+
     /** <code>ImageDataObject</code> which image is viewed. */
     private ImageDataObject storedObject;
-    
+
     /** Viewed image. */
     private NBImageIcon storedImage;
-    
+
     /** Component showing image. */
     private JPanel panel;
-    
+
     /** Scale of image. */
     private double scale = 1.0D;
-    
+
     /** On/off grid. */
     private boolean showGrid = false;
-    
+
     /** Increase/decrease factor. */
     private final double changeFactor = Math.sqrt(2.0D);
-    
+
     /** Grid color. */
     private final Color gridColor = Color.black;
-    
+
     /** Listens for name changes. */
     private PropertyChangeListener nameChangeL;
-    
+
     /** collection of all buttons in the toolbar */
-    private final Collection<JButton> toolbarButtons = new ArrayList<JButton>(11);
-    
+    private final Collection<JButton> toolbarButtons = new ArrayList<>(11);
+
     private Component view;
-    
+
     private static final RequestProcessor RP = new RequestProcessor("Image loader", 1, true);
-    
+
     private RequestProcessor.Task loadImageTask;
     private int imageHeight = 0;
     private int imageWidth = 0;
     private long imageSize = -1;
     private final DecimalFormat formatter = new DecimalFormat("#.##"); //NOI18N
-    
+
     /** Default constructor. Must be here, used during de-externalization */
     public ImageViewer () {
         super();
     }
-    
+
     /** Create a new image viewer.
      * @param obj the data object holding the image
      */
     public ImageViewer(ImageDataObject obj) {
         initialize(obj);
     }
-    
+
     /** Overriden to explicitely set persistence type of ImageViewer
      * to PERSISTENCE_ONLY_OPENED */
+    @Override
     public int getPersistenceType() {
         return TopComponent.PERSISTENCE_ONLY_OPENED;
     }
-    
+
     /** Reloads icon. */
     protected void reloadIcon() {
         resizePanel();
         panel.repaint();
     }
-    
+
     /** Initializes member variables and set listener for name changes on DataObject. */
     private void initialize(ImageDataObject obj) {
-        TopComponent.NodeName.connect (this, obj.getNodeDelegate ());
-        setToolTipText(FileUtil.getFileDisplayName(obj.getPrimaryFile()));
-        
+        setActivatedNodes(new Node[] {obj.getNodeDelegate()});
         storedObject = obj;
-        
+
         FileObject imageFile = storedObject.getPrimaryFile();
-        
+
         if (imageFile.isValid()) {
             imageSize = imageFile.getSize();
         } else {
             imageSize = -1;
         }
-            
-        // force closing panes in all workspaces, default is in current only
-        setCloseOperation(TopComponent.CLOSE_EACH);
-        
-        getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(ImageViewer.class, "ACS_ImageViewer"));        
-        
-        nameChangeL = new PropertyChangeListener() {
-            public void propertyChange(PropertyChangeEvent evt) {
-                if (DataObject.PROP_COOKIE.equals(evt.getPropertyName()) ||
-                DataObject.PROP_NAME.equals(evt.getPropertyName())) {
-                    updateNameInEDT();
-                }
+
+        getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(ImageViewer.class, "ACS_ImageViewer"));
+
+        nameChangeL = (PropertyChangeEvent evt) -> {
+            if (DataObject.PROP_COOKIE.equals(evt.getPropertyName()) ||
+                    DataObject.PROP_NAME.equals(evt.getPropertyName())) {
+                updateNameInEDT();
             }
         };
-        
-        obj.addPropertyChangeListener(WeakListeners.propertyChange(nameChangeL, obj));        
+        obj.addPropertyChangeListener(WeakListeners.propertyChange(nameChangeL, obj));
+        updateNameInEDT();
+
         setFocusable(true);
          /* try to load the image: */
         loadImage(storedObject);
@@ -171,18 +167,14 @@ public class ImageViewer extends CloneableTopComponent {
      * @see Bug #181283
      */
     private void updateNameInEDT() {
-        Mutex.EVENT.readAccess(new Runnable() {
-            @Override
-            public void run () {
-                updateName();
-            }
-        });
+        Mutex.EVENT.readAccess(this::updateName);
     }
-    
+
     /**
      */
     private Component createImageView() {
         panel = new JPanel() {
+            @Override
             protected void paintComponent(Graphics g) {
                 super.paintComponent(g);
                 g.drawImage(
@@ -204,7 +196,7 @@ public class ImageViewer extends CloneableTopComponent {
 
                     double gridDistance = getScale();
 
-                    if(gridDistance < 2) 
+                    if(gridDistance < 2)
                         // Disable painting of grid if no image pixels would be visible.
                         return;
 
@@ -232,53 +224,48 @@ public class ImageViewer extends CloneableTopComponent {
         panel.setPreferredSize(new Dimension(storedImage.getIconWidth(), storedImage.getIconHeight() ));
 
         final JScrollPane scrollPane = new JScrollPane(panel);
-        
-        MouseWheelListener mwl = new MouseWheelListener() {
 
-            @Override
-            public void mouseWheelMoved(MouseWheelEvent e) {
-                double oldScale = getScale();
-                // Point in scrolled pane
-                Point visiblePoint = e.getPoint();
+        MouseWheelListener mwl = (MouseWheelEvent e) -> {
+            double oldScale = getScale();
+            // Point in scrolled pane
+            Point visiblePoint = e.getPoint();
 
-                // "Picturepixel"
-                Point markedPoint = new Point(
-                        (int) (visiblePoint.getX() / oldScale),
-                        (int) (visiblePoint.getY() / oldScale));
+            // "Picturepixel"
+            Point markedPoint = new Point(
+                    (int) (visiblePoint.getX() / oldScale),
+                    (int) (visiblePoint.getY() / oldScale));
 
-                int clicks = e.getWheelRotation();
-                int clicks_abs = Math.abs(clicks);
-                for (int i = 0; i < clicks_abs; i++) {
-                    if (clicks < 0) {
-                        zoomIn();
-                    } else {
-                        zoomOut();
-                    }
+            int clicks = e.getWheelRotation();
+            int clicks_abs = Math.abs(clicks);
+            for (int i = 0; i < clicks_abs; i++) {
+                if (clicks < 0) {
+                    zoomIn();
+                } else {
+                    zoomOut();
                 }
-    
-                double newScale = getScale();
-                
-                Point markedPointInRealSpace = new Point(
-                        (int) (markedPoint.getX() * newScale),
-                        (int) (markedPoint.getY() * newScale)
-                        );
-                
-                Rectangle r = scrollPane.getViewport().getViewRect();
-                
-                r.setLocation(markedPointInRealSpace);
-                r.translate(-r.width / 2, - r.height / 2);
-                
-                panel.scrollRectToVisible(r);
-
             }
+
+            double newScale = getScale();
+
+            Point markedPointInRealSpace = new Point(
+                    (int) (markedPoint.getX() * newScale),
+                    (int) (markedPoint.getY() * newScale)
+            );
+
+            Rectangle r = scrollPane.getViewport().getViewRect();
+
+            r.setLocation(markedPointInRealSpace);
+            r.translate(-r.width / 2, - r.height / 2);
+
+            panel.scrollRectToVisible(r);
         };
-    
+
         panel.addMouseWheelListener(mwl);
-        
+
         class DragHandler implements MouseListener, MouseMotionListener {
             Point startDragPos = null;
             Point scrollPaneStartPos = null;
-            
+
             @Override
             public void mouseClicked(MouseEvent e) {
             }
@@ -315,7 +302,7 @@ public class ImageViewer extends CloneableTopComponent {
                     Point newPos = e.getLocationOnScreen();
                     int delta_x = newPos.x - startDragPos.x;
                     int delta_y = newPos.y - startDragPos.y;
-                    
+
                     Point scrollPanePos = scrollPaneStartPos.getLocation();
                     scrollPanePos.translate(-delta_x, -delta_y);
                     Dimension viewDim = scrollPane.getViewport().getViewRect().getSize();
@@ -340,15 +327,15 @@ public class ImageViewer extends CloneableTopComponent {
             public void mouseMoved(MouseEvent e) {
             }
         }
-        
+
         DragHandler dh = new DragHandler();
-        
+
         panel.addMouseListener(dh);
         panel.addMouseMotionListener(dh);
-        
+
         return scrollPane;
     }
-    
+
     /**
      */
     private Component createMessagePanel(final String msg) {
@@ -364,13 +351,13 @@ public class ImageViewer extends CloneableTopComponent {
                              10,   10));               //ipadx, ipady
         return msgPanel;
     }
-    
+
     /**
      */
     void updateView(final ImageDataObject imageObj) {
         loadImage(imageObj);
     }
-    
+
     /**
      * Enables or disables all toolbar buttons.
      *
@@ -379,46 +366,41 @@ public class ImageViewer extends CloneableTopComponent {
      */
     private void setToolbarButtonsEnabled(final boolean enabled) {
         assert toolbarButtons != null;
-        
+
         final Iterator<JButton> it = toolbarButtons.iterator();
         while (it.hasNext()) {
             it.next().setEnabled(enabled);
         }
     }
-    
+
     /**
      * Loads an image from the given <code>ImageDataObject</code>.
      * If the image is loaded successfully, it is stored
      * to field {@link #storedImage}. The field is <code>null</code>ed
      * in case of any failure.
      *
-     * @param  imageObj  <code>ImageDataObject</code> to load the image from     
+     * @param  imageObj  <code>ImageDataObject</code> to load the image from
      */
     private void loadImage(final ImageDataObject imageObj) {
-        loadImageTask = RP.create(new Runnable() {
-
-            public void run() {
-                try (ProgressHandle loadImageProgress = ProgressHandle.createHandle(NbBundle.getMessage(ImageViewer.class, "LBL_LoadingImage"))) {
-                    loadImageProgress.start();
-                    performLoadImage(imageObj);
-                }
+        loadImageTask = RP.create(() -> {
+            try (ProgressHandle loadImageProgress = ProgressHandle.createHandle(NbBundle.getMessage(ImageViewer.class, "LBL_LoadingImage"))) {
+                loadImageProgress.start();
+                performLoadImage(imageObj);
             }
         });
         loadImageTask.schedule(0);
-      
     }
-                
-   
 
+    @Override
     protected void componentClosed() {
         loadImageTask.cancel();
         super.componentClosed();
     }
-    
+
     private void performLoadImage(final ImageDataObject imageObj) {
         String errMsg;
         NBImageIcon image;
-        try {            
+        try {
             image = NBImageIcon.load(imageObj);
             if (image != null) {
                 errMsg = null;
@@ -429,15 +411,11 @@ public class ImageViewer extends CloneableTopComponent {
             image = null;
             errMsg = NbBundle.getMessage(ImageViewer.class, "MSG_ErrorWhileLoading");      //NOI18N
         }
-        assert (image == null) != (errMsg == null);        
+        assert (image == null) != (errMsg == null);
         final NBImageIcon fImage = image;
         final String fErrMsg = errMsg;
-        
-        SwingUtilities.invokeLater(new Runnable() {
-            public void run() {
-                showImage(fImage, fErrMsg);
-            }
-        });
+
+        SwingUtilities.invokeLater(() -> showImage(fImage, fErrMsg));
     }
 
     private void initToolbar() {
@@ -446,7 +424,7 @@ public class ImageViewer extends CloneableTopComponent {
         setLayout(new BorderLayout());
         add(toolbar, BorderLayout.NORTH);
     }
-    
+
     private void showImage(NBImageIcon image, String errorMessage) {
         boolean wasValid = (storedImage != null);
         storedImage = image;
@@ -464,7 +442,7 @@ public class ImageViewer extends CloneableTopComponent {
 
             imageWidth = storedImage.getIconWidth();
             imageHeight = storedImage.getIconHeight();
-            
+
             initToolbar();
         } else {
             view = createMessagePanel(errorMessage);
@@ -474,35 +452,36 @@ public class ImageViewer extends CloneableTopComponent {
             setToolbarButtonsEnabled(isValid);
         }
         revalidate();
-        repaint();        
+        repaint();
     }
 
     /** Creates toolbar. */
+    @SuppressWarnings("NestedAssignment")
     private JToolBar createToolBar() {
         // Definition of toolbar.
         JToolBar toolBar = new JToolBar();
         toolBar.putClientProperty("JToolBar.isRollover", Boolean.TRUE); //NOI18N
         toolBar.setFloatable (false);
-        toolBar.setName (NbBundle.getBundle(ImageViewer.class).getString("ACSN_Toolbar"));
-        toolBar.getAccessibleContext().setAccessibleDescription(NbBundle.getBundle(ImageViewer.class).getString("ACSD_Toolbar"));
+        toolBar.setName (NbBundle.getMessage(ImageViewer.class, "ACSN_Toolbar"));
+        toolBar.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(ImageViewer.class, "ACSD_Toolbar"));
             JButton outButton = new JButton(SystemAction.get(ZoomOutAction.class));
-            outButton.setToolTipText (NbBundle.getBundle(ImageViewer.class).getString("LBL_ZoomOut"));
-            outButton.setMnemonic(NbBundle.getBundle(ImageViewer.class).getString("ACS_Out_BTN_Mnem").charAt(0));
-            outButton.getAccessibleContext().setAccessibleDescription(NbBundle.getBundle(ImageViewer.class).getString("ACSD_Out_BTN"));
+            outButton.setToolTipText (NbBundle.getMessage(ImageViewer.class, "LBL_ZoomOut"));
+            outButton.setMnemonic(NbBundle.getMessage(ImageViewer.class, "ACS_Out_BTN_Mnem").charAt(0));
+            outButton.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(ImageViewer.class, "ACSD_Out_BTN"));
             outButton.setText("");
-        toolBar.add(outButton);       
+        toolBar.add(outButton);
         toolbarButtons.add(outButton);
             JButton inButton = new JButton(SystemAction.get(ZoomInAction.class));
-            inButton.setToolTipText (NbBundle.getBundle(ImageViewer.class).getString("LBL_ZoomIn"));
-            inButton.setMnemonic(NbBundle.getBundle(ImageViewer.class).getString("ACS_In_BTN_Mnem").charAt(0));
-            inButton.getAccessibleContext().setAccessibleDescription(NbBundle.getBundle(ImageViewer.class).getString("ACSD_In_BTN"));
+            inButton.setToolTipText (NbBundle.getMessage(ImageViewer.class, "LBL_ZoomIn"));
+            inButton.setMnemonic(NbBundle.getMessage(ImageViewer.class, "ACS_In_BTN_Mnem").charAt(0));
+            inButton.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(ImageViewer.class, "ACSD_In_BTN"));
             inButton.setText("");
         toolBar.add(inButton);
         toolbarButtons.add(inButton);
         toolBar.addSeparator(new Dimension(11, 0));
-        
+
         JButton button;
-        
+
         toolBar.add(button = getZoomButton(1,1));
         toolbarButtons.add(button);
         toolBar.addSeparator(new Dimension(11, 0));
@@ -527,7 +506,7 @@ public class ImageViewer extends CloneableTopComponent {
         toolBar.addSeparator(new Dimension(11, 0));
         toolBar.add(button = getGridButton());
         toolbarButtons.add(button);
-        
+
         // Image Dimension
         toolBar.addSeparator(new Dimension(11, 0));
         toolBar.add(new JLabel(NbBundle.getMessage(ImageViewer.class, "LBL_ImageDimensions", imageWidth, imageHeight)));
@@ -562,7 +541,7 @@ public class ImageViewer extends CloneableTopComponent {
 
         return toolBar;
     }
-    
+
     /** Updates the name and tooltip of this top component according to associated data object. */
     private void updateName () {
         // update name
@@ -573,26 +552,29 @@ public class ImageViewer extends CloneableTopComponent {
         setToolTipText(FileUtil.getFileDisplayName(fo));
     }
 
-    /** 
+    /**
      */
+    @Override
     public void open(){
         if (discard()) {
             return;
         }
         super.open();
     }
-    
+
     /**
      */
+    @Override
     protected String preferredID() {
         return getClass().getName();
     }
-    
+
     /** Gets HelpContext. */
+    @Override
     public HelpCtx getHelpCtx () {
         return HelpCtx.DEFAULT_HELP;
     }
-        
+
     /** This component should be discarded if the associated environment
      *  is not valid.
      */
@@ -600,8 +582,9 @@ public class ImageViewer extends CloneableTopComponent {
         return storedObject == null;
     }
 
+    @Override
     protected boolean closeLast() {
-        (storedObject.getCookie(ImageOpenSupport.class)).lastClosed();
+        (storedObject.getLookup().lookup(ImageOpenSupport.class)).lastClosed();
         return true;
     }
 
@@ -609,84 +592,92 @@ public class ImageViewer extends CloneableTopComponent {
      * to common superclass behaviour.
      * @param out the stream to serialize to
      */
+    @Override
     public void writeExternal (ObjectOutput out)
     throws IOException {
         super.writeExternal(out);
         out.writeObject(storedObject);
     }
-    
+
     /** Deserialize this top component.
      * Reads its data object and initializes itself in addition
      * to common superclass behaviour.
      * @param in the stream to deserialize from
      */
+    @Override
     public void readExternal (ObjectInput in)
     throws IOException, ClassNotFoundException {
         super.readExternal(in);
         storedObject = (ImageDataObject)in.readObject();
         // to reset the listener for FileObject changes
-        (storedObject.getCookie(ImageOpenSupport.class)).prepareViewer();
+        (storedObject.getLookup().lookup(ImageOpenSupport.class)).prepareViewer();
         initialize(storedObject);
     }
-    
+
     /** Creates cloned object which uses the same underlying data object. */
+    @Override
     protected CloneableTopComponent createClonedObject () {
         return new ImageViewer(storedObject);
     }
-    
+
     /** Overrides superclass method. Gets actions for this top component. */
-    public SystemAction[] getSystemActions() {
-        SystemAction[] oldValue = super.getSystemActions();
+    @Override
+    public Action[] getActions() {
+        Action[] superValue = super.getActions();
         SystemAction fsa = null;
         try {
             ClassLoader l = Lookup.getDefault().lookup(ClassLoader.class);
             if (l == null) {
                 l = getClass().getClassLoader();
             }
-            Class c = Class.forName("org.openide.actions.FileSystemAction", true, l).asSubclass(SystemAction.class); // NOI18N
-            fsa = (SystemAction) SystemAction.findObject(c, true);
-        } catch (Exception ex) {
+            Class<? extends SystemAction> c = Class
+                    .forName("org.openide.actions.FileSystemAction", true, l)  // NOI18N
+                    .asSubclass(SystemAction.class);
+            fsa = SystemAction.findObject(c, true);
+        } catch (ClassNotFoundException | RuntimeException ex) {
             // there are no filesystem actions
         }
 
-        return SystemAction.linkActions(new SystemAction[] {
-            SystemAction.get(ZoomInAction.class),
-            SystemAction.get(ZoomOutAction.class),
-            SystemAction.get(CustomZoomAction.class),
-            fsa,
-            null},
-            oldValue);
+        Action[] result = Arrays.copyOf(superValue, superValue.length + 6);
+        result[superValue.length] = null;
+        result[superValue.length + 1] = SystemAction.get(ZoomInAction.class);
+        result[superValue.length + 2] = SystemAction.get(ZoomOutAction.class);
+        result[superValue.length + 3] = SystemAction.get(CustomZoomAction.class);
+        result[superValue.length + 5] = fsa;
+
+        return result;
     }
-    
+
     /** Overrides superclass method. Gets <code>Icon</code>. */
+    @Override
     public Image getIcon () {
         return ImageUtilities.loadImage("org/netbeans/modules/image/imageObject.png"); // NOI18N
     }
-    
+
     /** Draws zoom in scaled image. */
     public void zoomIn() {
         scaleIn();
         resizePanel();
         panel.repaint(0, 0, panel.getWidth(), panel.getHeight());
     }
-    
+
     /** Draws zoom out scaled image. */
     public void zoomOut() {
         double oldScale = scale;
-        
+
         scaleOut();
-        
+
          // You can't still make picture smaller, but bigger why not?
         if(!isNewSizeOK()) {
             scale = oldScale;
-            
+
             return;
         }
-        
+
         resizePanel();
         panel.repaint(0, 0, panel.getWidth(), panel.getHeight());
     }
-    
+
     /** Resizes panel. */
     private void resizePanel() {
         panel.setPreferredSize(new Dimension(
@@ -695,106 +686,99 @@ public class ImageViewer extends CloneableTopComponent {
         );
         panel.revalidate();
     }
-    
+
     /** Tests new size of image. If image is smaller than  minimum
      *  size(1x1) zooming will be not performed.
      */
     private boolean isNewSizeOK() {
-        if (((getScale () * storedImage.getIconWidth ()) > 1) &&
-            ((getScale () * storedImage.getIconWidth ()) > 1)
-        ) return true;
-        return false;
+        return ((getScale () * storedImage.getIconWidth ()) > 1) &&
+                ((getScale () * storedImage.getIconWidth ()) > 1);
     }
-    
+
     /** Perform zoom with specific proportion.
      * @param fx numerator for scaled
      * @param fy denominator for scaled
      */
     public void customZoom(int fx, int fy) {
         double oldScale = scale;
-        
+
         scale = (double)fx/(double)fy;
         if(!isNewSizeOK()) {
             scale = oldScale;
-            
+
             return;
         }
-        
+
         resizePanel();
         panel.repaint(0, 0, panel.getWidth(), panel.getHeight());
     }
-    
+
     /** Return zooming factor.*/
     private double getScale () {
         return scale;
     }
-    
+
     /** Change proportion "out"*/
     private void scaleOut() {
-        scale = scale / changeFactor;
+        scale /= changeFactor;
     }
-    
+
     /** Change proportion "in"*/
     private void scaleIn() {
         double oldComputedScale = getScale ();
-        
+
         scale = changeFactor * scale;
-        
+
         double newComputedScale = getScale();
-        
+
         if (newComputedScale == oldComputedScale)
             // Has to increase.
             scale = newComputedScale + 1.0D;
     }
-    
+
     /** Gets zoom button. */
     private JButton getZoomButton(final int xf, final int yf) {
         // PENDING buttons should have their own icons.
         JButton button = new JButton(""+xf+":"+yf); // NOI18N
-        if (xf < yf)
-            button.setToolTipText (NbBundle.getBundle(ImageViewer.class).getString("LBL_ZoomOut") + " " + xf + " : " + yf);
-        else
-            button.setToolTipText (NbBundle.getBundle(ImageViewer.class).getString("LBL_ZoomIn") + " " + xf + " : " + yf);
-        button.getAccessibleContext().setAccessibleDescription(NbBundle.getBundle(ImageViewer.class).getString("ACS_Zoom_BTN"));
-        button.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent evt) {
-                customZoom(xf, yf);
-            }
+        if (xf < yf) {
+            button.setToolTipText (NbBundle.getMessage(ImageViewer.class, "LBL_ZoomOut") + " " + xf + " : " + yf);
+        } else {
+            button.setToolTipText (NbBundle.getMessage(ImageViewer.class, "LBL_ZoomIn") + " " + xf + " : " + yf);
+        }
+        button.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(ImageViewer.class, "ACS_Zoom_BTN"));
+        button.addActionListener((ActionEvent evt) -> {
+            customZoom(xf, yf);
         });
-        
+
         return button;
     }
-    
+
     private JButton getZoomButton() {
         // PENDING buttons should have their own icons.
-        JButton button = new JButton(NbBundle.getBundle(CustomZoomAction.class).getString("LBL_XtoY")); // NOI18N
-        button.setToolTipText (NbBundle.getBundle(ImageViewer.class).getString("LBL_CustomZoom"));
-        button.getAccessibleContext().setAccessibleDescription(NbBundle.getBundle(ImageViewer.class).getString("ACS_Zoom_BTN"));
-        button.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent evt) {
-                CustomZoomAction sa = SystemAction.get(CustomZoomAction.class);
-                sa.performAction ();
-            }
+        JButton button = new JButton(NbBundle.getMessage(CustomZoomAction.class, "LBL_XtoY")); // NOI18N
+        button.setToolTipText (NbBundle.getMessage(ImageViewer.class, "LBL_CustomZoom"));
+        button.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(ImageViewer.class, "ACS_Zoom_BTN"));
+        button.addActionListener((ActionEvent evt) -> {
+            CustomZoomAction sa = SystemAction.get(CustomZoomAction.class);
+            sa.performAction ();
         });
-        
+
         return button;
     }
-    
+
     /** Gets grid button.*/
     private JButton getGridButton() {
         // PENDING buttons should have their own icons.
         final JButton button = new JButton(" # "); // NOI18N
-        button.setToolTipText (NbBundle.getBundle(ImageViewer.class).getString("LBL_ShowHideGrid"));
-        button.getAccessibleContext().setAccessibleDescription(NbBundle.getBundle(ImageViewer.class).getString("ACS_Grid_BTN"));
-        button.setMnemonic(NbBundle.getBundle(ImageViewer.class).getString("ACS_Grid_BTN_Mnem").charAt(0));
-        button.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent evt) {
-                showGrid = !showGrid;
-                panel.repaint(0, 0, panel.getWidth(), panel.getHeight());
-            }
+        button.setToolTipText (NbBundle.getMessage(ImageViewer.class, "LBL_ShowHideGrid"));
+        button.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(ImageViewer.class, "ACS_Grid_BTN"));
+        button.setMnemonic(NbBundle.getMessage(ImageViewer.class, "ACS_Grid_BTN_Mnem").charAt(0));
+        button.addActionListener((ActionEvent evt) -> {
+            showGrid = !showGrid;
+            panel.repaint(0, 0, panel.getWidth(), panel.getHeight());
         });
-        
+
         return button;
     }
-    
+
 }

--- a/ide/image/src/org/netbeans/modules/image/NBImageIcon.java
+++ b/ide/image/src/org/netbeans/modules/image/NBImageIcon.java
@@ -39,7 +39,7 @@ class NBImageIcon extends ImageIcon implements Serializable {
     static final long serialVersionUID = -1730253055388017036L;
 
     /** Appropriate image data object */
-    ImageDataObject obj;
+    private final ImageDataObject obj;
 
     /**
      * Loads an image from an <code>ImageDataObject</code>.
@@ -58,7 +58,7 @@ class NBImageIcon extends ImageIcon implements Serializable {
         Image image = obj.getImage();
         return (image != null) ? new NBImageIcon(obj, image) : null;
     }
-    
+
     /** Construct a new icon.
      * @param obj the data object to represent the image in
      */
@@ -67,23 +67,23 @@ class NBImageIcon extends ImageIcon implements Serializable {
         super(image);  //mw
         this.obj = obj;
     }
-    
-    
+
+
     /** Get an object to be written to the stream instead of this object. */
     public Object writeReplace() {
         return new ResolvableHelper(obj);
     }
 
-    
+
     /** Helper class for serialization. */
-    static class ResolvableHelper implements Serializable {
-        
+    private static class ResolvableHelper implements Serializable {
+
         /** generated Serialized Version UID. */
         static final long serialVersionUID = -1120520132882774882L;
-        
+
         /** serializable data object. */
         ImageDataObject obj;
-        
+
         /** Constructs ResolvableHelper object for given ImageDataObject. */
         ResolvableHelper(ImageDataObject obj) {
             this.obj = obj;

--- a/ide/image/src/org/netbeans/modules/image/ZoomInAction.java
+++ b/ide/image/src/org/netbeans/modules/image/ZoomInAction.java
@@ -43,6 +43,7 @@ public class ZoomInAction extends CallableSystemAction {
 
 
     /** Perform action. */
+    @Override
     public void performAction() {
         TopComponent curComponent = TopComponent.getRegistry().getActivated();
         if (curComponent instanceof ImageViewer) {
@@ -51,21 +52,25 @@ public class ZoomInAction extends CallableSystemAction {
     }
     
     /** Gets action name. Implements superclass abstract method. */
+    @Override
     public String getName() {
         return NbBundle.getMessage(ZoomInAction.class, "LBL_ZoomIn");   //NOI18N
     }
     
     /** Gets action help context. Implemenets superclass abstract method.*/
+    @Override
     public HelpCtx getHelpCtx() {
         return HelpCtx.DEFAULT_HELP;
     }
     
     /** Overrides superclass method. */
+    @Override
     public boolean isEnabled() {
         return true;
     }
     
     /** Gets icon resource. Overrides superclass method. */
+    @Override
     protected String iconResource() {
         return "org/netbeans/modules/image/zoomIn.gif"; // NOI18N
     }

--- a/ide/image/src/org/netbeans/modules/image/ZoomOutAction.java
+++ b/ide/image/src/org/netbeans/modules/image/ZoomOutAction.java
@@ -43,29 +43,34 @@ public class ZoomOutAction extends CallableSystemAction {
 
 
     /** Peforms action. */
+    @Override
     public void performAction() {
         TopComponent curComponent = TopComponent.getRegistry().getActivated();
         if(curComponent instanceof ImageViewer)
             ((ImageViewer) curComponent).zoomOut();
-        
+
     }
 
     /** Gets name of action. Implements superclass abstract method. */
+    @Override
     public String getName() {
-        return NbBundle.getBundle(ZoomOutAction.class).getString("LBL_ZoomOut");
+        return NbBundle.getMessage(ZoomOutAction.class, "LBL_ZoomOut");
     }
-    
+
     /** Gets help context for action. Implements superclass abstract method. */
+    @Override
     public org.openide.util.HelpCtx getHelpCtx() {
         return HelpCtx.DEFAULT_HELP;
     }
 
     /** Overrides superclass method. */
+    @Override
     public boolean isEnabled() {
         return true;
     }
-    
+
     /** Gets icon resource. Overrides superclass method. */
+    @Override
     protected String iconResource() {
         return "org/netbeans/modules/image/zoomOut.gif"; // NOI18N
     }

--- a/ide/image/src/org/netbeans/modules/image/action/ExternalEditAction.java
+++ b/ide/image/src/org/netbeans/modules/image/action/ExternalEditAction.java
@@ -53,37 +53,34 @@ public final class ExternalEditAction implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        RP.post(new Runnable() {
-            @Override
-            public void run() {
-                boolean showInBrowser = true;
-                for (FileObject imageFO : list) {
-                    File imageFile;
-                    imageFile = FileUtil.toFile(imageFO);
-                    if (imageFile == null) {
-                        continue;
-                    }
+        RP.post(() -> {
+            boolean showInBrowser = true;
+            for (FileObject imageFO : list) {
+                File imageFile;
+                imageFile = FileUtil.toFile(imageFO);
+                if (imageFile == null) {
+                    continue;
+                }
 
-                    // open with Desktop API if its supported
-                    if (Desktop.isDesktopSupported()) {
-                        Desktop desktop = Desktop.getDesktop();
-                        if (desktop.isSupported(Desktop.Action.EDIT)) {
-                            showInBrowser = false;
-                            try {
-                                desktop.edit(imageFile);
-                            } catch (IOException ex) {
-                                Logger.getLogger(ExternalEditAction.class.getName()).info(NbBundle.getMessage(ExternalEditAction.class, "ERR_ExternalEditFile"));
-                                showInBrowser = true;
-                            }
+                // open with Desktop API if its supported
+                if (Desktop.isDesktopSupported()) {
+                    Desktop desktop = Desktop.getDesktop();
+                    if (desktop.isSupported(Desktop.Action.EDIT)) {
+                        showInBrowser = false;
+                        try {
+                            desktop.edit(imageFile);
+                        } catch (IOException ex) {
+                            Logger.getLogger(ExternalEditAction.class.getName()).info(NbBundle.getMessage(ExternalEditAction.class, "ERR_ExternalEditFile"));
+                            showInBrowser = true;
                         }
                     }
-                    // if Desktop API is not supported open in browser
-                    if (showInBrowser) {
-                        try {
-                            HtmlBrowser.URLDisplayer.getDefault().showURL(imageFile.toURI().toURL());
-                        } catch (MalformedURLException ex) {
-                            Logger.getLogger(ExternalEditAction.class.getName()).info(NbBundle.getMessage(ExternalEditAction.class, "ERR_ExternalEditFile"));
-                        }
+                }
+                // if Desktop API is not supported open in browser
+                if (showInBrowser) {
+                    try {
+                        HtmlBrowser.URLDisplayer.getDefault().showURL(imageFile.toURI().toURL());
+                    } catch (MalformedURLException ex) {
+                        Logger.getLogger(ExternalEditAction.class.getName()).info(NbBundle.getMessage(ExternalEditAction.class, "ERR_ExternalEditFile"));
                     }
                 }
             }

--- a/ide/image/src/org/netbeans/modules/image/navigation/ImagePreviewPanel.java
+++ b/ide/image/src/org/netbeans/modules/image/navigation/ImagePreviewPanel.java
@@ -24,6 +24,7 @@ import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import javax.swing.JPanel;
 import javax.swing.UIManager;
+import org.openide.awt.GraphicsUtils;
 import org.openide.util.NbBundle;
 
 /**
@@ -47,6 +48,7 @@ public class ImagePreviewPanel extends JPanel {
 
     @Override
     protected void paintComponent(Graphics g) {
+        GraphicsUtils.configureDefaultRenderingHints(g);
         super.paintComponent(g);
         if (image != null) {
             g.setColor(foreground);

--- a/ide/image/src/org/netbeans/modules/image/navigation/ImagePreviewPanel.java
+++ b/ide/image/src/org/netbeans/modules/image/navigation/ImagePreviewPanel.java
@@ -34,7 +34,7 @@ import org.openide.util.NbBundle;
  */
 public class ImagePreviewPanel extends JPanel {
 
-    BufferedImage image;
+    private BufferedImage image;
     private final int stringGapSize = 10;
     private final Color background = UIManager.getColor("Table.background");
     private final Color foreground = UIManager.getColor("Table.foreground");


### PR DESCRIPTION
The navigator window is not using antialiasing (left current version, right version from this PR):

![Bildschirmfoto vom 2023-03-13 19-37-46](https://user-images.githubusercontent.com/2179736/224814201-4ae18b60-2eb4-436a-85da-bc6a3dc66599.png)

When dragging images the cursor and the position on the image drifted apart, this is fixed. In the left part of the screenshot a drag start and end is shown for the original version, while the right side shows the new one (see the locations of the red cross and the red hand):

![drag-merged](https://user-images.githubusercontent.com/2179736/224814386-3234eba6-4162-4234-9865-e6a05a15ab8f.jpg)

As part of the warning fixes, the generation of the action list had to be updated and while doing this the order was modified, so that it is more clear (separator before the image actions block and between the image and filesystem actions):

![menu-merged](https://user-images.githubusercontent.com/2179736/224814684-b21f5713-6bb9-4845-9592-f08afd9a6387.png)
