### PR TITLE
Fix registration of Database node

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/database/DatabaseNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/database/DatabaseNode.java
@@ -79,7 +79,7 @@ public class DatabaseNode extends OCINode {
                     .map(d -> {
                         List<DatabaseConnectionStringProfile> profiles = d.getConnectionStrings().getProfiles();
                         DatabaseItem item = new DatabaseItem(
-                                OCID.of(d.getId(), "Database"), //NOI18N
+                                OCID.of(d.getId(), "Databases"), //NOI18N
                                 d.getDbName(),
                                 d.getServiceConsoleUrl(),
                                 getConnectionName(profiles));

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/resources/layer.xml
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/resources/layer.xml
@@ -154,7 +154,7 @@
                     </file>
                 </folder>
             </folder>
-            <folder name="Database">
+            <folder name="Databases">
                 <folder name="Nodes">
                     <file name="org-netbeans-modules-cloud-oracle-database-DatabaseNode-createNode.instance">
                         <!--org.netbeans.modules.cloud.oracle.database.DatabaseNode.createNode()-->


### PR DESCRIPTION
Oracle cloud Database node is registered under `Cloud/Oracle/Database/Nodes`, but the corresponding actions are registered under `Cloud/Oracle/Databases/Actions` (note the difference Database - Database**s**). This mismatch causes that the database actions (DownloadWalletAction and OpenServiceConsoleAction) are not displayed in the context menu of Database node. This PR fixes this difference.