### PR TITLE
macOS: dark window title bars

### DIFF
--- a/nb/ide.launcher/netbeans.conf
+++ b/nb/ide.launcher/netbeans.conf
@@ -63,7 +63,7 @@ netbeans_default_cachedir="${DEFAULT_CACHEDIR_ROOT}/@@metabuild.RawVersion@@"
 # (see: https://issues.apache.org/jira/browse/NETBEANS-1344)
 #
 
-netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.graphics.UseQuartz=true -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dsun.zip.disableMemoryMapping=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions"
+netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.application.appearance=system -J-Dapple.awt.graphics.UseQuartz=true -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dsun.zip.disableMemoryMapping=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions"
 
 # Default location of JDK:
 # (set by installer or commented out if launcher should decide)


### PR DESCRIPTION
This PR adds launch option `-Dapple.awt.application.appearance=system` to enabled dark window title bars if macOS is in dark mode.

With this PR:

![image](https://user-images.githubusercontent.com/5604048/228287537-6181f4d3-12fa-4f9e-9e0b-8ba036968232.png)

Without:

![image](https://user-images.githubusercontent.com/5604048/228287581-06e8f3bc-07be-4727-869d-5e82a53f163f.png)

Note that the window title bars get only dark if macOS dark appearance is enabled (in macOS System Preferences > General > Appearance). If macOS is in light mode, the window title bars get light color.