### PR TITLE
YAML: Step right curly and brackets when they are right to the caret

### DIFF
--- a/ide/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlKeystrokeHandler.java
+++ b/ide/languages.yaml/src/org/netbeans/modules/languages/yaml/YamlKeystrokeHandler.java
@@ -115,6 +115,13 @@ public class YamlKeystrokeHandler implements KeystrokeHandler {
             return true;
         }
 
+        if (((c == '}') || (c == ']')) && dotPos < doc.getLength()) {
+            if (String.valueOf(c).equals(doc.getText(dotPos, 1))) {
+                caret.setDot(dotPos + 1);
+                return true;
+            }
+        }
+        
         if ((c == '\'') || (c == '"')) {
             int sstart = target.getSelectionStart();
             int send = target.getSelectionEnd();

--- a/ide/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlKeystrokeHandlerTest.java
+++ b/ide/languages.yaml/test/unit/src/org/netbeans/modules/languages/yaml/YamlKeystrokeHandlerTest.java
@@ -189,6 +189,22 @@ public class YamlKeystrokeHandlerTest extends YamlTestBase {
         insertChar("foo: '^'", '\'', "foo: ''^");
     }
 
+    public void  testStepCurly1() throws Exception {
+        insertChar("foo: {^}", '}', "foo: {}^");
+    }
+
+    public void  testStepCurly2() throws Exception {
+        insertChar("foo: {{^}}", '}', "foo: {{}^}");
+    }
+
+    public void  testStepBracket1() throws Exception {
+        insertChar("foo: [^]", ']', "foo: []^");
+    }
+
+    public void  testStepBracket2() throws Exception {
+        insertChar("foo: [[^]]", ']', "foo: [[]^]");
+    }
+
     public void testDeleteSingle1() throws Exception {
         deleteChar("foo: '^'", "foo: ^");
     }


### PR DESCRIPTION
This one is a trivial change, I hope it's not disruptive.

It happens quite often that I need to edit YAML files outside of the IDE, and I accustomed the habit of typing `{}` and `[]` in pairs. This one makes the editor stepping though the right `]` and `}`-s.
