### PR TITLE
Avoid showing invalid types in the Fix Imports panel

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/actions/UsedNamesCollector.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/actions/UsedNamesCollector.java
@@ -164,7 +164,10 @@ public class UsedNamesCollector {
         }
 
         private boolean isValidTypeName(final String typeName) {
-            return !SPECIAL_NAMES.contains(typeName) && !Type.isPrimitive(typeName);
+            return !SPECIAL_NAMES.contains(typeName)
+                    && !Type.isPrimitive(typeName)
+                    && !typeName.contains("<") // NOI18N e.g. array<int, ClassName>
+                    && !typeName.contains("{"); // NOI18N e.g. array{'foo': int, "bar": string}
         }
 
         private boolean isValidAliasTypeName(final String typeName) {

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH4614/testGH4614_01.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH4614/testGH4614_01.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test1;
+
+class Foo {
+    
+}
+
+namespace Test2;
+
+class Test
+{
+    /**
+     * @param array<'foo', Foo> $param
+     */
+    public function test1(array $param): Foo {
+        return $param['foo'];
+    }
+
+    /**
+     * @param array{'foo': Foo, "bar": string} $param
+     */
+    public function test2(array $param): Foo {
+        return $param['foo'];
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH4614/testGH4614_01.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH4614/testGH4614_01.php.importData
@@ -1,0 +1,12 @@
+Caret position: 980
+Should show uses panel: true
+Defaults:
+ \Test1\Foo
+
+Names:
+ Foo
+
+Variants:
+ \Test1\Foo
+ Don't import.
+

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/ImportDataCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/ImportDataCreatorTest.java
@@ -114,6 +114,10 @@ public class ImportDataCreatorTest extends PHPTestBase {
         performTest("class Test^Class3 {");
     }
 
+    public void testGH4614_01() throws Exception {
+        performTest("public function test1(array $param): F^oo {");
+    }
+
     private void performTest(String caretLine) throws Exception {
         performTest(caretLine, null);
     }


### PR DESCRIPTION
Ignore the following cases

- `array<int, TypeName>`
- `array{'key': TypeName}`

#### Example

```php
<?php
namespace Test1;

class Foo {
    
}

namespace Test2;

class Test
{
    /**
     * @param array<'foo', Foo> $param
     */
    public function test1(array $param): Foo {
        return $param['foo'];
    }

    /**
     * @param array{'foo': Foo, "bar": string} $param
     */
    public function test2(array $param): Foo {
        return $param['foo'];
    }
}

```

#### Before:
![nb-php-avoid-showing-invalid-type-in-fix-imports-panel-before](https://user-images.githubusercontent.com/738383/229417216-38c22073-fe1d-49fa-b57c-1e7a188dcf28.png)


#### After:
![nb-php-avoid-showing-invalid-type-in-fix-imports-panel-after](https://user-images.githubusercontent.com/738383/229417222-0d8171b5-c261-45f6-b368-4327a18f9889.png)


