### PR TITLE
JS: Improve stability of JS model building (prevent cycles)

### DIFF
--- a/webcommon/javascript2.editor/test/unit/data/testfiles/structure/objectNameMatchingNestedFunction.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/structure/objectNameMatchingNestedFunction.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var Base = new function() {
+    function Base() {
+    }
+};

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/structure/objectNameMatchingNestedFunction.js.structure
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/structure/objectNameMatchingNestedFunction.js.structure
@@ -1,0 +1,2 @@
+Base:CLASS:[PUBLIC]:ESCAPED{Base}:
+  Base:METHOD:[PRIVATE]:ESCAPED{Base}ESCAPED{(}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsStructureScannerTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsStructureScannerTest.java
@@ -763,4 +763,7 @@ public class JsStructureScannerTest extends JsTestBase {
         checkStructure("testfiles/structure/issueGH4262.js");
     }
 
+    public void testObjectNameMatchingNestedFunction() throws Exception {
+        checkStructure("testfiles/structure/objectNameMatchingNestedFunction.js");
+    }
 }

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.javascript2.model;
 
-import org.netbeans.modules.javascript2.model.api.Occurrence;
 import org.netbeans.modules.javascript2.model.api.ModelUtils;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -192,7 +191,17 @@ public class JsObjectImpl extends JsElementImpl implements JsObject {
         return parent;
     }
 
+    @SuppressWarnings({"NestedAssignment", "AssertWithSideEffects"})
     public void setParent(JsObject newParent) {
+        boolean assertionsEnabled = false;
+        assert assertionsEnabled = true;
+        if (assertionsEnabled) {
+            for (JsObject checkParent = newParent; checkParent != null; checkParent = checkParent.getParent()) {
+                if (checkParent == this) {
+                    throw new AssertionError("Cycle detected in " + getFileObject().getPath());
+                }
+            }
+        }
         this.parent = newParent;
     }
 

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -981,7 +981,14 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
                 JsObject singleton = resolveThisInSingletonPattern(fncScope);
                 if (singleton != null) {
                     fncScope.setJsKind(JsElement.Kind.CONSTRUCTOR);
-                    if (fncScope.isAnonymous()) {
+                    // The second guard is necessary to prevent cyclic structures
+                    // for constructs like this:
+                    //
+                    // var Base = new function() {
+                    //    function Base() {
+                    //    }
+                    // };
+                    if (fncScope.isAnonymous() && !fncScope.getProperties().containsValue(singleton)) {
                         // TODO we probably should not move the properties, or at least increase offset range
                         // of the singleton to fit offsets of these methods in the singleton object
                         List<JsObject> properties = new ArrayList<>(fncScope.getProperties().values());

--- a/webcommon/javascript2.model/test/unit/data/testfiles/model/objectNameMatchingNestedFunction.js
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/model/objectNameMatchingNestedFunction.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var Base = new function() {
+    function Base() {
+    }
+};

--- a/webcommon/javascript2.model/test/unit/data/testfiles/model/objectNameMatchingNestedFunction.js.model
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/model/objectNameMatchingNestedFunction.js.model
@@ -1,0 +1,16 @@
+FUNCTION objectNameMatchingNestedFunction [ANONYMOUS: false, DECLARED: true - objectNameMatchingNestedFunction, MODIFIERS: PUBLIC, FILE]
+# RETURN TYPES
+undefined, RESOLVED: true
+# PROPERTIES
+Base : OBJECT Base [ANONYMOUS: false, DECLARED: true - Base, MODIFIERS: PUBLIC, OBJECT]
+     # PROPERTIES
+     objectNameMatchingNestedFunctionBase : FUNCTION objectNameMatchingNestedFunctionBase [ANONYMOUS: true, DECLARED: true - objectNameMatchingNestedFunctionBase, MODIFIERS: PRIVATE, CONSTRUCTOR]
+                                          # RETURN TYPES
+                                          Base.objectNameMatchingNestedFunctionBase, RESOLVED: true
+                                          # PROPERTIES
+                                          Base      : FUNCTION Base [ANONYMOUS: false, DECLARED: true - Base, MODIFIERS: PRIVATE, METHOD]
+                                                    # RETURN TYPES
+                                                    undefined, RESOLVED: true
+                                                    # PROPERTIES
+                                                    arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+                                          arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]

--- a/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
+++ b/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
@@ -277,4 +277,8 @@ public class ModelTest extends ModelTestBase {
         // and regenerated.
         checkModel("testfiles/model/complexPrototype.js");
     }
+
+    public void testObjectNameMatchingNestedFunction() throws Exception {
+        checkModel("testfiles/model/objectNameMatchingNestedFunction.js");
+    }
 }

--- a/webcommon/libs.nashorn/src/com/oracle/js/parser/Parser.java
+++ b/webcommon/libs.nashorn/src/com/oracle/js/parser/Parser.java
@@ -1967,7 +1967,6 @@ loop:
      * Verify destructuring variable declaration binding pattern and extract bound variable declarations.
      */
     private void verifyDestructuringBindingPattern(Expression pattern, Consumer<IdentNode> identifierCallback) {
-        assert pattern instanceof ObjectNode || pattern instanceof ArrayLiteralNode;
         pattern.accept(new VerifyDestructuringPatternNodeVisitor(new LexicalContext()) {
             @Override
             protected void verifySpreadElement(Expression lvalue) {

--- a/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/ParserTest.java
+++ b/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/ParserTest.java
@@ -274,6 +274,15 @@ public class ParserTest {
         assertParses(13, "const a = <table>{/* Test */ /* Test */ /* Test */}{ a = 3 }</table>");
     }
 
+    @Test
+    public void testBindingPattern() {
+        assertParses(13, "const buildTerserOptions = ({\n"
+                + "  ecma\n"
+                + "} = {}) => ({\n"
+                + "  ecma\n"
+                + "});");
+    }
+
     private Predicate<Node> functionNodeWithName(String name) {
         return n -> n instanceof FunctionNode && name.equals(((FunctionNode) n).getName());
     }


### PR DESCRIPTION
As analyzed by @akronenw certain JS files can lead the JS model generator of NetBeans
to create a cyclic structure. The structure looks like this:

```javascript
var Base = new function() {
     // a lot of code

    function Base() {
        // some code
    }

    // more code
}
```

This is turn is at least partially responsible for seemingly endless scanning.

The implemented fix added an assert that detects cycles in the generated model and fixes the
one detected when the `paper-full.js` file is parsed.

In addition a wrong assertion in the GraalJS fork is disabled, that triggered on angular projects
and prevented usage of NetBeans with activated assertions there.

This is not a full fix, but should improve the situation and make it easier to find other
problems in that area by just using NetBeans with assertions enabled (for example by running
a nightly build).

Closes: #4745