### PR TITLE
option window: category buttons foreground color fix.

### DIFF
--- a/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
+++ b/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
@@ -1155,7 +1155,6 @@ public class OptionsPanel extends JPanel {
             addMouseListener (this);
             setFocusable (false);
             setFocusTraversalKeysEnabled (false);
-            setForeground (getTabPanelForeground());
             
             if (isMac) {
                 setFont(labelFontMac);
@@ -1171,7 +1170,8 @@ public class OptionsPanel extends JPanel {
             } else {
                 setBorder (new EmptyBorder (2, 4, 2, 4));
             }
-            setBackground (getTabPanelBackground());
+            setBackground(getTabPanelBackground());
+            setForeground(getTabPanelForeground());
         }
         
         void setSelected () {
@@ -1189,7 +1189,8 @@ public class OptionsPanel extends JPanel {
                     new EmptyBorder (0, 2, 0, 2)
                 ));
             }
-            setBackground (selected);            
+            setBackground(selected);            
+            setForeground(getUIColorOrDefault("MenuItem.selectionForeground", getTabPanelForeground()));
         }
         
         void setHighlighted() {
@@ -1202,6 +1203,7 @@ public class OptionsPanel extends JPanel {
                         new EmptyBorder(0, 2, 0, 2)
                         ));
                 setBackground(highlighted);
+                setForeground(getTabPanelForeground());
             }
             if (!category.isHighlited()) {
                 if (categoryModel.getHighlitedCategoryID() != null) {


### PR DESCRIPTION
the custom buttons should set the correct foreground color when the highlighted color is set to retain contrast.

before:
![selected-forground-current](https://user-images.githubusercontent.com/114367/230726270-bc937f6b-ff46-436f-889e-faa76c3f5768.png)

after:
![selected-forground-fixed](https://user-images.githubusercontent.com/114367/230726275-17490274-97c6-4fc2-84d4-fef2eba19c37.png)

analog to:
![menu-foreground-change](https://user-images.githubusercontent.com/114367/230727006-c68bde98-782a-4a65-b8cb-8cb5f9d038d5.png)



(no changes visible when the accent color isn't set)