### PR TITLE
Upgraded Gradle Tooling to 8.1-rc-2 with JDK 20 Support

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
@@ -99,6 +99,7 @@ public final class GradleDistributionManager {
         GradleVersion.version("7.3"), // JDK-17
         GradleVersion.version("7.5"), // JDK-18
         GradleVersion.version("7.6"), // JDK-19
+        GradleVersion.version("8.1"), // JDK-20
     };
 
     final File gradleUserHome;
@@ -500,7 +501,9 @@ public final class GradleDistributionManager {
          */
         public int lastSupportedJava() {
             int i = JDK_COMPAT.length - 1;
-            while ((i >= 0) && version.compareTo(JDK_COMPAT[i]) < 0) {
+            //Make sure that even RC-s are considered to be compatible.
+            GradleVersion baseVersion = version.getBaseVersion();
+            while ((i >= 0) && baseVersion.compareTo(JDK_COMPAT[i]) < 0) {
                 i--;
             }
             return i + 9;

--- a/extide/libs.gradle/external/binaries-list
+++ b/extide/libs.gradle/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-21A1F0E6F9FB1A08D06602737FF2010288F9E934 https://repo.gradle.org/artifactory/libs-releases/org/gradle/gradle-tooling-api/8.0-rc-1/gradle-tooling-api-8.0-rc-1.jar gradle-tooling-api-8.0-rc-1.jar
+9BDE23C249C496F22A15B6202219170C5BCEF825 https://repo.gradle.org/artifactory/libs-releases/org/gradle/gradle-tooling-api/8.1-rc-2/gradle-tooling-api-8.1-rc-2.jar gradle-tooling-api-8.1-rc-2.jar

--- a/extide/libs.gradle/external/gradle-tooling-api-8.1-rc-2-license.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-8.1-rc-2-license.txt
@@ -1,7 +1,7 @@
 Name: Gradle Wrapper
 Description: Gradle Tooling API
-Version: 8.0-rc-1
-Files: gradle-tooling-api-8.0-rc-1.jar
+Version: 8.1-rc-2
+Files: gradle-tooling-api-8.1-rc-2.jar
 License: Apache-2.0
 Origin: Gradle Inc.
 URL: https://gradle.org/

--- a/extide/libs.gradle/external/gradle-tooling-api-8.1-rc-2-notice.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-8.1-rc-2-notice.txt
@@ -1,8 +1,8 @@
 Gradle Inc.'s Gradle Tooling API
-Copyright 2007-2022 Gradle Inc.
+Copyright 2007-2023 Gradle Inc.
 
 This product includes software developed at
 Gradle Inc. (https://gradle.org/).
 
 This product includes/uses SLF4J (https://www.slf4j.org/)
-developed by QOS.ch, 2004-2022
+developed by QOS.ch, 2004-2023

--- a/extide/libs.gradle/nbproject/project.properties
+++ b/extide/libs.gradle/nbproject/project.properties
@@ -22,4 +22,4 @@ javac.compilerargs=-Xlint -Xlint:-serial
 # For more information, please see http://wiki.netbeans.org/SignatureTest
 sigtest.gen.fail.on.error=false
 
-release.external/gradle-tooling-api-8.0-rc-1.jar=modules/gradle/gradle-tooling-api.jar
+release.external/gradle-tooling-api-8.1-rc-2.jar=modules/gradle/gradle-tooling-api.jar

--- a/extide/libs.gradle/nbproject/project.xml
+++ b/extide/libs.gradle/nbproject/project.xml
@@ -39,7 +39,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>gradle/gradle-tooling-api.jar</runtime-relative-path>
-                <binary-origin>external/gradle-tooling-api-8.0-rc-1.jar</binary-origin>
+                <binary-origin>external/gradle-tooling-api-8.1-rc-2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Well, the usual Gradle Tooling Update. If 8.1 GA would see the sun during the beta phase, I'm going to create another one.
