### PR TITLE
JS: Improve handling of private/static fields in JS classes

### DIFF
--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsStructureScanner.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsStructureScanner.java
@@ -156,7 +156,7 @@ public class JsStructureScanner implements StructureScanner {
                 }
             } else if (child.getJSKind() == JsElement.Kind.PROPERTY) {
                 if(child.isDeclared() && (child.getModifiers().contains(Modifier.PUBLIC)
-                        || !(jsObject.getParent() instanceof JsFunction)))
+                        || !(jsObject.getParent() instanceof JsFunction) || jsObject.getJSKind() == JsElement.Kind.CLASS))
                     collectedItems.add(new JsSimpleStructureItem(child, children.isEmpty() ? null : children, "prop-", result)); //NOI18N
             } else if ((child.getJSKind() == JsElement.Kind.VARIABLE || child.getJSKind() == JsElement.Kind.CONSTANT)&& child.isDeclared()
                 && (!jsObject.isAnonymous() || (jsObject.isAnonymous() && jsObject.getFullyQualifiedName().indexOf('.') == -1))) {

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/parser/asyncFunctions/asyncFunctions3.js.ast.xml
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/parser/asyncFunctions/asyncFunctions3.js.ast.xml
@@ -120,6 +120,7 @@
           </IdentNode>
           <!-- PropertyNode Value -->
           <FunctionNode name='ddddd' kind='NORMAL' start='97' end='131'>
+            <isMethod/>
             <isNamedFunctionExpression/>
             <isAsync/>
             <!-- FunctionNode Parameters -->

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/structure/issueGH4371.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/structure/issueGH4371.js
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class test {
+    fieldTest1 = 0;
+    #fieldTest2 = 1;
+
+    static fieldTest3 = 2;
+    static #fieldTest4 = 3;
+
+    // private
+    #test1() {};
+    async #test2() {}
+
+    // public
+    test3() {}
+    async test4() {}
+
+    // static private
+    static #test5() {}
+    static async #test6() {}
+
+    // static public
+    static test7() {}
+    static async test8() {}
+}

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/structure/issueGH4371.js.structure
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/structure/issueGH4371.js.structure
@@ -1,0 +1,13 @@
+test:CLASS:[PUBLIC]:ESCAPED{test}:
+  #fieldTest2:FIELD:[PROTECTED]:ESCAPED{#fieldTest2}<font color="#999999">ESCAPED{ : }Number</font>:
+  #fieldTest4:FIELD:[STATIC, PROTECTED]:ESCAPED{#fieldTest4}<font color="#999999">ESCAPED{ : }Number</font>:
+  #test1:METHOD:[PROTECTED]:ESCAPED{#test1}ESCAPED{(}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:
+  #test2:METHOD:[PROTECTED]:ESCAPED{#test2}ESCAPED{(}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:
+  #test5:METHOD:[STATIC, PROTECTED]:ESCAPED{#test5}ESCAPED{(}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:
+  #test6:METHOD:[STATIC, PROTECTED]:ESCAPED{#test6}ESCAPED{(}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:
+  fieldTest1:FIELD:[PUBLIC]:ESCAPED{fieldTest1}<font color="#999999">ESCAPED{ : }Number</font>:
+  fieldTest3:FIELD:[PUBLIC, STATIC]:ESCAPED{fieldTest3}<font color="#999999">ESCAPED{ : }Number</font>:
+  test3:METHOD:[PUBLIC]:ESCAPED{test3}ESCAPED{(}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:
+  test4:METHOD:[PUBLIC]:ESCAPED{test4}ESCAPED{(}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:
+  test7:METHOD:[PUBLIC, STATIC]:ESCAPED{test7}ESCAPED{(}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:
+  test8:METHOD:[PUBLIC, STATIC]:ESCAPED{test8}ESCAPED{(}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsStructureScannerTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsStructureScannerTest.java
@@ -754,4 +754,8 @@ public class JsStructureScannerTest extends JsTestBase {
     public void testIssue269106() throws Exception {
         checkStructure("testfiles/structure/issue269106.js");
     }
+
+    public void testIssueGH4371() throws Exception {
+        checkStructure("testfiles/structure/issueGH4371.js");
+    }
 }

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -2148,6 +2148,9 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
                         property.getModifiers().remove(Modifier.PUBLIC);
                         property.getModifiers().add(Modifier.PROTECTED);
                     }
+                    if(propertyNode.isStatic()) {
+                        property.getModifiers().add(Modifier.STATIC);
+                    }
                     if(value instanceof CallNode) {
                         // TODO for now, don't continue. There shoudl be handled cases liek
                         // in the testFiles/model/property02.js file

--- a/webcommon/libs.nashorn/external/binaries-list
+++ b/webcommon/libs.nashorn/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-E7865ABC417BD5973D5F8B10BC34FB870F6E2919 eu.doppel-helix.netbeans.lib:graaljs-parser:1.1
+188B87174403746227AEBD41B1A9E131FD77D4DA eu.doppel-helix.netbeans.lib:graaljs-parser:1.2

--- a/webcommon/libs.nashorn/external/graaljs-parser-1.2-license.txt
+++ b/webcommon/libs.nashorn/external/graaljs-parser-1.2-license.txt
@@ -1,5 +1,5 @@
 Name: Graal.js Parser
-Version: 1.1
+Version: 1.2
 Description: An ECMAScript 13 (ECMAScript 2022) compatible parser for JavaScript source code. Based on the parser of Graal.js (https://github.com/graalvm/graaljs).
 License: UPL
 Origin: https://github.com/matthiasblaesing/graaljs-nb

--- a/webcommon/libs.nashorn/nbproject/project.properties
+++ b/webcommon/libs.nashorn/nbproject/project.properties
@@ -19,4 +19,4 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/graaljs-parser-1.1.jar=modules/ext/graaljs-parser-1.1.jar
+release.external/graaljs-parser-1.2.jar=modules/ext/graaljs-parser-1.2.jar

--- a/webcommon/libs.nashorn/nbproject/project.xml
+++ b/webcommon/libs.nashorn/nbproject/project.xml
@@ -29,8 +29,8 @@
                 <subpackages>com.oracle.js.parser</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/graaljs-parser-1.1.jar</runtime-relative-path>
-                <binary-origin>external/graaljs-parser-1.1.jar</binary-origin>
+                <runtime-relative-path>ext/graaljs-parser-1.2.jar</runtime-relative-path>
+                <binary-origin>external/graaljs-parser-1.2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
With this PR the modifiers are now reported correctly for the following testcase, which is based on the original report in  #4371:

```javascript
class test {
    fieldTest1 = 0;
    #fieldTest2 = 1;

    static fieldTest3 = 2;
    static #fieldTest4 = 3;

    // private
    #test1() {};
    async #test2() {}

    // public
    test3() {}
    async test4() {}

    // static private
    static #test5() {}
    static async #test6() {}

    // static public
    static test7() {}
    static async test8() {}
}
```

Resulting structure:

![Bildschirmfoto vom 2023-03-18 23-55-19](https://user-images.githubusercontent.com/2179736/226144797-2f81d7a7-d6bd-4ded-9059-0f013c29a48e.png)

Closes: #4371
Closes: #5030