### PR TITLE
Action id of OpenServiceConsoleAction fixed

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/OpenServiceConsoleAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/OpenServiceConsoleAction.java
@@ -33,7 +33,7 @@ import org.openide.util.NbBundle.Messages;
 
 @ActionID(
         category = "Tools",
-        id = "org.netbeans.modules.cloud.oracle.OpenServiceConsoleAction"
+        id = "org.netbeans.modules.cloud.oracle.actions.OpenServiceConsoleAction"
 )
 @ActionRegistration(
         displayName = "#CTL_OpenServiceConsoleAction"


### PR DESCRIPTION
Action id of OpenServiceConsoleAction fixed to match its FQN and corresponding LSP command. Without this fix "Open Service Console" invoked from VSCode NBLS extension does nothting.