### PR TITLE
Report empty set if project does not use buildscript; prevent NPE.

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependencyResult.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependencyResult.java
@@ -230,7 +230,11 @@ public final class GradleDependencyResult implements DependencyResult, PropertyC
 
     @Override
     public Collection<FileObject> getDependencyFiles() {
-        FileObject fo = FileUtil.toFileObject(gp.getGradleFiles().getBuildScript());
+        File f = gp.getGradleFiles().getBuildScript();
+        if (f == null) {
+            return Collections.emptyList();
+        }
+        FileObject fo = FileUtil.toFileObject(f);
         return fo == null ? Collections.emptyList() : Collections.singletonList(fo);
     }
     


### PR DESCRIPTION
Project dependencies query will fail on a project with no `build.gradle`, with just `settings.gradle`; this setup is common for umbrella projects that only includes subprojects and have no dependencies themselves.

There's an unhandled state when the buildscript is not present so the toFileObject fails with a NPE. 