### PR TITLE
Update Online HTML5 templates:

### DIFF
--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/sites/OnlineSites.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/sites/OnlineSites.java
@@ -192,13 +192,13 @@ public abstract class OnlineSites implements SiteTemplateImplementation {
     public static class SiteHtml5Boilerplate extends OnlineSites {
 
         @NbBundle.Messages({
-            "SiteHtml5Boilerplate.name=HTML5 Boilerplate 5.3.0",
+            "SiteHtml5Boilerplate.name=HTML5 Boilerplate 8.0.0",
             "SiteHtml5Boilerplate.description=Site template from html5boilerplate.com.",
         })
         public SiteHtml5Boilerplate() {
             super("INIT.BOILER", Bundle.SiteHtml5Boilerplate_name(), Bundle.SiteHtml5Boilerplate_description(), // NOI18N
-                    "https://github.com/h5bp/html5-boilerplate/releases/download/5.3.0/html5-boilerplate_v5.3.0.zip", // NOI18N
-                    new File(SiteHelper.getJsLibsDirectory(), "html5-boilerplate-530.zip")); // NOI18N
+                    "https://github.com/h5bp/html5-boilerplate/releases/download/v8.0.0/html5-boilerplate_v8.0.0.zip", // NOI18N
+                    new File(SiteHelper.getJsLibsDirectory(), "html5-boilerplate-800.zip")); // NOI18N
         }
 
     }
@@ -207,13 +207,13 @@ public abstract class OnlineSites implements SiteTemplateImplementation {
     public static class SiteTwitterBootstrap extends OnlineSites {
 
         @NbBundle.Messages({
-            "SiteTwitterBootstrap.name=Twitter Bootstrap 3.3.6",
+            "SiteTwitterBootstrap.name=Twitter Bootstrap 5.2.3",
             "SiteTwitterBootstrap.description=Site template from getbootstrap.com.",
         })
         public SiteTwitterBootstrap() {
             super("TWITTER", Bundle.SiteTwitterBootstrap_name(), Bundle.SiteTwitterBootstrap_description(), // NOI18N
-                    "https://github.com/twbs/bootstrap/releases/download/v3.3.6/bootstrap-3.3.6-dist.zip", // NOI18N
-                    new File(SiteHelper.getJsLibsDirectory(), "twitter-bootstrap-336.zip")); // NOI18N
+                    "https://github.com/twbs/bootstrap/releases/download/v5.2.3/bootstrap-5.2.3-dist.zip", // NOI18N
+                    new File(SiteHelper.getJsLibsDirectory(), "twitter-bootstrap-523.zip")); // NOI18N
         }
 
     }


### PR DESCRIPTION
- Bump HTML5 Boilerplate to 8.0.0
- Bump Twitter Bootstrap to 5.2.3

Testing:
- Full build done
- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of `ant check-sigtests`
- Create and run HTML5/JS applications
- Checked that the correct version of the template is downloaded

HTML5 Boilerplate
![Screenshot from 2023-03-27 17-02-32](https://user-images.githubusercontent.com/9832133/228092939-347e625c-c2ed-419a-a056-ed0a6b2cee00.png)
Bootstrap 5.2.3
![Screenshot from 2023-03-27 17-01-14](https://user-images.githubusercontent.com/9832133/228092964-f1f8c755-a5b6-4911-bd07-a8ddd20d827d.png)
