### PR TITLE
Slf4j library upgrade

### DIFF
--- a/ide/slf4j.api/external/binaries-list
+++ b/ide/slf4j.api/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-2CD9B264F76E3D087EE21BFC99305928E1BDB443 org.slf4j:slf4j-api:1.7.28
+6C62681A2F655B49963A5983B8B0950A6120AE14 org.slf4j:slf4j-api:1.7.36

--- a/ide/slf4j.api/external/slf4j-api-1.7.36-license.txt
+++ b/ide/slf4j.api/external/slf4j-api-1.7.36-license.txt
@@ -1,5 +1,5 @@
 Name: SLF4J
-Version: 1.7.28
+Version: 1.7.36
 License: MIT-slf4j
 Origin: https://www.slf4j.org/
 Description: Simple Logging Facade for Java (SLF4J).

--- a/ide/slf4j.api/nbproject/project.properties
+++ b/ide/slf4j.api/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
-release.external/slf4j-api-1.7.28.jar=modules/slf4j-api.jar
+release.external/slf4j-api-1.7.36.jar=modules/slf4j-api.jar
 is.autoload=true

--- a/ide/slf4j.api/nbproject/project.xml
+++ b/ide/slf4j.api/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>slf4j-api.jar</runtime-relative-path>
-                <binary-origin>external/slf4j-api-1.7.28.jar</binary-origin>
+                <binary-origin>external/slf4j-api-1.7.36.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/slf4j.jdk14/external/binaries-list
+++ b/ide/slf4j.jdk14/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-7DD18B408288AD35CD4021A6E50F0E6E8C6454DE org.slf4j:slf4j-jdk14:1.7.28
+4A18AF6554BFE48B0F76EEC98119C417DA23C7E1 org.slf4j:slf4j-jdk14:1.7.36

--- a/ide/slf4j.jdk14/external/slf4j-jdk14-1.7.36-license.txt
+++ b/ide/slf4j.jdk14/external/slf4j-jdk14-1.7.36-license.txt
@@ -1,5 +1,5 @@
 Name: SLF4J
-Version: 1.7.28
+Version: 1.7.36
 License: MIT-slf4j
 Origin: https://www.slf4j.org/
 Description: Simple Logging Facade for Java (SLF4J).

--- a/ide/slf4j.jdk14/nbproject/project.properties
+++ b/ide/slf4j.jdk14/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/slf4j-jdk14-1.7.28.jar=modules/slf4j-jdk14.jar
+release.external/slf4j-jdk14-1.7.36.jar=modules/slf4j-jdk14.jar
 is.autoload=true

--- a/ide/slf4j.jdk14/nbproject/project.xml
+++ b/ide/slf4j.jdk14/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>slf4j-jdk14.jar</runtime-relative-path>
-                <binary-origin>external/slf4j-jdk14-1.7.28.jar</binary-origin>
+                <binary-origin>external/slf4j-jdk14-1.7.36.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -26,9 +26,9 @@ apisupport.feedreader/external/jdom-1.0.jar mobility.deployment.webdav/external/
 # db.sql.visualeditor/external/javacc-7.0.10.jar is used at compile-time only
 ide/db.sql.visualeditor/external/javacc-7.0.10.jar java/performance/external/javacc-7.0.10.jar
 
-# It happens that maven 3.3.9 uses commons-lang-2.6.jar, same as o.apache.commons.lang
-# and commons-io-2.5.jar, same as java.lsp.server
+# It happens that maven 3.9.1 uses slf4j-api-1.7.36.jar, same as slf4j.api
 # These are used independently, different functional goals
+ide/slf4j.api/external/slf4j-api-1.7.36.jar java/maven.embedder/external/apache-maven-3.9.1-bin.zip
 
 # Contains test data (badPackageFileInJar.jar is packaged twice) - this is an
 # upstream problem


### PR DESCRIPTION
Upgrade of slf4j library (both `ide/slf4j.api` and `ide/slf4j.jdk14`) to 1.7.36.