### PR TITLE
prepare NB 19 release cycle for JDK 11.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,7 +193,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21-ea' ]
+        java: [ '11', '17', '21-ea' ]
       fail-fast: false
     steps:
 
@@ -784,7 +784,10 @@ jobs:
 
       - name: java/api.maven
         run: ant $OPTS -f java/api.maven test
-        
+
+      - name: maven.apisupport
+        run: ant $OPTS -f apisupport/maven.apisupport test
+
       - name: java/hudson.maven
         run: ant $OPTS -f java/hudson.maven test
 
@@ -1183,7 +1186,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '11' ]
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
@@ -1463,9 +1466,6 @@ jobs:
 
       - name: apisupport.wizards
         run: ant $OPTS -f apisupport/apisupport.wizards test
-
-      - name: maven.apisupport
-        run: ant $OPTS -f apisupport/maven.apisupport test
 
       - name: timers
         run: ant $OPTS -f apisupport/timers test -Dtest.config=stable
@@ -2283,7 +2283,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '11' ]
 
     steps:
       - name: Set up JDK ${{ matrix.java }} 
@@ -2391,7 +2391,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '11' ]
 
     steps:
       - name: Set up JDK ${{ matrix.java }}


### PR DESCRIPTION
 - disable CV tests on JDK 8
 - move some more jobs to JDK 11

this configuration would allow us to move new modules like rust/go/hcl to JDK 11 and to upgrade exiting modules, like the maven-indexer #4999.

[new NB release policy](https://cwiki.apache.org/confluence/display/NETBEANS/Minimum+JDK+build+and+run+policy)