### PR TITLE
Adding a way to directly specify JTreg when no is known

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/Debugger.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/Debugger.java
@@ -55,7 +55,7 @@ public final class Debugger {
         NbProtocolServer server = new NbProtocolServer(context);
 
         Launcher<IDebugProtocolClient> serverLauncher = DSPLauncher.createServerLauncher(
-                server, io.first(), io.second(), null, ConsumeWithLookup::new);
+                server, io.first(), io.second(), null, del -> new ConsumeWithLookup(del, session));
         context.setClient(serverLauncher.getRemoteProxy());
         Future<Void> runningServer = serverLauncher.startListening();
         server.setRunningFuture(runningServer);
@@ -64,16 +64,18 @@ public final class Debugger {
 
     private static class ConsumeWithLookup implements MessageConsumer {
         private final MessageConsumer delegate;
+        private final LspSession session;
         private OperationContext topContext;
 
-        public ConsumeWithLookup(MessageConsumer delegate) {
+        public ConsumeWithLookup(MessageConsumer delegate, LspSession session) {
             this.delegate = delegate;
+            this.session = session;
         }
         
         @Override
         public void consume(Message message) throws MessageIssueException, JsonRpcException {
             InstanceContent ic = new InstanceContent();
-            ProxyLookup ll = new ProxyLookup(new AbstractLookup(ic), Lookup.getDefault());
+            ProxyLookup ll = new ProxyLookup(new AbstractLookup(ic), session.getLookup());
             // HACK: piggyback on LSP's client.
             if (topContext == null) {
                 topContext = OperationContext.find(null);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/Debugger.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/Debugger.java
@@ -55,7 +55,7 @@ public final class Debugger {
         NbProtocolServer server = new NbProtocolServer(context);
 
         Launcher<IDebugProtocolClient> serverLauncher = DSPLauncher.createServerLauncher(
-                server, io.first(), io.second(), null, del -> new ConsumeWithLookup(del, session));
+                server, io.first(), io.second(), null, ConsumeWithLookup::new);
         context.setClient(serverLauncher.getRemoteProxy());
         Future<Void> runningServer = serverLauncher.startListening();
         server.setRunningFuture(runningServer);
@@ -64,18 +64,16 @@ public final class Debugger {
 
     private static class ConsumeWithLookup implements MessageConsumer {
         private final MessageConsumer delegate;
-        private final LspSession session;
         private OperationContext topContext;
 
-        public ConsumeWithLookup(MessageConsumer delegate, LspSession session) {
+        public ConsumeWithLookup(MessageConsumer delegate) {
             this.delegate = delegate;
-            this.session = session;
         }
         
         @Override
         public void consume(Message message) throws MessageIssueException, JsonRpcException {
             InstanceContent ic = new InstanceContent();
-            ProxyLookup ll = new ProxyLookup(new AbstractLookup(ic), session.getLookup());
+            ProxyLookup ll = new ProxyLookup(new AbstractLookup(ic), Lookup.getDefault());
             // HACK: piggyback on LSP's client.
             if (topContext == null) {
                 topContext = OperationContext.find(null);

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ActionProviderImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ActionProviderImpl.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
+import java.io.StringWriter;
 import java.io.Writer;
 import java.net.InetAddress;
 import java.net.ServerSocket;
@@ -63,6 +64,7 @@ import org.netbeans.spi.project.ActionProvider;
 import org.netbeans.spi.project.ui.CustomizerProvider2;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
+import org.openide.NotifyDescriptor.InputLine;
 import org.openide.cookies.LineCookie;
 import org.openide.cookies.OpenCookie;
 import org.openide.execution.ExecutionEngine;
@@ -80,6 +82,7 @@ import org.openide.util.Mutex;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.Pair;
 import org.openide.util.RequestProcessor;
+import org.openide.util.RequestProcessor.Task;
 import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.windows.IOProvider;
@@ -120,7 +123,9 @@ public class ActionProviderImpl implements ActionProvider {
     @Messages({"# {0} - simple file name",
                "DN_Debugging=Debugging ({0})",
                "# {0} - simple file name",
-               "DN_Running=Running ({0})"})
+               "DN_Running=Running ({0})",
+               "LBL_IncorrectVersionSelectJTReg=Location of JTReg:",
+               "TITLE_IncorrectVersionSelectJTReg=Version of JTReg appears to be incorrect, please select a correct version"})
     public static ExecutorTask createAndRunTest(Lookup context, String command) {
         final FileObject file = context.lookup(FileObject.class);
         String ioName = COMMAND_DEBUG_TEST_SINGLE.equals(command) ? Bundle.DN_Debugging(file.getName()) : Bundle.DN_Running(file.getName());
@@ -300,12 +305,34 @@ public class ActionProviderImpl implements ActionProvider {
                     try {
                         stop.started();
                         Process jtregProcess = new ProcessBuilder(options).start();
-                        BACKGROUND.post(new CopyReaderWriter(new InputStreamReader(jtregProcess.getInputStream()), io.getOut()));
-                        BACKGROUND.post(new CopyReaderWriter(new InputStreamReader(jtregProcess.getErrorStream()), io.getErr()));
+                        StringWriter errorOutput = new StringWriter();
+                        Task outCopy = BACKGROUND.post(new CopyReaderWriter(new InputStreamReader(jtregProcess.getInputStream()), io.getOut()));
+                        Task errCopy = BACKGROUND.post(new CopyReaderWriter(new InputStreamReader(jtregProcess.getErrorStream()), io.getErr(), errorOutput));
                         BACKGROUND.post(new CopyReaderWriter(io.getIn(), new OutputStreamWriter(jtregProcess.getOutputStream())));
-                        jtregProcess.waitFor();
+                        int processResult = jtregProcess.waitFor();
+                        outCopy.waitFinished();
+                        errCopy.waitFinished();
+                        switch (processResult) {
+                            case 5: //error
+                                //check if it is a version error:
+                                if (errorOutput.toString().contains("jtreg version")) {
+                                    Settings settings = prj.getLookup().lookup(Settings.class);
+                                    String jtregLocation = settings.getJTregLocation();
+                                    InputLine nd = new InputLine(Bundle.LBL_IncorrectVersionSelectJTReg(), Bundle.TITLE_IncorrectVersionSelectJTReg(), NotifyDescriptor.OK_CANCEL_OPTION, NotifyDescriptor.ERROR_MESSAGE);
+                                    nd.setInputText(jtregLocation);
+                                    if (DialogDisplayer.getDefault().notify(nd) == NotifyDescriptor.OK_OPTION) {
+                                        settings.setJTregLocation(nd.getInputText());
+                                        BACKGROUND.post(() -> {
+                                            createAndRunTest(context, command);
+                                        });
+                                    }
+                                }
+                                break;
+                            default:
+                                printJTR(io, jtregWork, fullSourcePath, file);
+                                break;
+                        }
                         success = true;
-                        printJTR(io, jtregWork, fullSourcePath, file);
 
                         for (File refresh : toRefresh) {
                             FileUtil.refreshFor(refresh);
@@ -620,10 +647,8 @@ public class ActionProviderImpl implements ActionProvider {
     }
 
     @Messages({
-        "LBL_NoJTReg=No JTReg found, please specify JTReg location either when " +
-                    "configuring JDK build, or in the Project Properties.\n" +
-                    "Open Project Properties?\n",
-        "TITLE_NoJTReg=No JTReg found",
+        "LBL_SelectJTReg=JTreg Location:",
+        "TITLE_SelectJTReg=Please select JTReg location",
     })
     private static File findJTReg(FileObject file) {
         File buildDir = BuildUtils.getBuildTargetDir(file);
@@ -643,18 +668,23 @@ public class ActionProviderImpl implements ActionProvider {
             }
         }
         Project prj = FileOwnerQuery.getOwner(file);
-        String jtregLocation = prj.getLookup().lookup(Settings.class).getJTregLocation();
-        File jtregHome = jtregLocation != null ? new File(jtregLocation) : null;
-        File jtregJar = jtregHome != null ? new File(new File(jtregHome, "lib"), "jtreg.jar") : null;
-        if (jtregJar == null || !jtregJar.canRead()) {
-            NotifyDescriptor.Confirmation nd = new NotifyDescriptor.Confirmation(Bundle.LBL_NoJTReg(), Bundle.TITLE_NoJTReg(), NotifyDescriptor.OK_CANCEL_OPTION);
-            if (DialogDisplayer.getDefault().notify(nd) == NotifyDescriptor.OK_OPTION) {
-                CustomizerProvider2 p = prj.getLookup().lookup(CustomizerProvider2.class);
-                p.showCustomizer("test", null);
+        Settings settings = prj.getLookup().lookup(Settings.class);
+        while (true) {
+            String jtregLocation = settings.getJTregLocation();
+            File jtregHome = jtregLocation != null ? new File(jtregLocation) : null;
+            File jtregJar = jtregHome != null ? new File(new File(jtregHome, "lib"), "jtreg.jar") : null;
+            if (jtregJar == null || !jtregJar.canRead()) {
+                InputLine nd = new InputLine(Bundle.LBL_SelectJTReg(), Bundle.TITLE_SelectJTReg(), NotifyDescriptor.OK_CANCEL_OPTION, NotifyDescriptor.ERROR_MESSAGE);
+                nd.setInputText(jtregLocation);
+                if (DialogDisplayer.getDefault().notify(nd) == NotifyDescriptor.OK_OPTION) {
+                    settings.setJTregLocation(nd.getInputText());
+                    continue;
+                } else {
+                    return null;
+                }
             }
-            return null;
+            return jtregJar;
         }
-        return jtregJar;
     }
         private static final String JT_HOME_KEY = "JT_HOME:=";
 
@@ -847,10 +877,16 @@ public class ActionProviderImpl implements ActionProvider {
     private static final class CopyReaderWriter implements Runnable {
         private final Reader in;
         private final Writer out;
+        private final Writer secondaryOut;
 
         public CopyReaderWriter(Reader in, Writer out) {
+            this(in, out, null);
+        }
+
+        public CopyReaderWriter(Reader in, Writer out, Writer secondaryOut) {
             this.in = in;
             this.out = out;
+            this.secondaryOut = secondaryOut;
         }
 
         @Override
@@ -861,6 +897,9 @@ public class ActionProviderImpl implements ActionProvider {
 
                 while ((read = in.read(buf)) != (-1)) {
                     out.write(buf, 0, read);
+                    if (secondaryOut != null) {
+                        secondaryOut.write(buf, 0, read);
+                    }
                 }
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);


### PR DESCRIPTION
When an OpenJDK test is run, ask for JTreg when none can be found, and also look for JTreg version errors, and ask for a newer one if needed. This is particularly useful when running inside VS Code, as there's no Project configuration there.

For technical reasons, this also includes the setting of LSP lookup for debugger as in:
https://github.com/apache/netbeans/pull/5536


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
