### PR TITLE
JS: Improve handling of export declarations (references and classes)

### DIFF
--- a/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH5184_01.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH5184_01.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class test2 {
+}
+
+export {test2};

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH5184_01.js.testIssueGH5184_01.occurrences
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH5184_01.js.testIssueGH5184_01.occurrences
@@ -1,0 +1,2 @@
+class |>MARK_OCCURRENCES:test2<| {
+export {|>MARK_OCCURRENCES:te^st2<|};

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/structure/objectNameMatchingNestedFunction.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/structure/objectNameMatchingNestedFunction.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var Base = new function() {
+    function Base() {
+    }
+};

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/structure/objectNameMatchingNestedFunction.js.structure
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/structure/objectNameMatchingNestedFunction.js.structure
@@ -1,0 +1,2 @@
+Base:CLASS:[PUBLIC]:ESCAPED{Base}:
+  Base:METHOD:[PRIVATE]:ESCAPED{Base}ESCAPED{(}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsStructureScannerTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsStructureScannerTest.java
@@ -763,4 +763,7 @@ public class JsStructureScannerTest extends JsTestBase {
         checkStructure("testfiles/structure/issueGH4262.js");
     }
 
+    public void testObjectNameMatchingNestedFunction() throws Exception {
+        checkStructure("testfiles/structure/objectNameMatchingNestedFunction.js");
+    }
 }

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/navigation/GoToDeclarationTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/navigation/GoToDeclarationTest.java
@@ -137,5 +137,8 @@ public class GoToDeclarationTest extends JsTestBase {
     public void testImportedFile_03() throws Exception {
         checkDeclaration("testfiles/ecmascript6/importExport/importFindDeclaration01.js", "import { text as text3 } from \"l^ib/export02\";", "export02.js", 0);
     }
-    
+
+    public void testIssueGH5184_01() throws Exception {
+        checkDeclaration("testfiles/markoccurences/issueGH5184_01.js", "export {te^st2};", "class ^test2 {");
+    }
 }

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/navigation/MarkOccurrenceTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/navigation/MarkOccurrenceTest.java
@@ -2243,7 +2243,11 @@ public class MarkOccurrenceTest extends JsTestBase {
     public void testIssue258724_02() throws Exception {
         checkOccurrences("testfiles/markoccurences/issue258724.js", "return this.ag^e;", true);
     }
-    
+
+    public void testIssueGH5184_01() throws Exception {
+        checkOccurrences("testfiles/markoccurences/issueGH5184_01.js", "export {te^st2};", true);
+    }
+
     private String getTestName() {
         String name = getName();
         int indexOf = name.indexOf("_");

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.javascript2.model;
 
-import org.netbeans.modules.javascript2.model.api.Occurrence;
 import org.netbeans.modules.javascript2.model.api.ModelUtils;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -192,7 +191,17 @@ public class JsObjectImpl extends JsElementImpl implements JsObject {
         return parent;
     }
 
+    @SuppressWarnings({"NestedAssignment", "AssertWithSideEffects"})
     public void setParent(JsObject newParent) {
+        boolean assertionsEnabled = false;
+        assert assertionsEnabled = true;
+        if (assertionsEnabled) {
+            for (JsObject checkParent = newParent; checkParent != null; checkParent = checkParent.getParent()) {
+                if (checkParent == this) {
+                    throw new AssertionError("Cycle detected in " + getFileObject().getPath());
+                }
+            }
+        }
         this.parent = newParent;
     }
 

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -981,7 +981,14 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
                 JsObject singleton = resolveThisInSingletonPattern(fncScope);
                 if (singleton != null) {
                     fncScope.setJsKind(JsElement.Kind.CONSTRUCTOR);
-                    if (fncScope.isAnonymous()) {
+                    // The second guard is necessary to prevent cyclic structures
+                    // for constructs like this:
+                    //
+                    // var Base = new function() {
+                    //    function Base() {
+                    //    }
+                    // };
+                    if (fncScope.isAnonymous() && !fncScope.getProperties().containsValue(singleton)) {
                         // TODO we probably should not move the properties, or at least increase offset range
                         // of the singleton to fit offsets of these methods in the singleton object
                         List<JsObject> properties = new ArrayList<>(fncScope.getProperties().values());

--- a/webcommon/javascript2.model/test/unit/data/testfiles/model/objectNameMatchingNestedFunction.js
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/model/objectNameMatchingNestedFunction.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var Base = new function() {
+    function Base() {
+    }
+};

--- a/webcommon/javascript2.model/test/unit/data/testfiles/model/objectNameMatchingNestedFunction.js.model
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/model/objectNameMatchingNestedFunction.js.model
@@ -1,0 +1,16 @@
+FUNCTION objectNameMatchingNestedFunction [ANONYMOUS: false, DECLARED: true - objectNameMatchingNestedFunction, MODIFIERS: PUBLIC, FILE]
+# RETURN TYPES
+undefined, RESOLVED: true
+# PROPERTIES
+Base : OBJECT Base [ANONYMOUS: false, DECLARED: true - Base, MODIFIERS: PUBLIC, OBJECT]
+     # PROPERTIES
+     objectNameMatchingNestedFunctionBase : FUNCTION objectNameMatchingNestedFunctionBase [ANONYMOUS: true, DECLARED: true - objectNameMatchingNestedFunctionBase, MODIFIERS: PRIVATE, CONSTRUCTOR]
+                                          # RETURN TYPES
+                                          Base.objectNameMatchingNestedFunctionBase, RESOLVED: true
+                                          # PROPERTIES
+                                          Base      : FUNCTION Base [ANONYMOUS: false, DECLARED: true - Base, MODIFIERS: PRIVATE, METHOD]
+                                                    # RETURN TYPES
+                                                    undefined, RESOLVED: true
+                                                    # PROPERTIES
+                                                    arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+                                          arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]

--- a/webcommon/javascript2.model/test/unit/data/testfiles/structure/issueGH5184_02.js
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/structure/issueGH5184_02.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class test {
+    method1() {
+    }
+}

--- a/webcommon/javascript2.model/test/unit/data/testfiles/structure/issueGH5184_02.js.model
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/structure/issueGH5184_02.js.model
@@ -1,0 +1,11 @@
+FUNCTION issueGH5184_02 [ANONYMOUS: false, DECLARED: true - issueGH5184_02, MODIFIERS: PUBLIC, FILE]
+# RETURN TYPES
+undefined, RESOLVED: true
+# PROPERTIES
+test : OBJECT test [ANONYMOUS: false, DECLARED: true - test, MODIFIERS: PUBLIC, CLASS]
+     # PROPERTIES
+     method1 : FUNCTION method1 [ANONYMOUS: false, DECLARED: true - method1, MODIFIERS: PUBLIC, METHOD]
+             # RETURN TYPES
+             undefined, RESOLVED: true
+             # PROPERTIES
+             arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]

--- a/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
+++ b/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
@@ -277,4 +277,8 @@ public class ModelTest extends ModelTestBase {
         // and regenerated.
         checkModel("testfiles/model/complexPrototype.js");
     }
+
+    public void testObjectNameMatchingNestedFunction() throws Exception {
+        checkModel("testfiles/model/objectNameMatchingNestedFunction.js");
+    }
 }

--- a/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
+++ b/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
@@ -230,6 +230,10 @@ public class ModelTest extends ModelTestBase {
         checkModel("testfiles/model/issue251911.js");
     }
 
+    public void testIssueGH5184_02() throws Exception {
+        checkModel("testfiles/structure/issueGH5184_02.js");
+    }
+
     public void testPersonRevert() throws Exception {
         FileObject fo = getTestFile("testfiles/model/person.js.model");
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(fo.getInputStream()))) {

--- a/webcommon/libs.nashorn/src/com/oracle/js/parser/Parser.java
+++ b/webcommon/libs.nashorn/src/com/oracle/js/parser/Parser.java
@@ -1967,7 +1967,6 @@ loop:
      * Verify destructuring variable declaration binding pattern and extract bound variable declarations.
      */
     private void verifyDestructuringBindingPattern(Expression pattern, Consumer<IdentNode> identifierCallback) {
-        assert pattern instanceof ObjectNode || pattern instanceof ArrayLiteralNode;
         pattern.accept(new VerifyDestructuringPatternNodeVisitor(new LexicalContext()) {
             @Override
             protected void verifySpreadElement(Expression lvalue) {

--- a/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/DumpingVisitor.java
+++ b/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/DumpingVisitor.java
@@ -59,9 +59,11 @@ class DumpingVisitor extends NodeVisitor {
             System.out.println(indent() + node.getClass().getName() + " [" + ((LiteralNode) node).getValue() + "]");
         } else if (node instanceof FunctionNode) {
             FunctionNode fn = (FunctionNode) node;
-            System.out.printf("%s%s [%s, kind=%s, isAsync=%b, isMethod=%b]%n",
+            System.out.printf("%s%s [%s-%d, %s, kind=%s, isAsync=%b, isMethod=%b]%n",
                     indent(),
                     node.getClass().getName(),
+                    fn.getStart(),
+                    fn.getFinish(),
                     fn.getName(),
                     fn.getKind().name(),
                     fn.isAsync(),

--- a/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/ParserTest.java
+++ b/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/ParserTest.java
@@ -274,6 +274,15 @@ public class ParserTest {
         assertParses(13, "const a = <table>{/* Test */ /* Test */ /* Test */}{ a = 3 }</table>");
     }
 
+    @Test
+    public void testBindingPattern() {
+        assertParses(13, "const buildTerserOptions = ({\n"
+                + "  ecma\n"
+                + "} = {}) => ({\n"
+                + "  ecma\n"
+                + "});");
+    }
+
     private Predicate<Node> functionNodeWithName(String name) {
         return n -> n instanceof FunctionNode && name.equals(((FunctionNode) n).getName());
     }


### PR DESCRIPTION
At least two issues are fixed by this:

- "export class XY" construct is not parsed correctly resulting in
  a JS model for that class, that his missing methods
- "class XY {}; export {XY}" is not correctly parsed resulting missing
  declaration handling for that member

Example that was not correctly parsed:

```javascript
export class test {
	method(param){
		param;
	}
};

// this shows in navigator / highlighting works
class test2{
	method(param){
		param;
	}
}

// no highlighting, Go to declaration does not work
export {test2};
```

Closes: https://github.com/apache/netbeans/issues/5184