### PR TITLE
Fix code completion in `throw new` context #3806

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
@@ -272,7 +272,7 @@ public abstract class PHPCompletionItem implements CompletionProposal {
         ElementHandle elem = getElement();
         if (elem instanceof MethodElement) {
             final MethodElement method = (MethodElement) elem;
-            if (method.isConstructor() && request.context.equals(CompletionContext.NEW_CLASS)) {
+            if (method.isConstructor() && isNewClassContext(request.context)) {
                 elem = method.getType();
             }
         }
@@ -445,6 +445,11 @@ public abstract class PHPCompletionItem implements CompletionProposal {
             }
         }
         return result;
+    }
+
+    private boolean isNewClassContext(CompletionContext context) {
+        return context.equals(CompletionContext.NEW_CLASS)
+                || context.equals(CompletionContext.THROW_NEW);
     }
 
     static class NewClassItem extends MethodElementItem {

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh3806/gh3806.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh3806/gh3806.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class Exception implements \Throwable {
+    public function __construct(string $message = "", int $code = 0, ?\Throwable $previous = null) {}
+}
+
+throw new \Excep

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh3806/gh3806.php.testGH3806_01.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh3806/gh3806.php.testGH3806_01.cccustomtpl
@@ -1,0 +1,14 @@
+Name: Exception
+\Exception
+
+Name: Exception
+\Exception()
+
+Name: Exception
+\Exception(${php-cc-0  default="$message"})
+
+Name: Exception
+\Exception(${php-cc-0  default="$message"}, ${php-cc-1  default="$code"})
+
+Name: Exception
+\Exception(${php-cc-0  default="$message"}, ${php-cc-1  default="$code"}, ${php-cc-2  default="$previous"})

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH3806Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH3806Test.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class PHPCodeCompletionGH3806Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionGH3806Test(String testName) {
+        super(testName);
+    }
+
+    public void testGH3806_01() throws Exception {
+        checkCompletionCustomTemplateResult("testfiles/completion/lib/gh3806/gh3806.php", "throw new \\Excep^", null, true);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[] {
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/gh3806"))
+            })
+        );
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionTestBase.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionTestBase.java
@@ -113,7 +113,7 @@ public abstract class PHPCodeCompletionTestBase extends PHPTestBase {
         CodeCompletionHandler cc = getCodeCompleter();
         assertNotNull("getCodeCompleter must be implemented", cc);
 
-        Document doc = GsfUtilities.getDocument(parserResult.getSnapshot().getSource().getFileObject(), true);
+        Document doc = GsfUtilities.getADocument(parserResult.getSnapshot().getSource().getFileObject(), true);
         boolean upToOffset = type == CodeCompletionHandler.QueryType.COMPLETION;
         String prefix = cc.getPrefix(parserResult, caretOffset, upToOffset);
         if (prefix == null) {
@@ -198,9 +198,7 @@ public abstract class PHPCodeCompletionTestBase extends PHPTestBase {
     //~ Inner class
     public interface CompletionProposalFilter {
 
-        CompletionProposalFilter ACCEPT_ALL = proposal -> {
-            return true;
-        };
+        CompletionProposalFilter ACCEPT_ALL = proposal -> true;
 
         boolean accept(CompletionProposal proposal);
     }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/3806
- Handle it as well as the `new class` context
- Fix deprecated method `GsfUtilities.getDocument` to `GsfUtilities.getADocument`

Example:
```php
throw new \Excep^
```

Before:
```php
throw new Exception()
```

After:
```php
throw new \Exception()
```