### PR TITLE
don't block in NBM wizard + skip snapshots + more.

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
@@ -103,7 +103,7 @@ public class MavenNbModuleImpl implements NbModuleProvider {
     public static final String GROUPID_MOJO = "org.codehaus.mojo";
     public static final String GROUPID_APACHE = "org.apache.netbeans.utilities";
     public static final String NBM_PLUGIN = "nbm-maven-plugin";
-    static final String LATEST_NBM_PLUGIN_VERSION = "4.7";
+    static final String LATEST_NBM_PLUGIN_VERSION = "4.8";
 
     public static final String NETBEANSAPI_GROUPID = "org.netbeans.api";
 

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NBMNativeMWI.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NBMNativeMWI.java
@@ -28,13 +28,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import javax.xml.namespace.QName;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.PluginManagement;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.eclipse.aether.repository.RemoteRepository;
 import org.netbeans.modules.apisupport.project.api.EditableManifest;
 import org.netbeans.modules.maven.api.Constants;
 import org.netbeans.modules.maven.api.archetype.ProjectInfo;
@@ -164,17 +164,17 @@ final class NBMNativeMWI {
                 boolean isSnapshot = NbmWizardIterator.SNAPSHOT_VERSION.equals(netbeansDependencyVersion);
                 String snapshotRepoUrl = "https://repository.apache.org/content/repositories/snapshots/";
                 if (parent != null) {
-                    List<ArtifactRepository> repos = parent.getRemoteArtifactRepositories();
+                    List<RemoteRepository> repos = parent.getRemoteProjectRepositories();
                     if (repos != null) {
                         OUTER : 
-                        for (ArtifactRepository repo : repos) {
+                        for (RemoteRepository repo : repos) {
                             if (snapshotRepoUrl.equals(repo.getUrl()) || (snapshotRepoUrl + "/").equals(repo.getUrl()))
                             {
                                 addRepository = false;
                                 break;
                             }
                             if (repo.getMirroredRepositories() != null) {
-                                for (ArtifactRepository mirr : repo.getMirroredRepositories()) {
+                                for (RemoteRepository mirr : repo.getMirroredRepositories()) {
                                     if (snapshotRepoUrl.equals(mirr.getUrl()) || (snapshotRepoUrl + "/").equals(mirr.getUrl()))
                                     {
                                         addRepository = false;
@@ -290,7 +290,7 @@ final class NBMNativeMWI {
                 managedPVersion = null;
                 String source = null;
                 String target = null;
-                pVersion = "3.8.1";
+                pVersion = "3.11.0";
                 if (parent != null) {
                     //TODO do we want to support the case when the plugin is defined in parent pom with inherited=true?
                     PluginManagement pm = parent.getPluginManagement();
@@ -333,7 +333,7 @@ final class NBMNativeMWI {
                 addPlugin = true;
                 managedPVersion = null;
                 String useManifest = null;
-                pVersion = "3.1.2";
+                pVersion = "3.3.0";
                 if (parent != null) {
                     //TODO do we want to support the case when the plugin is defined in parent pom with inherited=true?
                     PluginManagement pm = parent.getPluginManagement();

--- a/apisupport/maven.apisupport/test/unit/src/org/netbeans/modules/maven/apisupport/NBMNativeMWITest.java
+++ b/apisupport/maven.apisupport/test/unit/src/org/netbeans/modules/maven/apisupport/NBMNativeMWITest.java
@@ -61,7 +61,7 @@ public class NBMNativeMWITest extends NbTestCase {
         assertEquals("nbm-maven-plugin", model.getBuild().getPlugins().get(0).getArtifactId());
         assertEquals(MavenNbModuleImpl.getLatestNbmPluginVersion(), model.getBuild().getPlugins().get(0).getVersion());
         assertEquals("maven-compiler-plugin", model.getBuild().getPlugins().get(1).getArtifactId());
-        assertEquals("3.8.1", model.getBuild().getPlugins().get(1).getVersion());
+        assertEquals("3.11.0", model.getBuild().getPlugins().get(1).getVersion());
         assertEquals(0, model.getRepositories().size());
     }
 
@@ -79,7 +79,7 @@ public class NBMNativeMWITest extends NbTestCase {
         assertEquals("nbm-maven-plugin", model.getBuild().getPlugins().get(0).getArtifactId());
         assertEquals(MavenNbModuleImpl.getLatestNbmPluginVersion(), model.getBuild().getPlugins().get(0).getVersion());
         assertEquals("maven-compiler-plugin", model.getBuild().getPlugins().get(1).getArtifactId());
-        assertEquals("3.8.1", model.getBuild().getPlugins().get(1).getVersion());
+        assertEquals("3.11.0", model.getBuild().getPlugins().get(1).getVersion());
         assertEquals(1, model.getRepositories().size());
     }
 
@@ -106,7 +106,7 @@ public class NBMNativeMWITest extends NbTestCase {
         assertEquals("nbm-maven-plugin", model.getBuild().getPlugins().get(0).getArtifactId());
         assertEquals(MavenNbModuleImpl.getLatestNbmPluginVersion(), model.getBuild().getPlugins().get(0).getVersion());
         assertEquals("maven-compiler-plugin", model.getBuild().getPlugins().get(1).getArtifactId());
-        assertEquals("3.8.1", model.getBuild().getPlugins().get(1).getVersion());
+        assertEquals("3.11.0", model.getBuild().getPlugins().get(1).getVersion());
         assertEquals(0, model.getRepositories().size());
     }
 
@@ -132,7 +132,7 @@ public class NBMNativeMWITest extends NbTestCase {
         assertEquals("nbm-maven-plugin", model.getBuild().getPlugins().get(0).getArtifactId());
         assertEquals(MavenNbModuleImpl.getLatestNbmPluginVersion(), model.getBuild().getPlugins().get(0).getVersion());
         assertEquals("maven-compiler-plugin", model.getBuild().getPlugins().get(1).getArtifactId());
-        assertEquals("3.8.1", model.getBuild().getPlugins().get(1).getVersion());
+        assertEquals("3.11.0", model.getBuild().getPlugins().get(1).getVersion());
         assertEquals(1, model.getRepositories().size());
     }
 
@@ -187,7 +187,7 @@ public class NBMNativeMWITest extends NbTestCase {
         assertEquals("nbm-maven-plugin", modeloutput.getBuild().getPlugins().get(0).getArtifactId());
         assertEquals(MavenNbModuleImpl.getLatestNbmPluginVersion(), modeloutput.getBuild().getPlugins().get(0).getVersion());
         assertEquals("maven-compiler-plugin", modeloutput.getBuild().getPlugins().get(1).getArtifactId());
-        assertEquals("3.8.1", modeloutput.getBuild().getPlugins().get(1).getVersion());
+        assertEquals("3.11.0", modeloutput.getBuild().getPlugins().get(1).getVersion());
         assertEquals(0, model.getRepositories().size());
     }
 

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/CompilerPluginVersionError.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/CompilerPluginVersionError.java
@@ -85,7 +85,7 @@ public class CompilerPluginVersionError implements POMErrorFixProvider {
             // note: this is the embedded plugin version
             // however, if this version here is compatible too we can exit, since we know it is not a downgrade and maven itself is compatible
             String version = PluginPropertyUtils.getPluginVersion(nbproject.getMavenProject(), Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER);
-            if (new ComparableVersion(version).compareTo(COMPILER_PLUGIN_VERSION) >= 0) {
+            if (version != null && new ComparableVersion(version).compareTo(COMPILER_PLUGIN_VERSION) >= 0) {
                 return Collections.emptyList();
             }
         }

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/UseReleaseOptionHint.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/UseReleaseOptionHint.java
@@ -86,7 +86,7 @@ public class UseReleaseOptionHint implements POMErrorFixProvider {
         if (nbproject != null) {
             // note: this is the embedded plugin version, only useful for downgrade checks
             String pluginVersion = PluginPropertyUtils.getPluginVersion(nbproject.getMavenProject(), Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER);
-            if (new ComparableVersion(pluginVersion).compareTo(COMPILER_PLUGIN_VERSION) <= 0) {
+            if (pluginVersion != null && new ComparableVersion(pluginVersion).compareTo(COMPILER_PLUGIN_VERSION) <= 0) {
                 return Collections.emptyList();
             }
         }


### PR DESCRIPTION
the new NBM project wizard could potentially block after finish is pressed, waiting for the indexer to provide complete results (#1999) for the archetype version query.
This is unnecessary since archetypes rarely change and the default is usually the correct version even if the index isn't ready yet, so we are ok with partial results.

Further, it didn't filter out snapshot releases, which could be potentially in the local repository too.

It could even downgrade the archetype version by accident under some circumstances when indexing got previously canceled since it assumed the version was always newer.

+ fixed some deprecations and NPEs in maven hints

+ bumped archetype and plugin version defaults to latest

might also fix some symptoms of #5727