### PR TITLE
add installer windows patch

### DIFF
--- a/harness/libs.nbi.engine/build.xml
+++ b/harness/libs.nbi.engine/build.xml
@@ -47,7 +47,20 @@
     </target>
 
     <target name="build-init" depends="projectized.build-init">
-        <unzip src="external/nbi.engine-external-binaries-11.zip" dest="${nbi.engine.dir}"/>
+        <delete dir="native/cleaner/windows/dist" /> 
+        <delete dir="native/launcher/windows/dist" />       
+        <unzip src="external/nbi.engine-external-binaries-11.zip" dest="${nbi.engine.dir}">
+            <patternset>
+                <exclude name="native/cleaner/windows/**/*.*"/>
+                <exclude name="native/launcher/windows/**/*.*"/>
+            </patternset>
+        </unzip>
+        <unzip src="external/nbi.engine-external-binaries-12.6.zip" dest="${nbi.engine.dir}">
+            <patternset>
+                <exclude name="LICENSE"/>
+                <exclude name="NOTICE"/>
+            </patternset>
+        </unzip>
     </target>
 
 </project>

--- a/harness/libs.nbi.engine/external/binaries-list
+++ b/harness/libs.nbi.engine/external/binaries-list
@@ -15,3 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 2B892D9E648A792EDB0F705378E06F84C322E208 nbi.engine-external-binaries-11.zip
+640048101CE355CF691AA63D1052DEF055505389 https://repository.apache.org/content/groups/snapshots/org/apache/netbeans/native/installers/12.6-SNAPSHOT/installers-12.6-20230411.112348-1-distribution.zip nbi.engine-external-binaries-12.6.zip


### PR DESCRIPTION
Hi this is an attempt to get the installer fixes from https://github.com/apache/netbeans-native-installers.

Using the Matthias hack to use external but at the end it should be a released installer. (Hopefully can be done before NB18)

I just hope I get the nbi well. 
