### PR TITLE
Remove dependencies on Autoupdate UI

### DIFF
--- a/ide/code.analysis/nbproject/project.xml
+++ b/ide/code.analysis/nbproject/project.xml
@@ -61,11 +61,11 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.autoupdate.ui</code-name-base>
+                    <code-name-base>org.netbeans.modules.autoupdate.services</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.35</specification-version>
+                        <specification-version>1.76</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/code.analysis/src/org/netbeans/modules/analysis/Utils.java
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/Utils.java
@@ -21,8 +21,8 @@ package org.netbeans.modules.analysis;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import org.netbeans.api.autoupdate.PluginInstaller;
 import org.netbeans.modules.analysis.spi.Analyzer.MissingPlugin;
-import org.netbeans.modules.autoupdate.ui.api.PluginManager;
 
 /**
  *
@@ -33,8 +33,9 @@ public class Utils {
     public static void installMissingPlugins(Collection<? extends MissingPlugin> inPlugins) {
         Set<MissingPlugin> plugins = new HashSet<MissingPlugin>(inPlugins);
 
+        // TODO: Shouldn't be this loop reduced to a single call to install multiple modules at once ?
         for (MissingPlugin missing : plugins) {
-            PluginManager.installSingle(SPIAccessor.ACCESSOR.getCNB(missing), SPIAccessor.ACCESSOR.getDisplayName(missing));
+            PluginInstaller.getDefault().install(SPIAccessor.ACCESSOR.getCNB(missing), SPIAccessor.ACCESSOR.getDisplayName(missing), null);
         }
     }
 }

--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -88,6 +88,7 @@ disabled.modules=\
     org.netbeans.modules.apisupport.harness,\
     org.netbeans.modules.applemenu,\
     org.netbeans.modules.autoupdate.pluginimporter,\
+    org.netbeans.modules.autoupdate.ui,\
     org.netbeans.modules.beans,\
     org.netbeans.modules.bugtracking,\
     org.netbeans.modules.bugtracking.bridge,\

--- a/java/java.source/nbproject/project.xml
+++ b/java/java.source/nbproject/project.xml
@@ -112,11 +112,11 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.autoupdate.ui</code-name-base>
+                    <code-name-base>org.netbeans.modules.autoupdate.services</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.46</specification-version>
+                        <specification-version>1.76</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
+++ b/java/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
@@ -19,19 +19,18 @@
 
 package org.netbeans.modules.java.source;
 
-import java.awt.Dialog;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
 import java.util.logging.Level;
 import java.util.prefs.Preferences;
 import org.netbeans.api.annotations.common.StaticResource;
-import org.netbeans.modules.autoupdate.ui.api.PluginManager;
+import org.netbeans.api.autoupdate.PluginInstaller;
 import org.netbeans.modules.java.source.usages.ClassIndexManager;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 import org.openide.modules.ModuleInstall;
 import org.openide.util.Exceptions;
-import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
 import org.openide.windows.WindowManager;
@@ -80,15 +79,12 @@ public class JBrowseModule extends ModuleInstall {
                 if (!NoJavacHelper.hasWorkingJavac() && !prefs.getBoolean(KEY_WARNING_SHOWN, false)) {
                     String install = Bundle.BN_Install();
                     try {
-                        Dialog[] d = new Dialog[1];
-                        DialogDescriptor dd = new DialogDescriptor(Bundle.DESC_FeaturesLimited(), Bundle.TITLE_FeaturesLimited(), true, new Object[] {install, DialogDescriptor.CANCEL_OPTION}, install, DialogDescriptor.DEFAULT_ALIGN, HelpCtx.DEFAULT_HELP, evt -> {
-                            if (install.equals(evt.getActionCommand())) {
-                                PluginManager.installSingle("org.netbeans.libs.nbjavacapi", Bundle.DN_nbjavac());
-                            }
-                            d[0].setVisible(false);
-                        });
-                        d[0] = DialogDisplayer.getDefault().createDialog(dd);
-                        d[0].setVisible(true);
+                        NotifyDescriptor msg = new NotifyDescriptor(Bundle.DESC_FeaturesLimited(), Bundle.TITLE_FeaturesLimited(), 
+                            NotifyDescriptor.DEFAULT_OPTION, NotifyDescriptor.WARNING_MESSAGE, new Object[] {install, DialogDescriptor.CANCEL_OPTION}, install);
+                        Object r = DialogDisplayer.getDefault().notify(msg);
+                        if (r == install) {
+                            PluginInstaller.getDefault().install("org.netbeans.libs.nbjavacapi", null, null, Bundle.DN_nbjavac()); // NOI18N
+                        }
                     } catch (HeadlessException ex) {
                         Exceptions.printStackTrace(Exceptions.attachSeverity(ex, Level.FINE));
                     }

--- a/java/junit/nbproject/project.xml
+++ b/java/junit/nbproject/project.xml
@@ -77,14 +77,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.autoupdate.ui</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>1.35</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.extexecution</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -109,11 +109,11 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.autoupdate.ui</code-name-base>
+                    <code-name-base>org.netbeans.modules.autoupdate.services</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.35</specification-version>
+                        <specification-version>1.76</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven/src/org/netbeans/modules/maven/problems/MissingModulesProblemProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/problems/MissingModulesProblemProvider.java
@@ -34,8 +34,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.SwingUtilities;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.api.autoupdate.PluginInstaller;
 import org.netbeans.api.project.Project;
-import org.netbeans.modules.autoupdate.ui.api.PluginManager;
 import org.netbeans.modules.maven.api.NbMavenProject;
 import static org.netbeans.modules.maven.problems.Bundle.*;
 import org.netbeans.spi.project.ProjectServiceProvider;
@@ -230,7 +230,7 @@ public class MissingModulesProblemProvider implements ProjectProblemsProvider {
                         SwingUtilities.invokeAndWait(new Runnable() {
                             @Override
                             public void run() {
-                                Object retval = PluginManager.install(Collections.singleton(codenamebase));
+                                Object retval = PluginInstaller.getDefault().install(codenamebase);
                                 res[0] = retval == null ? Result.create(Status.RESOLVED) : Result.create(Status.UNRESOLVED);
                             }
                         });

--- a/platform/autoupdate.services/apichanges.xml
+++ b/platform/autoupdate.services/apichanges.xml
@@ -33,6 +33,20 @@
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="plugin-installer">
+            <api name="general"/>
+            <summary>Simple API to install modules</summary>
+            <version major="1" minor="76"/>
+            <date day="18" month="3" year="2023"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes" binary="compatible" deletion="no" deprecation="no" semantic="compatible" source="compatible"/>
+            <description>
+                <a href="@TOP@/org/netbeans/api/autoupdate/PluginInstaller.html">Simplified API to install</a> additional plugins to avoid dependencies on UI part of the AutoUpdate. CLI and UI implementations
+                for the autoupdate plugs provides their implementations, UI is preferred.
+            </description>
+            <class package="org.netbeans.api.autoupdate" name="Plugininstaller"/>
+            <class package="org.netbeans.spi.autoupdate" name="PlugininstallerImplementation"/>
+        </change>
         <change id="unpack200">
             <api name="general"/>
             <summary>Allow alternative unpack200 implementation</summary>

--- a/platform/autoupdate.services/manifest.mf
+++ b/platform/autoupdate.services/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.autoupdate.services
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/autoupdate/services/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.75
+OpenIDE-Module-Specification-Version: 1.76
 OpenIDE-Module-Layer: org/netbeans/modules/autoupdate/services/resources/layer.xml
 AutoUpdate-Show-In-Client: false
 AutoUpdate-Essential-Module: true

--- a/platform/autoupdate.services/nbproject/project.xml
+++ b/platform/autoupdate.services/nbproject/project.xml
@@ -26,6 +26,15 @@
             <code-name-base>org.netbeans.modules.autoupdate.services</code-name-base>
             <module-dependencies>
                 <dependency>
+                    <code-name-base>org.netbeans.api.annotations.common</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.48</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -58,6 +67,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>1.60</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.dialogs</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/autoupdate.services/src/org/netbeans/api/autoupdate/PluginInstaller.java
+++ b/platform/autoupdate.services/src/org/netbeans/api/autoupdate/PluginInstaller.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.autoupdate;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.spi.autoupdate.PluginInstallerImplementation;
+import org.openide.NotifyDescriptor;
+import org.openide.util.Lookup;
+import org.openide.util.UserCancelException;
+
+/**
+ * Allows to programmatically install plugins. It serves as a frontend API to UI/CLI
+ * whichever is installed - other modules need to provide the actual installation provider to handle the requests. 
+ * No default implementation for the installation provider is present by default unless additional modules
+ * like {@code autoupdate.ui} is installed. If no providers are registered, the installation fails as if
+ * the user had rejected the operation using "Cancel" button.
+ * 
+ * @since 1.76
+ * @author sdedic
+ */
+public final class PluginInstaller {
+    private static final Logger LOG = Logger.getLogger(PluginInstaller.class.getName());
+    
+    private static PluginInstaller INSTANCE;
+    
+    public static PluginInstaller getDefault() {
+        if (INSTANCE != null) {
+            return INSTANCE;
+        }
+        // no sync needed, instance is stateless.
+        return INSTANCE = new PluginInstaller();
+    }
+    
+    /**
+     * Installs a single module. When reporting progress or messages, uses the supplied `displayName`; use {@code null}
+     * to use a generic description possibly based on the module name/codename. The method converts the {@link UserCancelException}
+     * thrown by the actual implementation into {@link NotifyDescriptor#CANCEL_OPTION} for compatibility with older code.
+     * Otherwise, see {@link #install(java.lang.String, java.lang.String, org.openide.util.Lookup, java.lang.Object...)}.
+     * 
+     * @param codenamebase codename base to install
+     * @param displayName title/heading for messages
+     * @param context additional context passed to the process
+     * @param alternativeOptions possible failure resolution choices
+     * @return null on success, {@link NotifyDescriptor#CANCEL_OPTION} if the operation is rejected (i.e. user cancel) or one of
+     * "alternativeOptions".
+     */
+    public Object install(@NonNull String codenamebase, @NonNull String displayName,
+            Lookup context, @NonNull Object... alternativeOptions) {
+        try {
+            return install(Collections.singleton(codenamebase), displayName, context, alternativeOptions);
+        } catch (UserCancelException ex) {
+            LOG.log(Level.FINE, "User cancelled", ex);
+            return NotifyDescriptor.CANCEL_OPTION;
+        } catch (OperationException ex) {
+            LOG.log(Level.WARNING, "Exception during install of " + codenamebase, ex);
+            return NotifyDescriptor.CANCEL_OPTION;
+        }
+    }
+    
+    /**
+     * Installs a single module. Uses some default title for possible progress indication during module search 
+     * and installation. Does not support alternative options. The method converts the {@link UserCancelException}
+     * thrown by the actual implementation into {@link NotifyDescriptor#CANCEL_OPTION} for compatibility with older code.
+     * Otherwise, see {@link #install(java.lang.String, java.lang.String, org.openide.util.Lookup, java.lang.Object...)}.
+     * 
+     * @param codenamebase codename base of the module to install
+     * @return null on success, {@link NotifyDescriptor#CANCEL_OPTION} if the operation is rejected (i.e. user cancel).
+     */
+    public Object install(@NonNull String codenamebase) {
+        return install(codenamebase, null, null);
+    }
+    
+    /**
+     * Attempts to install one or more plugins, specified by their codebases. During module + dependency search and download
+     * some interim progress messages can be displayed - the `displayName` will be used as a title, heading or otherwise provide
+     * informative context for those messages. If the display name is not provided, some generic title can be used (i.e. searching,
+     * installing).
+     * <p>
+     * If fetching the plugin catalog data fails on I/O, the user can get a choice to 
+     * retry the process or cancel the operation. `alternativeOptions` are presented as other alternative solutions. If the user
+     * chooses to cancel, operation ends with {@link NotifyDescriptor#CANCEL_OPTION}. The user can choose to retry the operation.
+     * The user can also select one of the `alternativeOptions`, which will terminate the operation with the chosen option as a result.
+     * During the download, the operation can be cancelled resulting in {@link NotifyDescriptor#CANCEL}.
+     * <p>
+     * If the operation completes successfully, the method returns {@code null}.
+     * <p>
+     * In the case that no installation provider is installed, the implementation throws {@link UserCancelException} as if the operation
+     * was rejected by the user.
+     * 
+     * @param codenamebases codename bases of modules to install. The modules will be installed in no particular order.
+     * @param displayName 
+     * @param alternativeOptions
+     * @return {@code null} on success. {@link NotifyDescriptor#CANCEL_OPTION} on cancel, or one of `alternativeOptions` on failure
+     * according to user's choice.
+     * @throws OperationException if the download or installation / enable operation fails.
+     * @throws UserCancelException if the operation is rejected.
+     */
+    public Object install(@NonNull Set<String> codenamebases, String displayName, Lookup context, Object... alternativeOptions) throws OperationException, UserCancelException {
+        PluginInstallerImplementation impl = Lookup.getDefault().lookup(PluginInstallerImplementation.class);
+        if (impl == null) {
+            throw new UserCancelException();
+        }
+        Object o = impl.install(codenamebases, displayName, context == null ? Lookup.EMPTY : context, alternativeOptions);
+        if (o == NotifyDescriptor.CLOSED_OPTION) {
+            return NotifyDescriptor.CANCEL_OPTION;
+        } else {
+            // even OK_OPTION would display in case of some failure.
+            return o;
+        }
+    }
+}

--- a/platform/autoupdate.services/src/org/netbeans/spi/autoupdate/PluginInstallerImplementation.java
+++ b/platform/autoupdate.services/src/org/netbeans/spi/autoupdate/PluginInstallerImplementation.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.spi.autoupdate;
+
+import java.util.Set;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.autoupdate.OperationException;
+import org.openide.NotifyDescriptor;
+import org.openide.util.Lookup;
+import org.openide.util.UserCancelException;
+
+/**
+ * Handles out plugin installation requests. An implementation should be provided for CLI, UI or remote UI as suitabke
+ * for the distribution that handles possible user interaction. As downloading the plugins often require license acceptance
+ * no default implementation is provided.
+ * 
+ * @since 1.76
+ * @author sdedic
+ */
+public interface PluginInstallerImplementation {
+    /**
+     * Attempts to install one or more plugins. Before the actual installation, some network I/O may occur
+     * to e.g. download catalog of plugins or download the plugin itself. The `displayName` serves as a context
+     * for possible progress messages or interactive UI. When the network I/O fails, the implementation
+     * may prompt the user and retry the operation or offer other remedies (and implement them).
+     * The `alternativeOptions` are other choices that should be presented to the user, and will be handled
+     * by the caller. Values accepted in `alternativeOptions are the same as with {@link NotifyDescriptor#setOptions}.
+     * <p>
+     * After the network operations complete, the implementation should install the plugin(s). Any report from this
+     * phase should be reported by throwing a {@link OperationException} that describes the failure.
+     * <p>
+     * On successful completion, returns {@code null}. In the case of a network error must return {@link NotifyDescriptor#CANCEL_OPTION}
+     * if the user cancelled the operation, one of the `additionalOption` values if the user selected an alternative choice.
+     * Retry (if offered) must be handled by the implementation.
+     * <p>
+     * If the user cancels the operation, the {@link UserCancelException} should be thrown to avoid dependency on Dialogs API; modules that use Dialogs API may
+     * return {@link NotifyDescriptor#CANCEL_OPTION}.
+     * 
+     * @param codenamebases codenames of plugins to install
+     * @param displayName context for possible progress or error messages
+     * @param alternativeOptions alternative network failure resolution choices
+     * @return {@code null} if successful, {@link NotifyDescriptor#CANCEL_OPTION} or one of `additionalOptions'.
+     * @throws OperationException on a failed operation.
+     * @throws UserCancelException if the user cancels the operation.
+     */
+    public Object install(@NonNull Set<String> codenamebases, String displayName, Lookup context, @NonNull Object... alternativeOptions)
+            throws OperationException, UserCancelException;
+}

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/GuiPluginInstallerImpl.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/GuiPluginInstallerImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.autoupdate.ui;
+
+import java.util.Set;
+import org.netbeans.api.autoupdate.OperationException;
+import org.netbeans.spi.autoupdate.PluginInstallerImplementation;
+import org.openide.NotifyDescriptor;
+import org.openide.util.Lookup;
+import org.openide.util.Parameters;
+import org.openide.util.UserCancelException;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * GUI implementation of the plugin installer, shows wizard etc. Register with a higher priority
+ * than CLI implementation.
+ * 
+ * @author sdedic
+ */
+@ServiceProvider(service = PluginInstallerImplementation.class, position = 30000)
+public class GuiPluginInstallerImpl implements PluginInstallerImplementation {
+
+    @Override
+    public Object install(Set<String> codenamebases, String displayName, Lookup context, Object... alternativeOptions) throws OperationException, UserCancelException {
+        // copied from PluginManager, but displayName handling changed.
+        Parameters.notNull("cnb", codenamebases); // NOI18N
+        Parameters.notNull("alternativeOptions", alternativeOptions); // NOI18N
+        if (codenamebases.isEmpty()) {
+            throw new IllegalArgumentException("No plugins to install");
+        }
+
+        Object o = new ModuleInstallerSupport(alternativeOptions).installPlugins(displayName, codenamebases);
+        if (o == NotifyDescriptor.CANCEL_OPTION) {
+            throw new UserCancelException();
+        } else {
+            return o;
+        }
+    }
+    
+}

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/ModuleInstallerSupport.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/ModuleInstallerSupport.java
@@ -107,7 +107,7 @@ public class ModuleInstallerSupport  {
             final String resolveTitle = displayName != null
                     ? resolve_title_single(displayName) : resolve_title();
 
-            final ProgressHandle handle = ProgressHandleFactory.createHandle(searchMessage);
+            final ProgressHandle handle = ProgressHandle.createHandle(searchMessage);
             initButtons();
             final DialogDescriptor searching = new DialogDescriptor(searchingPanel(new JLabel(searchMessage),
                     ProgressHandleFactory.createProgressComponent(handle)), resolveTitle, true, null);

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/api/PluginManager.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/api/PluginManager.java
@@ -30,6 +30,7 @@ import org.netbeans.api.autoupdate.InstallSupport;
 import org.netbeans.api.autoupdate.OperationContainer;
 import org.netbeans.api.autoupdate.OperationContainer.OperationInfo;
 import org.netbeans.api.autoupdate.OperationException;
+import org.netbeans.api.autoupdate.PluginInstaller;
 import org.netbeans.api.autoupdate.UpdateManager;
 import org.netbeans.api.autoupdate.UpdateUnit;
 import org.netbeans.modules.autoupdate.ui.ModuleInstallerSupport;
@@ -162,7 +163,11 @@ PluginManager.openInstallWizard(container);
      * and blocks (until the user clicks through), so either call from AWT dispatch
      * thread directly, or be sure you hold no locks and block no progress of other
      * threads to avoid deadlocks.
-     *
+     * <p>
+     * Although the method is not deprecated, modules that <b>only uses PluginManager.install<b> to
+     * install additional plugins should now depend on <code>autoupdate.services</code> directly,
+     * and use {@link PluginInstaller#install} to reduce UI dependencies.
+     * 
      * @param codenamebases the codenamebases of modules to install; must contain at least
      *             one codenamebase
      * @param alternativeOptions alternative options possibly displayed in error

--- a/platform/o.n.bootstrap/manifest.mf
+++ b/platform/o.n.bootstrap/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.bootstrap/1
-OpenIDE-Module-Specification-Version: 2.98
+OpenIDE-Module-Specification-Version: 2.99
 OpenIDE-Module-Localizing-Bundle: org/netbeans/Bundle.properties
 OpenIDE-Module-Recommends: org.netbeans.NetigsoFramework
 

--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -19,6 +19,7 @@
 
 package org.netbeans;
 
+import java.awt.GraphicsEnvironment;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.ByteArrayInputStream;
@@ -57,6 +58,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.jar.Manifest;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.openide.modules.Dependency;
 import org.openide.modules.ModuleInfo;
 import org.openide.modules.Modules;
@@ -80,6 +82,11 @@ import org.openide.util.lookup.ProxyLookup;
  * @author Jesse Glick
  */
 public final class ModuleManager extends Modules {
+    /**
+     * Used for dependency logging. Use -J-Dorg.netbeans.ModuleManager.deps.level=500 to enable. For brute-force extractions from the log,
+     * use {@code grep DEP: messages.log | cut -d : -f3- | sort | uniq}. The output is in "dot" format, just enclose in digraph block.
+     */
+    private static final Logger DEPLOG = Logger.getLogger(ModuleManager.class.getName() + ".deps");
 
     public static final String PROP_MODULES = "modules"; // NOI18N
     public static final String PROP_ENABLED_MODULES = "enabledModules"; // NOI18N
@@ -114,6 +121,11 @@ public final class ModuleManager extends Modules {
 
     // modules providing a given requires token; set may never be empty
     private final ProvidersOf providersOf = new ProvidersOf();
+    
+    /**
+     * Generic tokens provided "by the environment". Initially only one token is defined, <code>"netbeans:gui.swing"</code>
+     */
+    private final Set<String> environmentTokens = new HashSet<>();
 
     private final ModuleInstaller installer;
     private ModuleFactory moduleFactory;
@@ -165,6 +177,13 @@ public final class ModuleManager extends Modules {
             classLoader.setSystemClassLoader(
                 moduleFactory.getClasspathDelegateClassLoader(this, 
                     ModuleManager.class.getClassLoader()));
+        }
+        initializeEnvTokens();
+    }
+    
+    private void initializeEnvTokens() {
+        if (!GraphicsEnvironment.isHeadless()) {
+            environmentTokens.add("netbeans:gui.swing");
         }
     }
 
@@ -1680,7 +1699,8 @@ public final class ModuleManager extends Modules {
             }
             if (m.isEnabled()) throw new IllegalModuleException(IllegalModuleException.Reason.SIMULATE_ENABLE_ALREADY, m);
             if (!m.isValid()) throw new IllegalModuleException(IllegalModuleException.Reason.SIMULATE_ENABLE_INVALID, m);
-            maybeAddToEnableList(willEnable, modules, m, true);
+            addedBecauseOfDependent = null;
+            maybeAddToEnableList(willEnable, modules, m, true, null);
         }
         // XXX clumsy but should work:
         Set<Module> stillDisabled = new HashSet<Module>(this.modules);
@@ -1742,7 +1762,11 @@ public final class ModuleManager extends Modules {
         return false;
     }
     
-    private void maybeAddToEnableList(Set<Module> willEnable, Set<Module> mightEnable, Module m, boolean okToFail) {
+    private Module addedBecauseOfDependent;
+    private boolean eagerActivation;
+    private Set<Module> reported = new HashSet<>();
+    
+    private void maybeAddToEnableList(Set<Module> willEnable, Set<Module> mightEnable, Module m, boolean okToFail, String reason) {
         if (! missingDependencies(m).isEmpty()) {
             if (!okToFail) {
                 Util.err.warning("Module " + m + " had unexpected problems: " + missingDependencies(m));
@@ -1751,74 +1775,97 @@ public final class ModuleManager extends Modules {
             // Cannot satisfy its dependencies, exclude it.
             return;
         }
+        if (reported.add(m)) {
+            if (addedBecauseOfDependent == null) {
+                DEPLOG.log(Level.FINE, "DEP: \"" + m.getCodeNameBase() + '"' + (eagerActivation ? "[color=cornsilk]" : ""));
+            } else if (!addedBecauseOfDependent.getCodeNameBase().equals(m.getCodeNameBase())) {
+                DEPLOG.log(Level.FINE, "DEP: \"" + addedBecauseOfDependent.getCodeNameBase() + "\" "+ "->\""  
+                        + (reason != null ? "[label=\"" + reason + "\"]" : "")
+                        + " " + m.getCodeNameBase() + '"');
+            }
+        }
+
         if (!willEnable.add(m)) {
             // Already there, done.
             return;
         }
-        // need to register fragments eagerly, so they are available during
-        // dependency sort
-        Module host = attachModuleFragment(m);
-        if (host != null && !host.isEnabled()) {
-            maybeAddToEnableList(willEnable, mightEnable, host, okToFail);
-        }
-        // Also add anything it depends on, if not already there,
-        // or already enabled.
-        for (Dependency dep : m.getDependenciesArray()) {
-            if (dep.getType() == Dependency.TYPE_MODULE) {
-                String codeNameBase = (String)Util.parseCodeName(dep.getName())[0];
-                Module other = get(codeNameBase);
-                // Should never happen:
-                if (other == null) throw new IllegalStateException("Should have found module: " + codeNameBase); // NOI18N
-                if (! other.isEnabled()) {
-                    maybeAddToEnableList(willEnable, mightEnable, other, false);
-                }
-            } else if (
-                dep.getType() == Dependency.TYPE_REQUIRES || 
-                dep.getType() == Dependency.TYPE_NEEDS ||
-                dep.getType() == Dependency.TYPE_RECOMMENDS
-            ) {
-                Set<Module> providers = getProvidersOf().get(dep.getName());
-                if (providers == null) {
-                    assert dep.getType() == Dependency.TYPE_RECOMMENDS : "Should have found a provider of " + dep;
-                    continue;
-                }
-                // First check if >= 1 is already enabled or will be soon. If so, great.
-                boolean foundOne = false;
-                for (Module other : providers) {
-                    if (other.isEnabled() ||
-                            (other.getProblems().isEmpty() && mightEnable.contains(other))) {
-                        foundOne = true;
-                        break;
-                    }
-                }
-                if (foundOne) {
-                    // OK, we are satisfied.
-                    continue;
-                }
-                // All disabled. So add them all to the enable list.
-                for (Module other : providers) {
-                    // It is OK if one of them fails.
-                    maybeAddToEnableList(willEnable, mightEnable, other, true);
-                    // But we still check to ensure that at least one did not!
-                    if (!foundOne && willEnable.contains(other)) {
-                        foundOne = true;
-                        // and continue with the others, try to add them too...
-                    }
-                }
-                // Logic is that missingDependencies(m) should contain dep in this case.
-                assert foundOne || dep.getType() == Dependency.TYPE_RECOMMENDS : "Should have found a nonproblematic provider of " + dep + " among " + providers + " with willEnable=" + willEnable + " mightEnable=" + mightEnable;
+        Module outer = addedBecauseOfDependent;
+        boolean outerEagerActivatioon = eagerActivation;
+        Set<Module> outerReported = reported;
+        try {
+            reported = new HashSet<>();
+            addedBecauseOfDependent = m;
+            // need to register fragments eagerly, so they are available during
+            // dependency sort
+            Module host = attachModuleFragment(m);
+            if (host != null && !host.isEnabled()) {
+                maybeAddToEnableList(willEnable, mightEnable, host, okToFail, "Fragment host");
             }
-            // else some other kind of dependency that does not concern us
-        }
-        Collection<Module> frags = getAttachedFragments(m);
-        for (Module fragMod : frags) {
-            // do not enable regular fragments unless eager: if something depends on a fragment, it will 
-            // enable the fragment along with normal dependencies.
-            if (fragMod.isEager()) {
-                maybeAddToEnableList(willEnable, mightEnable, fragMod, fragMod.isAutoload() || fragMod.isEager());
+            
+            // Also add anything it depends on, if not already there,
+            // or already enabled.
+            for (Dependency dep : m.getDependenciesArray()) {
+                if (dep.getType() == Dependency.TYPE_MODULE) {
+                    String codeNameBase = (String)Util.parseCodeName(dep.getName())[0];
+                    Module other = get(codeNameBase);
+                    // Should never happen:
+                    if (other == null) throw new IllegalStateException("Should have found module: " + codeNameBase); // NOI18N
+                    if (! other.isEnabled()) {
+                        maybeAddToEnableList(willEnable, mightEnable, other, false, null);
+                    }
+                } else if (
+                    dep.getType() == Dependency.TYPE_REQUIRES || 
+                    dep.getType() == Dependency.TYPE_NEEDS ||
+                    dep.getType() == Dependency.TYPE_RECOMMENDS
+                ) {
+                    Set<Module> providers = getProvidersOf().get(dep.getName());
+                    if (providers == null) {
+                        assert dep.getType() == Dependency.TYPE_RECOMMENDS : "Should have found a provider of " + dep;
+                        continue;
+                    }
+                    // First check if >= 1 is already enabled or will be soon. If so, great.
+                    boolean foundOne = false;
+                    for (Module other : providers) {
+                        if (other.isEnabled() ||
+                                (other.getProblems().isEmpty() && mightEnable.contains(other))) {
+                            foundOne = true;
+                            break;
+                        }
+                    }
+                    if (foundOne) {
+                        // OK, we are satisfied.
+                        continue;
+                    }
+                    // All disabled. So add them all to the enable list.
+                    for (Module other : providers) {
+                        // It is OK if one of them fails.
+                        maybeAddToEnableList(willEnable, mightEnable, other, true, (dep.getName().startsWith("cnb.") ? null : "Provides " + dep.getName()));
+                        // But we still check to ensure that at least one did not!
+                        if (!foundOne && willEnable.contains(other)) {
+                            foundOne = true;
+                            // and continue with the others, try to add them too...
+                        }
+                    }
+                    // Logic is that missingDependencies(m) should contain dep in this case.
+                    assert foundOne || dep.getType() == Dependency.TYPE_RECOMMENDS : "Should have found a nonproblematic provider of " + dep + " among " + providers + " with willEnable=" + willEnable + " mightEnable=" + mightEnable;
+                }
+                // else some other kind of dependency that does not concern us
             }
+            Collection<Module> frags = getAttachedFragments(m);
+            for (Module fragMod : frags) {
+                // do not enable regular fragments unless eager: if something depends on a fragment, it will 
+                // enable the fragment along with normal dependencies.
+                if (fragMod.isEager()) {
+                    maybeAddToEnableList(willEnable, mightEnable, fragMod, fragMod.isAutoload() || fragMod.isEager(), "Fragment");
+                }
+            }
+        } finally {
+            reported = outerReported;
+            addedBecauseOfDependent = outer;
+            eagerActivation = outerEagerActivatioon;
         }
     }
+    
     private boolean searchForPossibleEager(Set<Module> willEnable, Set<Module> stillDisabled, Set<Module> mightEnable) {
         // Check for any eagers in stillDisabled which could be enabled based
         // on currently enabled modules and willEnable. For any such, remove from
@@ -1849,7 +1896,12 @@ public final class ModuleManager extends Modules {
                     // Go for it!
                     found = true;
                     it.remove();
-                    maybeAddToEnableList(willEnable, mightEnable, m, false);
+                    eagerActivation = true;
+                    try {
+                        maybeAddToEnableList(willEnable, mightEnable, m, false, "Eager");
+                    } finally {
+                        eagerActivation = false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR creates a mini-API for installing plugins. Currently modules depend on Autoupdate UI when they need to initiate installation of a plugin - but that's not necessary.  This PR creates a SPI, which is implemented by AU UI. In absence of UI, the installation fail - most of the modules do not check the outcome of the installation anyway.

With the dependency removed, AU UI can be removed from LSP distribution, which replaces the implementation done in #5620.
