### PR TITLE
Avoid being scrolled to the end of the editor in the preview panel for formatting options

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FmtOptions.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FmtOptions.java
@@ -44,6 +44,7 @@ import javax.swing.JEditorPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.BadLocationException;
@@ -543,6 +544,10 @@ public final class FmtOptions {
                 // Ignore it
             }
 
+            // keep the caret position
+            // to avoid being scrolled to the end of the editor
+            int caretPosition = pane.getCaretPosition();
+
             Rectangle visibleRectangle = pane.getVisibleRect();
             pane.setText(previewText);
             pane.setIgnoreRepaint(true);
@@ -569,8 +574,10 @@ public final class FmtOptions {
             } else {
                 LOGGER.warning(String.format("Can't format %s; it's not BaseDocument.", doc)); //NOI18N
             }
+            pane.setCaretPosition(caretPosition);
             pane.setIgnoreRepaint(false);
-            pane.scrollRectToVisible(visibleRectangle);
+            // invoke later because the preview pane is scrolled to the caret position when we change options after we scroll it anywhere
+            SwingUtilities.invokeLater(() -> pane.scrollRectToVisible(visibleRectangle));
             pane.repaint(100);
 
         }


### PR DESCRIPTION
- Currently, when the values of the formatting options are changed, the preview panel is scrolled to the end of the editor
- To avoid it, keep the caret position before reformatting

Before:
![nb-php-formatting-preview-before](https://user-images.githubusercontent.com/738383/229297802-454a7282-d3f8-41cc-b1c2-c3743a17fff5.gif)

After:
![nb-php-formatting-preview-after](https://user-images.githubusercontent.com/738383/229297809-c57611ea-83d9-4fd0-8eea-fdf9cd842546.gif)
