### PR TITLE
Better handling for dependencies w/o versions

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementation.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementation.java
@@ -184,6 +184,10 @@ public class GradleDependenciesImplementation implements ProjectDependenciesImpl
                 
                 for (GradleDependency dep : cfg.getDependencies()) {
                     this.cfg = cfg.getDependencyOrigin(dep);
+                    if (this.cfg == null) {
+                        // safeguard: we cannot determine the origin, so let's assume this configuration defines the dependency
+                        this.cfg = cfg;
+                    }
                     List<Dependency> ch = processLevel(cfg, dep, new HashSet<>());
                     Dependency n = createDependency(dep, ch);
                     rootDeps.add(n);


### PR DESCRIPTION
Consider dependency declaration as follows:
```
dependencies {
        implementation 'org.springframework.boot:spring-boot-starter-web'
        developmentOnly 'org.springframework.boot:spring-boot-devtools'
        testImplementation 'org.springframework.boot:spring-boot-starter-test'
}
```
there's no version specified for `spring-boot-devtools.

The [https://github.com/apache/netbeans/blob/master/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java#L1502](code that reports `developmentOnly_directChildren`) handles such situations using GAV without version (as specified in the buildfile) - `org.springframework.boot:spring-boot-devtools:`. 

The issue is that when **resolved** artifacts GAVs are matched against these direct children, the module dependency with resolved version is not matched to the version-less child. So I have added a path that attempts to strip a version and match again.
