### PR TITLE
apidoc master branch links fix

### DIFF
--- a/enterprise/j2ee.dd/arch.xml
+++ b/enterprise/j2ee.dd/arch.xml
@@ -256,47 +256,47 @@ It uses these API's:
         </api>
     </li>
     <li>
-        <api group="dtd" category="standard" name="web-app_2_2.dtd" type="import" url="http://java.sun.com/products/servlet/2.2/">
+        <api group="dtd" category="standard" name="web-app_2_2.dtd" type="import" url="https://java.sun.com/j2ee/dtds/web-app_2_2.dtd">
         DTD for web.xml in Servlet API 2.2
         </api>
     </li>
     <li>
-        <api group="dtd" category="standard" name="web-app_2_3.dtd" type="import" url="http://java.sun.com/products/servlet/download.html">
+        <api group="dtd" category="standard" name="web-app_2_3.dtd" type="import" url="https://www.oracle.com/webfolder/technetwork/jsc/dtd/web-app_2_3.dtd">
         DTD for web.xml in Servlet API 2.3
         </api>
     </li>
     <li>
-        <api group="dtd" category="standard" name="web-app_2_4.xsd" type="import" url="http://java.sun.com/products/servlet/download.html">
+        <api group="dtd" category="standard" name="web-app_2_4.xsd" type="import" url="https://www.oracle.com/webfolder/technetwork/jsc/xml/ns/j2ee/web-app_2_4.xsd">
         Schema for web.xml in Servlet API 2.4
         </api>
     </li>
     <li>
-        <api group="dtd" category="standard" name="appplication_1_3.dtd" type="import" url="http://java.sun.com/j2ee/download.html">
+        <api group="dtd" category="standard" name="appplication_1_3.dtd" type="import" url="https://www.oracle.com/webfolder/technetwork/jsc/dtd/application-client_1_3.dtd">
         DTD for application.xml in J2EE 1.3
         </api>
     </li>
     <li>
-        <api group="dtd" category="standard" name="application_1_4.xsd" type="import" url="http://java.sun.com/j2ee/download.html">
+        <api group="dtd" category="standard" name="application_1_4.xsd" type="import" url="https://www.oracle.com/webfolder/technetwork/jsc/xml/ns/j2ee/application_1_4.xsd">
         Schema for application.xml in J2EE 1.4
         </api>
     </li>
     <li>
-        <api group="dtd" category="standard" name="ejb-jar_1_1.dtd" type="import" url="http://java.sun.com/products/ejb/docs.html">
+        <api group="dtd" category="standard" name="ejb-jar_1_1.dtd" type="import" url="https://java.sun.com/j2ee/dtds/ejb-jar_1_1.dtd">
         DTD for ejb-jar.xml in EJB 1.1
         </api>
     </li>
     <li>
-        <api group="dtd" category="standard" name="ejb-jar_2_0.dtd" type="import" url="http://java.sun.com/products/ejb/docs.html">
+        <api group="dtd" category="standard" name="ejb-jar_2_0.dtd" type="import" url="https://java.sun.com/dtd/ejb-jar_2_0.dtd">
         DTD for ejb-jar.xml in EJB 2.0
         </api>
     </li>
     <li>
-        <api group="dtd" category="standard" name="ejb-jar_2_1.xsd" type="import" url="http://java.sun.com/products/ejb/docs.html">
+        <api group="dtd" category="standard" name="ejb-jar_2_1.xsd" type="import" url="https://www.oracle.com/webfolder/technetwork/jsc/xml/ns/j2ee/ejb-jar_2_1.xsd">
         Schema for ejb-jar.xml in EJB 2.1
         </api>
     </li>
     <li>
-        <api group="dtd" category="standard" name="j2ee_1_4.xsd" type="import" url="http://java.sun.com/j2ee/download.html">
+        <api group="dtd" category="standard" name="j2ee_1_4.xsd" type="import" url="https://www.oracle.com/webfolder/technetwork/jsc/xml/ns/j2ee/j2ee_1_4.xsd">
         Schema for deployment descriptors in J2EE 1.4
         </api>
     </li>
@@ -791,7 +791,7 @@ The size of ejb-jar.xml or application.xml files, the performance of schema2bean
 </ul>
 The reading/parsing and writing the web.xml is the bottleneck of the DD API performance. Than the schema2beans root object is <b>weakly</b> cached in memmory.
 However, those operations have no visible impact while working with web modules with standard-sized deployment descriptors.<br/>
-The measurements were not provided for DD API specifically, but there may have been some measurements made in <a href="http://schema2beans.netbeans.org">schema2beans infrastructure</a> that is used for DD API implementation. There should be no additional deficites added by DD API. 
+The measurements were not provided for DD API specifically, but there may have been some measurements made in <a href="https://netbeans.apache.org/projects/schema2beans/">schema2beans infrastructure</a> that is used for DD API implementation. There should be no additional deficites added by DD API. 
 </answer>
 <!--
         <question id="perf-limit" when="init">

--- a/enterprise/j2ee.dd/doc/ddapi_architecture.html
+++ b/enterprise/j2ee.dd/doc/ddapi_architecture.html
@@ -625,7 +625,7 @@ In this example, DD API client searches a servlet "CarServlet" and, if found, ad
 <li><b>October 2003</b> - DD API proposal and architecture discussion. [<font color=#ff0000>done</font>]</li> 
 <li><b>November 2003</b> - DD API initial implementation, NbUnit tests. [<font color=#ff0000>done</font>]</li>
 <li><b>December 2003</b> - DD API documentation, DD API architecture document, DD API architecture question document. [<font color=#ff0000>done</font>]</li>
-<li><b>December 5. 2003</b> - DD API review - the overall architecture [<font color=#ff0000>done</font>] See <a href="http://openide.netbeans.org/tutorial/reviews/opinions_37386.html">DDAPI Rewiev Report</a></li>
+<li><b>December 5. 2003</b> - DD API review - the overall architecture [<font color=#ff0000>done</font>] See <a href="https://netbeans.apache.org/projects/platform/openide/tutorial/review/opinions_37386.html">DDAPI Rewiev Report</a></li>
 <li><b>January 2004</b> - DD API review - architecture details (Commitment Review) </li>
 <li><b>January 2004</b> - implementation of  (final) changes emerging from DD API Commitment Review</li>
 </ul>
@@ -669,7 +669,7 @@ No dependences.
 </p>
 <a name="compat"/>
 <h2>9. Compatibility</h2>
-<a name="compat-standard"/>
+<a name="compat-standards"/>
 <h3>9. 1. With Standards</h3>
 <p>
 <b>Servlet 2.3, Servlet2.4, JAXP</b>
@@ -691,7 +691,7 @@ Not.
 <p>
 The reading/parsing and writing the web.xml is the bottleneck of the DD API performance. Than the schema2beans root object is <b>weakly</b> cached in memmory.
 However, those operations have no visible impact while working with web modules with standard-sized deployment descriptors.<br>
-The measurements were not provided for DD API specifically, but there may have been some measurements made in <a href="http://schema2beans.netbeans.org"><u>schema2beans infrastructure</u></a> that is used for DD API implementation. There should be no additional deficites added by DD API. 
+The measurements were not provided for DD API specifically, but there may have been some measurements made in <a href="https://netbeans.apache.org/projects/schema2beans/"><u>schema2beans infrastructure</u></a> that is used for DD API implementation. There should be no additional deficites added by DD API. 
 </p>
 <a name="perf-scale"/>
 <h3>11.1. Scalability</h3>

--- a/enterprise/j2eeserver/arch.xml
+++ b/enterprise/j2eeserver/arch.xml
@@ -80,7 +80,7 @@ J2EE Server Module provides support for development of J2EE modules and framewor
 </api>
 
 <p>
-J2EE Server Module enables using <a href="http://java.sun.com/j2ee/tools/deployment/index.jsp">
+J2EE Server Module enables using <a href="https://jcp.org/aboutJava/communityprocess/mrel/jsr088/index.html">
 J2EE Deployment API</a> (aka JSR88) for plugin integration.
 In addition to that it provides its own API for <b>incremental deployment</b>,
 JSP compilation, server life cycle management (start/stop/debugging mode).
@@ -122,7 +122,7 @@ implement Deployment API to classpath and to provide a
 layer file</a> that will 
 register the server in IDE (specifying URL, user name and password) and 
 register a 
-<a href="http://java.sun.com/j2ee/1.4/docs/api/javax/enterprise/deploy/spi/factories/DeploymentFactory.html">
+<a href="https://docs.oracle.com/javaee/1.4/api/javax/enterprise/deploy/spi/factories/DeploymentFactory.html">
 factory class</a> from Deployment API. Beside that server plugin must also implement some other mandatory APIs.
 </i></p>
 </usecase>
@@ -133,12 +133,12 @@ If a J2EE server does not support Deployment API still needs to be possible
 to implement a server plugin for it. 
 <p><i>
 In this case the plugin needs to implement the Deployment API interfaces (
-<a href="http://java.sun.com/j2ee/1.4/docs/api/javax/enterprise/deploy/spi/factories/DeploymentFactory.html">
+<a href="https://docs.oracle.com/javaee/1.4/api/javax/enterprise/deploy/spi/factories/DeploymentFactory.html">
 DeploymentFactory</a>, 
-<a href="http://java.sun.com/j2ee/1.4/docs/api/javax/enterprise/deploy/spi/DeploymentManager.html">
+<a href="https://docs.oracle.com/javaee/1.4/api/javax/enterprise/deploy/spi/DeploymentManager.html">
 DeploymentManager</a>) and delegate to whetever interface the specific J2EE server provides.
 An example of this is the Tomcat5 plugin implemented in 
-<a href="http://www.netbeans.org/source/browse/tomcatint/tomcat5/">tomcatint/tomcat5</a>
+<a href="https://github.com/apache/netbeans/tree/master/enterprise/tomcat5">tomcatint/tomcat5</a>
 module, although it only supports deployment of web modules and it also supports
 some optional interfaces defined by J2EE Server Module in addition to the Deployment API.
 </i></p>
@@ -475,12 +475,12 @@ Used for definition of server libraries.
                 </api>
             </li>
             <li>
-                <api name="EJB" type="import" category="standard" url="http://java.sun.com/products/ejb/docs.html#specs" group="java">
+                <api name="EJB" type="import" category="standard" url="https://jcp.org/aboutJava/communityprocess/final/jsr019/index.html" group="java">
                     Enterprise JavaBeans API 2.0.
                 </api>
             </li>
             <li>
-                <api name="J2EEDeploymentAPI" type="import" category="standard" url="http://java.sun.com/j2ee/tools/deployment/index.jsp" group="java">
+                <api name="J2EEDeploymentAPI" type="import" category="standard" url="https://jcp.org/aboutJava/communityprocess/mrel/jsr088/index.html" group="java">
                     J2EE Deployment API/JSR88. 
                     Part implemented by this module and used to communicate with 
                     server plugins and with devmodules.

--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -137,7 +137,7 @@ is the proper place.
                 </p>
                 <p>
                     Certain task and extension property values can be accessed by APIs, that allows NetBean plugins to access
-                    configuration of tasks within the script. See <a href="org-netbeans-modules-gradle/org/netbeans/modules/gradle/api/BuildPropertiesSupport.html">BuildPropertiesSupport</a>.
+                    configuration of tasks within the script. See <a href="@TOP@/org/netbeans/modules/gradle/api/BuildPropertiesSupport.html">BuildPropertiesSupport</a>.
                 </p>
             </description>
             <class package="org.netbeans.modules.gradle.api" name="GradleBaseProject"/>
@@ -177,7 +177,7 @@ is the proper place.
                     The new class <code>
                         <a href="@TOP@/org/netbeans/modules/gradle/api/GradleReport.html">GradleReport</a>
                     </code> that contain this information is available from
-                <code><a href="@TOP@/org/netbeans/modules/gradle/api/GradleBaseProject.html#getProblems">GradleBaseProject.getProblems()</a></code> method.
+                <code><a href="@TOP@/org/netbeans/modules/gradle/api/GradleBaseProject.html#getProblems--">GradleBaseProject.getProblems()</a></code> method.
                 </p>
             </description>
         </change>
@@ -206,7 +206,7 @@ is the proper place.
                 <a href="@TOP@/org/netbeans/modules/gradle/spi/GradleFiles.Kind.html#VERSION_CATALOG">GradleFiles.Kind.VERSION_CATALOG</a>
                 was addedd to represent <code>$rootDir/gradle.libs.versions.toml</code> file of the project.
                 <code>
-                    <a href="@TOP@/org-netbeans-modules-gradle/org/netbeans/modules/gradle/spi/GradleFiles.html#getFile-org.netbeans.modules.gradle.spi.GradleFiles.Kind-">GradleFiles.getKind(VERSION_CATALOG)</a>
+                    <a href="@TOP@/org/netbeans/modules/gradle/spi/GradleFiles.html#getFile-org.netbeans.modules.gradle.spi.GradleFiles.Kind-">GradleFiles.getKind(VERSION_CATALOG)</a>
                 </code> can be used to retrieve the represented file. (The file might not exists though.)
             </description>
             <class package="org.netbeans.modules.gradle.api" name="NbGradleProject"/>
@@ -311,16 +311,16 @@ is the proper place.
                     Concept of <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ProjectConfiguration.html">ProjectConfigurations</a> was implemented for
                     Gradle projects with <a href="@TOP@/org/netbeans/modules/gradle/api/execute/GradleExecConfiguration.html">GradleExecConfiguration</a> class. Configurations
                     can be created by the user and are stored in project private/shared configuration storage. Configurations can be contributed by Plugins using 
-                    <a href="@TOP@/org/netbeans/modules/gradle/spi/actions/GradleActionsProvider.html#define-configuration">GradleActionsProvider</a>. A configuration 
-                    <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ProjectConfigurationProvider.html#setActiveConfiguration--">can be activated</a> or 
+                    <a href="@TOP@/org/netbeans/modules/gradle/spi/actions/GradleActionsProvider.html">GradleActionsProvider</a>. A configuration 
+                    <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ProjectConfigurationProvider.html#setActiveConfiguration-C-">can be activated</a> or 
                     explicitly requested for <a href="@TOP@/org/netbeans/modules/gradle/api/execute/GradleExecConfiguration.html#request-for-invocation">action invocation.</a>.
                 </p>
                 <p>
-                    Actions can have different <a href="@TOP@/org/netbeans/modules/gradle/api/actions/ActionMapping.html">ActionMappings</a> in individual Configurations, user-defined
+                    Actions can have different <a href="@TOP@/org/netbeans/modules/gradle/api/execute/ActionMapping.html">ActionMappings</a> in individual Configurations, user-defined
                     or provided for specific configuration by <a href="@TOP@/org/netbeans/modules/gradle/spi/actions/GradleActionsProvider.html">GradleActionsProvider</a>.
                 </p>
                 <p>
-                    Action providers can be added fully declarative, using XML layer: See <a href="@TOP@/org/netbeans/modules/gradle/spi/actions/DefaultGradleActionsProvider.html##forProjectLayer-org.openide.filesystems.FileObject-">
+                    Action providers can be added fully declarative, using XML layer: See <a href="@TOP@/org/netbeans/modules/gradle/spi/actions/DefaultGradleActionsProvider.html#forProjectLayer-org.openide.filesystems.FileObject-">
                     DefaultGradleActionsProvider.forProjectLayer</a>
                 </p>
                 
@@ -415,7 +415,7 @@ is the proper place.
                     utility method which can replace tokens provided in ActionMapping arguments.
                 </p>
                 <p>
-                    Finally to support this token replacement, <a href="@TOP@/org/netbeans/modules/gradle/spi/actions/ReplacementTokenProvider.html">ReplacementTokenProvider</a>
+                    Finally to support this token replacement, <a href="@TOP@/org/netbeans/modules/gradle/spi/actions/ReplaceTokenProvider.html">ReplaceTokenProvider</a>
                     got a new static method <code>replaceTokens</code>.
                 </p>
             </description>
@@ -443,7 +443,7 @@ is the proper place.
             <compatibility binary="compatible" source="compatible"/>
             <description>
                 <p>
-                    <code><a href="@TOP@/org/netbeans/modules/gradle/spi/GradleFiles.html#isBuildSrcProject()">GradleFiles.isBuildSrcProject()</a></code> was
+                    <code><a href="@TOP@/org/netbeans/modules/gradle/spi/GradleFiles.html#isBuildSrcProject--">GradleFiles.isBuildSrcProject()</a></code> was
                     added to detect if a project id a buildSrc project, and a new file Kind has been introduced <code>BUILD_SRC</code>.
                 </p>
             </description>
@@ -507,7 +507,7 @@ is the proper place.
                     replacement planned for these API functions.
                 </p>
                 <p>
-                    Added <code><a href="@TOP@/org/netbeans/modules/gradle/spi/exectute/GradleJavaPlatformProvider.html">GradleJavaPlatformProvider</a></code>
+                    Added <code><a href="@TOP@/org/netbeans/modules/gradle/spi/execute/GradleJavaPlatformProvider.html">GradleJavaPlatformProvider</a></code>
                     which can be put into the project lookup, to be able to specify the JDK
                     to be used for Gradle build execution.
                 </p>

--- a/extide/gradle/arch.xml
+++ b/extide/gradle/arch.xml
@@ -291,7 +291,7 @@ publishPlugins&lt;/args&gt;
          </api>
          <api category="devel" group="java.io.File" name="nb-actions-config.xml" type="export">
              <p>
-                 An extension of <a href="#nb-actions-config.xml">nb-actions.config</a> is a per-Configuration action mapping.
+                 An extension of <a href="#java.io.File-nb-actions-config.xml">nb-actions.config</a> is a per-Configuration action mapping.
                  It can be placed in <b>nb-actions-</b><i>configurationID</i><b>.xml</b> with the same format and will apply only
                  if that specific Project Configuration is in effect.
              </p>

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleExecConfiguration.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleExecConfiguration.java
@@ -53,7 +53,7 @@ import org.openide.util.Lookup;
  * </div>
  * <p>
  * GradleExecConfigurations can be also declared by a Plugin that implements a
- * <a href="@TOP@/org/netbeans/spi/GradleActionsProvider.html#define-configuration">GradleActionsProvider</a>,
+ * {@link org.netbeans.modules.gradle.spi.actions.GradleActionsProvider },
  * or which uses {@link DefaultGradleActionsProvider#forProjectLayer(org.openide.filesystems.FileObject)}.
  * 
  * @since 2.13

--- a/extide/o.apache.tools.ant.module/arch.xml
+++ b/extide/o.apache.tools.ant.module/arch.xml
@@ -312,7 +312,7 @@
     <answer id="dep-non-nb">
         <ol>
             <li>
-                <api group="java" name="Ant" type="import" category="third" url="http://ant.apache.org/">
+                <api group="java" name="Ant" type="import" category="third" url="https://ant.apache.org">
                     Ant itself, of course.
                     1.8.0+ is required, 1.10.8 recommended (and currently bundled); some features may be limited to newer versions.
                 </api>
@@ -592,7 +592,7 @@
     <answer id="exec-property">
         <p>
             Generally not except for <a
-            href="http://ant.apache.org/manual/running.html#sysprops">properties
+            href="https://ant.apache.org/manual/running.html#sysprops">properties
             interpreted by Ant itself</a> and the following:
         </p>
         <ul>

--- a/ide/api.debugger/arch.xml
+++ b/ide/api.debugger/arch.xml
@@ -341,7 +341,7 @@ We would like to test 100% of our APIs.
         </question>
 -->
 <answer id="dep-nb">
-    <api name="OpenAPIs" type="import" category="official" url="http://openide.netbeans.org" group="java"/> 
+    <api name="OpenAPIs" type="import" category="official" group="java"/> 
 </answer>
 
 

--- a/ide/bugtracking/arch.xml
+++ b/ide/bugtracking/arch.xml
@@ -75,7 +75,7 @@
   <p>
       <b>Cookbook and sample implementation:</b><br/>
       For a more detailed description on how to start writting a bugtracking plugin for NetBeans see also the 
-      <a href="http://wiki.netbeans.org/BugtrackingCookbook">Bugtracking Cookbook</a> (sample module attached).
+      <a href="https://netbeans.apache.org/wiki/BugtrackingCookbook">Bugtracking Cookbook</a> (sample module attached).
   </p>
  </answer>
 
@@ -140,9 +140,9 @@
  <answer id="arch-usecases">
   <p>
       The main Bugtracking SPI and API Use Cases are based on:<br/>
-      - the <a href="http://xdesign-tools.cz.oracle.com/projects/netbeans/IssueTracking/">Bugtracking UI spec.</a><br/>      
-      - the <a href="http://wiki.netbeans.org/TaskManagementUseCases">Issue Management Use Cases</a>. 
-      For additional information see also <a href="http://wiki.netbeans.org/TaskDashboardDesignSpec">Tasks Dashboard UI spec</a><br/>
+  <!--     - the <a href="http://xdesign-tools.cz.oracle.com/projects/netbeans/IssueTracking/">Bugtracking UI spec.</a><br/>     --> 
+      - the <a href="https://netbeans.apache.org/wiki/TaskManagementUseCases">Issue Management Use Cases</a>. 
+      For additional information see also <a href="https://netbeans.apache.org/wiki/TaskDashboardDesignSpec">Tasks Dashboard UI spec</a><br/>
   </p>    
       
     <usecase id="1" name="Registration and setup">
@@ -170,7 +170,7 @@
     </usecase>
     
     <p>    
-        See also the more detailed <a href="http://wiki.netbeans.org/BugtrackingAPISPIUseCases">API/SPI requirements.</a>      
+        See also the more detailed <a href="https://netbeans.apache.org/wiki/BugtrackingAPISPIUseCases">API/SPI requirements.</a>      
     </p>
     
  </answer>

--- a/ide/diff/src/org/netbeans/api/diff/Difference.java
+++ b/ide/diff/src/org/netbeans/api/diff/Difference.java
@@ -54,8 +54,8 @@ public class Difference extends Object implements Serializable {
     
     /**
      * Creates a new instance of Difference
-     * @param type The type of the difference. Must be one of the <a href="#DELETE">DELETE</a>,
-     *             <a href="#ADD">ADD</a> or <a href="#CHANGE">CHANGE</a>
+     * @param type The type of the difference. Must be one of the {@link Part#DELETE DELETE},
+     *             {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE}
      * @param firstStart The line number on which the difference starts in the first file.
      * @param firstEnd The line number on which the difference ends in the first file.
      * @param secondStart The line number on which the difference starts in the second file.
@@ -67,8 +67,8 @@ public class Difference extends Object implements Serializable {
     
     /**
      * Creates a new instance of Difference
-     * @param type The type of the difference. Must be one of the <a href="#DELETE">DELETE</a>,
-     *             <a href="#ADD">ADD</a> or <a href="#CHANGE">CHANGE</a>
+     * @param type The type of the difference. Must be one of the {@link Part#DELETE DELETE},
+     *             {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE}
      * @param firstStart The line number on which the difference starts in the first file.
      * @param firstEnd The line number on which the difference ends in the first file.
      * @param secondStart The line number on which the difference starts in the second file.
@@ -83,8 +83,8 @@ public class Difference extends Object implements Serializable {
     
     /**
      * Creates a new instance of Difference
-     * @param type The type of the difference. Must be one of the <a href="#DELETE">DELETE</a>,
-     *             <a href="#ADD">ADD</a> or <a href="#CHANGE">CHANGE</a>
+     * @param type The type of the difference. Must be one of the {@link Part#DELETE DELETE},
+     *             {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE}
      * @param firstStart The line number on which the difference starts in the first file.
      * @param firstEnd The line number on which the difference ends in the first file.
      * @param secondStart The line number on which the difference starts in the second file.
@@ -115,8 +115,8 @@ public class Difference extends Object implements Serializable {
     }
 
     /**
-     * Get the difference type. It's one of <a href="#DELETE">DELETE</a>,
-     * <a href="#ADD">ADD</a> or <a href="#CHANGE">CHANGE</a> meaning
+     * Get the difference type. It's one of {@link Part#DELETE DELETE},
+     * {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE} meaning
      * respective change in second source.
      */
     public int getType() {
@@ -210,8 +210,8 @@ public class Difference extends Object implements Serializable {
     
         /**
           * Creates a new instance of LineDiff
-          * @param type The type of the difference. Must be one of the {<a href="#DELETE">DELETE</a>,
-          *             <a href="#ADD">ADD</a> or <a href="#CHANGE">CHANGE</a>
+          * @param type The type of the difference. Must be one of the {@link Part#DELETE DELETE},
+          *             {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE}
           * @param line The line number
           * @param pos1 The position on which the difference starts on this line.
           * @param pos2 The position on which the difference ends on this line.
@@ -227,8 +227,8 @@ public class Difference extends Object implements Serializable {
         }
         
         /**
-          * Get the difference type. It's one of <a href="#DELETE">DELETE</a>,
-          * <a href="#ADD">ADD</a> or <a href="#CHANGE">CHANGE</a>.
+          * Get the difference type. It's one of {@link Part#DELETE DELETE},
+          * {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE}.
           */
         public int getType() {
             return this.type;

--- a/ide/editor.bracesmatching/arch.xml
+++ b/ide/editor.bracesmatching/arch.xml
@@ -445,8 +445,8 @@
 
   <p>
   The usecases listed here were heavily inspired by comments in issues
-  <a href="http://www.netbeans.org/issues/show_bug.cgi?id=95126">95126</a> and
-  <a href="http://www.netbeans.org/issues/show_bug.cgi?id=66037">66037</a>.
+  <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=95126">95126</a> and
+  <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=66037">66037</a>.
   </p>
   
   <usecase id="usecase-1" name="Usecase 1. - Highlighting results">

--- a/ide/editor.codetemplates/arch.xml
+++ b/ide/editor.codetemplates/arch.xml
@@ -134,14 +134,14 @@ arrays of primitive data types).
 <answer id="arch-overall">
 
 <p>
-It is a module located under <a href="http://www.netbeans.org/source/browse/editor/codetemplates/#dirlist">/cvs/editor/codetemplates</a> directory.
+It is a module located under <a href="https://github.com/apache/netbeans/tree/master/ide/editor.codetemplates">ide/editor.codetemplates</a> directory.
 </p>
 
 It consists of
 <ul>
-    <li>API in <a href="http://www.netbeans.org/source/browse/editor/codetemplates/src/org/netbeans/lib/editor/codetemplates/api/Attic/">org.netbeans.lib.editor.codetemplates.api</a></li>
-    <li>SPI in <a href="http://www.netbeans.org/source/browse/editor/codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/Attic/">org.netbeans.lib.editor.codetemplates.spi</a></li>
-    <li>Implementation in <a href="http://www.netbeans.org/source/browse/editor/codetemplates/src/org/netbeans/lib/editor/codetemplates/Attic/">org.netbeans.lib.editor.codetemplates</a></li>
+    <li>API in <a href="https://github.com/apache/netbeans/tree/master/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/api">org.netbeans.lib.editor.codetemplates.api</a></li>
+    <li>SPI in <a href="https://github.com/apache/netbeans/tree/master/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi">org.netbeans.lib.editor.codetemplates.spi</a></li>
+    <li>Implementation in <a href="https://github.com/apache/netbeans/tree/master/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/">org.netbeans.lib.editor.codetemplates</a></li>
 </ul>
 
 <p>
@@ -165,7 +165,7 @@ Code Templates define <api name="CodeTemplatesAPI" group="java" type="export" ca
         </question>
 -->
 <answer id="arch-quality">
-The unit tests are available in <a href="http://www.netbeans.org/source/browse/editor/codetemplates/test/">cvs/editor/codetemplates/test</a>.
+The unit tests are available in <a href="https://github.com/apache/netbeans/tree/master/ide/editor.codetemplates/test">ide/editor.codetemplates/test</a>.
 <p/>
 The following scenarios are tested:
 <ul>

--- a/ide/editor.completion/arch.xml
+++ b/ide/editor.completion/arch.xml
@@ -697,7 +697,7 @@
     </ul>
   </api>
   <api category="private" group="systemproperty" name="org.netbeans.modules.editor.completion.slowness.report" type="export"
-  url="http://wiki.netbeans.org/FitnessViaPostMortem">
+  url="https://netbeans.apache.org/wiki/FitnessViaPostMortem">
       You can suppress automatic reporting of slow code completion computation
       by increasing value of <code>-J-Dorg.netbeans.modules.editor.completion.slowness.report</code>
       property to more than 2000 ms (the default value).

--- a/ide/editor.completion/src/org/netbeans/spi/editor/completion/CompletionItem.java
+++ b/ide/editor.completion/src/org/netbeans/spi/editor/completion/CompletionItem.java
@@ -31,7 +31,7 @@ import javax.swing.text.JTextComponent;
  *
  * <p><b>Related documentation</b></p>
  * <ul>
- *   <li><a href="http://platform.netbeans.org/tutorials/nbm-code-completion.html">NetBeans Code Completion Tutorial</a></li>
+ *   <li><a href="https://netbeans.apache.org/tutorials/nbm-code-completion.html">NetBeans Code Completion Tutorial</a></li>
  * </ul>
  *
  *

--- a/ide/editor.completion/src/org/netbeans/spi/editor/completion/CompletionProvider.java
+++ b/ide/editor.completion/src/org/netbeans/spi/editor/completion/CompletionProvider.java
@@ -30,7 +30,7 @@ import org.netbeans.spi.editor.mimelookup.MimeLocation;
  * for documents that are of the specified <code>mime-type</code>.
  * <p><b>Related documentation</b></p>
  * <ul>
- *   <li><a href="http://platform.netbeans.org/tutorials/nbm-code-completion.html">NetBeans Code Completion Tutorial</a></li>
+ *   <li><a href="https://netbeans.apache.org/tutorials/nbm-code-completion.html">NetBeans Code Completion Tutorial</a></li>
  * </ul>
  *
  * @author Miloslav Metelka, Dusan Balek

--- a/ide/editor.fold/arch.xml
+++ b/ide/editor.fold/arch.xml
@@ -49,7 +49,7 @@
 <answer id="arch-overall">
 The Code Folding was created to address requirements
 described in
-<a href="http://ui.netbeans.org/docs/ui/code_folding/cf_uispec.html">
+<a href="https://netbeans.apache.org/projects/ui/code_folding/cf_uispec.html">
 Code Folding UI Specification
 </a>
 

--- a/ide/editor.fold/src/org/netbeans/api/editor/fold/FoldType.java
+++ b/ide/editor.fold/src/org/netbeans/api/editor/fold/FoldType.java
@@ -268,7 +268,7 @@ public final class FoldType {
     
     /**
      * Checks whether the fold can act as the 'other' type.
-     * This check respect parent relationship (see {@link #parent}). The method returns true,
+     * This check respect parent relationship (see {@link #parent()}). The method returns true,
      * if semantics, operations, settings,... applicable to 'other' could be also applied on
      * this FoldType.
      * 

--- a/ide/editor.lib/arch.xml
+++ b/ide/editor.lib/arch.xml
@@ -286,7 +286,7 @@ mime-type (mentioned in the layer section here as well).
         </question>
 -->
 <answer id="dep-non-nb">
-    <api group="java" name="JAXP" type="import" category="standard" url="http://java.sun.com/xml/jaxp/dist/1.1/docs/api/"> 
+    <api group="java" name="JAXP" type="import" category="standard" url="https://www.oracle.com/java/technologies/jaxp-introduction.html"> 
     Standard XML APIs (DOM, SAX) - distributed with the IDE (in lib/ext/xml-apis*.jar),
     already part of JDK 1.4 and newer).
     </api>

--- a/ide/editor.lib/src/org/netbeans/editor/BaseKit.java
+++ b/ide/editor.lib/src/org/netbeans/editor/BaseKit.java
@@ -1354,7 +1354,7 @@ public class BaseKit extends DefaultEditorKit {
          * Check whether there was any important character typed
          * so that the line should be possibly reformatted.
          *
-         * @deprecated Please use <a href="@org-netbeans-modules-editor-indent@/org/netbeans/modules/editor/indent/spi/AutomatedIndenting.html">AutomatedIndentig</a>
+         * @deprecated Please use <a href="@org-netbeans-modules-editor-indent-support@/org/netbeans/modules/editor/indent/spi/support/AutomatedIndenting.html">AutomatedIndentig</a>
          *   or Typing Hooks instead, for details see
          *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
          */

--- a/ide/editor.lib/src/org/netbeans/editor/CodeFoldingSideBar.java
+++ b/ide/editor.lib/src/org/netbeans/editor/CodeFoldingSideBar.java
@@ -165,7 +165,7 @@ public class CodeFoldingSideBar extends JComponent implements Accessible {
     private int lowestAboveMouse = -1;
 
     /**
-     * Y-begin of the nearest fold, which starts below the {@link #mousePoint}. Undefined if mousePoint is null
+     * Y-begin of the nearest fold, which starts below the {@code #mousePoint}. Undefined if mousePoint is null
      */
     private int topmostBelowMouse = Integer.MAX_VALUE;
     
@@ -192,7 +192,7 @@ public class CodeFoldingSideBar extends JComponent implements Accessible {
     public static final int SINGLE_PAINT_MARK      = 4;
     
     /**
-     * Marker value for {@link #mousePoint} indicating that mouse is outside the Component.
+     * Marker value for {@code #mousePoint} indicating that mouse is outside the Component.
      */
     private static final int NO_MOUSE_POINT = -1;
     

--- a/ide/editor.lib/src/org/netbeans/editor/ext/ExtKit.java
+++ b/ide/editor.lib/src/org/netbeans/editor/ext/ExtKit.java
@@ -1080,7 +1080,7 @@ public class ExtKit extends BaseKit {
         /** 
          * Check the characters that should cause reindenting the line. 
          * 
-         * @deprecated Please use <a href="@org-netbeans-modules-editor-indent@/org/netbeans/modules/editor/indent/spi/support/AutomatedIndenting.html">AutomatedIndentig</a>
+         * @deprecated Please use <a href="@org-netbeans-modules-editor-indent-support@/org/netbeans/modules/editor/indent/spi/support/AutomatedIndenting.html">AutomatedIndentig</a>
          *   or Typing Hooks instead, for details see
          *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
          */

--- a/ide/editor.lib2/src/org/netbeans/api/editor/caret/package.html
+++ b/ide/editor.lib2/src/org/netbeans/api/editor/caret/package.html
@@ -71,7 +71,7 @@
   <p>
   The basics of the locking and events model of Swing documents is
   described in the javadoc of the
-  <a href="http://java.sun.com/j2se/1.5.0/docs/api/javax/swing/text/AbstractDocument.html">javax.swing.text.AbstractDocument</a>
+  <a href="@JDK@/javax/swing/text/AbstractDocument.html">javax.swing.text.AbstractDocument</a>
   class. Netbeans documents use the same patterns and so does the Caret API,
   because of its tight relation to documents. The fundamentals of the Swing documents
   locking model are that any changes to a document are done under the

--- a/ide/editor.settings/src/org/netbeans/api/editor/settings/CodeTemplateSettings.java
+++ b/ide/editor.settings/src/org/netbeans/api/editor/settings/CodeTemplateSettings.java
@@ -35,7 +35,7 @@ import javax.swing.KeyStroke;
  * 
  * <p><b>IMPORTANT</b>: There is a much more powerful API for working with editor
  * code templates in
- * <a href="@org-netbeans-lib-editor-codetemplates@/overview-summary.html">Editor Code Templates</a>
+ * <a href="@org-netbeans-modules-editor-codetemplates@/overview-summary.html">Editor Code Templates</a>
  * module. If you are retrieving this class from <code>MimeLookup</code> you should
  * should probably use the Editor Code Templates API instead.
  * 

--- a/ide/editor.util/src/org/netbeans/lib/editor/util/FlyOffsetGapList.java
+++ b/ide/editor.util/src/org/netbeans/lib/editor/util/FlyOffsetGapList.java
@@ -50,7 +50,7 @@ public abstract class FlyOffsetGapList<E> extends GapList<E> {
      *
      * @param elem element currently stored in the list.
      * @return raw offset of the element. It needs to be preprocessed
-     * by {@link #raw2RelOffset(int)} to become the real offset.
+     * by {@code #raw2RelOffset(int)} to become the real offset.
      */
     protected abstract int elementRawOffset(E elem);
 

--- a/ide/editor/arch.xml
+++ b/ide/editor/arch.xml
@@ -228,7 +228,7 @@ that depends on  NetBeans APIs specified in this document.
         </ul>
     </api> 
     <br/>
-    <api group="java" name="OpenAPIs" type="import" category="official" url="http://openide.netbeans.org"/> 
+    <api group="java" name="OpenAPIs" type="import" category="official"/> 
     <br/>
     <api group="java" name="CodeFoldingAPI" type="import" category="official"
         url="@org-netbeans-modules-editor-fold@/architecture-summary.html#java-CodeFoldingAPI"
@@ -254,7 +254,7 @@ that depends on  NetBeans APIs specified in this document.
         </question>
 -->
 <answer id="dep-non-nb">
-    <api group="java" name="JAXP" type="import" category="standard" url="http://java.sun.com/xml/jaxp/dist/1.1/docs/api/"> 
+    <api group="java" name="JAXP" type="import" category="standard" url="https://www.oracle.com/java/technologies/jaxp-introduction.html"> 
     Standard XML APIs (DOM, SAX) - distributed with the IDE (in ../editor.lib/ext/xml-apis*.jar),
     already part of JDK 1.4 and newer).
     </api>
@@ -520,7 +520,7 @@ No.
     </ul>
 
     <api type="import" name="NbKeymap.context" category="friend" group="java"
-     url="http://www.netbeans.org/source/browse/editor/src/org/netbeans/core/NbKeymap.html">
+     url="https://github.com/apache/netbeans/tree/master/platform/o.n.core/src/org/netbeans/core/NbKeymap.java">
         The <code>context</code> field is accessed by reflection
         from <a href="@org-netbeans-modules-editor-lib@/org/netbeans/editor/MultiKeymap.html">MultiKeymap</a>.
     </api>
@@ -843,13 +843,13 @@ No.
         <li>
             Annotation Types can be registered as .xml files under <i>Editors/AnnotationTypes</i>.
             <br/>
-            An example of a bookmark annotation descrioption xml file can be found
-            <a href="http://www.netbeans.org/source/browse/editor/src/org/netbeans/modules/editor/resources/AnnotationTypes/bookmark.xml">here</a>.
+            An example of a bookmark annotation description xml file can be found
+            <a href="https://github.com/apache/netbeans/tree/master/ide/editor/src/org/netbeans/modules/editor/resources/AnnotationTypes/">here</a>.
             <br/>
             DTDs can be found
-            <a href="http://www.netbeans.org/source/browse/editor/src/org/netbeans/modules/editor/resources/AnnotationTypes/annotation-type-1_0.dtd">here</a>
+            <a href="https://github.com/apache/netbeans/tree/master/ide/editor/src/org/netbeans/modules/editor/resources/AnnotationTypes/annotation-type-1_0.dtd">here</a>
             and
-            <a href="http://www.netbeans.org/source/browse/editor/src/org/netbeans/modules/editor/resources/AnnotationTypes/annotation-type-1_1.dtd">here</a>.
+            <a href="https://github.com/apache/netbeans/tree/master/ide/editor/src/org/netbeans/modules/editor/resources/AnnotationTypes/annotation-type-1_1.dtd">here</a>.
         </li>
 
         <li>Mime-type specific editor data under <i>/Editors/mime-type</i> folder (e.g. <i>/Editors/text/plain</i>).
@@ -950,7 +950,7 @@ No.
     </ul>
 
     <p>
-    Please see <a href="http://www.netbeans.org/source/browse/editor/src/org/netbeans/modules/editor/resources/layer.xml">layer.xml</a> for further details.
+    Please see <a href="https://github.com/apache/netbeans/tree/master/ide/editor/src/org/netbeans/modules/editor/resources/layer.xml">layer.xml</a> for further details.
     </p>
     
     <p>

--- a/ide/extexecution/src/org/netbeans/api/extexecution/ExecutionDescriptor.java
+++ b/ide/extexecution/src/org/netbeans/api/extexecution/ExecutionDescriptor.java
@@ -135,7 +135,7 @@ public final class ExecutionDescriptor {
      * <p>
      * If configured value is not <code>null</code> values configured via
      * methods {@link #controllable(boolean)}, {@link #rerunCondition(RerunCondition)}
-     * and {@link #getOptionsPath()} are ignored by {@link ExecutionService}.
+     * and {@code #getOptionsPath()} are ignored by {@link ExecutionService}.
      * <p>
      * The default (not configured) value is <code>null</code>.
      * <p>

--- a/ide/extexecution/src/org/netbeans/api/extexecution/ExecutionService.java
+++ b/ide/extexecution/src/org/netbeans/api/extexecution/ExecutionService.java
@@ -65,7 +65,7 @@ import org.openide.windows.OutputWriter;
  * <p>
  * Note that once service is run for the first time, subsequents runs can be
  * invoked by the user (rerun button) if it is allowed to do so
- * ({@link ExecutionDescriptor#isControllable()}).
+ * ({@code ExecutionDescriptor#isControllable()}).
  *
  * <div class="nonnormative">
  * <p>
@@ -133,7 +133,7 @@ public final class ExecutionService {
      * as a result of the {@link Future} is exit code of the process.
      * <p>
      * The output tabs are reused (if caller does not use the custom one,
-     * see {@link ExecutionDescriptor#getInputOutput()}) - the tab to reuse
+     * see {@code ExecutionDescriptor#getInputOutput()}) - the tab to reuse
      * (if any) is selected by having the same name and same buttons
      * (control and option). If there is no output tab to reuse new one
      * is opened.

--- a/ide/extexecution/src/org/netbeans/api/extexecution/input/InputProcessors.java
+++ b/ide/extexecution/src/org/netbeans/api/extexecution/input/InputProcessors.java
@@ -151,7 +151,7 @@ public final class InputProcessors {
 
     /**
      * Returns the processor that strips any
-     * <a href="http://en.wikipedia.org/wiki/ANSI_escape_code">ANSI escape sequences</a>
+     * <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">ANSI escape sequences</a>
      * and passes the result to the delegate.
      * <p>
      * Reset and close methods on the returned processor invokes

--- a/ide/lexer/src/org/netbeans/api/lexer/TokenId.java
+++ b/ide/lexer/src/org/netbeans/api/lexer/TokenId.java
@@ -70,7 +70,7 @@ package org.netbeans.api.lexer;
  *
  * <p>
  * Detailed information and rules for naming can be found
- * in <A href="http://lexer.netbeans.org/doc/token-id-naming.html">TokenId Naming</A>.
+ * in <A href="https://netbeans.apache.org/projects/lexer/token-id-naming.html">TokenId Naming</A>.
  *
  * @author Miloslav Metelka
  * @version 1.00

--- a/ide/lexer/src/org/netbeans/spi/lexer/Lexer.java
+++ b/ide/lexer/src/org/netbeans/spi/lexer/Lexer.java
@@ -47,16 +47,16 @@ import org.netbeans.api.lexer.Token;
  * Testing of newly written lexers can be performed in several ways.
  * The most simple way is to test batch lexing first
  * (see e.g.
- * <a href="http://www.netbeans.org/source/browse/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/Attic/SimpleLexerBatchTest.java">
+ * <a href="https://github.com/apache/netbeans/tree/master/ide/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLexerBatchTest.java">
  * org.netbeans.lib.lexer.test.simple.SimpleLexerBatchTest</a> in lexer module tests).
  * <br>
  * Then an "incremental" behavior of the new lexer can be tested
- * (see e.g. <a href="http://www.netbeans.org/source/browse/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/Attic/SimpleLexerIncTest.java">
+ * (see e.g. <a href="https://github.com/apache/netbeans/tree/master/ide/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLexerIncTest.java">
  * org.netbeans.lib.lexer.test.simple.SimpleLexerIncTest</a>).
  * <br>
  * Finally the lexer can be tested by random tests that randomly insert and remove
  * characters from the document
- * (see e.g. <a href="http://www.netbeans.org/source/browse/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/Attic/SimpleLexerRandomTest.java">
+ * (see e.g. <a href="https://github.com/apache/netbeans/tree/master/ide/lexer/test/unit/src/org/netbeans/lib/lexer/test/simple/SimpleLexerRandomTest.java">
  * org.netbeans.lib.lexer.test.simple.SimpleLexerRandomTest</a>).
  * <br>
  * Once these tests pass the lexer can be considered stable.

--- a/ide/libs.graalsdk/apichanges.xml
+++ b/ide/libs.graalsdk/apichanges.xml
@@ -40,7 +40,7 @@
           <compatibility binary="compatible" source="compatible" addition="yes"/>
           <description>
               Bridge that plugs
-              <a href="http://graalvm.org">GraalVM</a> languages
+              <a href="https://graalvm.org">GraalVM</a> languages
               into
               <a href="@org-netbeans-api-scripting@/org/netbeans/api/scripting/Scripting.html">Scripting.createManager()</a>
               to obtain enhanced version of

--- a/ide/libs.graalsdk/arch.xml
+++ b/ide/libs.graalsdk/arch.xml
@@ -51,7 +51,7 @@
  <answer id="arch-overall">
   <p>
     Bridge that plugs
-    <a href="http://graalvm.org">GraalVM</a> languages
+    <a href="https://graalvm.org">GraalVM</a> languages
     into
     <a href="@org-netbeans-api-scripting@/org/netbeans/api/scripting/Scripting.html">Scripting.createManager()</a>
     to obtain enhanced version of
@@ -123,7 +123,7 @@
  <answer id="arch-usecases">
   <p>
       <usecase id="createScriptEngineManager" name="Create ScriptEngineManager">
-          To access <a href="http://graalvm.org">GraalVM</a> languages
+          To access <a href="https://graalvm.org">GraalVM</a> languages
           use
           To create new instance script engine manager ready for the NetBeans
           execution environment use
@@ -172,7 +172,7 @@
  <answer id="arch-what">
   <p>
       Bridge that plugs
-      <a href="http://graalvm.org">GraalVM</a> languages
+      <a href="https://graalvm.org">GraalVM</a> languages
       into
       <a href="@org-netbeans-api-scripting@/org/netbeans/api/scripting/Scripting.html">Scripting.createManager()</a>
       can be found in this module.
@@ -542,7 +542,7 @@
  <answer id="exec-component">
   <p>
       <api name="GraalVM:Engine" type="export" group="property" category="stable">
-        When this module is used (on <a href="http://graalvm.org">GraalVM</a> or
+        When this module is used (on <a href="https://graalvm.org">GraalVM</a> or
         without)
         it automatically exports all available languages (obtained via
         <code>org.graalvm.polyglot.Engine</code>) as
@@ -552,13 +552,13 @@
         name.
       </api>
       <api name="allowAllAccess" type="export" group="property" category="stable">
-        By default all the <a href="http://graalvm.org">GraalVM</a> engines
+        By default all the <a href="https://graalvm.org">GraalVM</a> engines
         (named <code>GraalVM:something</code>)
         run in a very restricted, secure sandbox. See
         <a href="@TOP@/org/netbeans/libs/graalsdk/GraalSDK.html">GraalSDK</a>
         for details. That means the languages cannot
         access local files, ports, etc. Some languages (like
-        <a href="https://gihub.com/graalvm/fastr">>FastR</a>
+        <a href="https://github.com/graalvm/fastr">>FastR</a>
         implementation of the <b>R</b> language) need such access. In such
         case one has to allow such access. This can be done by
         <pre>

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/GraalSDK.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/GraalSDK.java
@@ -29,7 +29,7 @@ import org.graalvm.polyglot.HostAccess;
  * API and GraalVM; see the {@link org.netbeans.libs.graalsdk tutorial} for more details.
  * <h2>Security</h2>
  * <p>
- * By default all the <a href="http://graalvm.org">GraalVM</a> engines
+ * By default all the <a href="https://graalvm.org">GraalVM</a> engines
  * (named <code>GraalVM:something</code>)
  * run in a very restricted, secure sandbox:
  * </p>

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/package-info.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/package-info.java
@@ -26,7 +26,7 @@
  * This tutorial shows how to embed the various languages in a
  * NetBeans or even plain Java application via {@link org.netbeans.api.scripting.Scripting} helper methods. This
  * environment lets Java interoperate with standard as well as
- * <a href="http://graalvm.org">GraalVM</a> based
+ * <a href="https://graalvm.org">GraalVM</a> based
  * <em>guest languages</em> via <em>foreign objects</em> and <em>foreign functions</em>.
  * For example Java code
  * can directly access guest language methods, objects, classes,
@@ -46,10 +46,10 @@
  * <h2>Setup</h2>
  *
  * The most advanced features that this API provides work in cooperation with
- * <a href="http://graalvm.org">GraalVM</a>.
+ * <a href="https://graalvm.org">GraalVM</a>.
  * Downloading
- * <a href="http://graalvm.org">GraalVM</a> and running your (NetBeans) application on
- * <a href="http://graalvm.org">GraalVM</a> will give you access to the
+ * <a href="https://graalvm.org">GraalVM</a> and running your (NetBeans) application on
+ * <a href="https://graalvm.org">GraalVM</a> will give you access to the
  * polyglot features highlighted in this tutorial.
  * <p>
  * NetBeans modules are <a href="https://search.maven.org/search?q=org.netbeans.api">
@@ -87,7 +87,7 @@
  * <p>
  * {@snippet file="org/netbeans/libs/graalsdk/ScriptingTutorial.java" region="listAll"}
  * <p>
- * When the above code snippet is executed on <a href="http://graalvm.org">GraalVM</a> it may print:
+ * When the above code snippet is executed on <a href="https://graalvm.org">GraalVM</a> it may print:
  * <pre>
 Found Oracle Nashorn
 Found Graal.js
@@ -96,18 +96,18 @@ Found GraalVM:llvm
 Found GraalVM:python
  * </pre>
  * e.g. a mixture of standard script engines in the JDK with additional ones
- * provided as <a href="http://graalvm.org">GraalVM</a> languages located
+ * provided as <a href="https://graalvm.org">GraalVM</a> languages located
  * via dedicated implementation of {@link org.netbeans.spi.scripting.EngineProvider}
  * interface
  *
  * <h3>Add a language</h3>
  *
- * <a href="http://graalvm.org">GraalVM</a>
+ * <a href="https://graalvm.org">GraalVM</a>
  * download comes with highly efficient implementations of <em>JavaScript</em>.
  * Additional languages like
- * <a href="https://github.com/graalvm/truffleruby/">Ruby</a>,
- * the <a href="https://github.com/graalvm/fastr/">R</a> and
- * <a href="https://github.com/graalvm/graalpython/">Python</a>
+ * <a href="https://github.com/graalvm/truffleruby">Ruby</a>,
+ * the <a href="https://github.com/graalvm/fastr">R</a> and
+ * <a href="https://github.com/graalvm/graalpython">Python</a>
  * can be installed via the <code>bin/gu</code> <em>Graal Updater</em> tool:
  * <p>
  * <pre>
@@ -135,7 +135,7 @@ Found GraalVM:python
  * <p>
  * {@snippet file="org/netbeans/libs/graalsdk/ScriptingTutorial.java" region="testHelloWorldInPythonAndJavaScript"}
  * <p>
- * Languages provided by <a href="http://graalvm.org">GraalVM</a> use the
+ * Languages provided by <a href="https://graalvm.org">GraalVM</a> use the
  * {@link javax.script.ScriptEngineManager} created by
  * {@link org.netbeans.libs.graalsdk.Scripting#createManager()} factory
  * method as a connection point to talk to each other and mutually share
@@ -199,7 +199,7 @@ Found GraalVM:python
  *
  * {@snippet file="org/netbeans/libs/graalsdk/ScriptingTutorial.java" region="callRFunctionFromJava"}
  *
- * Don't forget to install support for the R language into your <a href="http://graalvm.org">GraalVM</a>
+ * Don't forget to install support for the R language into your <a href="https://graalvm.org">GraalVM</a>
  * instance:
  * <p>
  * <pre>
@@ -315,7 +315,7 @@ Found GraalVM:python
  *
  * <h3>View any Object as Map</h3>
  *
- * Each dynamic object coming from a <a href="http://graalvm.org">GraalVM</a>
+ * Each dynamic object coming from a <a href="https://graalvm.org">GraalVM</a>
  * language can be "cast" to a {@link java.util.Map}. Here is an example:
  *
  * <p>

--- a/ide/o.openidex.util/src/org/openidex/search/SearchInfo.java
+++ b/ide/o.openidex.util/src/org/openidex/search/SearchInfo.java
@@ -32,10 +32,10 @@ import org.openide.loaders.DataObject;
  * &ndash; in actions <em>Find</em> (since User Utilities 1.16)
  * and <em>Find in Projects</em> (since User Utilities 1.23).
  * Action <em>Find</em> obtains <code>SearchInfo</code> from
- * <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup()"><code>Lookup</code> of nodes</a>
+ * <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup--"><code>Lookup</code> of nodes</a>
  * the action was invoked on. Action <em>Find in Projects</em> obtains
  * <code>SearchInfo</code> from
- * <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()"><code>Lookup</code>
+ * <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--"><code>Lookup</code>
  * of the projects</a>.
  * </p>
  * <p>
@@ -45,8 +45,8 @@ import org.openide.loaders.DataObject;
  *
  * @see  SearchInfoFactory
  * @see  <a href="@org-openide-loaders@/org/openide/loaders/DataObject.html"><code>DataObject</code></a>
- * @see  <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup()"><code>Node.getLookup()</code></a>
- * @see  <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()"><code>Project.getLookup()</code></a>
+ * @see  <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup--"><code>Node.getLookup()</code></a>
+ * @see  <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--"><code>Project.getLookup()</code></a>
  * @since  org.openidex.util/3 3.2
  * @author  Marian Petras
  */

--- a/ide/parsing.api/arch.xml
+++ b/ide/parsing.api/arch.xml
@@ -295,7 +295,7 @@
 -->
  <answer id="arch-what">
   <p>
-      See <a href="http://wiki.netbeans.org/ParsingAPI">Parsing API homepage</a> for project requirements, motivation.
+      See <a href="https://netbeans.apache.org/wiki/ParsingAPI">Parsing API homepage</a> for project requirements, motivation.
   </p>
  </answer>
 

--- a/ide/parsing.indexing/arch.xml
+++ b/ide/parsing.indexing/arch.xml
@@ -150,7 +150,7 @@
 -->
  <answer id="arch-what">
   <p>
-      See <a href="http://wiki.netbeans.org/ParsingAPI">Parsing API homepage</a> for project requirements, motivation.
+      See <a href="https://netbeans.apache.org/wiki/ParsingAPI">Parsing API homepage</a> for project requirements, motivation.
   </p>
  </answer>
 

--- a/ide/project.ant/src/org/netbeans/spi/project/support/ant/SourcesHelper.java
+++ b/ide/project.ant/src/org/netbeans/spi/project/support/ant/SourcesHelper.java
@@ -405,7 +405,7 @@ public final class SourcesHelper {
          * </p>
          * @param value Ant-style includes; may contain Ant property substitutions;
          *                 Only files and folders matching the pattern (or patterns),
-         *                 and not specified in the {@link #excludes} list,
+         *                 and not specified in the {@link SourcesHelper.SourceRootConfig#excludes(String)} list,
          *                 will be {@link SourceGroup#contains included}.
          *                 Must not be <code>null</code>.
          * @return <code>this</code>
@@ -520,7 +520,7 @@ public final class SourcesHelper {
      * contain sources that should be considered part of the project.
      * <p>
      * If the actual value of the <code>location</code> parameter is inside the project directory
-     * and the root is not {@link SourceRootConfig#type typed},
+     * and the root is not {@link SourceRootConfig#type(String) typed},
      * this is simply ignored; so it safe to configure source roots
      * for any source directory which might be set to use an external path, even
      * if the common location is internal.
@@ -614,7 +614,7 @@ public final class SourcesHelper {
      * Useful for project type providers which have external paths holding build
      * products. These should not appear in {@link Sources}, yet it may be useful
      * for {@link FileOwnerQuery} to know the owning project (for example, in order
-     * for a project-specific <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceForBinaryQueryImplementation.html"><code>SourceForBinaryQueryImplementation</code></a> to work).
+     * for a project-specific <a href="@org-netbeans-api-java-classpath@/org/netbeans/spi/java/queries/SourceForBinaryQueryImplementation.html"><code>SourceForBinaryQueryImplementation</code></a> to work).
      * </p>
      * @param location a project-relative or absolute path giving the location
      *                 of a non-source tree; may contain Ant property substitutions
@@ -636,7 +636,7 @@ public final class SourcesHelper {
      * Useful for project type providers which have external paths holding build
      * products. These should not appear in {@link Sources}, yet it may be useful
      * for {@link FileOwnerQuery} to know the owning project (for example, in order
-     * for a project-specific <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceForBinaryQueryImplementation.html"><code>SourceForBinaryQueryImplementation</code></a> to work).
+     * for a project-specific <a href="@org-netbeans-api-java-classpath@/org/netbeans/spi/java/queries/SourceForBinaryQueryImplementation.html"><code>SourceForBinaryQueryImplementation</code></a> to work).
      * </p>
      * @param location a project-relative or absolute path giving the location
      *                 of a file; may contain Ant property substitutions

--- a/ide/projectapi/src/org/netbeans/api/project/FileOwnerQuery.java
+++ b/ide/projectapi/src/org/netbeans/api/project/FileOwnerQuery.java
@@ -44,7 +44,7 @@ import org.openide.util.LookupListener;
  * other implementations can be registered to lookup as well.
  * <p>
  * Warning: This class and it's methods may not be used within DataObject recognition in DataLoaders.
- * eg. in <a href="@org-openide-loaders@/org/openide/loaders/MultiFileLoader.html#findPrimaryFile-org-openide.fileystesm.FileObject-">MultiFileLoader</a>
+ * eg. in <a href="@org-openide-loaders@/org/openide/loaders/MultiFileLoader.html#findPrimaryFile-org.openide.filesystems.FileObject-">MultiFileLoader</a>
  *  
  * @author Jesse Glick
  */

--- a/ide/projectapi/src/org/netbeans/api/project/Project.java
+++ b/ide/projectapi/src/org/netbeans/api/project/Project.java
@@ -37,7 +37,7 @@ import org.openide.util.Lookup;
  * tools or services should <em>not</em> need to explicitly model projects, and
  * should not be using this API much or at all.</p>
  * </div>
- * @see <a href="http://wiki.netbeans.org/BuildSystemHowTo">NetBeans 4.0 Project &amp; Build System How-To</a>
+ * @see <a href="https://netbeans.apache.org/wiki/BuildSystemHowTo">NetBeans 4.0 Project &amp; Build System How-To</a>
  * @author Jesse Glick
  */
 public interface Project extends Lookup.Provider {
@@ -81,9 +81,9 @@ public interface Project extends Lookup.Provider {
      * <li>{@link org.netbeans.spi.queries.FileBuiltQueryImplementation}</li>
      * <li>{@link org.netbeans.spi.queries.SharabilityQueryImplementation}</li>
      * <li>{@link org.netbeans.spi.queries.FileEncodingQueryImplementation}</li>
-     * <li><a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/ProjectOpenedHook.html"><code>ProjectOpenedHook</code></a></li>
-     * <li><a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/RecommendedTemplates.html"><code>RecommendedTemplates</code></a></li>
-     * <li><a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/PrivilegedTemplates.html"><code>PrivilegedTemplates</code></a></li>
+     * <li><a href="@org-netbeans-modules-projectuiapi-base@/org/netbeans/spi/project/ui/ProjectOpenedHook.html"><code>ProjectOpenedHook</code></a></li>
+     * <li><a href="@org-netbeans-modules-projectuiapi-base@/org/netbeans/spi/project/ui/RecommendedTemplates.html"><code>RecommendedTemplates</code></a></li>
+     * <li><a href="@org-netbeans-modules-projectuiapi-base@/org/netbeans/spi/project/ui/PrivilegedTemplates.html"><code>PrivilegedTemplates</code></a></li>
      * <li><a href="@org-netbeans-api-java-classpath@/org/netbeans/spi/java/classpath/ClassPathProvider.html"><code>ClassPathProvider</code></a></li>
      * <li><a href="@org-netbeans-api-java-classpath@/org/netbeans/spi/java/queries/SourceForBinaryQueryImplementation.html"><code>SourceForBinaryQueryImplementation</code></a></li>
      * <li><a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceLevelQueryImplementation2.html"><code>SourceLevelQueryImplementation2</code></a></li>

--- a/ide/projectapi/src/org/netbeans/api/project/ProjectInformation.java
+++ b/ide/projectapi/src/org/netbeans/api/project/ProjectInformation.java
@@ -53,7 +53,7 @@ public interface ProjectInformation {
      * on disk, as (part of) an Ant property name, etc.
      * XXX precise format - at least conforms to XML NMTOKEN or ID
      * @return a code name
-     * @see <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/PropertyUtils.html#getUsablePropertyName(java.lang.String)"><code>PropertyUtils.getUsablePropertyName</code></a>
+     * @see <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/PropertyUtils.html#getUsablePropertyName-java.lang.String-"><code>PropertyUtils.getUsablePropertyName</code></a>
      */
     String getName();
     

--- a/ide/projectapi/src/org/netbeans/api/project/ProjectUtils.java
+++ b/ide/projectapi/src/org/netbeans/api/project/ProjectUtils.java
@@ -190,7 +190,7 @@ public class ProjectUtils {
      *         subproject graph, regardless of the candidate parameter, or if the
      *         candidate is not null and the master project does not currently have
      *         a cycle but would have one if the candidate were added as a subproject
-     * @see <a href="http://www.netbeans.org/issues/show_bug.cgi?id=43845">Issue #43845</a>
+     * @see <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=43845">Issue #43845</a>
      */
     public static boolean hasSubprojectCycles(final Project master, final Project candidate) {
         return ProjectManager.mutex().readAccess(new Mutex.Action<Boolean>() {

--- a/ide/projectapi/src/org/netbeans/spi/project/ProjectIconAnnotator.java
+++ b/ide/projectapi/src/org/netbeans/spi/project/ProjectIconAnnotator.java
@@ -54,7 +54,7 @@ import org.netbeans.api.project.ProjectInformation;
  * @author petrdvorak
  * @since 1.33
  * @see ProjectInformation#getIcon
- * @see <a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/LogicalViewProvider.html#createLogicalView()"><code>LogicalViewProvider.createLogicalView</code></a>
+ * @see <a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/LogicalViewProvider.html#createLogicalView--"><code>LogicalViewProvider.createLogicalView</code></a>
  */
 public interface ProjectIconAnnotator {
 

--- a/ide/projectapi/src/org/netbeans/spi/project/SubprojectProvider.java
+++ b/ide/projectapi/src/org/netbeans/spi/project/SubprojectProvider.java
@@ -32,7 +32,7 @@ import org.netbeans.api.project.Project;
  * <b>Note:</b>Since 1.56, there are a more specifically defined variants <code>DependencyProjectProvider</code> and <code>ProjectContainerProvider</code> that if defined in project provide a list of
  * projects the current project depends on or contains. In some project types ( currently maven support) that is the preferred and supported way of getting project's dependency projects and maven modules. 
  * @see Project#getLookup
- * @see <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/ReferenceHelper.html#createSubprojectProvider()"><code>ReferenceHelper.createSubprojectProvider</code></a>
+ * @see <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/ReferenceHelper.html#createSubprojectProvider--"><code>ReferenceHelper.createSubprojectProvider</code></a>
  * @author Jesse Glick
  */
 public interface SubprojectProvider {

--- a/ide/projectapi/src/org/netbeans/spi/project/doc-files/configurations.html
+++ b/ide/projectapi/src/org/netbeans/spi/project/doc-files/configurations.html
@@ -70,8 +70,8 @@
  <li>
   <p>
    Some kind of configurations for <code>j2seproject</code>s, tracked in
-   <a href="https://netbeans.org/issues/show_bug.cgi?id=49636">issue #49636</a> with many votes.
-   See also the <a href="http://wiki.netbeans.org/RunConfigurations49636">wiki page</a>.
+   <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=49636">issue #49636</a> with many votes.
+   See also the <a href="https://netbeans.apache.org/wiki/RunConfigurations49636">wiki page</a>.
   </p>
   <p>
    The most frequently requested ability, considered to be a functional regression in NB 4.0 from 3.x, is
@@ -93,7 +93,7 @@
  <li>
   <p>
    A common SPI for selecting configurations across project types, tracked in
-   <a href="https://netbeans.org/issues/show_bug.cgi?id=49652">issue #49652</a>. The proposed
+   <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=49652">issue #49652</a>. The proposed
    implementation addresses this, including a common GUI for switching configuration that can work with
    different project types.
   </p>

--- a/ide/projectui/arch.xml
+++ b/ide/projectui/arch.xml
@@ -115,7 +115,7 @@
   <p>
    Needed for working with projects in the IDE.
   </p>
-  <api name="RecentProjects" group="java" type="export" category="friend" url="http://www.netbeans.org/issues/show_bug.cgi?id=57073" >
+  <api name="RecentProjects" group="java" type="export" category="friend" url="https://bz.apache.org/netbeans/show_bug.cgi?id=57073" >
     <p>
      API can be used to get list of information about recently opened projects 
      in IDE. API provides project display name, icon and URL of project folder 
@@ -139,7 +139,7 @@
  <answer id="arch-what">
   <p>
    General user interface implementation for the project system. <a
-   href="http://projects.netbeans.org/buildsys/build-sys-ui-spec.html">UI
+   href="https://netbeans.apache.org/projects/buildsys/build-sys-ui-spec.html">UI
    Specification</a>
   </p>
  </answer>
@@ -387,7 +387,7 @@
         </question>
 -->
  <answer id="deploy-packages">
-  <api name="RecentProjects" group="java" type="export" category="friend" url="http://www.netbeans.org/issues/show_bug.cgi?id=57073" >
+  <api name="RecentProjects" group="java" type="export" category="friend" url="https://bz.apache.org/netbeans/show_bug.cgi?id=57073" >
     <p>
      There is package org.netbeans.modules.project.ui.api which is public and exposed
      as friend API.

--- a/ide/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectOpenedHook.java
+++ b/ide/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectOpenedHook.java
@@ -79,9 +79,9 @@ public abstract class ProjectOpenedHook {
      * <ul>
      * <li><p>
      * Update build scripts using
-     * <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/GeneratedFilesHelper.html#refreshBuildScript"><code>GeneratedFilesHelper.refreshBuildScript(...)</code></a>.
+     * <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/GeneratedFilesHelper.html#refreshBuildScript-java.lang.String-java.net.URL-boolean-"><code>GeneratedFilesHelper.refreshBuildScript(...)</code></a>.
      * </p></li>
-     * <li><p>Call <a href="@org-netbeans-api-java-classpath@/org/netbeans/api/java/classpath/GlobalPathRegistry.html#register"><code>GlobalPathRegistry.register(...)</code></a>
+     * <li><p>Call <a href="@org-netbeans-api-java-classpath@/org/netbeans/api/java/classpath/GlobalPathRegistry.html#register-java.lang.String-org.netbeans.api.java.classpath.ClassPath:A-"><code>GlobalPathRegistry.register(...)</code></a>
      * with source, compile, and boot paths known to the project.</p></li>
      * <li><p>Write property <code>user.properties.file</code> to <code>private.properties</code>
      * with absolute file path of the <code>build.properties</code> from 
@@ -105,7 +105,7 @@ public abstract class ProjectOpenedHook {
      * way (e.g. using
      * {@link org.netbeans.spi.project.AuxiliaryConfiguration}).
      * </p></li>
-     * <li><p>Call <a href="@org-netbeans-api-java-classpath@/org/netbeans/api/java/classpath/GlobalPathRegistry.html#unregister"><code>GlobalPathRegistry.unregister(...)</code></a>
+     * <li><p>Call <a href="@org-netbeans-api-java-classpath@/org/netbeans/api/java/classpath/GlobalPathRegistry.html#unregister-java.lang.String-org.netbeans.api.java.classpath.ClassPath:A-"><code>GlobalPathRegistry.unregister(...)</code></a>
      * with the same paths are were previously registered.</p></li>
      * </ul>
      * </div>

--- a/ide/spi.debugger.ui/arch.xml
+++ b/ide/spi.debugger.ui/arch.xml
@@ -361,7 +361,7 @@ We would like to test 100% of our APIs.
         </question>
 -->
 <answer id="dep-nb">
-    <api name="OpenAPIs" type="import" category="official" url="http://openide.netbeans.org" group="java"/> 
+    <api name="OpenAPIs" type="import" category="official" group="java"/> 
     <api name="ViewModel" type="import" category="official" group="java"/> 
     <api name="DebuggerCoreAPI" type="import" category="official" group="java"/> 
 </answer>

--- a/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupHint.java
+++ b/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupHint.java
@@ -24,7 +24,7 @@ package org.netbeans.spi.navigator;
  *
  * Usage: Implementation of this interface should be inserted into
  * client's specific topComponent's lookup, see
- * <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup()">TopComponent.getLookup()</a>
+ * <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup--">TopComponent.getLookup()</a>
  * method. When mentioned <code>TopComponent</code> gets active in the system, system will
  * ask <code>NavigatorLookupHint</code> implementation for content type
  * to show in Navigator UI.

--- a/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupPanelsPolicy.java
+++ b/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupPanelsPolicy.java
@@ -23,7 +23,7 @@ package org.netbeans.spi.navigator;
  * available NavigatorPanel implementations.<p>
  * 
  * Navigator infrastructure searches for instance of this interface in
- * <a href="@org-openide-util@/org/openide/util/Utilities.html#actionsGlobalContext()">Utilities.actionsGlobalContext()</a>
+ * <a href="@org-openide-util-ui@/org/openide/util/Utilities.html#actionsGlobalContext--">Utilities.actionsGlobalContext()</a>
  * lookup and then applies found policy on set of available 
  * <a href="@TOP@/org/netbeans/spi/navigator/NavigatorPanel.html">NavigatorPanel</a>
  * implementations.<p>
@@ -37,7 +37,7 @@ package org.netbeans.spi.navigator;
  *      <li>Implement this interface, return kind of policy that suits you from
  *          <code>getPanelsPolicy()</code> method.</li>
  *      <li>Put implementation instance into your TopComponent's subclass lookup,
- *          see <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup()">TopComponent.getLookup()</a>
+ *          see <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup--">TopComponent.getLookup()</a>
  *          for details.</li>
  *      <li>Now when your TopComponent becomes active in the system, found
  *          panels policy is used to limit/affect set of available NavigatorPanel

--- a/ide/spi.viewmodel/arch.xml
+++ b/ide/spi.viewmodel/arch.xml
@@ -161,7 +161,7 @@ We would like to test 100% of our APIs.
         </question>
 -->
 <answer id="dep-nb">
-    <api name="OpenAPIs" type="import" category="official" url="http://openide.netbeans.org" group="java"/> 
+    <api name="OpenAPIs" type="import" category="official" group="java"/> 
 </answer>
 
 

--- a/ide/versioning.core/arch.xml
+++ b/ide/versioning.core/arch.xml
@@ -118,7 +118,7 @@
  <answer id="arch-usecases">
   <p>
        Main and Popup Menu usecases come from the UI spec available here:         
-       <a href="http://ui.netbeans.org/docs/ui/VersioningSpecification/">Versioning UI spec</a>
+       <a href="https://netbeans.apache.org/projects/ui/versioningspecification/index.html">Versioning UI spec</a>
         <usecase id="1" name="Main Menu Itegration">
         All installed SCM systems must cooperate while constructing popup and main menus, see UI spec.
         </usecase>

--- a/ide/versioning/arch.xml
+++ b/ide/versioning/arch.xml
@@ -125,7 +125,7 @@
  <answer id="arch-usecases">
      <p>
        Main and Popup Menu usecases come from the UI spec available here:         
-       <a href="http://ui.netbeans.org/docs/ui/VersioningSpecification/">Versioning UI spec</a>
+       <a href="https://netbeans.apache.org/projects/ui/versioningspecification/index.html">Versioning UI spec</a>
         <usecase id="1" name="Main Menu Itegration">
         All installed SCM systems must cooperate while constructing popup and main menus, see UI spec.
         </usecase>

--- a/java/api.debugger.jpda/arch.xml
+++ b/java/api.debugger.jpda/arch.xml
@@ -296,7 +296,7 @@ We would like to test 100% of our APIs.
         </question>
 -->
 <answer id="dep-nb">
-    <api name="OpenAPIs" type="import" category="official" url="http://openide.netbeans.org" group="java"/>
+    <api name="OpenAPIs" type="import" category="official" group="java"/>
     <api name="DebuggerCoreAPI" type="import" category="official" url="@TOP@/@org-netbeans-api-debugger@" group="java"/>
     <api name="ViewModelAPI" type="import" category="official" url="@TOP@/@org-netbeans-spi-viewmodel@" group="java"/>
 </answer>

--- a/java/j2ee.metadata/arch.xml
+++ b/java/j2ee.metadata/arch.xml
@@ -217,9 +217,9 @@
 -->
  <answer id="arch-where">
   <p>
-   The sources for the module are in the NetBeans CVS in the 
-   <a href="http://www.netbeans.org/source/browse/j2ee/metadata/?only_with_tag=merged_model">j2ee/metadata</a>
-   directory on the <code>merged_model</code> branch.
+   The sources for the module are in the Apache NetBeans Git in the 
+   <a href="https://github.com/apache/netbeans/tree/master/java/j2ee.metadata">java/j2ee.metadata</a>
+   directory.
   </p>
  </answer>
 

--- a/java/java.j2seplatform/arch.xml
+++ b/java/java.j2seplatform/arch.xml
@@ -174,14 +174,14 @@
    <li>
     <p>
      J2SE-specific portion of <a
-     href="http://projects.netbeans.org/buildsys/j2se-project-ui-spec.html#Dialog_Java_Platform_Manager">Java
+     href="https://netbeans.apache.org/projects/buildsys/j2se-project-ui-spec.html#Dialog_Library_Manager">Java
      Platform Manager</a>.
     </p>
    </li>
    <li>
     <p>
      Class-library-specific portion of <a
-     href="http://projects.netbeans.org/buildsys/j2se-project-ui-spec.html#Dialog_Library_Manager">Library
+     href="https://netbeans.apache.org/projects/buildsys/j2se-project-ui-spec.html#Dialog_Java_Platform_Manager">Library
      Manager</a>.
     </p>
    </li>
@@ -364,7 +364,7 @@
               <b>no</b> will disable the attachers. No source/javadoc will be attached, and no user interaction will be started.
           </li>
           <li>
-              <b>yes</b> will permit the registered <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation#Definer.html">
+              <b>yes</b> will permit the registered <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation.Definer.html">
                   SourceJavadocAttacherImplementation.Definer</a> to attach an appropriate resource(s). <b>User interaction will be skipped</b>
           </li>
           <li>
@@ -387,7 +387,7 @@
               <b>no</b> will disable the attachers. No source/javadoc will be attached, and no user interaction will be started.
           </li>
           <li>
-              <b>yes</b> will permit the registered <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation#Definer.html">
+              <b>yes</b> will permit the registered <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation.Definer.html">
                   SourceJavadocAttacherImplementation.Definer</a> to attach an appropriate resource(s). <b>User interaction will be skipped</b>
           </li>
           <li>

--- a/java/java.j2seproject/arch.xml
+++ b/java/java.j2seproject/arch.xml
@@ -49,7 +49,7 @@
  <answer id="arch-overall">
   <p>
    Uses various project APIs to implement the project type. <a
-   href="http://projects.netbeans.org/buildsys/design.html">Build system design
+   href="https://netbeans.apache.org/projects/buildsys/design.html">Build system design
    document</a>
   </p>
   <ol>

--- a/java/java.project.ui/apichanges.xml
+++ b/java/java.project.ui/apichanges.xml
@@ -94,7 +94,7 @@ is the proper place.
                 Added the <code>superclass</code> and <code>interfaces</code> variables for use in FreeMarker 
                 templates used by the New Java File Wizard.
             </description>
-            <class name="NewJavaFileWizardIterator" package="org.netbeans.modules.java.project.ui"/>
+            <class name="NewJavaFileWizardIterator" package="org.netbeans.modules.java.project.ui" link="no"/>
         </change>
         <change id="BrokenReferencesSupport.createPlatformVersionProblemProvider">
             <api name="JavaProjectUI"/>

--- a/java/java.source.base/src/org/netbeans/api/java/source/package.html
+++ b/java/java.source.base/src/org/netbeans/api/java/source/package.html
@@ -26,7 +26,7 @@
   <body>
       <p>
       Permits inspection and modification of the structure of Java sources.
-      <a href="http://wiki.netbeans.org/Java_DevelopersGuide"><code>Java_DevelopersGuide</code></a> is a useful resource.
+      <a href="https://netbeans.apache.org/wiki/Java_DevelopersGuide"><code>Java_DevelopersGuide</code></a> is a useful resource.
       </p>
   </body>
 </html>

--- a/java/maven/arch.xml
+++ b/java/maven/arch.xml
@@ -118,7 +118,7 @@
     <api group="layer" name="MavenPackagingLookup" type="export" category="devel">
         <p>
             <code>Projects/org-netbeans-modules-maven/&lt;packaging-type>/Lookup</code> is added to the project's additional Lookup. The content is expected
-            to contain packaing-specific services and processors, for example, <a href="@TOP@/org/netbans/modules/maven/api/execute/PrerequisitesChecker.html">PrerequisitesCheckers</a>.
+            to contain packaing-specific services and processors, for example, <a href="@TOP@/org/netbeans/modules/maven/api/execute/PrerequisitesChecker.html">PrerequisitesCheckers</a>.
             In addition, <code>Projects/org-netbeans-modules-maven/_any/Lookup</code> defines services that act after the packaging-specific ones.
         </p>
         For the details and examples, see description in <a href="@TOP@/org/netbeans/modules/maven/api/execute/PrerequisitesChecker.html">PrerequisitesChecker javadoc</a>.
@@ -169,8 +169,8 @@
     <api group="lookup" name="ActionConfiguration" type="import" category="official">
         <p>
             Project API clients may place <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ProjectConfiguration.html">ProjectConfiguration</a> 
-            instance in the <b>context Lookup</b> passed to <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html##isActionEnabled-java.lang.String-org.openide.util.Lookup-">ActionProvider.isActionEnabled()</a> or 
-            <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html##invokeAction-java.lang.String-org.openide.util.Lookup-">ActionProvider.invokeAction()</a>. If such instance is present, the action is configured according to settings in the selected configuration.
+            instance in the <b>context Lookup</b> passed to <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html#isActionEnabled-java.lang.String-org.openide.util.Lookup-">ActionProvider.isActionEnabled()</a> or 
+            <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html#invokeAction-java.lang.String-org.openide.util.Lookup-">ActionProvider.invokeAction()</a>. If such instance is present, the action is configured according to settings in the selected configuration.
             If not present, the active configuration is used. See example in <a href="@TOP@/org/netbeans/modules/maven/api/NbMavenProject.html">NbMavenProject</a> documentation.
         </p>
     </api>

--- a/java/maven/src/org/netbeans/modules/maven/spi/actions/AbstractMavenActionsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/spi/actions/AbstractMavenActionsProvider.java
@@ -347,7 +347,7 @@ public abstract class AbstractMavenActionsProvider implements MavenActionsProvid
      * from multiple {@link MavenActionsProvider}s. 
      * <p>
      * <b>This is a part of Maven module's friend API.</b> If possible, use se  
-     * <a href="@org-netbeans-api-maven@/org/netbeans/spi/maven/MavenActions.html">MavenActions</a> to register
+     * <a href="@org-netbeans-api-maven@/org/netbeans/api/maven/MavenActions.html">MavenActions</a> to register
      * actions declaratively, using module layers.
      * 
      * @param mavenProject the maven project. 

--- a/nbbuild/javadoctools/disallowed-links.xml
+++ b/nbbuild/javadoctools/disallowed-links.xml
@@ -137,10 +137,9 @@
     <filter pattern="http://www\.netbeans\.org/ns/j2se-project/2\.xsd" accept="true"/>
     
     <!-- j2ee dtd-->
-    <filter pattern="http://java\.sun\.com/dtd/.*" accept="true"/>
-    <filter pattern="http://java\.sun\.com/j2ee/dtds/.*" accept="true"/>
+    <filter pattern="https://java\.sun\.com/dtd/.*" accept="true"/>
+    <filter pattern="https://java\.sun\.com/j2ee/dtds/.*" accept="true"/>
     <filter pattern="https://www\.oracle\.com/webfolder/technetwork/.*" accept="true"/>
-    <filter pattern="http://www\.oracle\.com/webfolder/technetwork/.*" accept="true"/>
     <filter pattern="https://jcp\.org/aboutJava/communityprocess/.*" accept="true"/>
     
     

--- a/platform/api.progress.nb/apichanges.xml
+++ b/platform/api.progress.nb/apichanges.xml
@@ -92,7 +92,7 @@ is the proper place.
           <author login="sdedic"/>
           <compatibility binary="compatible" source="compatible" addition="yes" deprecation="yes"/>
           <description>
-              The default action on <a href="@TOP@/org/netbeans/modules/progress/api/ProgressHandle.html">ProgressHandle</a> is sometimes non-visual: open a file, focus a result, 
+              The default action on <a href="@TOP@@org-netbeans-api-progress@/org/netbeans/api/progress/ProgressHandle.html">ProgressHandle</a> is sometimes non-visual: open a file, focus a result, 
               display an output window associated with the task, etc. Abstract action can be used now with the basic Progress API without
               dependency on NB- or Swing- specific APIs.
           </description>

--- a/platform/api.progress/apichanges.xml
+++ b/platform/api.progress/apichanges.xml
@@ -92,11 +92,11 @@ is the proper place.
           <author login="sdedic"/>
           <compatibility binary="compatible" source="compatible" addition="yes"/>
           <description>
-              The default action on <a href="@TOP@/org/netbeans/modules/progress/api/ProgressHandle.html">ProgressHandle</a> is sometimes non-visual: open a file, focus a result, 
+              The default action on <a href="@TOP@/org/netbeans/api/progress/ProgressHandle.html">ProgressHandle</a> is sometimes non-visual: open a file, focus a result, 
               display an output window associated with the task, etc. Abstract action can be used now with the basic Progress API without
               dependency on NB- or Swing- specific APIs.
           </description>
-          <class package="org.netbeans.modules.progress.api" name="ProgressHandle"/>
+          <class package="org.netbeans.api.progress" name="ProgressHandle"/>
           <class package="org.netbeans.modules.progress.spi" name="InternalHandle"/>
       </change>
       <change id="progresshandle.time">

--- a/platform/api.search/src/org/netbeans/spi/search/SearchInfoDefinition.java
+++ b/platform/api.search/src/org/netbeans/spi/search/SearchInfoDefinition.java
@@ -36,7 +36,7 @@ import org.openide.filesystems.FileObject;
  * <code>SearchInfoDefinition</code> objects are used in
  * action <em>Find in Projects</em>. Action obtains
  * <code>SearchInfoDefinition</code> from 
- * <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup()"><code>Lookup</code>
+ * <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup--"><code>Lookup</code>
  * of nodes or projects</a> the action was invoked on.
  * </p>
  *
@@ -77,8 +77,8 @@ import org.openide.filesystems.FileObject;
  * 
  * @see SearchInfoDefinitionFactory
  * @see FileObject
- * @see <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup()"><code>Node.getLookup()</code></a>
- * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()"><code>Project.getLookup()</code></a>
+ * @see <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup--"><code>Node.getLookup()</code></a>
+ * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--"><code>Project.getLookup()</code></a>
  *
  * @author Marian Petras
  */

--- a/platform/api.templates/src/org/netbeans/api/templates/FileBuilder.java
+++ b/platform/api.templates/src/org/netbeans/api/templates/FileBuilder.java
@@ -47,7 +47,7 @@ import org.openide.util.Parameters;
  * <p>
  * The file build request will be forwarded to {@link CreateFromTemplateHandler}s; if none
  * {@link CreateFromTemplateHandler#accept}s the request, the default procedure takes place,
- * depending on the {@link #defaultMode} setting (default: {@link Mode#COPY}).
+ * depending on the {@code #defaultMode} setting (default: {@link Mode#COPY}).
  * <p>
  * There are several values predefined:<ul>
  * <li>name - the created filename without extension

--- a/platform/autoupdate.services/apichanges.xml
+++ b/platform/autoupdate.services/apichanges.xml
@@ -44,8 +44,8 @@
                 <a href="@TOP@/org/netbeans/api/autoupdate/PluginInstaller.html">Simplified API to install</a> additional plugins to avoid dependencies on UI part of the AutoUpdate. CLI and UI implementations
                 for the autoupdate plugs provides their implementations, UI is preferred.
             </description>
-            <class package="org.netbeans.api.autoupdate" name="Plugininstaller"/>
-            <class package="org.netbeans.spi.autoupdate" name="PlugininstallerImplementation"/>
+            <class package="org.netbeans.api.autoupdate" name="PluginInstaller"/>
+            <class package="org.netbeans.spi.autoupdate" name="PluginInstallerImplementation"/>
         </change>
         <change id="unpack200">
             <api name="general"/>

--- a/platform/autoupdate.services/src/org/netbeans/api/autoupdate/InstallSupport.java
+++ b/platform/autoupdate.services/src/org/netbeans/api/autoupdate/InstallSupport.java
@@ -180,7 +180,7 @@ public final class InstallSupport {
      * @param uElement <code>UpdateElement</code> 
      * @return true for trusted <code>UpdateElement</code>
      * @see #doValidate
-     * @see <a href="http://java.sun.com/j2se/1.5.0/docs/api/java/security/cert/Certificate.html">java.security.cert.Certificate</a>
+     * @see <a href="@JDK@/java/security/cert/Certificate.html">java.security.cert.Certificate</a>
      */
     public boolean isTrusted(Installer validator, UpdateElement uElement) {
         return impl.isTrusted(validator, uElement);
@@ -191,7 +191,7 @@ public final class InstallSupport {
      * @param validator  <code>Installer</code> an instance of Installer has been returned by {link @doValidate}
      * @param uElement <code>UpdateElement</code> 
      * @return true for signed <code>UpdateElement</code>
-     * @see <a href="http://java.sun.com/j2se/1.5.0/docs/api/java/security/cert/Certificate.html">java.security.cert.Certificate</a>
+     * @see <a href="@JDK@/java/security/cert/Certificate.html">java.security.cert.Certificate</a>
      * @see #doValidate
      */
     public boolean isSigned(Installer validator, UpdateElement uElement) {
@@ -203,7 +203,7 @@ public final class InstallSupport {
      * @param validator  <code>Installer</code> an instance of Installer has been returned by {link @doValidate}
      * @param uElement <code>UpdateElement</code> 
      * @return true for signed and verified <code>UpdateElement</code>
-     * @see <a href="http://java.sun.com/j2se/1.5.0/docs/api/java/security/cert/Certificate.html">java.security.cert.Certificate</a>
+     * @see <a href="@JDK@/java/security/cert/Certificate.html">java.security.cert.Certificate</a>
      * @see #doValidate
      * @since 1.50
      */
@@ -216,7 +216,7 @@ public final class InstallSupport {
      * @param validator  <code>Installer</code> an instance of Installer has been returned by {link @doValidate}
      * @param uElement <code>UpdateElement</code> 
      * @return true for signed but not verified <code>UpdateElement</code>
-     * @see <a href="http://java.sun.com/j2se/1.5.0/docs/api/java/security/cert/Certificate.html">java.security.cert.Certificate</a>
+     * @see <a href="@JDK@/java/security/cert/Certificate.html">java.security.cert.Certificate</a>
      * @see #doValidate
      * @since 1.50
      */
@@ -229,7 +229,7 @@ public final class InstallSupport {
      * @param validator  <code>Installer</code> an instance of Installer has been returned by {link @doValidate}
      * @param uElement <code>UpdateElement</code> 
      * @return true for modified <code>UpdateElement</code>
-     * @see <a href="http://java.sun.com/j2se/1.5.0/docs/api/java/security/cert/Certificate.html">java.security.cert.Certificate</a>
+     * @see <a href="@JDK@/java/security/cert/Certificate.html">java.security.cert.Certificate</a>
      * @see #doValidate
      * @since 1.50
      */

--- a/platform/core.multiview/apichanges.xml
+++ b/platform/core.multiview/apichanges.xml
@@ -108,7 +108,7 @@ is the proper place.
         <description>
 	    Should a MultiViewElement allow spliting? Some applications
 	    may need that, some don't. There is a
-	    <a href="architecture-summary.html#branding-MultiViewElement.Spliting.Enabled">
+	    <a href="@TOP@architecture-summary.html#branding-org.netbeans.core.multiview.MultiViewElement.Spliting.Enabled">
 		branding API</a> to control such behavior now.
         </description>
         <issue number="228448"/>

--- a/platform/core.multiview/src/org/netbeans/core/spi/multiview/SourceViewMarker.java
+++ b/platform/core.multiview/src/org/netbeans/core/spi/multiview/SourceViewMarker.java
@@ -23,7 +23,7 @@ package org.netbeans.core.spi.multiview;
  * A marker interface for <code>MultiViewDescription</code> instances that allows to identify them
  * as containing source code. The associated <code>MultiViewElement</code>'s visual representation
  * is assumed to implement <code>CloneableEditorSupport.Pane</code> interface.
- * Fixes issue <a href="http://www.netbeans.org/issues/show_bug.cgi?id=68912">#68912</a>.
+ * Fixes issue <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=68912">#68912</a>.
  * @author Milos Kleint
  * @since org.netbeans.core.multiview 1.10
  */

--- a/platform/core.network/src/org/netbeans/core/network/proxy/pac/PacHelperMethodsMicrosoft.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/pac/PacHelperMethodsMicrosoft.java
@@ -123,7 +123,7 @@ public interface PacHelperMethodsMicrosoft {
      *       </li>
      *   <li>IPv4-mapped IPv6 address (e.g. {@code fe80::5efe:157.59.139.22} 
      *       doesn't seem to be working. This is strange as it is used in the 
-     *       example in <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/gg308482(v=vs.85).aspx">Microsoft's own documentation</a>. 
+     *       example in <a href="https://docs.microsoft.com/windows/win32/winhttp/sortipaddresslist?redirectedfrom=MSDN">Microsoft's own documentation</a>. 
      *       Such an IP literal seems to throw an error which means
      *       the PAC script will not return a result, which means IE will choose 
      *       its default option, namely "DIRECT".

--- a/platform/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluator.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluator.java
@@ -108,7 +108,7 @@ import org.openide.util.NbBundle;
  *       <td>???</td>
  *   </tr>
  *   <tr>
- *       <td class="tablersh">Support for <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/gg308476(v=vs.85).aspx">getClientVersion()</a></td>
+ *       <td class="tablersh">Support for <a href="https://docs.microsoft.com/windows/win32/winhttp/getclientversion?redirectedfrom=MSDN">getClientVersion()</a></td>
  *       <td>Yes<br>(returns "1.0")</td>
  *       <td>No</td>
  *       <td>No</td>

--- a/platform/core.network/src/org/netbeans/core/network/utils/IpAddressUtils.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/IpAddressUtils.java
@@ -125,7 +125,7 @@ public class IpAddressUtils {
      * <u>Java's default DNS timeout:</u>
      * <p>
      * The default timeout DNS lookup is described 
-     * <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/jndi/jndi-dns.html#PROP">
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jndi/jndi-dns.html#PROP">
      * in the documentation for JNDI</a> in properties:
      * <p>
      * &nbsp;&nbsp;{@code com.example.jndi.dns.timeout.initial}  (defaults to 1 sec in Java 8)<br>

--- a/platform/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/MimeLookupInitializer.java
+++ b/platform/editor.mimelookup/src/org/netbeans/spi/editor/mimelookup/MimeLookupInitializer.java
@@ -43,10 +43,6 @@ import org.openide.util.Lookup;
  *  <br>
  *  This process can be arbitrarily nested for embedded mime-types.
  *  
- * <p> 
- *  An example implementation of MimeLookupInitializer
- *  that works over xml layer file system can be found at mime lookup module
- *  implementation <a href="http://editor.netbeans.org/source/browse/editor/mimelookup/src/org/netbeans/modules/editor/mimelookup/Attic/LayerMimeLookupImplementation.java">LayerMimeLookupInitializer</a>
  *
  *  @author Miloslav Metelka, Martin Roskanin
  *  @deprecated Use {@link MimeDataProvider} instead.

--- a/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/api.html
+++ b/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/api.html
@@ -155,7 +155,7 @@ specify a <code>HelpCtx</code> in this fashion:
 
 <li> <a href="@org-openide-dialogs@/org/openide/WizardDescriptor.Panel.html#getHelp--"><code>WizardDescriptor.Panel.getHelpCtx()</code></a>
 
-<li> <a href="@org-openide-options@/org/openide/options/SystemOption.html#getHelpCtx--"><code>SystemOption.getHelpCtx()</code></a>
+<!-- deprecated <li> <a href="@org-openide-options@/org/openide/options/SystemOption.html#getHelpCtx--"><code>SystemOption.getHelpCtx()</code></a> -->
 
 <li> <a href="@org-openide-util-ui@/org/openide/ServiceType.html#getHelpCtx--"><code>ServiceType.getHelpCtx()</code></a>
 

--- a/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/help-guide.html
+++ b/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/help-guide.html
@@ -296,7 +296,7 @@ NetBeans IDE uses the Unite-Append merge type for the table of contents and the 
 merge type for the index. These merge types are set in the master help set and 
 propogate to any help sets that merge into the product, unless those help sets 
 override them with other merge types. For more information on merge types, see the 
-<a href="http://java.sun.com/products/javahelp/README.html">JavaHelp release 
+<a href="https://docs.oracle.com/cd/E19253-01/819-0913/819-0913.pdf">JavaHelp release 
 notes.</a></p>
 
 <p>The biggest resulting impact for module authors is the need to more carefully 
@@ -304,13 +304,13 @@ notes.</a></p>
  comprehensibly for users. Here are some general tips and rules of thumb:</p>
 <ul>
  <li>Use the most recent revision of 
-<a href="http://www.netbeans.org/source/browse/usersguide/javahelp/org/netbeans/modules/usersguide/ide-idx.xml">
+<a href="https://github.com/emilianbold/netbeans-releases/tree/master/usersguide/javahelp/org/netbeans/modules/usersguide/ide-idx.xml">
  the usersguide module index</a> as a guide for your indexing conventions to make your entries fit in 
  seamlessly.</li>
 <li><i>DO NOT</i> use manual separators in your indexes, 
 (e.g. &lt;indexitem text="-A-"&gt;&lt;/indexitem&gt;). These are superfluous 
 with merged indexes are suspected of triggering a bug in JH that crashes the 
-help system - see <a href="http://www.netbeans.org/issues/show_bug.cgi?id=39966"> 
+help system - see <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=39966">
 Issuezilla bug 39966</a>.</li>
 <li>Any TOC or index entry that contains sub-entries should have no 
 <samp>target</samp> attribute. This rule has been adopted because it is not 
@@ -321,7 +321,7 @@ consistent experience as to when to expect a topic to display. If you feel that
 
   <li>If you would like to insert entries into an existing TOC bucket, check 
   the most recent revision of the 
-<a href="http://www.netbeans.org/source/browse/usersguide/javahelp/org/netbeans/modules/usersguide/ide-toc.xml">
+<a href="https://github.com/emilianbold/netbeans-releases/tree/master/usersguide/javahelp/org/netbeans/modules/usersguide/ide-toc.xml">
  the usersguide module TOC</a>.</li>
  <li>If you organize your table of contents so that "Core IDE Help" is your 
 first-level TOC item, your help set will be slotted in under second level buckets 

--- a/platform/javahelp/src/org/netbeans/api/javahelp/package.html
+++ b/platform/javahelp/src/org/netbeans/api/javahelp/package.html
@@ -33,7 +33,7 @@ Used to add help to a module or display help.
 
 <li class="nonnormative"><p><a href="@TOP@org/netbeans/api/javahelp/doc-files/help-guide.html">Help Guide</a> (friendlier)</p></li>
 
-<li><p><a href="http://java.sun.com/products/javahelp/">JavaHelp Standard Extension</p></li>
+<li><p><a href="https://docs.oracle.com/cd/E19253-01/819-0913/819-0913.pdf">JavaHelp Standard Extension</p></li>
 
 </ol>
 

--- a/platform/o.n.core/arch.xml
+++ b/platform/o.n.core/arch.xml
@@ -506,7 +506,7 @@
  <answer id="exec-privateaccess">
   <p>
     <api type="export" name="NbKeymap.context" category="friend" group="java"
-     url="http://www.netbeans.org/source/browse/editor/src/org/netbeans/core/NbKeymap.html">
+     url="https://github.com/apache/netbeans/tree/master/platform/o.n.core/src/org/netbeans/core/NbKeymap.java">
         The <code>context</code> field is accessed from editor module by reflection
         from <a href="@org-netbeans-modules-editor-lib@/org/netbeans/editor/MultiKeymap.html">MultiKeymap</a>.
     </api>
@@ -599,7 +599,7 @@
             Then each exception shows the exception dialog.</li>    
        </ul>
    </api>
-   <api name="netbeans.hack.50423" category="private" group="systemproperty" type="export" url="http://www.netbeans.org/issues/show_bug.cgi?id=50423">
+   <api name="netbeans.hack.50423" category="private" group="systemproperty" type="export" url="https://bz.apache.org/netbeans/show_bug.cgi?id=50423">
         Set this property to <q>true</q> to workaround the bug #50423 which
         appears on some linuxes on JDK 1.5.
    </api>

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabDataModel.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabDataModel.java
@@ -183,7 +183,7 @@ public interface TabDataModel {
      * the tooltip property of the passed TabData object is not used to test
      * equality.
      *
-     * See also <a href="@org-netbeans-core-windows@/org/netbeans/core/windows/ui/TabData.html#equals()">org.netbeans.core.windows.ui.TabData.equals()</a><BR>
+     * @see TabData#equals(java.lang.Object)
      */
     public int indexOf(TabData td);
 

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabbedContainerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabbedContainerUI.java
@@ -36,12 +36,6 @@ import java.awt.event.MouseEvent;
  * Basic UI for tabbed containers.  Note this is distinct from the UI for the
  * embedded tab displayer component - that where all the interesting painting
  * logic is.
- * <p>
- * To provide an implementation of TabbedContainerUI, it is a far better idea to
- * subclass 
- * <a href="plaf/AbstractTabbedContainerUI.html">AbstractTabbedContainerUI</a>, 
- * <a href="plaf/BasicTabbedContainerUI.html">BasicTabbedContainerUI</a>, or 
- * <a href="plaf/BasicScrollingTabbedContainerUI.html">BasicScrollingTabbedContainerUI</a>.
  *
  * @author Tim Boudreau
  */

--- a/platform/openide.actions/apichanges.xml
+++ b/platform/openide.actions/apichanges.xml
@@ -116,14 +116,14 @@
             <p>
             Introduction of new action system, which generally means
             move from usage of <code>SystemAction</code> to <code>Action</code> instances.
-            Look at <a href="http://openide.netbeans.org/proposals/actions/index.html" shape="rect">
+            Look at <a href="https://netbeans.apache.org/projects/platform/openide/proposals/actions/index.html" shape="rect">
             general proposal</a>. That document also focuses on declarative actions
             usage which is not subject of current change, it will be part of later changes.
             </p>
 <p>
-            Current change is described by <a href="http://openide.netbeans.org/proposals/actions/impl.html" shape="rect">
+            Current change is described by <a href="https://netbeans.apache.org/projects/platform/openide/proposals/actions/impl.html" shape="rect">
             description of already implemented changes</a> which also summarizes
-            <a href="http://openide.netbeans.org/proposals/actions/impl.html#summaryAPI" shape="rect">
+            <a href="https://netbeans.apache.org/projects/platform/openide/proposals/actions/impl.html#summaryAPI" shape="rect">
             these API changes</a>.
             </p>
         </description>

--- a/platform/openide.actions/arch.xml
+++ b/platform/openide.actions/arch.xml
@@ -549,7 +549,7 @@ calls to <code>SharedClassObject.findObject</code> which calls constructor by re
 <answer id="format-clipboard">
 Implementations of cut, copy and paste (<code>CutAction</code>, <code>CopyAction</code>
 and <code>PasteAction</code>) reads/writes from/into clipboard. It uses standard
-<a href="http://java.sun.com/j2se/1.4.1/docs/api/java/awt/datatransfer/package-summary.html">java datatransfer mechanism</a>
+<a href="@JDK@/java/awt/datatransfer/package-summary.html">java datatransfer mechanism</a>
 and <a href="@org-openide-util-ui@/org/openide/util/datatransfer/package-summary.html">Netbeans extension to the mechanism</a>.
 </answer>
 

--- a/platform/openide.awt/src/org/openide/awt/UndoRedo.java
+++ b/platform/openide.awt/src/org/openide/awt/UndoRedo.java
@@ -38,7 +38,7 @@ import org.openide.util.Utilities;
  * <ul>
  *   <li><a href="@org-openide-actions@/org/openide/actions/UndoAction.html">org.openide.actions.UndoAction</a></li>
  *   <li><a href="@org-openide-actions@/org/openide/actions/RedoAction.html">org.openide.actions.RedoAction</a></li>
- *   <li><a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getUndoRedo()">org.openide.windows.TopComponent.getUndoRedo()</a></li>
+ *   <li><a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getUndoRedo--">org.openide.windows.TopComponent.getUndoRedo()</a></li>
  * </ul> 
  *
  * @author Jaroslav Tulach

--- a/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
+++ b/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
@@ -58,7 +58,7 @@ import org.openide.util.*;
  * <p><b>Related Tutorial</b>
  *
  * <ul>
- * <li><a href="http://platform.netbeans.org/tutorials/nbm-wizard.html">NetBeans Wizard Module Tutorial</a>
+ * <li><a href="https://netbeans.apache.org/tutorials/nbm-wizard.html">NetBeans Wizard Module Tutorial</a>
  * <li><a href="doc-files/wizard-guidebook.html">Wizard Guide</a>
  * </ul>
  *

--- a/platform/openide.execution/arch.xml
+++ b/platform/openide.execution/arch.xml
@@ -145,7 +145,7 @@ JRE is enough.
         </question>
 -->
 <answer id="dep-nb">
-<api name="OptionsAPI" group="java" type="import" category="official" url="@org-openide-options@/org/openide/options/doc-files/api.html"/>;
+<!-- not generated anymore <api name="OptionsAPI" group="java" type="import" category="official" url="@org-openide-options@/org/openide/options/doc-files/api.html"/>; -->
 <api group="java" name="WindowSystemAPI" type="import" category="official" url="@org-openide-windows@/org/openide/windows/doc-files/api.html"/>
 </answer>
 

--- a/platform/openide.execution/src/org/openide/execution/NbClassPath.java
+++ b/platform/openide.execution/src/org/openide/execution/NbClassPath.java
@@ -86,7 +86,7 @@ public final class NbClassPath extends Object implements java.io.Serializable {
 
     /** Creates class path describing additional libraries needed by the system.
      * Never use this class path as part of a user project!
-     * For more information consult the <a href="../doc-files/classpath.html">Module Class Path</a> document.
+     * For more information consult the <a href="@org-openide-modules@/org/openide/modules/doc-files/classpath.html">Module Class Path</a> document.
      * @deprecated There are generally no excuses to be using this method as part of a normal module;
      * its exact meaning is vague, and probably not what you want.
     */
@@ -104,7 +104,7 @@ public final class NbClassPath extends Object implements java.io.Serializable {
 
     /** Creates class path of the system.
      * Never use this class path as part of a user project!
-     * For more information consult the <a href="../doc-files/classpath.html">Module Class Path</a> document.
+     * For more information consult the <a href="@org-openide-modules@/org/openide/modules/doc-files/classpath.html">Module Class Path</a> document.
      * @deprecated There are generally no excuses to be using this method as part of a normal module;
      * its exact meaning is vague, and probably not what you want.
     */
@@ -133,7 +133,7 @@ public final class NbClassPath extends Object implements java.io.Serializable {
     /** Creates path describing boot class path of the system.
      * Never use this class path as part of a user project!
      * There are generally no excuses to be using this method as part of a normal module.
-     * For more information consult the <a href="../doc-files/classpath.html">Module Class Path</a> document.
+     * For more information consult the <a href="@org-openide-modules@/org/openide/modules/doc-files/classpath.html">Module Class Path</a> document.
     * @return class path of system class including extensions
      * @deprecated Use the Java Platform API instead.
     */

--- a/platform/openide.explorer/src/org/openide/explorer/doc-files/propertyViewCustomization.html
+++ b/platform/openide.explorer/src/org/openide/explorer/doc-files/propertyViewCustomization.html
@@ -82,13 +82,13 @@ value of the property edited by the property editor.
         return s;
     }
 </PRE>
-
+<!-- (too old not relevant)
 <p class="nonnormative"><a href="http://www.netbeans.org/source/browse/~checkout~/jarpackager/src/org/netbeans/modules/jarpackager/JarDataObject.java"><code>JarDataObject</code></a>
 is an example from NetBeans sources, though this module is now obsolete.</p>
 
 <p class="nonnormative"><a href="http://www.netbeans.org/source/browse/~checkout~/core/src/org/netbeans/core/ui/MountIterator.java"><code>MountIterator</code></a>
 is an example from NetBeans sources.</p>
-
+-->
 <H3><A name="disabling_ok"> When do you want to disable/enable OK when displaying custom property editor </a></H3>
 If you provide your own property editor implementation which supplies a GUI custom editor, that
 component will be displayed in a separate window with OK and Cancel buttons.
@@ -219,7 +219,7 @@ type) the custom parameter is ignored.
             bold, ... font. Be aware that due to the performance reason, the
             given <em>html</em> longer than 511 bytes will not be interpretted
             as html.
-            See <a href="http://www.netbeans.org/issues/show_bug.cgi?id=44152">issue 44152</a> for details.
+            See <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=44152">issue 44152</a> for details.
           </TD>
         </TR>
 	<TR> 
@@ -410,11 +410,10 @@ such an editor exists when creating JavaBean-related code; most
 commonly, this means that
 
 <a href="@org-openide-nodes@/org/openide/nodes/Node.Property.html#getPropertyEditor--">node properties</a>
-
+<!-- deprecated
 and
-
 <a href="@org-openide-options@/org/openide/options/SystemOption.html">system options</a>
-
+-->
 may declare a property to be of a certain type without explicitly
 specifying a property editor for it, and rely on the search path to
 provide a usable property editor so that the UI will function

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropUtils.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropUtils.java
@@ -1532,7 +1532,7 @@ final class PropUtils {
      * return true and don't override Node.Property.isDefaultValue(). The
      * isDefaultValue() return false by default.<br>
      * For more information and detailed reason why we do so see
-     * <a href="http://www.netbeans.org/issues/show_bug.cgi?id=51907">
+     * <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=51907">
      * Issue 51907</a>.
      */
     static boolean shallBeRDVEnabled(Node.Property property) {

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertyPanel.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertyPanel.java
@@ -1153,7 +1153,7 @@ public class PropertyPanel extends JComponent implements javax.accessibility.Acc
     /*
      * Overridden to fill in the background color, since Synth/GTKLookAndFeel ignores
      * setOpaque(true).
-     * @see http://www.netbeans.org/issues/show_bug.cgi?id=43024
+     * @see https://bz.apache.org/netbeans/show_bug.cgi?id=43024
      */
     @Override
     public void paint(Graphics g) {

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/editors/EnhancedCustomPropertyEditor.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/editors/EnhancedCustomPropertyEditor.java
@@ -29,10 +29,10 @@ import org.openide.explorer.propertysheet.PropertyEnv;
 * @author  Ian Formanek
 * @deprecated Use {@link PropertyEnv} instead. An example of what needs to be
 *    done can be found in the rewrite of
-*    <a href="http://hg.netbeans.org/main/diff/375290349033/o.n.core/src/org/netbeans/beaninfo/editors/RectangleCustomEditor.java">RectangleCustomEditor</a>.
+*    <a href="https://github.com/apache/netbeans/tree/master/platform/o.n.core/src/org/netbeans/beaninfo/editors/RectangleCustomEditor.java">RectangleCustomEditor</a>.
 *  Another example showing the changes in property editor as well as in its
 *  custom component can be found in
-*  <a href="http://hg.netbeans.org/main/rev/6ec9ed2b2062">NbProcessDescriptor{,Custom}Editor</a>.
+*  <a href="https://github.com/apache/netbeans/tree/master/platform/openide.execution/src/org/openide/execution/NbProcessDescriptor.java">NbProcessDescriptor{,Custom}Editor</a>.
 */
 public @Deprecated interface EnhancedCustomPropertyEditor {
     /** Get the customized property value.

--- a/platform/openide.explorer/src/org/openide/explorer/view/OutlineView.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/OutlineView.java
@@ -135,8 +135,8 @@ import org.openide.util.WeakListeners;
  * 
  * <p>Related documentation:
  * <ul>
- * <li><a href="http://weblogs.java.net/blog/timboudreau/archive/2008/06/egads_an_actual.html">Egads! An actual Swing Tree-Table!</a>
- * <li><a href="http://blogs.oracle.com/geertjan/entry/swing_outline_component">Swing Outline Component</a>
+ * <li><a href="https://netbeans.apache.org/blogs/timboudreau/egads_an_actual.html">Egads! An actual Swing Tree-Table!</a>
+ * <li><a href="https://netbeans.apache.org/blogs/geertjan/swing_outline_component.html">Swing Outline Component</a>
  * </ul>
  * 
  * 

--- a/platform/openide.explorer/test/unit/src/org/openide/explorer/view/TreeNodeLeakTest.java
+++ b/platform/openide.explorer/test/unit/src/org/openide/explorer/view/TreeNodeLeakTest.java
@@ -66,7 +66,7 @@ public final class TreeNodeLeakTest extends NbTestCase {
     }
     
     /**
-     * @see http://www.netbeans.org/issues/show_bug.cgi?id=84970
+     * @see https://bz.apache.org/netbeans/show_bug.cgi?id=84970
      */
     public void testNodesLeak() throws Exception {
         assert !EventQueue.isDispatchThread();

--- a/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
@@ -1403,7 +1403,7 @@ public final class FileUtil extends Object {
      * </code>
      * @param fo whose MIME type should be recognized
      * @param withinMIMETypes an array of MIME types. Only resolvers whose
-     * {@link MIMEResolver#getMIMETypes} contain one or more of the requested
+     * {@code MIMEResolver#getMIMETypes()} contain one or more of the requested
      * MIME types will be asked if they recognize the file. It is possible for
      * the resulting MIME type to not be a member of this list.
      * @return the MIME type for the FileObject, or <code>null</code> if

--- a/platform/openide.filesystems/src/org/openide/filesystems/Repository.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/Repository.java
@@ -1040,7 +1040,7 @@ public class Repository implements Serializable {
          * Repository instance even after the execution context shuts down; the contents of Repository and
          * its FileSystems may be limited in that case.
          * <p>
-         * Implementations must be reentrant (a call to {@link #getLocalRepository} can be made during 
+         * Implementations must be reentrant (a call to {@code getLocalRepository} can be made during 
          * construction of the Repository instance) and must not recurse infinitely.
          * 
          * @return local repository instance.
@@ -1051,7 +1051,7 @@ public class Repository implements Serializable {
          * Allows to delay attaching filesystems to the Repository. For backwards compatibility, the Repository
          * constructor still takes the default FileSystem instance. However it is better to actually publish the
          * FileSystem in the repository only after it is registered, and can be obtained using {@link #getDefault()} or
-         * {@link #getLocalRepository()}.
+         * {@code getLocalRepository()}.
          * <p>
          * This method wraps the Repository creation so that the default FileSystem is attached after the repository
          * is fully constructed. The `init' callable must create a new Repository instance.

--- a/platform/openide.filesystems/src/org/openide/filesystems/annotations/LayerGeneratingProcessor.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/annotations/LayerGeneratingProcessor.java
@@ -182,7 +182,7 @@ public abstract class LayerGeneratingProcessor extends AbstractProcessor {
      * The regular body of {@link #process}.
      * In the last round, one of the layer-generating processors will write out generated-layer.xml.
      * <p>Do not attempt to read or write the layer file directly; just use {@link #layer}.
-     * You may however wish to create other resource files yourself: see {@link LayerBuilder.File#url} for syntax.
+     * You may however wish to create other resource files yourself: see {@link LayerBuilder.File#url(String)} for syntax.
      * @param annotations as in {@link #process}
      * @param roundEnv as in {@link #process}
      * @return as in {@link #process}

--- a/platform/openide.loaders/apichanges.xml
+++ b/platform/openide.loaders/apichanges.xml
@@ -688,7 +688,7 @@ is the proper place.
             <a href="@TOP@/org/openide/loaders/DataObject.html">DataObject</a>.createFromTemplate,
             it passes as argument all its <a href="@org-openide-dialogs@/org/openide/WizardDescriptor.html#getProperties--">properties</a>
             to it with <code>wizard.</code> as a prefix. That way they are available to
-            underlying <a href="@TOP@/architecture-summary.html#script">scripting and templating
+            underlying <a href="@TOP@/architecture-summary.html#loaders-script">scripting and templating
             engines</a>.
         </p>
         </description>
@@ -786,7 +786,7 @@ is the proper place.
         that can be processed during instantiation of the template.
         </p>
         <p>
-        This is particallary useful when using <a href="@TOP@/architecture-summary.html#script">scripting and templating
+        This is particallary useful when using <a href="@TOP@/architecture-summary.html#loaders-script">scripting and templating
         languages</a> during create from template operation.
         </p>
         </description>
@@ -1093,7 +1093,7 @@ is the proper place.
         to be notified when the DataObject is being created, but the notification 
         shall be done when its constructor finishes otherwise magic race 
         conditions can happen, see for example 
-        <a href="http://www.netbeans.org/issues/show_bug.cgi?id=20022">issue 20022</a>.
+        <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=20022">issue 20022</a>.
         The previous solution was to wait 500ms after the start of DataObject's 
         constructor and notifying the creation than, but of course it means 
         that if the constructor takes longer time, we were in the same problem again.

--- a/platform/openide.loaders/src/org/openide/loaders/CreateFromTemplateHandler.java
+++ b/platform/openide.loaders/src/org/openide/loaders/CreateFromTemplateHandler.java
@@ -94,7 +94,7 @@ public abstract class CreateFromTemplateHandler extends org.netbeans.api.templat
      * include an extension (<em>*.*</em>), the handler should not append
      * any extension from the template.
      * @since org.openide.loaders 7.16
-     * @see <a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/templates/support/Templates.SimpleTargetChooserBuilder.html#freeFileExtension()"><code>Templates.SimpleTargetChooserBuilder.freeFileExtension</code></a>
+     * @see <a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/templates/support/Templates.SimpleTargetChooserBuilder.html#freeFileExtension--"><code>Templates.SimpleTargetChooserBuilder.freeFileExtension</code></a>
      */
     public static final String FREE_FILE_EXTENSION = "freeFileExtension"; // NOI18N
     

--- a/platform/openide.loaders/src/org/openide/loaders/DataLoader.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataLoader.java
@@ -558,7 +558,7 @@ public abstract class DataLoader extends SharedClassObject implements DataObject
     /** Get a registered loader from the pool.
      * @param loaderClass exact class of the loader (<em>not</em> its data object representation class)
      * @return the loader instance, or <code>null</code> if there is no such loader registered
-     * @see DataLoaderPool#allLoaders
+     * @see DataLoaderPool#allLoaders()
      */
     public static <T extends DataLoader> T getLoader(Class<T> loaderClass) {
         return findObject(loaderClass, true);

--- a/platform/openide.loaders/src/org/openide/loaders/DataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataObject.java
@@ -134,7 +134,7 @@ implements Node.Cookie, Serializable, HelpCtx.Provider, Lookup.Provider {
     private final DataLoader loader;
 
     /** property change listener support.
-     * Threading: lock free, changes HAS to go through {@link DataObject#changeSupportUpdater}.
+     * Threading: lock free, changes HAS to go through {@code DataObject#changeSupportUpdater}.
      */
     private volatile PropertyChangeSupport changeSupport;
 

--- a/platform/openide.loaders/src/org/openide/loaders/FilesSet.java
+++ b/platform/openide.loaders/src/org/openide/loaders/FilesSet.java
@@ -30,7 +30,7 @@ import org.openide.filesystems.FileObject;
  * <p>
  * This class is an implementation of performance enhancement #16396.
  *
- * @see <a href="http://www.netbeans.org/issues/show_bug.cgi?id=16396">Issue #16396</a>
+ * @see <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=16396">Issue #16396</a>
  *
  * @author  Petr Hamernik
  */

--- a/platform/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
@@ -1037,11 +1037,11 @@ public class InstanceDataObject extends MultiDataObject implements InstanceCooki
         return super.handleCreateFromTemplate(df, name);
     }
 
-    /* Copy a service sanely. For settings and serializable beans, special
+    /** Copy a service sanely. For settings and serializable beans, special
      * methods are used to write out the resulting files, and the name to
      * use is taken from the *display name* of the current file, as this is
      * what the user is accustomed to seeing (for ServiceType's especially).
-     * @see <a href="http://www.netbeans.org/issues/show_bug.cgi?id=16278">Issue #16278</a>
+     * @see <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=16278">Issue #16278</a>
      */
     @Override
     protected DataObject handleCopy(DataFolder df) throws IOException {

--- a/platform/openide.loaders/src/org/openide/loaders/TemplateWizard.java
+++ b/platform/openide.loaders/src/org/openide/loaders/TemplateWizard.java
@@ -872,7 +872,7 @@ public class TemplateWizard extends WizardDescriptor {
             throws IOException;
         
         /** Initializes the iterator after it is constructed.
-         * The iterator can for example obtain the {@link #targetChooser target chooser}
+         * The iterator can for example obtain the {@link #targetChooser() target chooser}
          * from the wizard if it does not wish to provide its own.
          * @param wiz template wizard that wishes to use the iterator
          */

--- a/platform/openide.loaders/src/org/openide/text/DataEditorSupport.java
+++ b/platform/openide.loaders/src/org/openide/text/DataEditorSupport.java
@@ -911,7 +911,7 @@ public class DataEditorSupport extends CloneableEditorSupport {
          * <p><b>Note: There is a contract (better saying a curse)
          * that this method has to call {@link #takeLock} method
          * in order to keep working some special filesystem's feature.
-         * See <a href="http://www.netbeans.org/issues/show_bug.cgi?id=28212">issue #28212</a></b>.
+         * See <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=28212">issue #28212</a></b>.
         *
         * @exception IOException if the environment cannot be marked modified
         *   (for example when the file is readonly), when such exception

--- a/platform/openide.modules/apichanges.xml
+++ b/platform/openide.modules/apichanges.xml
@@ -496,7 +496,7 @@ javax.xml.ws</pre>
         <description>
             Due to <a href="apichanges.html#split-of-openide-jar">split of openide.jar</a> some important branding files used during startup change their location. 
             Especially the to splash screen picture, location and color of progress bar and the application icon are now in <code>org.netbeans.core.startup</code>
-            package. Here is an example of the branding <a href="http://www.netbeans.org/source/browse/ide/branding/core/src/org/netbeans/core/startup/">as used by NetBeans IDE</a>.
+            package. Here is an example of the branding <a href="https://github.com/apache/netbeans/tree/master/nb/ide.branding">as used by NetBeans IDE</a>.
         </description>
     </change>
     <change id="split-of-openide-jar">
@@ -971,7 +971,7 @@ OpenIDE-Module-Requires: org.openide.compiler.CompilationEngine,
         API. Other packages are blocked from client modules.</p>
         <p>Utilizing this feature for already released modules
         is <b>very dangerous</b>. See issue
-        <a href="http://www.netbeans.org/issues/show_bug.cgi?id=31637">#31637</a>
+        <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=31637">#31637</a>
         for details.</p>
       </description>
       <issue number="19621"/>

--- a/platform/openide.modules/arch.xml
+++ b/platform/openide.modules/arch.xml
@@ -418,7 +418,7 @@ from the module system.
 Suppresses checks to ensure that module section classes are actually loaded
 from the module itself.
 </api>
-<api type="import" group="systemproperty" name="netbeans.full.hack" category="friend" url="http://wiki.netbeans.org/DevFaqNetBeansFullHack">
+<api type="import" group="systemproperty" name="netbeans.full.hack" category="friend" url="https://netbeans.apache.org/wiki/DevFaqNetBeansFullHack">
 Avoids using GUI when user-visible error conditions occur.
 </api>
 <api type="import" group="systemproperty" name="netbeans.mainclass" category="friend">
@@ -460,7 +460,7 @@ Prints messages when resources or classes are loaded from JARs.
         Of course components present in modules are initially loaded using
         reflection. Otherwise there is little semantic use of it (transparent
         optimizations only). One exception: pending a solution to <a
-        href="http://www.netbeans.org/issues/show_bug.cgi?id=29382">#29382</a>,
+        href="https://bz.apache.org/netbeans/show_bug.cgi?id=29382">#29382</a>,
         one portion of the Filesystems API is accessed via reflection when
         merging XML layers from modules.
     </answer>

--- a/platform/openide.modules/src/org/openide/modules/Places.java
+++ b/platform/openide.modules/src/org/openide/modules/Places.java
@@ -28,7 +28,7 @@ import org.openide.util.Lookup;
  * Provides access to standard file locations.
  * <div class="nonnormative">
  * This class should be used for limited purposes only. You might instead want to use:<ul>
- * <li><a href="@org-openide-filesystems@/org/openide/filesystems/FileUtil.html#getConfigFile(java.lang.String)"><code>FileUtil.getConfigFile</code></a>
+ * <li><a href="@org-openide-filesystems@/org/openide/filesystems/FileUtil.html#getConfigFile-java.lang.String-"><code>FileUtil.getConfigFile</code></a>
  * to find a file declared in an XML layer or created or overridden in the {@code config} subdirectory of the user directory.
  * <li>{@link InstalledFileLocator} to find modules installed as part of an NBM.
  * <li>{@code someClass.getProtectionDomain().getCodeSource().getLocation()} to find resources inside a module class loader.

--- a/platform/openide.modules/src/org/openide/modules/doc-files/api.html
+++ b/platform/openide.modules/src/org/openide/modules/doc-files/api.html
@@ -108,11 +108,11 @@ follow the style of others when not.
 
 <p>The basic idea for the format of modules is taken from the
 
-<a href="http://java.sun.com/products/j2se/1.5.0/docs/guide/extensions/index.html">Java Extension Mechanism</a>.
+<a href="https://docs.oracle.com/javase/1.5.0/docs/guide/extensions/index.html">Java Extension Mechanism</a>.
 
 The basic ideas behind the
 
-<a href="http://java.sun.com/products/j2se/1.5.0/docs/guide/versioning/index.html">Package Versioning Specification</a>
+<a href="https://docs.oracle.com/javase/1.5.0/docs/guide/versioning/index.html">Package Versioning Specification</a>
 
 is used to <a href="#how-vers">handle dependencies</a> both between
 modules and of modules to the system.
@@ -123,11 +123,11 @@ features, and what special option settings should be used when
 installing these features. Some of this information is
 listed in the
 
-<a href="http://java.sun.com/products/j2se/1.5.0/docs/guide/jar/manifest.html">manifest file</a>
+<a href="https://docs.oracle.com/javase/1.5.0/docs/guide/jar/jar.html#JAR%20Manifest">manifest file</a>
 
 using the customary format, and NetBeans-specific attributes. The
 
-<a href="http://java.sun.com/beans/glasgow/jaf.html">Java Activation Framework</a>,
+<a href="https://www.oracle.com/technetwork/java/jaf-1-150219.pdf">Java Activation Framework</a>,
 
 as well as JDK-internal features such as support for executable JAR
 files, was used as a model for how to specify the useful contents of a
@@ -705,7 +705,7 @@ is broken.
 
 At the heart of all these tags are the conventions used in the 
 
-<a href="http://java.sun.com/javase/6/docs/technotes/guides/versioning/">Package Versioning Specification</a>.
+<a href="https://docs.oracle.com/javase/6/docs/technotes/guides/versioning/">Package Versioning Specification</a>.
 
 While this documentation should be referred
 to for the full details and justification of this system, the basic
@@ -968,7 +968,7 @@ document which gives a fuller, more informal explanation.</p>
 
 <em>Since 4.44</em> a module can request to be enabled only on certain class
 of an operating system 
-(see issue <a href="http://www.netbeans.org/issues/show_bug.cgi?id=46833">46833</a>).
+(see issue <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=46833">46833</a>).
 This is done by requesting a special token to be present and the system makes sure that
 these tokens are enabled only when <em>NetBeans</em> run on requested class of OS.
 <p>
@@ -1085,7 +1085,7 @@ files, as of 3.21.</p>
 <p class="nonnormative">In the current implementation, modules may be
 bundled with other files using
 
-<a href="http://autoupdate.netbeans.org/nbm/nbm_package.html#structure">NBM files</a>
+<a href="https://netbeans.apache.org/projects/autoupdate/nbm/nbm_package.html#structure">NBM files</a>
 
 as provided by Auto Update, and the NetBeans build process premerges
 modules in the selected module config into one large installation

--- a/platform/openide.modules/src/org/openide/modules/doc-files/classpath.html
+++ b/platform/openide.modules/src/org/openide/modules/doc-files/classpath.html
@@ -174,7 +174,7 @@ OpenIDE-Module-Module-Dependencies: org.netbeans.modules.a
    NetBeans handles this situation by letting you use the <code>Class-Path</code>
    manifest attribute defined by the
 
-   <a href="http://java.sun.com/j2se/1.5.0/docs/guide/extensions/spec.html#bundled">Java Extension Mechanism</a>.
+   <a href="https://docs.oracle.com/javase/1.5.0/docs/guide/extensions/spec.html#bundled">Java Extension Mechanism</a>.
 
    The value of the attribute consists of one or more relative paths to library
    JARs, in the same directory as the module or (normally) beneath it.
@@ -586,7 +586,7 @@ OpenIDE-Module-Module-Dependencies: org.netbeans.modules.a = 1.0-alpha-2
 
   <p>Loading classes from the default (root) package is disabled. You can load resources from
      that package but a warning is printed. It is strongly discouraged to use the default package.
-     Please see the <a href="http://java.sun.com/docs/books/jls/second_edition/html/packages.doc.html#40169">
+     Please see the <a href="https://docs.oracle.com/javase/specs/jls/se6/html/packages.html#40169">
      Java Language Specification </a> for more details.
      You can suppress the warning using <code>-J-Dorg.netbeans.ProxyClassLoader.level=1000</code> command
      line switch.
@@ -606,8 +606,8 @@ OpenIDE-Module-Module-Dependencies: org.netbeans.modules.a = 1.0-alpha-2
   <h2>Using <samp>lib/*.jar</samp> or <samp>-cp</samp> sounds much easier but someone told me not to do it</h2>
 
   <p>The reason is similar to why JDK documentation about setting the class path for
-     <a href="http://java.sun.com/j2se/1.5.0/docs/tooldocs/windows/classpath.html">Windows</a> or
-     <a href="http://java.sun.com/j2se/1.5.0/docs/tooldocs/solaris/classpath.html">Solaris</a>
+     <a href="https://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/classpath.html">Windows</a> or
+     <a href="https://docs.oracle.com/javase/1.5.0/docs/tooldocs/solaris/classpath.html">Solaris</a>
      states that <code>-classpath</code> is prefered over environment variables.
      Adding classes (resources) to <samp>lib/ext/</samp> affects all Java applications
      running using this Java installation. 

--- a/platform/openide.modules/src/org/openide/modules/doc-files/i18n-branding.html
+++ b/platform/openide.modules/src/org/openide/modules/doc-files/i18n-branding.html
@@ -62,7 +62,7 @@ of modules in the IDE or platform.</p>
 
 <p>You will also want to see the
 
-<a href="http://java.sun.com/j2se/1.5.0/docs/guide/intl/index.html">JDK I18N documentation</a>
+<a href="https://docs.oracle.com/javase/1.5.0/docs/guide/intl/index.html">JDK I18N documentation</a>
 
 (including the list of supported locales) for background information.</p>
 
@@ -152,7 +152,7 @@ throw new IOException(NbBundle.getMessage(ThisClass.class, "EXC_missing_files",
 <!-- XXX talk about the Ant task instead? -->
 <p>There is a script
 
-<a href="http://www.netbeans.org/source/browse/~checkout~/nbbuild/misc/i18ncheck.pl"><code>nbbuild/misc/i18ncheck.pl</code></a>
+<a href="https://github.com/apache/netbeans/tree/master/nbbuild/misc/i18ncheck.pl"><code>nbbuild/misc/i18ncheck.pl</code></a>
 
 which can help check for I18N violations - unlocalized strings. You
 can run this script on source files just like a compiler: in fact,
@@ -603,7 +603,7 @@ locale variant JARs just tells the IDE to search these JARs in
 addition to the master JAR, but the lookup is still ultimately
 controlled by the resource names.</p>
 
-<p>The <a href="http://translatedfiles.netbeans.org/">NetBeans translation project</a>
+<p>The <a href="https://netbeans.apache.org/projects/translatedfiles/index.html">NetBeans translation project</a>
 normally creates these locale variants for modules included in the NetBeans
 distribution.</p>
 

--- a/platform/openide.nodes/src/org/openide/cookies/InstanceCookie.java
+++ b/platform/openide.nodes/src/org/openide/cookies/InstanceCookie.java
@@ -61,7 +61,7 @@ public interface InstanceCookie/*<T>*/ extends Node.Cookie {
 
     /**
      * Create or obtain an instance. For example 
-     * <a href="@org-openide-loaders@/org/openide/loaders/InstanceDataObject.html#instanceCreate()">InstanceDataObject</a>
+     * <a href="@org-openide-loaders@/org/openide/loaders/InstanceDataObject.html#instanceCreate--">InstanceDataObject</a>
      * (one of the most often used implementations of {@link InstanceCookie}) caches
      * previously returned instances.
      * 

--- a/platform/openide.nodes/src/org/openide/nodes/ChildFactory.java
+++ b/platform/openide.nodes/src/org/openide/nodes/ChildFactory.java
@@ -30,10 +30,10 @@ import org.openide.util.NbBundle;
  * Node.  Usage is to write a class that extends ChildFactory and
  * pass that to Children.create().  When the Node is expanded or its
  * children are programmatically requested, the
- * <a href="#createKeys(java.util.List)">createKeys(List &lt;T&gt;)</a> method
+ * {@link #createKeys(java.util.List) } method
  * will be invoked to create the List of objects to be modelled as Nodes.
  * Later, on demand, each object from the List will be passed in turn to
- * <a href="#createNodesForKey(java.lang.Object)">createNodesForKey(T)</a>,
+ * {@link #createNodesForKey(java.lang.Object)},
  * which may return an array of zero or more Nodes for the object.
  * <p>
  * A ChildFactory can be used either to create typical Children object, or

--- a/platform/openide.nodes/src/org/openide/nodes/doc-files/api.html
+++ b/platform/openide.nodes/src/org/openide/nodes/doc-files/api.html
@@ -115,7 +115,7 @@ A node is a sort of extension to the JavaBeans concept, adding some
 features that were necessary for the full functioning of explorer views. Some
 key components that were missing from the
 
-<a href="http://java.sun.com/beans/docs/spec.html">JavaBeans specification</a>:
+<a href="https://docs.oracle.com/javase/8/docs/technotes/guides/beans/index.html">JavaBeans specification</a>:
 
 <ul>
 

--- a/platform/openide.text/apichanges.xml
+++ b/platform/openide.text/apichanges.xml
@@ -532,7 +532,7 @@
         <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
         <description>
             <p>An <code>ActiveEditorDrop</code> interface has been added due to 
-                drag and drop callback support described at <a href="http://www.netbeans.org/issues/show_bug.cgi?id=61367">issue #61367</a>
+                drag and drop callback support described at <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=61367">issue #61367</a>
             </p>
         </description>
         <class package="org.openide.text" name="ActiveEditorDrop"/>

--- a/platform/openide.text/arch.xml
+++ b/platform/openide.text/arch.xml
@@ -172,7 +172,7 @@ Module uses following API's:
         url="@org-openide-util@/org/openide/util/doc-files/api.html"
     />
 </li>
-<li>
+<!-- no more generated <li>
     <api 
         name="SettingsAPI"
         group="java"
@@ -180,7 +180,7 @@ Module uses following API's:
         category="official"
         url="@org-openide-options@/org/openide/options/doc-files/api.html"
     />
-</li>
+</li>-->
 <li>
     <api 
         name="WindowSystemAPI"
@@ -356,7 +356,7 @@ This property can be used by the modules and is part of the Editor API.
 </api>
 
 <api type="export" group="property" name="javax.swing.text.Document.modificationListener" category="friend" >
-In order to fix <a href="http://www.netbeans.org/issues/show_bug.cgi?id=51872">issue 51872</a> the 
+In order to fix <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=51872">issue 51872</a> the 
 openide needs a way how to be notified about change of a document outside of its Document lock. 
 <code>DocumentListener</code>s are always notified under the lock, so a special contract has
 been established (since version 5.3) by registering an instance of <code>VetoableListener</code>
@@ -364,7 +364,7 @@ by calling <code>putProperty ("modificationListener", listener)</code>. The
 NetBeans aware documents are adviced to honor this property and call the listener
 outside of the document lock when a modification is made. The actual contract
 of the call can be seen in 
-<a href="http://www.netbeans.org/source/browse/openide/test/unit/src/org/openide/text/NbLikeEditorKit.java">NbLikeEditorKit.java</a> 
+<a href="https://github.com/apache/netbeans/tree/master/platform/openide.text/test/unit/src/org/openide/text/NbLikeEditorKit.java">NbLikeEditorKit.java</a> 
 in methods 
 <code>insertString</code> and <code>remove</code>.
 
@@ -459,7 +459,7 @@ The class which calls this is deprecated, but it is still in use by clients.
 Another reflection is used in QuietEditorPane, where DelegatingTransferHandler delegates
 also on two protected methods of TransferHandler: <code>createTransferable</code> and 
 <code>exportDone</code>. This delegation is needed because of drag and drop feature described
-in  <a href="http://www.netbeans.org/issues/show_bug.cgi?id=53439">issue #53439</a>
+in  <a href="https://bz.apache.org/netbeans/show_bug.cgi?id=53439">issue #53439</a>
 </answer>
 
 
@@ -771,7 +771,7 @@ No.
         </question>
 -->
 <answer id="exec-introspection">
-The Editor module operate with plain Swing <a href="http://java.sun.com/j2se/1.4/docs/api/javax/swing/text/Document.html">Document</a> in 
+The Editor module operate with plain Swing <a href="@JDK@/javax/swing/text/Document.html">Document</a> in 
 its APIs and checks whether the document does not implement some of the Netbeans extensions defined in
 <a href="@org-openide-text@/org/openide/text/NbDocument.html">NbDocument</a>.
 It also tries to retype <a href="@org-openide-windows@/org/openide/windows/CloneableTopComponent.Ref.html#getComponents--">CloneableTopComponent.Ref.getComponents()</a>

--- a/platform/openide.text/src/org/openide/text/NbDocument.java
+++ b/platform/openide.text/src/org/openide/text/NbDocument.java
@@ -513,7 +513,7 @@ public final class NbDocument extends Object {
      * at this time for an editor cookie.
      * <br>
      * The edit to be undone may be composed from instances of various undoable edit types
-     * (see <a href="@org-netbeans-modules-editor-lib2@/org/netbeans/spi/editor/document/UndoableEditWrapper.html">UndoableEditWrapper</a>).
+     * (see <a href="https://github.com/apache/netbeans/tree/master/ide/editor.document/src/org/netbeans/spi/editor/document/UndoableEditWrapper.java">UndoableEditWrapper</a>).
      *
      * @param <T> type of undoable edit to be retrieved.
      * @param ec editor cookie providing an undo/redo manager.
@@ -531,7 +531,7 @@ public final class NbDocument extends Object {
      * at this time for an editor cookie.
      * <br>
      * The edit to be undone may be composed from instances of various undoable edit types
-     * (see <a href="@org-netbeans-modules-editor-lib2@/org/netbeans/spi/editor/document/UndoableEditWrapper.html">UndoableEditWrapper</a>).
+     * (see <a href="https://github.com/apache/netbeans/tree/master/ide/editor.document/src/org/netbeans/spi/editor/document/UndoableEditWrapper.java">UndoableEditWrapper</a>).
      *
      * @param <T> type of undoable edit to be retrieved.
      * @param ec editor cookie providing an undo/redo manager.

--- a/platform/openide.text/src/org/openide/text/doc-files/api.html
+++ b/platform/openide.text/src/org/openide/text/doc-files/api.html
@@ -808,7 +808,7 @@ content types) into NetBeans, in place of the default
 editor. The basic requirement is that it conform to the Swing
 EditorKit conventions. The Swing Text system is rather complex, so if
 you are not familiar with it you should look at <a
-href="http://java.sun.com/products/jfc/tsc/text/text/text.html">Using
+href="https://docs.oracle.com/javase/tutorial/uiswing/components/text.html">Using
 the Swing Text Package</a>.
 
 <p>Beyond being a generic EditorKit, there are two significant pieces of

--- a/platform/openide.util.ui/apichanges.xml
+++ b/platform/openide.util.ui/apichanges.xml
@@ -421,7 +421,7 @@
                 A SPI <a href="@TOP@/org/openide/util/NetworkSettings.ProxyCredentialsProvider.html">
                 NetworkSettings.ProxyCredentialsProvider</a> allows NetBeans Platform
                 users to provide proxy and network credentials separately.
-                See <a href="http://wiki.netbeans.org/Authenticator">http://wiki.netbeans.org/Authenticator</a>
+                See <a href="https://netbeans.apache.org/wiki/Authenticator">https://netbeans.apache.org/wiki/Authenticator</a>
             </p>
         </description>
         <class package="org.openide.util" name="NetworkSettings"/>
@@ -440,7 +440,7 @@
                 user a question about the credentials. 
                 Invoke <a href="@TOP@/org/openide/util/NetworkSettings.html#suppressAuthenticationDialog-java.util.concurrent.Callable-">
                 suppressAuthenticationDialog</a> with a block of code where authentication dialog will be suppressed.                
-                See <a href="http://wiki.netbeans.org/Authenticator">http://wiki.netbeans.org/Authenticator</a>
+                See <a href="https://netbeans.apache.org/wiki/Authenticator">https://netbeans.apache.org/wiki/Authenticator</a>
             </p>
         </description>
         <class package="org.openide.util" name="NetworkSettings"/>
@@ -1063,8 +1063,7 @@
           <br/>
           To migrate your modules you can install Jackpot modules from
           autoupdate (if they are not yet part of your IDE) and apply
-          precreate <a href="http://www.netbeans.org/source/browse/openide/util/Attic/ErrorManagerJackpot.rules">
-          javapot error manager rule</a>.
+          precreate jackpot error manager rule.
           <br/>
           There is one possible incompatibility from end user point of view.
           The way to <em>enable logging</em> for certain components when

--- a/platform/openide.util.ui/arch.xml
+++ b/platform/openide.util.ui/arch.xml
@@ -300,7 +300,7 @@
  <answer id="exec-property">
      <ul>
          <li>
-             <api type="export" group="property" name="url" category="private">Images loaded by <a href="@TOP@/org/openide/util/ImageUtilities.html#loadImage__">ImageUtilities.loadImage</a>
+             <api type="export" group="property" name="url" category="private">Images loaded by <a href="@TOP@/org/openide/util/ImageUtilities.html#loadImage-java.lang.String-">ImageUtilities.loadImage</a>
              defines <code>"url"</code> image property for the loaded image.
              </api>
          </li>

--- a/platform/openide.util.ui/src/org/openide/util/ContextAwareAction.java
+++ b/platform/openide.util.ui/src/org/openide/util/ContextAwareAction.java
@@ -32,7 +32,7 @@ import javax.swing.Action;
  * presenter for the generic action, the menu will contain a presenter for the
  * context-aware instance. The context will then be taken from the GUI
  * environment where the context menu was shown; for example it may be a
- * <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup()">TopComponent's context</a>,
+ * <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup--">TopComponent's context</a>,
  * often taken from an activated node selection. The context action might be
  * enabled only if a certain "cookie" is present in that selection. When invoked,
  * the action need not search for an object to act on, since it can use the context.
@@ -40,7 +40,7 @@ import javax.swing.Action;
  *
  * @author Jaroslav Tulach, Peter Zavadsky
  *
- * @see <a href="http://wiki.netbeans.org/DevFaqActionContextSensitive">NetBeans FAQ</a>
+ * @see <a href="https://netbeans.apache.org/wiki/DevFaqActionContextSensitive">NetBeans FAQ</a>
  * @see org.openide.util.Utilities#actionsToPopup
  * @see org.openide.util.Utilities#actionsGlobalContext
  * @since 3.29

--- a/platform/openide.util.ui/src/org/openide/util/ContextGlobalProvider.java
+++ b/platform/openide.util.ui/src/org/openide/util/ContextGlobalProvider.java
@@ -28,10 +28,10 @@ package org.openide.util;
  * in current state it is reasonable to put there all currently active
  * <a href="@org-openide-nodes@/org/openide/nodes/Node.html">Node</a>, their cookies and {@link javax.swing.ActionMap}.
  * By default this interface is implemented by window system to delegate
- * to currently activated <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup()">TopComponent's  lookup</a>.
+ * to currently activated <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup--">TopComponent's  lookup</a>.
  * <p>
  * There is an external FAQ entry describing how to
- * <a href="http://wiki.netbeans.org/DevFaqAddGlobalContext">add content to
+ * <a href="https://netbeans.apache.org/wiki/DevFaqAddGlobalContext">add content to
  * the global context</a> by providing customized implementation of this
  * interface.
  * 

--- a/platform/openide.util.ui/src/org/openide/util/NetworkSettings.java
+++ b/platform/openide.util.ui/src/org/openide/util/NetworkSettings.java
@@ -124,12 +124,12 @@ public final class NetworkSettings {
     /** Suppress asking user a question about the authentication credentials while
      * running <code>blockOfCode</code>. It's a contract with NetBeans implementation
      * of {@link Authenticator}.
-     * In case a system is using other Authenticator implementation, it must call {@link #isAuthenticationDialogSuppressed} method. 
+     * In case a system is using other Authenticator implementation, it must call {@link #isAuthenticationDialogSuppressed()} method. 
      * 
      * @param blockOfCode {@link Callable} containing code which will be executed while authentication is suppressed
      * @return a result of calling of <code>blockOfCode</code> and may throw an exception.
      * @throws Exception 
-     * @see #isAuthenticationDialogSuppressed
+     * @see #isAuthenticationDialogSuppressed()
      * @since 8.17
      */
     public static <R> R suppressAuthenticationDialog(Callable<R> blockOfCode) throws Exception {
@@ -143,11 +143,11 @@ public final class NetworkSettings {
 
     /** A utility method for implementations of {@link Authenticator}
      * to suppress asking users a authentication question while running code posted
-     * in {@link #authenticationDialogSuppressed}.
+     * in {@code #authenticationDialogSuppressed}.
      * 
-     * @return true while running code posted in {@link #authenticationDialogSuppressed} method.
+     * @return true while running code posted in {@code #authenticationDialogSuppressed} method.
      * @since 8.17
-     * @see #authenticationDialogSuppressed
+     * @see authenticationDialogSuppressed
      */
     public static boolean isAuthenticationDialogSuppressed() {
         return Boolean.TRUE.equals(authenticationDialogSuppressed.get());
@@ -156,7 +156,7 @@ public final class NetworkSettings {
     /** Allows
      * NetBeans Platform users to provide own proxy and network credentials separately.
      * 
-     * @see <a href="http://wiki.netbeans.org/Authenticator">http://wiki.netbeans.org/Authenticator</a>
+     * @see <a href="https://netbeans.apache.org/wiki/Authenticator">https://netbeans.apache.org/wiki/Authenticator</a>
      * @author Jiri Rechtacek, Ondrej Vrabec
      * @since 8.17
      */

--- a/platform/openide.util.ui/src/org/openide/util/Utilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/Utilities.java
@@ -1902,7 +1902,7 @@ public final class Utilities {
      * this method; instead see {@link ContextAwareAction}.
      * @see ContextGlobalProvider
      * @see ContextAwareAction
-     * @see <a href="http://wiki.netbeans.org/DevFaqActionContextSensitive">NetBeans FAQ</a>
+     * @see <a href="https://netbeans.apache.org/wiki/DevFaqActionContextSensitive">NetBeans FAQ</a>
      * @return the context for actions
      * @since 4.10
      */

--- a/platform/openide.util.ui/src/org/openide/util/actions/BooleanStateAction.java
+++ b/platform/openide.util.ui/src/org/openide/util/actions/BooleanStateAction.java
@@ -26,7 +26,7 @@ package org.openide.util.actions;
 * <p>
 * This action is not the most effective way to implement checkbox in
 * a menu. Consider using more modern alternative:
-* <a href="@org-openide-awt@/org/openide/awt/Actions.html#checkbox(java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20boolean)">
+* <a href="@org-openide-awt@/org/openide/awt/Actions.html#checkbox-java.lang.String-java.lang.String-java.lang.String-java.lang.String-boolean-">
 * Actions.checkbox</a>, or declarative <a href="@org-openide-awt@/org/openide/awt/ActionState.html">ActionState annotation</a>.
 *
 * @author   Ian Formanek, Petr Hamernik

--- a/platform/openide.util.ui/src/org/openide/util/actions/CallbackSystemAction.java
+++ b/platform/openide.util.ui/src/org/openide/util/actions/CallbackSystemAction.java
@@ -107,7 +107,7 @@ public abstract class CallbackSystemAction extends CallableSystemAction implemen
     * This method is <em>too dynamic</em> it depends on the actuall order of callers and
     * is for example very fragile with respect to focus switching and correct delivering of
     * focus change events. That is why an alternative based on
-    * <a href="http://openide.netbeans.org/proposals/actions/design.html#callback">ActionMap proposal</a>
+    * <a href="https://netbeans.apache.org/projects/platform/openide/proposals/actions/design.html#callback">ActionMap proposal</a>
     * has been developed.
     * <P>
     * So if you are providing a <a href="@org-openide-windows@/org/openide/windows/TopComponent.html">TopComponent</a>

--- a/platform/openide.util.ui/src/org/openide/util/actions/SystemAction.java
+++ b/platform/openide.util.ui/src/org/openide/util/actions/SystemAction.java
@@ -291,7 +291,7 @@ public abstract class SystemAction extends SharedClassObject implements Action, 
     * If e.g. myIcon.gif is accompanied with myIcon_pressed.gif, myIcon_disabled.gif
     * and/or myIcon_rollover.gif these images are used to call methods on JButton.setPressedIcon(),
     * JButton.setDisabledIcon() and/or JButton.setRolloverIcon() with appropriate images.
-    * Please check <a href="@org-openide-awt@/org/openide/awt/Actions.html#connect(AbstractButton,%20Action)">Actions.connect</a> for
+    * Please check <a href="@org-openide-awt@/org/openide/awt/Actions.html#connect-javax.swing.AbstractButton-javax.swing.Action-">Actions.connect</a> for
     * additional info how this is achieved (using special "iconBase" key for getValue).
     * As of APIs version 3.24, this path will be used for a localized search automatically.
     * If you do not want an icon, do <em>not</em> override this to return a blank icon. Leave it null,

--- a/platform/openide.util.ui/src/org/openide/util/datatransfer/NewType.java
+++ b/platform/openide.util.ui/src/org/openide/util/datatransfer/NewType.java
@@ -24,7 +24,7 @@ import org.openide.util.NbBundle;
 import java.io.IOException;
 
 
-/** Describes a type that can be created anew. Used by <a href="@org-openide-nodes/org/openide/nodes.Node#getNewTypes">Node.getNewTypes</a>.
+/** Describes a type that can be created anew. Used by <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getNewTypes--">Node.getNewTypes</a>.
 *
 * @author Jaroslav Tulach
 */

--- a/platform/openide.util.ui/src/org/openide/util/datatransfer/PasteType.java
+++ b/platform/openide.util.ui/src/org/openide/util/datatransfer/PasteType.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 
 /** Clipboard operation providing one kind of paste action. Used by
-* <a href="@org-openide-nodes/org/openide/nodes.Node#getPasteTypes">Node.getPasteTypes</a>.
+* <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getPasteTypes-java.awt.datatransfer.Transferable-">Node.getPasteTypes</a>.
 *
 * @author Petr Hamernik
 */

--- a/platform/openide.util.ui/src/org/openide/util/doc-files/api.html
+++ b/platform/openide.util.ui/src/org/openide/util/doc-files/api.html
@@ -146,7 +146,7 @@ manually retrieve sets of instances as a client, which is not used
 very frequently in new code but helps to understand what lookup is
 doing behind the scenes. Then lookup itself is discussed, and how the
 standard instance lookup works and how it relates to JDK's 
-<a href="http://java.sun.com/j2se/1.5.0/docs/guide/jar/jar.html#Service%20Provider">
+<a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Service_Provider">
 standard for service provider registration</a>. 
 Lookup templates, which separate the
 provision of instances from the provision of categories, will be
@@ -442,7 +442,7 @@ impl.useIt();
 
 Such implementation has to be registered by some module to the system. 
 Either via layer as described above or as a JDK's
-<a href="http://java.sun.com/j2se/1.5.0/docs/guide/jar/jar.html#Service%20Provider">
+<a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Service_Provider">
 service provider</a>. If some module wants to register for example 
 <span class="type">org.me.MyService</span> it shall provide file name
 <span class="function-name">META-INF/services/org.me.MyService</span> in its own JAR
@@ -456,7 +456,7 @@ to answer the query in the above example.
 
 <div class="nonnormative">
     The Lookup supports two small extensions to the 
-    <a href="http://java.sun.com/j2se/1.5.0/docs/guide/jar/jar.html#Service%20Provider">JDK's
+    <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Service_Provider">JDK's
     standard</a>. It allows a module to remove class registered by
     another one. That is why it is possible to write a module that
     disables the <span class="type">org.you.MyServiceImpl</span> implementation

--- a/platform/openide.util.ui/src/org/openide/util/doc-files/preferences.html
+++ b/platform/openide.util.ui/src/org/openide/util/doc-files/preferences.html
@@ -26,7 +26,7 @@
   </head>
   <body>
     <h1 align="left">Preferences API in NetBeans</h1>
-    NetBeans adopts <a href="http://java.sun.com/j2se/1.5.0/docs/guide/preferences/">Java Preferences API</a>
+    NetBeans adopts <a href="https://docs.oracle.com/javase/1.5.0/docs/guide/preferences/index.html">Java Preferences API</a>
     standard to be used in NetBeans to
     store preference and configuration data to be able to adapt to the needs
     of different users. NetBeans keeps this standard and enhances it slightly
@@ -169,7 +169,7 @@
     registering the option into your layer.
     <H4 ALIGN=LEFT>How to document usage of Preferences API?</H4>
     Answer properly arch questions like any other <A
-      HREF="http://openide.netbeans.org/tutorial/api-design.html">APIs</A>. There was added new arch question related to
+      HREF="https://netbeans.apache.org/wiki/API_Design">APIs</A>. There was added new arch question related to
     preferences (resources-preferences). See example:
     <PRE>
 &lt;answer id="resources-preferences"&gt;
@@ -244,9 +244,8 @@ public class DerbyOptionsTest extends BasicTestForImport {
 If the tests  didn't pass then probably there is more complicated object graph
 serialized then you must subclass <CODE>PropertyProcessor</CODE> and put your
 own code in.
-(See as an example: <A HREF="http://www.netbeans.org/source/browse/ide/launcher/upgrade/src/org/netbeans/upgrade/systemoptions/TaskTagsProcessor.java?view=markup">TaskTagsProcessor</A>
- and here is a <A
-   HREF="http://www.netbeans.org/source/browse/ide/launcher/upgrade/test/unit/src/org/netbeans/upgrade/systemoptions/ExampleSettingsTest.java?view=markup">test</A>).
+(See as an example: <A HREF="https://github.com/apache/netbeans/tree/master/nb/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/TaskTagsProcessor.java">TaskTagsProcessor</A>
+ ).
  <H4 ALIGN=LEFT>How to write tests that needs Preferences API?</H4>
  Not persistent implementation of <code>java.util.prefs.Preferences</code> 
  is installed in place of the platform-specific default implementation for

--- a/platform/openide.util/src/org/openide/util/NbBundle.java
+++ b/platform/openide.util/src/org/openide/util/NbBundle.java
@@ -358,7 +358,7 @@ public class NbBundle extends Object {
     * safer when used from a module as this method relies on the module's
     * classloader to currently be part of the system classloader. NetBeans
     * does add enabled modules to this classloader, however calls to
-    * this variant of the method made in <a href="@org-openide-modules@/org/openide/modules/ModuleInstall.html#validate()">ModuleInstall.validate</a>,
+    * this variant of the method made in <a href="@org-openide-modules@/org/openide/modules/ModuleInstall.html#validate--">ModuleInstall.validate</a>,
     * or made soon after a module is uninstalled (due to background threads)
     * could fail unexpectedly.
     * @param baseName bundle basename

--- a/platform/openide.windows/arch.xml
+++ b/platform/openide.windows/arch.xml
@@ -63,7 +63,7 @@ frames, components.
         </question>
 -->
 <answer id="arch-overall">
-<a href="http://core.netbeans.org/windowsystem/index.html">Redesign documents</a>.
+<a href="https://netbeans.apache.org/projects/platform/core/windowsystem/index.html">Redesign documents</a>.
 </answer>
 
 

--- a/platform/options.api/apichanges.xml
+++ b/platform/options.api/apichanges.xml
@@ -75,14 +75,14 @@
         <compatibility addition="yes" semantic="incompatible">
             Compared to previous versions, the default changed - now 
             the restart is not needed. Applications can change that by using
-            <a href="architecture-summary.html#branding-OPT_RestartAfterImport">
+            <a href="architecture-summary.html#branding-org.netbeans.modules.options.export.OPT_RestartAfterImport">
             this branding API</a> and specifying <code>false</code> as the value
             of associated key.
         </compatibility>
         <description>
             Should an import of settings require a restart? Some applications 
             need that, some don't. There is a 
-            <a href="architecture-summary.html#branding-OPT_RestartAfterImport">
+            <a href="architecture-summary.html#branding-org.netbeans.modules.options.export.OPT_RestartAfterImport">
             branding API</a> to control such behavior now.
         </description>
         <issue number="226998"/>

--- a/platform/queries/src/org/netbeans/spi/queries/FileBuiltQueryImplementation.java
+++ b/platform/queries/src/org/netbeans/spi/queries/FileBuiltQueryImplementation.java
@@ -33,7 +33,7 @@ import org.openide.filesystems.FileObject;
  * the <code>org.netbeans.modules.projectapi</code> module.
  * </p>
  * @see FileBuiltQuery
- * @see <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/AntProjectHelper.html#createGlobFileBuiltQuery(java.lang.String[],%20java.lang.String[])"><code>AntProjectHelper.createGlobFileBuiltQuery(...)</code></a>
+ * @see <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/AntProjectHelper.html#createGlobFileBuiltQuery-org.netbeans.spi.project.support.ant.PropertyEvaluator-java.lang.String:A-java.lang.String:A-"><code>AntProjectHelper.createGlobFileBuiltQuery(...)</code></a>
  * @author Jesse Glick
  */
 public interface FileBuiltQueryImplementation {

--- a/platform/queries/src/org/netbeans/spi/queries/SharabilityQueryImplementation.java
+++ b/platform/queries/src/org/netbeans/spi/queries/SharabilityQueryImplementation.java
@@ -43,7 +43,7 @@ import java.io.File;
  * {@link org.openide.filesystems} with respect to threading semantics.
  * </p>
  * @see org.netbeans.api.queries.SharabilityQuery
- * @see <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/AntProjectHelper.html#createSharabilityQuery(java.lang.String[],%20java.lang.String[])"><code>AntProjectHelper.createSharabilityQuery(...)</code></a>
+ * @see <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/AntProjectHelper.html#createSharabilityQuery-org.netbeans.spi.project.support.ant.PropertyEvaluator-java.lang.String:A-java.lang.String:A-"><code>AntProjectHelper.createSharabilityQuery(...)</code></a>
  * @since 1.27
  * @author Jesse Glick
  * @deprecated Use {@link org.netbeans.spi.queries.SharabilityQueryImplementation2} instead.

--- a/platform/queries/src/org/netbeans/spi/queries/SharabilityQueryImplementation2.java
+++ b/platform/queries/src/org/netbeans/spi/queries/SharabilityQueryImplementation2.java
@@ -43,7 +43,7 @@ import org.netbeans.api.queries.SharabilityQuery.Sharability;
  * {@link org.openide.filesystems} with respect to threading semantics.
  * </p>
  * @see org.netbeans.api.queries.SharabilityQuery
- * @see <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/AntProjectHelper.html#createSharabilityQuery(java.lang.String[],%20java.lang.String[])"><code>AntProjectHelper.createSharabilityQuery(...)</code></a>
+ * @see <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/AntProjectHelper.html#createSharabilityQuery2-org.netbeans.spi.project.support.ant.PropertyEvaluator-java.lang.String:A-java.lang.String:A-"><code>AntProjectHelper.createSharabilityQuery(...)</code></a>
  * @author Jesse Glick
  * @author Alexander Simon
  * @since 1.27

--- a/platform/sendopts/src/org/netbeans/spi/sendopts/OptionProcessor.java
+++ b/platform/sendopts/src/org/netbeans/spi/sendopts/OptionProcessor.java
@@ -71,7 +71,7 @@ public abstract class OptionProcessor {
     /** Method to override in subclasses to create 
      * the right set of {@link Option}s.
      * See the factory methods that are part of the {@link Option}'s javadoc
-     * or read the <a href="@TOP@/architecture-summary.html#answer-usecases">
+     * or read the <a href="@TOP@/architecture-summary.html#answer-arch-usecases">
      * usecases</a> for the sendopts API.
      * <p>
      * 

--- a/platform/settings/src/org/netbeans/spi/settings/package.html
+++ b/platform/settings/src/org/netbeans/spi/settings/package.html
@@ -240,7 +240,7 @@ and plugged by DOMConvertor.delegateWrite into document:
 
 The <code>DOMConvertor.delegateRead/delegateWrite</code> also solve multiple references of an object
 that can appear in scope of a XML document. Attributes <code>ID</code>
-and <code>IDREF</code> are used in accordance with <a href="http://www.w3c.org/XML">the XML specification </a>.
+and <code>IDREF</code> are used in accordance with <a href="https://www.w3.org/XML">the XML specification </a>.
 
 <pre>
   ...

--- a/platform/uihandler/src/org/netbeans/modules/uihandler/api/doc-files/ui.html
+++ b/platform/uihandler/src/org/netbeans/modules/uihandler/api/doc-files/ui.html
@@ -192,7 +192,7 @@
 |                                                                               |
 |                                                                               |
 |                                                                               |
-|         An <a href="http://logger.netbeans.org/nonav/welcome/index.html">HTML page</a> describing the purpose of UI Gestures Collector          |
+|         An <strong>HTML page</strong> describing the purpose of UI Gestures Collector          |
 |      encourages to send the data, for the trade of nice statistics            |
 |                                                                               |
 |                                                                               |
@@ -264,7 +264,7 @@
 +-------------------------------------------------------------------------------+
 |  If you want to get informed about the state of this problem,                 |
 |  you need to be a registered user. If you're not registered,                  |
-|  you can <a href="http://www.netbeans.org/servlets/Join">register here</a>,                                                       |
+|  you can <strong>register here</strong>,                                                       |
 |  or you can send a report as a guest.                                         |
 |  Summary:  |_______________________________________________________________|  |
 |  Describe what you were doing when the exception occured:                     |


### PR DESCRIPTION
phase 2 of the apidoc .

This is part of https://github.com/apache/netbeans/pull/4450.
using the following to have ant javadoc -Dmetabuild.branch=master -Dapidocfullcheck=true.

Normaly build is apidoc error clean for master build (no idea yet for limited "release")

link to github file instead former mercurial
@link may be changed to @code as some item are protected and not public.
Hope this is enough.




