### PR TITLE
add missing error code to enable-preview hint

### DIFF
--- a/java/ant.hints/src/org/netbeans/modules/ant/hints/errors/EnablePreviewAntProj.java
+++ b/java/ant.hints/src/org/netbeans/modules/ant/hints/errors/EnablePreviewAntProj.java
@@ -55,7 +55,8 @@ public class EnablePreviewAntProj implements ErrorRule<Void> {
 
     private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
             "compiler.err.preview.feature.disabled",          // NOI18N
-            "compiler.err.preview.feature.disabled.plural")); // NOI18N
+            "compiler.err.preview.feature.disabled.plural",   // NOI18N
+            "compiler.err.is.preview"));                      // NOI18N
     private static final String ENABLE_PREVIEW_FLAG = "--enable-preview";   // NOI18N
     private static final String JAVAC_COMPILER_ARGS = "javac.compilerargs"; // NOI18N
     private static final String RUN_JVMARGS = "run.jvmargs"; // NOI18N

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/EnablePreviewSingleSourceFile.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/EnablePreviewSingleSourceFile.java
@@ -54,7 +54,8 @@ public class EnablePreviewSingleSourceFile implements ErrorRule<Void> {
 
     private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
             "compiler.err.preview.feature.disabled",           //NOI18N  
-            "compiler.err.preview.feature.disabled.plural")); // NOI18N
+            "compiler.err.preview.feature.disabled.plural",    // NOI18N
+            "compiler.err.is.preview"));                       // NOI18N
     private static final String ENABLE_PREVIEW_FLAG = "--enable-preview";   // NOI18N
     private static final String SOURCE_FLAG = "--source";   // NOI18N
 

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/errors/EnablePreviewMavenProj.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/errors/EnablePreviewMavenProj.java
@@ -61,14 +61,15 @@ import org.openide.filesystems.FileSystem;
  */
 public class EnablePreviewMavenProj implements ErrorRule<Void> {
 
-    private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
-            "compiler.err.preview.feature.disabled",
-            "compiler.err.preview.feature.disabled.plural")); // NOI18N
+    private static final Set<String> ERROR_CODES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "compiler.err.preview.feature.disabled",           // NOI18N
+            "compiler.err.preview.feature.disabled.plural",    // NOI18N
+            "compiler.err.is.preview")));                      // NOI18N
     private static final String ENABLE_PREVIEW_FLAG = "--enable-preview";   // NOI18N
 
     @Override
     public Set<String> getCodes() {
-        return Collections.unmodifiableSet(ERROR_CODES);
+        return ERROR_CODES;
     }
 
     @Override
@@ -186,7 +187,7 @@ public class EnablePreviewMavenProj implements ErrorRule<Void> {
         private static final String MAVEN_COMPILER_ARTIFACT_ID = "maven-compiler-plugin"; // NOI18N
         private static final String COMPILER_ID_PROPERTY = "compilerId"; // NOI18N
         private static final String COMPILER_ARG = "compilerArgs"; // NOI18N
-        private static final String MAVEN_COMPILER_VERSION = "3.3"; // NOI18N
+        private static final String MAVEN_COMPILER_VERSION = "3.11.0"; // NOI18N
         private static final String ARG = "arg";// NOI18N
         private POMComponentFactory factory;
 


### PR DESCRIPTION
extracted from #5802

test with:
```java
Thread.ofVirtual();
```
on JDK 20, which should trigger the hint. Applying the fix should add the required flags to the compiler plugin