### PR TITLE
Fix being shown incorrect documentation #4494

### DIFF
--- a/ide/csl.api/nbproject/project.properties
+++ b/ide/csl.api/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-spec.version.base=2.77.0
+spec.version.base=2.78.0
 is.autoload=true
 javac.source=1.8
 

--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -3062,8 +3062,12 @@ public abstract class CslTestBase extends NbTestCase {
     }
 
     public void checkCompletionDocumentation(final String file, final String caretLine, final boolean includeModifiers, final String itemPrefix) throws Exception {
+        checkCompletionDocumentation(file, caretLine, includeModifiers, itemPrefix, QueryType.COMPLETION);
+    }
+
+    public void checkCompletionDocumentation(final String file, final String caretLine, final boolean includeModifiers, final String itemPrefix, QueryType queryType) throws Exception {
         // TODO call TestCompilationInfo.setCaretOffset!
-        final QueryType type = QueryType.COMPLETION;
+        final QueryType type = queryType;
         final boolean caseSensitive = true;
 
         Source testSource = getTestSource(getTestFile(file));

--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -18,7 +18,7 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 nbjavac.ignore.missing.enclosing=**/CUP$ASTPHP5Parser$actions.class
 nbm.needs.restart=true
-spec.version.base=2.23.0
+spec.version.base=2.24.0
 release.external/predefined_vars-1.0.zip=docs/predefined_vars.zip
 sigtest.gen.fail.on.error=false
 

--- a/php/php.editor/nbproject/project.xml
+++ b/php/php.editor/nbproject/project.xml
@@ -84,7 +84,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.72</specification-version>
+                        <specification-version>2.78</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -330,7 +330,13 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
 
         PHPCompletionItem.CompletionRequest request = new PHPCompletionItem.CompletionRequest();
         request.context = context;
-        String prefix = getPrefix(info, caretOffset, true, PrefixBreaker.WITH_NS_PARTS);
+        QueryType queryType = completionContext.getQueryType();
+        String prefix;
+        if (queryType == QueryType.DOCUMENTATION) { // GH-4494
+            prefix = getPrefix(info, caretOffset, false, PrefixBreaker.WITH_NS_PARTS);
+        } else {
+            prefix = getPrefix(info, caretOffset, true, PrefixBreaker.WITH_NS_PARTS);
+        }
         if (prefix == null) {
             return CodeCompletionResult.NONE;
         }

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * function gh4494().
+ *
+ * @return void
+ */
+function gh4494(): void {
+}
+
+/**
+ * function gh4494_aa().
+ *
+ * @return void
+ */
+function gh4494_aa(): void {
+}
+
+/**
+ * function gh4494_aa_bb().
+ *
+ * @return void
+ */
+function gh4494_aa_bbb(): void {
+}
+
+/**
+ * function gh4494_aa_bb_cc().
+ *
+ * @return void
+ */
+function gh4494_aa_bb_cc(): void {
+}
+
+gh4494_aa_bb_cc();
+gh4494_aa_bbb();

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_01.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_01.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+gh44|94_aa_bbb();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     gh4494_aa_bbb()                 [PUBLIC]   issueGH4494.php
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>gh4494_aa_bbb</b><br/><br/>
+function gh4494_aa_bb().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_02.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_02.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+gh4494_aa|_bbb();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     gh4494_aa_bbb()                 [PUBLIC]   issueGH4494.php
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>gh4494_aa_bbb</b><br/><br/>
+function gh4494_aa_bb().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_03.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_03.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+gh4494_aa_b|bb();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     gh4494_aa_bbb()                 [PUBLIC]   issueGH4494.php
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>gh4494_aa_bbb</b><br/><br/>
+function gh4494_aa_bb().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_04.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_04.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+gh4494|_aa_bb_cc();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     gh4494_aa_bb_cc()               [PUBLIC]   issueGH4494.php
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>gh4494_aa_bb_cc</b><br/><br/>
+function gh4494_aa_bb_cc().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_05.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_05.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+gh4494_aa|_bb_cc();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     gh4494_aa_bb_cc()               [PUBLIC]   issueGH4494.php
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>gh4494_aa_bb_cc</b><br/><br/>
+function gh4494_aa_bb_cc().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_06.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_06.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+gh4494_aa_bb|_cc();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     gh4494_aa_bb_cc()               [PUBLIC]   issueGH4494.php
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>gh4494_aa_bb_cc</b><br/><br/>
+function gh4494_aa_bb_cc().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_07.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH4494.php.testIssueGH4494_07.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+gh4494_aa_bb_cc|();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     gh4494_aa_bb_cc()               [PUBLIC]   issueGH4494.php
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>gh4494_aa_bb_cc</b><br/><br/>
+function gh4494_aa_bb_cc().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.Map;
 import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.csl.api.CodeCompletionHandler.QueryType;
 import org.netbeans.modules.php.project.api.PhpSourcePath;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
@@ -291,6 +292,34 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
         checkCompletionDocumentation("testfiles/completion/documentation/issueGH5426.php", "        $this->testMetho^d(null);", false, "");
     }
 
+    public void testIssueGH4494_01() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH4494.php", "gh44^94_aa_bbb();");
+    }
+
+    public void testIssueGH4494_02() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH4494.php", "gh4494_aa^_bbb();");
+    }
+
+    public void testIssueGH4494_03() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH4494.php", "gh4494_aa_b^bb();");
+    }
+
+    public void testIssueGH4494_04() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH4494.php", "gh4494^_aa_bb_cc();");
+    }
+
+    public void testIssueGH4494_05() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH4494.php", "gh4494_aa^_bb_cc();");
+    }
+
+    public void testIssueGH4494_06() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH4494.php", "gh4494_aa_bb^_cc();");
+    }
+
+    public void testIssueGH4494_07() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH4494.php", "gh4494_aa_bb_cc^();");
+    }
+
     @Override
     protected String alterDocumentationForTest(String documentation) {
         int start = documentation.indexOf("file:");
@@ -314,6 +343,10 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
         if (followPhpdocumentor) {
             DocRenderer.PHPDocExtractor.UNIT_TEST_INHERITDOC_FOR_PHPDOCUMENTER = false;
         }
+    }
+
+    private void checkCompletionOnlyDocumentation(String filePath, String caretLine) throws Exception {
+        checkCompletionDocumentation(filePath, caretLine, false, "", QueryType.DOCUMENTATION);
     }
 
     @Override


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/4494
- Add a new test method for checking documentation when a `QueryType` is `DOCUMENTATION` to `CslTestBase`
- If `QueryType` is `DOCUMENTATION`, get a whole identifier as a prefix
- Add unit tests

### Example
```php
<?php

/**
 * function gh4494.
 *
 * @return void
 */
function gh4494(): void {
    
}

/**
 * function gh4494_aa().
 *
 * @return void
 */
function gh4494_aa(): void {
    
}

/**
 * function gh4494_aa_bb().
 *
 * @return void
 */
function gh4494_aa_bbb(): void {
    
}

/**
 * function gh4494_aa_bb_cc().
 *
 * @return void
 */
function gh4494_aa_bb_cc(): void {
    
}

gh4494_aa_bb_cc();

```
#### Before:

![nb-php-4494-before](https://user-images.githubusercontent.com/738383/226986882-e47b7bf3-1b67-4ee0-b336-dec771607281.gif)

#### After:

![nb-php-4494-after](https://user-images.githubusercontent.com/738383/226986903-33303dac-ba4d-4370-ac1b-fb64ceb2da89.gif)
