### PR TITLE
Fix an array formatting in a match arm #5186

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -300,6 +300,7 @@ public class FormatVisitor extends DefaultVisitor {
             if (formatTokens.get(formatTokens.size() - 1).getId() == FormatToken.Kind.WHITESPACE_INDENT
                     || path.get(1) instanceof ArrayElement
                     || path.get(1) instanceof FormalParameter
+                    || path.get(1) instanceof MatchArm
                     || path.get(1) instanceof CastExpression) {
                 // when the array is on the beginning of the line, indent items in normal way
                 delta = options.indentArrayItems;

--- a/php/php.editor/test/unit/data/testfiles/formatting/php80/matchExpressionWithArray_01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/php80/matchExpressionWithArray_01.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// GH-5186
+match(true){
+	'test' => [
+		'key' => 'value',
+		],
+};
+
+match (true) {
+'test1' => ['key' => 'value'],
+'test2' => [
+'key1' => 'value1',
+'nested' => [
+'key2' => 'value2',
+],
+],
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/php80/matchExpressionWithArray_01.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/php80/matchExpressionWithArray_01.php.formatted
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// GH-5186
+match (true) {
+    'test' => [
+        'key' => 'value',
+    ],
+};
+
+match (true) {
+    'test1' => ['key' => 'value'],
+    'test2' => [
+        'key1' => 'value1',
+        'nested' => [
+            'key2' => 'value2',
+        ],
+    ],
+};

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
@@ -943,6 +943,12 @@ public class PHPFormatterTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/php80/matchExpression_SameLine_02.php", options);
     }
 
+    // GH-5186
+    public void testMatchExpressionWithArray_01() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        reformatFileContents("testfiles/formatting/php80/matchExpressionWithArray_01.php", options);
+    }
+
     public void testAttributeSyntax_01() throws Exception {
         HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
         reformatFileContents("testfiles/formatting/php80/attributeSyntax_01.php", options);


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/5186

e.g.
```php
match(true){
	'test' => [
		'key' => 'value',
		],
};
```

Before: An array is broken
```php
match (true) {
    'test' => [
'key' => 'value',
    ],
};
```

After:
```php
match (true) {
    'test' => [
        'key' => 'value',
    ],
};
```
