### PR TITLE
make maven project properties window aware of the javac release option

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/api/ModelUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/ModelUtils.java
@@ -305,13 +305,13 @@ public final class ModelUtils {
     }
     
     /**
-     * Sets the Java source level of a project.
+     * Sets the Java source and target level of a project (will set release if previously set).
      * Use {@link PluginPropertyUtils#getPluginProperty(org.netbeans.api.project.Project,String,String,String,String,String)} first
      * ({@link Constants#GROUP_APACHE_PLUGINS}, {@link Constants#PLUGIN_COMPILER}, {@link Constants#SOURCE_PARAM}, {@code "compile"})
      * to make sure that the current level is actually not what you want.
      * 
-     * Please Note: THis method will not take existing configuration into account, especially the use of property (maven.compiler.source, maven.compiler.target)
-     * instead of plugin configuration is ignored.
+     * Please Note: This method will not take existing properties into account (maven.compiler.source, maven.compiler.target or maven.compiler.release),
+     * it is only updating the plugin configuration itself.
      * @param mdl a POM model
      * @param sourceLevel the desired source level
      * @since 2.19
@@ -339,8 +339,15 @@ public final class ModelUtils {
             conf = mdl.getFactory().createConfiguration();
             plugin.setConfiguration(conf);
         }
-        conf.setSimpleParameter(Constants.SOURCE_PARAM, sourceLevel);
-        conf.setSimpleParameter(Constants.TARGET_PARAM, sourceLevel);
+        if (conf.getSimpleParameter(Constants.RELEASE_PARAM) != null) {
+            conf.setSimpleParameter(Constants.RELEASE_PARAM, sourceLevel);
+            conf.setSimpleParameter(Constants.SOURCE_PARAM, null);
+            conf.setSimpleParameter(Constants.TARGET_PARAM, null);
+        } else {
+            conf.setSimpleParameter(Constants.SOURCE_PARAM, sourceLevel);
+            conf.setSimpleParameter(Constants.TARGET_PARAM, sourceLevel);
+        }
+        
     }
 
     /**

--- a/java/maven/src/org/netbeans/modules/maven/customizer/SourcesPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/SourcesPanel.java
@@ -76,8 +76,10 @@ public class SourcesPanel extends JPanel implements HelpCtx.Provider {
         @Override
         public void performOperation(POMModel model) {
             String s = PluginPropertyUtils.getPluginProperty(handle.getProject(), Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER, "source", null, null);
-            String t = PluginPropertyUtils.getPluginProperty(handle.getProject(), Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER, "source", null, null);
-            if (s == null && t == null) {
+            String t = PluginPropertyUtils.getPluginProperty(handle.getProject(), Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER, "target", null, null);
+            String r = PluginPropertyUtils.getPluginProperty(handle.getProject(), Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER, "release", null, null);
+            if (s == null && t == null && r == null) {
+                // set in project properties
                 Project p = model.getProject();
                 if (p != null) {
                     Properties prop = p.getProperties();
@@ -85,11 +87,25 @@ public class SourcesPanel extends JPanel implements HelpCtx.Provider {
                         prop = model.getFactory().createProperties();
                         p.setProperties(prop);
                     }
-                    prop.setProperty("maven.compiler.source", sourceLevel);
-                    prop.setProperty("maven.compiler.target", sourceLevel);
+                    if (prop.getProperty("maven.compiler.release") != null) {
+                        prop.setProperty("maven.compiler.release", sourceLevel);
+                        prop.setProperty("maven.compiler.source", null);
+                        prop.setProperty("maven.compiler.target", null);
+                    } else {
+                        prop.setProperty("maven.compiler.source", sourceLevel);
+                        prop.setProperty("maven.compiler.target", sourceLevel);
+                    }
                 }
             } else {
+                // set in plugin config
                 ModelUtils.setSourceLevel(model, sourceLevel);
+                // clear props, just in case
+                if (model.getProject() != null && model.getProject().getProperties() != null) {
+                    Properties prop = model.getProject().getProperties();
+                    prop.setProperty("maven.compiler.source", null);
+                    prop.setProperty("maven.compiler.target", null);
+                    prop.setProperty("maven.compiler.release", null);
+                }
             }
         }
     };


### PR DESCRIPTION
The project properties window will now update the release option if it can be found and use source/target as fallback. 

It will also make sure that both are not used at the same time. The option window itself will not convert anything to the release option, that is what the hints are for.

![maven-release-project-options](https://user-images.githubusercontent.com/114367/228995938-b15d8683-5769-49d4-80a4-0d3e49cc8fed.png)