### PR TITLE
Maven indexing: Retain download index setting even if index setting is disabled

### DIFF
--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
@@ -653,7 +653,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
     //spawn the indexing into a separate thread..
     private boolean spawnIndexLoadedRepo(final RepositoryInfo repo) {
 
-        if (!RepositoryPreferences.isIndexDownloadEnabled() && repo.isRemoteDownloadable()) {
+        if (!RepositoryPreferences.isIndexDownloadEnabledEffective() && repo.isRemoteDownloadable()) {
             LOGGER.log(Level.FINE, "Skipping remote index request for {0}", repo);
             return false;
         }
@@ -678,7 +678,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
     @Override
     public void indexRepo(final RepositoryInfo repo) {
         
-        if (!RepositoryPreferences.isIndexDownloadEnabled() && repo.isRemoteDownloadable()) {
+        if (!RepositoryPreferences.isIndexDownloadEnabledEffective() && repo.isRemoteDownloadable()) {
             LOGGER.log(Level.FINE, "Skipping remote index request for {0}", repo);
             return;
         }

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
@@ -390,6 +390,17 @@ public final class RepositoryPreferences {
         return getPreferences().getBoolean(PROP_DOWNLOAD_INDEX, getDefaultDownloadIndexEnabled());
     }
 
+    /**
+     * Downloading the remote index should only happen if indexing in general
+     * and downloading in particular are enabled.
+     *
+     * @since 2.60
+     * @return true if indexing and downloading are both enabled.
+     */
+    public static boolean isIndexDownloadEnabledEffective() {
+        return isIndexRepositories() && isIndexDownloadEnabled();
+    }
+
     @NbBundle.Messages({
         "# true or false:",
         "DEFAULT_DOWNLOAD_INDEX=true"

--- a/java/maven/src/org/netbeans/modules/maven/ProjectOpenedHookImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/ProjectOpenedHookImpl.java
@@ -203,7 +203,7 @@ public class ProjectOpenedHookImpl extends ProjectOpenedHook {
                                 LOGGER.log(Level.FINER, "Index once a Week :{0}", ri.getId());//NOI18N
                                 run = true;
                             }
-                            if (run && ri.isRemoteDownloadable() && RepositoryPreferences.isIndexDownloadEnabled()) {
+                            if (run && ri.isRemoteDownloadable()) {
                                 RepositoryIndexer.indexRepo(ri);
                             }
                         }

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
@@ -993,20 +993,9 @@ public class SettingsPanel extends javax.swing.JPanel {
         updateCheckboxes();
     }//GEN-LAST:event_cbEnableIndexingActionPerformed
 
-    // short term UI memory, to select index download again when indexing
-    // was toggled off and on by the user
-    private boolean indexDownloadWasEnabled = false;
-
     private void updateCheckboxes() {
-        if (!cbEnableIndexing.isSelected()) {
-            indexDownloadWasEnabled = cbEnableIndexDownload.isSelected();
-            cbEnableIndexDownload.setSelected(false);
-        } else if (indexDownloadWasEnabled) {
-            cbEnableIndexDownload.setSelected(true);
-        }
         cbEnableIndexDownload.setEnabled(cbEnableIndexing.isSelected());
     }
-
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btnDirectory;


### PR DESCRIPTION
When the maven general indexing is disabled, the setting for the index download is lost and forced to be false. Instead of loosing the value a new preferences getter is introduced, that calculates the effective value based on the two components:

- general indexing
- download index

Only if both settings are true, the effective value will be true.