### PR TITLE
Fixes for Java module graph (GH4227)

### DIFF
--- a/java/java.graph/src/org/netbeans/modules/java/graph/SearchVisitor.java
+++ b/java/java.graph/src/org/netbeans/modules/java/graph/SearchVisitor.java
@@ -44,7 +44,7 @@ class SearchVisitor implements GraphNodeVisitor {
         if (root == null) {
             root = node;
         }
-        if (scene.isIncluded(node)) {
+        if (!path.contains(node) && scene.isIncluded(node)) {
             GraphNode grNode = scene.getGraphNodeRepresentant(node);
             if (grNode == null) {
                 return false;
@@ -59,7 +59,7 @@ class SearchVisitor implements GraphNodeVisitor {
     }
 
     @Override public boolean endVisit(GraphNodeImplementation node) {
-        if (scene.isIncluded(node)) {
+        if (path.peek() == node) {
             path.pop();
         }
         return true;

--- a/java/java.module.graph/src/org/netbeans/modules/java/module/graph/DependencyCalculator.java
+++ b/java/java.module.graph/src/org/netbeans/modules/java/module/graph/DependencyCalculator.java
@@ -18,7 +18,7 @@
  */
 package org.netbeans.modules.java.module.graph;
 
-import com.sun.source.tree.Tree;
+import com.sun.source.tree.ModuleTree;
 import com.sun.source.util.TreePath;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,13 +31,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.lang.model.element.ModuleElement;
-import javax.tools.JavaFileObject;
 import org.netbeans.api.annotations.common.NonNull;
-import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.JavaSource;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.URLMapper;
 import org.openide.util.Exceptions;
 import org.openide.util.Parameters;
 
@@ -81,9 +78,9 @@ final class DependencyCalculator {
                 try {
                     js.runUserActionTask((cc)-> {
                         cc.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
-                        final List<? extends Tree> decls = cc.getCompilationUnit().getTypeDecls();
-                        final ModuleElement me =  !decls.isEmpty() && decls.get(0).getKind() == Tree.Kind.MODULE ?
-                                (ModuleElement) cc.getTrees().getElement(TreePath.getPath(cc.getCompilationUnit(), decls.get(0))) :
+                        final ModuleTree moduleTree = cc.getCompilationUnit().getModule();
+                        final ModuleElement me = moduleTree != null ?
+                                (ModuleElement) cc.getTrees().getElement(TreePath.getPath(cc.getCompilationUnit(), moduleTree)) :
                                 null;
                         if (me != null) {
                             final Map<String, ModuleNode> mods = new LinkedHashMap<>();


### PR DESCRIPTION
Fixes #4227 - Java module graph component failing to display with a NPE. This is caused by the same issue as fixed in #4780 whereby the module tree is no longer available from `cc.getCompilationUnit().getTypeDecls()` and should be obtained by `cc.getCompilationUnit().getModule()`. Need to look across the code base for other instances of this problem.

Second commit fixes a stack overflow noticed in the search function on the graph. This seems to be due to circular dependencies being reported in the underlying dependency graph - probably some other issues to look at there, but at least it doesn't blow up for now!