### PR TITLE
Better LSP command names, conflict resolution

### DIFF
--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
@@ -64,16 +64,26 @@ public class ProjectAuditCommand extends CodeActionsProvider {
     /**
      * Force executes the project audit using the supplied compartment and knowledgebase IDs.
      */
-    private static final String COMMAND_EXECUTE_AUDIT = "nbls.gcn.projectAudit.execute"; // NOI18N
+    private static final String COMMAND_EXECUTE_AUDIT = "nbls.projectAudit.execute"; // NOI18N
+    /**
+     * @deprecated will be removed in NB 19
+     */
+    private static final String COMMAND_EXECUTE_AUDIT_OLD = "nbls.gcn.projectAudit.execute"; // NOI18N
     
     /**
      * Displays the audit from the Knowledgebase and compartment.
      */
-    private static final String COMMAND_LOAD_AUDIT = "nbls.gcn.projectAudit.display"; // NOI18N
+    private static final String COMMAND_LOAD_AUDIT = "nbls.projectAudit.display"; // NOI18N
+    /**
+     * @deprecated will be removed in NB 19
+     */
+    private static final String COMMAND_LOAD_AUDIT_OLD = "nbls.gcn.projectAudit.display"; // NOI18N
     
     public static final Set<String> COMMANDS = new HashSet<>(Arrays.asList(
             COMMAND_EXECUTE_AUDIT,
-            COMMAND_LOAD_AUDIT
+            COMMAND_LOAD_AUDIT,
+            COMMAND_EXECUTE_AUDIT_OLD,
+            COMMAND_LOAD_AUDIT_OLD
     ));
     
     @Override
@@ -195,9 +205,11 @@ public class ProjectAuditCommand extends CodeActionsProvider {
             
             switch (command) {
                 case COMMAND_EXECUTE_AUDIT:
+                case COMMAND_EXECUTE_AUDIT_OLD:
                     exec = v.runProjectAudit(kb, auditOpts);
                     break;
-                case COMMAND_LOAD_AUDIT: {
+                case COMMAND_LOAD_AUDIT:
+                case COMMAND_LOAD_AUDIT_OLD: {
                     exec = v.runProjectAudit(kb, auditOpts.setRunIfNotExists(forceAudit).setAuditName(preferredName));
                     break;
                 }

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectMetadataCommand.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectMetadataCommand.java
@@ -51,10 +51,15 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service = CodeActionsProvider.class)
 public class ProjectMetadataCommand extends CodeActionsProvider {
-    private static final String COMMAND_ARTIFACTS = "nbls.gcn.project.artifacts"; // NOI18N
+    private static final String COMMAND_ARTIFACTS = "nbls.project.artifacts"; // NOI18N
+    /**
+     * @deprecated will be removed in NB 19
+     */
+    private static final String COMMAND_ARTIFACTS_OLD = "nbls.gcn.project.artifacts"; // NOI18N
 
     private static final Set<String> COMMANDS = new HashSet<>(Arrays.asList(
-            COMMAND_ARTIFACTS
+            COMMAND_ARTIFACTS,
+            COMMAND_ARTIFACTS_OLD
     ));
     private static final Set<String> ARTIFACT_BLOCK_FIELDS = new HashSet<>(Arrays.asList(
         "data" // NOI18N


### PR DESCRIPTION
Two features in this PR:
- some command IDs have 'gcn' in their name, and the extension that provoked creation of the commands is being renamed ... and the commands should have neutral IDs anyway. Old ids were kept and marked as deprecated, neutral new names introduced.
- there was a special case when checking for conflicts - if a specific extension was installed, the LS does not ask the user, but disables itself. I made that decision configurable by package.jsons of the enabled extensions; if an extension decides that NBLS should disable itself in favour of RH java, it will do that without asking.