### PR TITLE
Improve the appearance of disabled icons on FlatLAF Dark (and a tiny improvement on FlatLAF Light)

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -50,6 +50,8 @@ EditorTab.underlineColor=$TabbedPane.underlineColor
 EditorTab.inactiveUnderlineColor=#00000000
 EditorTab.tabSeparatorColor=darken($Component.borderColor,15%)
 
+TabControlIcon.disabledForeground=lighten(@background,15%)
+
 #---- ViewTab ----
 
 ViewTab.background=$EditorTab.background

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -85,7 +85,7 @@ nb.completion.selectedForeground=@selectionForeground
 #---- TabControlIcon ----
 
 TabControlIcon.foreground=tint(@foreground,40%)
-TabControlIcon.disabledForeground=lighten($TabControlIcon.foreground,25%)
+TabControlIcon.disabledForeground=lighten($TabControlIcon.foreground,27%)
 TabControlIcon.rolloverBackground=$Button.toolbar.hoverBackground
 TabControlIcon.pressedBackground=$Button.toolbar.pressedBackground
 TabControlIcon.close.rolloverBackground=#c74f50


### PR DESCRIPTION
Improve the appearance of disabled icons on dark LAFs, by adjusting ImageUtilities.DisabledButtonFilter.

Also adjust the disabled TabControlIcon color on both FlatLAF Light and FlatLAF Dark, to make these buttons more obviously disabled.

Before/after screenshots on FlatLAF Dark:

![disableimpr-dark](https://user-images.githubusercontent.com/886243/229314226-1d7da7f5-ae52-4351-99f5-d9803ac51ede.png)

Before/after screenshots on FlatLAF Light (just a tiny change to the <> icons):

![disableimpr-light](https://user-images.githubusercontent.com/886243/229314232-b9cf743c-2387-498d-a6ed-6dfd4f0b2ba6.png)