### PR TITLE
[maven hints] try to infer compiler plugin version from active maven version.

### DIFF
--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/PomModelUtils.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/PomModelUtils.java
@@ -37,6 +37,7 @@ import javax.swing.text.Document;
 import org.apache.maven.DefaultMaven;
 import org.apache.maven.Maven;
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.maven.building.Source;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.model.building.ModelBuildingException;
@@ -60,6 +61,7 @@ import org.netbeans.modules.maven.indexer.api.RepositoryPreferences;
 import org.netbeans.modules.maven.model.pom.POMComponent;
 import org.netbeans.modules.maven.model.pom.POMModel;
 import org.netbeans.modules.maven.model.pom.Properties;
+import org.netbeans.modules.maven.options.MavenSettings;
 import org.netbeans.modules.xml.xam.Model;
 import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.ErrorDescriptionFactory;
@@ -314,6 +316,21 @@ public final class PomModelUtils {
             }
         }
         return null;
+    }
+        
+    /*tests*/ static ComparableVersion activeMavenVersion = null;
+    private static File lastHome = null;
+    
+    static ComparableVersion getActiveMavenVersion() {
+        File home = EmbedderFactory.getMavenHome();
+        if (home != null && !home.equals(lastHome)) {
+            lastHome = home;
+            String version = MavenSettings.getCommandLineMavenVersion(home);
+            if (version != null) {
+                activeMavenVersion = new ComparableVersion(version);
+            }
+        }
+        return activeMavenVersion;
     }
 
 }

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -664,6 +664,7 @@
                 <package>org.netbeans.modules.maven.api.output</package>
                 <package>org.netbeans.modules.maven.api.problem</package>
                 <package>org.netbeans.modules.maven.execute</package>
+                <package>org.netbeans.modules.maven.options</package>
                 <package>org.netbeans.modules.maven.execute.model</package>
                 <package>org.netbeans.modules.maven.execute.model.io.jdom</package>
                 <package>org.netbeans.modules.maven.execute.model.io.xpp3</package>

--- a/java/maven/src/org/netbeans/modules/maven/api/ModuleInfoUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/ModuleInfoUtils.java
@@ -56,7 +56,7 @@ public final class ModuleInfoUtils {
      * there is a main module-info.java in the given project (has to be >= 3.6).
      * 
      * @param prj the project to be checked
-     * @return <code>true</code> if there is no mofule-info file or if the m-c-p version is new enough (>= 3.6). Otherwise <code>false</code>
+     * @return <code>true</code> if there is no module-info file or if the m-c-p version is new enough (>= 3.6). Otherwise <code>false</code>
      */
     public static boolean checkModuleInfoAndCompilerFit(Project prj) {
         NbMavenProject nbprj = prj.getLookup().lookup(NbMavenProject.class);
@@ -76,7 +76,7 @@ public final class ModuleInfoUtils {
         return new ComparableVersion(version).compareTo(new ComparableVersion(Constants.PLUGIN_COMPILER_VERSION_SUPPORTING_JDK9)) >= 0;
     }    
     
-    private static boolean hasModuleInfo(NbMavenProject nbprj) {
+    public static boolean hasModuleInfo(NbMavenProject nbprj) {
         MavenProject mavenProject = nbprj.getMavenProject();        
         return hasModuleInfoInSourceRoot(mavenProject.getCompileSourceRoots()) || 
                hasModuleInfoInSourceRoot(mavenProject.getTestCompileSourceRoots());


### PR DESCRIPTION
The plugin version query returns the version of the embedded maven distribution instead of the active distribution. This started causing issues the moment #5679 was implemented which upgrades embedded maven to a version which provides a JDK 9+ compatible plugins out of the box (which is a good thing).

We can workaround this problem by comparing maven versions, since we can infer the plugin version from it under certain conditions.

Fixes the release option and the module-info hint.