### PR TITLE
Service Console has been deprecated - use new replacement URL

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/database/DatabaseNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/database/DatabaseNode.java
@@ -81,7 +81,7 @@ public class DatabaseNode extends OCINode {
                         DatabaseItem item = new DatabaseItem(
                                 OCID.of(d.getId(), "Databases"), //NOI18N
                                 d.getDbName(),
-                                d.getServiceConsoleUrl(),
+                                d.getConnectionUrls().getApexUrl().replace("apex", "admin/_sdw"),
                                 getConnectionName(profiles));
                         StringBuilder sb = new StringBuilder();
                         sb.append(Bundle.LBL_WorkloadType(d.getDbWorkload().getValue()));


### PR DESCRIPTION
"Service Console" has been deprecated. See [this](https://adwc.uscom-east-1.oraclecloud.com/console/index.html?tenant_name=iam-ocid1.tenancy.oc1..fhfhfhfhfs33432232&database_name=adwdb1) link.
```
Service Console has been deprecated as of July 5th, 2022.
You can use Database Actions to access the same set of features available 
in Service Console. For more details on where to find each Service Console 
functionality in Database Actions, see the documentation.
```

This PR uses new replacement URL, which should provide similar functionality.
