### PR TITLE
Use wait node in VSCode for long running computation of children

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
@@ -476,9 +476,7 @@ public abstract class TreeViewProvider {
 
     public final CompletionStage<Node[]> getChildren(Node nodeOrNull) {
         Node node = getNodeOrRoot(nodeOrNull);
-        return CompletableFuture.supplyAsync(() -> {
-            return node.getChildren().getNodes(true);
-        }, INITIALIZE);
+        return CompletableFuture.completedFuture(node.getChildren().getNodes());
     }
 
     public final CompletionStage<Node> getParent(Node node) {

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
@@ -428,6 +428,8 @@ public class ProjectViewTest extends NbTestCase {
     }
     
     private TreeItem findChild(TreeItem parent, String childLabel) throws Exception {
+        TreeNodeRegistry reg = serverLookup.lookup(TreeNodeRegistry.class);
+        reg.findNode(parent.id).getChildren().getNodes(true);
         for (TreeItem candidate : getChildren(parent)) {
             if (childLabel.equals(candidate.label)) {
                 return candidate;
@@ -576,6 +578,8 @@ public class ProjectViewTest extends NbTestCase {
         
         TreeItem found = findChild(testRoot, "gradle");
         assertNotNull("Test package exists", found);
+        TreeNodeRegistry reg = serverLookup.lookup(TreeNodeRegistry.class);
+        reg.findNode(found.id).getChildren().getNodes(true);
         int[] childIds = server.getTreeViewService().getChildren(new NodeOperationParams(found.id)).get();
         assertEquals("Test package node is not empty", 1, childIds.length);
         

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -1013,6 +1013,10 @@
 				"codeicon": "open-preview"
 			},
 			{
+				"uriExpression": "nbres:/org/openide/nodes/wait.gif",
+				"codeicon": "watch"
+			},
+			{
 				"uriExpression": "nbres:/org/netbeans/modules/cloud/oracle/resources/yellow_dot.svg",
 				"codeicon": "circle-large-outline",
 				"color": "charts.yellow"


### PR DESCRIPTION
This PR tries to fix the issue, which manifest itself as VSCode error "Element with id xxx is already registered" when expanding nodes in Database view in VSCode. 
It turns out that the error was caused by asynchronous computation of children used netbeans database module and usage of `node.getChildren().getNodes(true)` in LSP server. This implementation causes that VSCode does not see `wait node` which is normally displayed in NetBeans, because `getNodes(true)` waits for all nodes and efectively invalides the asynchronous computation of children for the VSCode. However property change events and other changes for newly created nodes are fired from netbeans code and translated via LSP to VSCode - I believe that this causes mismatch between VSCode and LSP server. 
The fix changes `node.getChildren().getNodes(true)` to `node.getChildren().getNodes()` so that VSCode sees `wait node` and asynchronously computed nodes the same way as are presented in NetBeans. It is also not necessary to wrap `node.getChildren().getNodes()` in `CompletableFuture.supplyAsync()`, since `getNodes()` is designed not to block. Finally `wait node` icon was changed to use `watch` VCSode icon so that the UI of `wait node` match the VSCode LAF.
`java.lsp.server` unit tests were updated to wait for full children computation before accessing them via LSP API.