### PR TITLE
Disable PHPCCDocumentationTest.testIssueGH5347_02() in Windows

### DIFF
--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
@@ -28,6 +28,7 @@ import org.netbeans.modules.php.project.api.PhpSourcePath;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.util.Utilities;
 
 /**
  *
@@ -335,7 +336,12 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
 
     public void testIssueGH5347_02() throws Exception {
         // no golden file
-        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5347.php", "un^defined();", true);
+        // XXX
+        // sometimes occur with CI in Windows
+        // Working directory: D:\a\netbeans\netbeans\php\php.editor\build\test\\unit\work\o.n.m.p.e.c.P\testIssueGH5347_02
+        if (!Utilities.isWindows()) {
+            checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5347.php", "un^defined();", true);
+        }
     }
 
     public void testIssueGH5355_01() throws Exception {


### PR DESCRIPTION
- Sometimes, we get the following log: Working directory: D:\a\netbeans\netbeans\php\php.editor\build\test\unit\work\o.n.m.p.e.c.P\testIssueGH5347_02
- It is the working directory for a failed test

https://github.com/apache/netbeans/blob/7f8dfdeb60ce3bec5554fc19ddb40fac0388d885/harness/nbjunit/src/org/netbeans/junit/NbTestCase.java#L524-L547

https://github.com/apache/netbeans/blob/7f8dfdeb60ce3bec5554fc19ddb40fac0388d885/harness/nbjunit/src/org/netbeans/junit/NbTestCase.java#L472-L487