### PR TITLE
Fix GotoDeclaration in Enum implementing interface

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/ModelVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/ModelVisitor.java
@@ -439,7 +439,7 @@ public final class ModelVisitor extends DefaultTreePathVisitor {
                 Kind[] kinds = {Kind.CLASS, Kind.IFACE};
                 occurencesBuilder.prepare(kinds, namespaceName, fileScope);
             }
-        } else if (!(parent instanceof ClassDeclaration) && !(parent instanceof InterfaceDeclaration)
+        } else if (!(parent instanceof ClassDeclaration) && !(parent instanceof EnumDeclaration) && !(parent instanceof InterfaceDeclaration)
                 && !(parent instanceof FormalParameter) && !(parent instanceof InstanceOfExpression)
                 && !(parent instanceof UseTraitStatementPart) && !(parent instanceof TraitConflictResolutionDeclaration)
                 && !(parent instanceof TraitMethodAliasDeclaration) && !(parent instanceof IntersectionType)) {

--- a/php/php.editor/test/unit/data/testfiles/gotodeclaration/php81/testEnumerationsWithInterface/testEnumerationsWithInterface.php
+++ b/php/php.editor/test/unit/data/testfiles/gotodeclaration/php81/testEnumerationsWithInterface/testEnumerationsWithInterface.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum1;
+
+interface ExampleInterface1 {}
+interface ExampleInterface2 {}
+
+namespace Enum2;
+
+use Enum1\ExampleInterface1;
+use Enum1\ExampleInterface2;
+
+enum EnumImpl1 implements ExampleInterface1 {
+    case A = 'A';
+    case B = 'B';
+}
+
+enum EnumImpl2 implements ExampleInterface1, ExampleInterface2 {
+    case A = 'A';
+    case B = 'B';
+}

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php81/testEnumerationsWithInterface/testEnumerationsWithInterface.php
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php81/testEnumerationsWithInterface/testEnumerationsWithInterface.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Enum1;
+
+interface ExampleInterface1 {}
+interface ExampleInterface2 {}
+
+namespace Enum2;
+
+use Enum1\ExampleInterface1;
+use Enum1\ExampleInterface2;
+
+enum EnumImpl1 implements ExampleInterface1 {
+    case A = 'A';
+    case B = 'B';
+}
+
+enum EnumImpl2 implements ExampleInterface1, ExampleInterface2 {
+    case A = 'A';
+    case B = 'B';
+}

--- a/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_01a.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_01a.occurrences
@@ -1,0 +1,4 @@
+interface |>MARK_OCCURRENCES:ExampleInter^face1<| {}
+use Enum1\|>MARK_OCCURRENCES:ExampleInterface1<|;
+enum EnumImpl1 implements |>MARK_OCCURRENCES:ExampleInterface1<| {
+enum EnumImpl2 implements |>MARK_OCCURRENCES:ExampleInterface1<|, ExampleInterface2 {

--- a/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_01b.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_01b.occurrences
@@ -1,0 +1,4 @@
+interface |>MARK_OCCURRENCES:ExampleInterface1<| {}
+use Enum1\|>MARK_OCCURRENCES:ExampleInterf^ace1<|;
+enum EnumImpl1 implements |>MARK_OCCURRENCES:ExampleInterface1<| {
+enum EnumImpl2 implements |>MARK_OCCURRENCES:ExampleInterface1<|, ExampleInterface2 {

--- a/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_01c.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_01c.occurrences
@@ -1,0 +1,4 @@
+interface |>MARK_OCCURRENCES:ExampleInterface1<| {}
+use Enum1\|>MARK_OCCURRENCES:ExampleInterface1<|;
+enum EnumImpl1 implements |>MARK_OCCURRENCES:ExampleInterf^ace1<| {
+enum EnumImpl2 implements |>MARK_OCCURRENCES:ExampleInterface1<|, ExampleInterface2 {

--- a/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_01d.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_01d.occurrences
@@ -1,0 +1,4 @@
+interface |>MARK_OCCURRENCES:ExampleInterface1<| {}
+use Enum1\|>MARK_OCCURRENCES:ExampleInterface1<|;
+enum EnumImpl1 implements |>MARK_OCCURRENCES:ExampleInterface1<| {
+enum EnumImpl2 implements |>MARK_OCCURRENCES:ExampleInterfa^ce1<|, ExampleInterface2 {

--- a/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_02a.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_02a.occurrences
@@ -1,0 +1,3 @@
+interface |>MARK_OCCURRENCES:ExampleInterf^ace2<| {}
+use Enum1\|>MARK_OCCURRENCES:ExampleInterface2<|;
+enum EnumImpl2 implements ExampleInterface1, |>MARK_OCCURRENCES:ExampleInterface2<| {

--- a/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_02b.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_02b.occurrences
@@ -1,0 +1,3 @@
+interface |>MARK_OCCURRENCES:ExampleInterface2<| {}
+use Enum1\|>MARK_OCCURRENCES:ExampleInterfa^ce2<|;
+enum EnumImpl2 implements ExampleInterface1, |>MARK_OCCURRENCES:ExampleInterface2<| {

--- a/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_02c.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testEnumerationsWithInterface.php.testEnumerationsWithInterface_02c.occurrences
@@ -1,0 +1,3 @@
+interface |>MARK_OCCURRENCES:ExampleInterface2<| {}
+use Enum1\|>MARK_OCCURRENCES:ExampleInterface2<|;
+enum EnumImpl2 implements ExampleInterface1, |>MARK_OCCURRENCES:Exam^pleInterface2<| {

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationPHP81Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationPHP81Test.java
@@ -437,6 +437,26 @@ public class GotoDeclarationPHP81Test extends GotoDeclarationTestBase {
         checkDeclaration(getTestPath(), "$i::publicSt^aticMethod();", "    public static function ^publicStaticMethod(): void {");
     }
 
+    public void testEnumerationsWithInterface_01a() throws Exception {
+        checkDeclaration(getTestPath(), "use Enum1\\ExampleInter^face1;", "interface ^ExampleInterface1 {}");
+    }
+
+    public void testEnumerationsWithInterface_01b() throws Exception {
+        checkDeclaration(getTestPath(), "enum EnumImpl1 implements ExampleInterf^ace1 {", "interface ^ExampleInterface1 {}");
+    }
+
+    public void testEnumerationsWithInterface_01c() throws Exception {
+        checkDeclaration(getTestPath(), "enum EnumImpl2 implements ExampleInterfa^ce1, ExampleInterface2 {", "interface ^ExampleInterface1 {}");
+    }
+
+    public void testEnumerationsWithInterface_02a() throws Exception {
+        checkDeclaration(getTestPath(), "use Enum1\\ExampleInter^face2;", "interface ^ExampleInterface2 {}");
+    }
+
+    public void testEnumerationsWithInterface_02b() throws Exception {
+        checkDeclaration(getTestPath(), "enum EnumImpl2 implements ExampleInterface1, ExampleInterfa^ce2 {", "interface ^ExampleInterface2 {}");
+    }
+
     public void testEnumerationsWithBackingType_01() throws Exception {
         checkDeclaration(getTestPath(), "            static::CASE^1 => 'Case1',", "    case ^CASE1 = 1;");
     }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplPHP81Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplPHP81Test.java
@@ -493,6 +493,34 @@ public class OccurrencesFinderImplPHP81Test extends OccurrencesFinderImplTestBas
         checkOccurrences(getTestPath(), "        static::CONST^ANT2;", true);
     }
 
+    public void testEnumerationsWithInterface_01a() throws Exception {
+        checkOccurrences(getTestPath(), "interface ExampleInter^face1 {}", true);
+    }
+
+    public void testEnumerationsWithInterface_01b() throws Exception {
+        checkOccurrences(getTestPath(), "use Enum1\\ExampleInterf^ace1;", true);
+    }
+
+    public void testEnumerationsWithInterface_01c() throws Exception {
+        checkOccurrences(getTestPath(), "enum EnumImpl1 implements ExampleInterf^ace1 {", true);
+    }
+
+    public void testEnumerationsWithInterface_01d() throws Exception {
+        checkOccurrences(getTestPath(), "enum EnumImpl2 implements ExampleInterfa^ce1, ExampleInterface2 {", true);
+    }
+
+    public void testEnumerationsWithInterface_02a() throws Exception {
+        checkOccurrences(getTestPath(), "interface ExampleInterf^ace2 {}", true);
+    }
+
+    public void testEnumerationsWithInterface_02b() throws Exception {
+        checkOccurrences(getTestPath(), "use Enum1\\ExampleInterfa^ce2;", true);
+    }
+
+    public void testEnumerationsWithInterface_02c() throws Exception {
+        checkOccurrences(getTestPath(), "enum EnumImpl2 implements ExampleInterface1, Exam^pleInterface2 {", true);
+    }
+
     public void testEnumerationsWithBackingType_a01() throws Exception {
         checkOccurrences(getTestPath(), "    case C^ASE1 = 1;", true);
     }


### PR DESCRIPTION
#### Example

```php
<?php
namespace Enum1;

interface ExampleInterface1 {}
interface ExampleInterface2 {}

namespace Enum2;

use Enum1\ExampleInterface1;
use Enum1\ExampleInterface2;

enum EnumImpl1 implements ExampleInterface1 {
    case A = 'A';
    case B = 'B';
}

enum EnumImpl2 implements ExampleInterface1, ExampleInterface2 {
    case A = 'A';
    case B = 'B';
}
````

#### Before:
![nb-php-incorrect-goto-in-enum-before](https://user-images.githubusercontent.com/738383/227442047-647a3b1d-e323-4ca3-a2dc-6854b4bc63d8.gif)

#### After:
![nb-php-incorrect-goto-in-enum-after](https://user-images.githubusercontent.com/738383/227442070-271751a5-c887-4e34-86b6-a82208182f8b.gif)
