### PR TITLE
FlatLaf: change accent color in Options dialog (Appearance > FlatLaf)

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
@@ -25,8 +25,10 @@ Editors/FontsColors/FlatLafDark=FlatLaf Dark
 Editors/FontsColors/FlatLafLight=FlatLaf Light
 
 FlatLaf_DisplayName=FlatLaf
-KW_FlatLafOptions=FlatLaf, Look and Feel, Window decorations, Unified title bar, Embedded menu bar, underline menu, mnemonics
+KW_FlatLafOptions=FlatLaf, Look and Feel, Accent color, Window decorations, Unified title bar, Embedded menu bar, underline menu, mnemonics
 
+FlatLafOptionsPanel.accentColorLabel.text=Accent color:
+FlatLafOptionsPanel.needsRestartLabel.text=(needs restart)
 FlatLafOptionsPanel.useWindowDecorationsCheckBox.text=&Window decorations
 FlatLafOptionsPanel.unifiedTitleBarCheckBox.text=&Unified window title bar
 FlatLafOptionsPanel.menuBarEmbeddedCheckBox.text=&Embedded menu bar
@@ -41,6 +43,8 @@ FlatLafOptionsPanel.customProperties.content=\
 \# FlatLaf custom property overrides.\n\
 \# Save file and restart NetBeans to apply.\n\
 \# For full documentation see https://www.formdev.com/flatlaf/properties-files/\n\
-\#\n\
-\# @accentColor=#dd2222\n\
-\# [dark]@accentColor=#bb3232\n
+\#                        and https://www.formdev.com/flatlaf/components/\n\
+\#\n
+
+FlatLafOptionsPanel.restartTitle=Restart IDE
+FlatLafOptionsPanel.restartDetails=Click here to restart IDE and apply your selected accent color.

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -18,6 +18,15 @@
 Nb.LFCustoms={instance}org.netbeans.swing.laf.flatlaf.FlatLFCustoms
 
 
+# accent colors from https://github.com/89netraM/SystemColors/blob/master/src/net/asberg/macos/AccentColor.java
+nb.accentColors.predefined = \
+    blue: #0A84FF; \
+    purple: #BF5AF2; \
+    red: #FF453A; \
+    orange: #FF9F0A; \
+    green: #32D74B
+
+
 nb.explorer.unfocusedSelBg=@selectionInactiveBackground
 nb.explorer.unfocusedSelFg=@selectionInactiveForeground
 nb.explorer.noFocusSelectionBackground=@selectionInactiveBackground

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.form
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.form
@@ -44,6 +44,7 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
+          <Component id="advPanel" alignment="0" max="32767" attributes="0"/>
           <Group type="102" attributes="0">
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="useWindowDecorationsCheckBox" min="-2" max="-2" attributes="0"/>
@@ -51,15 +52,28 @@
                   <Component id="menuBarEmbeddedCheckBox" min="-2" max="-2" attributes="0"/>
                   <Component id="underlineMenuSelectionCheckBox" min="-2" max="-2" attributes="0"/>
                   <Component id="alwaysShowMnemonicsCheckBox" min="-2" max="-2" attributes="0"/>
+                  <Group type="102" alignment="0" attributes="0">
+                      <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
+                      <Component id="accentColorLabel" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="accentColorField" min="-2" pref="130" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="needsRestartLabel" min="-2" max="-2" attributes="0"/>
+                  </Group>
               </Group>
-              <EmptySpace pref="213" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
-          <Component id="advPanel" alignment="0" max="32767" attributes="0"/>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="accentColorField" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="needsRestartLabel" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="accentColorLabel" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="useWindowDecorationsCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="unifiedTitleBarCheckBox" min="-2" max="-2" attributes="0"/>
@@ -71,12 +85,31 @@
               <Component id="alwaysShowMnemonicsCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="separate" max="-2" attributes="0"/>
               <Component id="advPanel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace pref="69" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
   </Layout>
   <SubComponents>
+    <Component class="javax.swing.JLabel" name="accentColorLabel">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/swing/laf/flatlaf/Bundle.properties" key="FlatLafOptionsPanel.accentColorLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="org.openide.awt.ColorComboBox" name="accentColorField">
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="accentColorFieldActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JLabel" name="needsRestartLabel">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/swing/laf/flatlaf/Bundle.properties" key="FlatLafOptionsPanel.needsRestartLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
     <Component class="javax.swing.JCheckBox" name="useWindowDecorationsCheckBox">
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
@@ -144,7 +177,7 @@
               <Group type="102" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="customPropertiesLabel" max="32767" attributes="0"/>
+                      <Component id="customPropertiesLabel" pref="368" max="32767" attributes="0"/>
                       <Group type="102" attributes="0">
                           <Component id="customPropertiesButton" min="-2" max="-2" attributes="0"/>
                           <EmptySpace min="0" pref="0" max="32767" attributes="0"/>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.java
@@ -20,14 +20,24 @@ package org.netbeans.swing.laf.flatlaf;
 
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.util.SystemInfo;
+import java.awt.Color;
 import java.io.BufferedWriter;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Properties;
+import javax.swing.UIManager;
 import org.netbeans.api.actions.Editable;
 import org.netbeans.spi.options.OptionsPanelController;
+import org.openide.LifecycleManager;
+import org.openide.awt.Notification;
+import org.openide.awt.NotificationDisplayer;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.util.Exceptions;
+import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 
@@ -41,6 +51,9 @@ import org.openide.util.RequestProcessor;
 )
 public class FlatLafOptionsPanel extends javax.swing.JPanel {
 
+    private static final Color DEFAULT = new Color(0, true);
+    private static final Color currentAccentColor = FlatLafPrefs.getAccentColor();
+
     private static final RequestProcessor RP = new RequestProcessor(FlatLafOptionsPanel.class);
 
     private final FlatLafOptionsPanelController controller;
@@ -51,7 +64,47 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
     public FlatLafOptionsPanel(FlatLafOptionsPanelController controller) {
         this.controller = controller;
         initComponents();
+        initAccentColor();
         updateEnabled();
+    }
+
+    private void initAccentColor() {
+        ArrayList<String> names = new ArrayList<>();
+        ArrayList<Color> colors = new ArrayList<>();
+        names.add("default");
+        colors.add(DEFAULT);
+
+        String s = UIManager.getString("nb.accentColors.predefined");
+        if (s == null) {
+            // FlatLaf is not the current look and feel
+            Properties properties = new Properties();
+            try {
+                properties.load(getClass().getClassLoader().getResourceAsStream(
+                        "org/netbeans/swing/laf/flatlaf/FlatLaf.properties"));
+                s = properties.getProperty("nb.accentColors.predefined");
+            } catch (IOException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+
+        if (s != null) {
+            for (String part : s.split(";")) {
+                int sepIndex = part.indexOf(':');
+                if (sepIndex >= 1) {
+                    String name = part.substring(0, sepIndex).trim();
+                    String value = part.substring(sepIndex + 1).trim();
+                    if (!name.isEmpty() && !value.isEmpty()) {
+                        Color color = FlatLafPrefs.parseColor(value);
+                        if (color != null) {
+                            names.add(name);
+                            colors.add(color);
+                        }
+                    }
+                }
+            }
+        }
+
+        accentColorField.setModel(colors.toArray(new Color[0]), names.toArray(new String[0]));
     }
 
     private void updateEnabled() {
@@ -72,6 +125,9 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
+        accentColorLabel = new javax.swing.JLabel();
+        accentColorField = new org.openide.awt.ColorComboBox();
+        needsRestartLabel = new javax.swing.JLabel();
         useWindowDecorationsCheckBox = new javax.swing.JCheckBox();
         menuBarEmbeddedCheckBox = new javax.swing.JCheckBox();
         unifiedTitleBarCheckBox = new javax.swing.JCheckBox();
@@ -82,6 +138,16 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
         customPropertiesButton = new javax.swing.JButton();
 
         setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+        org.openide.awt.Mnemonics.setLocalizedText(accentColorLabel, org.openide.util.NbBundle.getMessage(FlatLafOptionsPanel.class, "FlatLafOptionsPanel.accentColorLabel.text")); // NOI18N
+
+        accentColorField.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                accentColorFieldActionPerformed(evt);
+            }
+        });
+
+        org.openide.awt.Mnemonics.setLocalizedText(needsRestartLabel, org.openide.util.NbBundle.getMessage(FlatLafOptionsPanel.class, "FlatLafOptionsPanel.needsRestartLabel.text")); // NOI18N
 
         org.openide.awt.Mnemonics.setLocalizedText(useWindowDecorationsCheckBox, org.openide.util.NbBundle.getMessage(FlatLafOptionsPanel.class, "FlatLafOptionsPanel.useWindowDecorationsCheckBox.text")); // NOI18N
         useWindowDecorationsCheckBox.addActionListener(new java.awt.event.ActionListener() {
@@ -136,7 +202,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
             .addGroup(advPanelLayout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(advPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(customPropertiesLabel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(customPropertiesLabel, javax.swing.GroupLayout.DEFAULT_SIZE, 368, Short.MAX_VALUE)
                     .addGroup(advPanelLayout.createSequentialGroup()
                         .addComponent(customPropertiesButton)
                         .addGap(0, 0, Short.MAX_VALUE)))
@@ -156,19 +222,31 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addComponent(advPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             .addGroup(layout.createSequentialGroup()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(useWindowDecorationsCheckBox)
                     .addComponent(unifiedTitleBarCheckBox)
                     .addComponent(menuBarEmbeddedCheckBox)
                     .addComponent(underlineMenuSelectionCheckBox)
-                    .addComponent(alwaysShowMnemonicsCheckBox))
-                .addContainerGap(213, Short.MAX_VALUE))
-            .addComponent(advPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(alwaysShowMnemonicsCheckBox)
+                    .addGroup(layout.createSequentialGroup()
+                        .addGap(0, 0, 0)
+                        .addComponent(accentColorLabel)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(accentColorField, javax.swing.GroupLayout.PREFERRED_SIZE, 130, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(needsRestartLabel)))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(accentColorField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(needsRestartLabel)
+                    .addComponent(accentColorLabel))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(useWindowDecorationsCheckBox)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(unifiedTitleBarCheckBox)
@@ -180,7 +258,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
                 .addComponent(alwaysShowMnemonicsCheckBox)
                 .addGap(18, 18, 18)
                 .addComponent(advPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap())
+                .addContainerGap(69, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -226,9 +304,14 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
         });
     }//GEN-LAST:event_customPropertiesButtonActionPerformed
 
+    private void accentColorFieldActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_accentColorFieldActionPerformed
+        fireChanged();
+    }//GEN-LAST:event_accentColorFieldActionPerformed
+
     private void fireChanged() {
         boolean isChanged = false;
-        if(useWindowDecorationsCheckBox.isSelected() != FlatLafPrefs.isUseWindowDecorations()
+        if(!Objects.equals(accentColorField.getSelectedColor(), getPrefsAccentColorOrDefault())
+                || useWindowDecorationsCheckBox.isSelected() != FlatLafPrefs.isUseWindowDecorations()
                 || unifiedTitleBarCheckBox.isSelected() != FlatLafPrefs.isUnifiedTitleBar()
                 || menuBarEmbeddedCheckBox.isSelected() != FlatLafPrefs.isMenuBarEmbedded()
                 || underlineMenuSelectionCheckBox.isSelected() != FlatLafPrefs.isUnderlineMenuSelection()
@@ -239,6 +322,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
     }
 
     protected void load() {
+        accentColorField.setSelectedColor(getPrefsAccentColorOrDefault());
         useWindowDecorationsCheckBox.setSelected(FlatLafPrefs.isUseWindowDecorations());
         unifiedTitleBarCheckBox.setSelected(FlatLafPrefs.isUnifiedTitleBar());
         menuBarEmbeddedCheckBox.setSelected(FlatLafPrefs.isMenuBarEmbedded());
@@ -249,12 +333,44 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
     }
 
     protected boolean store() {
+        Color accentColor = accentColorField.getSelectedColor();
+        FlatLafPrefs.setAccentColor(accentColor != DEFAULT ? accentColor : null);
         FlatLafPrefs.setUseWindowDecorations(useWindowDecorationsCheckBox.isSelected());
         FlatLafPrefs.setUnifiedTitleBar(unifiedTitleBarCheckBox.isSelected());
         FlatLafPrefs.setMenuBarEmbedded(menuBarEmbeddedCheckBox.isSelected());
         FlatLafPrefs.setUnderlineMenuSelection(underlineMenuSelectionCheckBox.isSelected());
         FlatLafPrefs.setAlwaysShowMnemonics(alwaysShowMnemonicsCheckBox.isSelected());
+
+        if (!Objects.equals(accentColor, currentAccentColor)) {
+            askForRestart();
+        }
         return false;
+    }
+
+    private static Notification restartNotification;
+
+    private void askForRestart() {
+        if(restartNotification != null) {
+            restartNotification.clear();
+        }
+        restartNotification = NotificationDisplayer.getDefault().notify(
+                NbBundle.getMessage(FlatLafOptionsPanel.class, "FlatLafOptionsPanel.restartTitle"),
+                ImageUtilities.loadImageIcon( "org/netbeans/core/windows/resources/restart.png", true ), //NOI18N
+                NbBundle.getMessage(FlatLafOptionsPanel.class, "FlatLafOptionsPanel.restartDetails"),
+                e -> {
+                    if(restartNotification != null) {
+                        restartNotification.clear();
+                        restartNotification = null;
+                    }
+                    LifecycleManager.getDefault().markForRestart();
+                    LifecycleManager.getDefault().exit();
+                },
+                NotificationDisplayer.Priority.NORMAL, NotificationDisplayer.Category.INFO);
+    }
+
+    private Color getPrefsAccentColorOrDefault() {
+        Color accentColor = FlatLafPrefs.getAccentColor();
+        return accentColor != null ? accentColor : DEFAULT;
     }
 
     boolean valid() {
@@ -263,11 +379,14 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private org.openide.awt.ColorComboBox accentColorField;
+    private javax.swing.JLabel accentColorLabel;
     private javax.swing.JPanel advPanel;
     private javax.swing.JCheckBox alwaysShowMnemonicsCheckBox;
     private javax.swing.JButton customPropertiesButton;
     private javax.swing.JLabel customPropertiesLabel;
     private javax.swing.JCheckBox menuBarEmbeddedCheckBox;
+    private javax.swing.JLabel needsRestartLabel;
     private javax.swing.JCheckBox underlineMenuSelectionCheckBox;
     private javax.swing.JCheckBox unifiedTitleBarCheckBox;
     private javax.swing.JCheckBox useWindowDecorationsCheckBox;

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafPrefs.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafPrefs.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.swing.laf.flatlaf;
 
+import java.awt.Color;
 import java.util.prefs.Preferences;
 import org.openide.util.NbPreferences;
 
@@ -27,6 +28,7 @@ import org.openide.util.NbPreferences;
  */
 class FlatLafPrefs {
 
+    private static final String ACCENT_COLOR = "accentColor";
     private static final String USE_WINDOW_DECORATIONS = "useWindowDecorations";
     private static final String UNIFIED_TITLE_BAR = "unifiedTitleBar";
     private static final String MENU_BAR_EMBEDDED = "menuBarEmbedded";
@@ -34,6 +36,28 @@ class FlatLafPrefs {
     private static final String ALWAYS_SHOW_MNEMONICS = "alwaysShowMnemonics";
 
     private static final Preferences prefs = NbPreferences.forModule(FlatLafPrefs.class);
+
+    static Color getAccentColor() {
+        return parseColor(prefs.get(ACCENT_COLOR, null));
+    }
+
+    static Color parseColor(String s) {
+        try {
+            return (s != null && s.startsWith("#"))
+                    ? new Color(Integer.parseInt(s.substring(1), 16))
+                    : null;
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    static void setAccentColor(Color accentColor) {
+        if (accentColor != null) {
+            prefs.put(ACCENT_COLOR, String.format("#%06x", accentColor.getRGB() & 0xffffff));
+        } else {
+            prefs.remove(ACCENT_COLOR);
+        }
+    }
 
     static boolean isUseWindowDecorations() {
         return prefs.getBoolean(USE_WINDOW_DECORATIONS, true);

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
@@ -53,6 +53,10 @@ public class Installer extends ModuleInstall {
             FlatLaf.registerCustomDefaultsSource(customFolder.toURL());
         }
 
+        FlatLaf.setSystemColorGetter( name -> {
+            return name.equals( "accent" ) ? FlatLafPrefs.getAccentColor() : null;
+        } );
+
         // don't allow FlatLaf to update UI on system font changes because this would
         // invoke UIManager.setLookAndFeel() and SwingUtilities.updateComponentTreeUI()
         System.setProperty( "flatlaf.updateUIOnSystemFontChange", "false" );


### PR DESCRIPTION
Since changing accent color in FlatLaf custom properties does not work as expected for Cupertino themes (see issue #5461),
I've added a combobox to the options dialog to allow setting accent color in UI. FlatLaf API is used to enable accent color so that it works correctly in Cupertino themes.

![grafik](https://user-images.githubusercontent.com/5604048/230694039-58bcd628-d42a-451a-b72f-2017d8e6939c.png)

There are some predefined accent colors, which work good for light and dark themes. These are the same colors that macOS (and FlatLaf Demo app) uses. There is also a "Custom" item in the combobox that allows to set any color.

![grafik](https://user-images.githubusercontent.com/5604048/230692669-ee92a742-d493-470a-ab04-4f594c6087c2.png)

The colors are defined in `FlatLaf.properties` (key `nb.accentColors.predefined`).
