### PR TITLE
Fix the highlighting for private constants of Enum

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/csl/SemanticAnalysis.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/csl/SemanticAnalysis.java
@@ -663,6 +663,7 @@ public class SemanticAnalysis extends SemanticAnalyzer {
             if (node.getBody() != null) {
                 node.getBody().accept(this);
                 scanMethodBodies();
+                addColoringForUnusedPrivateConstants();
             }
             needToScan.remove(typeInfo);
             removeFromPath();
@@ -819,6 +820,12 @@ public class SemanticAnalysis extends SemanticAnalyzer {
                     if (!isPrivate || parentNode instanceof TraitDeclaration) {
                         addColoringForNode(identifier, coloring);
                     } else {
+                        // NOTE: private constants, methods, and fields may be used in traits
+                        // currently, we don't check traits (if there is no performance problem, should check them if possible)
+                        // an enum is handled as a "final" class in PHP
+                        // so, virtually, "protected" is "private"
+                        // however, as written above, it may be used in traits
+                        // don't add protected items of Enum to unused items
                         privateUnusedConstants.put(new UnusedIdentifier(identifier.getName(), typeInfo), new ASTNodeColoring(identifier, coloring));
                     }
                 }

--- a/php/php.editor/test/unit/data/testfiles/semantic/enumerationsWithPrivateConst.php
+++ b/php/php.editor/test/unit/data/testfiles/semantic/enumerationsWithPrivateConst.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+enum UsedPrivateConst1 {
+
+    public const PUBLIC_CONST = 'public const';
+    private const PRIVATE_CONST = 'private const';
+    protected const PROTECTED_CONST = 'protected const';
+
+    case Case1;
+
+    private function test(): void {
+        self::PRIVATE_CONST;
+    }
+
+}
+
+enum UsedPrivateConst2 {
+
+    public const PUBLIC_CONST = 'public const';
+    private const PRIVATE_CONST = 'private const';
+    protected const PROTECTED_CONST = 'protected const';
+
+    case Case1;
+
+    private function test(): void {
+        static::PRIVATE_CONST;
+    }
+
+}
+
+enum UsedPrivateConst3 {
+
+    public const PUBLIC_CONST = 'public const';
+    private const PRIVATE_CONST = 'private const';
+    protected const PROTECTED_CONST = 'protected const';
+
+    case Case1;
+
+    private function test(): void {
+        UsedPrivateConst3::PRIVATE_CONST;
+    }
+
+}
+
+enum UnusedPrivateConst {
+
+    public const PUBLIC_CONST = 'public const';
+    private const PRIVATE_CONST = 'private const';
+    protected const PROTECTED_CONST = 'protected const';
+
+    case Case1;
+
+}

--- a/php/php.editor/test/unit/data/testfiles/semantic/enumerationsWithPrivateConst.php.semantic
+++ b/php/php.editor/test/unit/data/testfiles/semantic/enumerationsWithPrivateConst.php.semantic
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+enum |>CLASS:UsedPrivateConst1<| {
+
+    public const |>FIELD,STATIC:PUBLIC_CONST<| = 'public const';
+    private const |>FIELD,STATIC:PRIVATE_CONST<| = 'private const';
+    protected const |>FIELD,STATIC:PROTECTED_CONST<| = 'protected const';
+
+    case |>FIELD,STATIC:Case1<|;
+
+    private function |>METHOD,UNUSED:test<|(): void {
+        self::|>FIELD,STATIC:PRIVATE_CONST<|;
+    }
+
+}
+
+enum |>CLASS:UsedPrivateConst2<| {
+
+    public const |>FIELD,STATIC:PUBLIC_CONST<| = 'public const';
+    private const |>FIELD,STATIC:PRIVATE_CONST<| = 'private const';
+    protected const |>FIELD,STATIC:PROTECTED_CONST<| = 'protected const';
+
+    case |>FIELD,STATIC:Case1<|;
+
+    private function |>METHOD,UNUSED:test<|(): void {
+        static::|>FIELD,STATIC:PRIVATE_CONST<|;
+    }
+
+}
+
+enum |>CLASS:UsedPrivateConst3<| {
+
+    public const |>FIELD,STATIC:PUBLIC_CONST<| = 'public const';
+    private const |>FIELD,STATIC:PRIVATE_CONST<| = 'private const';
+    protected const |>FIELD,STATIC:PROTECTED_CONST<| = 'protected const';
+
+    case |>FIELD,STATIC:Case1<|;
+
+    private function |>METHOD,UNUSED:test<|(): void {
+        UsedPrivateConst3::|>FIELD,STATIC:PRIVATE_CONST<|;
+    }
+
+}
+
+enum |>CLASS:UnusedPrivateConst<| {
+
+    public const |>FIELD,STATIC:PUBLIC_CONST<| = 'public const';
+    private const |>FIELD,STATIC,UNUSED:PRIVATE_CONST<| = 'private const';
+    protected const |>FIELD,STATIC:PROTECTED_CONST<| = 'protected const';
+
+    case |>FIELD,STATIC:Case1<|;
+
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/SemanticAnalyzerTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/SemanticAnalyzerTest.java
@@ -214,6 +214,10 @@ public class SemanticAnalyzerTest extends SemanticAnalysisTestBase {
         checkSemantic("testfiles/semantic/enumerations.php");
     }
 
+    public void testEnumerationsWithPrivateConst() throws Exception {
+        checkSemantic("testfiles/semantic/enumerationsWithPrivateConst.php");
+    }
+
     public void testConstantsInTraits() throws Exception {
         checkSemantic("testfiles/semantic/constantsInTraits.php");
     }


### PR DESCRIPTION
#### Before:
![nb-php-enum-private-constants-before](https://user-images.githubusercontent.com/738383/227752026-768f5b65-5239-4c95-aa86-4b902533065d.png)

#### After:
![nb-php-enum-private-constants-after](https://user-images.githubusercontent.com/738383/227752028-be295c9f-b65e-4a10-a2c2-0aaba7058ebf.png)
