### PR TITLE
PHP: Fix the IntroduceSuggestion hint for Enum

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
@@ -320,6 +320,10 @@ public final class CodeUtils {
     public static String extractUnqualifiedClassName(StaticDispatch dispatch) {
         Parameters.notNull("dispatch", dispatch);
         Expression dispatcher = dispatch.getDispatcher();
+        if (dispatcher instanceof StaticConstantAccess) {
+            // e.g. EnumName::Case::staticMethod();
+            dispatcher = ((StaticConstantAccess) dispatcher).getDispatcher();
+        }
         return extractUnqualifiedName(dispatcher);
     }
 

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/ModelUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/ModelUtils.java
@@ -59,6 +59,7 @@ import org.netbeans.modules.php.editor.parser.PHPParseResult;
 import org.netbeans.modules.php.editor.parser.astnodes.Assignment;
 import org.netbeans.modules.php.editor.parser.astnodes.Expression;
 import org.netbeans.modules.php.editor.parser.astnodes.NamespaceDeclaration;
+import org.netbeans.modules.php.editor.parser.astnodes.StaticConstantAccess;
 import org.netbeans.modules.php.editor.parser.astnodes.StaticDispatch;
 import org.netbeans.modules.php.editor.parser.astnodes.VariableBase;
 import org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultVisitor;
@@ -198,8 +199,13 @@ public final class ModelUtils {
 
     public static Collection<? extends TypeScope> resolveType(Model model, StaticDispatch dispatch) {
         VariableScope variableScope = model.getVariableScope(dispatch.getStartOffset());
+        Expression staticDispatch = dispatch;
+        if (dispatch.getDispatcher() instanceof StaticConstantAccess) {
+            // e.g. EnumName::Case::method();
+            staticDispatch = ((StaticConstantAccess) dispatch.getDispatcher()).getDispatcher();
+        }
         QualifiedName fullyQualifiedName = VariousUtils.getFullyQualifiedName(
-                ASTNodeInfo.toQualifiedName(dispatch, true),
+                ASTNodeInfo.toQualifiedName(staticDispatch, true),
                 dispatch.getStartOffset(),
                 variableScope);
         NamespaceIndexFilter filter = new NamespaceIndexFilter(fullyQualifiedName.toString());

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
@@ -1666,9 +1666,9 @@ public final class VariousUtils {
             csi = (TypeScope) inScope;
         }
         if (csi != null) {
-            if ("self".equals(staticTypeName)) { //NOI18N
+            if (Type.SELF.equalsIgnoreCase(staticTypeName) || Type.STATIC.equalsIgnoreCase(staticTypeName)) {
                 return Collections.singletonList(csi);
-            } else if ("parent".equals(staticTypeName) && (csi instanceof ClassScope)) { //NOI18N
+            } else if (Type.PARENT.equalsIgnoreCase(staticTypeName) && (csi instanceof ClassScope)) {
                 return ((ClassScope) csi).getSuperClasses();
             }
         }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestion.java
@@ -869,6 +869,10 @@ public class IntroduceSuggestion extends SuggestionRule {
                     TraitScope trait = (TraitScope) typeScope;
                     elements.addAll(trait.getDeclaredFields());
                     elements.addAll(trait.getDeclaredMethods());
+                } else if (typeScope instanceof EnumScope) {
+                    EnumScope enumScope = (EnumScope) typeScope;
+                    elements.addAll(enumScope.getDeclaredEnumCases());
+                    elements.addAll(enumScope.getDeclaredMethods());
                 }
                 break;
             case FIELD:

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestion.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.php.editor.verification;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -51,13 +52,16 @@ import org.netbeans.modules.php.editor.api.QualifiedName;
 import org.netbeans.modules.php.editor.api.elements.BaseFunctionElement.PrintAs;
 import org.netbeans.modules.php.editor.api.elements.ClassElement;
 import org.netbeans.modules.php.editor.api.elements.ElementFilter;
+import org.netbeans.modules.php.editor.api.elements.EnumCaseElement;
 import org.netbeans.modules.php.editor.api.elements.FieldElement;
 import org.netbeans.modules.php.editor.api.elements.MethodElement;
 import org.netbeans.modules.php.editor.api.elements.TypeConstantElement;
 import org.netbeans.modules.php.editor.elements.MethodElementImpl;
 import org.netbeans.modules.php.editor.lexer.LexUtilities;
 import org.netbeans.modules.php.editor.lexer.PHPTokenId;
+import org.netbeans.modules.php.editor.model.CaseElement;
 import org.netbeans.modules.php.editor.model.ClassScope;
+import org.netbeans.modules.php.editor.model.EnumScope;
 import org.netbeans.modules.php.editor.model.InterfaceScope;
 import org.netbeans.modules.php.editor.model.MethodScope;
 import org.netbeans.modules.php.editor.model.Model;
@@ -134,14 +138,16 @@ public class IntroduceSuggestion extends SuggestionRule {
             final Model model = phpParseResult.getModel();
             IntroduceFixVisitor introduceFixVisitor = new IntroduceFixVisitor(model, lineBounds);
             phpParseResult.getProgram().accept(introduceFixVisitor);
-            IntroduceFix variableFix = introduceFixVisitor.getIntroduceFix();
-            if (variableFix != null) {
-                if (CancelSupport.getDefault().isCancelled()) {
-                    return;
+            List<IntroduceFix> variableFixes = introduceFixVisitor.getIntroduceFixes();
+            if (!variableFixes.isEmpty()) {
+                for (IntroduceFix variableFixe : variableFixes) {
+                    if (CancelSupport.getDefault().isCancelled()) {
+                        return;
+                    }
+                    hints.add(new Hint(IntroduceSuggestion.this, getDisplayName(),
+                            fileObject, variableFixe.getOffsetRange(),
+                            Collections.<HintFix>singletonList(variableFixe), 500));
                 }
-                hints.add(new Hint(IntroduceSuggestion.this, getDisplayName(),
-                        fileObject, variableFix.getOffsetRange(),
-                        Collections.<HintFix>singletonList(variableFix), 500));
             }
         }
     }
@@ -149,7 +155,7 @@ public class IntroduceSuggestion extends SuggestionRule {
     private static class IntroduceFixVisitor extends DefaultTreePathVisitor {
         private final Model model;
         private final OffsetRange lineBounds;
-        private IntroduceFix fix;
+        private final List<IntroduceFix> fixes = new ArrayList<>();
 
         IntroduceFixVisitor(Model model, OffsetRange lineBounds) {
             this.lineBounds = lineBounds;
@@ -185,7 +191,7 @@ public class IntroduceSuggestion extends SuggestionRule {
                     if (clzName != null && classes.isEmpty()) {
                         ClassElement clz = getIndexedClass(clzName);
                         if (clz == null) {
-                            fix = IntroduceClassFix.getInstance(clzName, model, instanceCreation);
+                            fixes.add(IntroduceClassFix.getInstance(clzName, model, instanceCreation));
                         }
                     }
                 }
@@ -209,9 +215,9 @@ public class IntroduceSuggestion extends SuggestionRule {
                         if (allMethods.isEmpty()) {
                             assert type != null;
                             FileObject fileObject = type.getFileObject();
-                            BaseDocument document = fileObject != null ? GsfUtilities.getDocument(fileObject, true) : null;
+                            BaseDocument document = fileObject != null ? (BaseDocument) GsfUtilities.getADocument(fileObject, true) : null;
                             if (document != null && fileObject.canWrite()) {
-                                fix = new IntroduceMethodFix(document, methodInvocation, type);
+                                fixes.add(new IntroduceMethodFix(document, methodInvocation, type));
                             }
                         }
                     }
@@ -240,9 +246,9 @@ public class IntroduceSuggestion extends SuggestionRule {
                         if (allMethods.isEmpty()) {
                             assert type != null;
                             FileObject fileObject = type.getFileObject();
-                            BaseDocument document = fileObject != null ? GsfUtilities.getDocument(fileObject, true) : null;
+                            BaseDocument document = fileObject != null ? (BaseDocument) GsfUtilities.getADocument(fileObject, true) : null;
                             if (document != null && fileObject.canWrite()) {
-                                fix = new IntroduceStaticMethodFix(document, methodInvocation, type);
+                                fixes.add(new IntroduceStaticMethodFix(document, methodInvocation, type));
                             }
                         }
                     }
@@ -267,10 +273,10 @@ public class IntroduceSuggestion extends SuggestionRule {
                         if (allFields.isEmpty()) {
                             assert type != null;
                             FileObject fileObject = type.getFileObject();
-                            BaseDocument document = fileObject != null ? GsfUtilities.getDocument(fileObject, false) : null;
+                            BaseDocument document = fileObject != null ? (BaseDocument) GsfUtilities.getADocument(fileObject, false) : null;
                             if (document != null && fileObject.canWrite()) {
                                 if (type instanceof ClassScope || type instanceof TraitScope) {
-                                    fix = new IntroduceFieldFix(document, fieldAccess, type);
+                                    fixes.add(new IntroduceFieldFix(document, fieldAccess, type));
                                 }
                             }
                         }
@@ -310,10 +316,10 @@ public class IntroduceSuggestion extends SuggestionRule {
                         if (allFields.isEmpty()) {
                             assert type != null;
                             FileObject fileObject = type.getFileObject();
-                            BaseDocument document = fileObject != null ? GsfUtilities.getDocument(fileObject, true) : null;
+                            BaseDocument document = fileObject != null ? (BaseDocument) GsfUtilities.getADocument(fileObject, true) : null;
                             if (document != null && fileObject.canWrite()) {
                                 if (type instanceof ClassScope || type instanceof TraitScope) {
-                                    fix = new IntroduceStaticFieldFix(document, fieldAccess, type);
+                                    fixes.add(new IntroduceStaticFieldFix(document, fieldAccess, type));
                                 }
                             }
                         }
@@ -341,12 +347,19 @@ public class IntroduceSuggestion extends SuggestionRule {
                         if (!(type instanceof TraitScope)) {
                             ElementQuery.Index index = model.getIndexScope().getIndex();
                             Set<TypeConstantElement> allConstants = ElementFilter.forName(NameKind.exact(constName)).filter(index.getAllTypeConstants(type));
-                            if (allConstants.isEmpty()) {
+                            Set<EnumCaseElement> allEnumCases = type instanceof EnumScope
+                                    ? ElementFilter.forName(NameKind.exact(constName)).filter(index.getAllEnumCases(type))
+                                    : Collections.emptySet();
+                            if (allConstants.isEmpty() && allEnumCases.isEmpty()) {
                                 assert type != null;
                                 FileObject fileObject = type.getFileObject();
-                                BaseDocument document = fileObject != null ? GsfUtilities.getDocument(fileObject, false) : null;
+                                BaseDocument document = fileObject != null ? (BaseDocument) GsfUtilities.getADocument(fileObject, false) : null;
+                                // if fileObject is null, document is null
                                 if (document != null && fileObject.canWrite()) {
-                                    fix = new IntroduceClassConstantFix(document, staticConstantAccess, (TypeScope) type);
+                                    fixes.add(new IntroduceClassConstantFix(document, staticConstantAccess, type));
+                                    if (type instanceof EnumScope) {
+                                        fixes.add(new IntroduceEnumCaseFix(document, staticConstantAccess, (EnumScope) type));
+                                    }
                                 }
                             }
                         }
@@ -358,10 +371,12 @@ public class IntroduceSuggestion extends SuggestionRule {
         }
 
         /**
-         * @return or null
+         * Get Fixes.
+         *
+         * @return fixes
          */
-        public IntroduceFix getIntroduceFix() {
-            return fix;
+        public List<IntroduceFix> getIntroduceFixes() {
+            return Collections.unmodifiableList(fixes);
         }
 
         private ClassElement getIndexedClass(String name) {
@@ -719,6 +734,79 @@ public class IntroduceSuggestion extends SuggestionRule {
         }
     }
 
+    private static class IntroduceEnumCaseFix extends IntroduceFix {
+
+        private final EnumScope type;
+        private final String template;
+        private final String enumCaseName;
+        private final String backingType;
+
+        public IntroduceEnumCaseFix(BaseDocument doc, StaticConstantAccess node, EnumScope type) {
+            super(doc, node);
+            this.type = type;
+            this.enumCaseName = ((StaticConstantAccess) node).getConstantName().getName();
+            this.backingType = type.getBackingType() != null ? type.getBackingType().toString() : null;
+            this.template = String.format(getTemplate(backingType), enumCaseName);
+        }
+
+        private String getTemplate(String backingType) {
+            String caseTemplate = "case %s;"; // NOI18N
+            if (backingType != null) {
+                if (Type.STRING.equals(backingType)) {
+                    caseTemplate = "case %s = '';"; // NOI18N
+                } else if (Type.INT.equals(backingType)) {
+                    caseTemplate = "case %s = " + (getLastIntIndex() + 1) + ";"; // NOI18N
+                }
+            }
+            return caseTemplate;
+        }
+
+        private int getLastIntIndex() {
+            int index = 0;
+            for (CaseElement enumCase : type.getDeclaredEnumCases()) {
+                String value = enumCase.getValue();
+                try {
+                    int intValue = Integer.parseInt(value);
+                    index = Integer.max(index, intValue);
+                } catch (NumberFormatException e) {
+                    // no-op
+                }
+            }
+            return index;
+        }
+
+        @Override
+        public void implement() throws Exception {
+            int templateOffset = getOffset();
+            EditList edits = new EditList(doc);
+            edits.replace(templateOffset, 0, "\n" + template, true, 0); // NOI18N
+            edits.apply();
+            int caretPositionFromEndOftemplate = Type.STRING.equalsIgnoreCase(backingType) ? 2 : 1;
+            templateOffset = LineDocumentUtils.getLineEnd(doc, templateOffset + 1) - caretPositionFromEndOftemplate;
+            UiUtils.open(type.getFileObject(), templateOffset);
+        }
+
+        @Override
+        @Messages({
+            "# {0} - Case name",
+            "# {1} - Type kind",
+            "# {2} - Type name",
+            "# {3} - File name",
+            "IntroduceHintEnumCaseDesc=Create Enum Case \"{0}\" in {1} \"{2}\" ({3})"
+        })
+        public String getDescription() {
+            String typeName = type.getName();
+            FileObject fileObject = type.getFileObject();
+            String fileName = fileObject == null ? UNKNOWN_FILE_NAME : fileObject.getNameExt();
+            String typeKindName = getTypeKindName(type);
+            return Bundle.IntroduceHintEnumCaseDesc(enumCaseName, typeKindName, typeName, fileName);
+        }
+
+        int getOffset() throws BadLocationException {
+            return IntroduceSuggestion.getOffset(doc, type, PhpElementKind.ENUM_CASE);
+        }
+    }
+
     abstract static class IntroduceFix implements HintFix {
 
         BaseDocument doc;
@@ -790,6 +878,12 @@ public class IntroduceSuggestion extends SuggestionRule {
                 } else if (typeScope instanceof TraitScope) {
                     TraitScope trait = (TraitScope) typeScope;
                     elements.addAll(trait.getDeclaredFields());
+                }
+                break;
+            case ENUM_CASE:
+                if (typeScope instanceof EnumScope) {
+                    EnumScope enumScope = (EnumScope) typeScope;
+                    elements.addAll(enumScope.getDeclaredEnumCases());
                 }
                 break;
             case TYPE_CONSTANT:
@@ -953,7 +1047,8 @@ public class IntroduceSuggestion extends SuggestionRule {
     @Messages({
         "IntroduceHintClassName=Class",
         "IntroduceHintInterfaceName=Interface",
-        "IntroduceHintTraitName=Trait"
+        "IntroduceHintTraitName=Trait",
+        "IntroduceHintEnumName=Enum",
     })
     private static String getTypeKindName(TypeScope typeScope) {
         if (typeScope instanceof ClassScope) {
@@ -962,6 +1057,8 @@ public class IntroduceSuggestion extends SuggestionRule {
             return Bundle.IntroduceHintInterfaceName();
         } else if (typeScope instanceof TraitScope) {
             return Bundle.IntroduceHintTraitName();
+        } else if (typeScope instanceof EnumScope) {
+            return Bundle.IntroduceHintEnumName();
         }
         assert false;
         return "?"; // NOI18N

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::Case3;
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumInt::Case3;
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumString::Case3;

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_01a.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_01a.fixed
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+    case Case3;
+
+}
+
+ExampleEnum::Case3;
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumInt::Case3;
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumString::Case3;

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_01b.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_01b.fixed
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+    const Case3 = "";
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::Case3;
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumInt::Case3;
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumString::Case3;

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_02a.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_02a.fixed
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::Case3;
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+    case Case3 = 3;
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumInt::Case3;
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumString::Case3;

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_02b.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_02b.fixed
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::Case3;
+
+enum BackedEnumInt: int {
+    const a = 1;
+    const Case3 = "";
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumInt::Case3;
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumString::Case3;

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_03a.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_03a.fixed
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::Case3;
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumInt::Case3;
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+    case Case3 = '';
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumString::Case3;

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_03b.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCaseFix_03b.fixed
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::Case3;
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumInt::Case3;
+
+enum BackedEnumString: string {
+    const a = 1;
+    const Case3 = "";
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+
+    public function publicMethod(): void {
+    }
+}
+
+BackedEnumString::Case3;

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCase_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCase_01.hints
@@ -1,0 +1,6 @@
+ExampleEnum::Ca^se3;
+------------------
+HINT:Introduce Hint
+FIX:Create Constant "Case3" in Enum "ExampleEnum" (testEnumCase.php)
+HINT:Introduce Hint
+FIX:Create Enum Case "Case3" in Enum "ExampleEnum" (testEnumCase.php)

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCase_02.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCase_02.hints
@@ -1,0 +1,6 @@
+BackedEnumInt::Case^3;
+--------------------
+HINT:Introduce Hint
+FIX:Create Constant "Case3" in Enum "BackedEnumInt" (testEnumCase.php)
+HINT:Introduce Hint
+FIX:Create Enum Case "Case3" in Enum "BackedEnumInt" (testEnumCase.php)

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCase_03.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumCase.php.testEnumCase_03.hints
@@ -1,0 +1,6 @@
+BackedEnumString::C^ase3;
+-----------------------
+HINT:Introduce Hint
+FIX:Create Constant "Case3" in Enum "BackedEnumString" (testEnumCase.php)
+HINT:Introduce Hint
+FIX:Create Enum Case "Case3" in Enum "BackedEnumString" (testEnumCase.php)

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::introduceStaticMethod();
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+        $this->introduceMethod();
+        self::introduceStaticMethod();
+        static::introduceStaticMethod();
+    }
+}
+
+BackedEnumInt::Case1->introduceMethod();
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+}
+
+BackedEnumString::Case2::introduceStaticMethod();

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_01.fixed
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+
+    public static function introduceStaticMethod() {
+        
+    }
+
+}
+
+ExampleEnum::introduceStaticMethod();
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+        $this->introduceMethod();
+        self::introduceStaticMethod();
+        static::introduceStaticMethod();
+    }
+}
+
+BackedEnumInt::Case1->introduceMethod();
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+}
+
+BackedEnumString::Case2::introduceStaticMethod();

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_02.fixed
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::introduceStaticMethod();
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+        $this->introduceMethod();
+        self::introduceStaticMethod();
+        static::introduceStaticMethod();
+    }
+
+    public function introduceMethod() {
+        
+    }
+
+}
+
+BackedEnumInt::Case1->introduceMethod();
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+}
+
+BackedEnumString::Case2::introduceStaticMethod();

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_03.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_03.fixed
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::introduceStaticMethod();
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+        $this->introduceMethod();
+        self::introduceStaticMethod();
+        static::introduceStaticMethod();
+    }
+
+    public static function introduceStaticMethod() {
+        
+    }
+
+}
+
+BackedEnumInt::Case1->introduceMethod();
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+}
+
+BackedEnumString::Case2::introduceStaticMethod();

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_04.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_04.fixed
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::introduceStaticMethod();
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+        $this->introduceMethod();
+        self::introduceStaticMethod();
+        static::introduceStaticMethod();
+    }
+
+    public static function introduceStaticMethod() {
+        
+    }
+
+}
+
+BackedEnumInt::Case1->introduceMethod();
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+}
+
+BackedEnumString::Case2::introduceStaticMethod();

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_05.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_05.fixed
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::introduceStaticMethod();
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+        $this->introduceMethod();
+        self::introduceStaticMethod();
+        static::introduceStaticMethod();
+    }
+
+    public function introduceMethod() {
+        
+    }
+
+}
+
+BackedEnumInt::Case1->introduceMethod();
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+}
+
+BackedEnumString::Case2::introduceStaticMethod();

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_06.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethodsFix_06.fixed
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+enum ExampleEnum {
+    const a = 1;
+
+    case Case1 = 100;
+    case Case2 = 'C';
+}
+
+ExampleEnum::introduceStaticMethod();
+
+enum BackedEnumInt: int {
+    const a = 1;
+
+    case Case1 = 1;
+    case Case2 = 2;
+
+    public function publicMethod(): void {
+        $this->introduceMethod();
+        self::introduceStaticMethod();
+        static::introduceStaticMethod();
+    }
+}
+
+BackedEnumInt::Case1->introduceMethod();
+
+enum BackedEnumString: string {
+    const a = 1;
+
+    case Case1 = 'A';
+    case Case2 = 'B';
+
+    public static function introduceStaticMethod() {
+        
+    }
+
+}
+
+BackedEnumString::Case2::introduceStaticMethod();

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_01.hints
@@ -1,0 +1,4 @@
+ExampleEnum::introduceStat^icMethod();
+------------------------------------
+HINT:Introduce Hint
+FIX:Create Method " introduceStaticMethod()" in Enum "ExampleEnum" (testEnumMethods.php)

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_02.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_02.hints
@@ -1,0 +1,4 @@
+        $this->introduceMeth^od();
+        ------------------------
+HINT:Introduce Hint
+FIX:Create Method " introduceMethod()" in Enum "BackedEnumInt" (testEnumMethods.php)

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_03.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_03.hints
@@ -1,0 +1,4 @@
+        self::introduceStaticMet^hod();
+        -----------------------------
+HINT:Introduce Hint
+FIX:Create Method " introduceStaticMethod()" in Enum "BackedEnumInt" (testEnumMethods.php)

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_04.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_04.hints
@@ -1,0 +1,4 @@
+        static::introduceStaticMeth^od();
+        -------------------------------
+HINT:Introduce Hint
+FIX:Create Method " introduceStaticMethod()" in Enum "BackedEnumInt" (testEnumMethods.php)

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_05.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_05.hints
@@ -1,0 +1,4 @@
+BackedEnumInt::Case1->introduceMet^hod();
+---------------------------------------
+HINT:Introduce Hint
+FIX:Create Method " introduceMethod()" in Enum "BackedEnumInt" (testEnumMethods.php)

--- a/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_06.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/IntroduceSuggestion/testEnumMethods.php.testEnumMethods_06.hints
@@ -1,0 +1,4 @@
+BackedEnumString::Case2::introdu^ceStaticMethod();
+------------------------------------------------
+HINT:Introduce Hint
+FIX:Create Method " introduceStaticMethod()" in Enum "BackedEnumString" (testEnumMethods.php)

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.verification;
+
+public class IntroduceSuggestionTest extends PHPHintsTestBase {
+
+    public IntroduceSuggestionTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected String getTestDirectory() {
+        return TEST_DIRECTORY + "IntroduceSuggestion/";
+    }
+
+    public void testEnumCase_01() throws Exception {
+        checkHints(new IntroduceSuggestion(), "testEnumCase.php", "ExampleEnum::Ca^se3;");
+    }
+
+    public void testEnumCase_02() throws Exception {
+        checkHints(new IntroduceSuggestion(), "testEnumCase.php", "BackedEnumInt::Case^3;");
+    }
+
+    public void testEnumCase_03() throws Exception {
+        checkHints(new IntroduceSuggestion(), "testEnumCase.php", "BackedEnumString::C^ase3;");
+    }
+
+    public void testEnumCaseFix_01a() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumCase.php", "ExampleEnum::Ca^se3;", "Create Enum Case");
+    }
+
+    public void testEnumCaseFix_01b() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumCase.php", "ExampleEnum::Ca^se3;", "Create Constant");
+    }
+
+    public void testEnumCaseFix_02a() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumCase.php", "BackedEnumInt::Case^3;", "Create Enum Case");
+    }
+
+    public void testEnumCaseFix_02b() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumCase.php", "BackedEnumInt::Case^3;", "Create Constant");
+    }
+
+    public void testEnumCaseFix_03a() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumCase.php", "BackedEnumString::C^ase3;", "Create Enum Case");
+    }
+
+    public void testEnumCaseFix_03b() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumCase.php", "BackedEnumString::C^ase3;", "Create Constant");
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestionTest.java
@@ -64,4 +64,52 @@ public class IntroduceSuggestionTest extends PHPHintsTestBase {
     public void testEnumCaseFix_03b() throws Exception {
         applyHint(new IntroduceSuggestion(), "testEnumCase.php", "BackedEnumString::C^ase3;", "Create Constant");
     }
+
+    public void testEnumMethods_01() throws Exception {
+        checkHints(new IntroduceSuggestion(), "testEnumMethods.php", "ExampleEnum::introduceStat^icMethod();");
+    }
+
+    public void testEnumMethods_02() throws Exception {
+        checkHints(new IntroduceSuggestion(), "testEnumMethods.php", "        $this->introduceMeth^od();");
+    }
+
+    public void testEnumMethods_03() throws Exception {
+        checkHints(new IntroduceSuggestion(), "testEnumMethods.php", "        self::introduceStaticMet^hod();");
+    }
+
+    public void testEnumMethods_04() throws Exception {
+        checkHints(new IntroduceSuggestion(), "testEnumMethods.php", "        static::introduceStaticMeth^od();");
+    }
+
+    public void testEnumMethods_05() throws Exception {
+        checkHints(new IntroduceSuggestion(), "testEnumMethods.php", "BackedEnumInt::Case1->introduceMet^hod();");
+    }
+
+    public void testEnumMethods_06() throws Exception {
+        checkHints(new IntroduceSuggestion(), "testEnumMethods.php", "BackedEnumString::Case2::introdu^ceStaticMethod();");
+    }
+
+    public void testEnumMethodsFix_01() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumMethods.php", "ExampleEnum::introduceStat^icMethod();", "Create Method");
+    }
+
+    public void testEnumMethodsFix_02() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumMethods.php", "        $this->introduceMeth^od();", "Create Method");
+    }
+
+    public void testEnumMethodsFix_03() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumMethods.php", "        self::introduceStaticMet^hod();", "Create Method");
+    }
+
+    public void testEnumMethodsFix_04() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumMethods.php", "        static::introduceStaticMeth^od();", "Create Method");
+    }
+
+    public void testEnumMethodsFix_05() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumMethods.php", "BackedEnumInt::Case1->introduceMet^hod();", "Create Method");
+    }
+
+    public void testEnumMethodsFix_06() throws Exception {
+        applyHint(new IntroduceSuggestion(), "testEnumMethods.php", "BackedEnumString::Case2::introdu^ceStaticMethod();", "Create Method");
+    }
 }


### PR DESCRIPTION
- Add a hint to introduce enum cases
- Fix the hint to introduce enum methods
- Fix the deprecated method (`GsfUtilities.getDocument`)

![nb-php-enum-introduce-suggestion-hint](https://user-images.githubusercontent.com/738383/227397624-128de872-ebee-4293-bceb-66a37481c126.gif)
