### PR TITLE
Upgrade Gradle Tooling API to 8.0.2

### DIFF
--- a/extide/libs.gradle/external/binaries-list
+++ b/extide/libs.gradle/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-21A1F0E6F9FB1A08D06602737FF2010288F9E934 https://repo.gradle.org/artifactory/libs-releases/org/gradle/gradle-tooling-api/8.0-rc-1/gradle-tooling-api-8.0-rc-1.jar gradle-tooling-api-8.0-rc-1.jar
+9632294B8D455F340939E9BC54C0C9DA3DB0B656 https://repo.gradle.org/artifactory/libs-releases/org/gradle/gradle-tooling-api/8.0.2/gradle-tooling-api-8.0.2.jar gradle-tooling-api-8.0.2.jar

--- a/extide/libs.gradle/external/gradle-tooling-api-8.0.2-license.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-8.0.2-license.txt
@@ -1,7 +1,7 @@
 Name: Gradle Wrapper
 Description: Gradle Tooling API
-Version: 8.0-rc-1
-Files: gradle-tooling-api-8.0-rc-1.jar
+Version: 8.0.2
+Files: gradle-tooling-api-8.0.2.jar
 License: Apache-2.0
 Origin: Gradle Inc.
 URL: https://gradle.org/

--- a/extide/libs.gradle/external/gradle-tooling-api-8.0.2-notice.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-8.0.2-notice.txt
@@ -1,8 +1,8 @@
 Gradle Inc.'s Gradle Tooling API
-Copyright 2007-2022 Gradle Inc.
+Copyright 2007-2023 Gradle Inc.
 
 This product includes software developed at
 Gradle Inc. (https://gradle.org/).
 
 This product includes/uses SLF4J (https://www.slf4j.org/)
-developed by QOS.ch, 2004-2022
+developed by QOS.ch, 2004-2023

--- a/extide/libs.gradle/manifest.mf
+++ b/extide/libs.gradle/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.libs.gradle/8
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/libs/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 8.1
+OpenIDE-Module-Specification-Version: 8.0.2.1

--- a/extide/libs.gradle/nbproject/project.properties
+++ b/extide/libs.gradle/nbproject/project.properties
@@ -22,4 +22,4 @@ javac.compilerargs=-Xlint -Xlint:-serial
 # For more information, please see http://wiki.netbeans.org/SignatureTest
 sigtest.gen.fail.on.error=false
 
-release.external/gradle-tooling-api-8.0-rc-1.jar=modules/gradle/gradle-tooling-api.jar
+release.external/gradle-tooling-api-8.0.2.jar=modules/gradle/gradle-tooling-api.jar

--- a/extide/libs.gradle/nbproject/project.xml
+++ b/extide/libs.gradle/nbproject/project.xml
@@ -39,7 +39,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>gradle/gradle-tooling-api.jar</runtime-relative-path>
-                <binary-origin>external/gradle-tooling-api-8.0-rc-1.jar</binary-origin>
+                <binary-origin>external/gradle-tooling-api-8.0.2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION

Gradle 8.0 is out with 2 patches, let's have the tooling updated.

FYI: I've experienced some strange thing while building this one. The Gradle Artifactory uses some CND, so the first few attempts downloading the jar failed. After a while the edge point cached the jar and it works ever since. I'm not that fan of that behavior, though I'm not sure if that has happened. Let's see how that behaves here...