### PR TITLE
Adding support for evaluating watches containing binding variables.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1271,9 +1271,6 @@ jobs:
       - name: Extract
         run: tar --zstd -xf build.tar.zst
 
-      - name: api.debugger.jpda
-        run: ant $OPTS -f java/api.debugger.jpda test
-
       - name: api.java
         run: ant $OPTS -f java/api.java test
 
@@ -1285,24 +1282,6 @@ jobs:
 
       - name: dbschema
         run: ant $OPTS -f java/dbschema test -Dtest.config=stable
-
-#      - name: debugger.jpda
-#        run: ant $OPTS -f java/debugger.jpda test
-
-      - name: debugger.jpda.js
-        run: ant $OPTS -f java/debugger.jpda.js test
-
-      - name: debugger.jpda.projects
-        run: ant $OPTS -f java/debugger.jpda.projects test
-
-      - name: debugger.jpda.projectsui
-        run: ant $OPTS -f java/debugger.jpda.projectsui test
-
-#      - name: debugger.jpda.truffle
-#        run: ant $OPTS -f java/debugger.jpda.truffle test
-
-#      - name: debugger.jpda.ui
-#        run: ant $OPTS -f java/debugger.jpda.ui test
 
       - name: editor.htmlui
         run: ant $OPTS -f java/editor.htmlui test
@@ -1541,6 +1520,66 @@ jobs:
       - name: spi.java.hints
         if: ${{ (matrix.config == 'batch2') && success() }}
         run: ant $OPTS -f java/spi.java.hints test
+
+      - name: Create Test Summary
+        uses: test-summary/action@v2
+        if: failure()
+        with:
+          paths: "./*/*/build/test/*/results/TEST-*.xml"
+
+
+  java-debugger-test:
+    name: Java Debugger tests on Linux/JDK ${{ matrix.java }}
+    # equals env.test_java == 'true'
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'Java') || contains(github.event.pull_request.labels.*.name, 'ci:all-tests') || github.event_name != 'pull_request' }}
+    needs: base-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        java: [ '11', '17' ]
+      fail-fast: false
+    steps:
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: ${{ env.default_java_distribution }}
+
+      - name: Setup Xvfb
+        run: |
+          echo "DISPLAY=:99.0" >> $GITHUB_ENV
+          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+
+      - name: Download Build
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+
+      - name: Extract
+        run: tar --zstd -xf build.tar.zst
+
+      - name: api.debugger.jpda
+        run: ant $OPTS -f java/api.debugger.jpda test
+
+      - name: debugger.jpda
+        run: ant $OPTS -f java/debugger.jpda test
+
+      - name: debugger.jpda.js
+        run: ant $OPTS -f java/debugger.jpda.js test
+
+      - name: debugger.jpda.projects
+        run: ant $OPTS -f java/debugger.jpda.projects test
+
+      - name: debugger.jpda.projectsui
+        run: ant $OPTS -f java/debugger.jpda.projectsui test
+
+#      - name: debugger.jpda.truffle
+#        run: ant $OPTS -f java/debugger.jpda.truffle test
+
+#      - name: debugger.jpda.ui
+#        run: ant $OPTS -f java/debugger.jpda.ui test
 
       - name: Create Test Summary
         uses: test-summary/action@v2
@@ -2405,6 +2444,7 @@ jobs:
       - harness-modules-test
       - java-modules-test
       - java-hints-test
+      - java-debugger-test
       - profiler-test
       - apisupport-modules-test
       - build-tools

--- a/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/IntroduceClass.java
+++ b/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/IntroduceClass.java
@@ -76,7 +76,7 @@ class IntroduceClass {
             }
             method = parentPath;
         }
-        CompilationUnitTree compilationUnit = info.getCompilationUnit();
+        CompilationUnitTree compilationUnit = treePath.getCompilationUnit();
         SourcePositions sourcePositions = info.getTrees().getSourcePositions();
         long endPosition = sourcePositions.getEndPosition(compilationUnit, method.getLeaf());
         if (TreeUtilities.CLASS_TREE_KINDS.contains(method.getLeaf().getKind())) {

--- a/java/debugger.jpda/nbproject/project.properties
+++ b/java/debugger.jpda/nbproject/project.properties
@@ -28,4 +28,26 @@ test-unit-sys-prop.test.dir.src=${basedir}/test/unit/src/
 test-unit-sys-prop.netbeans.user=${basedir}/work/nb_user_dir
 test.unit.cp.extra=../java.source.nbjavac/build/test-nb-javac/cluster/modules/org-netbeans-modules-java-source-nbjavac-test.jar
 
+test.jms.flags=\
+ --add-opens=jdk.jdi/com.sun.jdi=ALL-UNNAMED
+
+test.config.default.excludes=\
+    **/BreakpointsClassFilterTest.class,\
+    **/BreakpointsDeactivationTest.class,\
+    **/ClassBasedBreakpointTest.class,\
+    **/ConcurrencyTest.class,\
+    **/ConnectorsTest.class,\
+    **/EvaluationTest.class,\
+    **/HeapWalkingTest.class,\
+    **/JDIWrappersTest.class,\
+    **/JPDAWrappersTest.class,\
+    **/JPDAClassTypeTest.class,\
+    **/JspLineBreakpointTest.class,\
+    **/LineBreakpointTest.class,\
+    **/ListeningDICookieTest.class,\
+    **/MirrorValuesTest.class,\
+    **/MirrorAndDeadlockTest.class,\
+    **/MonitorAndDeadlockTest.class,\
+    **/StepTest.class,\
+    **/ThreadBreakpointTest.class
 

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorVisitor.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorVisitor.java
@@ -2130,6 +2130,7 @@ public class EvaluatorVisitor extends ErrorAwareTreePathScanner<Mirror, Evaluati
             case LOCAL_VARIABLE:
             case EXCEPTION_PARAMETER:
             case RESOURCE_VARIABLE:
+            case BINDING_VARIABLE:
                 ve = (VariableElement) elm;
                 String varName = ve.getSimpleName().toString();
                 ScriptVariable var = evaluationContext.getScriptVariableByName(varName);

--- a/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/EvaluatorDirectTest.java
+++ b/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/EvaluatorDirectTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.api.debugger.jpda;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import junit.framework.Test;
+import org.netbeans.api.debugger.DebuggerManager;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.java.source.ClasspathInfo;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.modules.SpecificationVersion;
+
+/**
+ * Tests evaluation of various expressions.
+ */
+public class EvaluatorDirectTest extends NbTestCase {
+    
+    private JPDASupport     support;
+
+    public EvaluatorDirectTest (String s) {
+        super (s);
+    }
+
+    public static Test suite() {
+        return JPDASupport.createTestSuite(EvaluatorDirectTest.class);
+    }
+    
+    protected void setUp () throws Exception {
+        super.setUp ();
+//        //PreferredCCParser is using SourceUtils.isScanInProgress() to modify behavior; ensure indexing is not running.
+        FileObject prjRoot = FileUtil.toFileObject(new File(System.getProperty("test.dir.src")));
+        assertNotNull(prjRoot);
+        Project prj = FileOwnerQuery.getOwner(prjRoot);
+        assertNotNull(prj);
+        Project annotationsPrj = FileOwnerQuery.getOwner(prj.getProjectDirectory().getParent().getParent().getFileObject("platform/api.annotations.common"));
+        assertNotNull(annotationsPrj);
+        OpenProjects.getDefault().open(new Project[] {annotationsPrj}, false);
+        JavaSource.create(ClasspathInfo.create(ClassPath.EMPTY, ClassPath.EMPTY, ClassPath.EMPTY)).runWhenScanFinished(p -> {}, true).get();
+        System.setProperty("debugger.evaluator2", "true");
+        JPDASupport.removeAllBreakpoints ();
+    }
+
+    public void testEvaluate() throws Exception {
+        SpecificationVersion javaVersion = new SpecificationVersion(System.getProperty("java.specification.version"));
+        SpecificationVersion version17 = new SpecificationVersion("17");
+        if (javaVersion.compareTo(version17) < 0) {
+            return ; //don't run on JDK < 17
+        }
+        String code = "public class Test {\n" +
+                      "    public static void main(String... args) {\n" +
+                      "        System.err.println(\"STARTED!!!\");\n" +
+                      "        Object o = \"Hello!\";\n" +
+                      "        if (o instanceof String s) {\n" +
+                      "            System.err.println(\"BEFORE BREAKPOINT\");\n" +
+                      "            System.err.println(s); //LBREAKPOINT\n" +
+                      "            System.err.println(\"AFTER BREAKPOINT\");\n" +
+                      "        }\n" +
+                      "    }\n" +
+                      "}\n";
+        clearWorkDir();
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+        assertNotNull(wd);
+        FileObject source = wd.createData("Test.java");
+        try (OutputStream out = source.getOutputStream();
+             Writer w = new OutputStreamWriter(out)) {
+            w.write(code);
+        }
+        Utils.BreakPositions bp = Utils.getBreakPositions(source.toURL());
+        LineBreakpoint lb = bp.getLineBreakpoints().get(0);
+        DebuggerManager.getDebuggerManager ().addBreakpoint (lb);
+        support = JPDASupport.attach (
+            new String[0],
+            FileUtil.toFile(source).getAbsolutePath(),
+            new String[0],
+            new File[0]
+        );
+        support.waitState (JPDADebugger.STATE_STOPPED);
+        Variable value = support.getDebugger ().evaluate("s");
+        assertEquals("\"Hello!\"", value.getValue());
+    }
+
+}

--- a/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/EvaluatorTest.java
+++ b/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/EvaluatorTest.java
@@ -72,7 +72,7 @@ public class EvaluatorTest extends NbTestCase {
         assertNotNull(prjRoot);
         Project prj = FileOwnerQuery.getOwner(prjRoot);
         assertNotNull(prj);
-        Project annotationsPrj = FileOwnerQuery.getOwner(prj.getProjectDirectory().getParent().getFileObject("api.annotations.common"));
+        Project annotationsPrj = FileOwnerQuery.getOwner(prj.getProjectDirectory().getParent().getParent().getFileObject("platform/api.annotations.common"));
         assertNotNull(annotationsPrj);
         OpenProjects.getDefault().open(new Project[] {annotationsPrj}, false);
         JavaSource.create(ClasspathInfo.create(ClassPath.EMPTY, ClassPath.EMPTY, ClassPath.EMPTY)).runWhenScanFinished(p -> {}, true).get();
@@ -84,7 +84,10 @@ public class EvaluatorTest extends NbTestCase {
         source = new URL(lb.getURL());
         DebuggerManager.getDebuggerManager ().addBreakpoint (lb);
         support = JPDASupport.attach (
-            "org.netbeans.api.debugger.jpda.testapps.EvaluatorApp"
+            new String[] {"--add-opens=java.desktop/java.beans=ALL-UNNAMED"},
+            "org.netbeans.api.debugger.jpda.testapps.EvaluatorApp",
+            new String[0],
+            new File[0]
         );
         support.waitState (JPDADebugger.STATE_STOPPED);
     }
@@ -115,7 +118,7 @@ public class EvaluatorTest extends NbTestCase {
             support.doFinish ();
         }
     }
-    
+
     public void testInstanceEvaluation() throws Exception {
         runInstanceEvaluation(1);
     }
@@ -255,6 +258,11 @@ public class EvaluatorTest extends NbTestCase {
         int end = str.indexOf('\n');
         if (end > 0) {
             str = str.substring(0, end);
+        }
+        int npe = str.indexOf("java.lang.NullPointerException");
+        if (npe >= 0) {
+            //NullPointerExceptions may have enhanced message, not produced by the interpreted debugger evaluator, strip such a message, if any:
+            str = str.substring(0, npe + "java.lang.NullPointerException".length());
         }
         return str;
     }

--- a/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JPDASupport.java
+++ b/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/JPDASupport.java
@@ -34,6 +34,8 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -168,7 +170,17 @@ public final class JPDASupport implements DebuggerManagerListener {
     }
     public static JPDASupport attach (String mainClass, String[] args, File[] classPath) throws IOException,
     DebuggerStartException {
-        Process process = launchVM (mainClass, args, classPath, "", true);
+        return attach(new String[0], mainClass, args, classPath);
+    }
+    public static JPDASupport attach (String[] vmArgs, String mainClass, String[] args, File[] classPath) throws IOException,
+    DebuggerStartException {
+        String sourceRoot = System.getProperty ("test.dir.src");
+        if (mainClass.endsWith(".java")) {
+            sourceRoot = new File(mainClass).getParent();
+        } else {
+            sourceRoot = System.getProperty ("test.dir.src");
+        }
+        Process process = launchVM (vmArgs, mainClass, args, classPath, "", true);
         String line = readLine (process.getInputStream ());
         int port = Integer.parseInt (line.substring (line.lastIndexOf (':') + 1).trim ());
         ProcessIO pio = new ProcessIO (process);
@@ -191,7 +203,7 @@ public final class JPDASupport implements DebuggerManagerListener {
         JPDADebugger jpdaDebugger = JPDADebugger.attach (
             "localhost", 
             port, 
-            createServices ()
+            createServices (sourceRoot)
         );
         return new JPDASupport (jpdaDebugger, pio);
     }
@@ -346,10 +358,9 @@ public final class JPDASupport implements DebuggerManagerListener {
     
     // other methods ...........................................................
     
-    private static Object[] createServices () {
+    private static Object[] createServices (String sourceRoot) {
         try {
             Map map = new HashMap ();
-            String sourceRoot = System.getProperty ("test.dir.src");
             URL sourceUrl = new File(sourceRoot).toURI().toURL();
             String sourceUrlStr = sourceUrl.toString() + "/";
             sourceUrl = new URL(sourceUrlStr);
@@ -381,6 +392,7 @@ public final class JPDASupport implements DebuggerManagerListener {
     }
     
     private static Process launchVM (
+        String[] vmArgs,
         String mainClass,
         String[] args,
         File[] extraCP,
@@ -391,24 +403,22 @@ public final class JPDASupport implements DebuggerManagerListener {
         String cp = getClassPath(extraCP);
         //System.err.println("CP = "+cp);
 
-        String [] cmdArray = new String [] {
-            System.getProperty ("java.home") + File.separatorChar + 
-                "bin" + File.separatorChar + "java",
-            "-agentlib:jdwp=transport=" + "dt_socket" + ",address=" + 
+        List<String> cmdArgs = new ArrayList<>();
+
+        cmdArgs.add(System.getProperty ("java.home") + File.separatorChar +
+                "bin" + File.separatorChar + "java");
+        cmdArgs.add("-agentlib:jdwp=transport=" + "dt_socket" + ",address=" +
                 connectorAddress + ",suspend=y,server=" + 
-                (server ? "y" : "n"),
-            "-classpath",
-            cp.substring(0, cp.length() -1),
-            mainClass
-        };
+                (server ? "y" : "n"));
+        cmdArgs.add("-classpath");
+        cmdArgs.add(cp.substring(0, cp.length() -1));
+        cmdArgs.addAll(Arrays.asList(vmArgs));
+        cmdArgs.add(mainClass);
         if (args != null && args.length > 0) {
-            String[] arr = new String[cmdArray.length + args.length];
-            System.arraycopy(cmdArray, 0, arr, 0, cmdArray.length);
-            System.arraycopy(args, 0, arr, cmdArray.length, args.length);
-            cmdArray = arr;
+            cmdArgs.addAll(Arrays.asList(args));
         }
 
-        ProcessBuilder pb = new ProcessBuilder().command(cmdArray);
+        ProcessBuilder pb = new ProcessBuilder().command(cmdArgs);
         String classesDir = System.getProperty("test.dir.classes");
         if (classesDir != null) {
             pb.directory(new File(classesDir));


### PR DESCRIPTION
When a watch contains a binding variable, it fails to show the value. This patch is trying to fix that - that's the  `case BINDING_VARIABLE:` change.

In addition to this, this patch is trying to:
 - add a test for the change, that will only execute under JDK 17.
 - run debugger.jpda tests on JDK 11 and JDK 17
 - disabling tests that failed for me locally - I used a fairly coarse way to disable them, so that e.g. in `EvaluationTest`, only one subtest fails. This could, presumably, be improved in further patches. IMO better to run some tests, than none.
 - the `info.getCompilationUnit()` -> `treePath.getCompilationUnit()` change is a bit tricky: if scanning is running, the TreePath may originate in a different javac instance than is the one held in `info`. Which then leads to end position `-1` (because the end position is held into CompilationUnitTree, but only for trees under that top-level tree), which will inject code at incorrect place. Using `treePath.getCompilationUnit()` is not 100% correct, I think, but it workarounds the issue at this specific place, at least


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
