### PR TITLE
FlatLaf: use NetBeans folder icons in NB Explorer

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -36,6 +36,12 @@ TabbedPane.tabHeight=30
 TabbedPane.inactiveUnderlineColor = $TabbedContainer.editor.contentBorderColor
 
 
+#---- Tree ----
+
+Tree.closedIcon = org.netbeans.swing.laf.flatlaf.icons.NBFlatTreeClosedIcon
+Tree.openIcon = org.netbeans.swing.laf.flatlaf.icons.NBFlatTreeOpenIcon
+
+
 #---- TabbedContainer ----
 
 TabbedContainer.editor.contentBorderColor=$Component.borderColor

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/icons/NBFlatAdapterIcon.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/icons/NBFlatAdapterIcon.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.swing.laf.flatlaf.icons;
+
+import com.formdev.flatlaf.util.UIScale;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.plaf.UIResource;
+import org.openide.util.ImageUtilities;
+
+/**
+ * Adapter class which allows a NetBeans-loaded PNG or SVG icon to be used as a FlatLAF
+ * configuration setting. Respects FlatLAF's own scaling properties, as in
+ * {@code com.formdev.flatlaf.icons.FlatAbstractIcon}.
+ */
+abstract class NBFlatAdapterIcon implements Icon, UIResource {
+    private final Icon delegate;
+
+    public NBFlatAdapterIcon(String resourcePath) {
+        if (resourcePath == null) {
+            throw new NullPointerException();
+        }
+        Image delegateImg = ImageUtilities.loadImage(resourcePath);
+        this.delegate = delegateImg == null ? new ImageIcon() : ImageUtilities.image2Icon(delegateImg);
+    }
+
+    @Override
+    public void paintIcon(Component c, Graphics g, int x, int y) {
+        Graphics2D g2 = (Graphics2D) g.create();
+        try {
+            g2.translate(x, y);
+            UIScale.scaleGraphics(g2);
+            delegate.paintIcon(c, g2, 0, 0);
+        } finally {
+            g2.dispose();
+        }
+    }
+
+    @Override
+    public int getIconWidth() {
+        return UIScale.scale(delegate.getIconWidth());
+    }
+
+    @Override
+    public int getIconHeight() {
+        return UIScale.scale(delegate.getIconHeight());
+    }
+}

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/icons/NBFlatTreeClosedIcon.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/icons/NBFlatTreeClosedIcon.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.swing.laf.flatlaf.icons;
+
+public class NBFlatTreeClosedIcon extends NBFlatAdapterIcon {
+    public NBFlatTreeClosedIcon() {
+        // Will load the SVG version if available.
+        super("org/netbeans/swing/plaf/resources/hidpi-folder-closed.png");
+    }
+}

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/icons/NBFlatTreeOpenIcon.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/icons/NBFlatTreeOpenIcon.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.swing.laf.flatlaf.icons;
+
+public class NBFlatTreeOpenIcon extends NBFlatAdapterIcon {
+    public NBFlatTreeOpenIcon() {
+        // Will load the SVG version if available.
+        super("org/netbeans/swing/plaf/resources/hidpi-folder-open.png");
+    }
+}


### PR DESCRIPTION
Currently there is a mix between NetBeans style icons and FlatLaf outlined folder icons in many views (e.g. in Projects or Files views), which does not look good. This PR replaces the FlatLaf folder icons with NetBeans style icons in NB Explorer component.

@eirikbakke @neilcsmith-net
ATM this PR uses icons from module `o.n.swing.plaf` in module `o.n.swing.laf.flatlaf`.
It works, but I'm not sure whether this is allowed?
Or is it better to copy the icons?

### Before:
![grafik](https://user-images.githubusercontent.com/5604048/229305053-64e489e9-17cf-421b-9087-b06aa70e7291.png)

### After:
![grafik](https://user-images.githubusercontent.com/5604048/229305104-d20407d3-c2b9-47f8-94fb-1abbdc2e9d36.png)

### Dark Before:
![grafik](https://user-images.githubusercontent.com/5604048/229305259-fc8976fd-7ee9-4e8c-89cc-95e4a0788dd3.png)

### Dark After:
![grafik](https://user-images.githubusercontent.com/5604048/229305244-41e6a9d0-7df3-44a3-86c5-d9c7e77fb2d4.png)

### New Project before:
![grafik](https://user-images.githubusercontent.com/5604048/229305383-503ccbb1-ff11-4656-880c-0f30430e09f2.png)

### New Project after:
![grafik](https://user-images.githubusercontent.com/5604048/229305398-2317ca54-6908-41ee-86cd-704565366153.png)




