### PR TITLE
release180 apidoc fixes

### DIFF
--- a/ide/editor.codetemplates/arch.xml
+++ b/ide/editor.codetemplates/arch.xml
@@ -476,7 +476,7 @@ JRE is sufficient.
                 is required.
             </api>
 </li>            
-<li><api type='import' group='java' category='private' name='org.openide.options' url='../org-openide-options/overview-summary.html' >
+<!-- deprecated <li><api type='import' group='java' category='private' name='org.openide.options' url='../org-openide-options/overview-summary.html' >
             The module is needed for compilation. 
         
             The module is used during runtime. 
@@ -485,7 +485,8 @@ JRE is sufficient.
                 6.2
                 is required.
             </api>
-</li>            
+</li>
+-->
 <li><api type='import' group='java' category='official' name='EditorAPI' url='../org-openide-text/overview-summary.html' >
             The module is needed for compilation. 
         

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
@@ -548,11 +548,11 @@ public final class MavenSettings  {
 	 * <ul>
 	 * <li>MAVEN_HOME</li>
 	 * <li>M2_HOME</li>
-	 * <li>PATH</li></ul>
-	 * </p>
+	 * <li>PATH</li>
+	 * </ul>
 	 * <p>Only the first appereance will be appended.</p>
 	 *
-	 * @returns the default external Maven runtime on the path.
+	 * @return the default external Maven runtime on the path.
 	 */
     public static String getDefaultExternalMavenRuntime() {
         String paths = System.getenv("PATH"); // NOI18N


### PR DESCRIPTION
Few fixes to have the apidoc doing correct linking and generation for the release branch.
not some other pr on netbeans-jenkins-lib as we need a more advanced jdk for apidoc generation.

 

