### PR TITLE
Show intersection types in the PHP doc window #5426

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5426.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5426.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH5426 {
+
+    /**
+     * Test field.
+     *
+     * @var TestClass&TestInterface
+     */
+    public $testField;
+
+    /**
+     * Test method.
+     *
+     * @param TestClass&TestInterface $test
+     * @return TestClass&TestInterface
+     */
+    public function testMethod($test) {
+    }
+
+    public function example(): void {
+        $this->testField;
+        $this->testMethod(null);
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5426.php.testIssueGH5426_01.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5426.php.testIssueGH5426_01.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->testFi|eld;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   TestClass&TestInterface testFi  [PUBLIC]   GH5426
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$testField</b><br/><br/>
+Test field.
+<br />
+<table>
+<tr><th align="left">Type:</th><td>TestClass & TestInterface</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5426.php.testIssueGH5426_02.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5426.php.testIssueGH5426_02.html
@@ -1,0 +1,15 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->testMetho|d(null);
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+METHOD     testMethod($test)               [PUBLIC]   GH5426
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>testMethod</b><br/><br/>
+Test method.
+<br />
+<h3>Parameters:</h3>
+<table cellspacing=0 style="border: 0px; width: 100%;">
+<tr><td>&nbsp;</td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr>TestClass & TestInterface</nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr><b>$test</b></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;width:80%;" >PHPDoc not found</td></tr>
+</table>
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>TestClass & TestInterface</td></tr></table></body></html>

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
@@ -262,15 +262,15 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
     public void testFunctionIntersectionTypeWithoutPhpDoc() throws Exception {
         checkCompletionDocumentation("testfiles/completion/documentation/functionWithoutPhpDoc.php", "testIntersectionTy^pe(null, null); // function", false, "");
     }
-    
+
     public void testIssueGH5427_01() throws Exception {
         checkCompletionDocumentation("testfiles/completion/documentation/issueGH5427.php", "$this->test_without_d^oc", false, "");
     }
-      
+
     public void testIssueGH5427_02() throws Exception {
         checkCompletionDocumentation("testfiles/completion/documentation/issueGH5427.php", "$this->test_without_v^ar_tag", false, "");
     }
-    
+
     public void testIssueGH5427_03() throws Exception {
         checkCompletionDocumentation("testfiles/completion/documentation/issueGH5427.php", "$this->test_with_v^ar_tag", false, "");
     }
@@ -278,11 +278,19 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
     public void testIssueGH5375_01() throws Exception {
         checkCompletionDocumentation("testfiles/completion/documentation/issueGH5375.php", "$this->test_without_v^ar_tag", false, "");
     }
-      
+
     public void testIssueGH5375_02() throws Exception {
         checkCompletionDocumentation("testfiles/completion/documentation/issueGH5375.php", "$this->test_with_v^ar_tag", false, "");
-    }    
-    
+    }
+
+    public void testIssueGH5426_01() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/issueGH5426.php", "        $this->testFi^eld;", false, "");
+    }
+
+    public void testIssueGH5426_02() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/issueGH5426.php", "        $this->testMetho^d(null);", false, "");
+    }
+
     @Override
     protected String alterDocumentationForTest(String documentation) {
         int start = documentation.indexOf("file:");


### PR DESCRIPTION
#5426

This problem occurs when fields and functions have intersection types only in PHPDoc.

e.g.
```php
class Example
{
    /**
     * @var Type1&Type2
     */
    public $field; // without type declaration
}
```

Before: `|` is shown instead of `&` (`Type1 | Type2`)

![nb-php-gh-5426-before](https://user-images.githubusercontent.com/738383/226156696-97300fe4-450c-438f-9a73-ddbdbd1b2227.png)

After: `&` is shown (`Type1 & Type2`)

![nb-php-gh-5426](https://user-images.githubusercontent.com/738383/226156547-78584904-a236-4e2e-b808-42633d97aed9.png)
