### PR TITLE
AnnotationProcessors shouldn't set the SourceVersion unless required

### DIFF
--- a/php/languages.neon/src/org/netbeans/modules/languages/neon/processors/MethodCompletionProviderProcessor.java
+++ b/php/languages.neon/src/org/netbeans/modules/languages/neon/processors/MethodCompletionProviderProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.languages.neon.completion.CompletionProviders;
@@ -37,7 +35,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Ondrej Brejla <obrejla@netbeans.org>
  */
 @ServiceProvider(service = Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 @SupportedAnnotationTypes("org.netbeans.modules.languages.neon.spi.completion.MethodCompletionProvider.Registration")
 public class MethodCompletionProviderProcessor extends LayerGeneratingProcessor {
 


### PR DESCRIPTION
The version for `MethodCompletionProviderProcessor` is automatically set in its super class `LayerGeneratingProcessor` https://github.com/apache/netbeans/pull/5843#issuecomment-1736554656.

~~`TreeShimsCopier` can simply set it to latest since it is only used internally.~~ resolved via #6495

this resolves warnings like:
```
warning: Supported source version 'RELEASE_7' from annotation processor
 'o.n.m.l.n.p.MethodCompletionProviderProcessor' less than -source '8'.
```

or:
```
warning: Supported source version 'RELEASE_8' from annotation processor 
org.netbeans.modules.java.source.TreeShimsCopier' less than -source '11'
```
