### PR TITLE
debugger.jpda: exclude AsynchStepTest to stabilize job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1564,7 +1564,7 @@ jobs:
         run: ant $OPTS -f java/api.debugger.jpda test
 
       - name: debugger.jpda
-        run: ant $OPTS -f java/debugger.jpda test
+        run: .github/retry.sh ant $OPTS -f java/debugger.jpda test
 
       - name: debugger.jpda.js
         run: ant $OPTS -f java/debugger.jpda.js test

--- a/java/debugger.jpda/nbproject/project.properties
+++ b/java/debugger.jpda/nbproject/project.properties
@@ -32,6 +32,7 @@ test.jms.flags=\
  --add-opens=jdk.jdi/com.sun.jdi=ALL-UNNAMED
 
 test.config.default.excludes=\
+    **/AsynchStepTest.class,\
     **/BreakpointsClassFilterTest.class,\
     **/BreakpointsDeactivationTest.class,\
     **/ClassBasedBreakpointTest.class,\


### PR DESCRIPTION
the new job added in #5763 fails a bit too often, we might have to exclude another test (its run in a matrix so it hurts twice as much).

https://github.com/apache/netbeans/actions/runs/4710224487 3 restarts
https://github.com/apache/netbeans/actions/runs/4710854667 1 restart

edit: wrapped in retry script since it failed again