### PR TITLE
`SourceUtils.findMatchingChild` should never return a folder

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
@@ -628,7 +628,9 @@ public class SourceUtils {
     private static FileObject findMatchingChild(String sourceFileName, Collection<FileObject> folders, boolean caseSensitive) {
         final Match matchSet = caseSensitive ? new CaseSensitiveMatch(sourceFileName) : new CaseInsensitiveMatch(sourceFileName);
         for (FileObject folder : folders) {
-            for (FileObject child : folder.getChildren()) {
+            FileObject[] children = folder.getChildren();
+            Arrays.sort(children, Comparator.comparing(FileObject::getNameExt)); // for determinism
+            for (FileObject child : children) {
                 if (matchSet.apply(child)) {
                     return child;
                 }
@@ -684,6 +686,9 @@ public class SourceUtils {
         }
 
         final boolean apply(final FileObject fo) {
+            if (fo.isFolder()) {
+                return false;
+            }
             if (fo.getNameExt().equals(name)) {
                 return true;
             }
@@ -1127,9 +1132,8 @@ public class SourceUtils {
     }
 
     /**
-     * Returns candidate filenames given a classname. The return value is either
-     * a String (top-level class, no $) or List&lt;String> as the JLS permits $ in
-     * class names.
+     * Returns candidate filenames given a classname.
+     * @return a single name (top-level class, no $) or multiple as the JLS permits $ in class names.
      */
     private static List<String> getSourceFileNames(String classFileName) {
         int index = classFileName.lastIndexOf('$');

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTest.java
@@ -321,6 +321,7 @@ public class SourceUtilsTest extends ClassIndexTestCase {
         FileObject srcInDefPkg = src.createData("Foo","java");
         assertNotNull(srcInDefPkg);
         FileObject sourceFile = src.createFolder("org").createFolder("me").createData("Test", "java");
+        src.getFileObject("org/me").createFolder("Test"); // https://github.com/apache/netbeans/issues/5738
         assertNotNull(sourceFile);
         ClasspathInfo cpInfo = ClasspathInfo.create(ClassPathSupport.createClassPath(new FileObject[0]), ClassPathSupport.createClassPath(new FileObject[0]),
             ClassPathSupport.createClassPath(new FileObject[]{src}));
@@ -337,16 +338,16 @@ public class SourceUtilsTest extends ClassIndexTestCase {
         ElementHandle<? extends Element> handle = ElementHandle.createTypeElementHandle(ElementKind.CLASS, "org.me.Test");
         assertNotNull (handle);
         FileObject result = SourceUtils.getFile(handle, cpInfo);
-        assertNotNull(result);
+        assertEquals(sourceFile, result);
         handle = ElementHandle.createTypeElementHandle(ElementKind.CLASS, "org.me.Test$Inner");
         result = SourceUtils.getFile(handle,cpInfo);
-        assertNotNull(result);
+        assertEquals(sourceFile, result);
         handle = ElementHandle.createPackageElementHandle("org.me");
         result = SourceUtils.getFile(handle,cpInfo);
-        assertNotNull(result);
+        assertEquals(sourceFile.getParent(), result);
         handle = ElementHandle.createTypeElementHandle(ElementKind.CLASS, "Foo");
         result = SourceUtils.getFile(handle,cpInfo);
-        assertNotNull(result);
+        assertEquals(srcInDefPkg, result);
     }
 
     public void testGetMainClasses() throws Exception {


### PR DESCRIPTION
Fixes #5738, a regression introduced by #5152 in NB 17.