### PR TITLE
Fix the problem that "Fix Imports" don't work when there are types that have the same suffix #5330

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/actions/UsedNamesCollector.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/actions/UsedNamesCollector.java
@@ -95,7 +95,12 @@ public class UsedNamesCollector {
                     break;
                 }
             } else {
-                if (useElement.getName().endsWith(firstSegmentName)) {
+                // GH-5330
+                // do not check the end string of the declared name
+                // check whether segment is the same name
+                // e.g. OtherSameNamePart and SameNamePart are end with "SameNamePart"
+                QualifiedName declaredName = QualifiedName.create(useElement.getName());
+                if (declaredName.getSegments().getLast().equals(firstSegmentName)) {
                     result = true;
                     break;
                 }

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH5330/01/testGH5330_01.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH5330/01/testGH5330_01.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test\SameName;
+
+class SameNamePart{};
+class OtherSameNamePart{};
+
+namespace Test;
+
+use Test\SameName\OtherSameNamePart;
+
+class Example {
+    public function __construct(
+            private OtherSameNamePart $otherSameName,
+            private SameNamePart $sameName,
+    ) {
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH5330/01/testGH5330_01.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH5330/01/testGH5330_01.php.fixUses
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test\SameName;
+
+class SameNamePart{};
+class OtherSameNamePart{};
+
+namespace Test;
+
+use Test\SameName\OtherSameNamePart;
+use Test\SameName\SameNamePart;
+
+class Example {
+    public function __construct(
+            private OtherSameNamePart $otherSameName,
+            private SameNamePart $sameName,
+    ) {
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH5330/testGH5330_01.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH5330/testGH5330_01.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test\SameName;
+
+class SameNamePart{};
+class OtherSameNamePart{};
+
+namespace Test;
+
+use Test\SameName\OtherSameNamePart;
+
+class Example {
+    public function __construct(
+            private OtherSameNamePart $otherSameName,
+            private SameNamePart $sameName,
+    ) {
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH5330/testGH5330_01.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH5330/testGH5330_01.php.importData
@@ -1,0 +1,12 @@
+Caret position: 956
+Should show uses panel: true
+Defaults:
+ \Test\SameName\SameNamePart
+
+Names:
+ SameNamePart
+
+Variants:
+ \Test\SameName\SameNamePart
+ Don't import.
+

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/FixUsesPerformerTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/FixUsesPerformerTest.java
@@ -604,6 +604,13 @@ public class FixUsesPerformerTest extends PHPTestBase {
         performTest("functio^nA();", selections, true, true, options);
     }
 
+    public void testGH5330_01() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\Test\\SameName\\SameNamePart", ItemVariant.Type.CLASS));
+        Options options = new Options(false, false, false, false, false, PhpVersion.PHP_81);
+        performTest("class Exam^ple {", selections, true, true, options);
+    }
+
     private String getTestResult(final String fileName, final String caretLine, final List<Selection> selections, final boolean removeUnusedUses, final boolean putInPSR12Order, final Options options) throws Exception {
         FileObject testFile = getTestFile(fileName);
 

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/ImportDataCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/ImportDataCreatorTest.java
@@ -118,6 +118,10 @@ public class ImportDataCreatorTest extends PHPTestBase {
         performTest("public function test1(array $param): F^oo {");
     }
 
+    public void testGH5330_01() throws Exception {
+        performTest("class Examp^le {");
+    }
+
     private void performTest(String caretLine) throws Exception {
         performTest(caretLine, null);
     }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/5330

Example:
```php
namespace Test\SameName;

class SameNamePart{};
class OtherSameNamePart{};

namespace Test;

use Test\SameName\OtherSameNamePart;

class Example {
    public function __construct(
            private OtherSameNamePart $otherSameName,
            private SameNamePart $sameName,
    ) {}
}
```
Before: `use Test\SameName\SameNamePart;` is **not** inserted

After: `use Test\SameName\SameNamePart;` is inserted
