### PR TITLE
disable compile-on-save by default in maven projects.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/api/execute/RunUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/execute/RunUtils.java
@@ -148,7 +148,7 @@ public final class RunUtils {
     @NbBundle.Messages({
         "#compile on save: all, none",
         "#NOI18N",
-        "DEFAULT_COMPILE_ON_SAVE=all"
+        "DEFAULT_COMPILE_ON_SAVE=none"
     })
     public static boolean isCompileOnSaveEnabled(Project prj) {
         AuxiliaryProperties auxprops = prj.getLookup().lookup(AuxiliaryProperties.class);

--- a/java/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.java
@@ -137,7 +137,7 @@ public class CompilePanel extends javax.swing.JPanel implements HelpCtx.Provider
 
             @Override
             public boolean getDefaultValue() {
-                return cosSupported;
+                return false; // see org.netbeans.modules.maven.api.execute.RunUtils#isCompileOnSaveEnabled
             }
 
             @Override

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/api/execute/Bundle_test.properties
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/api/execute/Bundle_test.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-DEFAULT_COMPILE_ON_SAVE=none
+DEFAULT_COMPILE_ON_SAVE=all

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/api/execute/RunUtilsTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/api/execute/RunUtilsTest.java
@@ -38,14 +38,14 @@ public class RunUtilsTest {
     public void testIsCompileOnSaveEnabledByDefault() {
         NbBundle.setBranding(null);
         boolean result = RunUtils.isCompileOnSaveEnabled(new MockPrj());
-        assertTrue("By default use CoS in NetBeans IDE", result);
+        assertFalse("CoS is off by default in the NetBeans IDE", result);
     }
     
     @Test
     public void testIsCompileOnSaveEnabledWithBranding() {
         NbBundle.setBranding("test");
         boolean result = RunUtils.isCompileOnSaveEnabled(new MockPrj());
-        assertFalse("Allow branding to disable CoS", result);
+        assertTrue("Allow branding to enable CoS", result);
     }
 
     private static class MockPrj implements Project {


### PR DESCRIPTION
"good defaults" round two, see [dev list](https://lists.apache.org/thread/rdflfdbt2v0cxz9mk198tonm0hnff1bg) or #5260

sets CoS default to `none`

some reasons why:
 - CoS is an intrusive feature which sidelines the build and compiles directly into the target folder (using javac from the NB runtime)
 - UX wise this asks for being an opt-in feature, enabling it via the checkbox will even display an info dialog stating the risks, a dialog users would never see when it is enabled by default
 - mvnd and other incremental improvements make CoS less interesting