### PR TITLE
Fix code completion for `@mixin` #4683

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/ClassScopeImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/ClassScopeImpl.java
@@ -39,6 +39,7 @@ import org.netbeans.modules.php.editor.api.elements.MethodElement;
 import org.netbeans.modules.php.editor.api.elements.TraitElement;
 import org.netbeans.modules.php.editor.api.elements.TypeConstantElement;
 import org.netbeans.modules.php.editor.api.elements.TypeElement;
+import org.netbeans.modules.php.editor.api.elements.TypeMemberElement;
 import org.netbeans.modules.php.editor.index.PHPIndexer;
 import org.netbeans.modules.php.editor.index.Signature;
 import org.netbeans.modules.php.editor.model.CaseElement;
@@ -333,6 +334,13 @@ class ClassScopeImpl extends TypeScopeImpl implements ClassScope, VariableNameFa
             Set<org.netbeans.modules.php.editor.api.elements.FieldElement> indexedFields = index.getAlllFields(traitScope);
             for (org.netbeans.modules.php.editor.api.elements.FieldElement field : indexedFields) {
                 allFields.add(new FieldElementImpl(traitScope, field));
+            }
+        }
+        // GH-4683 get fields of mixin
+        Set<TypeMemberElement> mixinTypeMembers = index.getAccessibleMixinTypeMembers(this, this);
+        for (TypeMemberElement mixinTypeMember : mixinTypeMembers) {
+            if (mixinTypeMember instanceof org.netbeans.modules.php.editor.api.elements.FieldElement) {
+                allFields.add((new FieldElementImpl(this, (org.netbeans.modules.php.editor.api.elements.FieldElement) mixinTypeMember)));
             }
         }
         return allFields;

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
@@ -1411,6 +1411,11 @@ public final class VariousUtils {
                                 }
                                 metaAll.insert(0, PRE_OPERATION_TYPE_DELIMITER + VariousUtils.TYPE_TYPE_PREFIX);
                             }
+                        } else if (isReference(token)) {
+                            // ->fieldName
+                            metaAll.insert(0, PRE_OPERATION_TYPE_DELIMITER + VariousUtils.FIELD_TYPE_PREFIX);
+                            state = State.REFERENCE;
+                            break;
                         } else {
                             metaAll = transformToFullyQualifiedType(metaAll, tokenSequence, varScope);
                             metaAll.insert(0, PRE_OPERATION_TYPE_DELIMITER + VariousUtils.TYPE_TYPE_PREFIX);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php
@@ -1,0 +1,128 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @property-read TestData $data
+ */
+class MixinClass {
+    public const PUBLIC_CONSTANT = "public const";
+    private const PRIVATE_CONSTANT = "private const";
+    protected const PROTECTED_CONSTANT = "protected const";
+
+    public static $publicStaticField;
+    private static $privateStaticField;
+    protected static $protectedStaticField;
+
+    public function __construct(
+        public readonly array $publicField,
+        private array $privatecField,
+        protected int $protectedField,
+    ) {
+
+    }
+
+    public function publicMethod(): void {
+
+    }
+
+    private function privateMethod(): void {
+
+    }
+
+    protected function protectedMethod(): void {
+
+    }
+
+    public static function publicStaticMethod(): void {
+
+    }
+
+    private static function privateStaticMethod(): void {
+
+    }
+
+    protected static function protectedStaticMethod(): void {
+
+    }
+}
+
+/**
+ * @mixin MixinClass
+ */
+class TestClass {
+
+    public function test(): void {
+        $this->data;
+        $this->data->publicField;
+        $this->data::PUBLIC_CONSTANT;
+    }
+
+}
+
+class TestData {
+
+    public const PUBLIC_CONSTANT = "public const";
+    private const PRIVATE_CONSTANT = "private const";
+    protected const PROTECTED_CONSTANT = "protected const";
+
+    public static $publicStaticField;
+    private static $privateStaticField;
+    protected static $protectedStaticField;
+
+    public function __construct(
+        public readonly array $publicField,
+        private array $privatecField,
+        protected int $protectedField,
+    ) {
+
+    }
+
+    public function publicMethod(): void {
+
+    }
+
+    private function privateMethod(): void {
+
+    }
+
+    protected function protectedMethod(): void {
+
+    }
+
+    public static function publicStaticMethod(): void {
+
+    }
+
+    private static function privateStaticMethod(): void {
+
+    }
+
+    protected static function protectedStaticMethod(): void {
+
+    }
+
+}
+
+$test = new TestClass();
+$data = new TestData([], [], 0);
+
+$test->data;
+$test->data->publicField;
+$test->data::PUBLIC_CONSTANT;

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_01.completion
@@ -1,0 +1,11 @@
+Code completion result for source line:
+$this->|data;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     protectedMethod()               [PROTECTE  MixinClass
+METHOD     protectedStaticMethod()         [PROTECTE  MixinClass
+METHOD     publicMethod()                  [PUBLIC]   MixinClass
+METHOD     publicStaticMethod()            [STATIC]   MixinClass
+METHOD     test()                          [PUBLIC]   TestClass
+VARIABLE   TestData data                   [PUBLIC]   MixinClass
+VARIABLE   array publicField               [PUBLIC]   MixinClass
+VARIABLE   int protectedField              [PROTECTE  MixinClass

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_02.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+$this->data->|publicField;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethod()                  [PUBLIC]   TestData
+METHOD     publicStaticMethod()            [STATIC]   TestData
+VARIABLE   array publicField               [PUBLIC]   TestData

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_03.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+$this->data::|PUBLIC_CONSTANT;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticMethod()            [STATIC]   TestData
+VARIABLE   ? $publicStaticField            [STATIC]   TestData
+CONSTANT   PUBLIC_CONSTANT "public const"  [PUBLIC]   TestData
+CONSTANT   class \TestData                 [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_04.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+$test->|data;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethod()                  [PUBLIC]   MixinClass
+METHOD     publicStaticMethod()            [STATIC]   MixinClass
+METHOD     test()                          [PUBLIC]   TestClass
+VARIABLE   TestData data                   [PUBLIC]   MixinClass
+VARIABLE   array publicField               [PUBLIC]   MixinClass

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_05.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+$test->data->|publicField;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethod()                  [PUBLIC]   TestData
+METHOD     publicStaticMethod()            [STATIC]   TestData
+VARIABLE   array publicField               [PUBLIC]   TestData

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh4683/gh4683.php.testGH3486_06.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+$test->data::|PUBLIC_CONSTANT;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicStaticMethod()            [STATIC]   TestData
+VARIABLE   ? $publicStaticField            [STATIC]   TestData
+CONSTANT   PUBLIC_CONSTANT "public const"  [PUBLIC]   TestData
+CONSTANT   class \TestData                 [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH4683Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH4683Test.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class PHPCodeCompletionGH4683Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionGH4683Test(String testName) {
+        super(testName);
+    }
+
+    public void testGH3486_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh4683/gh4683.php", "        $this->^data;", false);
+    }
+
+    public void testGH3486_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh4683/gh4683.php", "        $this->data->^publicField;", false);
+    }
+
+    public void testGH3486_03() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh4683/gh4683.php", "        $this->data::^PUBLIC_CONSTANT;", false);
+    }
+
+    public void testGH3486_04() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh4683/gh4683.php", "$test->^data;", false);
+    }
+
+    public void testGH3486_05() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh4683/gh4683.php", "$test->data->^publicField;", false);
+    }
+
+    public void testGH3486_06() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh4683/gh4683.php", "$test->data::^PUBLIC_CONSTANT;", false);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[] {
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/gh4683"))
+            })
+        );
+    }
+}


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/4683
- Also get mixin fields as inherited fields
- Fix CC for the following case: `$variable->field::STATIC_MEMBER;`
