### PR TITLE
Don't show documentation for an empty line #5347

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -332,11 +332,9 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
         request.context = context;
         QueryType queryType = completionContext.getQueryType();
         String prefix;
-        if (queryType == QueryType.DOCUMENTATION) { // GH-4494
-            prefix = getPrefix(info, caretOffset, false, PrefixBreaker.WITH_NS_PARTS);
-        } else {
-            prefix = getPrefix(info, caretOffset, true, PrefixBreaker.WITH_NS_PARTS);
-        }
+        // GH-4494 if query type is documentation, get a whole identifier as a prefix
+        boolean upToOffset = queryType != QueryType.DOCUMENTATION;
+        prefix = getPrefix(info, caretOffset, upToOffset, PrefixBreaker.WITH_NS_PARTS);
         if (prefix == null
                 || (queryType == QueryType.DOCUMENTATION && prefix.isEmpty())) {
             return CodeCompletionResult.NONE;

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -337,7 +337,8 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
         } else {
             prefix = getPrefix(info, caretOffset, true, PrefixBreaker.WITH_NS_PARTS);
         }
-        if (prefix == null) {
+        if (prefix == null
+                || (queryType == QueryType.DOCUMENTATION && prefix.isEmpty())) {
             return CodeCompletionResult.NONE;
         }
         prefix = prefix.trim().isEmpty() ? completionContext.getPrefix() : prefix;

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5347.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5347.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// test
+
+undefined();

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
@@ -328,6 +328,16 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
         checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH4494.php", "gh4494_aa_bb_cc^();");
     }
 
+    public void testIssueGH5347_01() throws Exception {
+        // no golden file
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5347.php", "^// test", true);
+    }
+
+    public void testIssueGH5347_02() throws Exception {
+        // no golden file
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5347.php", "un^defined();", true);
+    }
+
     @Override
     protected String alterDocumentationForTest(String documentation) {
         int start = documentation.indexOf("file:");
@@ -354,7 +364,21 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
     }
 
     private void checkCompletionOnlyDocumentation(String filePath, String caretLine) throws Exception {
-        checkCompletionDocumentation(filePath, caretLine, false, "", QueryType.DOCUMENTATION);
+        checkCompletionOnlyDocumentation(filePath, caretLine, false);
+    }
+
+    private void checkCompletionOnlyDocumentation(String filePath, String caretLine, boolean noDocument) throws Exception {
+        if (!noDocument) {
+            checkCompletionDocumentation(filePath, caretLine, false, "", QueryType.DOCUMENTATION);
+        } else {
+            try {
+                checkCompletionDocumentation(filePath, caretLine, false, "", QueryType.DOCUMENTATION);
+            } catch (AssertionError ex) {
+                // there is no completion item
+                return;
+            }
+            fail("Must not have documentation");
+        }
     }
 
     @Override


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/5347
- Don't show documentation if the prefix(whole identifier) is empty