### PR TITLE
#4818: Update string renderer to only escape undisplayable code points.

### DIFF
--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/RendererFactory.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/RendererFactory.java
@@ -481,13 +481,12 @@ final class RendererFactory {
             f = new JLabel().getFont();
         }
 
-        StringBuffer buf = new StringBuffer(str.length() * 6); // x -> \u1234
-        char[] chars = str.toCharArray();
+        StringBuilder buf = new StringBuilder(str.length() * 6); // x -> \u1234
+        final int length = str.length();
+        for (int offset = 0; offset < length; ) {
+            final int cp = str.codePointAt(offset);
 
-        for (int i = 0; i < chars.length; i++) {
-            char c = chars[i];
-
-            switch (c) {
+            switch (cp) {
             // label doesn't interpret tab correctly
             case '\t':
                 buf.append("        "); // NOI18N
@@ -511,19 +510,22 @@ final class RendererFactory {
 
             default:
 
-                if ((null == f) || f.canDisplay(c)) {
-                    buf.append(c);
+                if ((null == f) || f.canDisplay(cp)) {
+                    buf.appendCodePoint(cp);
                 } else {
-                    buf.append("\\u"); // NOI18N
+                    for (char c : Character.toChars(cp)) {
+                        buf.append("\\u"); // NOI18N
 
-                    String hex = Integer.toHexString(c);
+                        String hex = Integer.toHexString(c);
 
-                    for (int j = 0; j < (4 - hex.length()); j++)
-                        buf.append('0');
+                        for (int j = 0; j < (4 - hex.length()); j++)
+                            buf.append('0');
 
-                    buf.append(hex);
+                        buf.append(hex);
+                    }
                 }
             }
+            offset += Character.charCount(cp);
         }
 
         return buf.toString();

--- a/platform/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/StringRendererTest.java
+++ b/platform/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/StringRendererTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide.explorer.propertysheet;
+
+import static java.util.stream.Collectors.joining;
+
+import java.awt.Font;
+import java.awt.GraphicsEnvironment;
+import java.util.stream.Stream;
+import javax.swing.JLabel;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import org.netbeans.junit.NbTestCase;
+
+public class StringRendererTest extends NbTestCase {
+
+    private static final int MAX_DISPLAYABLE = 512;
+    private static final String TEXT = "a";
+    private static final String ESCAPED_TEXT = "\\u0061";
+    private static final String MAX_LENGTH_TEXT = Stream.generate(() -> TEXT)
+            .limit(MAX_DISPLAYABLE)
+            .collect(joining());
+    private static final String TOO_LONG_TEXT = Stream.generate(() -> TEXT)
+            .limit(MAX_DISPLAYABLE + 1)
+            .collect(joining());
+
+    public static Test suite() {
+        return GraphicsEnvironment.isHeadless() ? new TestSuite() : new TestSuite(StringRendererTest.class);
+    }
+
+    public StringRendererTest(String name) {
+        super(name);
+    }
+
+    private class TestFont extends Font {
+
+        public TestFont() {
+            super(new JLabel().getFont());
+        }
+
+        @Override
+        public boolean canDisplay(char c) {
+            return displayableChar;
+        }
+
+        @Override
+        public boolean canDisplay(int codePoint) {
+            return displayableCodePoint;
+        }
+    }
+
+    private boolean displayableChar;
+    private boolean displayableCodePoint;
+    private final Font font = new TestFont();
+
+    private JLabel stringRenderer;
+
+    @Override
+    protected void setUp() {
+        ReusablePropertyEnv env = new ReusablePropertyEnv();
+        RendererFactory factory = new RendererFactory(true, env, env.getReusablePropertyModel());
+        stringRenderer = (JLabel) factory.getStringRenderer();
+
+        displayableChar = true;
+        displayableCodePoint = true;
+        stringRenderer.setFont(font);
+    }
+
+    private void assertSettingText(String input, String expected) {
+        stringRenderer.setText(input);
+
+        assertEquals(expected, stringRenderer.getText());
+    }
+
+    public void testConvertsNullTextToEmptyString() {
+        assertSettingText(null, "");
+    }
+
+    public void testDisplayableTextIsUnchanged() {
+        assertSettingText(MAX_LENGTH_TEXT, MAX_LENGTH_TEXT);
+    }
+
+    public void testTruncatesToMaxLengthText() {
+        assertSettingText(TOO_LONG_TEXT, MAX_LENGTH_TEXT);
+    }
+
+    public void testShouldTransformTabsToSpaces() {
+        assertSettingText("\t", "        ");
+    }
+
+    public void testRemovesNewLines() {
+        assertSettingText("\n", "");
+    }
+
+    public void testRemovesCarriageReturns() {
+        assertSettingText("\r", "");
+    }
+
+    public void testRemovesLineFeeds() {
+        assertSettingText("\r", "");
+    }
+
+    public void testEscapesBackspaces() {
+        assertSettingText("\b", "\\b");
+    }
+
+    public void testEscapesFormFeeds() {
+        assertSettingText("\f", "\\f");
+    }
+
+    public void testEscapesUndisplayableText() {
+        displayableChar = false;
+        displayableCodePoint = false;
+
+        assertSettingText(TEXT, ESCAPED_TEXT);
+    }
+
+    public void testDoesNotEscapeDisplayableCodePoint() {
+        displayableChar = false;
+
+        assertSettingText(TEXT, TEXT);
+    }
+}


### PR DESCRIPTION
Text displayed in the property sheet is escaped if the target font does not have a glyph for some of the characters. The existing implementation escapes some Unicode characters even if the target font can display them. This is due to the reliance on `Font.canDisplay(char)` which does not handle all Unicode characters.

The solution here is to update `RendererFactory.makeDisplayable` to iterate over the code points in the string rather than the characters. It then uses `Font.canDisplay(int)` to validate the glyph availability using the code point.

Unit tests are included to verify the existing behavior is maintained. All passed for the original code except `testDoesNotEscapeDisplayableCodePoint`.

|Original|Updated|
|----|----|
|<img width="515" alt="Original (View)" src="https://user-images.githubusercontent.com/46196614/229578373-3ce79fb1-fd8a-4cf3-ada9-3a6c8a454ac0.png"><br>When viewing the 𝑣 character renders correctly in the design view but shows as \ud835\udc63 in the property sheet|<img width="499" alt="Updated (View)" src="https://user-images.githubusercontent.com/46196614/229578376-a000de90-30d8-472b-a420-1552b8078052.png"><br>The 𝑣 character is now rendered as expected but the undisplayable ⑙ character (at least on my system) still shows the unicode escape|
|<img width="496" alt="Updated (Edit)" src="https://user-images.githubusercontent.com/46196614/229576915-b0867a3c-9279-4424-8ddb-36b1547ca84b.png">|<img width="489" alt="Original (Edit)" src="https://user-images.githubusercontent.com/46196614/229576924-c4c8a46c-7cd0-4b0c-b3e9-afb0c875f8bc.png"><br>Edit mode is unchanged|
