### PR TITLE
Remove dependency of decl. hints on hints UI; UI plugs into hints SPI.

### DIFF
--- a/java/java.hints.declarative/nbproject/project.xml
+++ b/java/java.hints.declarative/nbproject/project.xml
@@ -142,14 +142,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.java.hints.ui</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <implementation-version/>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.java.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/idebinding/HintsActionProvider.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/idebinding/HintsActionProvider.java
@@ -24,16 +24,15 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import org.netbeans.modules.java.hints.declarative.DeclarativeHintRegistry;
 import org.netbeans.modules.java.hints.declarative.HintDataObject;
-import org.netbeans.modules.java.hints.spiimpl.refactoring.InspectAndRefactorUI;
 import org.netbeans.modules.java.hints.providers.spi.HintDescription;
 import org.netbeans.modules.java.hints.providers.spi.HintMetadata;
+import org.netbeans.modules.java.hints.spiimpl.Utilities;
 import org.netbeans.spi.project.ActionProvider;
 import org.openide.awt.StatusDisplayer;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
-import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -80,9 +79,8 @@ public class HintsActionProvider implements ActionProvider {
             StatusDisplayer.getDefault().setStatusText("No hints specified in " + FileUtil.getFileDisplayName(hdo.getPrimaryFile()));
             return;
         }
-
-        HintMetadata m = hints.entrySet().iterator().next().getKey();
-        InspectAndRefactorUI.openRefactoringUI(Lookups.singleton(new InspectAndRefactorUI.HintWrap(m, DeclarativeHintRegistry.join(hints))));
+        
+        Utilities.openRefactoringUIOrWarn(hints, null);
     }
 
     @Override

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/HintsRefactoringUIFactory.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/HintsRefactoringUIFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.hints.spiimpl.refactoring;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.netbeans.modules.java.hints.providers.spi.HintDescription;
+import org.netbeans.modules.java.hints.providers.spi.HintMetadata;
+import org.netbeans.modules.java.hints.spiimpl.HintsRefactoringFactory;
+import org.netbeans.modules.refactoring.spi.ui.RefactoringUI;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+@ServiceProvider(service = HintsRefactoringFactory.class)
+public class HintsRefactoringUIFactory implements HintsRefactoringFactory {
+
+    public static Collection<? extends HintDescription> join(Map<HintMetadata, Collection<? extends HintDescription>> hints) {
+        List<HintDescription> descs = new LinkedList<>();
+
+        for (Collection<? extends HintDescription> c : hints.values()) {
+            descs.addAll(c);
+        }
+
+        return descs;
+    }
+
+    @Override
+    public RefactoringUI createRefactoringUI(Map<HintMetadata, Collection<? extends HintDescription>> hints) {
+        if (hints.isEmpty()) {
+            return null;
+        }
+        HintMetadata m = hints.keySet().iterator().next();
+        InspectAndRefactorUI.HintWrap wrap = new InspectAndRefactorUI.HintWrap(m, join(hints));
+        return new InspectAndRefactorUI(null, true, false, Lookups.singleton(wrap));
+    }
+    
+}

--- a/java/java.hints/nbproject/project.xml
+++ b/java/java.hints/nbproject/project.xml
@@ -104,15 +104,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.code.analysis</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>0</release-version>
-                        <specification-version>1.0</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.editor</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -172,6 +172,7 @@ disabled.modules=\
     org.netbeans.modules.java.graph,\
     org.netbeans.modules.java.hints.declarative.test,\
     org.netbeans.modules.java.hints.test,\
+    org.netbeans.modules.java.hints.ui,\
     org.netbeans.modules.java.j2sedeploy,\
     org.netbeans.modules.java.j2seembedded,\
     org.netbeans.modules.java.j2semodule,\

--- a/java/spi.java.hints/apichanges.xml
+++ b/java/spi.java.hints/apichanges.xml
@@ -25,6 +25,22 @@
         <apidef name="JavaHintsSPI">Java Hints SPI</apidef>
     </apidefs>
     <changes>
+        <change id="openRefactoringUI">
+            <api name="JavaHintsSPI"/>
+            <summary>Added utility methods and SPI to open UI for hints</summary>
+            <version major="1" minor="53"/>
+            <date day="17" month="3" year="2021"/>
+            <compatibility addition="yes"/>
+            <description>
+                <p>
+                    Internal helper method added to open refactoring UI with selected hints. 
+                    <a href="@TOP@/org/netbeans/modules/java/hints/spiimpl/HintsRefactoringFactory.html">Added SPI</a> that 
+                    can be implemented by UI module(s) to actually provide the UI implementation.
+                </p>
+            </description>
+            <class package="org.netbeans.modules.java.hints.spiimpl" name="HintsRefactoringFactory"/>
+            <class package="org.netbeans.modules.java.hints.spiimpl" name="Utilities"/>
+        </change>
         <change id="JavaFixUtilities.isPrimary">
             <api name="JavaHintsSPI"/>
             <summary>Added JavaFixUtilities.isPrimary() utility</summary>

--- a/java/spi.java.hints/nbproject/project.properties
+++ b/java/spi.java.hints/nbproject/project.properties
@@ -17,7 +17,7 @@
 is.autoload=true
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=1.52.0
+spec.version.base=1.53.0
 requires.nb.javac=true
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/HintsRefactoringFactory.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/HintsRefactoringFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.hints.spiimpl;
+
+import java.util.Collection;
+import java.util.Map;
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.modules.java.hints.providers.spi.HintDescription;
+import org.netbeans.modules.java.hints.providers.spi.HintMetadata;
+import org.netbeans.modules.refactoring.spi.ui.RefactoringUI;
+import org.netbeans.modules.refactoring.spi.ui.UI;
+
+/**
+ * Creates a {@link RefactoringUI} initialized for the given collection of hints. The returned UI must be suitable for execution 
+ * using {@link UI#openRefactoringUI(org.netbeans.modules.refactoring.spi.ui.RefactoringUI)} and its variants.
+ * 
+ * @author sdedic
+ */
+public interface HintsRefactoringFactory {
+    /**
+     * Constructs a refactoring UI for the given collection of hints. The implementation may refuse creation if (any of) the requested
+     * hints are not suitable or unsupported by returning {@code null}.
+     * @param hintsCollection the hints 
+     * @return initialized UI delegate or {@code null}.
+     */
+    public @CheckForNull RefactoringUI   createRefactoringUI(@NonNull Map<HintMetadata, Collection<? extends HintDescription>> hintsCollection);
+}


### PR DESCRIPTION
The original idea was to ditch `java.hints.ui` from the LSP server, as it is Swing-based, but I've realized that `java.hints.declarative` depend on the `ui` directly just because of one call. 
I made a SPI to plug hints UI implemented in `java.hints.ui` and (private) API in `spiimpl` that displays the UI - so now `java.hints.declarative` only (implementation-)depends on `spi.java.hints`. 

