### PR TITLE
Prefer loading JS implementation from NB distribution

### DIFF
--- a/harness/nbjunit/src/org/netbeans/junit/NbTestCase.java
+++ b/harness/nbjunit/src/org/netbeans/junit/NbTestCase.java
@@ -61,6 +61,7 @@ import java.util.regex.Pattern;
 import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
 import junit.framework.TestResult;
+import org.junit.AssumptionViolatedException;
 import org.junit.Ignore;
 import org.netbeans.insane.live.LiveReferences;
 import org.netbeans.insane.live.Path;
@@ -74,6 +75,7 @@ import org.netbeans.junit.internal.NbModuleLogHandler;
  * Adds various abilities such as comparing golden files, getting a working
  * directory for test files, testing memory usage, etc.
  */
+
 public abstract class NbTestCase extends TestCase implements NbTest {
     static {
         MethodOrder.initialize();
@@ -474,6 +476,8 @@ public abstract class NbTestCase extends TestCase implements NbTest {
                     long now = System.nanoTime();
                     try {
                         runTest();
+                    } catch (AssumptionViolatedException ex) {
+                        // ignore, the test is assumed to be meaningless.
                     } catch (Throwable t) {
                         noteWorkDir(workdirNoCreate());
                         throw noteRandomness(t);

--- a/ide/libs.graalsdk.system/apichanges.xml
+++ b/ide/libs.graalsdk.system/apichanges.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<?xml-stylesheet type="text/xml" href="CHANGEME/nbbuild/javadoctools/apichanges.xsl"?>
+<!DOCTYPE apichanges PUBLIC "-//NetBeans//DTD API changes list 1.0//EN" "../../nbbuild/javadoctools/apichanges.dtd">
+
+
+<apichanges>
+    <apidefs>
+        <apidef name="GraalSDK">Graal SDK</apidef>
+    </apidefs>
+
+  <changes>
+      <change id="initial.version">
+          <api name="GraalSDK"/>
+          <summary>
+              Initial integration of Graal SDK
+          </summary>
+          <version major="1" minor="0"/>
+          <date day="1" month="2" year="2019"/>
+          <author login="jtulach"/>
+          <compatibility binary="compatible" source="compatible" addition="yes"/>
+          <description>
+              Bridge that plugs
+              <a href="https://graalvm.org">GraalVM</a> languages
+              into
+              <a href="@org-netbeans-api-scripting@/org/netbeans/api/scripting/Scripting.html">Scripting.createManager()</a>
+              to obtain enhanced version of
+              <a href="@JDK@/javax/script/ScriptEngineManager.html">ScriptEngineManager</a>.
+          </description>
+      </change>
+  </changes>
+
+    <!-- Now the surrounding HTML text and document structure: -->
+
+    <htmlcontents>
+<!--
+
+                            NO NO NO NO NO!
+
+         ==============>    DO NOT EDIT ME!  <==============
+
+          AUTOMATICALLY GENERATED FROM APICHANGES.XML, DO NOT EDIT
+
+                SEE CHANGEME/apichanges.xml
+
+-->
+    <head>
+      <title>Change History for the Progress API</title>
+      <link rel="stylesheet" href="prose.css" type="text/css"/>
+    </head>
+    <body>
+
+<p class="overviewlink"><a href="overview-summary.html">Overview</a></p>
+
+<h1>Introduction</h1>
+
+<p>This document lists changes made to the Progress API/SPI.</p>
+
+<!-- The actual lists of changes, as summaries and details: -->
+
+      <hr/><standard-changelists module-code-name="org.netbeans.api.progress"/>
+
+      <hr/><p>@FOOTER@</p>
+
+    </body>
+  </htmlcontents>
+
+</apichanges>

--- a/ide/libs.graalsdk.system/arch.xml
+++ b/ide/libs.graalsdk.system/arch.xml
@@ -1,0 +1,1163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "../../nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
+  <!ENTITY api-questions SYSTEM "../../nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
+]>
+
+<api-answers
+  question-version="1.29"
+  author="jtulach@apache.org"
+>
+
+  &api-questions;
+
+
+<!--
+        <question id="arch-overall" when="init">
+            Describe the overall architecture. 
+            <hint>
+            What will be API for 
+            <a href="http://wiki.netbeans.org/API_Design#Separate_API_for_clients_from_support_API">
+                clients and what support API</a>? 
+            What parts will be pluggable?
+            How will plug-ins be registered? Please use <code>&lt;api type="export"/&gt;</code>
+            to describe your general APIs and specify their
+            <a href="http://wiki.netbeans.org/API_Stability#Private">
+            stability categories</a>.
+            If possible please provide simple diagrams.
+            </hint>
+        </question>
+-->
+ <answer id="arch-overall">
+  <p>
+    Bridge that plugs
+    <a href="https://graalvm.org">GraalVM</a> languages
+    into
+    <a href="@org-netbeans-api-scripting@/org/netbeans/api/scripting/Scripting.html">Scripting.createManager()</a>
+    to obtain enhanced version of
+    <a href="@JDK@/javax/script/ScriptEngineManager.html">ScriptEngineManager</a>.
+    Please see the
+    <a href="@TOP@/org/netbeans/libs/graalsdk/package-summary.html">scripting tutorial</a>
+    to read about many interesting use-cases.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="arch-quality" when="init">
+            How will the <a href="http://www.netbeans.org/community/guidelines/q-evangelism.html">quality</a>
+            of your code be tested and 
+            how are future regressions going to be prevented?
+            <hint>
+            What kind of testing do
+            you want to use? How much functionality, in which areas,
+            should be covered by the tests? How you find out that your
+            project was successful?
+            </hint>
+        </question>
+-->
+ <answer id="arch-quality">
+  <p>
+   Unit tested.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="arch-time" when="init">
+            What are the time estimates of the work?
+            <hint>
+            Please express your estimates of how long the design, implementation,
+            stabilization are likely to last. How many people will be needed to
+            implement this and what is the expected milestone by which the work should be 
+            ready?
+            </hint>
+        </question>
+-->
+ <answer id="arch-time">
+  <p>
+      Ready for Apache NetBeans 11 release.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="arch-usecases" when="init">
+            <hint>
+                Content of this answer will be displayed as part of page at
+                http://www.netbeans.org/download/dev/javadoc/usecases.html 
+                You can use tags &lt;usecase name="name&gt; regular html description &lt;/usecase&gt;
+                and if you want to use an URL you can prefix if with @TOP@ to begin
+                at the root of your javadoc
+            </hint>
+        
+            Describe the main <a href="http://wiki.netbeans.org/API_Design#The_Importance_of_Being_Use_Case_Oriented">
+            use cases</a> of the new API. Who will use it under
+            what circumstances? What kind of code would typically need to be written
+            to use the module?
+        </question>
+-->
+ <answer id="arch-usecases">
+  <p>
+      <usecase id="createScriptEngineManager" name="Create ScriptEngineManager">
+          To access <a href="https://graalvm.org">GraalVM</a> languages
+          use
+          To create new instance script engine manager ready for the NetBeans
+          execution environment use
+          <api category="official" group="java" name="org.netbeans.api.scripting" type="import">
+              <a href="@org-netbeans-api-scripting@/org/netbeans/api/scripting/Scripting.html">Scripting</a>
+              class offers static <code>createManager()</code> method that
+              should be used whenever one needs an instance of
+              <a href="@JDK@/javax/script/ScriptEngineManager.html">ScriptEngineManager</a>
+              inside of NetBeans based application.
+          </api>
+          Many client oriented use-cases are covered in the
+          <a href="@TOP@/org/netbeans/libs/graalsdk/package-summary.html">scripting tutorial</a>.
+      </usecase>
+      <usecase id="org.graalvm.polyglot.wrapper" name="Re-export of GraalVM languages">
+          <api category="stable" group="java" name="org.graalvm.polyglot.wrapper" type="export">
+              This module re-exports all found GraalVM languages under
+              <code>GraalVM:lang</code> name and makes them accessible via
+              NetBeans <a href="@org-netbeans-api-scripting@/org/netbeans/api/scripting/Scripting.html">Scripting</a>
+              API.
+          </api>
+      </usecase>
+      <usecase id="org.graalvm.polyglot" name="Use Graal SDK directly">
+          <api category="third" group="java" name="org.graalvm.polyglot" type="export">
+              This module re-exports <code>org.graalvm.polyglot</code> APIs.
+              Use them to obtain access to the GraalVM directly, if you only
+              want to work with them and generic
+              <a href="@org-netbeans-api-scripting@/org/netbeans/api/scripting/Scripting.html">Scripting</a>
+              wrapper isn't enough.
+          </api>
+      </usecase>
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="arch-what" when="init">
+            What is this project good for?
+            <hint>
+            Please provide here a few lines describing the project, 
+            what problem it should solve, provide links to documentation, 
+            specifications, etc.
+            </hint>
+        </question>
+-->
+ <answer id="arch-what">
+  <p>
+      Bridge that plugs
+      <a href="https://graalvm.org">GraalVM</a> languages
+      into
+      <a href="@org-netbeans-api-scripting@/org/netbeans/api/scripting/Scripting.html">Scripting.createManager()</a>
+      can be found in this module.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="arch-where" when="impl">
+            Where one can find sources for your module?
+            <hint>
+                Please provide link to the Hg web client at
+                http://hg.netbeans.org/
+                or just use tag defaultanswer generate='here'
+            </hint>
+        </question>
+-->
+ <answer id="arch-where">
+  <defaultanswer generate='here' />
+ </answer>
+
+
+
+<!--
+        <question id="compat-deprecation" when="init">
+            How the introduction of your project influences functionality
+            provided by previous version of the product?
+            <hint>
+            If you are planning to deprecate/remove/change any existing APIs,
+            list them here accompanied with the reason explaining why you
+            are doing so.
+            </hint>
+        </question>
+-->
+ <answer id="compat-deprecation">
+  <p>
+   XXX no answer for compat-deprecation
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="compat-i18n" when="impl">
+            Is your module correctly internationalized?
+            <hint>
+            Correct internationalization means that it obeys instructions 
+            at <a href="http://www.netbeans.org/download/dev/javadoc/org-openide-modules/org/openide/modules/doc-files/i18n-branding.html">
+            NetBeans I18N pages</a>.
+            </hint>
+        </question>
+-->
+ <answer id="compat-i18n">
+  <p>
+   XXX no answer for compat-i18n
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="compat-standards" when="init">
+            Does the module implement or define any standards? Is the 
+            implementation exact or does it deviate somehow?
+        </question>
+-->
+ <answer id="compat-standards">
+  <p>
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="compat-version" when="impl">
+            Can your module coexist with earlier and future
+            versions of itself? Can you correctly read all old settings? Will future
+            versions be able to read your current settings? Can you read
+            or politely ignore settings stored by a future version?
+            
+            <hint>
+            Very helpful for reading settings is to store version number
+            there, so future versions can decide whether how to read/convert
+            the settings and older versions can ignore the new ones.
+            </hint>
+        </question>
+-->
+ <answer id="compat-version">
+  <p>
+   XXX no answer for compat-version
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="dep-jre" when="final">
+            Which version of JRE do you need (1.2, 1.3, 1.4, etc.)?
+            <hint>
+            It is expected that if your module runs on 1.x that it will run 
+            on 1.x+1 if no, state that please. Also describe here cases where
+            you run different code on different versions of JRE and why.
+            </hint>
+        </question>
+-->
+ <answer id="dep-jre">
+  <p>
+   XXX no answer for dep-jre
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="dep-jrejdk" when="final">
+            Do you require the JDK or is the JRE enough?
+        </question>
+-->
+ <answer id="dep-jrejdk">
+  <p>
+   XXX no answer for dep-jrejdk
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="dep-nb" when="init">
+            What other NetBeans projects and modules does this one depend on?
+            <hint>
+            Depending on other NetBeans projects influnces the ability of
+            users of your work to customize their own branded version of
+            NetBeans by enabling and disabling some modules. Too
+            much dependencies restrict this kind of customization. If that
+            is your case, then you may want to split your functionality into
+            pieces of autoload, eager and regular modules which can be
+            enabled independently. Usually the answer to this question
+            is generated from your <code>project.xml</code> file, but
+            if it is not guessed correctly, you can suppress it by
+            specifying &lt;defaultanswer generate="none"/&gt; and
+            write here your own. Please describe such projects as imported APIs using
+            the <code>&lt;api name="identification" type="import or export" category="stable" url="where is the description" /&gt;</code>.
+            By doing this information gets listed in the summary page of your
+            javadoc.
+            </hint>
+        </question>
+-->
+ <answer id="dep-nb">
+  <defaultanswer generate='here' />
+ </answer>
+
+
+
+<!--
+        <question id="dep-non-nb" when="init">
+            What other projects outside NetBeans does this one depend on?
+            
+            <hint>
+            Depending on 3rd party libraries is always problematic,
+            especially if they are not open source, as that complicates
+            the licensing scheme of NetBeans. Please enumerate your
+            external dependencies here, so it is correctly understood since
+            the begining what are the legal implications of your project.
+            Also please note that
+            some non-NetBeans projects are packaged as NetBeans modules
+            (see <a href="http://libs.netbeans.org/">libraries</a>) and
+            it is preferred to use this approach when more modules may
+            depend and share such third-party libraries.
+            </hint>
+        </question>
+-->
+ <answer id="dep-non-nb">
+  <p>
+   XXX no answer for dep-non-nb
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="dep-platform" when="init">
+            On which platforms does your module run? Does it run in the same
+            way on each?
+            <hint>
+            If you plan any dependency on OS or any usage of native code,
+            please describe why you are doing so and describe how you envision
+            to enforce the portability of your code.
+            Please note that there is a support for <a href="http://www.netbeans.org/download/dev/javadoc/org-openide-modules/org/openide/modules/doc-files/api.html#how-os-specific">OS conditionally
+            enabled modules</a> which together with autoload/eager modules
+            can allow you to enable to provide the best OS aware support
+            on certain OSes while providing compatibility bridge on the not
+            supported ones.
+            Also please list the supported
+            OSes/HW platforms and mentioned the lovest version of JDK required
+            for your project to run on. Also state whether JRE is enough or
+            you really need JDK.
+            </hint>
+        </question>
+-->
+ <answer id="dep-platform">
+  <p>
+   XXX no answer for dep-platform
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="deploy-dependencies" when="final">
+            What do other modules need to do to declare a dependency on this one,
+            in addition to or instead of the normal module dependency declaration
+            (e.g. tokens to require)?
+            <hint>
+                Provide a sample of the actual lines you would add to a module manifest
+                to declare a dependency, for example OpenIDE-Module-Requires: some.token.
+                If other modules should not depend on this module, or should just use a
+                simple regular module dependency, you can just answer "nothing". If you
+                intentionally expose a semistable API to clients using implementation
+                dependencies, you should mention that here (but there is no need to give
+                an example of usage).
+            </hint>
+        </question>
+-->
+ <answer id="deploy-dependencies">
+  <p>
+   XXX no answer for deploy-dependencies
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="deploy-jar" when="impl">
+            Do you deploy just module JAR file(s) or other files as well?
+            <hint>
+            Usually a module consist of one JAR file (perhaps with Class-Path
+            extensions) and also a configuration file that enables it. If you
+            have any other files, use
+            &lt;api group="java.io.File" name="yourname" type="export" category="friend"&gt;...&lt;/api&gt;
+            to define the location, name and stability of your files (of course
+            changing "yourname" and "friend" to suit your needs).
+            
+            If it uses more than one JAR, describe where they are located, how
+            they refer to each other. 
+            If it consist of module JAR(s) and other files, please describe
+            what is their purpose, why other files are necessary. Please 
+            make sure that installation/uninstallation leaves the system 
+            in state as it was before installation.
+            </hint>
+        </question>
+-->
+ <answer id="deploy-jar">
+  <p>
+   XXX no answer for deploy-jar
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="deploy-nbm" when="impl">
+            Can you deploy an NBM via the Update Center?
+            <hint>
+            If not why?
+            </hint>
+        </question>
+-->
+ <answer id="deploy-nbm">
+  <p>
+   XXX no answer for deploy-nbm
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="deploy-packages" when="init">
+            Are packages of your module made inaccessible by not declaring them
+            public?
+            
+            <hint>
+            By default NetBeans build harness treats all packages are private.
+            If you export some of them - either as public or friend packages,
+            you should have a reason. If the reason is described elsewhere
+            in this document, you can ignore this question.
+            </hint>
+        </question>
+-->
+ <answer id="deploy-packages">
+  <p>
+   XXX no answer for deploy-packages
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="deploy-shared" when="final">
+            Do you need to be installed in the shared location only, or in the user directory only,
+            or can your module be installed anywhere?
+            <hint>
+            Installation location shall not matter, if it does explain why.
+            Consider also whether <code>InstalledFileLocator</code> can help.
+            </hint>
+        </question>
+-->
+ <answer id="deploy-shared">
+  <p>
+   XXX no answer for deploy-shared
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-ant-tasks" when="impl">
+            Do you define or register any ant tasks that other can use?
+            
+            <hint>
+            If you provide an ant task that users can use, you need to be very
+            careful about its syntax and behaviour, as it most likely forms an
+	          API for end users and as there is a lot of end users, their reaction
+            when such API gets broken can be pretty strong.
+            </hint>
+        </question>
+-->
+ <answer id="exec-ant-tasks">
+  <p>
+   XXX no answer for exec-ant-tasks
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-classloader" when="impl">
+            Does your code create its own class loader(s)?
+            <hint>
+            A bit unusual. Please explain why and what for.
+            </hint>
+        </question>
+-->
+ <answer id="exec-classloader">
+  <p>
+   XXX no answer for exec-classloader
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-component" when="impl">
+            Is execution of your code influenced by any (string) property
+            of any of your components?
+            
+            <hint>
+            Often <code>JComponent.getClientProperty</code>, <code>Action.getValue</code>
+            or <code>PropertyDescriptor.getValue</code>, etc. are used to influence
+            a behavior of some code. This of course forms an interface that should
+            be documented. Also if one depends on some interface that an object
+            implements (<code>component instanceof Runnable</code>) that forms an
+            API as well.
+            </hint>
+        </question>
+-->
+ <answer id="exec-component">
+  <p>
+      <api name="GraalVM:Engine" type="export" group="property" category="stable">
+        When this module is used (on <a href="https://graalvm.org">GraalVM</a> or
+        without)
+        it automatically exports all available languages (obtained via
+        <code>org.graalvm.polyglot.Engine</code>) as
+        <a href="@JDK@/javax/script/ScriptEngine.html">ScriptEngine</a>
+        instances. These dynamically created engines use <code>GraalVM:</code>
+        prefix (<code>GraalVM:js</code>, <code>GraalVM:python</code>) in their
+        name.
+      </api>
+      <api name="allowAllAccess" type="export" group="property" category="stable">
+        By default all the <a href="https://graalvm.org">GraalVM</a> engines
+        (named <code>GraalVM:something</code>)
+        run in a very restricted, secure sandbox. See
+        <a href="@TOP@/org/netbeans/libs/graalsdk/GraalSDK.html">GraalSDK</a>
+        for details. That means the languages cannot
+        access local files, ports, etc. Some languages (like
+        <a href="https://github.com/graalvm/fastr">>FastR</a>
+        implementation of the <b>R</b> language) need such access. In such
+        case one has to allow such access. This can be done by
+        <pre>
+var eng = Scripting.createManager().getEngineByMimeType("application/x-r");
+eng.getContext().setAttribute("allowAllAccess", true, ScriptContext.GLOBAL_SCOPE)
+        </pre>
+      </api>
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-introspection" when="impl">
+            Does your module use any kind of runtime type information (<code>instanceof</code>,
+            work with <code>java.lang.Class</code>, etc.)?
+            <hint>
+            Check for cases when you have an object of type A and you also
+            expect it to (possibly) be of type B and do some special action. That
+            should be documented. The same applies on operations in meta-level
+            (Class.isInstance(...), Class.isAssignableFrom(...), etc.).
+            </hint>
+        </question>
+-->
+ <answer id="exec-introspection">
+  <p>
+   XXX no answer for exec-introspection
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-privateaccess" when="final">
+            Are you aware of any other parts of the system calling some of 
+            your methods by reflection?
+            <hint>
+            If so, describe the "contract" as an API. Likely private or friend one, but
+            still API and consider rewrite of it.
+            </hint>
+        </question>
+-->
+ <answer id="exec-privateaccess">
+  <p>
+   XXX no answer for exec-privateaccess
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-process" when="impl">
+            Do you execute an external process from your module? How do you ensure
+            that the result is the same on different platforms? Do you parse output?
+            Do you depend on result code?
+            <hint>
+            If you feed an input, parse the output please declare that as an API.
+            </hint>
+        </question>
+-->
+ <answer id="exec-process">
+  <p>
+   XXX no answer for exec-process
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-property" when="impl">
+            Is execution of your code influenced by any environment or
+            Java system (<code>System.getProperty</code>) property?
+            On a similar note, is there something interesting that you
+            pass to <code>java.util.logging.Logger</code>? Or do you observe
+            what others log?
+            <hint>
+            If there is a property that can change the behavior of your 
+            code, somebody will likely use it. You should describe what it does 
+            and the <a href="http://wiki.netbeans.org/API_Stability">stability category</a>
+            of this API. You may use
+            <pre>
+                &lt;api type="export" group="property" name="id" category="private" url="http://..."&gt;
+                    description of the property, where it is used, what it influence, etc.
+                &lt;/api&gt;            
+            </pre>
+            </hint>
+        </question>
+-->
+ <answer id="exec-property">
+  <p>
+   XXX no answer for exec-property
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-reflection" when="impl">
+            Does your code use Java Reflection to execute other code?
+            <hint>
+            This usually indicates a missing or insufficient API in the other
+            part of the system. If the other side is not aware of your dependency
+            this contract can be easily broken.
+            </hint>
+        </question>
+-->
+ <answer id="exec-reflection">
+  <p>
+   XXX no answer for exec-reflection
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-threading" when="init">
+            What threading models, if any, does your module adhere to? How the
+            project behaves with respect to threading?
+            <hint>
+                Is your API threadsafe? Can it be accessed from any threads or
+                just from some dedicated ones? Any special relation to AWT and
+                its Event Dispatch thread? Also
+                if your module calls foreign APIs which have a specific threading model,
+                indicate how you comply with the requirements for multithreaded access
+                (synchronization, mutexes, etc.) applicable to those APIs.
+                If your module defines any APIs, or has complex internal structures
+                that might be used from multiple threads, declare how you protect
+                data against concurrent access, race conditions, deadlocks, etc.,
+                and whether such rules are enforced by runtime warnings, errors, assertions, etc.
+                Examples: a class might be non-thread-safe (like Java Collections); might
+                be fully thread-safe (internal locking); might require access through a mutex
+                (and may or may not automatically acquire that mutex on behalf of a client method);
+                might be able to run only in the event queue; etc.
+                Also describe when any events are fired: synchronously, asynchronously, etc.
+                Ideas: <a href="http://core.netbeans.org/proposals/threading/index.html#recommendations">Threading Recommendations</a> (in progress)
+            </hint>
+        </question>
+-->
+ <answer id="exec-threading">
+  <p>
+   XXX no answer for exec-threading
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="format-clipboard" when="impl">
+            Which data flavors (if any) does your code read from or insert to
+            the clipboard (by access to clipboard on means calling methods on <code>java.awt.datatransfer.Transferable</code>?
+            
+            <hint>
+            Often Node's deal with clipboard by usage of <code>Node.clipboardCopy, Node.clipboardCut and Node.pasteTypes</code>.
+            Check your code for overriding these methods.
+            </hint>
+        </question>
+-->
+ <answer id="format-clipboard">
+  <p>
+   XXX no answer for format-clipboard
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="format-dnd" when="impl">
+            Which protocols (if any) does your code understand during Drag &amp; Drop?
+            <hint>
+            Often Node's deal with clipboard by usage of <code>Node.drag, Node.getDropType</code>. 
+            Check your code for overriding these methods. Btw. if they are not overridden, they
+            by default delegate to <code>Node.clipboardCopy, Node.clipboardCut and Node.pasteTypes</code>.
+            </hint>
+        </question>
+-->
+ <answer id="format-dnd">
+  <p>
+   XXX no answer for format-dnd
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="format-types" when="impl">
+            Which protocols and file formats (if any) does your module read or write on disk,
+            or transmit or receive over the network? Do you generate an ant build script?
+            Can it be edited and modified? 
+            
+            <hint>
+            <p>
+            Files can be read and written by other programs, modules and users. If they influence
+            your behaviour, make sure you either document the format or claim that it is a private
+            api (using the &lt;api&gt; tag). 
+            </p>
+            
+            <p>
+            If you generate an ant build file, this is very likely going to be seen by end users and
+            they will be attempted to edit it. You should be ready for that and provide here a link
+            to documentation that you have for such purposes and also describe how you are going to
+            understand such files during next release, when you (very likely) slightly change the 
+            format.
+            </p>
+            </hint>
+        </question>
+-->
+ <answer id="format-types">
+  <p>
+   XXX no answer for format-types
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="lookup-lookup" when="init">
+            Does your module use <code>org.openide.util.Lookup</code>
+            or any similar technology to find any components to communicate with? Which ones?
+            
+            <hint>
+            NetBeans is build around a generic registry of services called
+            lookup. It is preferable to use it for registration and discovery
+            if possible. See
+            <a href="http://www.netbeans.org/download/dev/javadoc/org-openide-util/org/openide/util/lookup/doc-files/index.html">
+            The Solution to Comunication Between Components
+            </a>. If you do not plan to use lookup and insist usage
+            of other solution, then please describe why it is not working for
+            you.
+            <br/>
+            When filling the final version of your arch document, please
+            describe the interfaces you are searching for, where 
+            are defined, whether you are searching for just one or more of them,
+            if the order is important, etc. Also classify the stability of such
+            API contract. Use &lt;api group=&amp;lookup&amp; /&gt; tag, so
+            your information gets listed in the summary page of your javadoc.
+            </hint>
+        </question>
+-->
+ <answer id="lookup-lookup">
+  <p>
+   XXX no answer for lookup-lookup
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="lookup-register" when="final">
+            Do you register anything into lookup for other code to find?
+            <hint>
+            Do you register using layer file or using a declarative annotation such as <code>@ServiceProvider</code>?
+            Who is supposed to find your component?
+            </hint>
+        </question>
+-->
+ <answer id="lookup-register">
+  <p>
+   XXX no answer for lookup-register
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="lookup-remove" when="final">
+            Do you remove entries of other modules from lookup?
+            <hint>
+            Why? Of course, that is possible, but it can be dangerous. Is the module
+            your are masking resource from aware of what you are doing?
+            </hint>
+        </question>
+-->
+ <answer id="lookup-remove">
+  <p>
+   XXX no answer for lookup-remove
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-exit" when="final">
+            Does your module run any code on exit?
+        </question>
+-->
+ <answer id="perf-exit">
+  <p>
+   XXX no answer for perf-exit
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-huge_dialogs" when="final">
+            Does your module contain any dialogs or wizards with a large number of
+            GUI controls such as combo boxes, lists, trees, or text areas?
+        </question>
+-->
+ <answer id="perf-huge_dialogs">
+  <p>
+   XXX no answer for perf-huge_dialogs
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-limit" when="init">
+            Are there any hard-coded or practical limits in the number or size of
+            elements your code can handle?
+            <hint>
+                Most of algorithms have increasing memory and speed complexity
+                with respect to size of data they operate on. What is the critical
+                part of your project that can be seen as a bottleneck with
+                respect to speed or required memory? What are the practical
+                sizes of data you tested your project with? What is your estimate
+                of potential size of data that would cause visible performance
+                problems? Is there some kind of check to detect such situation
+                and prevent "hard" crashes - for example the CloneableEditorSupport
+                checks for size of a file to be opened in editor
+                and if it is larger than 1Mb it shows a dialog giving the
+                user the right to decide - e.g. to cancel or commit suicide.
+            </hint>
+        </question>
+-->
+ <answer id="perf-limit">
+  <p>
+   XXX no answer for perf-limit
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-mem" when="final">
+            How much memory does your component consume? Estimate
+            with a relation to the number of windows, etc.
+        </question>
+-->
+ <answer id="perf-mem">
+  <p>
+   XXX no answer for perf-mem
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-menus" when="final">
+            Does your module use dynamically updated context menus, or
+            context-sensitive actions with complicated and slow enablement logic?
+            <hint>
+                If you do a lot of tricks when adding actions to regular or context menus, you can significantly
+                slow down display of the menu, even when the user is not using your action. Pay attention to
+                actions you add to the main menu bar, and to context menus of foreign nodes or components. If
+                the action is conditionally enabled, or changes its display dynamically, you need to check the
+                impact on performance. In some cases it may be more appropriate to make a simple action that is
+                always enabled but does more detailed checks in a dialog if it is actually run.
+            </hint>
+        </question>
+-->
+ <answer id="perf-menus">
+  <p>
+   XXX no answer for perf-menus
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-progress" when="final">
+            Does your module execute any long-running tasks?
+            
+            <hint>Long running tasks should never block 
+            AWT thread as it badly hurts the UI
+            <a href="http://performance.netbeans.org/responsiveness/issues.html">
+            responsiveness</a>.
+            Tasks like connecting over
+            network, computing huge amount of data, compilation
+            be done asynchronously (for example
+            using <code>RequestProcessor</code>), definitively it should 
+            not block AWT thread.
+            </hint>
+        </question>
+-->
+ <answer id="perf-progress">
+  <p>
+   XXX no answer for perf-progress
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-scale" when="init">
+            Which external criteria influence the performance of your
+            program (size of file in editor, number of files in menu, 
+            in source directory, etc.) and how well your code scales?
+            <hint>
+            Please include some estimates, there are other more detailed 
+            questions to answer in later phases of implementation. 
+            </hint>
+        </question>
+-->
+ <answer id="perf-scale">
+  <p>
+   XXX no answer for perf-scale
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-spi" when="init">
+            How the performance of the plugged in code will be enforced?
+            <hint>
+            If you allow foreign code to be plugged into your own module, how
+            do you enforce that it will behave correctly and quickly and will not
+            negatively influence the performance of your own module?
+            </hint>
+        </question>
+-->
+ <answer id="perf-spi">
+  <p>
+   XXX no answer for perf-spi
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-startup" when="final">
+            Does your module run any code on startup?
+        </question>
+-->
+ <answer id="perf-startup">
+  <p>
+   XXX no answer for perf-startup
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-wakeup" when="final">
+            Does any piece of your code wake up periodically and do something
+            even when the system is otherwise idle (no user interaction)?
+        </question>
+-->
+ <answer id="perf-wakeup">
+  <p>
+   XXX no answer for perf-wakeup
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="resources-file" when="final">
+            Does your module use <code>java.io.File</code> directly?
+            
+            <hint>
+            NetBeans provide a logical wrapper over plain files called 
+            <code>org.openide.filesystems.FileObject</code> that
+            provides uniform access to such resources and is the preferred
+            way that should be used. But of course there can be situations when
+            this is not suitable.
+            </hint>
+        </question>
+-->
+ <answer id="resources-file">
+  <p>
+   XXX no answer for resources-file
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="resources-layer" when="final">
+            Does your module provide own layer? Does it create any files or
+            folders in it? What it is trying to communicate by that and with which 
+            components?
+            
+            <hint>
+            NetBeans allows automatic and declarative installation of resources 
+            by module layers. Module register files into appropriate places
+            and other components use that information to perform their task
+            (build menu, toolbar, window layout, list of templates, set of
+            options, etc.). 
+            </hint>
+        </question>
+-->
+ <answer id="resources-layer">
+  <p>
+   XXX no answer for resources-layer
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="resources-mask" when="final">
+            Does your module mask/hide/override any resources provided by other modules in
+            their layers?
+            
+            <hint>
+            If you mask a file provided by another module, you probably depend
+            on that and do not want the other module to (for example) change
+            the file's name. That module shall thus make that file available as an API
+            of some stability category.
+            </hint>
+        </question>
+-->
+ <answer id="resources-mask">
+  <p>
+   XXX no answer for resources-mask
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="resources-preferences" when="final">
+            Does your module uses preferences via Preferences API? Does your module use NbPreferences or
+            or regular JDK Preferences ? Does it read, write or both ? 
+            Does it share preferences with other modules ? If so, then why ?
+            <hint>
+                You may use
+                    &lt;api type="export" group="preferences"
+                    name="preference node name" category="private"&gt;
+                    description of individual keys, where it is used, what it
+                    influences, whether the module reads/write it, etc.
+                    &lt;/api&gt;
+                Due to XML ID restrictions, rather than /org/netbeans/modules/foo give the "name" as org.netbeans.modules.foo.
+                Note that if you use NbPreferences this name will then be the same as the code name base of the module.
+            </hint>
+        </question>
+-->
+ <answer id="resources-preferences">
+  <p>
+   XXX no answer for resources-preferences
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="resources-read" when="final">
+            Does your module read any resources from layers? For what purpose?
+            
+            <hint>
+            As this is some kind of intermodule dependency, it is a kind of API.
+            Please describe it and classify according to 
+            <a href="http://wiki.netbeans.org/API_Design#What_is_an_API.3F">
+            common stability categories</a>.
+            </hint>
+        </question>
+-->
+ <answer id="resources-read">
+  <p>
+   XXX no answer for resources-read
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="security-grant" when="final">
+            Does your code grant additional rights to some other code?
+            <hint>Avoid using a class loader that adds extra
+            permissions to loaded code unless really necessary.
+            Also note that your API implementation
+            can also expose unneeded permissions to enemy code by
+            calling AccessController.doPrivileged().</hint>
+        </question>
+-->
+ <answer id="security-grant">
+  <p>
+   XXX no answer for security-grant
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="security-policy" when="final">
+            Does your functionality require modifications to the standard policy file?
+            <hint>Your code might pass control to third-party code not
+            coming from trusted domains. This could be code downloaded over the
+            network or code coming from libraries that are not bundled
+            with NetBeans. Which permissions need to be granted to which domains?</hint>
+        </question>
+-->
+ <answer id="security-policy">
+  <p>
+   XXX no answer for security-policy
+  </p>
+ </answer>
+
+</api-answers>

--- a/ide/libs.graalsdk.system/build.xml
+++ b/ide/libs.graalsdk.system/build.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project basedir="." default="build" name="ide/libs.graalsdk.system">
+    <description>Builds, tests, and runs the project org.netbeans.libs.graalsdk</description>
+    <import file="../../nbbuild/templates/projectized.xml"/>
+</project>

--- a/ide/libs.graalsdk.system/external/binaries-list
+++ b/ide/libs.graalsdk.system/external/binaries-list
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+8E62643FD621053E00EE52D797C7FBD08D7FDEDC org.graalvm.sdk:graal-sdk:20.3.0
+8968BDBE4058F4E6610AF0DC184BD885B236A2B1 org.graalvm.sdk:launcher-common:20.3.0

--- a/ide/libs.graalsdk.system/external/graal-sdk-20.3.0-license.txt
+++ b/ide/libs.graalsdk.system/external/graal-sdk-20.3.0-license.txt
@@ -1,0 +1,25 @@
+Name: Graal SDK and Truffle API
+Description: Graal SDK and Truffle API
+License: UPL
+Origin: https://github.com/oracle/graal
+Version: 20.3.0
+Files: graal-sdk-20.3.0.jar launcher-common-20.3.0.jar
+
+Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software, associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+
+(a) the Software, and
+
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software each a "Larger Work" to which the Software is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+
+This license is subject to the following condition:
+
+The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/ide/libs.graalsdk.system/manifest.mf
+++ b/ide/libs.graalsdk.system/manifest.mf
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+AutoUpdate-Show-In-Client: false
+OpenIDE-Module: org.netbeans.libs.graalsdk.system
+OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/graalsdk/system/Bundle.properties
+OpenIDE-Module-Specification-Version: 1.20
+OpenIDE-Module-Provides: org.netbeans.spi.scripting.EngineProvider
+OpenIDE-Module-Package-Dependencies: org.graalvm.polyglot[Engine]

--- a/ide/libs.graalsdk.system/nbproject/org-netbeans-libs-graalsdk.sig
+++ b/ide/libs.graalsdk.system/nbproject/org-netbeans-libs-graalsdk.sig
@@ -1,0 +1,1524 @@
+#Signature file v4.1
+#Version 1.19
+
+CLSS public abstract interface java.io.Serializable
+
+CLSS public abstract interface java.lang.AutoCloseable
+meth public abstract void close() throws java.lang.Exception
+
+CLSS public abstract interface java.lang.Comparable<%0 extends java.lang.Object>
+meth public abstract int compareTo({java.lang.Comparable%0})
+
+CLSS public abstract java.lang.Enum<%0 extends java.lang.Enum<{java.lang.Enum%0}>>
+cons protected init(java.lang.String,int)
+intf java.io.Serializable
+intf java.lang.Comparable<{java.lang.Enum%0}>
+meth protected final java.lang.Object clone() throws java.lang.CloneNotSupportedException
+meth protected final void finalize()
+meth public final boolean equals(java.lang.Object)
+meth public final int compareTo({java.lang.Enum%0})
+meth public final int hashCode()
+meth public final int ordinal()
+meth public final java.lang.Class<{java.lang.Enum%0}> getDeclaringClass()
+meth public final java.lang.String name()
+meth public java.lang.String toString()
+meth public static <%0 extends java.lang.Enum<{%%0}>> {%%0} valueOf(java.lang.Class<{%%0}>,java.lang.String)
+supr java.lang.Object
+
+CLSS public java.lang.Exception
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.Throwable
+
+CLSS public abstract interface !annotation java.lang.FunctionalInterface
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+
+CLSS public abstract interface java.lang.Iterable<%0 extends java.lang.Object>
+meth public abstract java.util.Iterator<{java.lang.Iterable%0}> iterator()
+meth public java.util.Spliterator<{java.lang.Iterable%0}> spliterator()
+meth public void forEach(java.util.function.Consumer<? super {java.lang.Iterable%0}>)
+
+CLSS public java.lang.Object
+cons public init()
+meth protected java.lang.Object clone() throws java.lang.CloneNotSupportedException
+meth protected void finalize() throws java.lang.Throwable
+meth public boolean equals(java.lang.Object)
+meth public final java.lang.Class<?> getClass()
+meth public final void notify()
+meth public final void notifyAll()
+meth public final void wait() throws java.lang.InterruptedException
+meth public final void wait(long) throws java.lang.InterruptedException
+meth public final void wait(long,int) throws java.lang.InterruptedException
+meth public int hashCode()
+meth public java.lang.String toString()
+
+CLSS public java.lang.RuntimeException
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.Exception
+
+CLSS public java.lang.Throwable
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+intf java.io.Serializable
+meth public final java.lang.Throwable[] getSuppressed()
+meth public final void addSuppressed(java.lang.Throwable)
+meth public java.lang.StackTraceElement[] getStackTrace()
+meth public java.lang.String getLocalizedMessage()
+meth public java.lang.String getMessage()
+meth public java.lang.String toString()
+meth public java.lang.Throwable fillInStackTrace()
+meth public java.lang.Throwable getCause()
+meth public java.lang.Throwable initCause(java.lang.Throwable)
+meth public void printStackTrace()
+meth public void printStackTrace(java.io.PrintStream)
+meth public void printStackTrace(java.io.PrintWriter)
+meth public void setStackTrace(java.lang.StackTraceElement[])
+supr java.lang.Object
+
+CLSS public abstract interface java.lang.annotation.Annotation
+meth public abstract boolean equals(java.lang.Object)
+meth public abstract int hashCode()
+meth public abstract java.lang.Class<? extends java.lang.annotation.Annotation> annotationType()
+meth public abstract java.lang.String toString()
+
+CLSS public abstract interface !annotation java.lang.annotation.Documented
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
+intf java.lang.annotation.Annotation
+
+CLSS public abstract interface !annotation java.lang.annotation.Retention
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract java.lang.annotation.RetentionPolicy value()
+
+CLSS public abstract interface !annotation java.lang.annotation.Target
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract java.lang.annotation.ElementType[] value()
+
+CLSS public abstract interface org.graalvm.collections.EconomicMap<%0 extends java.lang.Object, %1 extends java.lang.Object>
+intf org.graalvm.collections.UnmodifiableEconomicMap<{org.graalvm.collections.EconomicMap%0},{org.graalvm.collections.EconomicMap%1}>
+meth public abstract org.graalvm.collections.MapCursor<{org.graalvm.collections.EconomicMap%0},{org.graalvm.collections.EconomicMap%1}> getEntries()
+meth public abstract void clear()
+meth public abstract void replaceAll(java.util.function.BiFunction<? super {org.graalvm.collections.EconomicMap%0},? super {org.graalvm.collections.EconomicMap%1},? extends {org.graalvm.collections.EconomicMap%1}>)
+meth public abstract {org.graalvm.collections.EconomicMap%1} put({org.graalvm.collections.EconomicMap%0},{org.graalvm.collections.EconomicMap%1})
+meth public abstract {org.graalvm.collections.EconomicMap%1} removeKey({org.graalvm.collections.EconomicMap%0})
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> create()
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> create(int)
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> create(org.graalvm.collections.Equivalence)
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> create(org.graalvm.collections.Equivalence,int)
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> create(org.graalvm.collections.Equivalence,org.graalvm.collections.UnmodifiableEconomicMap<{%%0},{%%1}>)
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> create(org.graalvm.collections.UnmodifiableEconomicMap<{%%0},{%%1}>)
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> wrapMap(java.util.Map<{%%0},{%%1}>)
+meth public void putAll(org.graalvm.collections.EconomicMap<{org.graalvm.collections.EconomicMap%0},{org.graalvm.collections.EconomicMap%1}>)
+meth public void putAll(org.graalvm.collections.UnmodifiableEconomicMap<? extends {org.graalvm.collections.EconomicMap%0},? extends {org.graalvm.collections.EconomicMap%1}>)
+meth public {org.graalvm.collections.EconomicMap%1} putIfAbsent({org.graalvm.collections.EconomicMap%0},{org.graalvm.collections.EconomicMap%1})
+
+CLSS public abstract interface org.graalvm.collections.EconomicSet<%0 extends java.lang.Object>
+intf org.graalvm.collections.UnmodifiableEconomicSet<{org.graalvm.collections.EconomicSet%0}>
+meth public abstract boolean add({org.graalvm.collections.EconomicSet%0})
+meth public abstract void clear()
+meth public abstract void remove({org.graalvm.collections.EconomicSet%0})
+meth public static <%0 extends java.lang.Object> org.graalvm.collections.EconomicSet<{%%0}> create()
+meth public static <%0 extends java.lang.Object> org.graalvm.collections.EconomicSet<{%%0}> create(int)
+meth public static <%0 extends java.lang.Object> org.graalvm.collections.EconomicSet<{%%0}> create(org.graalvm.collections.Equivalence)
+meth public static <%0 extends java.lang.Object> org.graalvm.collections.EconomicSet<{%%0}> create(org.graalvm.collections.Equivalence,int)
+meth public static <%0 extends java.lang.Object> org.graalvm.collections.EconomicSet<{%%0}> create(org.graalvm.collections.Equivalence,org.graalvm.collections.UnmodifiableEconomicSet<{%%0}>)
+meth public static <%0 extends java.lang.Object> org.graalvm.collections.EconomicSet<{%%0}> create(org.graalvm.collections.UnmodifiableEconomicSet<{%%0}>)
+meth public void addAll(java.lang.Iterable<{org.graalvm.collections.EconomicSet%0}>)
+meth public void addAll(java.util.Iterator<{org.graalvm.collections.EconomicSet%0}>)
+meth public void addAll(org.graalvm.collections.EconomicSet<{org.graalvm.collections.EconomicSet%0}>)
+meth public void removeAll(java.lang.Iterable<{org.graalvm.collections.EconomicSet%0}>)
+meth public void removeAll(java.util.Iterator<{org.graalvm.collections.EconomicSet%0}>)
+meth public void removeAll(org.graalvm.collections.EconomicSet<{org.graalvm.collections.EconomicSet%0}>)
+meth public void retainAll(org.graalvm.collections.EconomicSet<{org.graalvm.collections.EconomicSet%0}>)
+
+CLSS public abstract org.graalvm.collections.Equivalence
+cons protected init()
+fld public final static org.graalvm.collections.Equivalence DEFAULT
+fld public final static org.graalvm.collections.Equivalence IDENTITY
+fld public final static org.graalvm.collections.Equivalence IDENTITY_WITH_SYSTEM_HASHCODE
+meth public abstract boolean equals(java.lang.Object,java.lang.Object)
+meth public abstract int hashCode(java.lang.Object)
+supr java.lang.Object
+
+CLSS public abstract interface org.graalvm.collections.MapCursor<%0 extends java.lang.Object, %1 extends java.lang.Object>
+intf org.graalvm.collections.UnmodifiableMapCursor<{org.graalvm.collections.MapCursor%0},{org.graalvm.collections.MapCursor%1}>
+meth public abstract void remove()
+
+CLSS public final org.graalvm.collections.Pair<%0 extends java.lang.Object, %1 extends java.lang.Object>
+meth public boolean equals(java.lang.Object)
+meth public int hashCode()
+meth public java.lang.String toString()
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.Pair<{%%0},{%%1}> create({%%0},{%%1})
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.Pair<{%%0},{%%1}> createLeft({%%0})
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.Pair<{%%0},{%%1}> createRight({%%1})
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.Pair<{%%0},{%%1}> empty()
+meth public {org.graalvm.collections.Pair%0} getLeft()
+meth public {org.graalvm.collections.Pair%1} getRight()
+supr java.lang.Object
+hfds EMPTY,left,right
+
+CLSS public abstract interface org.graalvm.collections.UnmodifiableEconomicMap<%0 extends java.lang.Object, %1 extends java.lang.Object>
+meth public abstract boolean containsKey({org.graalvm.collections.UnmodifiableEconomicMap%0})
+meth public abstract boolean isEmpty()
+meth public abstract int size()
+meth public abstract java.lang.Iterable<{org.graalvm.collections.UnmodifiableEconomicMap%0}> getKeys()
+meth public abstract java.lang.Iterable<{org.graalvm.collections.UnmodifiableEconomicMap%1}> getValues()
+meth public abstract org.graalvm.collections.UnmodifiableMapCursor<{org.graalvm.collections.UnmodifiableEconomicMap%0},{org.graalvm.collections.UnmodifiableEconomicMap%1}> getEntries()
+meth public abstract {org.graalvm.collections.UnmodifiableEconomicMap%1} get({org.graalvm.collections.UnmodifiableEconomicMap%0})
+meth public {org.graalvm.collections.UnmodifiableEconomicMap%1} get({org.graalvm.collections.UnmodifiableEconomicMap%0},{org.graalvm.collections.UnmodifiableEconomicMap%1})
+
+CLSS public abstract interface org.graalvm.collections.UnmodifiableEconomicSet<%0 extends java.lang.Object>
+intf java.lang.Iterable<{org.graalvm.collections.UnmodifiableEconomicSet%0}>
+meth public abstract boolean contains({org.graalvm.collections.UnmodifiableEconomicSet%0})
+meth public abstract boolean isEmpty()
+meth public abstract int size()
+meth public {org.graalvm.collections.UnmodifiableEconomicSet%0}[] toArray({org.graalvm.collections.UnmodifiableEconomicSet%0}[])
+
+CLSS public abstract interface org.graalvm.collections.UnmodifiableMapCursor<%0 extends java.lang.Object, %1 extends java.lang.Object>
+meth public abstract boolean advance()
+meth public abstract {org.graalvm.collections.UnmodifiableMapCursor%0} getKey()
+meth public abstract {org.graalvm.collections.UnmodifiableMapCursor%1} getValue()
+
+CLSS public abstract org.graalvm.home.HomeFinder
+cons public init()
+meth public abstract java.lang.String getVersion()
+meth public abstract java.nio.file.Path getHomeFolder()
+meth public abstract java.util.Map<java.lang.String,java.nio.file.Path> getLanguageHomes()
+meth public abstract java.util.Map<java.lang.String,java.nio.file.Path> getToolHomes()
+meth public static org.graalvm.home.HomeFinder getInstance()
+supr java.lang.Object
+
+CLSS public final org.graalvm.home.Version
+intf java.lang.Comparable<org.graalvm.home.Version>
+meth public !varargs int compareTo(int[])
+meth public !varargs static org.graalvm.home.Version create(int[])
+meth public boolean equals(java.lang.Object)
+meth public boolean isRelease()
+meth public boolean isSnapshot()
+meth public int compareTo(org.graalvm.home.Version)
+meth public int hashCode()
+meth public java.lang.String toString()
+meth public static org.graalvm.home.Version getCurrent()
+meth public static org.graalvm.home.Version parse(java.lang.String)
+supr java.lang.Object
+hfds MIN_VERSION_DIGITS,SNAPSHOT_STRING,SNAPSHOT_SUFFIX,snapshot,suffix,versions
+
+CLSS public final org.graalvm.nativeimage.CurrentIsolate
+meth public static org.graalvm.nativeimage.Isolate getIsolate()
+meth public static org.graalvm.nativeimage.IsolateThread getCurrentThread()
+supr java.lang.Object
+
+CLSS public final org.graalvm.nativeimage.ImageInfo
+fld public final static java.lang.String PROPERTY_IMAGE_CODE_KEY = "org.graalvm.nativeimage.imagecode"
+fld public final static java.lang.String PROPERTY_IMAGE_CODE_VALUE_BUILDTIME = "buildtime"
+fld public final static java.lang.String PROPERTY_IMAGE_CODE_VALUE_RUNTIME = "runtime"
+fld public final static java.lang.String PROPERTY_IMAGE_KIND_KEY = "org.graalvm.nativeimage.kind"
+fld public final static java.lang.String PROPERTY_IMAGE_KIND_VALUE_EXECUTABLE = "executable"
+fld public final static java.lang.String PROPERTY_IMAGE_KIND_VALUE_SHARED_LIBRARY = "shared"
+meth public static boolean inImageBuildtimeCode()
+meth public static boolean inImageCode()
+meth public static boolean inImageRuntimeCode()
+meth public static boolean isExecutable()
+meth public static boolean isSharedLibrary()
+supr java.lang.Object
+
+CLSS public final org.graalvm.nativeimage.ImageSingletons
+meth public static <%0 extends java.lang.Object> void add(java.lang.Class<{%%0}>,{%%0})
+meth public static <%0 extends java.lang.Object> {%%0} lookup(java.lang.Class<{%%0}>)
+meth public static boolean contains(java.lang.Class<?>)
+supr java.lang.Object
+
+CLSS public abstract interface org.graalvm.nativeimage.Isolate
+intf org.graalvm.word.PointerBase
+
+CLSS public abstract interface org.graalvm.nativeimage.IsolateThread
+intf org.graalvm.word.PointerBase
+
+CLSS public final org.graalvm.nativeimage.Isolates
+innr public final static CreateIsolateParameters
+innr public final static IsolateException
+meth public static org.graalvm.nativeimage.Isolate getIsolate(org.graalvm.nativeimage.IsolateThread)
+meth public static org.graalvm.nativeimage.IsolateThread attachCurrentThread(org.graalvm.nativeimage.Isolate)
+meth public static org.graalvm.nativeimage.IsolateThread createIsolate(org.graalvm.nativeimage.Isolates$CreateIsolateParameters)
+meth public static org.graalvm.nativeimage.IsolateThread getCurrentThread(org.graalvm.nativeimage.Isolate)
+meth public static void detachThread(org.graalvm.nativeimage.IsolateThread)
+meth public static void tearDownIsolate(org.graalvm.nativeimage.IsolateThread)
+supr java.lang.Object
+
+CLSS public final static org.graalvm.nativeimage.Isolates$CreateIsolateParameters
+ outer org.graalvm.nativeimage.Isolates
+innr public final static Builder
+meth public java.lang.String getAuxiliaryImagePath()
+meth public org.graalvm.word.UnsignedWord getAuxiliaryImageReservedSpaceSize()
+meth public org.graalvm.word.UnsignedWord getReservedAddressSpaceSize()
+meth public static org.graalvm.nativeimage.Isolates$CreateIsolateParameters getDefault()
+supr java.lang.Object
+hfds DEFAULT,auxiliaryImagePath,auxiliaryImageReservedSpaceSize,reservedAddressSpaceSize
+
+CLSS public final static org.graalvm.nativeimage.Isolates$CreateIsolateParameters$Builder
+ outer org.graalvm.nativeimage.Isolates$CreateIsolateParameters
+cons public init()
+meth public org.graalvm.nativeimage.Isolates$CreateIsolateParameters build()
+meth public org.graalvm.nativeimage.Isolates$CreateIsolateParameters$Builder auxiliaryImagePath(java.lang.String)
+meth public org.graalvm.nativeimage.Isolates$CreateIsolateParameters$Builder auxiliaryImageReservedSpaceSize(org.graalvm.word.UnsignedWord)
+meth public org.graalvm.nativeimage.Isolates$CreateIsolateParameters$Builder reservedAddressSpaceSize(org.graalvm.word.UnsignedWord)
+supr java.lang.Object
+hfds auxiliaryImagePath,auxiliaryImageReservedSpaceSize,reservedAddressSpaceSize
+
+CLSS public final static org.graalvm.nativeimage.Isolates$IsolateException
+ outer org.graalvm.nativeimage.Isolates
+cons public init(java.lang.String)
+supr java.lang.RuntimeException
+hfds serialVersionUID
+
+CLSS public abstract interface org.graalvm.nativeimage.LogHandler
+meth public abstract void fatalError()
+meth public abstract void flush()
+meth public abstract void log(org.graalvm.nativeimage.c.type.CCharPointer,org.graalvm.word.UnsignedWord)
+
+CLSS public abstract interface org.graalvm.nativeimage.ObjectHandle
+intf org.graalvm.word.ComparableWord
+
+CLSS public abstract interface org.graalvm.nativeimage.ObjectHandles
+meth public abstract <%0 extends java.lang.Object> {%%0} get(org.graalvm.nativeimage.ObjectHandle)
+meth public abstract org.graalvm.nativeimage.ObjectHandle create(java.lang.Object)
+meth public abstract void destroy(org.graalvm.nativeimage.ObjectHandle)
+meth public static org.graalvm.nativeimage.ObjectHandles create()
+meth public static org.graalvm.nativeimage.ObjectHandles getGlobal()
+
+CLSS public abstract interface org.graalvm.nativeimage.PinnedObject
+intf java.lang.AutoCloseable
+meth public abstract <%0 extends org.graalvm.word.PointerBase> {%%0} addressOfArrayElement(int)
+meth public abstract java.lang.Object getObject()
+meth public abstract org.graalvm.word.PointerBase addressOfObject()
+meth public abstract void close()
+meth public static org.graalvm.nativeimage.PinnedObject create(java.lang.Object)
+
+CLSS public abstract interface org.graalvm.nativeimage.Platform
+fld public final static java.lang.String PLATFORM_PROPERTY_NAME = "svm.platform"
+innr public abstract interface static AARCH64
+innr public abstract interface static AMD64
+innr public abstract interface static DARWIN
+innr public abstract interface static LINUX
+innr public abstract interface static WINDOWS
+innr public final static DARWIN_AARCH64
+innr public final static HOSTED_ONLY
+innr public final static LINUX_AARCH64
+innr public static DARWIN_AMD64
+innr public static LINUX_AMD64
+innr public static WINDOWS_AMD64
+meth public static boolean includedIn(java.lang.Class<? extends org.graalvm.nativeimage.Platform>)
+
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$AARCH64
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.Platform
+
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$AMD64
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.Platform
+
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$DARWIN
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
+
+CLSS public final static org.graalvm.nativeimage.Platform$DARWIN_AARCH64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$AARCH64
+intf org.graalvm.nativeimage.Platform$DARWIN
+supr java.lang.Object
+
+CLSS public static org.graalvm.nativeimage.Platform$DARWIN_AMD64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$AMD64
+intf org.graalvm.nativeimage.Platform$DARWIN
+supr java.lang.Object
+
+CLSS public final static org.graalvm.nativeimage.Platform$HOSTED_ONLY
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.Platform
+supr java.lang.Object
+
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$LINUX
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
+
+CLSS public final static org.graalvm.nativeimage.Platform$LINUX_AARCH64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$AARCH64
+intf org.graalvm.nativeimage.Platform$LINUX
+supr java.lang.Object
+
+CLSS public static org.graalvm.nativeimage.Platform$LINUX_AMD64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$AMD64
+intf org.graalvm.nativeimage.Platform$LINUX
+supr java.lang.Object
+
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$WINDOWS
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
+
+CLSS public static org.graalvm.nativeimage.Platform$WINDOWS_AMD64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$AMD64
+intf org.graalvm.nativeimage.Platform$WINDOWS
+supr java.lang.Object
+
+CLSS public abstract interface !annotation org.graalvm.nativeimage.Platforms
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE, METHOD, CONSTRUCTOR, FIELD, PACKAGE])
+intf java.lang.annotation.Annotation
+meth public abstract java.lang.Class<? extends org.graalvm.nativeimage.Platform>[] value()
+
+CLSS public final org.graalvm.nativeimage.ProcessProperties
+meth public !varargs static void exec(java.nio.file.Path,java.lang.String[])
+meth public static boolean destroy(long)
+meth public static boolean destroyForcibly(long)
+meth public static boolean isAlive(long)
+meth public static boolean setArgumentVectorProgramName(java.lang.String)
+meth public static int getArgumentVectorBlockSize()
+meth public static int waitForProcessExit(long)
+meth public static java.lang.String getArgumentVectorProgramName()
+meth public static java.lang.String getExecutableName()
+meth public static java.lang.String getObjectFile(java.lang.String)
+meth public static java.lang.String getObjectFile(org.graalvm.nativeimage.c.function.CEntryPointLiteral<?>)
+meth public static java.lang.String setLocale(java.lang.String,java.lang.String)
+meth public static long getProcessID()
+meth public static long getProcessID(java.lang.Process)
+supr java.lang.Object
+
+CLSS public final org.graalvm.nativeimage.RuntimeOptions
+innr public final static !enum OptionClass
+meth public static <%0 extends java.lang.Object> {%%0} get(java.lang.String)
+meth public static org.graalvm.options.OptionDescriptors getOptions()
+meth public static org.graalvm.options.OptionDescriptors getOptions(java.util.EnumSet<org.graalvm.nativeimage.RuntimeOptions$OptionClass>)
+meth public static void set(java.lang.String,java.lang.Object)
+supr java.lang.Object
+
+CLSS public final static !enum org.graalvm.nativeimage.RuntimeOptions$OptionClass
+ outer org.graalvm.nativeimage.RuntimeOptions
+fld public final static org.graalvm.nativeimage.RuntimeOptions$OptionClass Compiler
+fld public final static org.graalvm.nativeimage.RuntimeOptions$OptionClass VM
+meth public static org.graalvm.nativeimage.RuntimeOptions$OptionClass valueOf(java.lang.String)
+meth public static org.graalvm.nativeimage.RuntimeOptions$OptionClass[] values()
+supr java.lang.Enum<org.graalvm.nativeimage.RuntimeOptions$OptionClass>
+
+CLSS public final org.graalvm.nativeimage.StackValue
+meth public static <%0 extends org.graalvm.word.PointerBase> {%%0} get(int)
+meth public static <%0 extends org.graalvm.word.PointerBase> {%%0} get(int,int)
+meth public static <%0 extends org.graalvm.word.PointerBase> {%%0} get(int,java.lang.Class<{%%0}>)
+meth public static <%0 extends org.graalvm.word.PointerBase> {%%0} get(java.lang.Class<{%%0}>)
+supr java.lang.Object
+
+CLSS public final org.graalvm.nativeimage.Threading
+innr public abstract interface static RecurringCallback
+innr public abstract interface static RecurringCallbackAccess
+meth public static void registerRecurringCallback(long,java.util.concurrent.TimeUnit,org.graalvm.nativeimage.Threading$RecurringCallback)
+supr java.lang.Object
+
+CLSS public abstract interface static org.graalvm.nativeimage.Threading$RecurringCallback
+ outer org.graalvm.nativeimage.Threading
+ anno 0 java.lang.FunctionalInterface()
+meth public abstract void run(org.graalvm.nativeimage.Threading$RecurringCallbackAccess)
+
+CLSS public abstract interface static org.graalvm.nativeimage.Threading$RecurringCallbackAccess
+ outer org.graalvm.nativeimage.Threading
+meth public abstract void throwException(java.lang.Throwable)
+
+CLSS public final org.graalvm.nativeimage.UnmanagedMemory
+meth public static <%0 extends org.graalvm.word.PointerBase> {%%0} calloc(int)
+meth public static <%0 extends org.graalvm.word.PointerBase> {%%0} calloc(org.graalvm.word.UnsignedWord)
+meth public static <%0 extends org.graalvm.word.PointerBase> {%%0} malloc(int)
+meth public static <%0 extends org.graalvm.word.PointerBase> {%%0} malloc(org.graalvm.word.UnsignedWord)
+meth public static <%0 extends org.graalvm.word.PointerBase> {%%0} realloc({%%0},org.graalvm.word.UnsignedWord)
+meth public static void free(org.graalvm.word.PointerBase)
+supr java.lang.Object
+
+CLSS public final org.graalvm.nativeimage.VMRuntime
+meth public static void dumpHeap(java.lang.String,boolean) throws java.io.IOException
+meth public static void initialize()
+meth public static void shutdown()
+supr java.lang.Object
+
+CLSS public abstract interface !annotation org.graalvm.nativeimage.c.struct.CStruct
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault boolean addStructKeyword()
+meth public abstract !hasdefault boolean isIncomplete()
+meth public abstract !hasdefault java.lang.String value()
+
+CLSS public abstract interface org.graalvm.nativeimage.impl.InternalPlatform
+innr public abstract interface static PLATFORM_JNI
+
+CLSS public abstract interface static org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
+ outer org.graalvm.nativeimage.impl.InternalPlatform
+intf org.graalvm.nativeimage.Platform
+
+CLSS public final !enum org.graalvm.options.OptionCategory
+fld public final static org.graalvm.options.OptionCategory EXPERT
+fld public final static org.graalvm.options.OptionCategory INTERNAL
+fld public final static org.graalvm.options.OptionCategory USER
+meth public static org.graalvm.options.OptionCategory valueOf(java.lang.String)
+meth public static org.graalvm.options.OptionCategory[] values()
+supr java.lang.Enum<org.graalvm.options.OptionCategory>
+
+CLSS public final org.graalvm.options.OptionDescriptor
+innr public final Builder
+meth public boolean equals(java.lang.Object)
+meth public boolean isDeprecated()
+meth public boolean isOptionMap()
+meth public int hashCode()
+meth public java.lang.String getDeprecationMessage()
+meth public java.lang.String getHelp()
+meth public java.lang.String getName()
+meth public java.lang.String toString()
+meth public org.graalvm.options.OptionCategory getCategory()
+meth public org.graalvm.options.OptionKey<?> getKey()
+meth public org.graalvm.options.OptionStability getStability()
+meth public static <%0 extends java.lang.Object> org.graalvm.options.OptionDescriptor$Builder newBuilder(org.graalvm.options.OptionKey<{%%0}>,java.lang.String)
+supr java.lang.Object
+hfds EMPTY,category,deprecated,deprecationMessage,help,key,name,stability
+
+CLSS public final org.graalvm.options.OptionDescriptor$Builder
+ outer org.graalvm.options.OptionDescriptor
+meth public org.graalvm.options.OptionDescriptor build()
+meth public org.graalvm.options.OptionDescriptor$Builder category(org.graalvm.options.OptionCategory)
+meth public org.graalvm.options.OptionDescriptor$Builder deprecated(boolean)
+meth public org.graalvm.options.OptionDescriptor$Builder deprecationMessage(java.lang.String)
+meth public org.graalvm.options.OptionDescriptor$Builder help(java.lang.String)
+meth public org.graalvm.options.OptionDescriptor$Builder stability(org.graalvm.options.OptionStability)
+supr java.lang.Object
+hfds category,deprecated,deprecationMessage,help,key,name,stability
+
+CLSS public abstract interface org.graalvm.options.OptionDescriptors
+fld public final static org.graalvm.options.OptionDescriptors EMPTY
+intf java.lang.Iterable<org.graalvm.options.OptionDescriptor>
+meth public !varargs static org.graalvm.options.OptionDescriptors createUnion(org.graalvm.options.OptionDescriptors[])
+meth public abstract java.util.Iterator<org.graalvm.options.OptionDescriptor> iterator()
+meth public abstract org.graalvm.options.OptionDescriptor get(java.lang.String)
+meth public static org.graalvm.options.OptionDescriptors create(java.util.List<org.graalvm.options.OptionDescriptor>)
+
+CLSS public final org.graalvm.options.OptionKey<%0 extends java.lang.Object>
+cons public init({org.graalvm.options.OptionKey%0})
+cons public init({org.graalvm.options.OptionKey%0},org.graalvm.options.OptionType<{org.graalvm.options.OptionKey%0}>)
+meth public boolean hasBeenSet(org.graalvm.options.OptionValues)
+meth public org.graalvm.options.OptionType<{org.graalvm.options.OptionKey%0}> getType()
+meth public static <%0 extends java.lang.Object> org.graalvm.options.OptionKey<org.graalvm.options.OptionMap<{%%0}>> mapOf(java.lang.Class<{%%0}>)
+meth public {org.graalvm.options.OptionKey%0} getDefaultValue()
+meth public {org.graalvm.options.OptionKey%0} getValue(org.graalvm.options.OptionValues)
+supr java.lang.Object
+hfds defaultValue,type
+
+CLSS public final org.graalvm.options.OptionMap<%0 extends java.lang.Object>
+meth public boolean equals(java.lang.Object)
+meth public int hashCode()
+meth public java.util.Set<java.util.Map$Entry<java.lang.String,{org.graalvm.options.OptionMap%0}>> entrySet()
+meth public static <%0 extends java.lang.Object> org.graalvm.options.OptionMap<{%%0}> empty()
+meth public {org.graalvm.options.OptionMap%0} get(java.lang.String)
+supr java.lang.Object
+hfds EMPTY,backingMap,readonlyMap
+
+CLSS public final !enum org.graalvm.options.OptionStability
+fld public final static org.graalvm.options.OptionStability EXPERIMENTAL
+fld public final static org.graalvm.options.OptionStability STABLE
+meth public static org.graalvm.options.OptionStability valueOf(java.lang.String)
+meth public static org.graalvm.options.OptionStability[] values()
+supr java.lang.Enum<org.graalvm.options.OptionStability>
+
+CLSS public final org.graalvm.options.OptionType<%0 extends java.lang.Object>
+cons public init(java.lang.String,java.util.function.Function<java.lang.String,{org.graalvm.options.OptionType%0}>)
+cons public init(java.lang.String,java.util.function.Function<java.lang.String,{org.graalvm.options.OptionType%0}>,java.util.function.Consumer<{org.graalvm.options.OptionType%0}>)
+cons public init(java.lang.String,{org.graalvm.options.OptionType%0},java.util.function.Function<java.lang.String,{org.graalvm.options.OptionType%0}>)
+ anno 0 java.lang.Deprecated()
+cons public init(java.lang.String,{org.graalvm.options.OptionType%0},java.util.function.Function<java.lang.String,{org.graalvm.options.OptionType%0}>,java.util.function.Consumer<{org.graalvm.options.OptionType%0}>)
+ anno 0 java.lang.Deprecated()
+meth public java.lang.String getName()
+meth public java.lang.String toString()
+meth public static <%0 extends java.lang.Object> org.graalvm.options.OptionType<{%%0}> defaultType(java.lang.Class<{%%0}>)
+meth public static <%0 extends java.lang.Object> org.graalvm.options.OptionType<{%%0}> defaultType({%%0})
+meth public void validate({org.graalvm.options.OptionType%0})
+meth public {org.graalvm.options.OptionType%0} convert(java.lang.Object,java.lang.String,java.lang.String)
+meth public {org.graalvm.options.OptionType%0} convert(java.lang.String)
+meth public {org.graalvm.options.OptionType%0} getDefaultValue()
+ anno 0 java.lang.Deprecated()
+supr java.lang.Object
+hfds DEFAULTTYPES,EMPTY_VALIDATOR,converter,isOptionMap,name,validator
+hcls Converter
+
+CLSS public abstract interface org.graalvm.options.OptionValues
+meth public abstract <%0 extends java.lang.Object> void set(org.graalvm.options.OptionKey<{%%0}>,{%%0})
+ anno 0 java.lang.Deprecated()
+meth public abstract <%0 extends java.lang.Object> {%%0} get(org.graalvm.options.OptionKey<{%%0}>)
+meth public abstract boolean hasBeenSet(org.graalvm.options.OptionKey<?>)
+meth public abstract org.graalvm.options.OptionDescriptors getDescriptors()
+meth public boolean hasSetOptions()
+
+CLSS public final org.graalvm.polyglot.Context
+innr public final Builder
+intf java.lang.AutoCloseable
+meth public !varargs static org.graalvm.polyglot.Context create(java.lang.String[])
+meth public !varargs static org.graalvm.polyglot.Context$Builder newBuilder(java.lang.String[])
+meth public boolean equals(java.lang.Object)
+meth public boolean initialize(java.lang.String)
+meth public int hashCode()
+meth public org.graalvm.polyglot.Engine getEngine()
+meth public org.graalvm.polyglot.Value asValue(java.lang.Object)
+meth public org.graalvm.polyglot.Value eval(java.lang.String,java.lang.CharSequence)
+meth public org.graalvm.polyglot.Value eval(org.graalvm.polyglot.Source)
+meth public org.graalvm.polyglot.Value getBindings(java.lang.String)
+meth public org.graalvm.polyglot.Value getPolyglotBindings()
+meth public org.graalvm.polyglot.Value parse(java.lang.String,java.lang.CharSequence)
+meth public org.graalvm.polyglot.Value parse(org.graalvm.polyglot.Source)
+meth public static org.graalvm.polyglot.Context getCurrent()
+meth public void close()
+meth public void close(boolean)
+meth public void enter()
+meth public void interrupt(java.time.Duration) throws java.util.concurrent.TimeoutException
+meth public void leave()
+meth public void resetLimits()
+supr java.lang.Object
+hfds ALL_HOST_CLASSES,EMPTY,NO_HOST_CLASSES,UNSET_HOST_LOOKUP,impl
+
+CLSS public final org.graalvm.polyglot.Context$Builder
+ outer org.graalvm.polyglot.Context
+meth public org.graalvm.polyglot.Context build()
+meth public org.graalvm.polyglot.Context$Builder allowAllAccess(boolean)
+meth public org.graalvm.polyglot.Context$Builder allowCreateProcess(boolean)
+meth public org.graalvm.polyglot.Context$Builder allowCreateThread(boolean)
+meth public org.graalvm.polyglot.Context$Builder allowEnvironmentAccess(org.graalvm.polyglot.EnvironmentAccess)
+meth public org.graalvm.polyglot.Context$Builder allowExperimentalOptions(boolean)
+meth public org.graalvm.polyglot.Context$Builder allowHostAccess(boolean)
+ anno 0 java.lang.Deprecated()
+meth public org.graalvm.polyglot.Context$Builder allowHostAccess(org.graalvm.polyglot.HostAccess)
+meth public org.graalvm.polyglot.Context$Builder allowHostClassLoading(boolean)
+meth public org.graalvm.polyglot.Context$Builder allowHostClassLookup(java.util.function.Predicate<java.lang.String>)
+meth public org.graalvm.polyglot.Context$Builder allowIO(boolean)
+meth public org.graalvm.polyglot.Context$Builder allowNativeAccess(boolean)
+meth public org.graalvm.polyglot.Context$Builder allowPolyglotAccess(org.graalvm.polyglot.PolyglotAccess)
+meth public org.graalvm.polyglot.Context$Builder arguments(java.lang.String,java.lang.String[])
+meth public org.graalvm.polyglot.Context$Builder currentWorkingDirectory(java.nio.file.Path)
+meth public org.graalvm.polyglot.Context$Builder engine(org.graalvm.polyglot.Engine)
+meth public org.graalvm.polyglot.Context$Builder environment(java.lang.String,java.lang.String)
+meth public org.graalvm.polyglot.Context$Builder environment(java.util.Map<java.lang.String,java.lang.String>)
+meth public org.graalvm.polyglot.Context$Builder err(java.io.OutputStream)
+meth public org.graalvm.polyglot.Context$Builder fileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public org.graalvm.polyglot.Context$Builder hostClassFilter(java.util.function.Predicate<java.lang.String>)
+ anno 0 java.lang.Deprecated()
+meth public org.graalvm.polyglot.Context$Builder hostClassLoader(java.lang.ClassLoader)
+meth public org.graalvm.polyglot.Context$Builder in(java.io.InputStream)
+meth public org.graalvm.polyglot.Context$Builder logHandler(java.io.OutputStream)
+meth public org.graalvm.polyglot.Context$Builder logHandler(java.util.logging.Handler)
+meth public org.graalvm.polyglot.Context$Builder option(java.lang.String,java.lang.String)
+meth public org.graalvm.polyglot.Context$Builder options(java.util.Map<java.lang.String,java.lang.String>)
+meth public org.graalvm.polyglot.Context$Builder out(java.io.OutputStream)
+meth public org.graalvm.polyglot.Context$Builder processHandler(org.graalvm.polyglot.io.ProcessHandler)
+meth public org.graalvm.polyglot.Context$Builder resourceLimits(org.graalvm.polyglot.ResourceLimits)
+meth public org.graalvm.polyglot.Context$Builder serverTransport(org.graalvm.polyglot.io.MessageTransport)
+meth public org.graalvm.polyglot.Context$Builder timeZone(java.time.ZoneId)
+supr java.lang.Object
+hfds allowAllAccess,allowCreateProcess,allowCreateThread,allowExperimentalOptions,allowHostAccess,allowHostClassLoading,allowIO,allowNativeAccess,arguments,currentWorkingDirectory,customFileSystem,customLogHandler,environment,environmentAccess,err,hostAccess,hostClassFilter,hostClassLoader,in,messageTransport,onlyLanguages,options,out,polyglotAccess,processHandler,resourceLimits,sharedEngine,zone
+
+CLSS public final org.graalvm.polyglot.Engine
+innr public final Builder
+intf java.lang.AutoCloseable
+meth public java.lang.String getImplementationName()
+meth public java.lang.String getVersion()
+meth public java.util.Map<java.lang.String,org.graalvm.polyglot.Instrument> getInstruments()
+meth public java.util.Map<java.lang.String,org.graalvm.polyglot.Language> getLanguages()
+meth public java.util.Set<org.graalvm.polyglot.Source> getCachedSources()
+meth public org.graalvm.options.OptionDescriptors getOptions()
+meth public static java.nio.file.Path findHome()
+meth public static org.graalvm.polyglot.Engine create()
+meth public static org.graalvm.polyglot.Engine$Builder newBuilder()
+meth public void close()
+meth public void close(boolean)
+supr java.lang.Object
+hfds EMPTY,JDK8_OR_EARLIER,impl
+hcls APIAccessImpl,ImplHolder,PolyglotInvalid
+
+CLSS public final org.graalvm.polyglot.Engine$Builder
+ outer org.graalvm.polyglot.Engine
+meth public org.graalvm.polyglot.Engine build()
+meth public org.graalvm.polyglot.Engine$Builder allowExperimentalOptions(boolean)
+meth public org.graalvm.polyglot.Engine$Builder err(java.io.OutputStream)
+meth public org.graalvm.polyglot.Engine$Builder in(java.io.InputStream)
+meth public org.graalvm.polyglot.Engine$Builder logHandler(java.io.OutputStream)
+meth public org.graalvm.polyglot.Engine$Builder logHandler(java.util.logging.Handler)
+meth public org.graalvm.polyglot.Engine$Builder option(java.lang.String,java.lang.String)
+meth public org.graalvm.polyglot.Engine$Builder options(java.util.Map<java.lang.String,java.lang.String>)
+meth public org.graalvm.polyglot.Engine$Builder out(java.io.OutputStream)
+meth public org.graalvm.polyglot.Engine$Builder serverTransport(org.graalvm.polyglot.io.MessageTransport)
+meth public org.graalvm.polyglot.Engine$Builder useSystemProperties(boolean)
+supr java.lang.Object
+hfds allowExperimentalOptions,boundEngine,customLogHandler,err,in,messageTransport,options,out,useSystemProperties
+
+CLSS public final org.graalvm.polyglot.EnvironmentAccess
+fld public final static org.graalvm.polyglot.EnvironmentAccess INHERIT
+fld public final static org.graalvm.polyglot.EnvironmentAccess NONE
+supr java.lang.Object
+
+CLSS public final org.graalvm.polyglot.HostAccess
+fld public final static org.graalvm.polyglot.HostAccess ALL
+fld public final static org.graalvm.polyglot.HostAccess EXPLICIT
+fld public final static org.graalvm.polyglot.HostAccess NONE
+innr public abstract interface static !annotation Export
+innr public abstract interface static !annotation Implementable
+innr public final Builder
+innr public final static !enum TargetMappingPrecedence
+meth public boolean equals(java.lang.Object)
+meth public int hashCode()
+meth public java.lang.String toString()
+meth public static org.graalvm.polyglot.HostAccess$Builder newBuilder()
+meth public static org.graalvm.polyglot.HostAccess$Builder newBuilder(org.graalvm.polyglot.HostAccess)
+supr java.lang.Object
+hfds EMPTY,accessAnnotations,allowAllClassImplementations,allowAllInterfaceImplementations,allowArrayAccess,allowListAccess,allowPublic,excludeTypes,impl,implementableAnnotations,implementableTypes,members,name,targetMappings
+
+CLSS public final org.graalvm.polyglot.HostAccess$Builder
+ outer org.graalvm.polyglot.HostAccess
+meth public <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.polyglot.HostAccess$Builder targetTypeMapping(java.lang.Class<{%%0}>,java.lang.Class<{%%1}>,java.util.function.Predicate<{%%0}>,java.util.function.Function<{%%0},{%%1}>)
+meth public <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.polyglot.HostAccess$Builder targetTypeMapping(java.lang.Class<{%%0}>,java.lang.Class<{%%1}>,java.util.function.Predicate<{%%0}>,java.util.function.Function<{%%0},{%%1}>,org.graalvm.polyglot.HostAccess$TargetMappingPrecedence)
+meth public org.graalvm.polyglot.HostAccess build()
+meth public org.graalvm.polyglot.HostAccess$Builder allowAccess(java.lang.reflect.Executable)
+meth public org.graalvm.polyglot.HostAccess$Builder allowAccess(java.lang.reflect.Field)
+meth public org.graalvm.polyglot.HostAccess$Builder allowAccessAnnotatedBy(java.lang.Class<? extends java.lang.annotation.Annotation>)
+meth public org.graalvm.polyglot.HostAccess$Builder allowAllClassImplementations(boolean)
+meth public org.graalvm.polyglot.HostAccess$Builder allowAllImplementations(boolean)
+meth public org.graalvm.polyglot.HostAccess$Builder allowArrayAccess(boolean)
+meth public org.graalvm.polyglot.HostAccess$Builder allowImplementations(java.lang.Class<?>)
+meth public org.graalvm.polyglot.HostAccess$Builder allowImplementationsAnnotatedBy(java.lang.Class<? extends java.lang.annotation.Annotation>)
+meth public org.graalvm.polyglot.HostAccess$Builder allowListAccess(boolean)
+meth public org.graalvm.polyglot.HostAccess$Builder allowPublicAccess(boolean)
+meth public org.graalvm.polyglot.HostAccess$Builder denyAccess(java.lang.Class<?>)
+meth public org.graalvm.polyglot.HostAccess$Builder denyAccess(java.lang.Class<?>,boolean)
+supr java.lang.Object
+hfds accessAnnotations,allowAllClassImplementations,allowAllImplementations,allowArrayAccess,allowListAccess,allowPublic,excludeTypes,implementableTypes,implementationAnnotations,members,name,targetMappings
+
+CLSS public abstract interface static !annotation org.graalvm.polyglot.HostAccess$Export
+ outer org.graalvm.polyglot.HostAccess
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[CONSTRUCTOR, FIELD, METHOD])
+intf java.lang.annotation.Annotation
+
+CLSS public abstract interface static !annotation org.graalvm.polyglot.HostAccess$Implementable
+ outer org.graalvm.polyglot.HostAccess
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+
+CLSS public final static !enum org.graalvm.polyglot.HostAccess$TargetMappingPrecedence
+ outer org.graalvm.polyglot.HostAccess
+fld public final static org.graalvm.polyglot.HostAccess$TargetMappingPrecedence HIGH
+fld public final static org.graalvm.polyglot.HostAccess$TargetMappingPrecedence HIGHEST
+fld public final static org.graalvm.polyglot.HostAccess$TargetMappingPrecedence LOW
+fld public final static org.graalvm.polyglot.HostAccess$TargetMappingPrecedence LOWEST
+meth public static org.graalvm.polyglot.HostAccess$TargetMappingPrecedence valueOf(java.lang.String)
+meth public static org.graalvm.polyglot.HostAccess$TargetMappingPrecedence[] values()
+supr java.lang.Enum<org.graalvm.polyglot.HostAccess$TargetMappingPrecedence>
+
+CLSS public final org.graalvm.polyglot.Instrument
+meth public <%0 extends java.lang.Object> {%%0} lookup(java.lang.Class<{%%0}>)
+meth public java.lang.String getId()
+meth public java.lang.String getName()
+meth public java.lang.String getVersion()
+meth public org.graalvm.options.OptionDescriptors getOptions()
+supr java.lang.Object
+hfds impl
+
+CLSS public final org.graalvm.polyglot.Language
+meth public boolean isInteractive()
+meth public java.lang.String getDefaultMimeType()
+meth public java.lang.String getId()
+meth public java.lang.String getImplementationName()
+meth public java.lang.String getName()
+meth public java.lang.String getVersion()
+meth public java.util.Set<java.lang.String> getMimeTypes()
+meth public org.graalvm.options.OptionDescriptors getOptions()
+supr java.lang.Object
+hfds impl
+
+CLSS public final org.graalvm.polyglot.PolyglotAccess
+fld public final static org.graalvm.polyglot.PolyglotAccess ALL
+fld public final static org.graalvm.polyglot.PolyglotAccess NONE
+innr public final Builder
+meth public static org.graalvm.polyglot.PolyglotAccess$Builder newBuilder()
+supr java.lang.Object
+hfds EMPTY,allAccess,bindingsAccess,evalAccess
+
+CLSS public final org.graalvm.polyglot.PolyglotAccess$Builder
+ outer org.graalvm.polyglot.PolyglotAccess
+meth public !varargs org.graalvm.polyglot.PolyglotAccess$Builder allowEvalBetween(java.lang.String[])
+meth public !varargs org.graalvm.polyglot.PolyglotAccess$Builder denyEvalBetween(java.lang.String[])
+meth public org.graalvm.polyglot.PolyglotAccess build()
+meth public org.graalvm.polyglot.PolyglotAccess$Builder allowBindingsAccess(java.lang.String)
+meth public org.graalvm.polyglot.PolyglotAccess$Builder allowEval(java.lang.String,java.lang.String)
+meth public org.graalvm.polyglot.PolyglotAccess$Builder denyBindingsAccess(java.lang.String)
+meth public org.graalvm.polyglot.PolyglotAccess$Builder denyEval(java.lang.String,java.lang.String)
+supr java.lang.Object
+hfds bindingsAccess,evalAccess
+
+CLSS public final org.graalvm.polyglot.PolyglotException
+innr public final StackFrame
+meth public boolean equals(java.lang.Object)
+meth public boolean isCancelled()
+meth public boolean isExit()
+meth public boolean isGuestException()
+meth public boolean isHostException()
+meth public boolean isIncompleteSource()
+meth public boolean isInternalError()
+meth public boolean isInterrupted()
+meth public boolean isResourceExhausted()
+meth public boolean isSyntaxError()
+meth public int getExitStatus()
+meth public int hashCode()
+meth public java.lang.Iterable<org.graalvm.polyglot.PolyglotException$StackFrame> getPolyglotStackTrace()
+meth public java.lang.StackTraceElement[] getStackTrace()
+meth public java.lang.String getMessage()
+meth public java.lang.Throwable asHostException()
+meth public java.lang.Throwable fillInStackTrace()
+meth public org.graalvm.polyglot.SourceSection getSourceLocation()
+meth public org.graalvm.polyglot.Value getGuestObject()
+meth public void printStackTrace()
+meth public void printStackTrace(java.io.PrintStream)
+meth public void printStackTrace(java.io.PrintWriter)
+meth public void setStackTrace(java.lang.StackTraceElement[])
+supr java.lang.RuntimeException
+hfds impl
+
+CLSS public final org.graalvm.polyglot.PolyglotException$StackFrame
+ outer org.graalvm.polyglot.PolyglotException
+meth public boolean isGuestFrame()
+meth public boolean isHostFrame()
+meth public java.lang.StackTraceElement toHostFrame()
+meth public java.lang.String getRootName()
+meth public java.lang.String toString()
+meth public org.graalvm.polyglot.Language getLanguage()
+meth public org.graalvm.polyglot.SourceSection getSourceLocation()
+supr java.lang.Object
+hfds impl
+
+CLSS public final org.graalvm.polyglot.ResourceLimitEvent
+meth public java.lang.String toString()
+meth public org.graalvm.polyglot.Context getContext()
+supr java.lang.Object
+hfds impl
+
+CLSS public final org.graalvm.polyglot.ResourceLimits
+innr public final Builder
+meth public static org.graalvm.polyglot.ResourceLimits$Builder newBuilder()
+supr java.lang.Object
+hfds EMPTY,impl
+
+CLSS public final org.graalvm.polyglot.ResourceLimits$Builder
+ outer org.graalvm.polyglot.ResourceLimits
+meth public org.graalvm.polyglot.ResourceLimits build()
+meth public org.graalvm.polyglot.ResourceLimits$Builder onLimit(java.util.function.Consumer<org.graalvm.polyglot.ResourceLimitEvent>)
+meth public org.graalvm.polyglot.ResourceLimits$Builder statementLimit(long,java.util.function.Predicate<org.graalvm.polyglot.Source>)
+supr java.lang.Object
+hfds onLimit,statementLimit,statementLimitSourceFilter,timeLimit,timeLimitAccuracy
+
+CLSS public final org.graalvm.polyglot.Source
+innr public Builder
+meth public boolean equals(java.lang.Object)
+meth public boolean hasBytes()
+meth public boolean hasCharacters()
+meth public boolean isInteractive()
+meth public boolean isInternal()
+meth public int getColumnNumber(int)
+meth public int getLength()
+meth public int getLineCount()
+meth public int getLineLength(int)
+meth public int getLineNumber(int)
+meth public int getLineStartOffset(int)
+meth public int hashCode()
+meth public java.io.InputStream getInputStream()
+ anno 0 java.lang.Deprecated()
+meth public java.io.Reader getReader()
+meth public java.lang.CharSequence getCharacters()
+meth public java.lang.CharSequence getCharacters(int)
+meth public java.lang.String getLanguage()
+meth public java.lang.String getMimeType()
+meth public java.lang.String getName()
+meth public java.lang.String getPath()
+meth public java.lang.String toString()
+meth public java.net.URI getURI()
+meth public java.net.URL getURL()
+meth public org.graalvm.polyglot.io.ByteSequence getBytes()
+meth public static java.lang.String findLanguage(java.io.File) throws java.io.IOException
+meth public static java.lang.String findLanguage(java.lang.String)
+meth public static java.lang.String findLanguage(java.net.URL) throws java.io.IOException
+meth public static java.lang.String findMimeType(java.io.File) throws java.io.IOException
+meth public static java.lang.String findMimeType(java.net.URL) throws java.io.IOException
+meth public static org.graalvm.polyglot.Source create(java.lang.String,java.lang.CharSequence)
+meth public static org.graalvm.polyglot.Source$Builder newBuilder(java.lang.String,java.io.File)
+meth public static org.graalvm.polyglot.Source$Builder newBuilder(java.lang.String,java.io.Reader,java.lang.String)
+meth public static org.graalvm.polyglot.Source$Builder newBuilder(java.lang.String,java.lang.CharSequence,java.lang.String)
+meth public static org.graalvm.polyglot.Source$Builder newBuilder(java.lang.String,java.net.URL)
+meth public static org.graalvm.polyglot.Source$Builder newBuilder(java.lang.String,org.graalvm.polyglot.io.ByteSequence,java.lang.String)
+supr java.lang.Object
+hfds EMPTY,IMPL,impl
+
+CLSS public org.graalvm.polyglot.Source$Builder
+ outer org.graalvm.polyglot.Source
+meth public org.graalvm.polyglot.Source build() throws java.io.IOException
+meth public org.graalvm.polyglot.Source buildLiteral()
+meth public org.graalvm.polyglot.Source$Builder cached(boolean)
+meth public org.graalvm.polyglot.Source$Builder content(java.lang.CharSequence)
+meth public org.graalvm.polyglot.Source$Builder content(java.lang.String)
+meth public org.graalvm.polyglot.Source$Builder content(org.graalvm.polyglot.io.ByteSequence)
+meth public org.graalvm.polyglot.Source$Builder encoding(java.nio.charset.Charset)
+meth public org.graalvm.polyglot.Source$Builder interactive(boolean)
+meth public org.graalvm.polyglot.Source$Builder internal(boolean)
+meth public org.graalvm.polyglot.Source$Builder mimeType(java.lang.String)
+meth public org.graalvm.polyglot.Source$Builder name(java.lang.String)
+meth public org.graalvm.polyglot.Source$Builder uri(java.net.URI)
+supr java.lang.Object
+hfds cached,content,fileEncoding,interactive,internal,language,mimeType,name,origin,uri
+
+CLSS public final org.graalvm.polyglot.SourceSection
+meth public boolean equals(java.lang.Object)
+meth public boolean hasCharIndex()
+meth public boolean hasColumns()
+meth public boolean hasLines()
+meth public boolean isAvailable()
+meth public int getCharEndIndex()
+meth public int getCharIndex()
+meth public int getCharLength()
+meth public int getEndColumn()
+meth public int getEndLine()
+meth public int getStartColumn()
+meth public int getStartLine()
+meth public int hashCode()
+meth public java.lang.CharSequence getCharacters()
+meth public java.lang.CharSequence getCode()
+ anno 0 java.lang.Deprecated()
+meth public java.lang.String toString()
+meth public org.graalvm.polyglot.Source getSource()
+supr java.lang.Object
+hfds IMPL,impl,source
+
+CLSS public abstract org.graalvm.polyglot.TypeLiteral<%0 extends java.lang.Object>
+cons protected init()
+meth public final boolean equals(java.lang.Object)
+meth public final int hashCode()
+meth public final java.lang.Class<{org.graalvm.polyglot.TypeLiteral%0}> getRawType()
+meth public final java.lang.String toString()
+meth public final java.lang.reflect.Type getType()
+supr java.lang.Object
+hfds rawType,type
+
+CLSS public final org.graalvm.polyglot.Value
+meth public !varargs org.graalvm.polyglot.Value execute(java.lang.Object[])
+meth public !varargs org.graalvm.polyglot.Value invokeMember(java.lang.String,java.lang.Object[])
+meth public !varargs org.graalvm.polyglot.Value newInstance(java.lang.Object[])
+meth public !varargs void executeVoid(java.lang.Object[])
+meth public <%0 extends java.lang.Object> {%%0} as(java.lang.Class<{%%0}>)
+meth public <%0 extends java.lang.Object> {%%0} as(org.graalvm.polyglot.TypeLiteral<{%%0}>)
+meth public <%0 extends java.lang.Object> {%%0} asHostObject()
+meth public <%0 extends org.graalvm.polyglot.proxy.Proxy> {%%0} asProxyObject()
+meth public boolean asBoolean()
+meth public boolean canExecute()
+meth public boolean canInstantiate()
+meth public boolean canInvokeMember(java.lang.String)
+meth public boolean equals(java.lang.Object)
+meth public boolean fitsInByte()
+meth public boolean fitsInDouble()
+meth public boolean fitsInFloat()
+meth public boolean fitsInInt()
+meth public boolean fitsInLong()
+meth public boolean fitsInShort()
+meth public boolean hasArrayElements()
+meth public boolean hasMember(java.lang.String)
+meth public boolean hasMembers()
+meth public boolean isBoolean()
+meth public boolean isDate()
+meth public boolean isDuration()
+meth public boolean isException()
+meth public boolean isHostObject()
+meth public boolean isInstant()
+meth public boolean isMetaInstance(java.lang.Object)
+meth public boolean isMetaObject()
+meth public boolean isNativePointer()
+meth public boolean isNull()
+meth public boolean isNumber()
+meth public boolean isProxyObject()
+meth public boolean isString()
+meth public boolean isTime()
+meth public boolean isTimeZone()
+meth public boolean removeArrayElement(long)
+meth public boolean removeMember(java.lang.String)
+meth public byte asByte()
+meth public double asDouble()
+meth public float asFloat()
+meth public int asInt()
+meth public int hashCode()
+meth public java.lang.RuntimeException throwException()
+meth public java.lang.String asString()
+meth public java.lang.String getMetaQualifiedName()
+meth public java.lang.String getMetaSimpleName()
+meth public java.lang.String toString()
+meth public java.time.Duration asDuration()
+meth public java.time.Instant asInstant()
+meth public java.time.LocalDate asDate()
+meth public java.time.LocalTime asTime()
+meth public java.time.ZoneId asTimeZone()
+meth public java.util.Set<java.lang.String> getMemberKeys()
+meth public long asLong()
+meth public long asNativePointer()
+meth public long getArraySize()
+meth public org.graalvm.polyglot.Context getContext()
+meth public org.graalvm.polyglot.SourceSection getSourceLocation()
+meth public org.graalvm.polyglot.Value getArrayElement(long)
+meth public org.graalvm.polyglot.Value getMember(java.lang.String)
+meth public org.graalvm.polyglot.Value getMetaObject()
+meth public short asShort()
+meth public static org.graalvm.polyglot.Value asValue(java.lang.Object)
+meth public void putMember(java.lang.String,java.lang.Object)
+meth public void setArrayElement(long,java.lang.Object)
+supr java.lang.Object
+hfds impl,receiver
+
+CLSS public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init()
+innr public abstract static APIAccess
+innr public abstract static AbstractContextImpl
+innr public abstract static AbstractEngineImpl
+innr public abstract static AbstractExceptionImpl
+innr public abstract static AbstractInstrumentImpl
+innr public abstract static AbstractLanguageImpl
+innr public abstract static AbstractManagementImpl
+innr public abstract static AbstractSourceImpl
+innr public abstract static AbstractSourceSectionImpl
+innr public abstract static AbstractStackFrameImpl
+innr public abstract static AbstractValueImpl
+innr public abstract static IOAccess
+innr public abstract static ManagementAccess
+meth protected void initialize()
+meth public abstract <%0 extends java.lang.Object, %1 extends java.lang.Object> java.lang.Object newTargetTypeMapping(java.lang.Class<{%%0}>,java.lang.Class<{%%1}>,java.util.function.Predicate<{%%0}>,java.util.function.Function<{%%0},{%%1}>,org.graalvm.polyglot.HostAccess$TargetMappingPrecedence)
+meth public abstract java.lang.Class<?> loadLanguageClass(java.lang.String)
+meth public abstract java.lang.Object buildLimits(long,java.util.function.Predicate<org.graalvm.polyglot.Source>,java.util.function.Consumer<org.graalvm.polyglot.ResourceLimitEvent>)
+meth public abstract java.util.Collection<org.graalvm.polyglot.Engine> findActiveEngines()
+meth public abstract org.graalvm.polyglot.Context getCurrentContext()
+meth public abstract org.graalvm.polyglot.Context getLimitEventContext(java.lang.Object)
+meth public abstract org.graalvm.polyglot.Engine buildEngine(java.io.OutputStream,java.io.OutputStream,java.io.InputStream,java.util.Map<java.lang.String,java.lang.String>,boolean,boolean,boolean,org.graalvm.polyglot.io.MessageTransport,java.lang.Object,org.graalvm.polyglot.HostAccess)
+meth public abstract org.graalvm.polyglot.Value asValue(java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractManagementImpl getManagementImpl()
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceImpl getSourceImpl()
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceSectionImpl getSourceSectionImpl()
+meth public abstract org.graalvm.polyglot.io.FileSystem newDefaultFileSystem()
+meth public abstract void preInitializeEngine()
+meth public abstract void resetPreInitializedEngine()
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccess getIO()
+meth public final void setConstructors(org.graalvm.polyglot.impl.AbstractPolyglotImpl$APIAccess)
+meth public final void setIO(org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccess)
+meth public final void setMonitoring(org.graalvm.polyglot.impl.AbstractPolyglotImpl$ManagementAccess)
+meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$APIAccess getAPIAccess()
+meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$ManagementAccess getManagement()
+supr java.lang.Object
+hfds api,io,management
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$APIAccess
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init()
+meth public abstract boolean allowsAccess(org.graalvm.polyglot.HostAccess,java.lang.reflect.AnnotatedElement)
+meth public abstract boolean allowsImplementation(org.graalvm.polyglot.HostAccess,java.lang.Class<?>)
+meth public abstract boolean isArrayAccessible(org.graalvm.polyglot.HostAccess)
+meth public abstract boolean isListAccessible(org.graalvm.polyglot.HostAccess)
+meth public abstract java.lang.Object getHostAccessImpl(org.graalvm.polyglot.HostAccess)
+meth public abstract java.lang.Object getImpl(org.graalvm.polyglot.ResourceLimits)
+meth public abstract java.lang.Object getReceiver(org.graalvm.polyglot.Value)
+meth public abstract java.lang.String validatePolyglotAccess(org.graalvm.polyglot.PolyglotAccess,org.graalvm.collections.UnmodifiableEconomicSet<java.lang.String>)
+meth public abstract java.util.List<java.lang.Object> getTargetMappings(org.graalvm.polyglot.HostAccess)
+meth public abstract org.graalvm.collections.UnmodifiableEconomicSet<java.lang.String> getBindingsAccess(org.graalvm.polyglot.PolyglotAccess)
+meth public abstract org.graalvm.collections.UnmodifiableEconomicSet<java.lang.String> getEvalAccess(org.graalvm.polyglot.PolyglotAccess,java.lang.String)
+meth public abstract org.graalvm.polyglot.Context newContext(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractContextImpl)
+meth public abstract org.graalvm.polyglot.Engine newEngine(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractEngineImpl)
+meth public abstract org.graalvm.polyglot.Instrument newInstrument(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractInstrumentImpl)
+meth public abstract org.graalvm.polyglot.Language newLanguage(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractLanguageImpl)
+meth public abstract org.graalvm.polyglot.PolyglotException newLanguageException(java.lang.String,org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExceptionImpl)
+meth public abstract org.graalvm.polyglot.PolyglotException$StackFrame newPolyglotStackTraceElement(org.graalvm.polyglot.PolyglotException,org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractStackFrameImpl)
+meth public abstract org.graalvm.polyglot.ResourceLimitEvent newResourceLimitsEvent(java.lang.Object)
+meth public abstract org.graalvm.polyglot.Source newSource(java.lang.Object)
+meth public abstract org.graalvm.polyglot.SourceSection newSourceSection(org.graalvm.polyglot.Source,java.lang.Object)
+meth public abstract org.graalvm.polyglot.Value newValue(java.lang.Object,org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractValueImpl)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractContextImpl getImpl(org.graalvm.polyglot.Context)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractEngineImpl getImpl(org.graalvm.polyglot.Engine)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExceptionImpl getImpl(org.graalvm.polyglot.PolyglotException)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractInstrumentImpl getImpl(org.graalvm.polyglot.Instrument)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractLanguageImpl getImpl(org.graalvm.polyglot.Language)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractStackFrameImpl getImpl(org.graalvm.polyglot.PolyglotException$StackFrame)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractValueImpl getImpl(org.graalvm.polyglot.Value)
+meth public abstract void setHostAccessImpl(org.graalvm.polyglot.HostAccess,java.lang.Object)
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractContextImpl
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract boolean initializeLanguage(java.lang.String)
+meth public abstract boolean interrupt(org.graalvm.polyglot.Context,java.time.Duration)
+meth public abstract org.graalvm.polyglot.Engine getEngineImpl(org.graalvm.polyglot.Context)
+meth public abstract org.graalvm.polyglot.Value asValue(java.lang.Object)
+meth public abstract org.graalvm.polyglot.Value eval(java.lang.String,java.lang.Object)
+meth public abstract org.graalvm.polyglot.Value getBindings(java.lang.String)
+meth public abstract org.graalvm.polyglot.Value getPolyglotBindings()
+meth public abstract org.graalvm.polyglot.Value parse(java.lang.String,java.lang.Object)
+meth public abstract void close(org.graalvm.polyglot.Context,boolean)
+meth public abstract void explicitEnter(org.graalvm.polyglot.Context)
+meth public abstract void explicitLeave(org.graalvm.polyglot.Context)
+meth public abstract void resetLimits()
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractEngineImpl
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract java.lang.String getImplementationName()
+meth public abstract java.util.Map<java.lang.String,org.graalvm.polyglot.Instrument> getInstruments()
+meth public abstract java.util.Map<java.lang.String,org.graalvm.polyglot.Language> getLanguages()
+meth public abstract java.util.Set<org.graalvm.polyglot.Source> getCachedSources()
+meth public abstract org.graalvm.options.OptionDescriptors getOptions()
+meth public abstract org.graalvm.polyglot.Context createContext(java.io.OutputStream,java.io.OutputStream,java.io.InputStream,boolean,org.graalvm.polyglot.HostAccess,org.graalvm.polyglot.PolyglotAccess,boolean,boolean,boolean,boolean,boolean,java.util.function.Predicate<java.lang.String>,java.util.Map<java.lang.String,java.lang.String>,java.util.Map<java.lang.String,java.lang.String[]>,java.lang.String[],org.graalvm.polyglot.io.FileSystem,java.lang.Object,boolean,org.graalvm.polyglot.io.ProcessHandler,org.graalvm.polyglot.EnvironmentAccess,java.util.Map<java.lang.String,java.lang.String>,java.time.ZoneId,java.lang.Object,java.lang.String,java.lang.ClassLoader)
+meth public abstract org.graalvm.polyglot.Instrument requirePublicInstrument(java.lang.String)
+meth public abstract org.graalvm.polyglot.Language requirePublicLanguage(java.lang.String)
+meth public abstract void close(org.graalvm.polyglot.Engine,boolean)
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExceptionImpl
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract boolean isCancelled()
+meth public abstract boolean isExit()
+meth public abstract boolean isHostException()
+meth public abstract boolean isIncompleteSource()
+meth public abstract boolean isInternalError()
+meth public abstract boolean isInterrupted()
+meth public abstract boolean isResourceExhausted()
+meth public abstract boolean isSyntaxError()
+meth public abstract int getExitStatus()
+meth public abstract java.lang.Iterable<org.graalvm.polyglot.PolyglotException$StackFrame> getPolyglotStackTrace()
+meth public abstract java.lang.StackTraceElement[] getStackTrace()
+meth public abstract java.lang.String getMessage()
+meth public abstract java.lang.Throwable asHostException()
+meth public abstract org.graalvm.polyglot.SourceSection getSourceLocation()
+meth public abstract org.graalvm.polyglot.Value getGuestObject()
+meth public abstract void onCreate(org.graalvm.polyglot.PolyglotException)
+meth public abstract void printStackTrace(java.io.PrintStream)
+meth public abstract void printStackTrace(java.io.PrintWriter)
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractInstrumentImpl
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract <%0 extends java.lang.Object> {%%0} lookup(java.lang.Class<{%%0}>)
+meth public abstract java.lang.String getId()
+meth public abstract java.lang.String getName()
+meth public abstract java.lang.String getVersion()
+meth public abstract org.graalvm.options.OptionDescriptors getOptions()
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractLanguageImpl
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract boolean isInteractive()
+meth public abstract java.lang.String getDefaultMimeType()
+meth public abstract java.lang.String getId()
+meth public abstract java.lang.String getImplementationName()
+meth public abstract java.lang.String getName()
+meth public abstract java.lang.String getVersion()
+meth public abstract java.util.Set<java.lang.String> getMimeTypes()
+meth public abstract org.graalvm.options.OptionDescriptors getOptions()
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractManagementImpl
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract boolean isExecutionEventExpression(java.lang.Object)
+meth public abstract boolean isExecutionEventRoot(java.lang.Object)
+meth public abstract boolean isExecutionEventStatement(java.lang.Object)
+meth public abstract java.lang.Object attachExecutionListener(org.graalvm.polyglot.Engine,java.util.function.Consumer<org.graalvm.polyglot.management.ExecutionEvent>,java.util.function.Consumer<org.graalvm.polyglot.management.ExecutionEvent>,boolean,boolean,boolean,java.util.function.Predicate<org.graalvm.polyglot.Source>,java.util.function.Predicate<java.lang.String>,boolean,boolean,boolean)
+meth public abstract java.lang.String getExecutionEventRootName(java.lang.Object)
+meth public abstract java.util.List<org.graalvm.polyglot.Value> getExecutionEventInputValues(java.lang.Object)
+meth public abstract org.graalvm.polyglot.PolyglotException getExecutionEventException(java.lang.Object)
+meth public abstract org.graalvm.polyglot.SourceSection getExecutionEventLocation(java.lang.Object)
+meth public abstract org.graalvm.polyglot.Value getExecutionEventReturnValue(java.lang.Object)
+meth public abstract void closeExecutionListener(java.lang.Object)
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceImpl
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+fld protected final org.graalvm.polyglot.impl.AbstractPolyglotImpl engineImpl
+meth public abstract boolean equals(java.lang.Object,java.lang.Object)
+meth public abstract boolean hasBytes(java.lang.Object)
+meth public abstract boolean hasCharacters(java.lang.Object)
+meth public abstract boolean isInteractive(java.lang.Object)
+meth public abstract boolean isInternal(java.lang.Object)
+meth public abstract int getColumnNumber(java.lang.Object,int)
+meth public abstract int getLength(java.lang.Object)
+meth public abstract int getLineCount(java.lang.Object)
+meth public abstract int getLineLength(java.lang.Object,int)
+meth public abstract int getLineNumber(java.lang.Object,int)
+meth public abstract int getLineStartOffset(java.lang.Object,int)
+meth public abstract int hashCode(java.lang.Object)
+meth public abstract java.io.InputStream getInputStream(java.lang.Object)
+meth public abstract java.io.Reader getReader(java.lang.Object)
+meth public abstract java.lang.CharSequence getCharacters(java.lang.Object)
+meth public abstract java.lang.CharSequence getCharacters(java.lang.Object,int)
+meth public abstract java.lang.String findLanguage(java.io.File) throws java.io.IOException
+meth public abstract java.lang.String findLanguage(java.lang.String)
+meth public abstract java.lang.String findLanguage(java.net.URL) throws java.io.IOException
+meth public abstract java.lang.String findMimeType(java.io.File) throws java.io.IOException
+meth public abstract java.lang.String findMimeType(java.net.URL) throws java.io.IOException
+meth public abstract java.lang.String getLanguage(java.lang.Object)
+meth public abstract java.lang.String getMimeType(java.lang.Object)
+meth public abstract java.lang.String getName(java.lang.Object)
+meth public abstract java.lang.String getPath(java.lang.Object)
+meth public abstract java.lang.String toString(java.lang.Object)
+meth public abstract java.net.URI getURI(java.lang.Object)
+meth public abstract java.net.URL getURL(java.lang.Object)
+meth public abstract org.graalvm.polyglot.Source build(java.lang.String,java.lang.Object,java.net.URI,java.lang.String,java.lang.String,java.lang.Object,boolean,boolean,boolean,java.nio.charset.Charset) throws java.io.IOException
+meth public abstract org.graalvm.polyglot.io.ByteSequence getBytes(java.lang.Object)
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceSectionImpl
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract boolean equals(java.lang.Object,java.lang.Object)
+meth public abstract boolean hasCharIndex(java.lang.Object)
+meth public abstract boolean hasColumns(java.lang.Object)
+meth public abstract boolean hasLines(java.lang.Object)
+meth public abstract boolean isAvailable(java.lang.Object)
+meth public abstract int getCharEndIndex(java.lang.Object)
+meth public abstract int getCharIndex(java.lang.Object)
+meth public abstract int getCharLength(java.lang.Object)
+meth public abstract int getEndColumn(java.lang.Object)
+meth public abstract int getEndLine(java.lang.Object)
+meth public abstract int getStartColumn(java.lang.Object)
+meth public abstract int getStartLine(java.lang.Object)
+meth public abstract int hashCode(java.lang.Object)
+meth public abstract java.lang.CharSequence getCode(java.lang.Object)
+meth public abstract java.lang.String toString(java.lang.Object)
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractStackFrameImpl
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract boolean isHostFrame()
+meth public abstract java.lang.StackTraceElement toHostFrame()
+meth public abstract java.lang.String getRootName()
+meth public abstract java.lang.String toStringImpl(int)
+meth public abstract org.graalvm.polyglot.Language getLanguage()
+meth public abstract org.graalvm.polyglot.SourceSection getSourceLocation()
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractValueImpl
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract <%0 extends java.lang.Object> {%%0} as(java.lang.Object,java.lang.Class<{%%0}>)
+meth public abstract <%0 extends java.lang.Object> {%%0} as(java.lang.Object,org.graalvm.polyglot.TypeLiteral<{%%0}>)
+meth public abstract boolean asBoolean(java.lang.Object)
+meth public abstract boolean equalsImpl(java.lang.Object,java.lang.Object)
+meth public abstract boolean isMetaInstance(java.lang.Object,java.lang.Object)
+meth public abstract boolean removeArrayElement(java.lang.Object,long)
+meth public abstract boolean removeMember(java.lang.Object,java.lang.String)
+meth public abstract byte asByte(java.lang.Object)
+meth public abstract double asDouble(java.lang.Object)
+meth public abstract float asFloat(java.lang.Object)
+meth public abstract int asInt(java.lang.Object)
+meth public abstract int hashCodeImpl(java.lang.Object)
+meth public abstract java.lang.Object asHostObject(java.lang.Object)
+meth public abstract java.lang.Object asProxyObject(java.lang.Object)
+meth public abstract java.lang.RuntimeException throwException(java.lang.Object)
+meth public abstract java.lang.String asString(java.lang.Object)
+meth public abstract java.lang.String getMetaQualifiedName(java.lang.Object)
+meth public abstract java.lang.String getMetaSimpleName(java.lang.Object)
+meth public abstract java.lang.String toString(java.lang.Object)
+meth public abstract java.time.Duration asDuration(java.lang.Object)
+meth public abstract java.time.Instant asInstant(java.lang.Object)
+meth public abstract java.time.LocalDate asDate(java.lang.Object)
+meth public abstract java.time.LocalTime asTime(java.lang.Object)
+meth public abstract java.time.ZoneId asTimeZone(java.lang.Object)
+meth public abstract long asLong(java.lang.Object)
+meth public abstract long asNativePointer(java.lang.Object)
+meth public abstract long getArraySize(java.lang.Object)
+meth public abstract org.graalvm.polyglot.SourceSection getSourceLocation(java.lang.Object)
+meth public abstract org.graalvm.polyglot.Value execute(java.lang.Object)
+meth public abstract org.graalvm.polyglot.Value execute(java.lang.Object,java.lang.Object[])
+meth public abstract org.graalvm.polyglot.Value getArrayElement(java.lang.Object,long)
+meth public abstract org.graalvm.polyglot.Value getMember(java.lang.Object,java.lang.String)
+meth public abstract org.graalvm.polyglot.Value getMetaObject(java.lang.Object)
+meth public abstract org.graalvm.polyglot.Value invoke(java.lang.Object,java.lang.String)
+meth public abstract org.graalvm.polyglot.Value invoke(java.lang.Object,java.lang.String,java.lang.Object[])
+meth public abstract org.graalvm.polyglot.Value newInstance(java.lang.Object,java.lang.Object[])
+meth public abstract short asShort(java.lang.Object)
+meth public abstract void executeVoid(java.lang.Object)
+meth public abstract void executeVoid(java.lang.Object,java.lang.Object[])
+meth public abstract void putMember(java.lang.Object,java.lang.String,java.lang.Object)
+meth public abstract void setArrayElement(java.lang.Object,long,java.lang.Object)
+meth public boolean canExecute(java.lang.Object)
+meth public boolean canInstantiate(java.lang.Object)
+meth public boolean canInvoke(java.lang.String,java.lang.Object)
+meth public boolean fitsInByte(java.lang.Object)
+meth public boolean fitsInDouble(java.lang.Object)
+meth public boolean fitsInFloat(java.lang.Object)
+meth public boolean fitsInInt(java.lang.Object)
+meth public boolean fitsInLong(java.lang.Object)
+meth public boolean fitsInShort(java.lang.Object)
+meth public boolean hasArrayElements(java.lang.Object)
+meth public boolean hasMember(java.lang.Object,java.lang.String)
+meth public boolean hasMembers(java.lang.Object)
+meth public boolean isBoolean(java.lang.Object)
+meth public boolean isDate(java.lang.Object)
+meth public boolean isDuration(java.lang.Object)
+meth public boolean isException(java.lang.Object)
+meth public boolean isHostObject(java.lang.Object)
+meth public boolean isMetaObject(java.lang.Object)
+meth public boolean isNativePointer(java.lang.Object)
+meth public boolean isNull(java.lang.Object)
+meth public boolean isNumber(java.lang.Object)
+meth public boolean isProxyObject(java.lang.Object)
+meth public boolean isString(java.lang.Object)
+meth public boolean isTime(java.lang.Object)
+meth public boolean isTimeZone(java.lang.Object)
+meth public java.util.Set<java.lang.String> getMemberKeys(java.lang.Object)
+meth public org.graalvm.polyglot.Context getContext()
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccess
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init()
+meth public abstract java.io.OutputStream getOutputStream(org.graalvm.polyglot.io.ProcessHandler$Redirect)
+meth public abstract org.graalvm.polyglot.io.ProcessHandler$ProcessCommand newProcessCommand(java.util.List<java.lang.String>,java.lang.String,java.util.Map<java.lang.String,java.lang.String>,boolean,org.graalvm.polyglot.io.ProcessHandler$Redirect,org.graalvm.polyglot.io.ProcessHandler$Redirect,org.graalvm.polyglot.io.ProcessHandler$Redirect)
+meth public abstract org.graalvm.polyglot.io.ProcessHandler$Redirect createRedirectToStream(java.io.OutputStream)
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$ManagementAccess
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init()
+meth public abstract org.graalvm.polyglot.management.ExecutionEvent newExecutionEvent(java.lang.Object)
+supr java.lang.Object
+
+CLSS public abstract interface org.graalvm.polyglot.io.ByteSequence
+meth public abstract byte byteAt(int)
+meth public abstract int length()
+meth public byte[] toByteArray()
+meth public java.util.stream.IntStream bytes()
+meth public org.graalvm.polyglot.io.ByteSequence subSequence(int,int)
+meth public static org.graalvm.polyglot.io.ByteSequence create(byte[])
+
+CLSS public abstract interface org.graalvm.polyglot.io.FileSystem
+meth public !varargs boolean isSameFile(java.nio.file.Path,java.nio.file.Path,java.nio.file.LinkOption[]) throws java.io.IOException
+meth public !varargs void copy(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption[]) throws java.io.IOException
+meth public !varargs void createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute<?>[]) throws java.io.IOException
+meth public !varargs void move(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption[]) throws java.io.IOException
+meth public !varargs void setAttribute(java.nio.file.Path,java.lang.String,java.lang.Object,java.nio.file.LinkOption[]) throws java.io.IOException
+meth public abstract !varargs java.nio.channels.SeekableByteChannel newByteChannel(java.nio.file.Path,java.util.Set<? extends java.nio.file.OpenOption>,java.nio.file.attribute.FileAttribute<?>[]) throws java.io.IOException
+meth public abstract !varargs java.nio.file.Path toRealPath(java.nio.file.Path,java.nio.file.LinkOption[]) throws java.io.IOException
+meth public abstract !varargs java.util.Map<java.lang.String,java.lang.Object> readAttributes(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption[]) throws java.io.IOException
+meth public abstract !varargs void checkAccess(java.nio.file.Path,java.util.Set<? extends java.nio.file.AccessMode>,java.nio.file.LinkOption[]) throws java.io.IOException
+meth public abstract !varargs void createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute<?>[]) throws java.io.IOException
+meth public abstract java.nio.file.DirectoryStream<java.nio.file.Path> newDirectoryStream(java.nio.file.Path,java.nio.file.DirectoryStream$Filter<? super java.nio.file.Path>) throws java.io.IOException
+meth public abstract java.nio.file.Path parsePath(java.lang.String)
+meth public abstract java.nio.file.Path parsePath(java.net.URI)
+meth public abstract java.nio.file.Path toAbsolutePath(java.nio.file.Path)
+meth public abstract void delete(java.nio.file.Path) throws java.io.IOException
+meth public java.lang.String getMimeType(java.nio.file.Path)
+meth public java.lang.String getPathSeparator()
+meth public java.lang.String getSeparator()
+meth public java.nio.charset.Charset getEncoding(java.nio.file.Path)
+meth public java.nio.file.Path getTempDirectory()
+meth public java.nio.file.Path readSymbolicLink(java.nio.file.Path) throws java.io.IOException
+meth public static org.graalvm.polyglot.io.FileSystem newDefaultFileSystem()
+meth public void createLink(java.nio.file.Path,java.nio.file.Path) throws java.io.IOException
+meth public void setCurrentWorkingDirectory(java.nio.file.Path)
+
+CLSS public abstract interface org.graalvm.polyglot.io.MessageEndpoint
+meth public abstract void sendBinary(java.nio.ByteBuffer) throws java.io.IOException
+meth public abstract void sendClose() throws java.io.IOException
+meth public abstract void sendPing(java.nio.ByteBuffer) throws java.io.IOException
+meth public abstract void sendPong(java.nio.ByteBuffer) throws java.io.IOException
+meth public abstract void sendText(java.lang.String) throws java.io.IOException
+
+CLSS public abstract interface org.graalvm.polyglot.io.MessageTransport
+innr public final static VetoException
+meth public abstract org.graalvm.polyglot.io.MessageEndpoint open(java.net.URI,org.graalvm.polyglot.io.MessageEndpoint) throws java.io.IOException,org.graalvm.polyglot.io.MessageTransport$VetoException
+
+CLSS public final static org.graalvm.polyglot.io.MessageTransport$VetoException
+ outer org.graalvm.polyglot.io.MessageTransport
+cons public init(java.lang.String)
+supr java.lang.Exception
+hfds serialVersionUID
+
+CLSS public abstract interface org.graalvm.polyglot.io.ProcessHandler
+innr public final static ProcessCommand
+innr public final static Redirect
+meth public abstract java.lang.Process start(org.graalvm.polyglot.io.ProcessHandler$ProcessCommand) throws java.io.IOException
+
+CLSS public final static org.graalvm.polyglot.io.ProcessHandler$ProcessCommand
+ outer org.graalvm.polyglot.io.ProcessHandler
+meth public boolean isRedirectErrorStream()
+meth public java.lang.String getDirectory()
+meth public java.util.List<java.lang.String> getCommand()
+meth public java.util.Map<java.lang.String,java.lang.String> getEnvironment()
+meth public org.graalvm.polyglot.io.ProcessHandler$Redirect getErrorRedirect()
+meth public org.graalvm.polyglot.io.ProcessHandler$Redirect getInputRedirect()
+meth public org.graalvm.polyglot.io.ProcessHandler$Redirect getOutputRedirect()
+supr java.lang.Object
+hfds cmd,cwd,environment,errorRedirect,inputRedirect,outputRedirect,redirectErrorStream
+
+CLSS public final static org.graalvm.polyglot.io.ProcessHandler$Redirect
+ outer org.graalvm.polyglot.io.ProcessHandler
+fld public final static org.graalvm.polyglot.io.ProcessHandler$Redirect INHERIT
+fld public final static org.graalvm.polyglot.io.ProcessHandler$Redirect PIPE
+meth public boolean equals(java.lang.Object)
+meth public int hashCode()
+meth public java.lang.String toString()
+supr java.lang.Object
+hfds stream,type
+hcls Type
+
+CLSS public final org.graalvm.polyglot.management.ExecutionEvent
+meth public boolean isExpression()
+meth public boolean isRoot()
+meth public boolean isStatement()
+meth public java.lang.String getRootName()
+meth public java.lang.String toString()
+meth public java.util.List<org.graalvm.polyglot.Value> getInputValues()
+meth public org.graalvm.polyglot.PolyglotException getException()
+meth public org.graalvm.polyglot.SourceSection getLocation()
+meth public org.graalvm.polyglot.Value getReturnValue()
+supr java.lang.Object
+hfds impl
+
+CLSS public final org.graalvm.polyglot.management.ExecutionListener
+innr public final Builder
+intf java.lang.AutoCloseable
+meth public static org.graalvm.polyglot.management.ExecutionListener$Builder newBuilder()
+meth public void close()
+supr java.lang.Object
+hfds EMPTY,impl
+
+CLSS public final org.graalvm.polyglot.management.ExecutionListener$Builder
+ outer org.graalvm.polyglot.management.ExecutionListener
+meth public org.graalvm.polyglot.management.ExecutionListener attach(org.graalvm.polyglot.Engine)
+meth public org.graalvm.polyglot.management.ExecutionListener$Builder collectExceptions(boolean)
+meth public org.graalvm.polyglot.management.ExecutionListener$Builder collectInputValues(boolean)
+meth public org.graalvm.polyglot.management.ExecutionListener$Builder collectReturnValue(boolean)
+meth public org.graalvm.polyglot.management.ExecutionListener$Builder expressions(boolean)
+meth public org.graalvm.polyglot.management.ExecutionListener$Builder onEnter(java.util.function.Consumer<org.graalvm.polyglot.management.ExecutionEvent>)
+meth public org.graalvm.polyglot.management.ExecutionListener$Builder onReturn(java.util.function.Consumer<org.graalvm.polyglot.management.ExecutionEvent>)
+meth public org.graalvm.polyglot.management.ExecutionListener$Builder rootNameFilter(java.util.function.Predicate<java.lang.String>)
+meth public org.graalvm.polyglot.management.ExecutionListener$Builder roots(boolean)
+meth public org.graalvm.polyglot.management.ExecutionListener$Builder sourceFilter(java.util.function.Predicate<org.graalvm.polyglot.Source>)
+meth public org.graalvm.polyglot.management.ExecutionListener$Builder statements(boolean)
+supr java.lang.Object
+hfds collectExceptions,collectInputValues,collectReturnValues,expressions,onEnter,onReturn,rootNameFilter,roots,sourceFilter,statements
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.Proxy
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyArray
+intf org.graalvm.polyglot.proxy.Proxy
+meth public !varargs static org.graalvm.polyglot.proxy.ProxyArray fromArray(java.lang.Object[])
+meth public abstract java.lang.Object get(long)
+meth public abstract long getSize()
+meth public abstract void set(long,org.graalvm.polyglot.Value)
+meth public boolean remove(long)
+meth public static org.graalvm.polyglot.proxy.ProxyArray fromList(java.util.List<java.lang.Object>)
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyDate
+intf org.graalvm.polyglot.proxy.Proxy
+meth public abstract java.time.LocalDate asDate()
+meth public static org.graalvm.polyglot.proxy.ProxyDate from(java.time.LocalDate)
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyDuration
+intf org.graalvm.polyglot.proxy.Proxy
+meth public abstract java.time.Duration asDuration()
+meth public static org.graalvm.polyglot.proxy.ProxyDuration from(java.time.Duration)
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyExecutable
+ anno 0 java.lang.FunctionalInterface()
+intf org.graalvm.polyglot.proxy.Proxy
+meth public abstract !varargs java.lang.Object execute(org.graalvm.polyglot.Value[])
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyInstant
+intf org.graalvm.polyglot.proxy.ProxyDate
+intf org.graalvm.polyglot.proxy.ProxyTime
+intf org.graalvm.polyglot.proxy.ProxyTimeZone
+meth public abstract java.time.Instant asInstant()
+meth public java.time.LocalDate asDate()
+meth public java.time.LocalTime asTime()
+meth public java.time.ZoneId asTimeZone()
+meth public static org.graalvm.polyglot.proxy.ProxyInstant from(java.time.Instant)
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyInstantiable
+ anno 0 java.lang.FunctionalInterface()
+intf org.graalvm.polyglot.proxy.Proxy
+meth public abstract !varargs java.lang.Object newInstance(org.graalvm.polyglot.Value[])
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyNativeObject
+intf org.graalvm.polyglot.proxy.Proxy
+meth public abstract long asPointer()
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyObject
+intf org.graalvm.polyglot.proxy.Proxy
+meth public abstract boolean hasMember(java.lang.String)
+meth public abstract java.lang.Object getMember(java.lang.String)
+meth public abstract java.lang.Object getMemberKeys()
+meth public abstract void putMember(java.lang.String,org.graalvm.polyglot.Value)
+meth public boolean removeMember(java.lang.String)
+meth public static org.graalvm.polyglot.proxy.ProxyObject fromMap(java.util.Map<java.lang.String,java.lang.Object>)
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyTime
+intf org.graalvm.polyglot.proxy.Proxy
+meth public abstract java.time.LocalTime asTime()
+meth public static org.graalvm.polyglot.proxy.ProxyTime from(java.time.LocalTime)
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyTimeZone
+intf org.graalvm.polyglot.proxy.Proxy
+meth public abstract java.time.ZoneId asTimeZone()
+meth public static org.graalvm.polyglot.proxy.ProxyTimeZone from(java.time.ZoneId)
+
+CLSS public abstract interface org.graalvm.word.ComparableWord
+intf org.graalvm.word.WordBase
+meth public abstract boolean equal(org.graalvm.word.ComparableWord)
+meth public abstract boolean notEqual(org.graalvm.word.ComparableWord)
+
+CLSS public abstract interface org.graalvm.word.PointerBase
+intf org.graalvm.word.ComparableWord
+meth public abstract boolean isNonNull()
+meth public abstract boolean isNull()
+
+CLSS public abstract interface org.graalvm.word.WordBase
+meth public abstract boolean equals(java.lang.Object)
+ anno 0 java.lang.Deprecated()
+meth public abstract long rawValue()
+
+CLSS public final org.netbeans.libs.graalsdk.GraalSDK
+supr java.lang.Object
+
+CLSS abstract interface org.netbeans.libs.graalsdk.package-info
+

--- a/ide/libs.graalsdk.system/nbproject/project.properties
+++ b/ide/libs.graalsdk.system/nbproject/project.properties
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+javac.source=1.8
+javac.compilerargs=-Xlint -Xlint:-serial
+is.eager=true
+
+javadoc.arch=${basedir}/arch.xml
+javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/libs.graalsdk.system/nbproject/project.xml
+++ b/ide/libs.graalsdk.system/nbproject/project.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.apisupport.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/nb-module-project/3">
+            <code-name-base>org.netbeans.libs.graalsdk.system</code-name-base>
+            <module-dependencies>
+                <dependency>
+                    <code-name-base>org.netbeans.api.scripting</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.2</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.modules</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.68</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.10</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.lookup</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>8.36</specification-version>
+                    </run-dependency>
+                </dependency>
+            </module-dependencies>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.api.scripting</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.graalsdk</code-name-base>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
+            <public-packages/>
+            <class-path-extension>
+                <runtime-relative-path></runtime-relative-path>
+                <binary-origin>external/graal-sdk-20.3.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path></runtime-relative-path>
+                <binary-origin>external/launcher-common-20.3.0.jar</binary-origin>
+            </class-path-extension>
+        </data>
+    </configuration>
+</project>

--- a/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/Bundle.properties
+++ b/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/Bundle.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+OpenIDE-Module-Name=GraalVM JDK Polyglot Integration
+OpenIDE-Module-Display-Category=Libraries

--- a/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/GraalContext.java
+++ b/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/GraalContext.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.graalsdk.system;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.SimpleBindings;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.HostAccess;
+import org.graalvm.polyglot.PolyglotAccess;
+import org.openide.util.io.ReaderInputStream;
+
+final class GraalContext implements ScriptContext {
+    private static final String ALLOW_ALL_ACCESS = "allowAllAccess"; // NOI18N
+    private Context ctx;
+    private final WriterOutputStream writer = new WriterOutputStream(new OutputStreamWriter(System.out));
+    private final WriterOutputStream errorWriter = new WriterOutputStream(new OutputStreamWriter(System.err));
+    private Reader reader;
+    private final Bindings globals;
+    private SimpleBindings bindings;
+    private boolean allowAllAccess;
+    private final ClassLoader languagesClassLoader;
+
+    // @start region="SANDBOX"
+    private static final HostAccess SANDBOX = HostAccess.newBuilder().
+            allowPublicAccess(true).
+            allowArrayAccess(true).
+            allowListAccess(true).
+            allowAllImplementations(true).
+            denyAccess(Class.class).
+            denyAccess(Method.class).
+            denyAccess(Field.class).
+            denyAccess(Proxy.class).
+            denyAccess(Object.class, false).
+            build();
+    // @end region="SANDBOX"
+
+    GraalContext(Bindings globals, ClassLoader langClassLoader) {
+        this.globals = globals;
+        this.languagesClassLoader = langClassLoader;
+    }
+    
+    final synchronized Context ctx() {
+        if (ctx == null) {
+            final Context.Builder b = Context.newBuilder();
+            b.out(writer);
+            b.err(errorWriter);
+            if (reader != null) {
+                try {
+                    b.in(new ReaderInputStream(reader, "UTF-8"));
+                } catch (IOException ex) {
+                    throw raise(RuntimeException.class, ex);
+                }
+            }
+            b.allowPolyglotAccess(PolyglotAccess.ALL);
+            if (Boolean.TRUE.equals(getAttribute(ALLOW_ALL_ACCESS, ScriptContext.GLOBAL_SCOPE))) {
+                b.allowHostAccess(HostAccess.ALL);
+                b.allowAllAccess(true);
+            } else {
+                b.allowHostAccess(SANDBOX);
+            }
+            ctx = b.build();
+            if (globals != null) {
+                for (String k : globals.keySet()) {
+                    if (!ALLOW_ALL_ACCESS.equals(k)) {
+                        ctx.getPolyglotBindings().putMember(k, globals.get(k));
+                    }
+                }
+            }
+        }
+        return ctx;
+    }
+    
+    /**
+     * Executes code under a specific thread context classloader. Restores the context classloader
+     * after executing the code.
+     * @param <T> type of the return value
+     * @param code code that produces the return value
+     * @param loader context classloader to be used during `code' execution
+     * @return the value returned by the `code'.
+     */
+    static <T> T executeWithClassLoader(Supplier<T> code, ClassLoader loader) {
+        final ClassLoader ctxLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(loader);
+            return code.get();
+        } finally {
+            Thread.currentThread().setContextClassLoader(ctxLoader);
+        }
+    }
+
+    Bindings getGlobals() {
+        return globals;
+    }
+
+    @Override
+    public void setBindings(Bindings bindings, int scope) {
+        throw new UnsupportedOperationException();
+    }
+    
+    @Override
+    @SuppressWarnings("unchecked")
+    public Bindings getBindings(int scope) {
+        assertGlobalScope(scope);
+        if (bindings == null) {
+            Map<String,Object> map = ctx().getPolyglotBindings().as(Map.class);
+            bindings = new SimpleBindings(map);
+        }
+        return bindings;
+    }
+
+    private void assertGlobalScope(int scope) throws IllegalArgumentException {
+        if (scope != GLOBAL_SCOPE) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public void setAttribute(String name, Object value, int scope) {
+        assertGlobalScope(scope);
+        if (ALLOW_ALL_ACCESS.equals(name)) {
+            if (this.ctx == null) {
+                this.allowAllAccess = Boolean.TRUE.equals(value);
+                return;
+            }
+            throw new IllegalStateException();
+        }
+        if (ctx != null) {
+            getBindings(ScriptContext.GLOBAL_SCOPE).put(name, value);
+        } else if (globals != null) {
+            globals.put(name, value);
+        }
+    }
+
+    @Override
+    public Object getAttribute(String name, int scope) {
+        assertGlobalScope(scope);
+        return getGlobalAttribute(name);
+    }
+    
+    private Object getGlobalAttribute(String name) {
+        if (ALLOW_ALL_ACCESS.equals(name)) {
+            if (this.allowAllAccess) {
+                return true;
+            }
+        } else if (ctx != null) {
+            return getBindings(ScriptContext.GLOBAL_SCOPE).get(name);
+        } 
+        return globals == null ? null : globals.get(name);
+    }
+
+    @Override
+    public Object removeAttribute(String name, int scope) {
+        assertGlobalScope(scope);
+        if (ctx != null) {
+            Bindings b = getBindings(ScriptContext.GLOBAL_SCOPE);
+            return b.remove(name);
+        }
+        return globals == null ? null : globals.remove(name);
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        // only handle the global ones:
+        return getGlobalAttribute(name);
+    }
+
+    @Override
+    public int getAttributesScope(String name) {
+        if (ALLOW_ALL_ACCESS.equals(name)) {
+            return GLOBAL_SCOPE;
+        }
+        if (ctx != null && getBindings(ScriptContext.GLOBAL_SCOPE).containsKey(name)) {
+            return GLOBAL_SCOPE;
+        }
+        if (globals != null && globals.containsKey(name)) {
+            return GLOBAL_SCOPE;
+        }
+        return -1;
+    }
+
+    @Override
+    public Writer getWriter() {
+        return writer.getWriter();
+    }
+
+    @Override
+    public Writer getErrorWriter() {
+        return errorWriter.getWriter();
+    }
+
+    @Override
+    public void setWriter(Writer writer) {
+        this.writer.setWriter(writer);
+    }
+
+    @Override
+    public void setErrorWriter(Writer writer) {
+        this.errorWriter.setWriter(writer);
+    }
+
+    @Override
+    public Reader getReader() {
+        return this.reader;
+    }
+
+    @Override
+    public void setReader(Reader reader) {
+        if (ctx != null) {
+            throw new IllegalStateException("Too late. Context has already been created!");
+        }
+        this.reader = reader;
+    }
+
+    @Override
+    public List<Integer> getScopes() {
+        return Collections.nCopies(1, GLOBAL_SCOPE);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Exception> T raise(Class<T> aClass, Throwable ex) throws T {
+        throw (T) ex;
+    }
+}

--- a/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/GraalEngine.java
+++ b/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/GraalEngine.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.graalsdk.system;
+
+import java.io.Reader;
+import javax.script.Bindings;
+import javax.script.Invocable;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+import org.graalvm.polyglot.PolyglotException;
+import org.graalvm.polyglot.Source;
+import org.graalvm.polyglot.Value;
+
+final class GraalEngine implements ScriptEngine, Invocable {
+
+    private final GraalEngineFactory factory;
+    private final ScriptContext langContext;
+
+    GraalEngine(GraalEngineFactory f) {
+        this.factory = f;
+        this.langContext = new LangContext(factory.id, f.ctx);
+    }
+
+    private String id() {
+        return factory.id;
+    }
+
+    @Override
+    public ScriptContext getContext() {
+        return langContext;
+    }
+
+    @Override
+    public GraalEngineFactory getFactory() {
+        return factory;
+    }
+
+    @Override
+    public Object eval(String src, ScriptContext arg1) throws ScriptException {
+        Value result = evalImpl(arg1, src);
+        return unbox(result);
+    }
+    
+    private static interface ScriptAction {
+        public Value run();
+    }
+    
+    private Value handleException(ScriptAction r) throws ScriptException {
+        try {
+            return r.run();
+        } catch (PolyglotException e) {
+            if (e.isHostException()) {
+                e.initCause(e.asHostException());
+                throw e;
+            }
+            // avoid exposing polyglot stack frames - might be confusing.
+            throw new ScriptException(e);
+        }
+    }
+
+    private Value evalImpl(ScriptContext arg1, String src) throws ScriptException {
+        return handleException(() -> ((GraalContext) arg1).ctx().eval(id(), src));
+    }
+    
+    @Override
+    public Object eval(Reader arg0, ScriptContext arg1) throws ScriptException {
+        Source src = Source.newBuilder(id(), arg0, null).buildLiteral();
+        Value result = handleException(() -> ((GraalContext)arg1).ctx().eval(src));
+        return unbox(result);
+    }
+
+    @Override
+    public Object eval(String arg0) throws ScriptException {
+        return eval(arg0, factory.ctx);
+    }
+
+    @Override
+    public Object eval(Reader arg0) throws ScriptException {
+        return eval(arg0, factory.ctx);
+    }
+
+    @Override
+    public Object eval(String arg0, Bindings arg1) throws ScriptException {
+        throw new ScriptException("Cannot use alternative bindings!");
+    }
+
+    @Override
+    public Object eval(Reader arg0, Bindings arg1) throws ScriptException {
+        throw new ScriptException("Cannot use alternative bindings!");
+    }
+
+    @Override
+    public void put(String arg0, Object arg1) {
+        getBindings(ScriptContext.ENGINE_SCOPE).put(arg0, arg1);
+    }
+
+    @Override
+    public Object get(String arg0) {
+        return getBindings(ScriptContext.ENGINE_SCOPE).get(arg0);
+    }
+
+    @Override
+    public Bindings getBindings(int scope) {
+        return getContext().getBindings(scope);
+    }
+
+    @Override
+    public void setBindings(Bindings arg0, int arg1) {
+        // allow setting the same bindins as already active in the factory;
+        // this is done by ScriptEngineManager before it returns the engine.
+        if (arg1 == ScriptContext.GLOBAL_SCOPE) {
+            if (factory.ctx.getGlobals() == arg0) {
+                return;
+            }
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Bindings createBindings() {
+        return null;
+    }
+
+    @Override
+    public void setContext(ScriptContext arg0) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Object invokeMethod(Object thiz, String name, Object... args) throws ScriptException, NoSuchMethodException {
+        final Value thisValue = factory.ctx.ctx().asValue(thiz);
+        if (!thisValue.canInvokeMember(name)) {
+            if (!thisValue.hasMember(name)) {
+                throw new NoSuchMethodException(name);
+            } else {
+                throw new NoSuchMethodException(name + " is not a function");
+            }
+        }
+        return unbox(handleException(() -> thisValue.invokeMember(name, args)));
+    }
+    
+    private GraalContext graalContext() {
+        return factory.ctx;
+    }
+
+    @Override
+    public Object invokeFunction(String name, Object... args) throws ScriptException, NoSuchMethodException {
+        final Value fn = evalImpl(graalContext(), name);
+        return unbox(handleException(() -> fn.execute(args)));
+    }
+
+    @Override
+    public <T> T getInterface(Class<T> clasz) {
+        return getInterface(graalContext().ctx().getPolyglotBindings(), clasz);
+    }
+
+    @Override
+    public <T> T getInterface(Object thiz, Class<T> clasz) {
+        try {
+            if (thiz instanceof Value) {
+                return ((Value) thiz).as(clasz);
+            }
+            Value v = factory.ctx.ctx().asValue(thiz);
+            T ret = v.as(clasz);
+            if (ret != null) {
+                return ret;
+            }
+        } catch (ClassCastException ex) {
+            // the interface is not supported on the value object; ignore.
+        }
+        if (clasz.isInstance(thiz)) {
+            return clasz.cast(thiz);
+        }
+        return null;
+    }
+
+    private Object unbox(Value result) {
+        if (result.isNull()) {
+            return null;
+        }
+        return result.as(Object.class);
+    }
+}

--- a/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/GraalEngineFactory.java
+++ b/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/GraalEngineFactory.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.graalsdk.system;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import org.graalvm.polyglot.Language;
+
+final class GraalEngineFactory implements ScriptEngineFactory {
+
+    final String id;
+    final Language language;
+    final GraalContext ctx;
+    private GraalEngine eng;
+
+    GraalEngineFactory(GraalContext ctx, String id, Language language) {
+        this.id = id;
+        this.language = language;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public String getEngineName() {
+        return "GraalVM:" + language.getId();
+    }
+
+    @Override
+    public String getEngineVersion() {
+        return language.getVersion();
+    }
+
+    @Override
+    public List<String> getExtensions() {
+        return Collections.singletonList(id);
+    }
+
+    @Override
+    public List<String> getMimeTypes() {
+        return new ArrayList<>(language.getMimeTypes());
+    }
+
+    @Override
+    public List<String> getNames() {
+        return Arrays.asList(language.getName(), getEngineName());
+    }
+
+    @Override
+    public String getLanguageName() {
+        return language.getName();
+    }
+
+    @Override
+    public String getLanguageVersion() {
+        return language.getVersion();
+    }
+
+    @Override
+    public Object getParameter(String arg0) {
+        return null;
+    }
+
+    @Override
+    public String getMethodCallSyntax(String arg0, String arg1, String... arg2) {
+        return null;
+    }
+
+    @Override
+    public String getOutputStatement(String arg0) {
+        return null;
+    }
+
+    @Override
+    public String getProgram(String... arg0) {
+        return null;
+    }
+
+    @Override
+    public ScriptEngine getScriptEngine() {
+        // return the same instance to indicate the engines actually
+        // retain all the context through Polyglot Context object.
+        synchronized (this) {
+            if (eng == null) {
+                eng = new GraalEngine(this);
+            }
+            return eng;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "GraalEngineFactory[" + id + "]";
+    }
+}

--- a/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/GraalSystemEnginesProvider.java
+++ b/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/GraalSystemEnginesProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.graalsdk.system;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.script.Bindings;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.Language;
+import org.netbeans.spi.scripting.EngineProvider;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.ServiceProvider;
+
+@ServiceProvider(service = EngineProvider.class)
+public final class GraalSystemEnginesProvider implements EngineProvider {
+    private Throwable disable;
+
+    public GraalSystemEnginesProvider() {
+    }
+
+    @Override
+    public List<ScriptEngineFactory> factories() {
+        return factories(null);
+    }
+
+    @Override
+    public List<ScriptEngineFactory> factories(ScriptEngineManager m) {
+        List<ScriptEngineFactory> arr = new ArrayList<>();
+        try {
+            if (disable == null) {
+                enumerateLanguages(arr, m == null ? null : m.getBindings());
+            }
+        } catch (IllegalStateException | LinkageError err) {
+            disable = err;
+        }
+        return arr;
+    }
+    
+    private void enumerateLanguages(List<ScriptEngineFactory> arr, Bindings globals) {
+        final GraalContext ctx = new GraalContext(globals, Lookup.getDefault().lookup(ClassLoader.class));
+        try (Engine engine = Engine.newBuilder().build()) {
+            for (Map.Entry<String, Language> entry : engine.getLanguages().entrySet()) {
+                arr.add(new GraalEngineFactory(ctx, entry.getKey(), entry.getValue()));
+            }
+        }
+    }
+}

--- a/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/LangContext.java
+++ b/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/LangContext.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.graalsdk.system;
+
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.SimpleBindings;
+import org.graalvm.polyglot.Context;
+
+/**
+ *
+ * @author sdedic
+ */
+final class LangContext implements ScriptContext {
+    final String   langId;
+    final GraalContext  global;
+    Bindings langBindings;
+
+    public LangContext(String langId, GraalContext global) {
+        this.langId = langId;
+        this.global = global;
+    }
+
+    @Override
+    public void setBindings(Bindings arg0, int arg1) {
+        throw new UnsupportedOperationException("Not supported."); 
+    }
+
+    @Override
+    public Bindings getBindings(int scope) {
+        if (scope == ENGINE_SCOPE) {
+            synchronized (this) {
+                if (langBindings != null) {
+                    return langBindings;
+                }
+            }
+            if (langBindings == null) {
+                Context c = global.ctx();
+                synchronized (this) {
+                    if (langBindings == null) {
+                        langBindings = new SimpleBindings(c.getBindings(langId).as(Map.class));
+                    }
+                }
+            }
+            return langBindings;
+        }
+        return global.getBindings(scope);
+    }
+
+    @Override
+    public void setAttribute(String key, Object value, int scope) {
+        if (scope == GLOBAL_SCOPE) {
+            global.setAttribute(key, value, scope);
+            return;
+        }
+        getBindings(scope).put(key, value);
+    }
+
+    @Override
+    public Object getAttribute(String key, int scope) {
+        if (scope == GLOBAL_SCOPE) {
+            return global.getAttribute(key, scope);
+        }
+        return getBindings(scope).get(key);
+    }
+
+    @Override
+    public Object removeAttribute(String key, int scope) {
+        if (scope == GLOBAL_SCOPE) {
+            return global.removeAttribute(key, scope);
+        }
+        return getBindings(scope).remove(key);
+    }
+
+    @Override
+    public Object getAttribute(String key) {
+        Bindings eb = getBindings(ENGINE_SCOPE);
+        if (eb.containsKey(key)) {
+            return eb.get(key);
+        } else {
+            return global.getAttribute(key);
+        }
+    }
+
+    @Override
+    public int getAttributesScope(String key) {
+        Bindings eb = getBindings(ENGINE_SCOPE);
+        if (eb.containsKey(key)) {
+            return GLOBAL_SCOPE;
+        } else {
+            return global.getAttributesScope(key);
+        }
+    }
+
+    @Override
+    public Writer getWriter() {
+        return global.getWriter();
+    }
+
+    @Override
+    public Writer getErrorWriter() {
+        return global.getErrorWriter();
+    }
+
+    @Override
+    public void setWriter(Writer writer) {
+        global.setWriter(writer);
+    }
+
+    @Override
+    public void setErrorWriter(Writer writer) {
+        global.setErrorWriter(writer);
+    }
+
+    @Override
+    public Reader getReader() {
+        return global.getReader();
+    }
+
+    @Override
+    public void setReader(Reader reader) {
+        global.setReader(reader);
+    }
+
+    @Override
+    public List<Integer> getScopes() {
+        return Arrays.asList(ENGINE_SCOPE, GLOBAL_SCOPE);
+    }
+}

--- a/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/WriterOutputStream.java
+++ b/ide/libs.graalsdk.system/src/org/netbeans/libs/graalsdk/system/WriterOutputStream.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.graalsdk.system;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Stream backed by a Writer. Uses UTF-8 to decode characters from the stream.
+ */
+class WriterOutputStream extends OutputStream {
+    private static final Logger LOG = Logger.getLogger(WriterOutputStream.class.getName());
+
+    private boolean writeImmediately = true;
+
+    private final CharsetDecoder decoder;
+    private final ByteBuffer decoderIn = ByteBuffer.allocate(128);
+    private final CharBuffer decoderOut;
+    private Writer writer;
+
+    public WriterOutputStream(Writer out) {
+        this.writer = out;
+        this.decoder = StandardCharsets.UTF_8.
+                newDecoder().
+                onMalformedInput(CodingErrorAction.REPLACE).
+                onUnmappableCharacter(CodingErrorAction.REPLACE).
+                replaceWith("?"); //NOI18N
+        this.decoderOut = CharBuffer.allocate(2048);
+    }
+
+    public void setWriter(Writer out) {
+        try {
+            flush();
+        } catch (IOException ex) {
+            LOG.log(Level.SEVERE, null, ex);
+        }
+        writer = out;
+    }
+
+    public Writer getWriter() {
+        return writer;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        decoderIn.put((byte) b);
+        processInput(false);
+        if (writeImmediately) {
+            flushOutput();
+        }
+    }
+
+    @Override
+    public void write(final byte[] b, int off, int len) throws IOException {
+        while (len > 0) {
+            final int c = Math.min(len, decoderIn.remaining());
+            decoderIn.put(b, off, c);
+            processInput(false);
+            len -= c;
+            off += c;
+        }
+        if (writeImmediately) {
+            flushOutput();
+        }
+    }
+
+    private void flushOutput() throws IOException {
+        if (decoderOut.position() > 0) {
+            writer.write(decoderOut.array(), 0, decoderOut.position());
+            decoderOut.rewind();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        processInput(true);
+        flushOutput();
+        writer.close();
+    }
+
+    @Override
+    public void flush() throws IOException {
+        flushOutput();
+        writer.flush();
+    }
+
+    private void processInput(final boolean endOfInput) throws IOException {
+        // Prepare decoderIn for reading
+        decoderIn.flip();
+        CoderResult coderResult;
+        while (true) {
+            coderResult = decoder.decode(decoderIn, decoderOut, endOfInput);
+            if (coderResult.isOverflow()) {
+                flushOutput();
+            } else if (coderResult.isUnderflow()) {
+                break;
+            } else {
+                    // The decoder is configured to replace malformed input and unmappable characters,
+                // so we should not get here.
+                throw new IOException("Unexpected coder result"); //NOI18N
+            }
+        }
+        // Discard the bytes that have been read
+        decoderIn.compact();
+    }
+}

--- a/ide/libs.graalsdk.system/test/unit/src/org/netbeans/libs/graalsdk/system/GraalEnginesTest.java
+++ b/ide/libs.graalsdk.system/test/unit/src/org/netbeans/libs/graalsdk/system/GraalEnginesTest.java
@@ -16,30 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.libs.graalsdk;
+package org.netbeans.libs.graalsdk.system;
 
-import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.netbeans.junit.NbModuleSuite;
+import org.netbeans.junit.NbTestSuite;
 import org.openide.util.Lookup;
 
-public class JavaScriptEnginesTest {
-
-
-    public static final junit.framework.Test suite() {
+/**
+ *
+ * @author sdedic
+ */
+public class GraalEnginesTest {
+    public static Test suite() throws Exception {
         NbModuleSuite.Configuration cfg = NbModuleSuite.emptyConfiguration().
-                honorAutoloadEager(true).
-                gui(false);
-        
-        return cfg.clusters("platform|webcommon|ide").addTest(S.class).suite();
+            clusters("platform|webcommon|ide").
+            honorAutoloadEager(true).
+            gui(false);
+        return cfg.addTest(GraalEnginesTest.S.class).suite();
     }
-    
+
     public static class S extends TestSuite {
         public S() throws Exception {
-            ClassLoader ldr = Lookup.getDefault().lookup(ClassLoader.class);
-            Class c = ldr.loadClass("org.netbeans.libs.graalsdk.JavaScriptEnginesTest2");
-            Method m = c.getMethod("createTests", TestSuite.class);
-            m.invoke(null, this);
+            ClassLoader parent = Lookup.getDefault().lookup(ClassLoader.class);
+            URL u = getClass().getProtectionDomain().getCodeSource().getLocation();
+            ClassLoader ldr = new URLClassLoader(new URL[] { u }, parent);
+            Class c = ldr.loadClass("org.netbeans.libs.graalsdk.system.GraalEnginesTest2");
+            addTest(new NbTestSuite(c));
         }
     }
 }

--- a/ide/libs.graalsdk.system/test/unit/src/org/netbeans/libs/graalsdk/system/Sum.java
+++ b/ide/libs.graalsdk.system/test/unit/src/org/netbeans/libs/graalsdk/system/Sum.java
@@ -16,25 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.api.scripting;
+package org.netbeans.libs.graalsdk.system;
 
-import javax.script.ScriptEngine;
-import static org.junit.Assume.assumeTrue;
-import org.netbeans.junit.NbTestCase;
+public class Sum {
+    public int sum;
+    public Object err;
 
-public class ScriptingTutorialTest extends NbTestCase {
-    public ScriptingTutorialTest(String name) {
-        super(name);
+    public void increment() {
+        sum++;
     }
 
-    public void testFourtyTwo() throws Exception {
-        // @start region="testFourtyTwo"
-        ScriptEngine js = Scripting.createManager().getEngineByMimeType("text/javascript");
-        assumeTrue(js != null || System.getProperty("java.vendor.version").contains("Graal"));
-
-        Number x = (Number) js.eval("6 * 7");
-
-        assert x.intValue() == 42;
-        // @end region="testFourtyTwo"
+    final void add(int x) {
+        sum += x;
     }
 }

--- a/ide/libs.graalsdk/manifest.mf
+++ b/ide/libs.graalsdk/manifest.mf
@@ -5,3 +5,5 @@ OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/graalsdk/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.20
 OpenIDE-Module-Provides: org.netbeans.spi.scripting.EngineProvider
 OpenIDE-Module-Recommends: com.oracle.truffle.polyglot.PolyglotImpl
+OpenIDE-Module-Hide-Classpath-Packages: org.graalvm.collections.**, org.graalvm.home.**, org.graalvm.nativeimage.**,
+    org.graalvm.options.**, org.graalvm.polyglot.**, org.graalvm.word.**

--- a/ide/libs.graalsdk/nbproject/project.xml
+++ b/ide/libs.graalsdk/nbproject/project.xml
@@ -34,6 +34,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.openide.modules</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.68</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.util</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -66,6 +74,14 @@
                         <code-name-base>org.netbeans.api.scripting</code-name-base>
                         <recursive/>
                         <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.graaljs</code-name-base>
+                        <recursive/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.graalsdk.system</code-name-base>
+                        <recursive/>
                     </test-dependency>
                 </test-type>
             </test-dependencies>

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalContext.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalContext.java
@@ -26,9 +26,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import javax.script.Bindings;
 import javax.script.ScriptContext;
 import javax.script.SimpleBindings;
@@ -46,6 +46,7 @@ final class GraalContext implements ScriptContext {
     private final Bindings globals;
     private SimpleBindings bindings;
     private boolean allowAllAccess;
+    private final ClassLoader languagesClassLoader;
 
     // @start region="SANDBOX"
     private static final HostAccess SANDBOX = HostAccess.newBuilder().
@@ -61,8 +62,9 @@ final class GraalContext implements ScriptContext {
             build();
     // @end region="SANDBOX"
 
-    GraalContext(Bindings globals) {
+    GraalContext(Bindings globals, ClassLoader langClassLoader) {
         this.globals = globals;
+        this.languagesClassLoader = langClassLoader;
     }
     
     final synchronized Context ctx() {
@@ -84,7 +86,11 @@ final class GraalContext implements ScriptContext {
             } else {
                 b.allowHostAccess(SANDBOX);
             }
-            ctx = b.build();
+            // allow hosts access to all available classes
+            b.hostClassLoader(Thread.currentThread().getContextClassLoader());
+            // but ensure the context classsloader during build() is the 'correct one' - see
+            // Context javadocs.
+            ctx = executeWithClassLoader(() -> b.build(), languagesClassLoader);
             if (globals != null) {
                 for (String k : globals.keySet()) {
                     if (!ALLOW_ALL_ACCESS.equals(k)) {
@@ -96,6 +102,24 @@ final class GraalContext implements ScriptContext {
         return ctx;
     }
     
+    /**
+     * Executes code under a specific thread context classloader. Restores the context classloader
+     * after executing the code.
+     * @param <T> type of the return value
+     * @param code code that produces the return value
+     * @param loader context classloader to be used during `code' execution
+     * @return the value returned by the `code'.
+     */
+    static <T> T executeWithClassLoader(Supplier<T> code, ClassLoader loader) {
+        final ClassLoader ctxLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(loader);
+            return code.get();
+        } finally {
+            Thread.currentThread().setContextClassLoader(ctxLoader);
+        }
+    }
+
     Bindings getGlobals() {
         return globals;
     }

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEnginesProvider.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEnginesProvider.java
@@ -18,18 +18,30 @@
  */
 package org.netbeans.libs.graalsdk.impl;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import javax.script.Bindings;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
 import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.Language;
 import org.netbeans.spi.scripting.EngineProvider;
+import org.openide.modules.Dependency;
+import org.openide.modules.ModuleInfo;
+import org.openide.modules.Modules;
+import org.openide.util.Lookup;
 import org.openide.util.lookup.ServiceProvider;
 
-@ServiceProvider(service = EngineProvider.class)
+// The module libs.graalsdk.system defines another provider that assumes the last
+// position and is able to override languages provided by this module by the system-provided 
+// libraries.
+@ServiceProvider(service = EngineProvider.class, position = 100000)
 public final class GraalEnginesProvider implements EngineProvider {
     private Throwable disable;
 
@@ -53,13 +65,85 @@ public final class GraalEnginesProvider implements EngineProvider {
         }
         return arr;
     }
-
-    private void enumerateLanguages(List<ScriptEngineFactory> arr, Bindings globals) {
-        final GraalContext ctx = new GraalContext(globals);
-        try (Engine engine = Engine.newBuilder().build()) {
-            for (Map.Entry<String, Language> entry : engine.getLanguages().entrySet()) {
-                arr.add(new GraalEngineFactory(ctx, entry.getKey(), entry.getValue()));
+    
+    // @GuardedBy(this)
+    private ClassLoader currentAllLoader;
+    
+    // @GuardedBy(this)
+    private ClassLoader languagesLoader;
+    
+    private ClassLoader createGraalDependentClassLoader() {
+        ClassLoader allLoader = Lookup.getDefault().lookup(ClassLoader.class);
+        synchronized (this) {
+            if (languagesLoader != null && currentAllLoader == allLoader) {
+                return languagesLoader;
+            }
+            languagesLoader = null;
+        }
+        Collection<? extends ModuleInfo> modules = new ArrayList<>(Lookup.getDefault().lookupAll(ModuleInfo.class));
+        ModuleInfo thisModule = Modules.getDefault().ownerOf(getClass());
+        Map<String, ModuleInfo> dependentsOfSDK = new LinkedHashMap<>();
+        if (thisModule == null) {
+            // this happens only when mod system is not active, i.e. in tests.
+            return allLoader;
+        }
+        dependentsOfSDK.put(thisModule.getCodeName(), thisModule);
+        
+        boolean added;
+        do {
+            added = false;
+            for (Iterator<? extends ModuleInfo> it = modules.iterator(); it.hasNext(); ) {
+                ModuleInfo m = it.next();
+                for (Dependency d : m.getDependencies()) {
+                    if (d.getType() == Dependency.TYPE_MODULE) {
+                        if (dependentsOfSDK.keySet().contains(d.getName())) {
+                            dependentsOfSDK.put(m.getCodeName(), m);
+                            it.remove();
+                            added = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        } while (!added);
+        
+        ClassLoader created;
+        try {
+            BiFunction<String, ClassLoader, Boolean> decideDelegation = (n, c) -> c == null ? false : true;
+            
+            // this is a hack that allows to use good implementation of a classloader ...
+            // there should have to be an API for this in the module system.
+            Class pcl = Class.forName("org.netbeans.ProxyClassLoader", true, allLoader);
+            Constructor ctor = pcl.getConstructor(ClassLoader[].class, Boolean.TYPE, BiFunction.class);
+            ClassLoader[] delegates = new ClassLoader[dependentsOfSDK.size()];
+            int index = delegates.length -1;
+            // reverse the order: in the LinkedHashMap, the 1st entry is GraalSDK, following by direct dependents
+            // if some of module deeper in the hierarchy masks JDK packages, it should be consulted first, so the
+            for (ModuleInfo mi : dependentsOfSDK.values()) {
+                delegates[index--] = mi.getClassLoader();
+            }
+            created = (ClassLoader)ctor.newInstance(delegates, true, decideDelegation);
+        } catch (ReflectiveOperationException ex) {
+            created = allLoader;
+        }
+        synchronized (this) {
+            if ((currentAllLoader == null || currentAllLoader == allLoader) && languagesLoader == null) {
+                languagesLoader = created;
             }
         }
+        return created;
+    }
+    
+    private void enumerateLanguages(List<ScriptEngineFactory> arr, Bindings globals) {
+        ClassLoader langLoader = createGraalDependentClassLoader();
+        final GraalContext ctx = new GraalContext(globals, langLoader);
+        GraalContext.executeWithClassLoader(() -> {
+            try (Engine engine = Engine.newBuilder().build()) {
+                for (Map.Entry<String, Language> entry : engine.getLanguages().entrySet()) {
+                    arr.add(new GraalEngineFactory(ctx, entry.getKey(), entry.getValue()));
+                }
+            }
+            return null;
+        }, langLoader);
     }
 }

--- a/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/JavaScriptEnginesTest2.java
+++ b/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/JavaScriptEnginesTest2.java
@@ -1,0 +1,490 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.graalsdk;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import javax.script.Bindings;
+import javax.script.Invocable;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+import junit.framework.TestSuite;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Assume;
+import static org.junit.Assume.assumeFalse;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import org.netbeans.api.scripting.Scripting;
+import org.netbeans.junit.NbTestCase;
+
+/**
+ *
+ * @author sdedic
+ */
+public class JavaScriptEnginesTest2 extends NbTestCase {
+    @Parameterized.Parameters(name = "{1}:{0}@{4}={2}")
+    public static Object[][] engines() {
+        List<Object[]> arr = new ArrayList<>();
+        fillArray(Scripting.newBuilder().build(), false, arr);
+        final ScriptEngineManager man = Scripting.newBuilder().allowAllAccess(true).build();
+        fillArray(man, true, arr);
+        return arr.toArray(new Object[0][]);
+    }
+    
+    public static void createTests(TestSuite suite) {
+        Object[][] data = engines();
+        for (Object[] row : data) {
+            for (Method m : JavaScriptEnginesTest2.class.getMethods())  {
+                final org.junit.Test ann = m.getAnnotation(org.junit.Test.class);
+                if (ann == null) {
+                    continue;
+                }
+                junit.framework.Test t = new JavaScriptEnginesTest2(m.getName(), (String)row[0], 
+                        row[1], (String)row[2], (ScriptEngine)row[3], (boolean)row[4]);
+                suite.addTest(t);
+            }
+        }
+    }
+
+    private static void fillArray(final ScriptEngineManager man, boolean allowAllAccess, List<Object[]> arr) {
+        for (ScriptEngineFactory f : man.getEngineFactories()) {
+            final String name = f.getEngineName();
+            if (
+                    f.getMimeTypes().contains("text/javascript") ||
+                    name.contains("Nashorn")
+                    ) {
+                final ScriptEngine eng = f.getScriptEngine();
+                arr.add(new Object[] { name, "engineFactories", implName(eng), eng, allowAllAccess });
+                for (String n : eng.getFactory().getNames()) {
+                    ScriptEngine byName = n == null ? null : man.getEngineByName(n);
+                    if (byName != null && eng.getClass() == byName.getClass()) {
+                        arr.add(new Object[] { n, "name", implName(byName), byName, allowAllAccess });
+                    }
+                }
+                for (String t : eng.getFactory().getMimeTypes()) {
+                    ScriptEngine byType = t == null ? null : man.getEngineByMimeType(t);
+                    if (byType != null && eng.getClass() == byType.getClass()) {
+                        arr.add(new Object[] { t, "type", implName(byType), byType, allowAllAccess });
+                    }
+                }
+                for (String e : eng.getFactory().getExtensions()) {
+                    ScriptEngine byExt = e == null ? null : man.getEngineByExtension(e);
+                    if (byExt != null && eng.getClass() == byExt.getClass()) {
+                        arr.add(new Object[] { e, "ext", implName(byExt), byExt, allowAllAccess });
+                    }
+                }
+            }
+        }
+    }
+
+    private static String implName(Object obj) {
+        return obj.getClass().getSimpleName();
+    }
+
+    private final String engineName;
+    private final ScriptEngine engine;
+    private final boolean allowAllAccess;
+
+
+    public JavaScriptEnginesTest2(String testName, String engineName, Object info, String implName, ScriptEngine engine, boolean allowAllAccess) {
+        super(testName);
+        this.engineName = engineName;
+        this.engine = engine;
+        this.allowAllAccess = allowAllAccess;
+    }
+
+    private Invocable inv() {
+        assertTrue("Engines are invocable: " + engine, engine instanceof Invocable);
+        return (Invocable) engine;
+    }
+
+    @Test
+    public void fourtyTwo() throws Exception {
+        Object fourtyTwo = engine.eval("6 * 7");
+        assertTrue("Number: " + fourtyTwo, fourtyTwo instanceof Number);
+        assertEquals("fourtyTwo", 42, ((Number)fourtyTwo).intValue());
+    }
+
+    public interface Call {
+        public int call(int x, int y);
+    }
+
+    @Test
+    public void mul() throws Exception {
+        Object mul = engine.eval("(function(x, y) { return x * y; })");
+        assertNotNull("creates function object", mul);
+
+        Call call = inv().getInterface(mul, Call.class);
+        assertNotNull("Converted obj to Call: " + mul, call);
+
+        assertEquals("fourtyTwo", 42, call.call(7, 6));
+    }
+
+    public interface Mul {
+        public int mul(double x, long y);
+        public long mulExported(int x, float y);
+    }
+
+    @Test
+    public void globalMul() throws Exception {
+        Object none = engine.eval("\n"
+                + "function mul(x, y) {\n"
+                + "  return x * y;\n"
+                + "}\n"
+                + "this.mulExported = mul;\n"
+                + "if (typeof Polyglot !== 'undefined') {\n"
+                + "  Polyglot.export('mulExported', mul);\n"
+                + "}"
+                + "undefined\n"
+                + ""
+        );
+        assertNull("creates nothing", none);
+
+        Mul global = inv().getInterface(Mul.class);
+        assertNotNull("mul function visible as Mul: " + none, global);
+
+        try {
+            assertEquals("seventy seven", 77, global.mul(11, 7));
+        } catch (Exception ex) {
+            assertTrue("GraalVM:js exposes only exported symbols: " + engine.getFactory().getNames(), engine.getFactory().getNames().contains("GraalVM:js"));
+        }
+        assertEquals("mulExported is accessible in all engines", 77, global.mulExported(11, 7));
+    }
+
+    @Test
+    public void typeOfTrue() throws Exception {
+        Object tot = engine.eval("typeof true");
+        assertEquals("boolean", tot);
+    }
+
+    @Test
+    public void undefinedIsNull() throws Exception {
+        Object undef = engine.eval("undefined");
+        assertNull(undef);
+    }
+
+    @Test
+    public void exposeObject() throws Exception {
+        Object rawPoint = engine.eval("({ x : 5, y : -3, z : function(a) { return Math.floor(a * a); } })");
+        assertNotNull(rawPoint);
+
+        Point point = inv().getInterface(rawPoint, Point.class);
+        if (point == null) {
+            assumeNotNashorn();
+            assumeNotGraalJsFromJDK();
+        }
+        assertNotNull("Converted to typed interface", point);
+
+        assertEquals(5, point.x(), 0.1);
+        assertEquals(-3, point.y());
+
+        assertEquals("Power of sqrt(2) rounded", 2, point.z(1.42));
+    }
+
+    @Test
+    public void classOfString() throws Exception {
+        if (!allowAllAccess) {
+            return;
+        }
+        Object clazz = engine.eval("\n"
+            + "var s = '';\n"
+            + "var n;\n"
+            + "try {\n"
+            + "  var c = s.getClass();\n"
+            + "  n = c.getName();\n"
+            + "} catch (e) {\n"
+            + "  n = null;\n"
+            + "}\n"
+            + "n\n"
+        );
+        assertNull("No getClass attribute of string", clazz);
+    }
+
+    @Test
+    public void accessJavaObject() throws Exception {
+        Object fn = engine.eval("(function(obj) {\n"
+                + "  obj.sum += 5;\n"
+                + "  obj.increment();\n"
+                + "  try {\n"
+                + "    obj.add(6);\n"
+                + "  } catch (e) {\n"
+                + "    obj.err = e\n"
+                + "  }\n"
+                + "  return obj.sum;\n"
+                + "})\n");
+        assertNotNull(fn);
+
+        Sum sum = new Sum();
+        sum.sum = -5;
+        Object res = inv().invokeMethod(fn, "call", null, sum);
+
+        assertEquals("Incremented to one", 1, sum.sum);
+        assertTrue("Got a number: " + res, res instanceof Number);
+        assertEquals(1, ((Number) res).intValue());
+        assertNotNull("There was an error calling non-public add method: " + sum.err, sum.err);
+    }
+
+    @Test
+    public void classOfSum() throws Exception {
+        if (!allowAllAccess) {
+            return;
+        }
+        Assume.assumeFalse("GraalJSScriptEngine".equals(engine.getClass().getSimpleName()));
+
+        Object fn = engine.eval("(function(obj) {\n"
+                + "  try {\n"
+                + "     return obj.getClass().getName();\n"
+                + "  } catch (e) {\n"
+                + "     return null;\n"
+                + "  }\n"
+                + "})\n");
+        Object clazz = inv().invokeMethod(fn, "call", null, "Huuu");
+        assertNull("No getClass attribute of string", clazz);
+    }
+
+    @Test
+    public void sumArrayOfInt() throws Exception {
+        assertSumArray(new int[] { 1, 2, 3, 4, 5, 6 });
+    }
+
+    @Test
+    public void sumArrayOfObject() throws Exception {
+        assertSumArray(new Object[] { 1, 2, 3, 4, 5, 6 });
+    }
+
+    @Test
+    public void sumArrayOfInteger() throws Exception {
+        assertSumArray(new Integer[] { 1, 2, 3, 4, 5, 6 });
+    }
+
+    private void assertSumArray(Object arr) throws Exception {
+        engine.eval("\n"
+                + "function sum(arr) {\n"
+                + "  var r = 0;\n"
+                + "  for (var i = 0; i < arr.length; i++) {\n"
+                + "    r += arr[i];\n"
+                + "  }\n"
+                + "  return r;\n"
+                + "}\n");
+
+        Object res = inv().invokeFunction("sum", arr);
+
+        assertTrue("Is number: " + res, res instanceof Number);
+        assertEquals("Twenty one", 21, ((Number)res).intValue());
+    }
+
+
+    @Test
+    public void returnArrayInJS() throws Exception {
+        Assume.assumeFalse("Broken in GraalVM 20.3.0 fixed in GraalVM 21.1.0", "25.272-b10-jvmci-20.3-b06".equals(System.getProperty("java.vm.version")));
+
+        Object fn = engine.eval("(function(obj) {\n"
+                + "  return [ 1, 2, 'a', Math.PI, obj ];\n"
+                + "})\n");
+        assertNotNull(fn);
+
+        Sum sum = new Sum();
+        Object raw = ((Invocable) engine).invokeMethod(fn, "call", null, sum);
+        
+        ArrayLike res = ((Invocable) engine).getInterface(raw, ArrayLike.class);
+        if (res == null) {
+            assumeNotNashorn();
+            assumeNotGraalJsFromJDK();
+        }
+        assertNotNull("Result looks like array", res);
+
+        List<?> list = ((Invocable) engine).getInterface(raw, List.class);
+        assertEquals("Length of five", 5, list.size());
+        assertEquals(1, list.get(0));
+        assertEquals(2, list.get(1));
+        assertEquals("a", list.get(2));
+        assertEquals(Math.PI, list.get(3));
+        assertEquals(sum, list.get(4));
+    }
+
+    private void assumeNotNashorn() {
+        Assume.assumeFalse(engine.getFactory().getNames().contains("Nashorn"));
+    }
+
+    private void assumeNotGraalJsFromJDK() {
+        Assume.assumeFalse(engine.getFactory().getNames().contains("Graal.js"));
+    }
+
+    @Test
+    public void nonInvocableInvoke() throws Exception {
+        class ObscureObj {
+        }
+        ObscureObj obj = new ObscureObj();
+        try {
+            ((Invocable) engine).invokeMethod(obj, "unknown");
+            fail("There is no such method unknown!");
+        } catch (NoSuchMethodException | IllegalArgumentException ex) {
+            // OK
+        }
+    }
+
+    @Test
+    public void nonFunctionInvoke() throws Exception {
+        Object obj = engine.eval("\n"
+                + "new Object()\n"
+                + "\n");
+        try {
+            Object res = ((Invocable) engine).invokeMethod(obj, "unknown");
+            fail("There is no such method unknown!" + res);
+        } catch (NullPointerException | NoSuchMethodException ex) {
+            // OK
+        }
+    }
+
+    public static interface ArrayLike {
+        int length();
+    }
+
+    public static interface Point {
+        public double x();
+        public long y();
+        public long z(double v);
+    }
+
+    @Test
+    public void output() throws Exception {
+        StringWriter w = new StringWriter();
+        engine.getContext().setWriter(w);
+        engine.eval("print('Ahoj');");
+        assertEquals("Ahoj\n", w.toString());
+    }
+
+    @Test(expected = ScriptException.class)
+    public void error() throws Exception {
+        try {
+            engine.eval("throw 'Hi'");
+            Assert.fail("Exception expected");
+        } catch (ScriptException ex) {
+            // ok
+        }
+    }
+
+    /**
+     * Checks that exception originating in the script/lang code will be reported
+     * as ScriptException.
+     * @throws Exception 
+     */
+    @Test
+    public void guestExceptionReportedAsRuntime() throws Exception {
+        try {
+            engine.eval("var a = null; a.fn();");
+            fail("Exception expected");
+        } catch (ScriptException ex) {
+            Throwable c = ex.getCause();
+            Assert.assertThat(c, CoreMatchers.is(CoreMatchers.instanceOf(RuntimeException.class)));
+        }
+    }
+
+    public class Callback {
+        public void fn() throws Exception {
+            throw new NoSuchElementException();
+        }
+        
+        public void fn2() throws IOException {
+            throw new IOException();
+        }
+    }
+    
+    /**
+     * Checks that exception thrown in the callback Java code is reported 'as is'.
+     * @throws Exception 
+     */
+    @Test
+    public void hostCheckedExceptionAccessible() throws Exception {
+        // Note: this seems to be broken on GraalVM's JDK js - runtime exceptions are wrapped into
+        // polyglot wrapper and cannot be determined through the chain of getCauses().
+        assumeFalse(engine.getFactory().getEngineName().toLowerCase().contains("graal.js"));
+        
+        try {
+            engine.eval("var x; function setGlobalX(p) { x = p }");
+            ((Invocable)engine).invokeFunction("setGlobalX", new Callback());
+            engine.eval("x.fn2();");
+            fail("Exception expected");
+        } catch (RuntimeException ex) {
+            Throwable c = ex.getCause();
+            Assert.assertThat(c, CoreMatchers.is(CoreMatchers.instanceOf(IOException.class)));
+        } catch (Exception ex) {
+            fail("Runtime subclass is expected");
+        }
+    }
+
+    /**
+     * Checks that exception thrown in the callback Java code is reported 'as is'.
+     * @throws Exception 
+     */
+    @Test
+    public void hostRuntimeExceptionsAccessible() throws Exception {
+        // Note: this seems to be broken on GraalVM's JDK js - runtime exceptions are wrapped into
+        // polyglot wrapper and cannot be determined through the chain of getCauses().
+        assumeFalse(engine.getFactory().getEngineName().toLowerCase().contains("graal.js"));
+        
+        try {
+            engine.eval("var x; function setGlobalX(p) { x = p }");
+            ((Invocable)engine).invokeFunction("setGlobalX", new Callback());
+            engine.eval("x.fn();");
+            fail("Exception expected");
+        } catch (ScriptException ex) {
+            Throwable c = ex.getCause();
+            Assert.assertThat(c, CoreMatchers.is(CoreMatchers.instanceOf(NoSuchElementException.class)));
+        } catch (NoSuchElementException ex) {
+            // this is OK
+        } catch (Exception ex) {
+            
+        }
+    }
+    
+    /** 
+     * Checks that values assigned by various mehtods are visible:
+     * @throws Exception 
+     */
+    @Test
+    public void testEngineGlobalVariablesVisible() throws Exception {
+        Bindings b = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+        b.put("a", 1111);
+        Object o = engine.eval("var b = 3333; a");
+        assertEquals(1111, o);
+        assertEquals(3333, b.get("b"));
+        
+        engine.getContext().setAttribute("a", 2222, ScriptContext.ENGINE_SCOPE);
+        o = engine.eval("var b = 4444; a");
+        assertEquals(2222, o);
+        assertEquals(4444, engine.getContext().getAttribute("b"));
+        assertEquals(4444, engine.getContext().getAttribute("b", ScriptContext.ENGINE_SCOPE));
+        assertNull(engine.getContext().getAttribute("b", ScriptContext.GLOBAL_SCOPE));
+        
+    }
+}

--- a/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/ScriptingTutorialTest.java
+++ b/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/ScriptingTutorialTest.java
@@ -40,6 +40,7 @@ public class ScriptingTutorialTest extends NbTestCase {
 
         return NbModuleSuite.emptyConfiguration()
             .gui(false)
+            .clusters("platform|webcommon|ide")
             .honorAutoloadEager(true)
             .addTest(ScriptingTutorial.class)
             .suite();

--- a/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/impl/GraalContextTest.java
+++ b/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/impl/GraalContextTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.libs.graalsdk;
+package org.netbeans.libs.graalsdk.impl;
 
 import java.io.Reader;
 import java.io.StringReader;
@@ -25,6 +25,7 @@ import javax.script.ScriptException;
 import javax.script.SimpleBindings;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import org.junit.Assume;
 import org.junit.Test;
 import org.netbeans.api.scripting.Scripting;
 
@@ -36,6 +37,7 @@ public class GraalContextTest {
     @Test
     public void setReaderWords() throws Exception {
         ScriptEngine js = Scripting.createManager().getEngineByMimeType("text/javascript");
+        Assume.assumeNotNull("Need js", js);
         String jsName = js.getFactory().getEngineName();
         Reader my = new StringReader("Hello\nthere\n!");
         js.getContext().setReader(my);

--- a/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/impl/GraalEnginesTest.java
+++ b/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/impl/GraalEnginesTest.java
@@ -1,0 +1,409 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.graalsdk.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.script.Bindings;
+import javax.script.Invocable;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Assume;
+import static org.junit.Assume.assumeNotNull;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.netbeans.api.scripting.Scripting;
+
+public final class GraalEnginesTest {
+    @BeforeClass
+    public static void skipIfNoPolyglotFound() {
+        try {
+            Class.forName("org.graalvm.polyglot.Engine").getMethod("create").invoke(null);
+        } catch (ClassNotFoundException ex) {
+            Assume.assumeNoException("Skip if no Engine is found", ex);
+        } catch (ReflectiveOperationException ex) {
+            Assume.assumeNoException("Error when initializing Engine", ex);
+        }
+    }
+
+    @Test
+    public void invokeEngineViaGeneratedScriptEngine() {
+        ScriptEngineManager man = Scripting.createManager();
+        ScriptEngine llvm = man.getEngineByName("GraalVM:llvm");
+        assumeNotNull("Need llvm. Found: " + man.getEngineFactories(), llvm);
+
+        ScriptEngineFactory jsFactory = null;
+        ScriptEngineFactory graalvmJsFactory = null;
+        ScriptEngineFactory llvmFactory = null;
+
+        StringBuilder log = new StringBuilder();
+        for (ScriptEngineFactory factory : man.getEngineFactories()) {
+            final List<String> engineNames = factory.getNames();
+            final List<String> types = factory.getMimeTypes();
+
+            log.append("\nclass: ").append(factory.getClass().getSimpleName())
+                .append("\nnames: ").append(engineNames)
+                .append("\ntypes: ").append(types);
+
+            if (engineNames.contains("LLVM")) {
+                llvmFactory = factory;
+            }
+            if (types.contains("text/javascript")) {
+                if (factory.getEngineName().startsWith("GraalVM:")) {
+                    // assertNull("No previous generic GraalVM javascript factory: " + graalvmJsFactory, graalvmJsFactory);
+                    graalvmJsFactory = factory;
+                } else if (!factory.getEngineName().equalsIgnoreCase("Oracle Nashorn")) {
+                    // assertNull("No previous javascript factory: " + jsFactory, jsFactory);
+                    jsFactory = factory;
+                }
+            }
+        }
+
+        assertNotNull("llvm factory found: " + log, llvmFactory);
+        assertNotNull("js factory found: " + log, jsFactory);
+        assertNotNull("Generic GraalVM js factory found: " + log, graalvmJsFactory);
+    }
+
+    private static final String MUL =
+          "def mul(x, y):\n"
+        + "  return x * y\n"
+        + "mul\n"
+        + "\n";
+
+    @Test
+    public void pythonDirect() throws Exception {
+        assumeNotNull("Need python", Scripting.createManager().getEngineByMimeType("text/x-python"));
+        final Context ctx = Context.newBuilder().allowAllAccess(true).build();
+        Value mul = ctx.eval("python", MUL);
+        Value fourtyTwo = mul.execute(6, 7);
+        Assert.assertEquals("Fourty two", 42, fourtyTwo.asInt());
+    }
+
+    public static interface Mul {
+        public int multiplyTwoNumbers(int x, int y);
+    }
+
+    @Test
+    public void pythonFn() throws Exception {
+        ScriptEngine python = Scripting.createManager().getEngineByMimeType("text/x-python");
+        assumeNotNull("Need python", python);
+        Object rawMul = python.eval(MUL);
+        assertNotNull("mul created", rawMul);
+        assertTrue("Engines are invocable: " + python, python instanceof Invocable);
+        final Invocable inv = (Invocable)python;
+
+        Object res = inv.invokeFunction("mul", 6, 7);
+        assertNotNull("Expecting non-null", res);
+
+        assertTrue("Expecting number: " + res + " type: " + res.getClass(), res instanceof Number);
+        assertEquals(42, ((Number)res).intValue());
+
+        Mul mul = inv.getInterface(rawMul, Mul.class);
+        assertEquals(42, mul.multiplyTwoNumbers(7, 6));
+    }
+
+    @Test
+    public void javaScriptFn() throws Exception {
+        ScriptEngine js = Scripting.createManager().getEngineByName("GraalVM:js");
+        Object rawFn = js.eval("(function (x, y) { return x * y; })");
+
+        assertTrue("Engines are invocable: " + js, js instanceof Invocable);
+        final Invocable inv = (Invocable)js;
+
+        Mul mul = inv.getInterface(rawFn, Mul.class);
+        assertEquals(42, mul.multiplyTwoNumbers(7, 6));
+    }
+
+    @Test
+    public void pythonObjAccess() throws Exception {
+        ScriptEngine python = Scripting.createManager().getEngineByMimeType("text/x-python");
+        assumeNotNull("Need python", python);
+        Object rawPoint = python.eval(
+            "class O:\n" +
+            "  x = 5\n" +
+            "  y = -3\n" +
+            "  def z(self, x):\n" +
+            "    return x * x\n" +
+            "O()\n"
+        );
+        assertNotNull("Object created", rawPoint);
+
+        final Invocable inv = (Invocable)python;
+        Point point = inv.getInterface(rawPoint, Point.class);
+        assertNotNull("Object wrapped", point);
+
+        assertEquals(5, point.x());
+        assertEquals(-3, point.y(), 0.1);
+        assertEquals("Power of sqrt(2)", 2, point.z(1.42), 0.1);
+    }
+
+    @Test
+    public void returnArrayInPython() throws Exception {
+        ScriptEngine python = Scripting.createManager().getEngineByMimeType("text/x-python");
+        assumeNotNull("Need python", python);
+        python.eval("\n"
+                + "import math\n"
+                + "\n"
+                + "def arr(x):\n"
+                + "  return [ 1, 2, 'a', math.pi, x ]\n"
+                + "\n"
+        );
+
+        assertTrue("Engines are invocable: " + python, python instanceof Invocable);
+        final Invocable inv = (Invocable)python;
+
+        Sum sum = new Sum();
+        Object raw = inv.invokeFunction("arr", sum);
+
+        List<?> list = inv.getInterface(raw, List.class);
+        assertNotNull("List " + list, list);
+        assertEquals("Length of five", 5, list.size());
+
+        List<?> list2 = inv.getInterface(list, List.class);
+        assertNotNull("List 2 " + list2, list2);
+        assertEquals("Length 2 of five", 5, list2.size());
+
+        assertEquals(1, list.get(0));
+        assertEquals(2, list.get(1));
+        assertEquals("a", list.get(2));
+        assertEquals(Math.PI, list.get(3));
+        assertEquals(sum, list.get(4));
+    }
+
+
+    @Test
+    public void returnArrayInJS() throws Exception {
+        Assume.assumeFalse("Broken in GraalVM 20.3.0 fixed in GraalVM 21.1.0", "25.272-b10-jvmci-20.3-b06".equals(System.getProperty("java.vm.version")));
+
+        ScriptEngine js = Scripting.createManager().getEngineByName("GraalVM:js");
+        Object fn = js.eval("(function(obj) {\n"
+                + "  return [ 1, 2, 'a', Math.PI, obj ];\n"
+                + "})\n");
+        assertNotNull(fn);
+
+        Sum sum = new Sum();
+        Object raw = ((Invocable) js).invokeMethod(fn, "call", null, sum);
+
+        List<?> list = ((Invocable) js).getInterface(raw, List.class);
+        assertNotNull("List " + list, list);
+        assertEquals("Length of five", 5, list.size());
+
+        ArrLike like = ((Invocable) js).getInterface(raw, ArrLike.class);
+        assertNotNull("Array like " + like, like);
+        // known bug in GraalJS 20.3.0
+        // assertEquals("Length of five", 5, like.length());
+
+        
+        assertEquals(1, list.get(0));
+        assertEquals(2, list.get(1));
+        assertEquals("a", list.get(2));
+        assertEquals(Math.PI, list.get(3));
+        assertEquals(sum, list.get(4));
+    }
+
+    public interface ArrLike {
+        public int length();
+    }
+
+    @Test
+    public void returnMapInJS() throws Exception {
+        ScriptEngine js = Scripting.createManager().getEngineByName("GraalVM:js");
+        Object fn = js.eval("(function() {\n"
+                + "  return {\n"
+                + "    'x' : 1,\n"
+                + "    'y' : 2,\n"
+                + "  };\n"
+                + "})\n");
+        assertNotNull(fn);
+
+        Object raw = ((Invocable) js).invokeMethod(fn, "call");
+
+        Map<?,?> map = ((Invocable) js).getInterface(raw, Map.class);
+
+        assertEquals(1, map.get("x"));
+        assertEquals(2, map.get("y"));
+        assertEquals("Expecting just two elements: " + map, 2, map.size());
+    }
+
+    public interface Point {
+        public int x();
+        public double y();
+        public double z(double a);
+    }
+
+    @Test
+    public void accessPolyglotBindings() throws Exception {
+        ScriptEngineManager man = Scripting.createManager();
+        ScriptEngine js = man.getEngineByName("GraalVM:js");
+        ScriptEngine python = man.getEngineByName("GraalVM:python");
+        assumeNotNull("Need python", python);
+        
+        List<Integer> scopes = js.getContext().getScopes();
+        assertEquals(2, scopes.size());
+        assertEquals(ScriptContext.GLOBAL_SCOPE, scopes.get(1).intValue());
+
+        Bindings bindings = js.getBindings(ScriptContext.GLOBAL_SCOPE);
+        bindings.put("x", 42);
+
+        js.eval("\n"
+            + "var x = Polyglot.import('x');\n"
+            + "Polyglot.export('y', x);\n"
+            + ""
+        );
+
+        Object y = python.eval("\n"
+            + "import polyglot;\n"
+            + "polyglot.import_value('y')"
+        );
+
+        assertTrue("Expecting number, but was: " + y, y instanceof Number);
+        assertEquals(42, ((Number)y).intValue());
+    }
+
+    public interface TwoNumbers {
+        public int fourtyTwo();
+        public int eightyOne();
+    }
+
+    @Test
+    public void accessPolyglotBindings2() throws Exception {
+        ScriptEngineManager man = Scripting.createManager();
+        ScriptEngine python = man.getEngineByName("GraalVM:python");
+        ScriptEngine js = man.getEngineByName("GraalVM:js");
+        assumeNotNull("Need python", python);
+        
+        python.eval("\n"
+                + "import polyglot;\n"
+                + "@polyglot.export_value\n"
+                + "def fourtyTwo():\n"
+                + "  return 42\n"
+                + "\n"
+        );
+
+        js.eval("\n"
+                + "Polyglot.export('eightyOne', function() {\n"
+                + "  return 81;\n"
+                + "});\n"
+        );
+
+        TwoNumbers numbers1 = ((Invocable)python).getInterface(TwoNumbers.class);
+
+        assertEquals("Fourty two from python", 42, numbers1.fourtyTwo());
+        assertEquals("Eighty one from python", 81, numbers1.eightyOne());
+
+        TwoNumbers numbers2 = ((Invocable)js).getInterface(TwoNumbers.class);
+
+        assertEquals("Fourty two from JS", 42, numbers2.fourtyTwo());
+        assertEquals("Eighty one from JS", 81, numbers2.eightyOne());
+    }
+    
+    /**
+     * Attributes that have been set up as global scope should be accessible as polyglot 
+     * bindings. Polyglot bindings should be visible as global scope attributes.
+     * @throws Exception 
+     */
+    @Test
+    public void polyglotBindingsAsAttributes() throws Exception {
+        ScriptEngineManager man = Scripting.newBuilder().build();
+
+        ScriptEngine snake = man.getEngineByName("GraalVM:python");
+        ScriptEngine js = man.getEngineByName("GraalVM:js");
+        assumeNotNull("Need python", snake);
+        assumeNotNull("Need js", js);
+        
+        snake.getContext().setAttribute("preSnake", 1111, ScriptContext.GLOBAL_SCOPE);
+        js.getContext().setAttribute("preJs", 2222, ScriptContext.GLOBAL_SCOPE);
+        
+        Bindings pythonBindings = snake.getBindings(ScriptContext.GLOBAL_SCOPE);
+        Bindings jsBindings = js.getBindings(ScriptContext.GLOBAL_SCOPE);
+
+        pythonBindings.put("ctxSnake", 3333);
+        jsBindings.put("ctxJs", 4444);
+        
+        Object s = js.eval("var s = '' + Polyglot.import('preSnake') + Polyglot.import('preJs') + Polyglot.import('ctxSnake') + Polyglot.import('ctxJs');" 
+                + "Polyglot.export('s', s); s;");
+        assertEquals("1111222233334444", s);
+
+        assertEquals(s, js.getContext().getAttribute("s"));
+        assertEquals(s, js.getContext().getAttribute("s", ScriptContext.GLOBAL_SCOPE));
+        
+        assertEquals(s, snake.getContext().getAttribute("s"));
+        assertEquals(s, snake.getContext().getAttribute("s", ScriptContext.GLOBAL_SCOPE));
+
+    }
+
+    @Test
+    public void hostAccessGlobalAttributeWorks() throws Exception {
+        ScriptEngineManager man = Scripting.createManager();
+        ScriptEngine js = man.getEngineByName("GraalVM:js");
+        
+        js.getContext().setAttribute("allowAllAccess", true, ScriptContext.GLOBAL_SCOPE);
+        Object o = js.eval("var a = new java.util.ArrayList(); Polyglot.export('a', a); a;");
+        
+        assertTrue(o instanceof ArrayList);
+    }
+
+    @Test
+    public void allAccessEnabledBuilder() throws Exception {
+        ScriptEngineManager man = Scripting.newBuilder().allowAllAccess(true).build();
+        ScriptEngine js = man.getEngineByName("GraalVM:js");
+        
+        // consistency of builder / attribute
+        assertEquals(Boolean.TRUE, js.getContext().getAttribute("allowAllAccess"));
+        
+        Object o = js.eval("new java.util.ArrayList();");
+        assertTrue(o instanceof ArrayList);
+        
+        // consistency after Polyglot init:
+        assertEquals(Boolean.TRUE, js.getContext().getAttribute("allowAllAccess"));
+        // should not be exported into the language or polyglot
+        assertNull(js.get("allowAllAccess"));
+        // or its bindings
+        assertNull(js.getBindings(ScriptContext.GLOBAL_SCOPE).get("allowAllAccess"));
+    }
+
+    @Test
+    public void allAccessEnabledAttribute() throws Exception {
+        ScriptEngineManager man = Scripting.newBuilder().build();
+        ScriptEngine js = man.getEngineByName("GraalVM:js");
+
+        js.getContext().setAttribute("allowAllAccess", true, ScriptContext.GLOBAL_SCOPE);
+
+        Object o = js.eval("new java.util.ArrayList();");
+        assertTrue(o instanceof ArrayList);
+
+        // consistency after Polyglot init:
+        assertEquals(Boolean.TRUE, js.getContext().getAttribute("allowAllAccess"));
+        // should not be in engine scope
+        assertNull(js.get("allowAllAccess"));
+        // or its bindings
+        assertNull(js.getBindings(ScriptContext.GLOBAL_SCOPE).get("allowAllAccess"));
+    }
+    
+}

--- a/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/impl/Sum.java
+++ b/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/impl/Sum.java
@@ -16,25 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.api.scripting;
+package org.netbeans.libs.graalsdk.impl;
 
-import javax.script.ScriptEngine;
-import static org.junit.Assume.assumeTrue;
-import org.netbeans.junit.NbTestCase;
+public class Sum {
+    public int sum;
+    public Object err;
 
-public class ScriptingTutorialTest extends NbTestCase {
-    public ScriptingTutorialTest(String name) {
-        super(name);
+    public void increment() {
+        sum++;
     }
 
-    public void testFourtyTwo() throws Exception {
-        // @start region="testFourtyTwo"
-        ScriptEngine js = Scripting.createManager().getEngineByMimeType("text/javascript");
-        assumeTrue(js != null || System.getProperty("java.vendor.version").contains("Graal"));
-
-        Number x = (Number) js.eval("6 * 7");
-
-        assert x.intValue() == 42;
-        // @end region="testFourtyTwo"
+    final void add(int x) {
+        sum += x;
     }
 }

--- a/ide/libs.truffleapi/manifest.mf
+++ b/ide/libs.truffleapi/manifest.mf
@@ -4,3 +4,5 @@ OpenIDE-Module: org.netbeans.libs.truffleapi
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/truffle/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.20
 OpenIDE-Module-Provides: com.oracle.truffle.polyglot.PolyglotImpl
+OpenIDE-Module-Hide-Classpath-Packages: com.oracle.truffle.**,jdk.vm.ci.services.**
+

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -390,6 +390,7 @@ nb.cluster.ide=\
         libs.freemarker,\
         libs.git,\
         libs.graalsdk,\
+        libs.graalsdk.system,\
         libs.ini4j,\
         libs.jaxb,\
         libs.jcodings,\

--- a/platform/api.scripting/nbproject/project.xml
+++ b/platform/api.scripting/nbproject/project.xml
@@ -42,6 +42,11 @@
                         <recursive/>
                         <compile-dependency/>
                     </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.graaljs</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
                 </test-type>
             </test-dependencies>
             <public-packages>

--- a/platform/api.scripting/src/org/netbeans/api/scripting/Scripting.java
+++ b/platform/api.scripting/src/org/netbeans/api/scripting/Scripting.java
@@ -162,6 +162,9 @@ public final class Scripting {
                     it.set(new GraalJSWrapperFactory(f));
                 }
             }
+            // reverse the list: as later engines override the earlier ones in MIME mappings, so
+            // they should be enumerated first, to give them higher precedence
+            Collections.reverse(all);
             return all;
         }
 

--- a/platform/libs.junit4/nbproject/project.xml
+++ b/platform/libs.junit4/nbproject/project.xml
@@ -41,6 +41,7 @@
                 <package>org.junit.experimental.theories</package>
                 <package>org.junit.experimental.theories.suppliers</package>
                 <package>org.junit.function</package>
+                <package>org.junit.internal</package>
                 <package>org.junit.matchers</package>
                 <package>org.junit.rules</package>
                 <package>org.junit.runner</package>

--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -1305,7 +1305,7 @@ public final class ModuleManager extends Modules {
     private void enable(Set<Module> modules, boolean honorAutoloadEager) throws IllegalArgumentException, InvalidException {
         assertWritable();
         Util.err.log(Level.FINE, "enable: {0}", modules);
-        /* Consider eager modules:
+        /* Consider eager modules: 
         if (modules.isEmpty()) {
             return;
         }
@@ -1940,6 +1940,15 @@ public final class ModuleManager extends Modules {
                     }
                 }
                 if (!foundOne) return false;
+            } else if (dep.getType() == Dependency.TYPE_JAVA) {
+                if (! Util.checkJavaDependency(dep)) {
+                    return false;
+                }
+            } else if (dep.getType() == Dependency.TYPE_PACKAGE) {
+                // eager modules check only appclassloader
+                if (!Util.checkPackageDependency(dep, classLoader)) {
+                    return false;
+                }
             }
             // else some other dep type
         }

--- a/platform/o.n.bootstrap/src/org/netbeans/ProxyClassLoader.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ProxyClassLoader.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openide.util.Enumerations;
@@ -65,6 +66,8 @@ public class ProxyClassLoader extends ClassLoader {
 
     /** keeps information about parent classloaders, system classloader, etc.*/
     volatile ProxyClassParents parents;
+    
+    private BiFunction<String, ClassLoader, Boolean> delegatingPredicate;
 
     /** Create a multi-parented classloader.
      * @param parents all direct parents of this classloader, except system one.
@@ -74,6 +77,17 @@ public class ProxyClassLoader extends ClassLoader {
     public ProxyClassLoader(ClassLoader[] parents, boolean transitive) {
         super(TOP_CL);
         this.parents = ProxyClassParents.coalesceParents(this, parents, TOP_CL, transitive);
+    }
+    
+    /** Create a multi-parented classloader.
+     * @param parents all direct parents of this classloader, except system one.
+     * @param transitive whether other PCLs depending on this one will
+     *                   automatically search through its parent list
+     */
+    public ProxyClassLoader(ClassLoader[] parents, boolean transitive, BiFunction<String, ClassLoader, Boolean> delegatingPredicate) {
+        super(TOP_CL);
+        this.parents = ProxyClassParents.coalesceParents(this, parents, TOP_CL, transitive);
+        this.delegatingPredicate = delegatingPredicate;
     }
     
     protected final void addCoveredPackages(Iterable<String> coveredPackages) {
@@ -549,7 +563,11 @@ public class ProxyClassLoader extends ClassLoader {
     }
     
     protected boolean shouldDelegateResource(String pkg, ClassLoader parent) {
-         return true;
+         if (delegatingPredicate != null) {
+             return delegatingPredicate.apply(pkg, parent);
+         } else {
+             return true;
+         }
     }
 
     /** Called before releasing the classloader so it can itself unregister

--- a/webcommon/libs.graaljs/manifest.mf
+++ b/webcommon/libs.graaljs/manifest.mf
@@ -5,3 +5,5 @@ OpenIDE-Module-Layer: org/netbeans/libs/graaljs/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/graaljs/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.20
 OpenIDE-Module-Provides: javax.script.ScriptEngine.js,org.netbeans.libs.graaljs
+OpenIDE-Module-Hide-Classpath-Packages: com.oracle.truffle.js.scriptengine.**, 
+    com.oracle.js.parser.**, com.oracle.truffle.js.**

--- a/webcommon/libs.graaljs/test/unit/src/org/netbeans/libs/graaljs/GraalJSTest.java
+++ b/webcommon/libs.graaljs/test/unit/src/org/netbeans/libs/graaljs/GraalJSTest.java
@@ -18,100 +18,31 @@
  */
 package org.netbeans.libs.graaljs;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineFactory;
-import javax.script.ScriptEngineManager;
 import junit.framework.Test;
-import org.graalvm.polyglot.Context;
-import org.junit.AssumptionViolatedException;
-import org.netbeans.api.scripting.Scripting;
+import junit.framework.TestSuite;
 import org.netbeans.junit.NbModuleSuite;
 import org.netbeans.junit.NbTestCase;
-import org.netbeans.libs.graalsdk.JavaScriptEnginesTest;
+import org.netbeans.junit.NbTestSuite;
+import org.openide.util.Lookup;
 
 public final class GraalJSTest extends NbTestCase {
     public GraalJSTest(String name) {
         super(name);
     }
 
-    public static Test suite() {
-        return NbModuleSuite.createConfiguration(GraalJSTest.class).
+    public static Test suite() throws Exception {
+        NbModuleSuite.Configuration cfg = NbModuleSuite.emptyConfiguration().
+            clusters("platform|webcommon|ide").
             honorAutoloadEager(true).
-            gui(false).
-            suite();
+            gui(false);
+        return cfg.addTest(GraalJSTest2.class).suite();
     }
 
-
-    public void testDirectEvaluationOfGraalJS() {
-        Context ctx = Context.newBuilder("js").build();
-        int fourtyTwo = ctx.eval("js", "6 * 7").asInt();
-        assertEquals(42, fourtyTwo);
-    }
-
-    public void testJavaScriptEngineIsGraalJS() {
-        ScriptEngineManager m = Scripting.createManager();
-        StringBuilder sb = new StringBuilder();
-        for (ScriptEngineFactory f : m.getEngineFactories()) {
-            sb.append("\nf: ").append(f.getEngineName()).append(" ext: ").append(f.getMimeTypes());
+    public static class S extends TestSuite {
+        public S() throws Exception {
+            ClassLoader parent = Lookup.getDefault().lookup(ClassLoader.class);
+            Class c = parent.loadClass("org.netbeans.libs.graaljs.GraalJSTest2");
+            addTest(new NbTestSuite(c));
         }
-        ScriptEngine text = m.getEngineByMimeType("text/javascript");
-        assertEquals(sb.toString(), "GraalVM:js", text.getFactory().getEngineName());
-
-        ScriptEngine app = m.getEngineByMimeType("application/javascript");
-        assertEquals(sb.toString(), "GraalVM:js", app.getFactory().getEngineName());
-    }
-
-    public void testDeleteASymbol() throws Exception {
-        ScriptEngine eng = Scripting.createManager().getEngineByName("GraalVM:js");
-        Object function = eng.eval("typeof isFinite");
-        eng.eval("delete isFinite");
-        Object undefined = eng.eval("typeof isFinite");
-
-        assertEquals("Defined at first", "function", function);
-        assertEquals("Deleted later", "undefined", undefined);
-    }
-
-    public void testAllJavaScriptEnginesTest() throws Throwable {
-        StringWriter w = new StringWriter();
-        PrintWriter pw = new PrintWriter(w);
-        boolean err = false;
-        Method[] testMethods = JavaScriptEnginesTest.class.getMethods();
-        for (Method m : testMethods) {
-            final org.junit.Test ann = m.getAnnotation(org.junit.Test.class);
-            if (ann == null) {
-                continue;
-            }
-            ScriptEngine eng = Scripting.createManager().getEngineByName("GraalVM:js");
-            err |= invokeTestMethod(eng, false, pw, m, ann);
-            ScriptEngine engAllow = Scripting.newBuilder().allowAllAccess(true).build().getEngineByName("GraalVM:js");
-            err |= invokeTestMethod(engAllow, true, pw, m, ann);
-        }
-        pw.flush();
-        if (err) {
-            fail(w.toString());
-        }
-    }
-
-    private static boolean invokeTestMethod(ScriptEngine eng, final boolean allowAllAccess, PrintWriter pw, Method m, final org.junit.Test ann) throws IllegalAccessException, IllegalArgumentException {
-        JavaScriptEnginesTest instance = new JavaScriptEnginesTest("GraalVM:js", null, null, eng, allowAllAccess);
-        try {
-            pw.println("Invoking " + m.getName() + " allowAllAccess: " + allowAllAccess);
-            m.invoke(instance);
-        } catch (InvocationTargetException invEx) {
-            if (invEx.getCause() instanceof AssumptionViolatedException) {
-                return false;
-            }
-            if (ann.expected().equals(invEx.getCause().getClass())) {
-                pw.println("Expected exception received " + ann.expected().getName());
-            } else {
-                invEx.getCause().printStackTrace(pw);
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/webcommon/libs.graaljs/test/unit/src/org/netbeans/libs/graaljs/GraalJSTest2.java
+++ b/webcommon/libs.graaljs/test/unit/src/org/netbeans/libs/graaljs/GraalJSTest2.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.graaljs;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import org.graalvm.polyglot.Context;
+import org.junit.AssumptionViolatedException;
+import org.netbeans.api.scripting.Scripting;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.libs.graalsdk.GraalSDK;
+import org.netbeans.libs.graalsdk.JavaScriptEnginesTest;
+import org.netbeans.libs.graalsdk.JavaScriptEnginesTest2;
+import org.openide.modules.Dependency;
+import org.openide.modules.ModuleInfo;
+import org.openide.modules.Modules;
+import org.openide.util.Lookup;
+
+public final class GraalJSTest2 extends NbTestCase {
+    public GraalJSTest2(String name) {
+        super(name);
+    }
+
+    private ClassLoader createGraalDependentClassLoader() {
+        ClassLoader allLoader = Lookup.getDefault().lookup(ClassLoader.class);
+        Collection<? extends ModuleInfo> modules = new ArrayList<>(Lookup.getDefault().lookupAll(ModuleInfo.class));
+        ModuleInfo thisModule = Modules.getDefault().ownerOf(GraalSDK.class);
+        Map<String, ModuleInfo> dependentsOfSDK = new LinkedHashMap<>();
+        if (thisModule == null) {
+            // this happens only when mod system is not active, i.e. in tests.
+            return allLoader;
+        }
+        dependentsOfSDK.put(thisModule.getCodeName(), thisModule);
+        
+        boolean added;
+        do {
+            added = false;
+            for (Iterator<? extends ModuleInfo> it = modules.iterator(); it.hasNext(); ) {
+                ModuleInfo m = it.next();
+                for (Dependency d : m.getDependencies()) {
+                    if (d.getType() == Dependency.TYPE_MODULE) {
+                        if (dependentsOfSDK.keySet().contains(d.getName())) {
+                            dependentsOfSDK.put(m.getCodeName(), m);
+                            it.remove();
+                            added = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        } while (!added);
+        
+        ClassLoader created;
+        try {
+            BiFunction<String, ClassLoader, Boolean> decideDelegation = (n, c) -> c == null ? false : true;
+            
+            // this is a hack that allows to use good implementation of a classloader ...
+            // there should have to be an API for this in the module system.
+            Class pcl = Class.forName("org.netbeans.ProxyClassLoader", true, allLoader);
+            Constructor ctor = pcl.getConstructor(ClassLoader[].class, Boolean.TYPE, BiFunction.class);
+            ClassLoader[] delegates = new ClassLoader[dependentsOfSDK.size()];
+            int index = delegates.length -1;
+            // reverse the order: in the LinkedHashMap, the 1st entry is GraalSDK, following by direct dependents
+            // if some of module deeper in the hierarchy masks JDK packages, it should be consulted first, so the
+            for (ModuleInfo mi : dependentsOfSDK.values()) {
+                delegates[index--] = mi.getClassLoader();
+            }
+            created = (ClassLoader)ctor.newInstance(delegates, true, decideDelegation);
+        } catch (ReflectiveOperationException ex) {
+            created = allLoader;
+        }
+        return created;
+    }
+    
+    public void testDirectEvaluationOfGraalJS() {
+        // must use a special trick with a ClassLoader, so that the context builder gathers appropriate things from the modules.
+        // The code must be the same as in GraalEngineProvider
+        Thread.currentThread().setContextClassLoader(createGraalDependentClassLoader());
+        Context ctx = Context.newBuilder("js").build();
+        int fourtyTwo = ctx.eval("js", "6 * 7").asInt();
+        assertEquals(42, fourtyTwo);
+    }
+    
+    public void testJavaScriptEngineIsGraalJS() {
+        ScriptEngineManager m = Scripting.createManager();
+        StringBuilder sb = new StringBuilder();
+        for (ScriptEngineFactory f : m.getEngineFactories()) {
+            sb.append("\nf: ").append(f.getEngineName()).append(" ext: ").append(f.getMimeTypes());
+        }
+        ScriptEngine text = m.getEngineByMimeType("text/javascript");
+        assertEquals(sb.toString(), "GraalVM:js", text.getFactory().getEngineName());
+
+        ScriptEngine app = m.getEngineByMimeType("application/javascript");
+        assertEquals(sb.toString(), "GraalVM:js", app.getFactory().getEngineName());
+    }
+
+    public void testDeleteASymbol() throws Exception {
+        ScriptEngine eng = Scripting.createManager().getEngineByName("GraalVM:js");
+        Object function = eng.eval("typeof isFinite");
+        eng.eval("delete isFinite");
+        Object undefined = eng.eval("typeof isFinite");
+
+        assertEquals("Defined at first", "function", function);
+        assertEquals("Deleted later", "undefined", undefined);
+    }
+
+    public void testAllJavaScriptEnginesTest() throws Throwable {
+        StringWriter w = new StringWriter();
+        PrintWriter pw = new PrintWriter(w);
+        boolean err = false;
+        Method[] testMethods = JavaScriptEnginesTest.class.getMethods();
+        for (Method m : testMethods) {
+            final org.junit.Test ann = m.getAnnotation(org.junit.Test.class);
+            if (ann == null) {
+                continue;
+            }
+            ScriptEngine eng = Scripting.createManager().getEngineByName("GraalVM:js");
+            err |= invokeTestMethod(eng, false, pw, m, ann);
+            ScriptEngine engAllow = Scripting.newBuilder().allowAllAccess(true).build().getEngineByName("GraalVM:js");
+            err |= invokeTestMethod(engAllow, true, pw, m, ann);
+        }
+        pw.flush();
+        if (err) {
+            fail(w.toString());
+        }
+    }
+
+    private static boolean invokeTestMethod(ScriptEngine eng, final boolean allowAllAccess, PrintWriter pw, Method m, final org.junit.Test ann) throws IllegalAccessException, IllegalArgumentException {
+        JavaScriptEnginesTest2 instance = new JavaScriptEnginesTest2(m.getName(), "GraalVM:js", null, null, eng, allowAllAccess);
+        try {
+            pw.println("Invoking " + m.getName() + " allowAllAccess: " + allowAllAccess);
+            m.invoke(instance);
+        } catch (InvocationTargetException invEx) {
+            if (invEx.getCause() instanceof AssumptionViolatedException) {
+                return false;
+            }
+            if (ann.expected().equals(invEx.getCause().getClass())) {
+                pw.println("Expected exception received " + ann.expected().getName());
+            } else {
+                invEx.getCause().printStackTrace(pw);
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
**This PR goes against vsnetbeans_1703 release branch!**

Initially, GraalVM distributed js in the base package - it made sense to prefer JDK-first approach. Through the time, graalvm (graalsdk, truffle) implementaiton changed so that JDK-provided GraalSDK refuses to load application languages available e.g.  in contet class loader - AND GraalVM JDK stopped to distribute Javascript.

As  a result, on GraalVM _without_ javascript installed, NetBeans fail to load JS engine even though NetBeans itself distributes the engine - since GraalSDK classes load parent-first from the JDK, and then they refuse to plug in NetBeans-provided JS/truffle implementation.

This PR is a partial "hotfix" that masks out graalSDK+truffle from the JDK to allow loading from the NB distribution. A special loader is needed so that GraalSDK module can find language implementatiosn distributed with NetBeans -- the "all-classloader" would load JDK implementation (if present) of GraalSDK internal interfaces instead (with the consequences described above).

I needed to use optimized logic of `ProxyClassLoader` - and did not want to make a `friend` dependency just for this hotfix. I have a more elaborate fix in mind, which should follow in a 1-2 weeks, that will formalize this classloading hell somehow, changing API of the module system.