### PR TITLE
[GH-5355] PHP: Corrects the display of the guessed return type for a function or method in the documentation

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/DocRenderer.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/DocRenderer.java
@@ -608,9 +608,15 @@ final class DocRenderer {
                 if (type.isResolved()) {
                     QualifiedName typeName = type.getTypeName(true);
                     if (typeName != null) {
-                        if (sb.length() > 0
-                                && (typeKind == Type.Kind.UNION || typeKind == Type.Kind.INTERSECTION)) {
-                            sb.append(" ").append(typeKind.getSign()).append(" "); // NOI18N
+                        if (sb.length() > 0) {
+                                if (typeKind == Type.Kind.INTERSECTION) {
+                                    sb.append(" ").append(typeKind.getSign()).append(" "); // NOI18N
+                                } else {
+                                    //GH-5355: If a function returns multiple types
+                                    //and doesn't have a declared return type,
+                                    //it's always a union type.
+                                    sb.append(" ").append(Type.Kind.UNION.getSign()).append(" "); // NOI18N
+                                }
                         }
                         if (type.isNullableType()) {
                             sb.append(CodeUtils.NULLABLE_TYPE_PREFIX);

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5355.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5355.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class ClassName {
+
+    public function testMethod($a) {
+        if ($a) {
+            return 1;
+        }
+        return 'str';
+    }
+
+    public function test() {
+        $this->testMethod(null);
+    }
+}
+
+function testFunction($a) {
+    if ($a) {
+        return 1;
+    }
+    return 'str';
+}
+
+testFunction(null);

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5355.php.testIssueGH5355_01.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5355.php.testIssueGH5355_01.html
@@ -1,0 +1,13 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->testMetho|d(null);
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+METHOD     testMethod($a)                  [PUBLIC]   ClassName
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>testMethod</b><br/><br/><br />
+<h3>Parameters:</h3>
+<table cellspacing=0 style="border: 0px; width: 100%;">
+<tr><td>&nbsp;</td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr><b>$a</b></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;width:80%;" >PHPDoc not found</td></tr>
+</table>
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>string | int</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5355.php.testIssueGH5355_02.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5355.php.testIssueGH5355_02.html
@@ -1,0 +1,13 @@
+<html><body>
+<pre>Code completion result for source line:
+testFunctio|n(null);
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+METHOD     testFunction($a)                [PUBLIC]   issueGH5355.php
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>testFunction</b><br/><br/><br />
+<h3>Parameters:</h3>
+<table cellspacing=0 style="border: 0px; width: 100%;">
+<tr><td>&nbsp;</td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr><b>$a</b></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;width:80%;" >PHPDoc not found</td></tr>
+</table>
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>string | int</td></tr></table></body></html>

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
@@ -338,6 +338,14 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
         checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5347.php", "un^defined();", true);
     }
 
+    public void testIssueGH5355_01() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/issueGH5355.php", "$this->testMetho^d(null);", false, "");
+    }
+
+    public void testIssueGH5355_02() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/issueGH5355.php", "testFunctio^n(null);", false, "");
+    }
+
     @Override
     protected String alterDocumentationForTest(String documentation) {
         int start = documentation.indexOf("file:");


### PR DESCRIPTION

```php
function testFunction($a) {
    if ($a) {
        return 1;
    }
    return 'str';
}

testFunction(null);
```
before:
![function_before](https://user-images.githubusercontent.com/9607501/230140253-c6e73cb1-b35c-4a65-bd10-4799f6ea1c82.png)

after:
![function_after](https://user-images.githubusercontent.com/9607501/230140294-2ee921f3-9583-43c7-b485-32d274fac9dc.png)


