### PR TITLE
Show antlr, go, tom, yaml  languages in auto-update, moved them to Editing

### DIFF
--- a/ide/languages.go/manifest.mf
+++ b/ide/languages.go/manifest.mf
@@ -3,4 +3,4 @@ OpenIDE-Module: org.netbeans.modules.languages.go
 OpenIDE-Module-Layer: org/netbeans/modules/languages/go/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/languages/go/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.0
-AutoUpdate-Show-In-Client: false
+AutoUpdate-Show-In-Client: true

--- a/ide/languages.go/src/org/netbeans/modules/languages/go/Bundle.properties
+++ b/ide/languages.go/src/org/netbeans/modules/languages/go/Bundle.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 OpenIDE-Module-Name=Go Language Editor Support
-OpenIDE-Module-Display-Category=IDE
+OpenIDE-Module-Display-Category=Editing
 OpenIDE-Module-Short-Description=Support for editing Go Language Files.
 OpenIDE-Module-Long-Description=Support for editing Go Language files.
 

--- a/ide/languages.toml/manifest.mf
+++ b/ide/languages.toml/manifest.mf
@@ -3,4 +3,4 @@ OpenIDE-Module: org.netbeans.modules.languages.toml
 OpenIDE-Module-Layer: org/netbeans/modules/languages/toml/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/languages/toml/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.2
-AutoUpdate-Show-In-Client: false
+AutoUpdate-Show-In-Client: true

--- a/ide/languages.toml/src/org/netbeans/modules/languages/toml/Bundle.properties
+++ b/ide/languages.toml/src/org/netbeans/modules/languages/toml/Bundle.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 OpenIDE-Module-Name=TOML Editor Support
-OpenIDE-Module-Display-Category=Base IDE
+OpenIDE-Module-Display-Category=Editing
 OpenIDE-Module-Short-Description=Support for editing TOML files.
 OpenIDE-Module-Long-Description=Support for editing TOML files.
 

--- a/ide/languages.yaml/manifest.mf
+++ b/ide/languages.yaml/manifest.mf
@@ -3,4 +3,4 @@ OpenIDE-Module: org.netbeans.modules.languages.yaml
 OpenIDE-Module-Layer: org/netbeans/modules/languages/yaml/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/languages/yaml/Bundle.properties
 OpenIDE-Module-Specification-Version: 2.52
-AutoUpdate-Show-In-Client: false
+AutoUpdate-Show-In-Client: true

--- a/ide/languages.yaml/src/org/netbeans/modules/languages/yaml/Bundle.properties
+++ b/ide/languages.yaml/src/org/netbeans/modules/languages/yaml/Bundle.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 OpenIDE-Module-Name=YAML Editor Support
-OpenIDE-Module-Display-Category=Ruby
+OpenIDE-Module-Display-Category=Editing
 OpenIDE-Module-Short-Description=Support for editing YAML files.
 OpenIDE-Module-Long-Description=Support for editing YAML files.
 

--- a/java/languages.antlr/manifest.mf
+++ b/java/languages.antlr/manifest.mf
@@ -3,4 +3,4 @@ OpenIDE-Module: org.netbeans.modules.languages.antlr
 OpenIDE-Module-Layer: org/netbeans/modules/languages/antlr/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/languages/antlr/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.2
-AutoUpdate-Show-In-Client: false
+AutoUpdate-Show-In-Client: true

--- a/java/languages.antlr/src/org/netbeans/modules/languages/antlr/Bundle.properties
+++ b/java/languages.antlr/src/org/netbeans/modules/languages/antlr/Bundle.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 OpenIDE-Module-Name=ANTLR Grammar Editor Support
-OpenIDE-Module-Display-Category=Java
+OpenIDE-Module-Display-Category=Editing
 OpenIDE-Module-Short-Description=Support for editing ANTLR Grammar files.
 OpenIDE-Module-Long-Description=Support for editing ANTLR v3 and v4 Grammar files.
 


### PR DESCRIPTION
While I was trying to disable the HCL support in the plugin manager for some testing, I realized that it is not possible as it was hidden.

I also changed their category to `Editing`, it felt a bit better. These might change later, if some language support goes beyond editing.