### PR TITLE
apidoc error/warning fix (#6)

### DIFF
--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/IntrospectedInfo.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/IntrospectedInfo.java
@@ -59,10 +59,10 @@ import org.openide.util.WeakListeners;
  * and makes them safely serializable (stores only classnames, etc.).
  * <p>
  * All task and type names may be namespace-qualified for use
- * in Ant 1.6: a name of the form <samp>nsuri:localname</samp> refers to
- * an XML element with namespace <samp>nsuri</samp> and local name <samp>localname</samp>.
+ * in Ant 1.6: a name of the form <code>nsuri:localname</code> refers to
+ * an XML element with namespace <code>nsuri</code> and local name <code>localname</code>.
  * Attribute names could also be similarly qualified, but in practice attributes
- * used in Ant never have a defined namespace. The prefix <samp>antlib:org.apache.tools.ant:</samp>
+ * used in Ant never have a defined namespace. The prefix <code>antlib:org.apache.tools.ant:</code>
  * is implied, not expressed, on Ant core element names (for backwards compatibility).
  * Subelement names are *not* namespace-qualified here, even though in the script
  * they would be - because the namespace used in the script will actually vary

--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/support/ActionUtils.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/support/ActionUtils.java
@@ -122,11 +122,11 @@ public final class ActionUtils {
      * </p>
      * @param context a selection as provided to e.g. <code>ActionProvider.isActionEnabled(...)</code>
      * @param dir a constraining parent directory, or null to not check for a parent directory
-     * @param suffix a file suffix (e.g. <samp>.java</samp>) to constrain files by,
+     * @param suffix a file suffix (e.g. <code>.java</code>) to constrain files by,
      *               or null to not check suffixes
      * @param strict if true, all files in the selection have to be accepted
      * @return a nonempty selection of disk files, or null
-     * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html#isActionEnabled(java.lang.String,%20org.openide.util.Lookup)"><code>ActionProvider.isActionEnabled(...)</code></a>
+     * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html#isActionEnabled-java.lang.String-org.openide.util.Lookup-"><code>ActionProvider.isActionEnabled(...)</code></a>
      */
     public static FileObject[] findSelectedFiles(Lookup context, FileObject dir, String suffix, boolean strict) {
         if (dir != null && !dir.isFolder()) {
@@ -181,7 +181,7 @@ public final class ActionUtils {
      * <span class="nonnormative">(If you expect the target files to be created
      * by Ant you do not need this method, since Ant's mappers suffice.)</span>
      * The file paths considered by the regular expression (if supplied) always use
-     * <samp>/</samp> as the separator.
+     * <code>/</code> as the separator.
      * <p class="nonnormative">
      * Typical usage to map a set of Java source files to corresponding tests:
      * <code>regexpMapFiles(files, srcDir, Pattern.compile("/([^/]+)\\.java"), testSrcDir, "/\\1Test.java", true)</code>
@@ -239,7 +239,7 @@ public final class ActionUtils {
     /**
      * Create an "includes" string such as is accepted by many Ant commands
      * as well as filesets.
-     * <samp>/</samp> is always used as the separator in the relative paths.
+     * <code>/</code> is always used as the separator in the relative paths.
      * @param files a list of files or folders to include, in the case of folder
      * the generated include contains recursively all files under the folder.
      * @param dir a directory in which all the files reside
@@ -254,7 +254,7 @@ public final class ActionUtils {
     /**
      * Create an "includes" string such as is accepted by many Ant commands
      * as well as filesets.
-     * <samp>/</samp> is always used as the separator in the relative paths.
+     * <code>/</code> is always used as the separator in the relative paths.
      * @param files a list of files or folders to include, in the case of folder
      * the generated include contains recursively all files under the folder.
      * @param dir a directory in which all the files reside

--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/support/TargetLister.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/support/TargetLister.java
@@ -138,7 +138,7 @@ public class TargetLister {
         
         /**
          * Gets the qualified name of the target.
-         * This consists of the name of the project followed by a dot (<samp>.</samp>)
+         * This consists of the name of the project followed by a dot (<code>.</code>)
          * followed by the simple target name.
          * (Or just the simple target name in case the project has no defined name;
          * questionable whether this is even legal.)
@@ -200,13 +200,13 @@ public class TargetLister {
         
         /**
          * Tests whether a target is marked as internal to the script.
-         * Currently this means that the target name begins with a hyphen (<samp>-</samp>),
+         * Currently this means that the target name begins with a hyphen (<code>-</code>),
          * though the precise semantics may be changed according to changes in Ant.
          * Conventionally, internal targets are not intended to be run directly, and only
          * exist to be called from other targets. As such, they should not normally
          * be presented in the context of targets you might want to run.
          * @return true if this is marked as an internal target, false for a regular target
-         * @see <a href="http://issues.apache.org/bugzilla/show_bug.cgi?id=22020">Ant issue #22020</a>
+         * @see <a href="https://bz.apache.org/bugzilla/show_bug.cgi?id=22020">Ant issue #22020</a>
          */
         public boolean isInternal() {
             String n = getName();

--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AntLogger.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/AntLogger.java
@@ -72,14 +72,14 @@ import java.io.File;
  * which may or may not handle any events which have not already been consumed
  * (marking them consumed itself) and will typically process message logged events
  * by printing them to the output somehow, using hyperlinks for common file error
- * patterns such as <samp>/path/to/File.java:34: some message</samp>. It may also
+ * patterns such as <code>/path/to/File.java:34: some message</code>. It may also
  * handle sequences of messages logged within a task in the format
  * </p>
  * <pre>&nbsp;/path/to/File.java:34: you cannot throw a bogus exception here
  * &nbsp;        throw new Exception("bogus!");
  * &nbsp;                            ^</pre>
  * <p>
- * by linking to the column number indicated by the caret (<samp>^</samp>).
+ * by linking to the column number indicated by the caret (<code>^</code>).
  * </p>
  * <p>
  * Please Note: Using <code>System.out</code> or <code>System.err</code> in your subclass 
@@ -88,7 +88,7 @@ import java.io.File;
  * </p>
  * </div>
  * @author Jesse Glick
- * @see <a href="http://www.netbeans.org/issues/show_bug.cgi?id=42525">Issue #42525</a>
+ * @see <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=42525">Issue #42525</a>
  * @since org.apache.tools.ant.module/3 3.12
  */
 public abstract class AntLogger {

--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/package.html
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/package.html
@@ -63,7 +63,7 @@ Create a JAR file containing the task class(es), named
 <samp>org-netbeans-modules-foo.jar</samp>.
 Create an entry in that JAR <samp>org/netbeans/modules/foo/antlib.xml</samp>
 listing tasks (or types, macrodefs, etc.) you wish to define, in the
-<a href="http://ant.apache.org/manual/CoreTypes/antlib.html">standard Antlib format</a>.
+<a href="https://ant.apache.org/manual/Types/antlib.html">standard Antlib format</a>.
 For example:</p>
 
 <pre>
@@ -131,7 +131,7 @@ there is no possibility of name clashes with unrelated tasks:</p>
 </pre>
 
 <p>Complete working example of task registration:
-<a href="http://www.netbeans.org/source/browse/ant/browsetask/"><samp>ant/browsetask</samp>
+<a href="https://github.com/apache/netbeans/tree/master/java/ant.browsetask"><samp>java/ant.browsetask</samp>
 module</a></p>
 
 </body>

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/Bundle.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/Bundle.java
@@ -97,11 +97,11 @@ public class Bundle {
         return getString(getBundle(bundle), key);
     }
     
-    /** Gets string from bundle, removes mnemonic (i.e. '&' or '(&X)') from it
+    /** Gets string from bundle, removes mnemonic (i.e. '&amp;' or '(&amp;X)') from it
      * and cuts parameters like {0} from the end.
      * @param bundle path to bundle (e.g. "org.netbeans.core.Bundle")
      * @param key key of requested string
-     * @return string from bundle in current locale. Mnemonic (i.e. '&' or '(&X)')
+     * @return string from bundle in current locale. Mnemonic (i.e. '&amp;' or '(&amp;X)')
      * is removed and parameter patterns are also removed starting by first '{'.
      */
     public static String getStringTrimmed(String bundle, String key) {
@@ -118,7 +118,7 @@ public class Bundle {
         return java.text.MessageFormat.format(getString(bundle, key), params);
     }
     
-    /** Gets string from bundle and formats it. It removes mnemonic (i.e. '&' or '(&X)') 
+    /** Gets string from bundle and formats it. It removes mnemonic (i.e. '&amp;' or '(&amp;X)') 
      * from it and cuts parameters like {0} from the end if any.
      * @param bundle path to bundle (e.g. "org.netbeans.core.Bundle")
      * @param key key of requested string
@@ -130,7 +130,7 @@ public class Bundle {
         return trim(getString(getBundle(bundle), key, params));
     }
     
-    /** Removes mnemonic (i.e. '&' or '(&X)') and cut parameters like {0} from the end.
+    /** Removes mnemonic (i.e. '&amp;' or '(&amp;X)') and cut parameters like {0} from the end.
      * @param value string to modify
      * @return string with removed mnemonic and parameters like {0} from the end.
      */
@@ -146,7 +146,7 @@ public class Bundle {
 
     /**
      * Removes an ampersand from a text string; commonly used to strip out unneeded mnemonics.
-     * Replaces the first occurence of <samp>&amp;?</samp> by <samp>?</samp> or <samp>(&amp;??</samp> by the empty string 
+     * Replaces the first occurence of <em>&amp;?</em> by <samp>?</samp> or <samp>(&amp;??</samp> by the empty string 
      * where <samp>?</samp> is a wildcard for any character.
      * <samp>&amp;?</samp> is a shortcut in English locale.
      * <samp>(&amp;?)</samp> is a shortcut in Japanese locale.

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/FavoritesOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/FavoritesOperator.java
@@ -28,7 +28,7 @@ import org.netbeans.jemmy.operators.JTreeOperator;
  * Functionality related to files tree is delegated to JTreeOperator (method
  * tree()) and nodes.<p>
  *
- * Example:<p>
+ * Example:
  * <pre>
  *      FavoritesOperator fo = FavoritesOperator.invoke();
  *      // or when Favorites pane is already opened

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/OptionsOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/OptionsOperator.java
@@ -163,7 +163,7 @@ public class OptionsOperator extends NbDialogOperator {
     //definition levels
 
     /**
-     * Shows definition levels column by clicking on the "<<" table
+     * Shows definition levels column by clicking on the "&lt;&lt;" table
      * column title.
      */
     public void showLevels() {
@@ -302,7 +302,7 @@ public class OptionsOperator extends NbDialogOperator {
     }
 
     /**
-     * Clicks on "<<" column header.
+     * Clicks on "&lt;&lt;" column header.
      */
     protected void clickOnSecondHeader() {
         JTableHeader header = treeTable().getTableHeader();
@@ -365,7 +365,7 @@ public class OptionsOperator extends NbDialogOperator {
                                                "OpenIDE-Module-Display-Category"));
     }
 
-    /** Selects Fonts & Colors category. */
+    /** Selects Fonts &amp; Colors category. */
     public void selectFontAndColors() {
         selectCategory(Bundle.getStringTrimmed("org.netbeans.modules.options.colors.Bundle",
                                                "CTL_Font_And_Color_Options"));

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/WizardOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/WizardOperator.java
@@ -71,8 +71,8 @@ public class WizardOperator extends NbDialogOperator {
         return _btNext;
     }
     
-    /** Returns operator of "< Back" button.
-     * @return  JButtonOperator instance of "< Back" button
+    /** Returns operator of "&lt; Back" button.
+     * @return  JButtonOperator instance of "&lt; Back" button
      */
     public JButtonOperator btBack() {
         if (_btBack == null) {
@@ -108,7 +108,7 @@ public class WizardOperator extends NbDialogOperator {
         btNext().push();
     }
     
-    /** Pushes "< Back" button. */
+    /** Pushes "&lt; Back" button. */
     public void back() {
         btBack().push();
     }

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/actions/AddLocaleAction.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/actions/AddLocaleAction.java
@@ -23,7 +23,7 @@ import org.netbeans.jellytools.Bundle;
 /** Used to call "Add | Locale..." popup menu item on properties node.
  * @see Action
  * @see ActionNoBlock
- * @see org.netbeans.jellytools.nodes.PropertiesNode
+ * @see <a href="@org-netbeans-modules-jellytools-ide@/org/netbeans/jellytools/nodes/PropertiesNode.html">org.netbeans.jellytools.nodes.PropertiesNode</a>
  * @author <a href="mailto:vojtech.sigler@sun.com">Vojtech Sigler</a> */
 public class AddLocaleAction extends ActionNoBlock {
 

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/actions/EditAction.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/actions/EditAction.java
@@ -23,9 +23,9 @@ import org.netbeans.jellytools.Bundle;
 /** Used to call "Edit" popup menu item or
  * "org.openide.actions.EditAction".
  * @see Action
- * @see org.netbeans.jellytools.nodes.PropertiesNode
- * @see org.netbeans.jellytools.nodes.URLNode
- * @see org.netbeans.jellytools.nodes.FormNode
+ * @see <a href="@org-netbeans-modules-jellytools-ide@/org/netbeans/jellytools/nodes/PropertiesNode.html">org.netbeans.jellytools.nodes.PropertiesNode</a>
+ * @see <a href="@org-netbeans-modules-jellytools-ide@/org/netbeans/jellytools/nodes/URLNode.html">org.netbeans.jellytools.nodes.URLNode</a>
+ * @see <a href="@org-netbeans-modules-jellytools-java@/org/netbeans/jellytools/nodes/FormNode.html">org.netbeans.jellytools.nodes.FormNode</a>
  * @author <a href="mailto:adam.sotona@sun.com">Adam Sotona</a> */
 public class EditAction extends Action {
 

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/actions/ExploreFromHereAction.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/actions/ExploreFromHereAction.java
@@ -23,7 +23,7 @@ import org.netbeans.jellytools.Bundle;
 /** Used to call "Explore From Here" popup menu item,
  * "org.openide.actions.OpenLocalExplorerAction".
  * @see Action
- * @see org.netbeans.jellytools.nodes.FolderNode
+ * @see <a href="@org-netbeans-modules-jellytools-ide@/org/netbeans/jellytools/nodes/FolderNode.html">org.netbeans.jellytools.nodes.FolderNode</a>
  * @author <a href="mailto:adam.sotona@sun.com">Adam Sotona</a> */
 public class ExploreFromHereAction extends Action {
 

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/nodes/Node.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/nodes/Node.java
@@ -37,7 +37,7 @@ import org.openide.explorer.view.Visualizer;
  * Ancestor class for all nodes.<p> Nodes should help to easier testing of
  * JTree's. The most frequent usage in IDE is in file views but nodes can be
  * used in any component which includes a JTree instance. Nodes are also used as
- * parameters for action's performing. <p> Example:<p>
+ * parameters for action's performing. <p> Example:
  * <pre>
  *     Node node = new Node(new SourcePackagesNode("My Project"), "org.netbeans.jellytools.nodes|Node.java");
  *     System.out.println(node.getText());

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ClasspathCustomEditorOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ClasspathCustomEditorOperator.java
@@ -39,7 +39,7 @@ import org.netbeans.jemmy.operators.*;
 public class ClasspathCustomEditorOperator extends NbDialogOperator {
 
     /** Creates new ClasspathCustomEditorOperator
-     * @throws TimeoutExpiredException when NbDialog not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when NbDialog not found
      * @param title String title of custom editor */
     public ClasspathCustomEditorOperator(String title) {
         super(title);
@@ -60,7 +60,7 @@ public class ClasspathCustomEditorOperator extends NbDialogOperator {
 
 
     /** Tries to find Add Directory... JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btAddDirectory() {
@@ -73,7 +73,7 @@ public class ClasspathCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find "Move Down" JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btMoveDown() {
@@ -86,7 +86,7 @@ public class ClasspathCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find null JList in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JListOperator
      */
     public JListOperator lstClasspath() {
@@ -97,7 +97,7 @@ public class ClasspathCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find Add JAR/ZIP... JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btAddJARZIP() {
@@ -110,7 +110,7 @@ public class ClasspathCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find "Remove" JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btRemove() {
@@ -123,7 +123,7 @@ public class ClasspathCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find "Move Up" JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btMoveUp() {
@@ -136,7 +136,7 @@ public class ClasspathCustomEditorOperator extends NbDialogOperator {
     }
 
     /** clicks on Add Directory... JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      * @return FileCustomEditorOperator of directory selector */
     public FileCustomEditorOperator addDirectory() {
         btAddDirectory().pushNoBlock();
@@ -146,14 +146,14 @@ public class ClasspathCustomEditorOperator extends NbDialogOperator {
     }
 
     /** clicks on "Move Down" JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      */
     public void moveDown() {
         btMoveDown().push();
     }
 
     /** clicks on Add JAR/ZIP... JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      * @return FileCustomEditorOperator of JAR or ZIP file selector */
     public FileCustomEditorOperator addJARZIP() {
         btAddJARZIP().pushNoBlock();
@@ -222,14 +222,14 @@ public class ClasspathCustomEditorOperator extends NbDialogOperator {
     }
 
     /** clicks on "Remove" JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      */
     public void remove() {
         btRemove().push();
     }
 
     /** clicks on "Move Up" JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      */
     public void moveUp() {
         btMoveUp().push();

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/properties/editors/FontCustomEditorOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/properties/editors/FontCustomEditorOperator.java
@@ -36,7 +36,7 @@ import org.netbeans.jemmy.operators.*;
 public class FontCustomEditorOperator extends NbDialogOperator {
 
     /** Creates new FontCustomEditorOperator
-     * @throws TimeoutExpiredException when NbDialog not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when NbDialog not found
      * @param title String title of custom editor */
     public FontCustomEditorOperator(String title) {
         super(title);
@@ -65,7 +65,7 @@ public class FontCustomEditorOperator extends NbDialogOperator {
 
 
     /** Tries to find null JList in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JListOperator
      */
     public JListOperator lstFontName() {
@@ -76,7 +76,7 @@ public class FontCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find null JList in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JListOperator
      */
     public JListOperator lstFontSize() {
@@ -87,7 +87,7 @@ public class FontCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find null JTextField in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JTextFieldOperator
      */
     public JTextFieldOperator txtFontName() {
@@ -98,7 +98,7 @@ public class FontCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find null JTextField in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JTextFieldOperator
      */
     public JTextFieldOperator txtFontSize() {
@@ -109,7 +109,7 @@ public class FontCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find null JTextField in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JTextFieldOperator
      */
     public JTextFieldOperator txtFontStyle() {
@@ -120,7 +120,7 @@ public class FontCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find null JList in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JListOperator
      */
     public JListOperator lstFontStyle() {

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ProcessDescriptorCustomEditorOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ProcessDescriptorCustomEditorOperator.java
@@ -40,7 +40,7 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
 public class ProcessDescriptorCustomEditorOperator extends NbDialogOperator {
 
     /** Creates new ProcessDescriptorCustomEditorOperator
-     * @throws TimeoutExpiredException when NbDialog not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when NbDialog not found
      * @param title String title of custom editor */
     public ProcessDescriptorCustomEditorOperator(String title) {
         super(title);
@@ -58,7 +58,7 @@ public class ProcessDescriptorCustomEditorOperator extends NbDialogOperator {
     private JTextAreaOperator _txtArguments;
 
     /** Tries to find null JTextArea in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JTextAreaOperator
      */
     public JTextAreaOperator txtArgumentKey() {
@@ -69,7 +69,7 @@ public class ProcessDescriptorCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find Browse... JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btSelectProcessExecutable() {
@@ -82,7 +82,7 @@ public class ProcessDescriptorCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find null JTextField in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JTextFieldOperator
      */
     public JTextFieldOperator txtProcess() {
@@ -93,7 +93,7 @@ public class ProcessDescriptorCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find null JTextArea in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JTextAreaOperator
      */
     public JTextAreaOperator txtArguments() {
@@ -110,7 +110,7 @@ public class ProcessDescriptorCustomEditorOperator extends NbDialogOperator {
     }
 
     /** clicks on ... JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      * @return FileCustomEditorOperator */
     public FileCustomEditorOperator selectProcessExecutable() {
         btSelectProcessExecutable().pushNoBlock();

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/properties/editors/StringArrayCustomEditorOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/properties/editors/StringArrayCustomEditorOperator.java
@@ -34,7 +34,7 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
 public class StringArrayCustomEditorOperator extends NbDialogOperator {
 
     /** Creates new StringArrayCustomEditorOperator
-     * @throws TimeoutExpiredException when NbDialog not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when NbDialog not found
      * @param title String title of custom editor */
     public StringArrayCustomEditorOperator(String title) {
         super(title);
@@ -59,7 +59,7 @@ public class StringArrayCustomEditorOperator extends NbDialogOperator {
     //******************************
 
     /** Tries to find "Edit" JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btEdit() {
@@ -72,7 +72,7 @@ public class StringArrayCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find "Down" JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btDown() {
@@ -85,7 +85,7 @@ public class StringArrayCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find "Up" JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btUp() {
@@ -98,7 +98,7 @@ public class StringArrayCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find "Add" JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btAdd() {
@@ -111,7 +111,7 @@ public class StringArrayCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find JList in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JListOperator
      */
     public JListOperator lstItemList() {
@@ -122,7 +122,7 @@ public class StringArrayCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find "Remove" JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btRemove() {
@@ -135,7 +135,7 @@ public class StringArrayCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find null JTextField in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JTextFieldOperator
      */
     public JTextFieldOperator txtItemText() {
@@ -146,35 +146,35 @@ public class StringArrayCustomEditorOperator extends NbDialogOperator {
     }
 
     /** clicks on "Edit" JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      */
     public void edit() {
         btEdit().push();
     }
 
     /** clicks on "Down" JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      */
     public void down() {
         btDown().push();
     }
 
     /** clicks on "Up" JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      */
     public void up() {
         btUp().push();
     }
 
     /** clicks on "Add" JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      */
     public void add() {
         btAdd().push();
     }
 
     /** clicks on "Remove" JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      */
     public void remove() {
         btRemove().push();

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/widgets/ConnectionWidgetOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/widgets/ConnectionWidgetOperator.java
@@ -165,7 +165,7 @@ public class ConnectionWidgetOperator extends WidgetOperator {
     }
 
     /** Returns list of control points.
-     * @return List<Point> of control points
+     * @return {@code List<Point>} of control points
      */
     @SuppressWarnings("unchecked")
     public List<Point> getControlPoints() {

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/widgets/LabelWidgetOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/widgets/LabelWidgetOperator.java
@@ -60,7 +60,6 @@ public class LabelWidgetOperator extends WidgetOperator {
     /** Waits for LabelWidget with specified label under given parent.
      * @param parentWidgetOper parent WidgetOperator
      * @param label label of widget
-     * @param index index of widget to be found
      */
     public LabelWidgetOperator(WidgetOperator parentWidgetOper, String label) {
         this(parentWidgetOper, label, 0);

--- a/ide/core.ide/src/org/netbeans/api/core/ide/ServicesTabNodeRegistration.java
+++ b/ide/core.ide/src/org/netbeans/api/core/ide/ServicesTabNodeRegistration.java
@@ -30,7 +30,7 @@ import org.openide.nodes.Node;
  * static method that returns {@link Node}. Its presence means that
  * the node shall appear in the <em>Services</em> tab.
  * @since org.netbeans.core.ide/1 1.15
- * @author Jaroslav Tulach <jtulach@netbeans.org>
+ * @author Jaroslav Tulach &lt;jtulach@netbeans.org&gt;
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target({ ElementType.METHOD, ElementType.TYPE })

--- a/ide/db/src/org/netbeans/api/db/explorer/DatabaseConnection.java
+++ b/ide/db/src/org/netbeans/api/db/explorer/DatabaseConnection.java
@@ -319,7 +319,7 @@ public final class DatabaseConnection {
      * Returns the {@link java.sql.Connection} instance which encapsulates 
      * the physical connection to the database if this database connection
      * is connected. Note that "connected" here means "connected using the
-     * Database Explorer". Unless <code>test</code is set to <code>true</code>,
+     * Database Explorer". Unless <code>test</code> is set to <code>true</code>,
      * there is no check if {@link java.sql.Connection#close}
      * has been called on the returned connection. However,
      * clients should not call <code>Connection.close()</code> on the returned

--- a/ide/db/src/org/netbeans/api/db/explorer/node/BaseNode.java
+++ b/ide/db/src/org/netbeans/api/db/explorer/node/BaseNode.java
@@ -189,10 +189,6 @@ public abstract class BaseNode extends AbstractNode {
     /**
      * Set up the node
      * 
-     * @param dataLookup the data lookup
-     * @param layerEntry the name of the layer entry folder
-     * @param factory the associated child node factory, or null if this node
-     * doesn't provide child nodes.
      */
     protected void setup() {
         // put the node registry and this node into the lookup

--- a/ide/db/src/org/netbeans/api/db/explorer/node/ChildNodeFactory.java
+++ b/ide/db/src/org/netbeans/api/db/explorer/node/ChildNodeFactory.java
@@ -41,7 +41,7 @@ public class ChildNodeFactory extends ChildFactory<Lookup> {
     /**
      * Constructor. 
      * 
-     * @param dataLookup the associated data lookup
+     * @param lookup the associated data lookup
      */
     public ChildNodeFactory(Lookup lookup) {
         dataLookup = lookup;

--- a/ide/diff/src/org/netbeans/api/diff/PatchUtils.java
+++ b/ide/diff/src/org/netbeans/api/diff/PatchUtils.java
@@ -44,7 +44,7 @@ public class PatchUtils {
      * 
      * @param patch the patch file
      * @param context the file or folder to be updated with the patch
-     * @throws PatchException
+     * @throws org.netbeans.modules.diff.builtin.PatchException
      * @throws IOException - the patch is invalid or cannot be applied
      * @since 1.19
      */
@@ -60,7 +60,7 @@ public class PatchUtils {
      *  <li>normal</li>
      *  <li>unified</li>
      * </ul>
-     * @param file patch file
+     * @param patch patch file
      * @return true if the given input stream is a patch otherwise false
      * @throws IOException
      * @since 1.19

--- a/ide/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/BraceContext.java
+++ b/ide/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/BraceContext.java
@@ -25,19 +25,19 @@ import javax.swing.text.Position;
  * by a semantically connected text, such as `if' statement or `while' statement in a do-while
  * loop in Java. Such text may be displayed as a context for the brace highlight. The marked text
  * should include the brace sign itself.
- * <p/>
+ * <p>
  * It may be necessary to provide a completely unrelated context, such is in the example
  * of if-else statement. The 'else' does not provide enough information itself as it is 
  * just a negation of earlier condition. Such related piece of text can be reported as 'related' 
- * BraceContext instance. Note that <i>related</b> instances may be chained - see the example below.
- * <p/>
+ * BraceContext instance. Note that <i>related</i> instances may be chained - see the example below.
+ * <p>
  * The infrastructure uses the provided information to present the context to the user. If 
  * a 'related' positions are present the infrastructure will attempt to present the source
  * on the 'context' and 'related' positions in the source text order (e.g. displays portion of the document);
  * contents between 'context' and 'related' positions may be suppressed.
- * <p/>
+ * <p>
  * An example of context and related areas for Java (PHP) if-elseif-else, with the origin t
- * <code><pre>
+ * <pre>{@code
  *  //  vvvvvvvvvvvvvvvvv -- related
  *      if (condition1) {
  *  //  vvvvvvvvvvvvvvvvvvvvvvvvvvv -- related
@@ -48,7 +48,7 @@ import javax.swing.text.Position;
  *      ...
  *      }
  * //   ^ -- origin/caret location
- * </pre></code>
+ * }</pre>
  * @author sdedic
  */
 public final class BraceContext {

--- a/ide/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/BracesMatcher.java
+++ b/ide/editor.bracesmatching/src/org/netbeans/spi/editor/bracesmatching/BracesMatcher.java
@@ -126,7 +126,6 @@ public interface BracesMatcher {
      * <p>It is essential for all implementations to respond when thread running
      * this method is interrupted and abort the task and return immediately. This can
      * be done simply by checking the thread's status like in the code below.
-     * <p>
      * 
      * <pre>
      * if (MatcherContext.isTaskCanceled()) {
@@ -158,7 +157,7 @@ public interface BracesMatcher {
          * of the origin will be passed in, but the implementation should be prepared to
          * handle (or ignore) each of the starting offsets reported by {@link #findOrigin()} or 
          * {@link #findMatches()}.
-         * <p/>
+         * <p>
          * Note: the document is <b>not read locked</b> by the caller. If the passed position does
          * not exist in the document, or seems obsolete, the SPI should return {@code null}.
          * 

--- a/ide/editor.completion/src/org/netbeans/spi/editor/completion/CompletionItem.java
+++ b/ide/editor.completion/src/org/netbeans/spi/editor/completion/CompletionItem.java
@@ -44,7 +44,7 @@ public interface CompletionItem {
     /**
      * Gets invoked when user presses <code>VK_ENTER</code> key
      * or when she double-clicks on this item with the mouse cursor.
-     * <br/>
+     * <br>
      * This method gets invoked from AWT thread.
      *
      * @param component non-null text component for which the completion was invoked.
@@ -62,7 +62,7 @@ public interface CompletionItem {
     /**
      * Process the key pressed when this completion item was selected
      * in the completion popup window.
-     * <br/>
+     * <br>
      * This method gets invoked from AWT thread.
      *
      * @param evt non-null key event of the pressed key. It should be consumed
@@ -120,7 +120,7 @@ public interface CompletionItem {
      * <br>
      * The implementation can invoke the {@link #defaultAction(JTextComponent)}
      * if necessary.
-     * <br/>
+     * <br>
      * This method gets invoked from AWT thread.
      *
      * @param component non-null text component for which the completion was invoked.

--- a/ide/editor.completion/src/org/netbeans/spi/editor/completion/CompletionTask.java
+++ b/ide/editor.completion/src/org/netbeans/spi/editor/completion/CompletionTask.java
@@ -75,7 +75,7 @@ public interface CompletionTask {
      * 
      * @param resultSet non-null result set to which the results
      *  of the refreshing must be added.
-     *  <br/>
+     *  <br>
      *  Null result set may be passed in case the <code>query()</code>
      *  was not invoked yet and user has typed a character. In this case
      *  the provider may hide the completion

--- a/ide/editor.completion/src/org/netbeans/spi/editor/completion/support/AsyncCompletionQuery.java
+++ b/ide/editor.completion/src/org/netbeans/spi/editor/completion/support/AsyncCompletionQuery.java
@@ -43,10 +43,10 @@ public abstract class AsyncCompletionQuery {
 
     /**
      * Called in response to <code>CompletionTask.refresh(null)</code>.
-     * <br/>
+     * <br>
      * The method gets invoked once the the user types a character
      * but the <code>CompletionTask.query()</code> was not yet invoked.
-     * <br/>
+     * <br>
      * The method may want to inspect the typed character before the caret
      * position and decide whether the completion should be hidden
      * if the typed character is inappropriate e.g. ";" for java completion.

--- a/ide/editor.completion/src/org/netbeans/spi/editor/completion/support/CompletionUtilities.java
+++ b/ide/editor.completion/src/org/netbeans/spi/editor/completion/support/CompletionUtilities.java
@@ -79,7 +79,7 @@ public final class CompletionUtilities {
 
     /**
      * Get preferred width of the item by knowing its left and right html texts.
-     * <br/>
+     * <br>
      * It is supposed that the item will have an icon 16x16 and an appropriate
      * space is reserved for it.
      *
@@ -117,21 +117,21 @@ public final class CompletionUtilities {
      * 
      * @param leftHtmlText html text that will be displayed on the left side
      *  of the item's rendering area next to the icon.
-     *  <br/>
+     *  <br>
      *  It may be null which indicates that no left text will be displayed.
-     *  <br/>
+     *  <br>
      *  If there's not enough horizontal space in the rendering area
      *  the text will be shrinked and "..." will be displayed at the end.
      *
      * @param rightHtmlText html text that will be aligned to the right edge
      *  of the item's rendering area.
-     *  <br/>
+     *  <br>
      *  It may be null which means that no right text will be displayed.
-     *  <br/>
+     *  <br>
      *  The right text is always attempted to be fully displayed unlike
      *  the left text that may be shrinked if there's not enough rendering space
      *  in the horizontal direction.
-     *  <br/>
+     *  <br>
      *  If there's not enough space even for the right text it will be shrinked
      *  and "..." will be displayed at the end of the rendered string.
      * @param g non-null graphics through which the rendering happens.
@@ -186,7 +186,7 @@ public final class CompletionUtilities {
 
     /**
      * Builder for simple {@link CompletionItem} instances.
-     * <br/>
+     * <br>
      * Example usage:
      * <pre>
      * CompletionUtilities.newCompletionItemBuilder(insertText)

--- a/ide/editor/src/org/netbeans/modules/editor/EditorWarmUpTask.java
+++ b/ide/editor/src/org/netbeans/modules/editor/EditorWarmUpTask.java
@@ -28,7 +28,7 @@ import org.netbeans.modules.editor.options.AnnotationTypesFolder;
  * pre-initialize some suitable parts of the module to improve first time usage
  * experience - which might suffer from long response time due to class loading
  * and various initialization.
- * See {@link org.netbeans.core.AfterStartWarmUp} for details about how the task is run.
+ * See <a href="https://github.com/apache/netbeans/blob/master/platform/core.startup/src/org/netbeans/core/startup/WarmUpSupport.java">WarmUpSupport</a> for details about how the task is run.
  *
  */
 

--- a/ide/editor/src/org/netbeans/modules/editor/options/AnnotationTypeProcessor.java
+++ b/ide/editor/src/org/netbeans/modules/editor/options/AnnotationTypeProcessor.java
@@ -108,7 +108,7 @@ public class AnnotationTypeProcessor implements XMLDataObject.Processor, Instanc
 
     /** Create an instance.
      * @return the instance of type {@link #instanceClass}
-     * @exception IOException if an I/O error occured
+     * @exception java.io.IOException if an I/O error occured
      * @exception ClassNotFoundException if a class was not found
      */
     public Object instanceCreate() throws java.io.IOException, ClassNotFoundException {
@@ -122,8 +122,6 @@ public class AnnotationTypeProcessor implements XMLDataObject.Processor, Instanc
      * class without actually creating it.
      *
      * @return the representation class of the instance
-     * @exception IOException if an I/O error occurred
-     * @exception ClassNotFoundException if a class was not found
      */
     public Class instanceClass() {
         return AnnotationType.class;

--- a/ide/jellytools.ide/src/org/netbeans/jellytools/FilesTabOperator.java
+++ b/ide/jellytools.ide/src/org/netbeans/jellytools/FilesTabOperator.java
@@ -29,7 +29,7 @@ import org.netbeans.jemmy.operators.JTreeOperator;
  * Functionality related to Projects tree is delegated to JTreeOperator (method
  * tree()) and nodes (method getProjectNode()).<p>
  *
- * Example:<p>
+ * Example:
  * <pre>
  *      FilesTabOperator fto = new FilesTabOperator();
  *      // or when Files pane is not already opened

--- a/ide/jellytools.ide/src/org/netbeans/jellytools/ProjectsTabOperator.java
+++ b/ide/jellytools.ide/src/org/netbeans/jellytools/ProjectsTabOperator.java
@@ -32,7 +32,7 @@ import org.netbeans.jemmy.operators.JTreeOperator;
  * Functionality related to Projects tree is delegated to JTreeOperator (method
  * tree()) and nodes (method getRootNode()).<p>
  *
- * Example:<p>
+ * Example:
  * <pre>
  *      ProjectsTabOperator pto = new ProjectsTabOperator();
  *      // or when Projects pane is not already opened

--- a/ide/jellytools.ide/src/org/netbeans/jellytools/RuntimeTabOperator.java
+++ b/ide/jellytools.ide/src/org/netbeans/jellytools/RuntimeTabOperator.java
@@ -28,7 +28,7 @@ import org.netbeans.jemmy.operators.JTreeOperator;
 /** Operator handling Services TopComponent.<p>
  * Functionality related to Services tree is delegated to JTreeOperator (method
  * tree()) and nodes (method getRootNode()).<p>
- * Example:<p>
+ * Example:
  * <pre>
  *      RuntimeTabOperator rto = RuntimeTabOperator.invoke();
  *      // or when Runtime pane is already opened

--- a/ide/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/DebugProjectAction.java
+++ b/ide/jellytools.ide/src/org/netbeans/jellytools/modules/debugger/actions/DebugProjectAction.java
@@ -25,7 +25,7 @@ import org.netbeans.jellytools.actions.Action;
  * Used to call "Debug" popup menu item on project's root node.
  *
  * @see Action
- * @see org.netbeans.jellytools.nodes.JavaProjectRootNode
+ * @see <a href="@org-netbeans-modules-jellytools-java@/org/netbeans/jellytools/nodes/JavaProjectRootNode.html">org.netbeans.jellytools.nodes.JavaProjectRootNode</a>
  * @author Vojtech Sigler
  */
 public class DebugProjectAction extends Action {

--- a/ide/jumpto/src/org/netbeans/spi/jumpto/symbol/SymbolProvider.java
+++ b/ide/jumpto/src/org/netbeans/spi/jumpto/symbol/SymbolProvider.java
@@ -63,7 +63,7 @@ public interface SymbolProvider {
      * up calling {@link #cancel} on the same symbol provider during the operation, in which
      * case the method can return incomplete results. If there is a "current project",
      * the Go To Symbol infrastructure will perform the search in two passes; first it
-     * will call {@link #getSymbolNames} with the current project, which should be a reasonably
+     * will call {@link SymbolDescriptor#getSymbolName()} with the current project, which should be a reasonably
      * fast search, and display those symbols first. It will then call the method again
      * with a null project, which should return all symbols.
      * <p>
@@ -242,7 +242,7 @@ public interface SymbolProvider {
         /**
           * Adds list of result descriptors.
           *
-          * @param  symbolDescriptor  symbol descriptor to be added to result
+          * @param  symbolDescriptors  symbol descriptor to be added to result
           */
         @SuppressWarnings("unchecked")
         public void addResult(List<? extends SymbolDescriptor> symbolDescriptors) {

--- a/ide/jumpto/src/org/netbeans/spi/jumpto/type/TypeDescriptor.java
+++ b/ide/jumpto/src/org/netbeans/spi/jumpto/type/TypeDescriptor.java
@@ -113,7 +113,7 @@ public abstract class TypeDescriptor extends Descriptor {
      * This will only be called when the dialog is opening the type, so
      * does not have to be as fast as the other descriptor attributes.
      * 
-     * @todo This method is intended to replace the open() call below.
+     * XXX This method is intended to replace the open() call below.
      *
      * @return The document offset of the type declaration in the declaration file
      */
@@ -121,7 +121,7 @@ public abstract class TypeDescriptor extends Descriptor {
      
     /**
      * Open the type declaration in the editor. 
-     * @todo Should we nuke this method and only have type declarations return
+     * XXX Should we nuke this method and only have type declarations return
      *   their offsets? I looked at the Java implementation and it's leveraging 
      *   some utility methods to open the type declaration; I have similar methods
      *   in Ruby. It might be more convenient

--- a/ide/jumpto/src/org/netbeans/spi/jumpto/type/TypeProvider.java
+++ b/ide/jumpto/src/org/netbeans/spi/jumpto/type/TypeProvider.java
@@ -32,7 +32,7 @@ import org.openide.util.Parameters;
  *
  * The Type Providers are registered in Lookup.
  *
- * @todo Should we return a Collection rather than a List?
+ * XXX Should we return a Collection rather than a List?
  *
  * @author Tor Norbye
  */
@@ -63,7 +63,7 @@ public interface TypeProvider {
      * up calling {@link #cancel} on the same type provider during the operation, in which
      * case the method can return incomplete results. If there is a "current project",
      * the Go To Type infrastructure will perform the search in two passes; first it
-     * will call {@link #getTypeNames} with the current project, which should be a reasonably
+     * will call {@link TypeDescriptor#getTypeName()} with the current project, which should be a reasonably
      * fast search, and display those types first. It will then call the method again
      * with a null project, which should return all types.
      * <p>
@@ -226,7 +226,7 @@ public interface TypeProvider {
         /**
           * Adds list of result descriptors.
           *
-          * @param  typeDescriptor  type descriptor to be added to result
+          * @param  typeDescriptors  type descriptor to be added to result
           */
         public void addResult(@NonNull final List<? extends TypeDescriptor> typeDescriptors) {
             for (TypeDescriptor typeDescriptor : typeDescriptors) {

--- a/ide/project.libraries.ui/src/org/netbeans/api/project/libraries/LibraryChooser.java
+++ b/ide/project.libraries.ui/src/org/netbeans/api/project/libraries/LibraryChooser.java
@@ -57,8 +57,8 @@ public final class LibraryChooser {
     }
 
     /**
-     * Filter for use by {@link LibraryChooser#createPanel()} or 
-     * {@link LibraryChooser#showDialog()}.
+     * Filter for use by {@link #createPanel(LibraryManager, org.netbeans.api.project.libraries.LibraryChooser.Filter)} or 
+     * {@link #showDialog(LibraryManager, org.netbeans.api.project.libraries.LibraryChooser.Filter, org.netbeans.api.project.libraries.LibraryChooser.LibraryImportHandler) }.
      */
     public interface Filter {
 

--- a/ide/projectui/src/org/netbeans/modules/project/ui/api/ProjectTemplates.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/api/ProjectTemplates.java
@@ -29,7 +29,7 @@ public class ProjectTemplates {
 
     /**
      * {@link String}-valued action property for a project category (subfolder code name) to select.
-     * @deprecated use {@link CommonProjectActions.PRESELECT_CATEGORY} instead
+     * @deprecated use {@link CommonProjectActions#PRESELECT_CATEGORY} instead
      */
     @Deprecated
     public static final String PRESELECT_CATEGORY = CommonProjectActions.PRESELECT_CATEGORY;

--- a/ide/projectui/src/org/netbeans/modules/project/ui/api/UnloadedProjectInformation.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/api/UnloadedProjectInformation.java
@@ -68,7 +68,7 @@ public final class UnloadedProjectInformation {
     
     /**
      * Gets URL of the project folder location
-     * Use {@link ProjectManager#findProject} to get the project
+     * Use {@link org.netbeans.api.project.ProjectManager#findProject} to get the project
      * @return url of the project folder
      */
     public URL getURL() {

--- a/ide/projectuiapi/apichanges.xml
+++ b/ide/projectuiapi/apichanges.xml
@@ -93,7 +93,7 @@ is the proper place.
             <description>
                 <p>
                     <a href="@TOP@/org/netbeans/api/project/ui/ProjectProblems.html">ProjectProblems API</a> now delegates to 
-                    <a href="@TOP@/org/netbeans/spi/project/ui/ProjectProblemsImplementation .html">ProjectProblemsImplementation</a> 
+                    <a href="@TOP@/org/netbeans/spi/project/ui/ProjectProblemsImplementation.html">ProjectProblemsImplementation</a>
                     registered in default Lookup.
                 </p>
             </description>

--- a/ide/projectuiapi/src/org/netbeans/spi/project/ui/LogicalViewProvider.java
+++ b/ide/projectuiapi/src/org/netbeans/spi/project/ui/LogicalViewProvider.java
@@ -38,8 +38,7 @@ public interface LogicalViewProvider extends PathFinder {
      * this call should always create a fresh node with no parent.
      * The node's lookup should contain the project object.
      * <p>
-     * The node need not bother implementing {@linkplain org.openide.filesystems.FileSystem.Status badging}
-     * for the root node; any files {@linkplain org.netbeans.api.project.Sources contained} in the project will
+     * For the root node; any files {@linkplain org.netbeans.api.project.Sources contained} in the project will
      * be considered as badging sources automatically. Other subnodes representing
      * various collections of files may still need explicit badging logic.
      * <em>As of <code>org.netbeans.modules.projectuiapi/1 1.31</code></em>

--- a/ide/projectuiapi/src/org/netbeans/spi/project/ui/PathFinder.java
+++ b/ide/projectuiapi/src/org/netbeans/spi/project/ui/PathFinder.java
@@ -54,7 +54,7 @@ public interface PathFinder {
     *     assert Collections.singleton(target).equals(new HashSet(res));
     * }
     * </pre>
-    * @param root a root node. E.g. a node from {@link #createLogicalView} or some wapper
+    * @param root a root node. E.g. a node from {@link LogicalViewProvider#createLogicalView} or some wapper
     *        (FilterNode) around the node. The provider of the functionality is
     *        responsible for finding the appropriate node in the wrapper's children.
     * @param target a target cookie, such as a {@link org.openide.loaders.DataObject}

--- a/ide/projectuiapi/src/org/netbeans/spi/project/ui/ProjectProblemsImplementation.java
+++ b/ide/projectuiapi/src/org/netbeans/spi/project/ui/ProjectProblemsImplementation.java
@@ -23,7 +23,7 @@ import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.project.Project;
 
 /**
- * Interface that plugs in the actual implementation of UI for {@link ProjectProblems} API.
+ * Interface that plugs in the actual implementation of UI for {@link org.netbeans.api.project.ui.ProjectProblems} API.
  * 
  * @author Tomas Zezula, Svatopluk Dedic
  */

--- a/ide/projectuiapi/src/org/netbeans/spi/project/ui/support/NodeList.java
+++ b/ide/projectuiapi/src/org/netbeans/spi/project/ui/support/NodeList.java
@@ -25,7 +25,7 @@ import org.openide.nodes.Node;
 
 /**
  * Represents a series of nodes which can be spliced into a children list.
- * @param K the type of key you would like to use to represent nodes
+ * @param <K> the type of key you would like to use to represent nodes
  * @author mkleint
  * @since org.netbeans.modules.projectuiapi/1 1.18
  * @see NodeFactory

--- a/ide/projectuiapi/src/org/netbeans/spi/project/ui/templates/support/Templates.java
+++ b/ide/projectuiapi/src/org/netbeans/spi/project/ui/templates/support/Templates.java
@@ -281,7 +281,7 @@ public class Templates {
          * By default, the file extension is fixed to be the same as that of the template:
          * whatever is entered for the filename is taken to be a base name only.
          * In this mode, the GUI makes it possible to use an alternate extension: it
-         * simply checks for a file name containing a period (<samp>.</samp>) and
+         * simply checks for a file name containing a period (<em>.</em>) and
          * suppresses the automatic appending of the template's extension,
          * taking the entered filename as complete.
          * @return this builder

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/CopyRefactoring.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/CopyRefactoring.java
@@ -42,7 +42,8 @@ public final class CopyRefactoring extends AbstractRefactoring {
     /**
      * Creates a new instance of CopyRefactoring.
      * Copy Refactoring implementations currently understand the following types:
-     * <table border="1">
+     * <table>
+     *   <caption>CopyRefactoring types supported</caption>
      *   <tr><th>Module</th><th>Types the Module Understands</th><th>Implementation</th></tr>
      *   <tr><td>Refactoring API (Default impl.)</td><td>{@link org.openide.filesystems.FileObject}(s)</td><td>Does file copy</td></tr>
      *   <tr><td>Java Refactoring</td><td><ul>
@@ -59,7 +60,8 @@ public final class CopyRefactoring extends AbstractRefactoring {
     /**
      * Target for copying.
      * Copy Refactoring implementations currently understand the following types:
-     * <table border="1">
+     * <table>
+     *   <caption>CopyRefactoring types supported</caption>
      *   <tr><th>Module</th><th>Types the Module Understands</th><th>Implementation</th></tr>
      *   <tr><td>Refactoring API (Default impl.)</td><td>{@link java.net.URL}</td>
      *        <td>Creates directory corresponding to specified URL (if it does not exist) and copies all FileObjects into this folder.</td></tr>

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/MoveRefactoring.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/MoveRefactoring.java
@@ -41,12 +41,13 @@ public final class MoveRefactoring extends AbstractRefactoring {
     /**
      * Public constructor takes Lookup containing objects to refactor as parameter.
      * Move Refactoring implementations currently understand following types:
-     * <table border="1">
+     * <table>
+     *   <caption>MoveRefactoring types supported</caption>
      *   <tr><th>Module</th><th>Types the Module Understands</th><th>Implementation</th></tr>
      *   <tr><td>Refactoring API (Default impl.)</td><td>{@link org.openide.filesystems.FileObject}(s)</td><td>Does file(s) move</td></tr>
      *   <tr><td>Java Refactoring</td><td>{@link org.openide.filesystems.FileObject}(s) with content type text/x-java</td><td>Does refactoring inside .java files</td></tr>
-     *   <tr><td></td><td>{@link org.netbeans.api.java.source.TreePathHandle}(s)</td><td>Does refactoring of members in .java files</td></tr>
-     *   <tr><td></td><td>{@link org.netbeans.api.java.source.TreePathHandle} of class</td><td>Does refactoring of class in .java files</td></tr>
+     *   <tr><td></td><td><a href="@org-netbeans-modules-java-source-base@/org/netbeans/api/java/source/TreePathHandle.html">org.netbeans.api.java.source.TreePathHandle</a>(s)</td><td>Does refactoring of members in .java files</td></tr>
+     *   <tr><td></td><td><a href="@org-netbeans-modules-java-source-base@/org/netbeans/api/java/source/TreePathHandle.html">org.netbeans.api.java.source.TreePathHandle</a> of class</td><td>Does refactoring of class in .java files</td></tr>
      * </table>
      * @param objectsToMove store your objects into Lookup
      */
@@ -57,13 +58,14 @@ public final class MoveRefactoring extends AbstractRefactoring {
     /**
      * Target for moving.
      * Move Refactoring implementations currently understand following types:
-     * <table border="1">
+     * <table>
+     * <caption>MoveRefactoring types supported</caption>
      *   <tr><th>Module</th><th>Types the Module Understands</th><th>Implementation</th></tr>
      *   <tr><td>Refactoring API (Default impl.)</td><td>{@link java.net.URL}</td>
      *        <td>Creates directory corresponding to specified {@link java.net.URL} if does not 
      *            exist and moves all FileObjects into this folder.</td></tr>
      *   <tr><td>Java Refactoring</td><td>{@link java.net.URL}</td><td>Does move refactoring inside .java files</td></tr>
-     *   <tr><td></td><td>{@link org.netbeans.api.java.source.TreePathHandle}</td><td>Does refactoring of members in .java files</td></tr>
+     *   <tr><td></td><td><a href="@org-netbeans-modules-java-source-base@/org/netbeans/api/java/source/TreePathHandle.html">org.netbeans.api.java.source.TreePathHandle</a></td><td>Does refactoring of members in .java files</td></tr>
      * </table>
      * @param target
      */

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/RefactoringElement.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/RefactoringElement.java
@@ -121,7 +121,7 @@ public final class RefactoringElement {
     
     /**
      * Shows this element in refactoring preview are
-     * @see org.netbeans.modules.refactoring.api.ui.UI#setComponentForRefactoringPreview
+     * @see org.netbeans.modules.refactoring.spi.ui.UI#setComponentForRefactoringPreview
      */
     public void showPreview() {
         impl.showPreview();

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/RenameRefactoring.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/RenameRefactoring.java
@@ -38,15 +38,16 @@ public final class RenameRefactoring extends AbstractRefactoring {
     /**
      * Creates a new instance of RenameRefactoring.
      * Rename Refactoring implementations currently understand following types:
-     * <table border="1">
+     * <table>
+     * <caption>RenameRefactoring type supported</caption>
      *   <tr><th>Module</th><th>Types the Module Understands</th><th>Implementation</th></tr>
      *   <tr><td>Refactoring API (Default impl.)</td><td>FileObject</td><td>Does file rename</td></tr>
      *   <tr><td>Java Refactoring</td><td><ul>
      *                                    <li>{@link org.openide.filesystems.FileObject}(s) with content type text/x-java (class rename)
      *                                    <li>{@link org.openide.filesystems.FileObject} (folder) folder rename 
-     *                                    <li>{@link org.netbeans.api.java.source.TreePathHandle} (class, field, method rename)
-     *                                    <li>{@link org.netbeans.api.fileinfo.NonRecursiveFolder} package rename</td>
-     *                                    </ul>
+     *                                    <li><a href="@org-netbeans-modules-java-source-base@/org/netbeans/api/java/source/TreePathHandle.html">org.netbeans.api.java.source.TreePathHandle</a> (class, field, method rename)
+     *                                    <li>{@link org.netbeans.api.fileinfo.NonRecursiveFolder} package rename
+     *                                    </ul></td>
      *                              <td>Does refactoring inside .java files. 
      *                               In case of FolderRename it also does corresponding file moves</td></tr>
      * </table>

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/SafeDeleteRefactoring.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/SafeDeleteRefactoring.java
@@ -38,11 +38,12 @@ public final class SafeDeleteRefactoring extends AbstractRefactoring {
      * elements as parameter.
      * 
      * Safe Delete Refactoring implementations currently understand following types:
-     * <table border="1">
+     * <table>
+     *   <caption>SafeDeleteRefactoring types supported</caption>
      *   <tr><th>Module</th><th>Types the Module Understands</th><th>Implementation</th></tr>
      *   <tr><td>Refactoring API (Default impl.)</td><td>FileObject</td><td>Does file delete</td></tr>
      *   <tr><td>Java Refactoring</td><td><ul><li>{@link org.openide.filesystems.FileObject}(s) with content type text/x-java (safly delete class)
-     *                                <li>{@link org.netbeans.api.java.source.TreePathHandle} (class, field, method)</td>
+     *                                <li><a href="@org-netbeans-modules-java-source-base@/org/netbeans/api/java/source/TreePathHandle.html">org.netbeans.api.java.source.TreePathHandle</a> (class, field, method)</ul></td>
      *                              <td>Check for usages and does refactoring inside .java files.</td></tr>
      * </table>
      * @param namedElements The elements to be safely deleted

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/SingleCopyRefactoring.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/SingleCopyRefactoring.java
@@ -41,7 +41,8 @@ public final class SingleCopyRefactoring extends AbstractRefactoring {
     /**
      * Creates a new instance of SingleCopyRefactoring.
      * Single Copy Refactoring implementations currently understand following types:
-     * <table border="1">
+     * <table>
+     *   <caption>SingleCopyRefactoring types supported</caption>
      *   <tr><th>Module</th><th>Types the Module Understands</th><th>Implementation</th></tr>
      *   <tr><td>Refactoring API (Default impl.)</td><td>{@link org.openide.filesystems.FileObject}</td><td>Does file copy</td></tr>
      *   <tr><td>Java Refactoring</td><td><ul>
@@ -58,7 +59,8 @@ public final class SingleCopyRefactoring extends AbstractRefactoring {
     /**
      * Target for copying.
      * Single Copy Refactoring implementations currently understand following types:
-     * <table border="1">
+     * <table>
+     *   <caption>SingleCopyRefactoring types supported</caption>
      *   <tr><th>Module</th><th>Types the Module Understands</th><th>Implementation</th></tr>
      *   <tr><td>Refactoring API (Default impl.)</td><td>{@link java.net.URL}</td>
      *        <td>Creates directory corresponding to specified URL (if does not 

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/WhereUsedQuery.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/WhereUsedQuery.java
@@ -36,12 +36,12 @@ import org.openide.util.Parameters;
  */
 public final class WhereUsedQuery extends AbstractRefactoring {
     /**
-     * key for {@link #getBooleanValue()}
+     * key for {@link #getBooleanValue(Object)}
      * is search in comments requested?
      */
     public static final String SEARCH_IN_COMMENTS = "SEARCH_IN_COMMENTS"; // NOI18N
     /**
-     * key for {@link #getBooleanValue()}
+     * key for {@link #getBooleanValue(Object)}
      * is find references requested?
      */
     public static final String FIND_REFERENCES = "FIND_REFERENCES"; // NOI18N
@@ -49,11 +49,12 @@ public final class WhereUsedQuery extends AbstractRefactoring {
     /**
      * Creates a new instance of WhereUsedQuery.
      * WhereUsedQuery implementations currently understand following types:
-     * <table border="1">
+     * <table>
+     * <caption>WhereUsedQuery types supported</caption>
      *   <tr><th>Module</th><th>Types the Module Understands</th><th>Implementation</th></tr>
      *   <tr><td>Java Refactoring</td><td><ul>
      *                                    <li>{@link org.openide.filesystems.FileObject} with content type text/x-java (class references)
-     *                                    <li>{@link org.netbeans.api.java.source.TreePathHandle} (class, field, method references)
+     *                                    <li><a href="@org-netbeans-modules-java-source-base@/org/netbeans/api/java/source/TreePathHandle.html">org.netbeans.api.java.source.TreePathHandle</a> (class, field, method references)
      *                                    </ul>
      *                              <td>Finds references</td></tr>
      * </table>

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/BackupFacility.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/BackupFacility.java
@@ -128,11 +128,11 @@ public abstract class BackupFacility {
     /**
      * Handle class representing handle to file(s), which were backuped
      * by
-     * {@link  org.netbeans.modules.refactoring.spi.BackupFacility#backup()}
+     * {@link  org.netbeans.modules.refactoring.spi.BackupFacility#backup(FileObject...)}
      */
     public interface Handle {
         /**
-         * restore file(s), which was stored by  {@link  org.netbeans.modules.refactoring.spi.BackupFacility#backup()}
+         * restore file(s), which was stored by  {@link  org.netbeans.modules.refactoring.spi.BackupFacility#backup(FileObject...)}
          * @throws java.io.IOException if restore failed.
          */
         void restore() throws IOException;

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/FiltersManager.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/FiltersManager.java
@@ -24,7 +24,7 @@ import org.netbeans.modules.refactoring.spi.ui.FiltersDescription;
 /**
  * Handles creation and manipulation with boolean state filters.
  *
- * @author Ralph Benjamin Ruijs <ralphbenjamin@netbeans.org>
+ * @author Ralph Benjamin Ruijs &lt;ralphbenjamin@netbeans.org&gt;
  * @see FiltersDescription
  * @since 1.29
  */

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringElementImplementation.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringElementImplementation.java
@@ -134,7 +134,7 @@ public interface RefactoringElementImplementation {
     
     /**
      * Shows this element in refactoring preview are
-     * @see org.netbeans.modules.refactoring.api.ui.UI#setComponentForRefactoringPreview
+     * @see org.netbeans.modules.refactoring.spi.ui.UI#setComponentForRefactoringPreview
      */
     void showPreview();
     

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringElementsBag.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/RefactoringElementsBag.java
@@ -161,7 +161,7 @@ public final class RefactoringElementsBag {
     
     /**
      * fileChanges are performed after all element changes
-     * @param changes changes to be performed
+     * @param refactoring changes to be performed
      * @see Transaction
      * @see BackupFacility
      */

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ExpandableTreeElement.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ExpandableTreeElement.java
@@ -27,7 +27,7 @@ import org.openide.util.Cancellable;
  * it will be called from outside of AWT.
  * 
  * @author Jan Lahoda
- * @author Ralph Benjamin Ruijs <ralphbenjamin@netbeans.org>
+ * @author Ralph Benjamin Ruijs &lt;ralphbenjamin@netbeans.org&gt;
  * @see TreeElement
  * @since 1.30
  */

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/FiltersDescription.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/FiltersDescription.java
@@ -25,7 +25,7 @@ import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.modules.refactoring.api.impl.SPIUIAccessor;
 
 /**
- * @author Ralph Benjamin Ruijs <ralphbenjamin@netbeans.org>
+ * @author Ralph Benjamin Ruijs &lt;ralphbenjamin@netbeans.org&gt;
  * @since 1.29
  */
 public final class FiltersDescription {

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopePanel.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopePanel.java
@@ -50,7 +50,7 @@ import org.openide.util.lookup.Lookups;
  * button (a JButton with ellipses) will be displayed when any of the registered
  * scopes is customizable.
  *
- * @author Ralph Benjamin Ruijs <ralphbenjamin@netbeans.org>
+ * @author Ralph Benjamin Ruijs &lt;ralphbenjamin@netbeans.org&gt;
  * @since 1.30
  */
 public final class ScopePanel extends javax.swing.JPanel {

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeProvider.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeProvider.java
@@ -35,11 +35,10 @@ import org.openide.util.Lookup;
  * ScopeProvider is used to add a scope to the {@link ScopePanel}.
  *
  * @see ScopePanel
- * @see ScopeDescription
  * @see ScopeReference
  *
  * @author Jan Lahoda
- * @author Ralph Benjamin Ruijs <ralphbenjamin@netbeans.org>
+ * @author Ralph Benjamin Ruijs &lt;ralphbenjamin@netbeans.org&gt;
  *
  * @since 1.30
  */
@@ -72,7 +71,6 @@ public abstract class ScopeProvider {
      *
      * @see ScopeProvider#initialize(org.openide.util.Lookup,
      * java.util.concurrent.atomic.AtomicBoolean)
-     * @see ScopeDescription
      * @return an icon for the Scope, or null if the default should be used.
      */
     @CheckForNull
@@ -110,11 +108,10 @@ public abstract class ScopeProvider {
      * scopes which can be customized by the user.
      *
      * @see ScopePanel
-     * @see ScopeDescription
      * @see ScopeReference
      *
      * @author Jan Lahoda
-     * @author Ralph Benjamin Ruijs <ralphbenjamin@netbeans.org>
+     * @author Ralph Benjamin Ruijs &lt;ralphbenjamin@netbeans.org&gt;
      *
      * @since 1.30
      */
@@ -146,7 +143,7 @@ public abstract class ScopeProvider {
      * no arguments.
      * 
      * @author Jan Lahoda
-     * @author Ralph Benjamin Ruijs <ralphbenjamin@netbeans.org>
+     * @author Ralph Benjamin Ruijs &lt;ralphbenjamin@netbeans.org&gt;
      * @since 1.30
      */
     @Target({ElementType.TYPE})

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeReference.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeReference.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 /**
  * A reference to a Scope Description to be used by a {@link ScopePanel}
  *
- * @author Ralph Benjamin Ruijs <ralphbenjamin@netbeans.org>
+ * @author Ralph Benjamin Ruijs &lt;ralphbenjamin@netbeans.org&gt;
  * @since 1.30
  */
 @Target({ElementType.TYPE})
@@ -35,14 +35,13 @@ public @interface ScopeReference {
 
     /**
      * Into which location one wants to place the reference? Translates to
-     * {@link FileUtil#getConfigFile(java.lang.String)}.
+     * {@link org.openide.filesystems.FileUtil#getConfigFile(java.lang.String)}.
      */
     String path();
 
     /**
-     * Identification of the scope this reference shall point to. Usually this
-     * is specified as {@link ScopeDescription} peer annotation, but in case one
-     * was to create references to scopes defined by someone else, one can
+     * Identification of the scope this reference shall point to. 
+     * In case one was to create references to scopes defined by someone else, one can
      * specify the id() here.
      */
     String id() default "";

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeReferences.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/ScopeReferences.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 /**
  * Allows registration of multiple {@link ScopeReference}s for a single type.
  *
- * @author Ralph Benjamin Ruijs <ralphbenjamin@netbeans.org>
+ * @author Ralph Benjamin Ruijs &lt;ralphbenjamin@netbeans.org&gt;
  */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.SOURCE)

--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/AttachType.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/AttachType.java
@@ -67,7 +67,7 @@ public abstract class AttachType {
     public abstract JComponent getCustomizer ();
 
     /**
-     * Return the implementation of {@link Controller} interface.<br/>
+     * Return the implementation of {@link Controller} interface.<br>
      * It's not desired to implement the {@link Controller} interface
      * by JComponent returned from {@link #getCustomizer()} method, because
      * of the clash of {@link Controller#isValid()} method with

--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/BreakpointType.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/BreakpointType.java
@@ -74,7 +74,7 @@ public abstract class BreakpointType {
     public abstract JComponent getCustomizer ();
 
     /**
-     * Return the implementation of {@link Controller} interface.<br/>
+     * Return the implementation of {@link Controller} interface.<br>
      * It's not desired to implement the {@link Controller} interface
      * by JComponent returned from {@link #getCustomizer()} method, because
      * of the clash of {@link Controller#isValid()} method with

--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/DebuggingView.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/DebuggingView.java
@@ -267,7 +267,7 @@ public final class DebuggingView {
          * By marking the implementation class with this annotation,
          * you automatically register that implementation for use by the debugging view.
          * The class must be public and have a public constructor which takes
-         * no arguments or takes {@link ContextProvider} as an argument.
+         * no arguments or takes {@link org.netbeans.spi.debugger.ContextProvider} as an argument.
          *
          * @author Martin Entlicher
          */

--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EditorContextDispatcher.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EditorContextDispatcher.java
@@ -79,7 +79,9 @@ import org.openide.util.WeakListeners;
  * <p>The EditorContextDispatcher provides convenient access to currently selected
  * elements and recently selected elements in the GUI.
  * 
- * <H2>Typical usage:</H2>
+ * <p>
+ * <strong>Typical usage:</strong>
+ * </p>
  * Attach a listener based on file MIME type. The usage of WeakListeners is
  * preferred, unless the listener can be removed explicitely.
  * <pre>

--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EngineComponentsProvider.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EngineComponentsProvider.java
@@ -132,7 +132,7 @@ public interface EngineComponentsProvider {
         /**
          * Create a component information about a {@link TopComponent},
          * which is opened by default.
-         * @param tcName The ID of the {@link TopComponent}
+         * @param tcId The ID of the {@link TopComponent}
          * @return A component information.
          */
         public static ComponentInfo create(String tcId) {
@@ -141,7 +141,7 @@ public interface EngineComponentsProvider {
         
         /**
          * Create a component information about a {@link TopComponent}.
-         * @param tcName The ID of the {@link TopComponent}
+         * @param tcId The ID of the {@link TopComponent}
          * @param opened <code>true</code> if the component should be opened,
          *               <code>false</code> otherwise.
          * @return A component information.
@@ -152,7 +152,7 @@ public interface EngineComponentsProvider {
         
         /**
          * Create a component information about a {@link TopComponent}.
-         * @param tcName The ID of the {@link TopComponent}
+         * @param tcId The ID of the {@link TopComponent}
          * @param opened <code>true</code> if the component should be opened,
          *               <code>false</code> otherwise.
          * @param minimized <code>true</code> if the component should be opened in a minimized state,

--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/MethodChooser.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/MethodChooser.java
@@ -82,7 +82,7 @@ import org.openide.windows.TopComponent;
  *
  * <p>Method chooser does not use any special highlighting for the background of the
  * area where the selection takes place. If it is required it can be done by attaching
- * instances of {@link Annotation} to the proper source file's lines. These annotation should
+ * instances of {@link org.openide.text.Annotation} to the proper source file's lines. These annotation should
  * be added before calling {@link #showUI} and removed after calling {@link #releaseUI}.
  *
  * <p>To display the method chooser's ui correctly, it is required to register

--- a/ide/spi.editor.hints/src/org/netbeans/spi/editor/hints/ErrorDescriptionFactory.java
+++ b/ide/spi.editor.hints/src/org/netbeans/spi/editor/hints/ErrorDescriptionFactory.java
@@ -321,8 +321,9 @@ public class ErrorDescriptionFactory {
      * @param description the text of the error/warning
      * @param details optional "more details" describing the error/warning
      * @param fixes a collection of {@link Fix}es that should be shown for the error/warning
-     * @param file for which the {@link ErrorDescription} should be created
-     * @param errorBounds start and end position of the error/warning
+     * @param doc for which the {@link ErrorDescription} should be created
+     * @param start start position of the error/warning
+     * @param end end position of the error/warning
      * @return a newly created {@link ErrorDescription} based on the given parameters
      * @since 1.39
      */

--- a/ide/spi.editor.hints/src/org/netbeans/spi/editor/hints/PositionRefresher.java
+++ b/ide/spi.editor.hints/src/org/netbeans/spi/editor/hints/PositionRefresher.java
@@ -36,7 +36,7 @@ import javax.swing.text.Document;
 public interface PositionRefresher {
 
     /**
-     * @param position current caret position inside document
+     * @param context current caret position inside document
      * @param doc current document
      * @return map of layer name to {@link ErrorDescription}s for current line
      */

--- a/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupPanelsPolicy.java
+++ b/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupPanelsPolicy.java
@@ -20,22 +20,22 @@
 package org.netbeans.spi.navigator;
 
 /** Interface for SPI clients who want to affect searching mechanism for
- * available NavigatorPanel implementations.<p></p>
+ * available NavigatorPanel implementations.<p>
  * 
  * Navigator infrastructure searches for instance of this interface in
  * <a href="@org-openide-util@/org/openide/util/Utilities.html#actionsGlobalContext()">Utilities.actionsGlobalContext()</a>
  * lookup and then applies found policy on set of available 
  * <a href="@TOP@/org/netbeans/spi/navigator/NavigatorPanel.html">NavigatorPanel</a>
- * implementations.<p></p>
+ * implementations.<p>
  * 
  * Note that multiple instances of this interface are not supported in
  * Utilities.actionsGlobalContext() lookup, one instance is chosen randomly
- * in this case.<p></p>
+ * in this case.<p>
  * 
  * Common Usage: 
  *  <ul>
  *      <li>Implement this interface, return kind of policy that suits you from
- *          <code>getPanelsPolicy()</code></li> method.
+ *          <code>getPanelsPolicy()</code> method.</li>
  *      <li>Put implementation instance into your TopComponent's subclass lookup,
  *          see <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup()">TopComponent.getLookup()</a>
  *          for details.</li>
@@ -53,7 +53,7 @@ public interface NavigatorLookupPanelsPolicy {
     /** Shows only NavigatorPanel implementations available through
      * <a href="@TOP@/org/netbeans/spi/navigator/NavigatorLookupHint.html">NavigatorLookupHint</a>
      * in Navigator window, hides NavigatorPanels
-     * available from DataObject of active Node.<br></br>
+     * available from DataObject of active Node.<br>
      * 
      * Use when you want to remove NavigatorPanels of active Node from Navigator
      * window. 

--- a/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorPanel.java
+++ b/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorPanel.java
@@ -86,18 +86,18 @@ public interface NavigatorPanel {
     
     
     /** Returns Lookup that will be integrated into Lookup of Navigator UI
-     * TopComponent. Allows clients to achieve several things:<p></p>
+     * TopComponent. Allows clients to achieve several things:<p>
      * 
-     * 1) Specify activated Node of Navigator UI TopComponent when this panel is active.<br></br>
+     * 1) Specify activated Node of Navigator UI TopComponent when this panel is active.<br>
      * If returned lookup contains Nodes, they will act as activated nodes of 
-     * Navigator UI TopComponent (navigator window).<br></br>
+     * Navigator UI TopComponent (navigator window).<br>
      * 
      * Method may return null, signalizing that default mechanism should be enabled.
      * Default mechanism chooses first Node from Utilities.actionsGlobalContext()
      * (current system-wide activated Node) as activated Node for Navigator's TopComponent.
-     * <p></p>
+     * <p>
      * 
-     * 2) Enable support for Toolbar or main menu global actions in NavigatorPanel.<br></br>
+     * 2) Enable support for Toolbar or main menu global actions in NavigatorPanel.<br>
      * ActionMap contained in this Lookup will be part of Utilities.actionsGlobalContext()
      * when Navigator UI TopComponent (navigator window) is active in the system. 
      *   

--- a/ide/spi.palette/src/org/netbeans/spi/palette/PaletteItemRegistration.java
+++ b/ide/spi.palette/src/org/netbeans/spi/palette/PaletteItemRegistration.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
     body = "<br>",
     name = "New Line",
     tooltip = "<br>")}</li>
- * <li><b>at class level</b> on class implementing {@link ActiveEditorDrop}.<br><br>
+ * <li><b>at class level</b> on class implementing {@link org.openide.text.ActiveEditorDrop}.<br><br>
  * {@code @PaletteItemRegistration(
     paletteid = "HTMLPalette",
     category = "HTML",
@@ -50,7 +50,7 @@ import java.lang.annotation.Target;
  * </li>
  * </ul>
  * 
- * @author Eric Barboni <skygo@netbeans.org>
+ * @author Eric Barboni &lt;skygo@netbeans.org&gt;
  * @since 1.40
  */
 @Retention(RetentionPolicy.SOURCE)

--- a/ide/spi.palette/src/org/netbeans/spi/palette/PaletteItemRegistrations.java
+++ b/ide/spi.palette/src/org/netbeans/spi/palette/PaletteItemRegistrations.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * May be uses to allow multiple
  * {@link PaletteItemRegistration PaletteItemRegistration} at one place.
  *
- * @author Eric Barboni <skygo@netbeans.org>
+ * @author Eric Barboni &lt;skygo@netbeans.org&gt;
  *
  * @since 1.40
  */

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/api/VCSFileProxy.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/api/VCSFileProxy.java
@@ -241,7 +241,7 @@ public final class VCSFileProxy implements Comparable<VCSFileProxy>{
     
     /**
      * Determines whether this file is a directory or not.
-     * <b>This method might block for a longer time and shouldn't be called in EDT.
+     * <b>This method might block for a longer time and shouldn't be called in EDT.</b>
      * 
      * @return <code>true</code> if this file exists and is a directory, otherwise <code>false</code>
      * @see File#isDirectory() 
@@ -260,7 +260,7 @@ public final class VCSFileProxy implements Comparable<VCSFileProxy>{
     
     /**
      * Determines whether this file is a normal file or not.
-     * <b>This method might block for a longer time and shouldn't be called in EDT.
+     * <b>This method might block for a longer time and shouldn't be called in EDT.</b>
      * 
      * @return <code>true</code> if this file is a normal file, otherwise <code>false</code>
      * @see File#isFile() 
@@ -279,7 +279,7 @@ public final class VCSFileProxy implements Comparable<VCSFileProxy>{
     
     /**
      * Determines whether this file is writable or not.
-     * <b>This method might block for a longer time and shouldn't be called in EDT.
+     * <b>This method might block for a longer time and shouldn't be called in EDT.</b>
      * 
      * @return <code>true</code> if this file is writable, otherwise <code>false</code>
      * @see File#canWrite() 
@@ -294,7 +294,7 @@ public final class VCSFileProxy implements Comparable<VCSFileProxy>{
     
     /**
      * Determines the last time this file was modified.
-     * <b>This method might block for a longer time and shouldn't be called in EDT.
+     * <b>This method might block for a longer time and shouldn't be called in EDT.</b>
      * 
      * @return A <code>long</code> value representing the time the file was
      *         last modified.
@@ -310,7 +310,7 @@ public final class VCSFileProxy implements Comparable<VCSFileProxy>{
     
     /**
      * Returns this files parent or <code>null</code> if this file doesn't have a parent.
-     * <b>This method might block for a longer time and shouldn't be called in EDT.
+     * <b>This method might block for a longer time and shouldn't be called in EDT.</b>
      * 
      * @return this files parent 
      * @see File#getParentFile() 
@@ -346,7 +346,7 @@ public final class VCSFileProxy implements Comparable<VCSFileProxy>{
     
     /**
      * Determines whether this file exists or not.
-     * <b>This method might block for a longer time and shouldn't be called in EDT.
+     * <b>This method might block for a longer time and shouldn't be called in EDT.</b>
      * 
      * @return <code>true</code> if this files exists, otherwise <code>false</code>
      * @see File#exists() 
@@ -361,7 +361,7 @@ public final class VCSFileProxy implements Comparable<VCSFileProxy>{
     
     /**
      * Returns an array of files located in a directory given by this file.
-     * <b>This method might block for a longer time and shouldn't be called in EDT.
+     * <b>This method might block for a longer time and shouldn't be called in EDT.</b>
      * 
      * @return an array of files located in a directory given by this file or 
      * <code>null</code> if this file isn't a directory or an error occurs.
@@ -387,7 +387,7 @@ public final class VCSFileProxy implements Comparable<VCSFileProxy>{
     /**
      * Returns the corresponding java.io.File in case this instance was created 
      * based either on java.io.File or a {@link FileObject} based on java.io.File.
-     * <b>This method might block for a longer time and shouldn't be called in EDT.
+     * <b>This method might block for a longer time and shouldn't be called in EDT.</b>
      * 
      * @return the corresponding java.io.File instance or <Code>null</code> if none
      * is available.
@@ -403,7 +403,7 @@ public final class VCSFileProxy implements Comparable<VCSFileProxy>{
     
     /**
      * Returns the corresponding FileObject.
-     * <b>This method might block for a longer time and shouldn't be called in EDT.
+     * <b>This method might block for a longer time and shouldn't be called in EDT.</b>
      * 
      * @return the corresponding FileObject or <code>null</code> if none available
      */
@@ -417,7 +417,7 @@ public final class VCSFileProxy implements Comparable<VCSFileProxy>{
 
     /**
      * Normalize a file path to a clean form.
-     * <b>This method might block for a longer time and shouldn't be called in EDT.
+     * <b>This method might block for a longer time and shouldn't be called in EDT.</b>
      * 
      * @return a VCSFileProxy with a normalized file path
      * @see FileUtil#normalizePath(java.lang.String) 

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/api/VersioningSupport.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/api/VersioningSupport.java
@@ -106,8 +106,8 @@ public final class VersioningSupport {
      * <p>Versioning systems <strong>must NOT</strong> scan a folder if this method returns true and should consider it as unversioned.</p>
      *
      * @param folder a folder to query
-     * @link http://www.netbeans.org/bugzilla/show_bug.cgi?id=105161
-     * @link http://www.netbeans.org/bugzilla/show_bug.cgi?id=195284
+     * @see <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=105161">#105161</a>
+     * @see <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=195284">#195284</a>
      * @return true if the given folder is excluded from version control, false otherwise
      */
     public static boolean isExcluded (VCSFileProxy folder) {

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSContext.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSContext.java
@@ -237,7 +237,7 @@ public final class VCSContext {
      * returns both of them and getRootFiles returns only the folder /var. 
      * This method is suitable for versioning systems that DO manage folders, such as Clearcase. 
      * 
-     * @return Set<VCSFileProxy> set of Files this context represents
+     * @return Set&lt;VCSFileProxy&gt; set of Files this context represents
      * @see #getRootFiles() 
      */ 
     public Set<VCSFileProxy> getFiles() {
@@ -251,7 +251,7 @@ public final class VCSContext {
      * returns both of them and getRootFiles returns only the folder /var. 
      * This method is suitable for versioning systems that do not manage folders, such as CVS. 
      * 
-     * @return Set<VCSFileProxy> set of Files this context represents
+     * @return Set&lt;VCSFileProxy&gt; set of Files this context represents
      * @see #getFiles() 
      */ 
     public Set<VCSFileProxy> getRootFiles() {
@@ -264,7 +264,7 @@ public final class VCSContext {
      * run on a project that contains a subproject should not touch any files in the subproject. Therefore the VCSContext for
      * the action would contain one root file (the project's root) and one exclusion (subproject root).
      * 
-     * @return Set<VCSFileProxy> set of files and folders that are not part of (are excluded from) this context. 
+     * @return Set&lt;VCSFileProxy&gt; set of files and folders that are not part of (are excluded from) this context. 
      * All their descendants are excluded too.
      */ 
     public Set<VCSFileProxy> getExclusions() {

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSHistoryProvider.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSHistoryProvider.java
@@ -63,24 +63,24 @@ public interface VCSHistoryProvider {
      * in places with limited space, but should be descriptive enough to identify the 
      * particular user or revision - e.g in case of Mercurial it would be something like:
      * 
-     * <table border="0" cellpadding="1" cellspacing="1">
-     *   <tr align="left">
+     * <table>
+     *   <caption>example of output for Mercurial</caption>
+     *   <tr>
      *     <th bgcolor="#CCCCFF"></th>
      *     <th bgcolor="#CCCCFF">short</th>
      *     <th bgcolor="#CCCCFF">long</th>
      *   </tr>
-     *   <tr align="left">
+     *   <tr>
      *     <td>revision</td>
      *     <td>210767</td>
      *     <td>210767:2dd617e260fc</td>
      *   </tr>
-     *   <tr align="left">
+     *   <tr>
      *     <td>user</td>
      *     <td>john.doe@netbeans.org</td>
      *     <td>John Doe &lt;john.doe@netbeans.org&gt;</td>
      *   </tr>
      * </table>
-     * </p> 
      */
     public static final class HistoryEntry {
         private Date dateTime;
@@ -236,7 +236,7 @@ public interface VCSHistoryProvider {
          * 
          * @throws IOException if it wasn't possible to set the message
          * 
-         * @throws IllegalStateException if no {@link #MessageEditProvider} was passed to this HistoryEntry instance
+         * @throws IllegalStateException if no {@link MessageEditProvider} was passed to this HistoryEntry instance
          */        
         public void setMessage(String message) throws IOException {
             if(!canEdit()) throw new IllegalStateException("This entry is read-only");
@@ -389,10 +389,10 @@ public interface VCSHistoryProvider {
     
     /**
      * Implement and pass over to {@link HistoryEntry} in case 
-     * {@link HistoryEntry#getRevisionFile(java.io.File, java.io.File)}
+     * {@link HistoryEntry#getRevisionFile(VCSFileProxy, VCSFileProxy)}
      * is expected to work.
      * 
-     * @see HistoryEntry#getRevisionFile(java.io.File, java.io.File) 
+     * @see HistoryEntry#getRevisionFile(VCSFileProxy, VCSFileProxy) 
      */    
     public interface RevisionProvider {
         void getRevisionFile(VCSFileProxy originalFile, VCSFileProxy revisionFile);

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSInterceptor.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSInterceptor.java
@@ -237,7 +237,7 @@ public abstract class VCSInterceptor {
      * Each series of beforeChange/afterChange events is preceded by at least one beforeEdit event.
      * 
      * @param file file that was just locked and is expected to change
-     * @throws IOEexceptin in case it wasn't possible to unlock the file.
+     * @throws IOException in case it wasn't possible to unlock the file.
      */
     public void beforeEdit(VCSFileProxy file) throws IOException {
     }

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSVisibilityQuery.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/spi/VCSVisibilityQuery.java
@@ -48,7 +48,7 @@ public abstract class VCSVisibilityQuery {
     /**
      * Notify a visibility change
      * 
-     * @param VCSFileProxy[] the files with a changed visibility
+     * @param file the files with a changed visibility
      * @since 1.10
      */
     protected final void fireVisibilityChanged(VCSFileProxy... file) {

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/spi/VersioningSystem.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/spi/VersioningSystem.java
@@ -41,7 +41,7 @@ import org.openide.awt.ActionRegistration;
  * - file system handler
  * - diff provider
  * 
- * Versioning system registration can be done via {@link VersioningSystem#Registration}. 
+ * Versioning system registration can be done via {@link VersioningSystem.Registration}. 
  *
  * @author Maros Sandor
  * @author Tomas Stupka
@@ -212,10 +212,10 @@ public abstract class VersioningSystem {
      * menu items and handle file visibility without having to activate the particular 
      * VCS System until an explicit user action or relevant file event occurs.
      * </p>
-     * See also {@link org.netbeans.modules.versioning.spi.VersioningSystem}.
+     * See also <a href="@org-netbeans-modules-versioning@/org/netbeans/modules/versioning/spi/VersioningSystem.html">org.netbeans.modules.versioning.spi.VersioningSystem</a>.
      * 
      * @author Tomas Stupka
-     * @see org.netbeans.modules.versioning.spi.VersioningSystem
+     * @see <a href="@org-netbeans-modules-versioning@/org/netbeans/modules/versioning/spi/VersioningSystem.html">org.netbeans.modules.versioning.spi.VersioningSystem</a>
      * @see org.openide.util.lookup.ServiceProvider
      */
     @Retention(RetentionPolicy.SOURCE)
@@ -230,10 +230,10 @@ public abstract class VersioningSystem {
          * Examples: CVS, Subversion, Mercurial, Teamware, SourceSafe, VSS, Clearcase, Local History.
          * </p>
          * <p>
-         * Corresponds with the property value {@link org.netbeans.modules.versioning.spi.VersioningSystem#PROP_DISPLAY_NAME} 
-         * when used together with {@link org.netbeans.modules.versioning.spi.VersioningSystem}.
+         * Corresponds with the property value <a href="@org-netbeans-modules-versioning@/org/netbeans/modules/versioning/spi/VersioningSystem.html#PROP_DISPLAY_NAME">org.netbeans.modules.versioning.spi.VersioningSystem#PROP_DISPLAY_NAME</a>
+         * when used together with <a href="@org-netbeans-modules-versioning@/org/netbeans/modules/versioning/spi/VersioningSystem.html">org.netbeans.modules.versioning.spi.VersioningSystem</a>.
          * </p>
-         * @see org.netbeans.modules.versioning.spi.VersioningSystem#PROP_DISPLAY_NAME
+         * @see <a href="@org-netbeans-modules-versioning@/org/netbeans/modules/versioning/spi/VersioningSystem.html#PROP_DISPLAY_NAME">org.netbeans.modules.versioning.spi.VersioningSystem#PROP_DISPLAY_NAME</a>
          */
         public String displayName();
         
@@ -242,12 +242,11 @@ public abstract class VersioningSystem {
          * Short name of the versioning system, it will be used as menu label and it should define a mnemonic key.
          * </p>
          * <p>
-         * Examples: &CVS, &Subversion, &Mercurial, &Teamware, &SourceSafe, &VSS, &Clearcase, Local &History.
+         * Examples: &amp;CVS, &amp;Subversion, &amp;Mercurial, &amp;Teamware, &amp;SourceSafe, &amp;VSS, &amp;Clearcase, Local &amp;History.
          * </p>
          * <p>
-         * Corresponds with the property value {@link org.netbeans.modules.versioning.spi.VersioningSystem#PROP_MENU_LABEL}.
-         * <p>
-         * @see org.netbeans.modules.versioning.spi.VersioningSystem#PROP_MENU_LABEL
+         * Corresponds with the property value <a href="@org-netbeans-modules-versioning@/org/netbeans/modules/versioning/spi/VersioningSystem.html#PROP_MENU_LABEL">org.netbeans.modules.versioning.spi.VersioningSystem#PROP_MENU_LABEL</a>.
+         * @see <a href="@org-netbeans-modules-versioning@/org/netbeans/modules/versioning/spi/VersioningSystem.html#PROP_MENU_LABEL">org.netbeans.modules.versioning.spi.VersioningSystem#PROP_MENU_LABEL</a>
          */
         public String menuLabel();
         
@@ -268,8 +267,8 @@ public abstract class VersioningSystem {
          *  <li>{".svn", "_svn"}</li>
          *  <li>{".hg"}</li>
          *  <li>{".git"}</li>
-         * <ul>
-         * @see #getTopmostManagedAncestor(org.netbeans.modules.versioning.fileproxy.api.VCSFileProxy)) 
+         * </ul>
+         * @see #getTopmostManagedAncestor(VCSFileProxy)
          */
         public String[] metadataFolderNames();
         
@@ -284,7 +283,6 @@ public abstract class VersioningSystem {
          * </ul>
          * returning "Subversion" would make the VCS infrastructure to look for actions under the {@link ActionReference} 
          * paths <code>"Versioning/Subversion/Actions/Unversioned"</code> and <code>"Versioning/Subversion/Actions/Global"</code>.
-         * </p>
          * <p>
          * You can also make use of the {@link ActionRegistration#menuText} and {@link ActionRegistration#popupText} 
          * attributes, in case you need a different text in the Main Menu item and a projects popup menu item.
@@ -295,29 +293,28 @@ public abstract class VersioningSystem {
          * <p>
          * Register a <code>VersioningSystem</code> with the <code>actionCategory</code> "Subversion".
          * </p>
-         * <p>
-         * <code> <pre>
-         * <samp>@</samp>VersioningSystem.Registration(actionsCategory="<b>Subversion</b>")
+         * <pre><code>
+         * &#64;VersioningSystem.Registration(actionsCategory="<b>Subversion</b>")
          * public class SubversionVCS extends VersioningSystem {
          *    ...
          * }
-         * </code></pre></p>
+         * </code></pre>
          * 
          * <p>
          * Register the <code>ImportAction</code> under the <code>ActionReference</code> path 
          * <code>"Versioning/Subversion/Actions/Unversioned"</code> and set <br> 
-         * <code>ActionRegistration.popupText</code> to <code>"Import into &Subversion Repository..."</code> and<br> 
-         * <code>ActionRegistration.menuText</code> to <code>"I&mport into Repository..."</code>.
+         * <code>ActionRegistration.popupText</code> to <code>"Import into &amp;Subversion Repository..."</code> and<br> 
+         * <code>ActionRegistration.menuText</code> to <code>"I&amp;mport into Repository..."</code>.
          * <br></p>
          * 
-         * <p><code> <pre>
-         * <samp>@</samp>ActionID(id = "org.netbeans.modules.subversion.ui.project.ImportAction", category = "Subversion")
-         * <samp>@</samp>ActionRegistration(displayName = "Import into Repository...", popupText="Import into &Subversion Repository...", menuText="I&mport into Repository...")
-         * <samp>@</samp>ActionReferences({ <samp>@</samp>ActionReference(path="<b>Versioning/Subversion/Actions/Unversioned</b>", position=1) })
+         * <pre><code>
+         * &#64;ActionID(id = "org.netbeans.modules.subversion.ui.project.ImportAction", category = "Subversion")
+         * &#64;ActionRegistration(displayName = "Import into Repository...", popupText="Import into &amp;Subversion Repository...", menuText="I&amp;mport into Repository...")
+         * &#64;ActionReferences({&#64;ActionReference(path="<b>Versioning/Subversion/Actions/Unversioned</b>", position=1) })
          * public final class ImportAction implements ActionListener {
          *   ...
          * }
-         * </code></pre></p>
+         * </code></pre>
          * <p>
          * The Main Menu for an unversioned project then will be:<br>
          * <code>Main Menu > Team > Subversion > Import into <u>R</u>epository...</code>

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/util/Utils.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/util/Utils.java
@@ -124,7 +124,7 @@ public final class Utils {
     /**
      * Notifies about visibility changes according to {@link VisibilityQueryImplementation}
      * 
-     * @param File[] the files with a changed visibility
+     * @param files the files with a changed visibility
      */
     public static void fireVisibilityChanged(File... files) {
         VCSFileProxy[] proxies = new VCSFileProxy[files.length];

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/util/VCSSystemProvider.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/util/VCSSystemProvider.java
@@ -32,8 +32,7 @@ import org.netbeans.spi.queries.CollocationQueryImplementation2;
 /**
  * Warning: VCS internal use only. Not to be implemented by clients.
  * 
- * Provides implementations for {@link org.netbeans.modules.versioning.spi.VersioningSystem} 
- * and {@link org.netbeans.modules.versioning.fileproxy.spi.VersioningSystem}
+ * Provides implementations for <a href="@org-netbeans-modules-versioning@/org/netbeans/modules/versioning/spi/VersioningSystem.html">org.netbeans.modules.versioning.spi.VersioningSystem</a>
  * 
  * @author Tomas Stupka
  */
@@ -59,8 +58,7 @@ public abstract class VCSSystemProvider {
     public abstract Collection<VersioningSystem> getVersioningSystems();
     
     /**
-     * Provides abstraction either over a {@link org.netbeans.modules.versioning.fileproxy.spi.VersioningSystem}
-     * or a {@link org.netbeans.modules.versioning.spi.VersioningSystem}
+     * Provides abstraction either over a <a href="@org-netbeans-modules-versioning@/org/netbeans/modules/versioning/spi/VersioningSystem.html">org.netbeans.modules.versioning.spi.VersioningSystem</a>
      * @param <S> 
      */
     public interface VersioningSystem<S> {

--- a/ide/versioning/src/org/netbeans/modules/versioning/spi/VCSContext.java
+++ b/ide/versioning/src/org/netbeans/modules/versioning/spi/VCSContext.java
@@ -116,7 +116,7 @@ public final class VCSContext {
      * returns both of them and getRootFiles returns only the folder /var. 
      * This method is suitable for versioning systems that DO manage folders, such as Clearcase. 
      * 
-     * @return Set<File> set of Files this context represents
+     * @return Set&lt;File&gt; set of Files this context represents
      * @see #getRootFiles() 
      * @since 1.6
      */ 
@@ -134,7 +134,7 @@ public final class VCSContext {
      * returns both of them and getRootFiles returns only the folder /var. 
      * This method is suitable for versioning systems that do not manage folders, such as CVS. 
      * 
-     * @return Set<File> set of Files this context represents
+     * @return Set&lt;File&gt; set of Files this context represents
      * @see #getFiles() 
      */ 
     public Set<File> getRootFiles() {
@@ -150,7 +150,7 @@ public final class VCSContext {
      * run on a project that contains a subproject should not touch any files in the subproject. Therefore the VCSContext for
      * the action would contain one root file (the project's root) and one exclusion (subproject root).
      * 
-     * @return Set<File> set of files and folders that are not part of (are excluded from) this context. 
+     * @return Set&lt;File&gt; set of files and folders that are not part of (are excluded from) this context. 
      * All their descendands are excluded too.
      */ 
     public Set<File> getExclusions() {

--- a/ide/versioning/src/org/netbeans/modules/versioning/spi/VCSHistoryProvider.java
+++ b/ide/versioning/src/org/netbeans/modules/versioning/spi/VCSHistoryProvider.java
@@ -68,25 +68,25 @@ public interface VCSHistoryProvider {
      * The <code>usernameShort</code> and <code>revisionShort</code> will be displayed 
      * in places with limited space, but should be descriptive enough to identify the 
      * particular user or revision - e.g in case of Mercurial it would be something like:
-     * 
-     * <table border="0" cellpadding="1" cellspacing="1">
-     *   <tr align="left">
+     * e border="0"
+     * <table>
+     *   <caption>example of output for Mercurial</caption>
+     *   <tr>
      *     <th bgcolor="#CCCCFF"></th>
      *     <th bgcolor="#CCCCFF">short</th>
      *     <th bgcolor="#CCCCFF">long</th>
      *   </tr>
-     *   <tr align="left">
+     *   <tr>
      *     <td>revision</td>
      *     <td>210767</td>
      *     <td>210767:2dd617e260fc</td>
      *   </tr>
-     *   <tr align="left">
+     *   <tr>
      *     <td>user</td>
      *     <td>john.doe@netbeans.org</td>
      *     <td>John Doe &lt;john.doe@netbeans.org&gt;</td>
      *   </tr>
      * </table>
-     * </p> 
      * 
      * @since 1.29
      */
@@ -253,7 +253,7 @@ public interface VCSHistoryProvider {
          * 
          * @throws IOException if it wasn't possible to set the message
          * 
-         * @throws IllegalStateException if no {@link #MessageEditProvider} was passed to this HistoryEntry instance
+         * @throws IllegalStateException if no {@link MessageEditProvider} was passed to this HistoryEntry instance
          *
          * @since 1.29
          */

--- a/ide/versioning/src/org/netbeans/modules/versioning/spi/VCSVisibilityQuery.java
+++ b/ide/versioning/src/org/netbeans/modules/versioning/spi/VCSVisibilityQuery.java
@@ -48,7 +48,7 @@ public abstract class VCSVisibilityQuery {
     /**
      * Notify a visibility change
      * 
-     * @param File[] the files with a changed visibility
+     * @param files the files with a changed visibility
      * @since 1.37
      */
     protected final void fireVisibilityChanged(File... files) {

--- a/ide/versioning/src/org/netbeans/modules/versioning/spi/VersioningSupport.java
+++ b/ide/versioning/src/org/netbeans/modules/versioning/spi/VersioningSupport.java
@@ -113,8 +113,8 @@ public final class VersioningSupport {
      * <p>Versioning systems <strong>must NOT</strong> scan a folder if this method returns true and should consider it as unversioned.</p>
      *
      * @param folder a folder to query
-     * @link http://www.netbeans.org/bugzilla/show_bug.cgi?id=105161
-     * @link http://www.netbeans.org/bugzilla/show_bug.cgi?id=195284
+     * @see <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=105161">#105161</a>
+     * @see <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=195284">#195284</a>
      * @since 1.25
      * @return true if the given folder is excluded from version control, false otherwise
      */

--- a/ide/versioning/src/org/netbeans/modules/versioning/spi/VersioningSystem.java
+++ b/ide/versioning/src/org/netbeans/modules/versioning/spi/VersioningSystem.java
@@ -45,7 +45,7 @@ import org.openide.awt.ActionRegistration;
  * Versioning system registration can be done in one of the following ways:
  * <ul>
  *  <li>via {@link org.openide.util.lookup.ServiceProvider}.</li>  
- *  <li>via {@link org.netbeans.modules.versioning.spi.VersioningSystem#Registration}. (recommended) </li> 
+ *  <li>via {@link org.netbeans.modules.versioning.spi.VersioningSystem.Registration}. (recommended) </li> 
  * </ul>
  *
  * @author Maros Sandor
@@ -62,7 +62,7 @@ public abstract class VersioningSystem {
 
     /**
      * Short name of the versioning system, it will be used as menu label and it should define a mnemonic key.
-     * Examples: &CVS, &Subversion, &Mercurial, &Teamware, &SourceSafe, &VSS, &Clearcase, Local &History.
+     * Examples: &amp;CVS, &amp;Subversion, &amp;Mercurial, &amp;Teamware, &amp;SourceSafe, &amp;VSS, &amp;Clearcase, Local &amp;History.
      * @see #getProperty(String) 
      * @see #putProperty(String, Object)  
      */
@@ -324,11 +324,11 @@ public abstract class VersioningSystem {
          * Short name of the versioning system, it will be used as menu label and it should define a mnemonic key.
          * </p>
          * <p>
-         * Examples: &CVS, &Subversion, &Mercurial, &Teamware, &SourceSafe, &VSS, &Clearcase, Local &History.
+         * Examples: &amp;CVS, &amp;Subversion, &amp;Mercurial, &amp;Teamware, &amp;SourceSafe, &amp;VSS, &amp;Clearcase, Local &amp;History.
          * </p>
          * <p>
          * Corresponds with the property value {@link org.netbeans.modules.versioning.spi.VersioningSystem#PROP_MENU_LABEL}.
-         * <p>
+         *
          * @see org.netbeans.modules.versioning.spi.VersioningSystem#PROP_MENU_LABEL
          */
         public String menuLabel();
@@ -350,7 +350,7 @@ public abstract class VersioningSystem {
          *  <li>{".svn", "_svn"}</li>
          *  <li>{".hg"}</li>
          *  <li>{".git"}</li>
-         * <ul>
+         * </ul>
          * @see #getTopmostManagedAncestor(java.io.File) 
          */
         public String[] metadataFolderNames();
@@ -366,7 +366,6 @@ public abstract class VersioningSystem {
          * </ul>
          * returning "Subversion" would make the VCS infrastructure to look for actions under the {@link ActionReference} 
          * paths <code>"Versioning/Subversion/Actions/Unversioned"</code> and <code>"Versioning/Subversion/Actions/Global"</code>.
-         * </p>
          * <p>
          * You can also make use of the {@link ActionRegistration#menuText} and {@link ActionRegistration#popupText} 
          * attributes, in case you need a different text in the Main Menu item and a projects popup menu item.
@@ -377,29 +376,29 @@ public abstract class VersioningSystem {
          * <p>
          * Register a <code>VersioningSystem</code> with the <code>actionCategory</code> "Subversion".
          * </p>
-         * <p>
-         * <code> <pre>
-         * <samp>@</samp>VersioningSystem.Registration(actionsCategory="<b>Subversion</b>")
+         * 
+         * <pre><code>
+         * &#64;VersioningSystem.Registration(actionsCategory="<b>Subversion</b>")
          * public class SubversionVCS extends VersioningSystem {
          *    ...
          * }
-         * </code></pre></p>
+         * </code></pre>
          * 
          * <p>
          * Register the <code>ImportAction</code> under the <code>ActionReference</code> path 
          * <code>"Versioning/Subversion/Actions/Unversioned"</code> and set <br> 
-         * <code>ActionRegistration.popupText</code> to <code>"Import into &Subversion Repository..."</code> and<br> 
-         * <code>ActionRegistration.menuText</code> to <code>"I&mport into Repository..."</code>.
+         * <code>ActionRegistration.popupText</code> to <code>"Import into &amp;Subversion Repository..."</code> and<br> 
+         * <code>ActionRegistration.menuText</code> to <code>"I&amp;mport into Repository..."</code>.
          * <br></p>
          * 
-         * <p><code> <pre>
-         * <samp>@</samp>ActionID(id = "org.netbeans.modules.subversion.ui.project.ImportAction", category = "Subversion")
-         * <samp>@</samp>ActionRegistration(displayName = "Import into Repository...", popupText="Import into &Subversion Repository...", menuText="I&mport into Repository...")
-         * <samp>@</samp>ActionReferences({ <samp>@</samp>ActionReference(path="<b>Versioning/Subversion/Actions/Unversioned</b>", position=1) })
+         * <pre><code>
+         * &#64;ActionID(id = "org.netbeans.modules.subversion.ui.project.ImportAction", category = "Subversion")
+         * &#64;ActionRegistration(displayName = "Import into Repository...", popupText="Import into &amp;Subversion Repository...", menuText="I&amp;mport into Repository...")
+         * &#64;ActionReferences({&#64;ActionReference(path="<b>Versioning/Subversion/Actions/Unversioned</b>", position=1) })
          * public final class ImportAction implements ActionListener {
          *   ...
          * }
-         * </code></pre></p>
+         * </code></pre>
          * <p>
          * The Main Menu for an unversioned project then will be:<br>
          * <code>Main Menu > Team > Subversion > Import into <u>R</u>epository...</code>

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/XDMModel.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/XDMModel.java
@@ -607,7 +607,7 @@ public class XDMModel {
     
     /**
      * This api deletes given node from a tree.
-     * @param node The node  to be deleted.
+     * @param n The node  to be deleted.
      * @return The parent node resulted by deletion of this node.
      */
     public synchronized List<Node> delete(Node n) {
@@ -621,8 +621,8 @@ public class XDMModel {
     
     /**
      * This api changes index of the given node.
-     * @param nodes The nodes to be moved.
-     * @param indexes the new indexes of the nodes.
+     * @param n The nodes to be moved.
+     * @param index the new indexe of the node.
      * @return The parent node resulted by deletion of this node.
      */
     public synchronized List<Node> reorder(Node parent, Node n, final int index) {
@@ -650,8 +650,9 @@ public class XDMModel {
     
     /**
      * This api changes indexes of the given node children.
-     * @param nodes The nodes to be moved.
-     * @param indexes the new indexes of the nodes.
+     * @param parent The parent node from which the nodes is to be reordered.
+     * @param permutation integer array with index represents current index and 
+     * value is final index after reordered
      * @return The parent node resulted by deletion of this node.
      */
     public synchronized List<Node> reorderChildren(Node parent, final int[] permutation) {
@@ -892,7 +893,7 @@ public class XDMModel {
     /**
      * This returns the statuc of the model.
      * @return the status.
-     * @see #Status
+     * @see Status
      */
     public synchronized Status getStatus() {
         return status;

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/DiffFinder.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/DiffFinder.java
@@ -41,7 +41,7 @@ import org.w3c.dom.NodeList;
 
 /**
  * This class is used by XDMTreeDiff (Both Sync and Undo/Redo) to find difference
- * between 2 XML and returns List<DiffEvent>
+ * between 2 XML and returns {@code List<DiffEvent>}
  *
  * @author Ayub Khan
  */

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/Difference.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/Difference.java
@@ -51,7 +51,7 @@ public abstract class Difference {
     }
     
     /**
-     * @returns info on removed node.
+     * @return info on removed node.
      */
     public NodeInfo getOldNodeInfo() {
         return oldNodeInfo;

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/NodeInfo.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/diff/NodeInfo.java
@@ -58,7 +58,7 @@ public class NodeInfo {
     }
     
     /**
-     * @returns position of removed in the original parent or
+     * @return position of removed in the original parent or
      *          position of the added in the final parent.
      */
     public int getPosition() {
@@ -73,7 +73,7 @@ public class NodeInfo {
     }
     
     /**
-     * @returns document the node is captured in (a node in xdm tree can be in
+     * @return document the node is captured in (a node in xdm tree can be in
      * multiple document roots).
      */
     public Document getDocument() {
@@ -81,14 +81,14 @@ public class NodeInfo {
     }
     
     /**
-     * @returns original path from parent to root.
+     * @return original path from parent to root.
      */
     public List<Node> getOriginalAncestors() {
         return Collections.unmodifiableList(ancestors1);
     }
     
     /**
-     * @returns new path to root from parent of added or removed node.
+     * @return new path to root from parent of added or removed node.
      * Note that this path need to be updated
      */
     public List<Node> getNewAncestors() {

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Document.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Document.java
@@ -463,7 +463,8 @@ public class Document extends NodeImpl implements Node, org.w3c.dom.Document {
      *   instantiate.
      * @return A new <code>Element</code> object with the following 
      *   attributes:
-     * <table border='1' cellpadding='3'>
+     * <table>
+     * <caption>Element object attributes</caption>
      * <tr>
      * <th>Attribute</th>
      * <th>Value</th>
@@ -549,7 +550,8 @@ public class Document extends NodeImpl implements Node, org.w3c.dom.Document {
      * @param qualifiedName The qualified name of the attribute to 
      *   instantiate.
      * @return A new <code>Attr</code> object with the following attributes:
-     * <table border='1' cellpadding='3'>
+     * <table>
+     * <caption>Attr object attributes</caption>
      * <tr>
      * <th>
      *   Attribute</th>

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Element.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Element.java
@@ -35,15 +35,15 @@ import org.w3c.dom.NodeList;
 
 /**
  * This class represents the XML Element.
- * An element is of the form <elmName[attributes]/> or <element[attributes]>[TextNode]</elmName>
+ * An element is of the form {@code <elmName[attributes]/>} or {@code <element[attributes]>[TextNode]</elmName>}
  * In terms of tokens attibute can have upto 12 tokens.
- * Start of start element token, <.
+ * Start of start element token, &lt;.
  * element namespace token, optional.
  * element namespace seperator, optional.
  * element name token.
  * whitespace token, optional.
  * end of start element token, > or />.
- * start of end element token, </.
+ * start of end element token, &lt;/.
  * element namespace token, optional.
  * element namespace seperator, optional.
  * element name token.
@@ -651,7 +651,7 @@ public class Element extends NodeImpl implements Node, org.w3c.dom.Element {
      * This api is provided for XDMModel purposes only.
      * @param newAttr The new attribute to be added.
      * @param index The index at which attribute to be added
-     * @throws IndexOutOfBoundsException if the index is out of range (index < 0 || index > size()).
+     * @throws IndexOutOfBoundsException if the index is out of range (index &lt; 0 || index &gt; size()).
      * @throws IllegalStateException if a newAttr has already been added to a tree.
      */
     public void addAttribute(Attribute newAttr, int index) {
@@ -666,7 +666,7 @@ public class Element extends NodeImpl implements Node, org.w3c.dom.Element {
      * This api is provided for XDMModel purposes only.
      * @param attr The new attribute to be moved.
      * @param index The index at which attribute to be moved
-     * @throws IndexOutOfBoundsException if the index is out of range (index < 0 || index > size()).
+     * @throws IndexOutOfBoundsException if the index is out of range (index &lt; 0 || index &gt; size()).
      * @throws IllegalStateException if a attr has not already been added to a tree.
      */
     public void reorderAttribute(Attribute attr, int index) {

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/NamedNodeMapImpl.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/NamedNodeMapImpl.java
@@ -44,7 +44,7 @@ public final class NamedNodeMapImpl implements NamedNodeMap {
     
     /**
      * Creates new NamedNodeMapImpl
-     * @param peer a map to delegate to. It must not be modified after this contructor call!
+     * @param attributes a map to delegate to. It must not be modified after this contructor call!
      */
     public NamedNodeMapImpl(List<Attribute> attributes) {
         if (attributes == null) throw new NullPointerException();

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Node.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Node.java
@@ -45,7 +45,7 @@ public interface Node extends org.w3c.dom.Node {
 	
 	/**
 	 * @return tree if node has already been added to the tree. 
-	 * @see #addedToTree()
+	 * @see #addedToTree(XDMModel)
 	 */
 	boolean isInTree();
 

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/NodeImpl.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/NodeImpl.java
@@ -353,7 +353,7 @@ public abstract class NodeImpl implements Node, Cloneable {
      * Adds the node newChild to the end of the list of children of this node.
      * Since the model is immutable checks if current node and node being added
      * are not already in tree.
-     * @param newChild - The node to add.
+     * @param node - The node to add.
      * @return The node added.
      */
     public Node appendChild(org.w3c.dom.Node node) {
@@ -372,8 +372,8 @@ public abstract class NodeImpl implements Node, Cloneable {
      * Repalces the node oldNode with newNode.
      * Since the model is immutable checks if current node
      * and the node being put, are not already in tree.
-     * @param newChild - The new node to put in the child list.
-     * @param oldChild - The node being replaced in the list.
+     * @param newNode - The new node to put in the child list.
+     * @param oldNode - The node being replaced in the list.
      * @return The node replaced.
      */
     public Node replaceChild(org.w3c.dom.Node newNode, org.w3c.dom.Node oldNode) {

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Text.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Text.java
@@ -137,7 +137,7 @@ public class Text extends NodeImpl implements Node, org.w3c.dom.Text {
      * "ent" contains an <code>Element</code> node which cannot be removed.
      * @param content The content of the replacing <code>Text</code> node.
      * @return The <code>Text</code> node created with the specified content.
-     * @exception DOMException
+     * @exception org.w3c.dom.DOMException
      *   NO_MODIFICATION_ALLOWED_ERR: Raised if one of the <code>Text</code> 
      *   nodes being replaced is readonly.
      * @since DOM Level 3
@@ -159,7 +159,7 @@ public class Text extends NodeImpl implements Node, org.w3c.dom.Text {
      * @param offset The 16-bit unit offset at which to split, starting from 
      *   <code>0</code>.
      * @return The new node, of the same type as this node.
-     * @exception DOMException
+     * @exception org.w3c.dom.DOMException
      *   INDEX_SIZE_ERR: Raised if the specified offset is negative or greater 
      *   than the number of 16-bit units in <code>data</code>.
      *   <br>NO_MODIFICATION_ALLOWED_ERR: Raised if this node is readonly.
@@ -190,7 +190,7 @@ public class Text extends NodeImpl implements Node, org.w3c.dom.Text {
      * not fit into a single <code>DOMString</code>. In such cases, the user 
      * may call <code>substringData</code> to retrieve the data in 
      * appropriately sized pieces.
-     * @exception DOMException
+     * @exception org.w3c.dom.DOMException
      *   NO_MODIFICATION_ALLOWED_ERR: Raised when the node is readonly.
      */
     public void setData(String text) {
@@ -207,7 +207,7 @@ public class Text extends NodeImpl implements Node, org.w3c.dom.Text {
      * success, <code>data</code> provides access to the concatenation of 
      * <code>data</code> and the <code>DOMString</code> specified.
      * @param arg The <code>DOMString</code> to append.
-     * @exception DOMException
+     * @exception org.w3c.dom.DOMException
      *   NO_MODIFICATION_ALLOWED_ERR: Raised if this node is readonly.
      */
     public void appendData(String arg) {
@@ -226,7 +226,7 @@ public class Text extends NodeImpl implements Node, org.w3c.dom.Text {
      *    method invocation).
      * @param arg The <code>DOMString</code> with which the range must be 
      *   replaced.
-     * @exception DOMException
+     * @exception org.w3c.dom.DOMException
      *   INDEX_SIZE_ERR: Raised if the specified <code>offset</code> is 
      *   negative or greater than the number of 16-bit units in 
      *   <code>data</code>, or if the specified <code>count</code> is 
@@ -241,7 +241,7 @@ public class Text extends NodeImpl implements Node, org.w3c.dom.Text {
      * Insert a string at the specified 16-bit unit offset.
      * @param offset The character offset at which to insert.
      * @param arg The <code>DOMString</code> to insert.
-     * @exception DOMException
+     * @exception org.w3c.dom.DOMException
      *   INDEX_SIZE_ERR: Raised if the specified <code>offset</code> is 
      *   negative or greater than the number of 16-bit units in 
      *   <code>data</code>.
@@ -258,7 +258,7 @@ public class Text extends NodeImpl implements Node, org.w3c.dom.Text {
      * @return The specified substring. If the sum of <code>offset</code> and 
      *   <code>count</code> exceeds the <code>length</code>, then all 16-bit 
      *   units to the end of the data are returned.
-     * @exception DOMException
+     * @exception org.w3c.dom.DOMException
      *   INDEX_SIZE_ERR: Raised if the specified <code>offset</code> is 
      *   negative or greater than the number of 16-bit units in 
      *   <code>data</code>, or if the specified <code>count</code> is 
@@ -279,7 +279,7 @@ public class Text extends NodeImpl implements Node, org.w3c.dom.Text {
      * not fit into a single <code>DOMString</code>. In such cases, the user 
      * may call <code>substringData</code> to retrieve the data in 
      * appropriately sized pieces.
-     * @exception DOMException
+     * @exception org.w3c.dom.DOMException
      *   DOMSTRING_SIZE_ERR: Raised when it would return more characters than 
      *   fit in a <code>DOMString</code> variable on the implementation 
      *   platform.
@@ -301,7 +301,7 @@ public class Text extends NodeImpl implements Node, org.w3c.dom.Text {
      *   <code>offset</code> and <code>count</code> exceeds 
      *   <code>length</code> then all 16-bit units from <code>offset</code> 
      *   to the end of the data are deleted.
-     * @exception DOMException
+     * @exception org.w3c.dom.DOMException
      *   INDEX_SIZE_ERR: Raised if the specified <code>offset</code> is 
      *   negative or greater than the number of 16-bit units in 
      *   <code>data</code>, or if the specified <code>count</code> is 

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/XPathFinder.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/visitor/XPathFinder.java
@@ -101,7 +101,7 @@ public class XPathFinder extends ChildVisitor {
     /**
      * @return the nodes correspond to specified xpath.
      * @param root context in which to find the node.
-     * @param xpath location path for the attribute or element.
+     * @param xpathExpression location path for the attribute or element.
      */
     public List<Node> findNodes(Document root, String xpathExpression) {
         if (root == null || root.getDocumentElement() == null) {

--- a/java/java.platform.ui/src/org/netbeans/spi/java/platform/CustomPlatformInstall.java
+++ b/java/java.platform.ui/src/org/netbeans/spi/java/platform/CustomPlatformInstall.java
@@ -24,7 +24,7 @@ import org.openide.WizardDescriptor;
 
 /**
  * Defines an API for registering custom Java platform installer. The installer
- * is responsible for instantiation of {@link JavaPlatform} through the provided
+ * is responsible for instantiation of {@link org.netbeans.api.java.platform.JavaPlatform} through the provided
  * TemplateWizard.Iterator. If your installer selects the platform on the local disk you
  * probably don't want to use this class, the {@link PlatformInstall} class
  * creates an platform chooser for you. You want to use this class if the
@@ -38,7 +38,7 @@ import org.openide.WizardDescriptor;
 public abstract class CustomPlatformInstall extends GeneralPlatformInstall {
     
     /**
-     * Returns the {@link WizardDescriptor#InstantiatingIterator} used to install
+     * Returns the {@link WizardDescriptor.InstantiatingIterator} used to install
      * the platform. The platform definition file returned by the instantiate method
      * should be created in the Services/Platforms/org-netbeans-api-java-Platform
      * folder on the system filesystem.

--- a/java/java.project/src/org/netbeans/spi/java/project/classpath/ProjectModulesModifier.java
+++ b/java/java.project/src/org/netbeans/spi/java/project/classpath/ProjectModulesModifier.java
@@ -32,10 +32,10 @@ import org.openide.filesystems.FileObject;
  * it is not sufficient just to add artifacts on classpath - modular projects cannot access unnamed module,
  * so the project would not see such classes/resources during compilation. Even if added to the module path,
  * a directive needs to be added so that compiler and runtime honour the dependency.
- * <p/>
+ * <p>
  * This SPI allows the project implementation for modular project to diverge additions to a more suitable classpath,
  * and to update the module information.
- * <p/>
+ * <p>
  * Project-specific implementation should be placed in <b>project lookup</b>. If not present, default implementation
  * will handle the requests, so that artifacts, libraries and projects will land on {@link JavaClassPathConstants#MODULE_COMPILE_PATH}
  * or {@link JavaClassPathConstants#MODULE_EXECUTE_PATH} respectively. The default implementation does nothing for projects (sources), which do
@@ -52,7 +52,7 @@ public interface ProjectModulesModifier {
      * diverge the request to some other classpath type.
      * If the project is not modular, or modular project can use artifacts from the original classpath
      * type, the value of {@code null} should be returned. If {@code null} is returned,
-     * the {@link #addRequiredModules} or {@link #removeRequiredModuels} should not be called.
+     * the {@link #addRequiredModules} or {@link #removeRequiredModules} should not be called.
      * 
      * @param classPathType original classpath type
      * @param projectArtifact source, directory which will determine the proper {@code module-info.java}

--- a/java/java.project/src/org/netbeans/spi/java/project/support/JavadocAndSourceRootDetection.java
+++ b/java/java.project/src/org/netbeans/spi/java/project/support/JavadocAndSourceRootDetection.java
@@ -65,7 +65,7 @@ public class JavadocAndSourceRootDetection {
     /**
      * Finds Javadoc root inside of given folder.
      *
-     * @param fo base folder to start search in; routine will traverse 5 folders
+     * @param baseFolder base folder to start search in; routine will traverse 5 folders
      *  deep before giving up; cannot be null; must be folder
      * @return found Javadoc root or null if none found
      */

--- a/java/java.source.base/src/org/netbeans/api/java/source/ClassIndex.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ClassIndex.java
@@ -329,8 +329,8 @@ public final class ClassIndex {
     /**
      * Returns a set of {@link ElementHandle}s containing reference(s) to given type element.
      * @param element the {@link ElementHandle} of a {@link TypeElement} for which usages should be found
-     * @param searchKind type of reference, {@see SearchKind}
-     * @param scope to search in {@see SearchScope}
+     * @param searchKind type of reference, {@link SearchKind}
+     * @param scope to search in {@link SearchScope}
      * @return set of {@link ElementHandle}s containing the reference(s)
      * It may return null when the caller is a CancellableTask&lt;CompilationInfo&gt; and is cancelled
      * inside call of this method.
@@ -355,8 +355,8 @@ public final class ClassIndex {
     /**
      * Returns a set of {@link ElementHandle}s containing reference(s) to given package element.
      * @param element the {@link ElementHandle} of a {@link PackageElement} for which usages should be found
-     * @param searchKind type of reference, {@see SearchKind}
-     * @param scope to search in {@see SearchScope}
+     * @param searchKind type of reference, {@link SearchKind}
+     * @param scope to search in {@link SearchScope}
      * @return set of {@link ElementHandle}s containing the reference(s)
      * It may return null when the caller is a CancellableTask&lt;CompilationInfo&gt; and is cancelled
      * inside call of this method.
@@ -382,8 +382,8 @@ public final class ClassIndex {
     /**
      * Returns a set of source files containing reference(s) to given type element.
      * @param element the {@link ElementHandle} of a {@link TypeElement} for which usages should be found
-     * @param searchKind type of reference, {@see SearchKind}
-     * @param scope to search in {@see SearchScope}
+     * @param searchKind type of reference, {@link SearchKind}
+     * @param scope to search in {@link SearchScope}
      * @return set of {@link FileObject}s containing the reference(s)
      * It may return null when the caller is a CancellableTask&lt;CompilationInfo&gt; and is cancelled
      * inside call of this method.
@@ -408,9 +408,9 @@ public final class ClassIndex {
     /**
      * Returns a set of source or binary files containing reference(s) to given type element.
      * @param element the {@link ElementHandle} of a {@link TypeElement} for which usages should be found
-     * @param searchKind type of reference, {@see SearchKind}
-     * @param scope to search in {@see SearchScope}
-     * @param resourceType to return resource in, {@see ResourceType}. The {@link ResourceType#BINARY}
+     * @param searchKind type of reference, {@link SearchKind}
+     * @param scope to search in {@link SearchScope}
+     * @param resourceType to return resource in, {@link ResourceType}. The {@link ResourceType#BINARY}
      * produces no result for source roots. For binary roots it does not do SourceForBinaryQuery translation and
      * returns class files. The {@link ResourceType#SOURCE} for binary roots does SourceForBinaryQuery translation
      * and returns corresponding java files or no result when there is no SourceForBinaryQuery configured for given binary root.
@@ -454,8 +454,8 @@ public final class ClassIndex {
     /**
      * Returns a set of source files containing reference(s) to given package element.
      * @param element the {@link ElementHandle} of a {@link PackageElement} for which usages should be found
-     * @param searchKind type of reference, {@see SearchKind}
-     * @param scope to search in {@see SearchScope}
+     * @param searchKind type of reference, {@link SearchKind}
+     * @param scope to search in {@link SearchScope}
      * @return set of {@link FileObject}s containing the reference(s)
      * It may return null when the caller is a CancellableTask&lt;CompilationInfo&gt; and is cancelled
      * inside call of this method.
@@ -518,8 +518,8 @@ public final class ClassIndex {
      * Returns {@link ElementHandle}s for all declared types in given classpath corresponding to the name.
      * @param name case sensitive prefix, case insensitive prefix, exact simple name,
      * camel case or regular expression depending on the kind parameter.
-     * @param kind of the name {@see NameKind}
-     * @param scope to search in {@see SearchScope}
+     * @param kind of the name {@link NameKind}
+     * @param scope to search in {@link SearchScope}
      * @return set of all matched declared types
      * It may return null when the caller is a CancellableTask&lt;CompilationInfo&gt; and is cancelled
      * inside call of this method.
@@ -535,8 +535,8 @@ public final class ClassIndex {
      * Returns {@link ElementHandle}s for all declared modules in given classpath corresponding to the name.
      * @param name case sensitive prefix, case insensitive prefix, exact simple name,
      * camel case or regular expression depending on the kind parameter.
-     * @param kind of the name {@see NameKind}
-     * @param scope to search in {@see SearchScope}
+     * @param kind of the name {@link NameKind}
+     * @param scope to search in {@link SearchScope}
      * @return set of all matched modules
      * It may return null when the caller is a CancellableTask&lt;CompilationInfo&gt; and is cancelled
      * inside call of this method.
@@ -592,8 +592,8 @@ public final class ClassIndex {
      * Returns descriptions of symbols found on the given classpath and matching the additional criteria.
      * @param name case sensitive prefix, case insensitive prefix, exact simple name,
      * camel case or regular expression depending on the kind parameter.
-     * @param kind of the name {@see NameKind}
-     * @param scope to search in {@see SearchScope}
+     * @param kind of the name {@link NameKind}
+     * @param scope to search in {@link SearchScope}
      * @return iterable of {@link Symbols} describing found symbols matching the specified criteria.
      * It may return null when the caller is a CancellableTask&lt;CompilationInfo&gt; and is cancelled
      * inside call of this method.
@@ -675,7 +675,7 @@ public final class ClassIndex {
      * @param prefix of the package name
      * @param directOnly if true treats the packages as folders and returns only
      * the nearest component of the package.
-     * @param scope to search in {@see SearchScope}
+     * @param scope to search in {@link SearchScope}
      * @return set of all matched package names
      * It may return null when the caller is a CancellableTask&lt;CompilationInfo&gt; and is cancelled
      * inside call of this method.

--- a/java/java.source.base/src/org/netbeans/api/java/source/ClassIndexListener.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ClassIndexListener.java
@@ -24,7 +24,7 @@ import java.util.EventListener;
 /**
  * Listener for changes in {@link ClassIndex}.
 * <P>
-* When attached to a {ClassIndex} it listens for addition,
+* When attached to a {@link ClassIndex} it listens for addition,
 * removal and modification of declared types.
 * <P>
 *
@@ -55,7 +55,7 @@ public interface ClassIndexListener extends EventListener {
     
     /**
      * Called when new roots are added
-     * into the {@link ClassPath} for which the {@link ClassIndex}
+     * into the {@link org.netbeans.api.java.classpath.ClassPath} for which the {@link ClassIndex}
      * was created.
      * @param event specifying the added roots
      */
@@ -63,7 +63,7 @@ public interface ClassIndexListener extends EventListener {
     
     /**
      * Called when root are removed
-     * from the {@link ClassPath} for which the {@link ClassIndex}
+     * from the {@link org.netbeans.api.java.classpath.ClassPath} for which the {@link ClassIndex}
      * was created.
      * @param event specifying the removed roots
      */

--- a/java/java.source.base/src/org/netbeans/api/java/source/ClasspathInfo.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ClasspathInfo.java
@@ -260,8 +260,8 @@ public final class ClasspathInfo {
      * <div class="nonnormative">
      * <p>
      * It uses the {@link Document#StreamDescriptionProperty} to obtain the
-     * {@link DataObject} for the {@link Document} and creates a {@link ClasspathInfo}
-     * for the primary file of the {@link DataObject}
+     * <a href="@org-openide-loaders@/org/openide/loaders/DataObject.html">DataObject</a> for the {@link Document} and creates a {@link ClasspathInfo}
+     * for the primary file of the <a href="@org-openide-loaders@/org/openide/loaders/DataObject.html">DataObject</a>
      * </p>
      * </div>
      * @param doc a document for which the {@link ClasspathInfo} should be created

--- a/java/java.source.base/src/org/netbeans/api/java/source/CodeStyle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/CodeStyle.java
@@ -258,7 +258,7 @@ public final class CodeStyle {
      * Determines whether the dependencies between members must be used when sorting.
      * It returns true only if some sorting option is available (default: off) and the dependency
      * inspection is enabled (default: true).
-     * <p/>
+     * <p>
      * Changing member order without looking for dependencies may result in incorrect code. A field
      * must be declared textually first, and only then it can be referenced by simple name from field
      * initializers and class/instance initializers - see defect #249199.

--- a/java/java.source.base/src/org/netbeans/api/java/source/CodeStyleUtils.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/CodeStyleUtils.java
@@ -25,7 +25,7 @@ import org.netbeans.lib.editor.util.CharSequenceUtilities;
 
 /**
  *
- * @author Ralph Benjamin Ruijs <ralphbenjamin@netbeans.org>
+ * @author Ralph Benjamin Ruijs &lt;ralphbenjamin@netbeans.org&gt;
  * @since 0.123
  */
 public final class CodeStyleUtils {

--- a/java/java.source.base/src/org/netbeans/api/java/source/Comment.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/Comment.java
@@ -87,7 +87,6 @@ public final class Comment {
     /**
      * Define a comment, using specified style.
      * @param style the style of comment
-     * @param indent indentation of comment
      * @param text textual content of comment. With or without proper escaping
      * @return new comment
      */

--- a/java/java.source.base/src/org/netbeans/api/java/source/CompilationController.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/CompilationController.java
@@ -51,7 +51,7 @@ public class CompilationController extends CompilationInfo {
 
     /**
      * Returns an instance of the {@link CompilationController} for
-     * given {@link Parser.Result} if it is a result
+     * given {@link org.netbeans.modules.parsing.spi.Parser.Result} if it is a result
      * of a java parser.
      * @param result for which the {@link CompilationController} should be
      * returned.
@@ -74,10 +74,12 @@ public class CompilationController extends CompilationInfo {
     /** Moves the state to required phase. If given state was already reached 
      * the state is not changed. The method will throw exception if a state is 
      * illegal required. Acceptable parameters for thid method are <BR>
-     * <LI>{@link org.netbeans.api.java.source.JavaSource.Phase.PARSED}
-     * <LI>{@link org.netbeans.api.java.source.JavaSource.Phase.ELEMENTS_RESOLVED}
-     * <LI>{@link org.netbeans.api.java.source.JavaSource.Phase.RESOLVED}
-     * <LI>{@link org.netbeans.api.java.source.JavaSource.Phase.UP_TO_DATE}   
+     * <UL>
+     * <LI>{@link org.netbeans.api.java.source.JavaSource.Phase#PARSED}
+     * <LI>{@link org.netbeans.api.java.source.JavaSource.Phase#ELEMENTS_RESOLVED}
+     * <LI>{@link org.netbeans.api.java.source.JavaSource.Phase#RESOLVED}
+     * <LI>{@link org.netbeans.api.java.source.JavaSource.Phase#UP_TO_DATE}   
+     * </UL>
      * @param phase The required phase
      * @return the reached state
      * @throws IllegalArgumentException in case that given state can not be 

--- a/java/java.source.base/src/org/netbeans/api/java/source/CompilationInfo.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/CompilationInfo.java
@@ -98,7 +98,7 @@ public class CompilationInfo {
 
     /**
      * Returns an instance of the {@link CompilationInfo} for
-     * given {@link Parser.Result} if it is a result
+     * given {@link org.netbeans.modules.parsing.spi.Parser.Result} if it is a result
      * of a java parser.
      * @param result for which the {@link CompilationInfo} should be
      * returned.
@@ -206,9 +206,9 @@ public class CompilationInfo {
     
     /**
      * Returns all top level elements defined in file for which the {@link CompilationInfo}
-     * was created. The {@link CompilationInfo} has to be in phase {@link JavaSource#Phase#ELEMENTS_RESOLVED}.
+     * was created. The {@link CompilationInfo} has to be in phase {@link JavaSource.Phase#ELEMENTS_RESOLVED}.
      * @return list of top level elements, it may return null when this {@link CompilationInfo} is not
-     * in phase {@link JavaSource#Phase#ELEMENTS_RESOLVED} or higher.
+     * in phase {@link JavaSource.Phase#ELEMENTS_RESOLVED} or higher.
      * @throws IllegalStateException is thrown when the {@link JavaSource} was created with no files
      * @since 0.14
      */
@@ -363,8 +363,8 @@ public class CompilationInfo {
             
     /**
      * Returns {@link Document} of this {@link CompilationInfoImpl}
-     * @return Document or null when the {@link DataObject} doesn't
-     * exist or has no {@link EditorCookie}.
+     * @return Document or null when the <a href="@org-openide-loaders@/org/openide/loaders/DataObject.html">DataObject</a> doesn't
+     * exist or has no <a href="@org-openide-text@/org/openide/cookies/EditorCookie.html">EditorCookie</a>.
      * @throws java.io.IOException
      */
     public @CheckForNull Document getDocument() throws IOException { //XXX cleanup: IOException is no longer required? Used by PositionEstimator, DiffFacility
@@ -431,7 +431,7 @@ public class CompilationInfo {
         return impl.getCachedValue(key);
     }
 
-    /**Put a value into a cache under the given key. The {@link #clearPolicy} parameter specifies the latest time the
+    /**Put a value into a cache under the given key. The {@code clearPolicy} parameter specifies the latest time the
      * references to the key and value should be cleared. The infrastructure is free to clear the references at any earlier time.
      * The clients should not depend on this cache for correctness, only to improve performance.
      *

--- a/java/java.source.base/src/org/netbeans/api/java/source/DocTreePathHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/DocTreePathHandle.java
@@ -47,7 +47,7 @@ import org.openide.util.Parameters;
 /**
  * Represents a handle for {@link TreePath} which can be kept and later resolved
  * by another javac. The Javac {@link Element}s are valid only in the single
- * {@link javax.tools.CompilationTask} or single run of the
+ * {@link javax.tools.JavaCompiler.CompilationTask} or single run of the
  * {@link org.netbeans.api.java.source.CancellableTask}. If the client needs to
  * keep a reference to the {@link TreePath} and use it in the other
  * CancellableTask he has to serialize it into the {@link TreePathHandle}.
@@ -55,7 +55,7 @@ import org.openide.util.Parameters;
  * <p>
  * Typical usage of TreePathHandle enclElIsCorrespondingEl:
  * </p>
- * <pre>
+ * <pre>{@code
  * final TreePathHandle[] tpHandle = new TreePathHandle[1];
  * javaSource.runCompileControlTask(new CancellableTask<CompilationController>() {
  *     public void run(CompilationController compilationController) {
@@ -73,7 +73,7 @@ import org.openide.util.Parameters;
  *         ....
  *    }
  * },priority);
- * </pre>
+ * }</pre>
  * </div>
  *
  *
@@ -97,10 +97,10 @@ public final class DocTreePathHandle {
      * Resolves an {@link DocTreePath} from the {@link DocTreePathHandle}.
      *
      * @param compilationInfo representing the
-     * {@link javax.tools.CompilationTask}
+     * {@link javax.tools.JavaCompiler.CompilationTask}
      * @return resolved subclass of {@link DocTreePath} or null if the doctree does
      * not exist on the classpath/sourcepath of
-     * {@link javax.tools.CompilationTask}.
+     * {@link javax.tools.JavaCompiler.CompilationTask}.
      * @throws IllegalArgumentException when this {@link DocTreePathHandle} is not
      * created for a source represented by the compilationInfo.
      */
@@ -140,10 +140,10 @@ public final class DocTreePathHandle {
     }
 
     /**
-     * Returns the {@link DocTree.Kind} of this DocTreePathHandle, it returns the kind
-     * of the {@link DocTree} from which the handle was created.
+     * Returns the {@link com.sun.source.doctree.DocTree.Kind} of this DocTreePathHandle, it returns the kind
+     * of the {@link com.sun.source.doctree.DocTree} from which the handle was created.
      *
-     * @return {@link Tree.Kind}
+     * @return {@link com.sun.source.doctree.DocTree.Kind}
      */
     public DocTree.Kind getKind() {
         return this.delegate.getKind();
@@ -247,10 +247,10 @@ public final class DocTreePathHandle {
          * Resolves an {@link TreePath} from the {@link TreePathHandle}.
          *
          * @param javac representing the
-         * {@link javax.tools.CompilationTask}
+         * {@link javax.tools.JavaCompiler.CompilationTask}
          * @return resolved subclass of {@link Element} or null if the element
          * does not exist on the classpath/sourcepath of
-         * {@link javax.tools.CompilationTask}.
+         * {@link javax.tools.JavaCompiler.CompilationTask}.
          * @throws IllegalArgumentException when this {@link TreePathHandle} is
          * not created for a source represented by the compilationInfo.
          */

--- a/java/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
@@ -53,7 +53,7 @@ import org.openide.util.WeakSet;
 /**
  * Represents a handle for {@link Element} which can be kept and later resolved
  * by another javac. The javac {@link Element}s are valid only in a single
- * {@link javax.tools.CompilationTask} or a single run of a
+ * {@link javax.tools.JavaCompiler.CompilationTask} or a single run of a
  * {@link CancellableTask}. A client needing to
  * keep a reference to an {@link Element} and use it in another {@link CancellableTask}
  * must serialize it into an {@link ElementHandle}.
@@ -106,10 +106,10 @@ public final class ElementHandle<T extends Element> {
     
     /**
      * Resolves an {@link Element} from the {@link ElementHandle}.
-     * @param compilationInfo representing the {@link javax.tools.CompilationTask}
+     * @param compilationInfo representing the {@link javax.tools.JavaCompiler.CompilationTask}
      * in which the {@link Element} should be resolved.
      * @return resolved subclass of {@link Element} or null if the elment does not exist on
-     * the classpath/sourcepath of {@link javax.tools.CompilationTask}.
+     * the classpath/sourcepath of {@link javax.tools.JavaCompiler.CompilationTask}.
      */
     @SuppressWarnings ("unchecked")     // NOI18N
     public @CheckForNull T resolve (@NonNull final CompilationInfo compilationInfo) {
@@ -331,7 +331,7 @@ public final class ElementHandle<T extends Element> {
      * {@link ElementHandle}. When the {@link ElementHandle} doesn't represent
      * a {@link TypeElement} it throws a {@link IllegalStateException}
      * @return the qualified name
-     * @throws an {@link IllegalStateException} when this {@link ElementHandle} 
+     * @throws IllegalStateException when this {@link ElementHandle} 
      * isn't created for the {@link TypeElement}.
      */
     public @NonNull String getBinaryName () throws IllegalStateException {
@@ -352,7 +352,7 @@ public final class ElementHandle<T extends Element> {
      * {@link ElementHandle}. When the {@link ElementHandle} doesn't represent
      * a {@link TypeElement} it throws a {@link IllegalStateException}
      * @return the qualified name
-     * @throws an {@link IllegalStateException} when this {@link ElementHandle} 
+     * @throws IllegalStateException when this {@link ElementHandle} 
      * isn't creatred for the {@link TypeElement}.
      */
     public @NonNull String getQualifiedName () throws IllegalStateException {
@@ -557,7 +557,7 @@ public final class ElementHandle<T extends Element> {
     }
     
     
-    /**@inheritDoc*/
+    /**{@inheritDoc}*/
     @Override
     public int hashCode () {
         int hashCode = 0;
@@ -569,7 +569,7 @@ public final class ElementHandle<T extends Element> {
         return hashCode;
     }
     
-    /**@inheritDoc*/
+    /**{@inheritDoc}*/
     @Override
     public boolean equals (Object other) {
         if (other instanceof ElementHandle) {

--- a/java/java.source.base/src/org/netbeans/api/java/source/ElementUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ElementUtilities.java
@@ -289,11 +289,11 @@ public final class ElementUtilities {
      * will <b>also</b> map to the outer class' scope. The caller can then determine, based on {@link Element#getEnclosingElement()} and
      * the mapped Scope whether the symbol is directly declared, or inherited. Non-member symbols (variables, parameters, try resources, ...) 
      * map to Scope of their defining Method.
-     * <p/>
+     * <p>
      * If an Element from outer Scope is hidden by a similar Element
      * in inner scope, only the Element visible to the passed Scope is returned. For example, if both the starting (inner) class and its outer class
      * define method m(), only InnerClass.m() will be returned.
-     * <p/>
+     * <p>
      * Note that {@link Scope#getEnclosingMethod()} returns non-null even for class scopes of local or anonymous classes; check both {@link Scope#getEnclosingClass()}
      * and {@link Scope#getEnclosingMethod()} and their relationship to get the appropriate Element associated with the Scope.
      * 
@@ -677,7 +677,7 @@ public final class ElementUtilities {
     /**
      * Finds all unimplemented methods in the given type and supertypes, but possibly include
      * also interface default methods.
-     * <p/>
+     * <p>
      * If the platform configured for the type is older than JDK8, the method is equivalent
      * to {@link #findUnimplementedMethods(javax.lang.model.element.TypeElement)}. If `includeDefaults'
      * is {@code true}, returns also default methods as if the methods were required to be
@@ -819,7 +819,7 @@ public final class ElementUtilities {
      *         See method format for more details on parameter types.</dd>
      * </dl>
      * 
-     * @param elementDescription the description of the element that should be checked for existence
+     * @param description the description of the element that should be checked for existence
      * @return the found element, or null if not available
      * @since 0.115
      */

--- a/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
@@ -186,7 +186,7 @@ public final class GeneratorUtilities {
 
     /**
      * Inserts a member to a class. Using the rules specified in the {@link CodeStyle}
-     * it finds the proper place for the member and calls {@link TreeMaker.insertClassMember}
+     * it finds the proper place for the member and calls {@link TreeMaker#insertClassMember}
      *
      * @param clazz the class to insert the member to
      * @param member the member to add
@@ -316,7 +316,7 @@ public final class GeneratorUtilities {
 
     /**
      * Inserts members to a class. Using the rules specified in the {@link CodeStyle}
-     * it finds the proper place for each of the members and calls {@link TreeMaker.insertClassMember}
+     * it finds the proper place for each of the members and calls {@link TreeMaker#insertClassMember}
      *
      * @param clazz the class to insert the members to
      * @param members the members to insert
@@ -377,7 +377,7 @@ public final class GeneratorUtilities {
     
     /**
      * Inserts a member to a class. Using the rules specified in the {@link CodeStyle}
-     * it finds the proper place for the member and calls {@link TreeMaker.insertClassMember}
+     * it finds the proper place for the member and calls {@link TreeMaker#insertClassMember}
      *
      * @param clazz the class to insert the member to
      * @param member the member to add
@@ -495,7 +495,7 @@ public final class GeneratorUtilities {
      * if 'collectNames' is set, it collects field names from the class definition. If
      * 'insertedName' is not null, it also collects references to that name in 
      * 'revDependencies'.
-     * <p/>
+     * <p>
      * For the secondPass, set 'collectNames' to false: the visitor will collect
      * dependencies of the scanned node into 'dependencies'. After 2 passes,
      * the revDependencies and dependencies can be used to determine partial order
@@ -664,7 +664,7 @@ public final class GeneratorUtilities {
     
     /**
      * Inserts members to a class. Using the rules specified in the {@link CodeStyle}
-     * it finds the proper place for each of the members and calls {@link TreeMaker.insertClassMember}
+     * it finds the proper place for each of the members and calls {@link TreeMaker#insertClassMember}
      *
      * @param clazz the class to insert the members to
      * @param members the members to insert
@@ -751,7 +751,7 @@ public final class GeneratorUtilities {
         return createMethod(method, clazz, false);
     }
 
-    /**Create a new method tree for the given method element. The method will be created as if it were member of {@link asMemberOf} type
+    /**Create a new method tree for the given method element. The method will be created as if it were member of {@code asMemberOf} type
      * (see also {@link Types#asMemberOf(javax.lang.model.type.DeclaredType,javax.lang.model.element.Element)}).
      * The new method will have an empty body.
      *
@@ -1517,7 +1517,8 @@ public final class GeneratorUtilities {
      * converted from a single value into an array.
      *
      * The typical trees passed as {@code attributeValuesToAdd} are:
-     * <table border="1">
+     * <table>
+     * <caption>Typical tree</caption>
      *     <tr>
      *         <th>attribute type</th>
      *         <th>expected tree type</th>
@@ -1570,7 +1571,8 @@ public final class GeneratorUtilities {
      * {@link CompilationUnitTree} from {@code package-info.java}.
      *
      * The typical trees passed as {@code attributeValuesToAdd} are:
-     * <table border="1">
+     * <table>
+     * <caption>Typical tree</caption>
      *     <tr>
      *         <th>attribute type</th>
      *         <th>expected tree type</th>

--- a/java/java.source.base/src/org/netbeans/api/java/source/JavaSource.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/JavaSource.java
@@ -325,7 +325,7 @@ public final class JavaSource {
     }
 
     /**
-     * Returns a {@link JavaSource} instance associated to the given {@link javax.swing.Document},
+     * Returns a {@link JavaSource} instance associated to the given {@link Document},
      * it returns null if the {@link Document} is not
      * associated with data type providing the {@link JavaSource}.
      * @param doc {@link Document} for which the {@link JavaSource} should be found/created.
@@ -410,7 +410,7 @@ public final class JavaSource {
      * this task does not finish.<BR>
      * @see org.netbeans.api.java.source.CancellableTask for information about implementation requirements
      * @param task The task which.
-     * @param shared if true the java compiler may be reused by other {@link org.netbeans.api.java.source.CancellableTasks},
+     * @param shared if true the java compiler may be reused by other {@link org.netbeans.api.java.source.CancellableTask}s,
      * the value false may have negative impact on the IDE performance.
      * <div class="nonnormative">
      * <p>
@@ -595,11 +595,11 @@ public final class JavaSource {
      * the given task and returns, the task is performed when the background scan completes by
      * the thread doing the background scan.
      * @param task to be performed
-     * @param shared if true the java compiler may be reused by other {@link org.netbeans.api.java.source.CancellableTasks},
+     * @param shared if true the java compiler may be reused by other {@link org.netbeans.api.java.source.CancellableTask}s,
      * the value false may have negative impact on the IDE performance.
      * @return {@link Future} which can be used to find out the sate of the task {@link Future#isDone} or {@link Future#isCancelled}.
      * The caller may cancel the task using {@link Future#cancel} or wait until the task is performed {@link Future#get}.
-     * @throws IOException encapsulating the exception thrown by {@link CancellableTasks#run}
+     * @throws IOException encapsulating the exception thrown by {@link CancellableTask#run}
      * @since 0.12
      */
     public @NonNull Future<Void> runWhenScanFinished (final @NonNull Task<CompilationController> task, final boolean shared) throws IOException {

--- a/java/java.source.base/src/org/netbeans/api/java/source/JavaSourceTaskFactory.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/JavaSourceTaskFactory.java
@@ -43,9 +43,9 @@ import org.openide.util.RequestProcessor;
  *
  * This factory should be registered in the global lookup using {@link org.openide.util.lookup.ServiceProvider}.
  * 
- * @see EditorAwareJavaSourceTaskFactory
- * @see CaretAwareJavaSourceTaskFactory
- * @see LookupBasedJavaSourceTaskFactory
+ * @see <a href="@org-netbeans-modules-java-source@/org/netbeans/api/java/source/support/EditorAwareJavaSourceTaskFactory.html">EditorAwareJavaSourceTaskFactory</a>
+ * @see <a href="@org-netbeans-modules-java-source@/org/netbeans/api/java/source/support/CaretAwareJavaSourceTaskFactory.html">CaretAwareJavaSourceTaskFactory</a>
+ * @see <a href="@org-netbeans-modules-java-source@/org/netbeans/api/java/source/support/LookupBasedJavaSourceTaskFactory.html">LookupBasedJavaSourceTaskFactory</a>
  *
  * @author Jan Lahoda
  */
@@ -97,7 +97,7 @@ public abstract class JavaSourceTaskFactory {
     }
 
     /**Create task for a given file. This task will be registered into the {@link JavaSource}
-     * parsing harness with a given {@link #getPriority priority} and {@link #getPhase phase}.
+     * parsing harness with a given {@link Priority priority} and {@link Phase phase}.
      *
      * Please note that this method should run as quickly as possible.
      *
@@ -112,14 +112,14 @@ public abstract class JavaSourceTaskFactory {
      * of this factory.
      *
      * If this list changes, a change event should be fired to all registered
-     * {@link ChangeListener}s.
+     * {@link javax.swing.event.ChangeListener}s.
      *
      * @return list of {@link FileObject} on which tasks from this factory should be
      * registered.
      * @see #createTask
-     * @see #addChangeListener
-     * @see EditorAwareJavaSourceTaskFactory
-     * @see CaretAwareJavaSourceTaskFactory
+     * {@code addChangeListener}
+     * @see <a href="@org-netbeans-modules-java-source@/org/netbeans/api/java/source/support/EditorAwareJavaSourceTaskFactory.html">EditorAwareJavaSourceTaskFactory</a>
+     * @see <a href="@org-netbeans-modules-java-source@/org/netbeans/api/java/source/support/CaretAwareJavaSourceTaskFactory.html">CaretAwareJavaSourceTaskFactory</a>
      */
     protected abstract @NonNull Collection<FileObject> getFileObjects();
 

--- a/java/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
@@ -440,7 +440,7 @@ public final class ModificationResult {
      * Returned string represents preview of resulting source. No difference
      * really is applied. Respects {@code isExcluded()} flag of difference.
      * 
-     * @param   there can be more resulting source, user has to specify
+     * @param fileObject there can be more resulting source, user has to specify
      *          which wants to preview.
      * @return  if changes are applied source looks like return string
      * @throws  IllegalArgumentException if the provided {@link FileObject} is not
@@ -556,7 +556,7 @@ public final class ModificationResult {
          * Gets flag if it is possible to write to guarded sections.
          * @return {@code true} in case the difference may be written even into
          *          guarded sections.
-         * @see #guards(boolean)
+         * @see #setCommitToGuards(boolean)
          * @since 0.33
          */
         public boolean isCommitToGuards() {

--- a/java/java.source.base/src/org/netbeans/api/java/source/ScanUtils.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ScanUtils.java
@@ -43,7 +43,7 @@ import org.openide.util.Parameters;
  * There are two variants of {@link JavaSource#runUserActionTask}, which support <b>abort and restart</b> of the user task,
  * if the task indicates incomplete data and the scanning is in progress. The restart is done in a hope that, after scanning
  * completes, the missing types or elements will appear.
- * <p/>
+ * <p>
  * The user task may use other provided wrapper methods to:
  * <ul>
  * <li>{@link #checkElement} to assert element's presence and validity
@@ -51,9 +51,9 @@ import org.openide.util.Parameters;
  * </ul>
  * Note that even though the user task run when all the parsing/scanning is over, there's no guarantee that data obtained from
  * the parser structures will be complete and valid - the source code may be really broken, dependency could be missing etc.
- * <p/>
+ * <p>
  * An example pattern how to use this class is:
- * <code><pre>
+ * <pre>{@code
  * final TreePath tp = ... ; // obtain a tree path
  * ScanUtils.waitUserActionTask(new Task&lt;{@link CompilationController}>() {
  *      public void run(CompilationController ctrl) {
@@ -67,7 +67,7 @@ import org.openide.util.Parameters;
  *          }
  *      }
  * };
- * </pre></code>
+ * }</pre>
  *
  * @author Svata Dedic
  * @since 0.95
@@ -79,7 +79,7 @@ public final class ScanUtils {
      * Runs the user task through {@link JavaSource#runUserActionTask}, and returns Future completion handle for it. 
      * The executed Task may indicate that it does not have enough data when scan is in progress, through e.g. {@link #checkElement}.
      * If so, processing of the Task will abort, and will be restarted when the scan finishes.
-     * <p/>
+     * <p>
      * For more details, see description of {@link #postUserTask(org.netbeans.modules.parsing.api.Source, org.netbeans.modules.parsing.api.UserTask) }.
      *
      * @param src JavaSource to process
@@ -108,12 +108,12 @@ public final class ScanUtils {
      * Runs the user task, and returns Future completion handle for it. 
      * The executed Task may indicate that it does not have enough data when scan is in progress, through e.g. {@link #checkElement}.
      * If so, processing of the Task will abort, and will be restarted when the scan finishes.
-     * <p/>
+     * <p>
      * The task <b>may run asynchronously</b>, pay attention to synchronization of task's output
      * data. The first attempt to run the task MAY execute synchronously. Do not call the method from
      * Swing EDT, if the task typically takes non-trivial time to complete (see {@link JavaSource#runUserActionTask}
      * for discussion).
-     * <p/>
+     * <p>
      * As {@code postUserTask} may decide to defer the task execution, {@code postUserTask} cannot reliably report exceptions thrown
      * from the parsing infrastructure. The Task itself is responsible for handling exceptions and propagating them
      * to the caller, the {@code post} method will just log the exception.
@@ -143,10 +143,10 @@ public final class ScanUtils {
      * The executed Task may indicate that it does not have enough data when scan is in progress, through e.g. {@link #checkElement}.
      * If so, processing of the Task will abort, and will be restarted when the scan finishes. The {@code waitUserActionTask} method
      * will wait until the rescheduled task completes.
-     * <p/>
+     * <p>
      * Unlike {@link #postUserActionTask}, this method propagates exceptiosn from the Task to the caller, even if the Task
      * is postponed and waited for.
-     * <p/>
+     * <p>
      * Calling this method from Swing ED thread is prohibited.
      *
      * @param src java source to process
@@ -198,17 +198,17 @@ public final class ScanUtils {
      * The executed Task may indicate that it does not have enough data when scan is in progress, through e.g. {@link #checkElement}.
      * If so, processing of the Task will abort, and will be restarted when the scan finishes. The {@code waitUserTask} method
      * will wait until the rescheduled task completes.
-     * <p/>
+     * <p>
      * Unlike {@link #postUserTask}, this method propagates exceptiosn from the Task to the caller, even if the Task
      * is postponed and waited for.
-     * <p/>
+     * <p>
      * Calling this method from Swing ED thread is prohibited.
      *
      * @param src java source to process
-     * @param uat task to execute
+     * @param task task to execute
      * 
      * @throws ParseException in the case of a failure in the user task, or scheduling failure (propagated from {@link JavaSource#runUserActionTask},
-     * {@link ParserManager#parseWhenScanFinished(java.util.Collection, org.netbeans.modules.parsing.api.UserTask) 
+     * {@link ParserManager#parseWhenScanFinished(java.util.Collection, org.netbeans.modules.parsing.api.UserTask) }
      *
      * @see ParserManager#parse(java.util.Collection, org.netbeans.modules.parsing.api.UserTask) 
      * @see ParserManager#parseWhenScanFinished(java.util.Collection, org.netbeans.modules.parsing.api.UserTask) 
@@ -259,25 +259,25 @@ public final class ScanUtils {
 
     /**
      * Checks that the Element is valid, is not erroneous. If the Element is {@code null} or erroneous and
-     * scanning is running, the method throws a {@link RetryWhenScanFinished} exception to
+     * scanning is running, the method throws a {@link ScanUtils.RetryWhenScanFinished} exception to
      * indicate that the action should be retried. The method should be only used in code, which
      * is directly or indirectly executed by {@link #waitUserActionTask}, otherwise {@link IllegalStateException}
      * will be thrown.
-     * <p/>
+     * <p>
      * If scan is not running, the method always returns the value of 'e' parameter.
-     * <p/>
+     * <p>
      * An example usage is as follows:
      * <code>
      * TreePath tp = ...;
      * Element e = checkElement(cu.getTrees().getElement(tp));
      * </code>
-     * <p/>
+     * <p>
      * <b>Note:</b> the method may be only called from within {@link #waitUserActionTask}, it aborts
      * the current processing under assumption the user task will be restarted. It is illegal to call the
      * method if not running as user task - IllegalStateException will be thrown.
      *
      * @param e the Element to check
-     * @param s the source of the Element
+     * @param info the source of the Element
      * @return the original Element, to support 'fluent' pattern
      *
      * @throws IllegalStateException if not called from within user task
@@ -305,8 +305,8 @@ public final class ScanUtils {
     /**
      * Aborts the user task and calls it again when parsing finishes, if a typename is not available.
      *
-     * @param el the Element which causes the trouble
-     * @param s source of the Element
+     * @param ci the Element which causes the trouble
+     * @param handle of the Element
      * @throws IllegalStateException if not called from within {@link #waitUserActionTask} and the like
      *
      */
@@ -512,7 +512,7 @@ public final class ScanUtils {
      * retried when parsing is finished. The exception derives from the {@link Error}
      * class to bypass ill-written code, which caught {@link RuntimeException} or
      * even {@link Exception}.
-     * <p/>
+     * <p>
      * The exception is interpreted by the Java Source infrastructure and is not
      * meant to be ever thrown or caught by regular application code. It's deliberately
      * package-private so users are not tempted to throw or catch it.

--- a/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
@@ -484,7 +484,7 @@ public class SourceUtils {
      * @return the defining {@link FileObject} or null if it cannot be
      * found
      *
-     * @deprecated use {@link getFile(ElementHandle, ClasspathInfo)}
+     * @deprecated use {@link #getFile(ElementHandle, ClasspathInfo)}
      */
     @Deprecated
     public static FileObject getFile (Element element, final ClasspathInfo cpInfo) {
@@ -1290,7 +1290,7 @@ public class SourceUtils {
     /**
      * Returns names of all modules within given scope.
      * @param info the CompilationInfo used to resolve modules
-     * @param scope to search in {@see SearchScope}
+     * @param scope to search in {@link ClassIndex.SearchScope}
      * @return set of module names
      * @since 2.23
      */

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
@@ -92,7 +92,7 @@ import org.openide.util.Parameters;
  * You can obtain appropriate instance of this class by getting it from working
  * copy:
  *
- * <pre>
+ * <pre>{@code
  * CancellableTask task = new CancellableTask<WorkingCopy>() {
  *
  *        public void run(WorkingCopy workingCopy) throws Exception {
@@ -101,9 +101,9 @@ import org.openide.util.Parameters;
  *        }
  *        ...
  *    }; 
- * </pre>
+ * }</pre>
  *
- * @see <a href="http://wiki.netbeans.org/wiki/view/JavaHT_Modification">How do I do modification to a source file?</a> 
+ * @see <a href="https://netbeans.apache.org/wiki/JavaHT_Modification">How do I do modification to a source file?</a>
  *
  * @author Tom Ball
  * @author Pavel Flaska
@@ -1134,7 +1134,7 @@ public final class TreeMaker {
     /**
      * Creates a new TryTree.
      *
-     * @param resource     the resources of the try clause. The elements of the list
+     * @param resources     the resources of the try clause. The elements of the list
      *                     should either be {@link VariableTree}s or {@link ExpressionTree}s.
      * @param tryBlock     the statement block in the try clause.
      * @param catches      the list of catch clauses, or an empty list.
@@ -1257,8 +1257,6 @@ public final class TreeMaker {
      * @param name name of the binding variable
      * @param type the type of the pattern
      * @return the newly created BindingPatternTree
-     * @throws NoSuchMethodException if the used javac does not support
-     *                               BindingPatternTree.
      */
     @Deprecated
     public Tree BindingPattern(CharSequence name,
@@ -1268,7 +1266,7 @@ public final class TreeMaker {
     
       /**
      * Creates a new Tree for a given VariableTree
-     * @specication : 15.20.2
+     * specication : 15.20.2
      * @param vt the VariableTree of the pattern
      * @see com.sun.source.tree.BindingPatternTree
      * @return the newly created BindingPatternTree
@@ -1569,7 +1567,7 @@ public final class TreeMaker {
      * </pre>
      *
      * You can get it e.g. with this code:
-     * <pre>
+     * <pre>{@code
      *   TreeMaker make = workingCopy.getTreeMaker();
      *   ClassTree node = ...;
      *   // create method modifiers
@@ -1596,7 +1594,7 @@ public final class TreeMaker {
      *   );
      *   // rewrite the original class node with the new one containing newMethod
      *   workingCopy.rewrite(node, <b>make.addClassMember(node, newMethod)</b>);
-     * </pre>
+     * }</pre>
      *
      * @param   clazz    class tree containing members list.
      * @param   member   element to be appended to members list.
@@ -3305,7 +3303,7 @@ public final class TreeMaker {
      * Marks a tree as a replacement of some old one. The hint may cause surrounding whitespace to be 
      * carried over to the new tree and comments to be attached to the same (similar) positions
      * as in the old tree. 
-     * <p/>
+     * <p>
      * If 'defaultOnly' is true, the hint is only added if no previous hint exists. You generally want
      * to force the hint, in code manipulation operations. Bulk tree transformers should preserve existing
      * hints - the {@link TreeUtilities#translate} preserves existing relationships.

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreePathHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreePathHandle.java
@@ -61,7 +61,7 @@ import org.openide.util.Parameters;
 /**                                                                                                                                                                                                                            
  * Represents a handle for {@link TreePath} which can be kept and later resolved                                                                                                                                               
  * by another javac. The Javac {@link Element}s are valid only in the single                                                                                                                                                   
- * {@link javax.tools.CompilationTask} or single run of the                                                                                                                                                                    
+ * {@link javax.tools.JavaCompiler.CompilationTask} or single run of the                                                                                                                                                                    
  * {@link org.netbeans.api.java.source.CancellableTask}. If the client needs to                                                                                                                                                
  * keep a reference to the {@link TreePath} and use it in the other CancellableTask                                                                                                                                            
  * he has to serialize it into the {@link TreePathHandle}.                                                                                                                                                                     
@@ -69,7 +69,7 @@ import org.openide.util.Parameters;
  * <p>                                                                                                                                                                                                                         
  * Typical usage of TreePathHandle enclElIsCorrespondingEl:                                                                                                                                                                    
  * </p>                                                                                                                                                                                                                        
- * <pre>                                                                                                                                                                                                                       
+ * <pre>{@code                                                                                                                                                                                                       
  * final TreePathHandle[] tpHandle = new TreePathHandle[1];                                                                                                                                                                    
  * javaSource.runCompileControlTask(new CancellableTask<CompilationController>() {                                                                                                                                             
  *     public void run(CompilationController compilationController) {                                                                                                                                                          
@@ -79,7 +79,7 @@ import org.openide.util.Parameters;
  *         treePathHandle[0] = TreePathHandle.create (element, compilationController);                                                                                                                                         
  *    }                                                                                                                                                                                                                        
  * },priority);                                                                                                                                                                                                                
- *                                                                                                                                                                                                                             
+ *                                                                                                                                                                                        
  * otherJavaSource.runCompileControlTask(new CancellableTask<CompilationController>() {                                                                                                                                        
  *     public void run(CompilationController compilationController) {                                                                                                                                                          
  *         parameter.toPhase(Phase.RESOLVED);                                                                                                                                                                                  
@@ -87,7 +87,7 @@ import org.openide.util.Parameters;
  *         ....                                                                                                                                                                                                                
  *    }                                                                                                                                                                                                                        
  * },priority);                                                                                                                                                                                                                
- * </pre>                                                                                                                                                                                                                      
+ * }</pre>                                                                                                                                                                                                                      
  * </div>                                                                                                                                                                                                                      
  *                                                                                                                                                                                                                             
  *                                                                                                                                                                                                                             
@@ -117,9 +117,9 @@ public final class TreePathHandle {
                                                                                                                                                                                                                                
     /**                                                                                                                                                                                                                        
      * Resolves an {@link TreePath} from the {@link TreePathHandle}.                                                                                                                                                           
-     * @param compilationInfo representing the {@link javax.tools.CompilationTask}                                                                                                                                             
+     * @param compilationInfo representing the {@link javax.tools.JavaCompiler.CompilationTask}                                                                                                                                             
      * @return resolved subclass of {@link Element} or null if the element does not exist on                                                                                                                                    
-     * the classpath/sourcepath of {@link javax.tools.CompilationTask}.
+     * the classpath/sourcepath of {@link javax.tools.JavaCompiler.CompilationTask}.
      * @throws IllegalArgumentException when this {@link TreePathHandle} is not created for a source
      * represented by the compilationInfo.
      */                                                                                                                                                                                                                        
@@ -151,9 +151,9 @@ public final class TreePathHandle {
                                                                                                                                                                                                                                
     /**                                                                                                                                                                                                                        
      * Resolves an {@link Element} from the {@link TreePathHandle}.                                                                                                                                                            
-     * @param compilationInfo representing the {@link javax.tools.CompilationTask}                                                                                                                                             
+     * @param info representing the {@link javax.tools.JavaCompiler.CompilationTask}                                                                                                                                             
      * @return resolved subclass of {@link Element} or null if the element does not exist on                                                                                                                                    
-     * the classpath/sourcepath of {@link javax.tools.CompilationTask}.                                                                                                                                                        
+     * the classpath/sourcepath of {@link javax.tools.JavaCompiler.CompilationTask}.                                                                                                                                                        
      */                                                                                                                                                                                                                        
     public Element resolveElement(final CompilationInfo info) {
         Parameters.notNull("info", info);
@@ -166,7 +166,7 @@ public final class TreePathHandle {
     }
     
     /**
-     * returns {@link ElemntHandle} corresponding to this {@link TreePathHandle}
+     * returns {@link ElementHandle} corresponding to this {@link TreePathHandle}
      * @return {@link ElementHandle} or null if this {@link TreePathHandle} does
      * not represent any {@link Element}
      * @since 0.93
@@ -177,11 +177,11 @@ public final class TreePathHandle {
     }
                                                                                                                                                                                                                                
     /**                                                                                                                                                                                                                        
-     * Returns the {@link Tree.Kind} of this TreePathHandle,                                                                                                                                                                   
-     * it returns the kind of the {@link Tree} from which the handle                                                                                                                                           
+     * Returns the {@link com.sun.source.tree.Tree.Kind} of this TreePathHandle,                                                                                                                                                                   
+     * it returns the kind of the {@link com.sun.source.tree.Tree} from which the handle                                                                                                                                           
      * was created.                                                                                                                                                                                                            
      *                                                                                                                                                                                                                         
-     * @return {@link Tree.Kind}                                                                                                                                                                                               
+     * @return {@link com.sun.source.tree.Tree.Kind}                                                                                                                                                                                               
      */                                                                                                                                                                                                                        
     public Tree.Kind getKind() {
         return this.delegate.getKind();
@@ -190,7 +190,7 @@ public final class TreePathHandle {
     /**                                                                                                                                                                                                                        
      * Factory method for creating {@link TreePathHandle}.                                                                                                                                                                     
      *                                                                                                                                                                                                                         
-     * @param treePath for which the {@link TrePathHandle} should be created.                                                                                                                                                  
+     * @param treePath for which the {@link TreePathHandle} should be created.                                                                                                                                                  
      * @param info 
      * @return a new {@link TreePathHandle}                                                                                                                                                                                    
      * @throws java.lang.IllegalArgumentException if arguments are not supported
@@ -254,7 +254,7 @@ public final class TreePathHandle {
     /**                                                                                                                                                                                                                        
      * Factory method for creating {@link TreePathHandle}.                                                                                                                                                                     
      *                                                                                                                                                                                                                         
-     * @param element for which the {@link TrePathHandle} should be created.                                                                                                                                                  
+     * @param element for which the {@link TreePathHandle} should be created.                                                                                                                                                  
      * @param info 
      * @return a new {@link TreePathHandle}                                                                                                                                                                                    
      * @throws java.lang.IllegalArgumentException if arguments are not supported
@@ -421,9 +421,9 @@ public final class TreePathHandle {
 
         /**                                                                                                                                                                                                                        
          * Resolves an {@link TreePath} from the {@link TreePathHandle}.                                                                                                                                                           
-         * @param compilationInfo representing the {@link javax.tools.CompilationTask}                                                                                                                                             
+         * @param compilationInfo representing the {@link javax.tools.JavaCompiler.CompilationTask}                                                                                                                                             
          * @return resolved subclass of {@link Element} or null if the element does not exist on                                                                                                                                    
-         * the classpath/sourcepath of {@link javax.tools.CompilationTask}.
+         * the classpath/sourcepath of {@link javax.tools.JavaCompiler.CompilationTask}.
          * @throws IllegalArgumentException when this {@link TreePathHandle} is not created for a source
          * represented by the compilationInfo.
          */
@@ -510,9 +510,9 @@ public final class TreePathHandle {
 
         /**                                                                                                                                                                                                                        
          * Resolves an {@link Element} from the {@link TreePathHandle}.                                                                                                                                                            
-         * @param compilationInfo representing the {@link javax.tools.CompilationTask}                                                                                                                                             
+         * @param compilationInfo representing the {@link javax.tools.JavaCompiler.CompilationTask}                                                                                                                                             
          * @return resolved subclass of {@link Element} or null if the element does not exist on                                                                                                                                    
-         * the classpath/sourcepath of {@link javax.tools.CompilationTask}.                                                                                                                                                        
+         * the classpath/sourcepath of {@link javax.tools.JavaCompiler.CompilationTask}.                                                                                                                                                        
          */
         public Element resolveElement(final CompilationInfo info) {
             if (correspondingEl != null) {

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -1044,7 +1044,7 @@ public final class TreeUtilities {
 
     /**Find span of the {@link ClassTree}'s body in the source.
      * Returns starting and ending offset of the body in the source code that was parsed
-     * (ie. {@link CompilationInfo.getText()}, which may differ from the positions in the source
+     * (ie. {@link CompilationInfo#getText()}, which may differ from the positions in the source
      * document if it has been already altered.
      * 
      * @param clazz class which body should be searched for
@@ -1082,7 +1082,7 @@ public final class TreeUtilities {
     
     /**Find span of the {@link ClassTree#getSimpleName()} identifier in the source.
      * Returns starting and ending offset of the name in the source code that was parsed
-     * (ie. {@link CompilationInfo.getText()}, which may differ from the positions in the source
+     * (ie. {@link CompilationInfo#getText()}, which may differ from the positions in the source
      * document if it has been already altered.
      * 
      * @param clazz class which name should be searched for
@@ -1095,7 +1095,7 @@ public final class TreeUtilities {
     
     /**Find span of the {@link MethodTree#getName()} identifier in the source.
      * Returns starting and ending offset of the name in the source code that was parsed
-     * (ie. {@link CompilationInfo.getText()}, which may differ from the positions in the source
+     * (ie. {@link CompilationInfo#getText()}, which may differ from the positions in the source
      * document if it has been already altered.
      * 
      * @param method method which name should be searched for
@@ -1128,7 +1128,7 @@ public final class TreeUtilities {
     
     /**Find span of the {@link VariableTree#getName()} identifier in the source.
      * Returns starting and ending offset of the name in the source code that was parsed
-     * (ie. {@link CompilationInfo.getText()}, which may differ from the positions in the source
+     * (ie. {@link CompilationInfo#getText()}, which may differ from the positions in the source
      * document if it has been already altered.
      * 
      * @param var variable which name should be searched for
@@ -1141,7 +1141,7 @@ public final class TreeUtilities {
     
     /**Find span of the {@link LabeledStatementTree#getLabel()} identifier in the source.
      * Returns starting and ending offset of the name in the source code that was parsed
-     * (ie. {@link CompilationInfo.getText()}, which may differ from the positions in the source
+     * (ie. {@link CompilationInfo#getText()}, which may differ from the positions in the source
      * document if it has been already altered.
      * 
      * @param lst labeled statement which name should be searched for
@@ -1154,7 +1154,7 @@ public final class TreeUtilities {
     
     /**Find span of the {@link TypeParameterTree#getName()} identifier in the source.
      * Returns starting and ending offset of the name in the source code that was parsed
-     * (ie. {@link CompilationInfo.getText()}, which may differ from the positions in the source
+     * (ie. {@link CompilationInfo#getText()}, which may differ from the positions in the source
      * document if it has been already altered.
      * 
      * @param tpt type parameter which name should be searched for
@@ -1167,7 +1167,7 @@ public final class TreeUtilities {
     
     /**Find span of the {@link LabeledStatementTree#getLabel()} identifier in the source.
      * Returns starting and ending offset of the name in the source code that was parsed
-     * (ie. {@link CompilationInfo.getText()}, which may differ from the positions in the source
+     * (ie. {@link CompilationInfo#getText()}, which may differ from the positions in the source
      * document if it has been already altered.
      * 
      * @param brk labeled statement which name should be searched for
@@ -1180,7 +1180,7 @@ public final class TreeUtilities {
     
     /**Find span of the {@link LabeledStatementTree#getLabel()} identifier in the source.
      * Returns starting and ending offset of the name in the source code that was parsed
-     * (ie. {@link CompilationInfo.getText()}, which may differ from the positions in the source
+     * (ie. {@link CompilationInfo#getText()}, which may differ from the positions in the source
      * document if it has been already altered.
      * 
      * @param cont labeled statement which name should be searched for
@@ -1193,7 +1193,7 @@ public final class TreeUtilities {
     
     /**Find span of the {@link MethodTree#getParameters()} parameter list in the source.
      * Returns the position of the opening and closing parentheses of the parameter list
-     * in the source code that was parsed (ie. {@link CompilationInfo.getText()}, which
+     * in the source code that was parsed (ie. {@link CompilationInfo#getText()}, which
      * may differ from the positions in the source document if it has been already altered.
      * 
      * @param method method which parameter list should be searched for
@@ -1237,7 +1237,7 @@ public final class TreeUtilities {
     
     /**Find span of the {@link MemberSelectTree#getIdentifier()} identifier in the source.
      * Returns starting and ending offset of the name in the source code that was parsed
-     * (ie. {@link CompilationInfo.getText()}, which may differ from the positions in the source
+     * (ie. {@link CompilationInfo#getText()}, which may differ from the positions in the source
      * document if it has been already altered.
      * 
      * @param mst member select which identifier should be searched for
@@ -1250,7 +1250,7 @@ public final class TreeUtilities {
     
     /**Find span of the {@link MemberReferenceTree#getName()} identifier in the source.
      * Returns starting and ending offset of the name in the source code that was parsed
-     * (ie. {@link CompilationInfo.getText()}, which may differ from the positions in the source
+     * (ie. {@link CompilationInfo#getText()}, which may differ from the positions in the source
      * document if it has been already altered.
      * 
      * @param mst member reference for which the identifier should be searched for
@@ -1263,7 +1263,7 @@ public final class TreeUtilities {
     
     /**Find span of the name in the DocTree's reference tree (see {@link #getReferenceName(com.sun.source.util.DocTreePath)}
      * identifier in the source. Returns starting and ending offset of the name in
-     * the source code that was parsed (ie. {@link CompilationInfo.getText()}, which
+     * the source code that was parsed (ie. {@link CompilationInfo#getText()}, which
      * may differ from the positions in the source document if it has been already
      * altered.
      * 
@@ -1469,23 +1469,23 @@ public final class TreeUtilities {
         }
     }
 
-    /**Decode escapes defined in: http://wikis.sun.com/display/mlvm/ProjectCoinProposal, 3.1-3.9.
+    /**Decode escapes defined in: https://openjdk.org/projects/coin, 3.1-3.9.
      * Must be a full token text, including possible #".
      *
      * @param text to decode
      * @return decoded escapes from the identifier
-     * @see http://wikis.sun.com/display/mlvm/ProjectCoinProposal
+     * @see <a href="https://openjdk.org/projects/coin">ProjectCoinProposal</a>
      * @since 0.56
      */
     public @NonNull CharSequence decodeIdentifier(@NonNull CharSequence text) {
         return decodeIdentifierInternal(text);
     }
 
-    /**Encode identifier using escapes defined in: http://wikis.sun.com/display/mlvm/ProjectCoinProposal, 3.1-3.9.
+    /**Encode identifier using escapes defined in: https://openjdk.org/projects/coin, 3.1-3.9.
      *
-     * @param text to encode
+     * @param ident to encode
      * @return encoded identifier, including #" if necessary
-     * @see http://wikis.sun.com/display/mlvm/ProjectCoinProposal
+     * @see <a href="https://openjdk.org/projects/coin">ProjectCoinProposal</a>
      * @since 0.56
      */
     public @NonNull CharSequence encodeIdentifier(@NonNull CharSequence ident) {

--- a/java/java.source.base/src/org/netbeans/api/java/source/TypeMirrorHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TypeMirrorHandle.java
@@ -61,7 +61,7 @@ import org.netbeans.api.annotations.common.NonNull;
 /**
  * Represents a handle for {@link TypeMirror} which can be kept and later resolved
  * by another javac. The Javac {@link TypeMirror}s are valid only in the single
- * {@link javax.tools.CompilationTask} or single run of the
+ * {@link javax.tools.JavaCompiler.CompilationTask} or single run of the
  * {@link org.netbeans.api.java.source.CancellableTask}. If the client needs to
  * keep a reference to the {@link TypeMirror} and use it in the other CancellableTask
  * he has to serialize it into the {@link TypeMirrorHandle}.
@@ -69,7 +69,7 @@ import org.netbeans.api.annotations.common.NonNull;
  * <p>
  ** Typical usage of TypeMirrorHandle is:
  * </p>
- * <pre>
+ * <pre>{@code
  * final TypeMirrorHandle[] typeMirrorHandle = new TypeMirrorHandle[1];
  * javaSource.runCompileControlTask(new CancellableTask<CompilationController>() {
  *     public void run(CompilationController compilationController) {
@@ -87,10 +87,10 @@ import org.netbeans.api.annotations.common.NonNull;
  *         ....
  *    }
  * },priority);
- * </pre>
+ * }</pre>
  * </div>
  * Currently, not all the {@link TypeMirror} {@link TypeKind kinds} are supported by handle.
- * The unsupported {@link TykeKind kinds} are: {@link TypeKind#EXECUTABLE}, {@link TypeKind#OTHER},
+ * The unsupported {@link TypeKind kinds} are: {@link TypeKind#EXECUTABLE}, {@link TypeKind#OTHER},
  * and {@link TypeKind#PACKAGE}.
  *
  * @author Jan Lahoda, Dusan Balek
@@ -109,9 +109,9 @@ public final class TypeMirrorHandle<T extends TypeMirror> {
     
     /**
      * Factory method for creating {@link TypeMirrorHandle}.
-     * @param {@link TypeMirror} for which the {@link TypeMirrorHandle} should be created.
+     * @param tm for which the {@link TypeMirrorHandle} should be created.
      * Not all the {@link TypeMirror} {@link TypeKind kinds} are currently supported.
-     * The unsupported {@link TykeKind kinds} are: {@link TypeKind#EXECUTABLE}, {@link TypeKind#OTHER},
+     * The unsupported {@link TypeKind kinds} are: {@link TypeKind#EXECUTABLE}, {@link TypeKind#OTHER},
      * and {@link TypeKind#PACKAGE}.
      * @return a new {@link TypeMirrorHandle}
      * @throws IllegalArgumentException if the {@link TypeMirror} is of an unsupported
@@ -222,10 +222,10 @@ public final class TypeMirrorHandle<T extends TypeMirror> {
     
     /**
      * Resolves an {@link TypeMirror} from the {@link TypeMirrorHandle}.
-     * @param {@link CompilationInfo} representing the {@link javax.tools.CompilationTask}
+     * @param info representing the {@link javax.tools.JavaCompiler.CompilationTask}
      * in which the {@link TypeMirror} should be resolved.
      * @return resolved subclass of {@link TypeMirror} or null if the type cannot be
-     * resolved in this {@link javax.tools.CompilationTask}.
+     * resolved in this {@link javax.tools.JavaCompiler.CompilationTask}.
      */
     public T resolve(@NonNull CompilationInfo info) {
         return resolve(info, new HashMap<TypeMirrorHandle, PlaceholderType>());

--- a/java/java.source.base/src/org/netbeans/api/java/source/TypeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TypeUtilities.java
@@ -150,7 +150,7 @@ public final class TypeUtilities {
      * Returns a TypeMirror which can be represented in a source as a type declarator. The returned TypeMirror,
      * if not erroneous, can be used as type of a variable or a method's return type. The method will attempt to
      * infer proper wildcards or bounds.
-     * <p/>
+     * <p>
      * If the type could be represented in source, the method returns a type of {@link TypeKind#ERROR}.
      * 
      * @param type the type to be polished

--- a/java/java.source.base/src/org/netbeans/api/java/source/WorkingCopy.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/WorkingCopy.java
@@ -166,7 +166,7 @@ public class WorkingCopy extends CompilationController {
 
     /**
      * Returns an instance of the {@link WorkingCopy} for
-     * given {@link Parser.Result} if it is a result
+     * given {@link org.netbeans.modules.parsing.spi.Parser.Result} if it is a result
      * of a java parser.
      * @param result for which the {@link WorkingCopy} should be
      * returned.
@@ -310,7 +310,7 @@ public class WorkingCopy extends CompilationController {
      * <p>
      * <code>tree</code> and <code>newTree</code> cannot be <code>null</code>.
      * If <code>oldTree</code> is null, <code>newTree</code> must be of kind
-     * {@link DocTree.Kind#DOC_COMMENT DOC_COMMENT}.
+     * {@link com.sun.source.doctree.DocTree.Kind#DOC_COMMENT DOC_COMMENT}.
      * 
      * @param tree     the tree to which the doctrees belong.
      * @param oldTree  tree to be replaced, use tree already represented in

--- a/java/java.source.base/src/org/netbeans/api/java/source/support/CancellableTreePathScanner.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/support/CancellableTreePathScanner.java
@@ -60,7 +60,7 @@ public class CancellableTreePathScanner<R,P> extends ErrorAwareTreePathScanner<R
         internalCanceled.set(true);
     }
 
-    /** @inheritDoc
+    /** {@inheritDoc}
      */
     public R scan(Tree tree, P p) {
         if (isCanceled())
@@ -69,7 +69,7 @@ public class CancellableTreePathScanner<R,P> extends ErrorAwareTreePathScanner<R
         return super.scan(tree, p);
     }
 
-    /** @inheritDoc
+    /** {@inheritDoc}
      */
     public R scan(Iterable<? extends Tree> trees, P p) {
         if (isCanceled())

--- a/java/java.source.base/src/org/netbeans/api/java/source/support/CancellableTreeScanner.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/support/CancellableTreeScanner.java
@@ -60,7 +60,7 @@ public class CancellableTreeScanner<R,P> extends ErrorAwareTreeScanner<R,P> {
         internalCanceled.set(true);
     }
 
-    /** @inheritDoc
+    /** {@inheritDoc}
      */
     public R scan(Tree tree, P p) {
         if (isCanceled())
@@ -69,7 +69,7 @@ public class CancellableTreeScanner<R,P> extends ErrorAwareTreeScanner<R,P> {
         return super.scan(tree, p);
     }
 
-    /** @inheritDoc
+    /** {@inheritDoc}
      */
     public R scan(Iterable<? extends Tree> trees, P p) {
         if (isCanceled())

--- a/java/java.source.base/src/org/netbeans/api/java/source/support/ProfileSupport.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/support/ProfileSupport.java
@@ -206,7 +206,7 @@ public class ProfileSupport {
      */
     public interface ViolationCollectorFactory {
         /**
-         * Creates a new {@lni ViolationCollector} for given root.
+         * Creates a new {@link ViolationCollector} for given root.
          * @param root the root to be validated
          * @return a new {@link ViolationCollector}
          */

--- a/java/java.source.base/src/org/netbeans/modules/java/source/JavadocHelper.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/JavadocHelper.java
@@ -70,7 +70,6 @@ import javax.swing.text.MutableAttributeSet;
 import javax.swing.text.html.HTML;
 import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.html.parser.ParserDelegator;
-import org.netbeans.api.*;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;

--- a/java/jellytools.java/src/org/netbeans/jellytools/ClasspathStepOperator.java
+++ b/java/jellytools.java/src/org/netbeans/jellytools/ClasspathStepOperator.java
@@ -33,8 +33,6 @@ import javax.swing.JTextField;
  * Handle "Classpath" panel of the New Project wizard
  * for J2SE Ant Project.<br>
  * Usage:
- * <pre>
- * </pre>
  * 
  * @author tb115823
  */

--- a/java/jellytools.java/src/org/netbeans/jellytools/modules/form/properties/editors/FormCustomEditorOperator.java
+++ b/java/jellytools.java/src/org/netbeans/jellytools/modules/form/properties/editors/FormCustomEditorOperator.java
@@ -35,7 +35,7 @@ import org.netbeans.jemmy.operators.*;
  * Contains Default, OK and Cancel buttons,
  * combobox enabling to change editor (DimensionEditor/Value from existing component).
  * <p>
- * Example:<p>
+ * Example:
  * <pre>
  *  ...
  *  property.openEditor();
@@ -50,7 +50,7 @@ import org.netbeans.jemmy.operators.*;
 public class FormCustomEditorOperator extends NbDialogOperator {
 
     /** Search for FormCustomEditor with defined title
-     * @throws TimeoutExpiredException when NbDialog not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when NbDialog not found
      * @param title title of FormCustomEditor (mostly property name) */
     public FormCustomEditorOperator(String title) {
         super(title);
@@ -60,7 +60,7 @@ public class FormCustomEditorOperator extends NbDialogOperator {
     private JComboBoxOperator _cboMode;
 
     /** Tries to find "Default" JButton in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JButtonOperator
      */
     public JButtonOperator btDefault() {
@@ -73,7 +73,7 @@ public class FormCustomEditorOperator extends NbDialogOperator {
     }
 
     /** Tries to find JComboBox in this dialog.
-     * @throws TimeoutExpiredException when component not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when component not found
      * @return JComboBoxOperator */
     public JComboBoxOperator cboMode() {
         if (_cboMode==null) {
@@ -83,7 +83,7 @@ public class FormCustomEditorOperator extends NbDialogOperator {
     }
 
     /** clicks on "Default" JButton
-     * @throws TimeoutExpiredException when JButton not found
+     * @throws org.netbeans.jemmy.TimeoutExpiredException when JButton not found
      */
     public void setDefault() {
         btDefault().push();

--- a/platform/api.search/src/org/netbeans/spi/search/SearchInfoDefinition.java
+++ b/platform/api.search/src/org/netbeans/spi/search/SearchInfoDefinition.java
@@ -48,7 +48,7 @@ import org.openide.filesystems.FileObject;
  * In most cases, you do not need to create custom implementation. You can 
  * use some factory method in {@link SearchInfoDefinitionFactory}.
  * 
- * <div clas="nonnormative">
+ * <div class="nonnormative">
  * <p>Example:</p>
  * <pre>
  * {@code

--- a/platform/api.search/src/org/netbeans/spi/search/SearchInfoDefinitionFactory.java
+++ b/platform/api.search/src/org/netbeans/spi/search/SearchInfoDefinitionFactory.java
@@ -175,7 +175,7 @@ public final class SearchInfoDefinitionFactory {
      * Convenience method for creating search info for a list of roots with
      * default filters.
      *
-     * @see #createSearchInfo(.FileObject[], SearchFilterDefinition[])
+     * @see #createSearchInfo(FileObject[], SearchFilterDefinition[])
      */
     public static @NonNull SearchInfoDefinition createSearchInfo(
             @NonNull FileObject[] roots) {
@@ -197,7 +197,7 @@ public final class SearchInfoDefinitionFactory {
      * <p> In case you want to create node children in the node constructor, you
      * can create children in one constructor and pass them to another
      * constructor:</p>
-     * <pre class="nonnormative"">
+     * <pre class="nonnormative">
      * {@code
      * public ExampleNode() {
      *    this(Children.create(someChildrenFactory, true));

--- a/platform/core.network/src/org/netbeans/core/network/proxy/pac/PacHelperMethodsNetscape.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/pac/PacHelperMethodsNetscape.java
@@ -256,7 +256,7 @@ public interface PacHelperMethodsNetscape {
      * <br>
      * @param args up to max 3 arguments
      * @return 
-     * @see org.netbeans.network.proxy.pac.datetime.PacUtilsDateTime#WEEKDAY_NAMES
+     * @see org.netbeans.core.network.proxy.pac.datetime.PacUtilsDateTime#WEEKDAY_NAMES
      */
     public boolean weekdayRange(Object... args);
 
@@ -279,7 +279,6 @@ public interface PacHelperMethodsNetscape {
      * Even if not shown above, the {@code gmt} parameter can always be
      * added as an (optional) last parameter.
      * 
-     * <p>
      * <ul>
      *    <li>{@code day} is the day of month between 1 and 31 (as an integer).
      *    </li>
@@ -320,7 +319,7 @@ public interface PacHelperMethodsNetscape {
      *     true from beginning of year 1995 until the end of year 1997.
      * </pre>
      * 
-     * @see org.netbeans.network.proxy.pac.datetime.PacUtilsDateTime#MONTH_NAMES
+     * @see org.netbeans.core.network.proxy.pac.datetime.PacUtilsDateTime#MONTH_NAMES
      * @param args
      * @return 
      */
@@ -339,7 +338,6 @@ public interface PacHelperMethodsNetscape {
      * </pre>
      * Even if not shown above, the {@code gmt} parameter can always be
      * added as an (optional) last parameter.
-     * <p>
      * <ul>
      *    <li>{@code hour} is the hour from 0 to 23. (0 is midnight, 23 is 11 pm.)
      *    </li>

--- a/platform/core.network/src/org/netbeans/core/network/proxy/pac/PacUtils.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/pac/PacUtils.java
@@ -30,7 +30,7 @@ import org.netbeans.core.network.utils.SimpleObjCache;
 /**
  * Methods and constants useful in PAC script evaluation.
  * 
- * @see org.netbeans.network.proxy.pac.datetime.PacUtilsDateTime
+ * @see org.netbeans.core.network.proxy.pac.datetime.PacUtilsDateTime
  * 
  * @author lbruun
  */
@@ -54,17 +54,18 @@ public class PacUtils {
      *
      * <p>
      * This method supports all GLOB wildcards, such as
-     * <table border="0" style="order-collapse: separate;border-spacing: 50px 0;" summary="">
-     * <tr align="left"><td>{@code *}</td><td>matches any number of any
+     * <table>
+     * <caption>Example of translation</caption>
+     * <tr><td>{@code *}</td><td>matches any number of any
      * characters including none</td>
-     * <tr align="left"><td>{@code ?}</td><td>matches any single character</td>
-     * <tr align="left"><td>{@code [abc]}</td><td>matches one character given in
+     * <tr><td>{@code ?}</td><td>matches any single character</td>
+     * <tr><td>{@code [abc]}</td><td>matches one character given in
      * the bracket</td>
-     * <tr align="left"><td>{@code [a-z]}</td><td>matches one character from the
+     * <tr><td>{@code [a-z]}</td><td>matches one character from the
      * range given in the bracket</td>
-     * <tr align="left"><td>{@code [!abc]}</td><td>matches one character
+     * <tr><td>{@code [!abc]}</td><td>matches one character
      * <i>not</i> given in the bracket</td>
-     * <tr align="left"><td>{@code [!a-z]}</td><td>matches one character
+     * <tr><td>{@code [!a-z]}</td><td>matches one character
      * <i>not</i> from the range given in the bracket</td>
      * </table>
      *

--- a/platform/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluator.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluator.java
@@ -51,12 +51,15 @@ import org.openide.util.NbBundle;
  * NetBeans implementation of a PAC script evaluator. This implementation
  * is the one returned by {@link NbPacScriptEvaluatorFactory}.
  *
- * <h3>Features comparison</h3>
+ * <p>
+ * <strong>Features comparison</strong>
+ * <p>
  * There are differences between how browsers have implemented the PAC
  * evaluation functionality. In the following the Apache NetBeans implementation
  * (this class) is pitched against some of the major browsers.<br><br>
  *
- * <table summary="" style="table-layout: fixed; width:100%;" border="1" cellpadding="10" cellspacing="0">
+ * <table>
+ *   <caption>Features comparison</caption>
  *   <tr><th class="tablersh">Behavior</th>
  *       <th>Apache<br>NetBeans</th>
  *       <th>Chrome<br>{@code 61.0.3163.100}</th>
@@ -167,7 +170,9 @@ import org.openide.util.NbBundle;
  *    at finding the host's correct IP address, in particular on a multi-homed
  *    computer.
  *
- * <h3>Customization</h3>
+ * <p>
+ * <strong>Customization</strong>
+ * <p>
  * The implementation for
  * {@link org.netbeans.core.network.proxy.pac.PacHelperMethods PacHelperMethods} is
  * found via the global lookup. If you are unhappy with the implementation

--- a/platform/core.network/src/org/netbeans/core/network/utils/HostnameUtils.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/HostnameUtils.java
@@ -36,8 +36,7 @@ public class HostnameUtils {
      * name on the network.
      * 
      * <p>
-     * IMPLEMENTATION:
-     * <p>
+     * IMPLEMENTATION: 
      * <ul>
      *   <li>On Unix-like OSes (incl Mac OS X) this is the value as returned from
      *       the {@code gethostname()} function from the standard C Library. </li>

--- a/platform/core.network/src/org/netbeans/core/network/utils/IpAddressUtils.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/IpAddressUtils.java
@@ -207,7 +207,7 @@ public class IpAddressUtils {
 
     /**
      * Performs a name service lookup with a timeout. Same as 
-     * {@link #nameResolveArr(java.lang.String, int, org.netbeans.network.IpAddressUtils.IpTypePreference) nameResolveArr()}
+     * {@link #nameResolveArr(java.lang.String, int, IpTypePreference) nameResolveArr()}
      * but only returns a single address. 
      * 
      * @see #nameResolveArr(String, int, IpTypePreference) 
@@ -235,7 +235,7 @@ public class IpAddressUtils {
     
     /**
      * Performs a name service lookup with a timeout. Same as 
-     * {@link #nameResolveArr(java.lang.String, int, org.netbeans.network.IpAddressUtils.IpTypePreference) nameResolveArr()}
+     * {@link #nameResolveArr(java.lang.String, int, IpTypePreference) nameResolveArr()}
      * but only returns a single address and uses 
      * {@link IpTypePreference#ANY_JDK_PREF IpTypePreference.ANY_JDK_PREF}.
      * 

--- a/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
@@ -47,7 +47,6 @@ import org.openide.util.RequestProcessor;
 /**
  * Methods for determining the local host's own address. The methods provide
  * two benefits over the core JDK classes.:
- * <p>
  * <ul>
  *    <li><i>Caching</i>. Results from the methods are cached and can therefore
  *       be returned without blocking. An application should call 
@@ -250,13 +249,13 @@ public class LocalAddressUtils {
      * Returns the addresses of the local host.
      * 
      * <p>This is achieved by retrieving the
-     * {@link org.netbeans.network.hname.HostnameUtils#getNetworkHostname() name-of-the-host} 
+     * {@link HostnameUtils#getNetworkHostname() name-of-the-host} 
      * from the system, then resolving that name into a list of {@code InetAddress}es. 
      * 
      * <p>This method returns a cached result and is therefore likely not to
      * block unless this is the first time this class is being referenced.
      * 
-     * @see org.netbeans.network.hname.HostnameUtils#getNetworkHostname()
+     * @see HostnameUtils#getNetworkHostname()
      * @see InetAddress#getAllByName(java.lang.String) 
      * @param ipTypePref filter
      * @return

--- a/platform/options.api/src/org/netbeans/api/options/OptionsDisplayer.java
+++ b/platform/options.api/src/org/netbeans/api/options/OptionsDisplayer.java
@@ -53,7 +53,7 @@ public final class OptionsDisplayer {
      * @since 1.29
      */
     public static final String KEYMAPS = "Keymaps"; // NOI18N
-    /** Registration name of FontsAndColors category (aka Fonts & Colors).
+    /** Registration name of FontsAndColors category (aka Fonts &amp; Colors).
      * @since 1.29
      */
     public static final String FONTSANDCOLORS = "FontsAndColors"; // NOI18N

--- a/platform/options.api/src/org/netbeans/spi/options/AdvancedOption.java
+++ b/platform/options.api/src/org/netbeans/spi/options/AdvancedOption.java
@@ -44,19 +44,19 @@ import java.util.concurrent.Callable;
  * &lt;/folder&gt;</pre>
  *
  * where:
- * <br/><b>controller</b> should be an instance of <code>OptionsPanelController</code>
- * <br/><b>displayName</b> should be a localized string for your tab display name
- * <br/><b>toolTip</b> should be a localized string for your tab tool tip
+ * <br><b>controller</b> should be an instance of <code>OptionsPanelController</code>
+ * <br><b>displayName</b> should be a localized string for your tab display name
+ * <br><b>toolTip</b> should be a localized string for your tab tool tip
  * <span class="nonnormative"><strong>Currently unused.</strong></span>
- * <br/><b>keywords</b> should be localized keywords list, separated by comma in Bundle, for quickserach purposes
- * <br/><b>keywordsCategory</b> should be relative path to your panel inside Options dialog
- * <br/><br/>
+ * <br><b>keywords</b> should be localized keywords list, separated by comma in Bundle, for quickserach purposes
+ * <br><b>keywordsCategory</b> should be relative path to your panel inside Options dialog
+ * <br><br>
  * No explicit sorting recognized (may be sorted e.g. by display name).
  *
  * <p><b>Related documentation</b>
  *
  * <ul>
- * <li><a href="http://platform.netbeans.org/tutorials/nbm-options.html">NetBeans Options Window Module Tutorial</a>
+ * <li><a href="https://netbeans.apache.org/tutorials/nbm-options.html">NetBeans Options Window Module Tutorial</a>
  * </ul>
  *
  * @see OptionsCategory

--- a/platform/options.api/src/org/netbeans/spi/options/OptionsCategory.java
+++ b/platform/options.api/src/org/netbeans/spi/options/OptionsCategory.java
@@ -29,7 +29,7 @@ import org.openide.nodes.AbstractNode;
 import org.openide.util.ImageUtilities;
 
 /**
- * This class represents one category (like "Fonts & Colors"
+ * This class represents one category (like "Fonts &amp; Colors"
  * or "Editor") in Options Dialog.
  * <p>Normally panels are registered using one of the annotations in {@link OptionsPanelController}.
  * They may also be registered in a layer manually as follows:
@@ -50,17 +50,17 @@ import org.openide.util.ImageUtilities;
  *   &lt;/folder&gt;</pre>
  *
  * where:
- * <br/><b>controller</b> should be an instance of <code>OptionsPanelController</code>
- * <br/><b>title</b> should be a localized string where title of your tab inside OD is stored
+ * <br><b>controller</b> should be an instance of <code>OptionsPanelController</code>
+ * <br><b>title</b> should be a localized string where title of your tab inside OD is stored
  * <span class="nonnormative"><strong>Currently unused.</strong></span>
- * <br/><b>categoryName</b> should be a localized string for your tab's category name
- * <br/><b>iconBase</b> should be relative path to icon wou wish to display inside OD
- * <br/><b>keywords</b> should be localized keywords list, separated by comma in Bundle, for quickserach purposes
- * <br/><b>keywordsCategory</b> should be relative path to your panel inside Options dialog
- * <br/><b>description</b> should be a localized string where your tab description is stored
+ * <br><b>categoryName</b> should be a localized string for your tab's category name
+ * <br><b>iconBase</b> should be relative path to icon wou wish to display inside OD
+ * <br><b>keywords</b> should be localized keywords list, separated by comma in Bundle, for quickserach purposes
+ * <br><b>keywordsCategory</b> should be relative path to your panel inside Options dialog
+ * <br><b>description</b> should be a localized string where your tab description is stored
  * <span class="nonnormative"><strong>Currently unused.</strong></span>
  *
- * <br/><br/>
+ * <br><br>
  * Or, when registering a category with sub-panels, instead of
  * <pre style="background-color: rgb(255, 255, 153);">
  *            &lt;attr name="controller" newvalue="org.netbeans.core.ui.options.general.GeneralOptionsPanelController"/&gt;
@@ -71,7 +71,7 @@ import org.openide.util.ImageUtilities;
  * </pre>
  * and supply a folder where instaces of <code>AdvancedOption</code> should be
  * registered. Its instances would be found automatically and shown as sub-panels
-  <br/><br/>
+  <br><br>
  * Use standard {@code position} attributes to sort items registered in layers.
  *
  * @see AdvancedOption

--- a/platform/options.api/src/org/netbeans/spi/options/OptionsPanelController.java
+++ b/platform/options.api/src/org/netbeans/spi/options/OptionsPanelController.java
@@ -337,7 +337,7 @@ public abstract class OptionsPanelController {
 
     /**
      * Registers keywords for some panel in the Options dialog. Should be placed
-     * on a {@link JPanel} instance.
+     * on a {@link javax.swing.JPanel} instance.
      *
      * @since org.netbeans.modules.options.api/1 1.29
      */
@@ -352,30 +352,25 @@ public abstract class OptionsPanelController {
          * <p> Each entry in the provided array is split around comma character.
          * For example:
          *
-         * <blockquote><table cellpadding=1 cellspacing=0 summary="Split
-         * examples showing array and keywords"> <tr> <th>Provided array</th>
-         * <th>Keywords</th> </tr> <tr><td align=center>{ "Boo", "fOo" }</td>
-         * <td><tt>{ "BOO", "FOO" }</tt></td></tr>
-         * </tr> <tr><td align=center>{ "boo and", "foo" }</td>
-         * <td><tt>{ "BOO AND", "FOO" }</tt></td></tr>
-         * </tr> <tr><td align=center>{ "boo,and", "foo" }</td>
-         * <td><tt>{ "BOO", "AND", "FOO" }</tt></td></tr> 
+         * <blockquote><table>
+         * <caption>Split examples showing array and keywords</caption>
+         * <tr><th>Provided array</th><th>Keywords</th></tr> 
+         * <tr><td align=center>{ "Boo", "fOo" }</td><td><tt>{ "BOO", "FOO" }</tt></td></tr>
+         * <tr><td align=center>{ "boo and", "foo" }</td><td><tt>{ "BOO AND", "FOO" }</tt></td></tr>
+         * <tr><td align=center>{ "boo,and", "foo" }</td><td><tt>{ "BOO", "AND", "FOO" }</tt></td></tr> 
          * </table></blockquote>
          *
          * <p> The user's search-text is split around the space character to form words.
          * All words need to be present in a panel to yield a successful search.
          * The registered keywords {"Boo,anD", "fOo"}, for example, yield the following results with these search-texts:
          *
-         * <blockquote><table cellpadding=1 cellspacing=0 summary="Search
-         * examples showing search-text and results"> <tr> <th>User's search-text</th>
-         * <th>Result</th> </tr> <tr><td align=center>"boo"</td>
-         * <td><tt>keyword found</tt></td></tr>
-         * <tr><td align=center>"nd"</td>
-         * <td><tt>keyword found</tt></td></tr>
-         * <tr><td align=center>"boo and"</td>
-         * <td><tt>keyword found</tt></td></tr>
-         * <tr><td align=center>"boo moo"</td>
-         * <td><tt>keyword NOT found</tt></td></tr>
+         * <blockquote><table> 
+         * <caption>Search examples showing search-text and results</caption>
+         * <tr><th>User's search-text</th><th>Result</th></tr>
+         * <tr><td align=center>"boo"</td><td><tt>keyword found</tt></td></tr>
+         * <tr><td align=center>"nd"</td><td><tt>keyword found</tt></td></tr>
+         * <tr><td align=center>"boo and"</td><td><tt>keyword found</tt></td></tr>
+         * <tr><td align=center>"boo moo"</td><td><tt>keyword NOT found</tt></td></tr>
          * </table></blockquote>
          */
         String[] keywords();
@@ -394,7 +389,7 @@ public abstract class OptionsPanelController {
 
         /**
          * Optional title that must be used if the panel is part of a tabbed pane, such as when it is
-         * in the Editor, Fonts & Colors, Java, PHP, C/C++ or Miscellaneous categories, matching the
+         * in the Editor, Fonts &amp; Colors, Java, PHP, C/C++ or Miscellaneous categories, matching the
          * {@link SubRegistration#displayName}.
          * 
          * You may use {@code #key} syntax.


### PR DESCRIPTION
This is a sixth split of the big PR https://github.com/apache/netbeans/pull/4450.
using the following to have ant javadoc -Dmetabuild.branch=master -Dapidocfullcheck=true.

About 3/4 of the module pass.

I did a comment on a code modification that is removal of import. I don't know why it fails with this import. Many classes have unused import and no issue.

As part of the refactoring.api fixes it seems that annotationprocessor is supporting a never implemented type. (see inline comment)
