### PR TITLE
Fixed Formatting under Project Properties

### DIFF
--- a/ide/options.editor/src/org/netbeans/modules/options/indentation/FormattingPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/indentation/FormattingPanel.java
@@ -204,7 +204,9 @@ public final class FormattingPanel extends JPanel implements PropertyChangeListe
             jSplitPane1.resetToPreferredSizes();
             
             // parent might need a scrollbar now due to category panel change
-            getParent().validate();
+            if (getParent() != null) {
+                getParent().validate();
+            }
         }
     }
     


### PR DESCRIPTION
Fixes NPE Cannot invoke "java.awt.Container.validate()" because the return value of "org.netbeans.modules.options.indentation.FormattingPanel.getParent()" is null at org.netbeans.modules.options.indentation.FormattingPanel.propertyChange(FormattingPanel.java:207)

Caused by change in #5625.

To reproduce open PHP or Java project. Open Project Properties and then select Formatting category.
