### PR TITLE
Fix for PHPUnit 10 #5790

### DIFF
--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/PhpUnitVersion.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/PhpUnitVersion.java
@@ -18,7 +18,11 @@
  */
 package org.netbeans.modules.php.phpunit;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.netbeans.api.annotations.common.NonNull;
 import org.openide.util.NbBundle;
+import org.openide.util.Parameters;
 
 @NbBundle.Messages({
     "PhpUnitVersion.PHP_UNIT_9=PHPUnit 9 or earlier",
@@ -29,6 +33,9 @@ public enum PhpUnitVersion {
     PHP_UNIT_9(Bundle.PhpUnitVersion_PHP_UNIT_9()),
     PHP_UNIT_10(Bundle.PhpUnitVersion_PHP_UNIT_10()),
     ;
+
+    private static final Logger LOGGER = Logger.getLogger(PhpUnitVersion.class.getName());
+
     private final String displayName;
 
     private PhpUnitVersion(String displayName) {
@@ -40,8 +47,37 @@ public enum PhpUnitVersion {
         return phpUnitVersions[0];
     }
 
+    /**
+     * Get PhpUnitVersion from string.
+     * If the version is unexpected pattern, the default version is returned ({@link #getDefault()}).
+     *
+     * @param version the version (expected pattern: <major>.<minor>.<patch> e.g. 10.0.1)
+     * @return PhpUnitVersion
+     */
+    public static PhpUnitVersion fromString(@NonNull String version) {
+        Parameters.notNull("version", version); // NOI18N
+        String[] versions = version.split("\\."); // NOI18N
+        try {
+            int majorVersion = Integer.parseInt(versions[0]);
+            if (majorVersion >= 10) {
+                return PHP_UNIT_10;
+            } else if (majorVersion <= 9) {
+                return PHP_UNIT_9;
+            } else {
+                LOGGER.log(Level.WARNING, "Unexpected PHPUnit major version:{0} ({1})", new Object[]{majorVersion, version}); // NOI18N
+            }
+        } catch (NumberFormatException ex) {
+            // no-op
+        }
+        return getDefault();
+    }
+
     public String getDisplayName() {
         return displayName;
+    }
+
+    public boolean useNetBeansSuite() {
+        return this == PHP_UNIT_9;
     }
 
     @Override

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/PhpUnitVersion.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/PhpUnitVersion.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.phpunit;
+
+import org.openide.util.NbBundle;
+
+@NbBundle.Messages({
+    "PhpUnitVersion.PHP_UNIT_9=PHPUnit 9 or earlier",
+    "PhpUnitVersion.PHP_UNIT_10=PHPUnit 10 or later",
+})
+public enum PhpUnitVersion {
+    // please order from oldest to newest
+    PHP_UNIT_9(Bundle.PhpUnitVersion_PHP_UNIT_9()),
+    PHP_UNIT_10(Bundle.PhpUnitVersion_PHP_UNIT_10()),
+    ;
+    private final String displayName;
+
+    private PhpUnitVersion(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public static PhpUnitVersion getDefault() {
+        PhpUnitVersion[] phpUnitVersions = PhpUnitVersion.values();
+        return phpUnitVersions[0];
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String toString() {
+        return getDisplayName();
+    }
+}

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/commands/PhpUnit.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/commands/PhpUnit.java
@@ -34,12 +34,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.extexecution.ExecutionDescriptor;
 import org.netbeans.api.extexecution.base.input.InputProcessor;
 import org.netbeans.api.extexecution.base.input.InputProcessors;
@@ -75,6 +78,7 @@ import org.openide.loaders.DataFolder;
 import org.openide.loaders.DataObject;
 import org.openide.modules.InstalledFileLocator;
 import org.openide.util.NbBundle;
+import org.openide.windows.InputOutput;
 
 /**
  * PHPUnit 3.4+ support.
@@ -106,6 +110,7 @@ public final class PhpUnit {
     private static final String LIST_GROUPS_PARAM = "--list-groups"; // NOI18N
     private static final String GROUP_PARAM = "--group"; // NOI18N
     private static final String PARAM_SEPARATOR = "--"; // NOI18N
+    private static final String VERSION_PARAM = "--version"; // NOI18N
     // bootstrap & config
     private static final String BOOTSTRAP_PARAM = "--bootstrap"; // NOI18N
     private static final String BOOTSTRAP_FILENAME = "bootstrap%s.php"; // NOI18N
@@ -137,6 +142,8 @@ public final class PhpUnit {
 
     // #200489
     private static volatile File suite; // ok if it is fetched more times
+
+    private static final ConcurrentMap<PhpModule, PhpUnitVersion> VERSIONS = new ConcurrentHashMap<>();
 
     private final String phpUnitPath;
 
@@ -200,6 +207,15 @@ public final class PhpUnit {
         return new PhpUnit(path);
     }
 
+    public static void resetVersions() {
+        VERSIONS.clear();
+    }
+
+    public static String getVersionLine(String path) {
+        PhpUnit phpUnit = new PhpUnit(path);
+        return phpUnit.getVersionLine((PhpModule) null);
+    }
+
     @CheckForNull
     private static String validateDefault() {
         ValidationResult result = new PhpUnitOptionsValidator()
@@ -233,6 +249,51 @@ public final class PhpUnit {
             assert suite != null : "Cannot find NB test suite?!";
         }
         return suite;
+    }
+
+    @NbBundle.Messages({
+        "PhpUnit.getting.phpUnit.version=Getting the version...",
+        "PhpUnit.notFound.phpUnit.version=PHPUnit version not found",
+    })
+    public String getVersionLine(@NullAllowed PhpModule phpModule) {
+        PhpExecutable phpUnit = phpModule != null ? getExecutable(phpModule) : new PhpExecutable(phpUnitPath);
+        if (phpUnit != null) {
+            phpUnit.additionalParameters(Arrays.asList(VERSION_PARAM));
+            final PhpUnitLineProcessor lineProcessor = new PhpUnitLineProcessor();
+            ExecutionDescriptor silentDescriptor = getSilentDescriptor();
+            PhpUnitOutputProcessorFactory outputProcessorFactory = new PhpUnitOutputProcessorFactory(lineProcessor);
+            try {
+                phpUnit.runAndWait(silentDescriptor, outputProcessorFactory, Bundle.PhpUnit_getting_phpUnit_version());
+                String version = lineProcessor.getLinesAsText();
+                return !version.isEmpty() ? version : Bundle.PhpUnit_notFound_phpUnit_version();
+            } catch (ExecutionException ex) {
+                LOGGER.log(Level.INFO, null, ex);
+            }
+        }
+        return Bundle.PhpUnit_notFound_phpUnit_version();
+    }
+
+    private PhpUnitVersion getVersion(PhpModule phpModule) {
+        return getVersion(phpModule, false);
+    }
+
+    private PhpUnitVersion getVersion(PhpModule phpModule, boolean force) {
+        PhpUnitVersion phpUnitVersion = VERSIONS.get(phpModule);
+        if (phpUnitVersion != null && !force) {
+            return phpUnitVersion;
+        }
+        String versionLine = getVersionLine(phpModule);
+        phpUnitVersion = getVersion(versionLine);
+        VERSIONS.putIfAbsent(phpModule, phpUnitVersion);
+        return phpUnitVersion;
+    }
+
+    private PhpUnitVersion getVersion(String versionLine) {
+        String[] versionParts = versionLine.split(" "); // NOI18N e.g. PHPUnit 10.0.1 by ...
+        if (versionParts.length >= 2) {
+            return PhpUnitVersion.fromString(versionParts[1]);
+        }
+        return PhpUnitVersion.getDefault();
     }
 
     @CheckForNull
@@ -403,11 +464,12 @@ public final class PhpUnit {
                 // only test dir and use 'phpunit' command only
                 useNbSuite = false;
             }
+            PhpUnitVersion version = getVersion(phpModule);
             if (useNbSuite) {
                 // standard suite
                 // #218607 - hotfix
                 //params.add(SUITE_NAME)
-                if (PhpUnitPreferences.getPhpUnitVersion(phpModule) == PhpUnitVersion.PHP_UNIT_9) {
+                if (version.useNetBeansSuite()) {
                     params.add(getNbSuite().getAbsolutePath());
                 } else {
                     // GH-5790 we can use NetBeansSuite.php no longer with PHPUnit 10
@@ -455,6 +517,11 @@ public final class PhpUnit {
         // #236397 - cannot be controllable
         return new ExecutionDescriptor()
                 .optionsPath(PhpUnitOptionsPanelController.OPTIONS_PATH);
+    }
+
+    private ExecutionDescriptor getSilentDescriptor() {
+        return new ExecutionDescriptor()
+                .inputOutput(InputOutput.NULL);
     }
 
     // #170120
@@ -790,6 +857,50 @@ public final class PhpUnit {
             return hasOutput;
         }
 
+    }
+
+    private static final class PhpUnitOutputProcessorFactory implements ExecutionDescriptor.InputProcessorFactory2 {
+
+        private final LineProcessor lineProcessor;
+
+        public PhpUnitOutputProcessorFactory(LineProcessor lineProcessor) {
+            this.lineProcessor = lineProcessor;
+        }
+
+        @Override
+        public InputProcessor newInputProcessor(InputProcessor defaultProcessor) {
+            return InputProcessors.ansiStripping(InputProcessors.bridge(lineProcessor));
+        }
+    }
+
+    private static final class PhpUnitLineProcessor implements LineProcessor {
+
+        private final List<String> lines = new ArrayList<>();
+
+        @Override
+        public void processLine(String line) {
+            lines.add(line);
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        public List<String> getLines() {
+            return Collections.unmodifiableList(lines);
+        }
+
+        public String getLinesAsText() {
+            StringBuilder sb = new StringBuilder();
+            for (String string : lines) {
+                sb.append(string).append("\n"); // NOI18N
+            }
+            return sb.toString().trim();
+        }
     }
 
     private static final class TestParams {

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/commands/PhpUnit.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/commands/PhpUnit.java
@@ -54,6 +54,7 @@ import org.netbeans.modules.php.api.util.FileUtils;
 import org.netbeans.modules.php.api.util.StringUtils;
 import org.netbeans.modules.php.api.util.UiUtils;
 import org.netbeans.modules.php.api.validation.ValidationResult;
+import org.netbeans.modules.php.phpunit.PhpUnitVersion;
 import org.netbeans.modules.php.phpunit.options.PhpUnitOptions;
 import org.netbeans.modules.php.phpunit.options.PhpUnitOptionsValidator;
 import org.netbeans.modules.php.phpunit.preferences.PhpUnitPreferences;
@@ -406,7 +407,12 @@ public final class PhpUnit {
                 // standard suite
                 // #218607 - hotfix
                 //params.add(SUITE_NAME)
-                params.add(getNbSuite().getAbsolutePath());
+                if (PhpUnitPreferences.getPhpUnitVersion(phpModule) == PhpUnitVersion.PHP_UNIT_9) {
+                    params.add(getNbSuite().getAbsolutePath());
+                } else {
+                    // GH-5790 we can use NetBeansSuite.php no longer with PHPUnit 10
+                    params.add(FileUtil.toFile(startFiles.get(0)).getAbsolutePath());
+                }
                 // #254276
                 //params.add(PARAM_SEPARATOR);
                 //params.add(String.format(SUITE_RUN, joinPaths(startFiles, SUITE_PATH_DELIMITER)));

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/preferences/PhpUnitPreferences.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/preferences/PhpUnitPreferences.java
@@ -21,9 +21,11 @@ package org.netbeans.modules.php.phpunit.preferences;
 import java.io.File;
 import java.util.List;
 import java.util.prefs.Preferences;
+import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.modules.php.api.phpmodule.PhpModule;
 import org.netbeans.modules.php.api.util.StringUtils;
 import org.netbeans.modules.php.phpunit.PhpUnitTestingProvider;
+import org.netbeans.modules.php.phpunit.PhpUnitVersion;
 import org.netbeans.spi.project.support.ant.PropertyUtils;
 import org.openide.filesystems.FileUtil;
 
@@ -41,6 +43,7 @@ public final class PhpUnitPreferences {
     private static final String CUSTOM_SUITE_PATH = "customSuite.path"; // NOI18N
     private static final String PHP_UNIT_ENABLED = "phpUnit.enabled"; // NOI18N
     private static final String PHP_UNIT_PATH = "phpUnit.path"; // NOI18N
+    private static final String PHP_UNIT_VERSION = "phpUnit.version"; // NOI18N
     private static final String RUN_PHPUNIT_ONLY = "test.run.phpunit.only"; // NOI18N
     private static final String RUN_ALL_TEST_FILES = "test.run.all"; // NOI18N
     private static final String ASK_FOR_TEST_GROUPS = "test.groups.ask"; // NOI18N
@@ -153,6 +156,25 @@ public final class PhpUnitPreferences {
 
     public static void setTestGroups(PhpModule phpModule, List<String> testGroups) {
         getPreferences(phpModule).put(TEST_GROUPS, StringUtils.implode(testGroups, TEST_GROUPS_DELIMITER));
+    }
+
+    public static PhpUnitVersion getPhpUnitVersion(PhpModule phpModule) {
+        return getPhpUnitVersion(getPreferences(phpModule).get(PHP_UNIT_VERSION, null));
+    }
+
+    public static void setPhpUnitVersion(PhpModule phpModule, PhpUnitVersion version) {
+        getPreferences(phpModule).put(PHP_UNIT_VERSION, version.name());
+    }
+
+    private static PhpUnitVersion getPhpUnitVersion(@NullAllowed String version) {
+        if (version != null) {
+            try {
+                return PhpUnitVersion.valueOf(version);
+            } catch (Exception ex) {
+                // no-op
+            }
+        }
+        return PhpUnitVersion.getDefault();
     }
 
     private static Preferences getPreferences(PhpModule module) {

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties
@@ -68,6 +68,4 @@ CustomizerPhpUnit.scriptLabel.text=PHPUnit Script:
 CustomizerPhpUnit.scriptBrowseButton.text=Brow&se...
 CustomizerPhpUnit.runPhpUnitOnlyCheckBox.text=&Test Project Using Just 'phpunit' Command
 CustomizerPhpUnit.versionLabel.text=PHPUnit &Version:
-CustomizerPhpUnit.versionComboBox.AccessibleContext.accessibleDescription=Select PHPUnit version for your project
 CustomizerPhpUnit.versionLabel.AccessibleContext.accessibleDescription=PHPUnit version label
-CustomizerPhpUnit.versionComboBox.AccessibleContext.accessibleName=PHPUnit Version

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties
@@ -67,3 +67,7 @@ CustomizerPhpUnit.scriptCheckBox.text=Use Custom PHPUnit Script
 CustomizerPhpUnit.scriptLabel.text=PHPUnit Script:
 CustomizerPhpUnit.scriptBrowseButton.text=Brow&se...
 CustomizerPhpUnit.runPhpUnitOnlyCheckBox.text=&Test Project Using Just 'phpunit' Command
+CustomizerPhpUnit.versionLabel.text=PHPUnit &Version:
+CustomizerPhpUnit.versionComboBox.AccessibleContext.accessibleDescription=Select PHPUnit version for your project
+CustomizerPhpUnit.versionLabel.AccessibleContext.accessibleDescription=PHPUnit version label
+CustomizerPhpUnit.versionComboBox.AccessibleContext.accessibleName=PHPUnit Version

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/CustomizerPhpUnit.form
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/CustomizerPhpUnit.form
@@ -103,6 +103,11 @@
               </Group>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
+          <Group type="102" attributes="0">
+              <Component id="versionLabel" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="versionComboBox" max="32767" attributes="0"/>
+          </Group>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
@@ -152,6 +157,11 @@
               <Component id="runTestUsingUnitCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="askForTestGroupsCheckBox" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="versionLabel" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="versionComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
@@ -468,6 +478,39 @@
           <ResourceString bundle="org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties" key="CustomizerPhpUnit.askForTestGroupsCheckBox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="versionLabel">
+      <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="versionComboBox"/>
+        </Property>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties" key="CustomizerPhpUnit.versionLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <AccessibilityProperties>
+        <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties" key="CustomizerPhpUnit.versionLabel.AccessibleContext.accessibleDescription" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </AccessibilityProperties>
+    </Component>
+    <Component class="javax.swing.JComboBox" name="versionComboBox">
+      <Properties>
+        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+          <StringArray count="0"/>
+        </Property>
+      </Properties>
+      <AccessibilityProperties>
+        <Property name="AccessibleContext.accessibleName" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties" key="CustomizerPhpUnit.versionComboBox.AccessibleContext.accessibleName" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+        <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties" key="CustomizerPhpUnit.versionComboBox.AccessibleContext.accessibleDescription" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </AccessibilityProperties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;PhpUnitVersion&gt;"/>
+      </AuxValues>
     </Component>
   </SubComponents>
 </Form>

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/CustomizerPhpUnit.form
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/CustomizerPhpUnit.form
@@ -106,7 +106,8 @@
           <Group type="102" attributes="0">
               <Component id="versionLabel" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="versionComboBox" max="32767" attributes="0"/>
+              <Component id="versionLineLabel" min="-2" max="-2" attributes="0"/>
+              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -160,7 +161,7 @@
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="versionLabel" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="versionComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="versionLineLabel" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
@@ -482,7 +483,7 @@
     <Component class="javax.swing.JLabel" name="versionLabel">
       <Properties>
         <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
-          <ComponentRef name="versionComboBox"/>
+          <ComponentRef name="default"/>
         </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties" key="CustomizerPhpUnit.versionLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
@@ -494,23 +495,10 @@
         </Property>
       </AccessibilityProperties>
     </Component>
-    <Component class="javax.swing.JComboBox" name="versionComboBox">
+    <Component class="javax.swing.JLabel" name="versionLineLabel">
       <Properties>
-        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
-          <StringArray count="0"/>
-        </Property>
+        <Property name="text" type="java.lang.String" value="VERSION" noResource="true"/>
       </Properties>
-      <AccessibilityProperties>
-        <Property name="AccessibleContext.accessibleName" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties" key="CustomizerPhpUnit.versionComboBox.AccessibleContext.accessibleName" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-        <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties" key="CustomizerPhpUnit.versionComboBox.AccessibleContext.accessibleDescription" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-      </AccessibilityProperties>
-      <AuxValues>
-        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;PhpUnitVersion&gt;"/>
-      </AuxValues>
     </Component>
   </SubComponents>
 </Form>

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/CustomizerPhpUnit.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/CustomizerPhpUnit.java
@@ -25,10 +25,12 @@ import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.io.File;
+import javax.swing.DefaultComboBoxModel;
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -39,6 +41,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import org.netbeans.modules.php.api.phpmodule.PhpModule;
 import org.netbeans.modules.php.api.validation.ValidationResult;
+import org.netbeans.modules.php.phpunit.PhpUnitVersion;
 import org.netbeans.modules.php.phpunit.commands.PhpUnit;
 import org.netbeans.modules.php.phpunit.preferences.PhpUnitPreferences;
 import org.netbeans.modules.php.phpunit.preferences.PhpUnitPreferencesValidator;
@@ -88,6 +91,7 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
         runPhpUnitOnlyCheckBox.setSelected(PhpUnitPreferences.getRunPhpUnitOnly(phpModule));
         runTestUsingUnitCheckBox.setSelected(PhpUnitPreferences.getRunAllTestFiles(phpModule));
         askForTestGroupsCheckBox.setSelected(PhpUnitPreferences.getAskForTestGroups(phpModule));
+        initPhpUnitVersion();
 
         enableFile(bootstrapCheckBox.isSelected(), bootstrapLabel, bootstrapTextField, bootstrapGenerateButton, bootstrapBrowseButton, bootstrapForCreateTestsCheckBox);
         enableFile(configurationCheckBox.isSelected(), configurationLabel, configurationTextField, configurationGenerateButton, configurationBrowseButton);
@@ -150,6 +154,7 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
         PhpUnitPreferences.setRunPhpUnitOnly(phpModule, runPhpUnitOnlyCheckBox.isSelected());
         PhpUnitPreferences.setRunAllTestFiles(phpModule, runTestUsingUnitCheckBox.isSelected());
         PhpUnitPreferences.setAskForTestGroups(phpModule, askForTestGroupsCheckBox.isSelected());
+        PhpUnitPreferences.setPhpUnitVersion(phpModule, (PhpUnitVersion) versionComboBox.getSelectedItem());
     }
 
     private void initFile(boolean enabled, String file, JCheckBox checkBox, JTextField textField) {
@@ -236,6 +241,12 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
         return true;
     }
 
+    private void initPhpUnitVersion() {
+        PhpUnitVersion phpVersion = PhpUnitPreferences.getPhpUnitVersion(phpModule);
+        assert phpVersion != null;
+        versionComboBox.setModel(new PhpUnitVersionComboBoxModel(phpVersion));
+    }
+
     /** This method is called from within the constructor to
      * initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is
@@ -268,6 +279,8 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
         runPhpUnitOnlyCheckBox = new JCheckBox();
         runTestUsingUnitCheckBox = new JCheckBox();
         askForTestGroupsCheckBox = new JCheckBox();
+        versionLabel = new JLabel();
+        versionComboBox = new JComboBox<>();
 
         bootstrapLabel.setLabelFor(bootstrapTextField);
         Mnemonics.setLocalizedText(bootstrapLabel, NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.bootstrapLabel.text")); // NOI18N
@@ -349,6 +362,9 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
 
         Mnemonics.setLocalizedText(askForTestGroupsCheckBox, NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.askForTestGroupsCheckBox.text")); // NOI18N
 
+        versionLabel.setLabelFor(versionComboBox);
+        Mnemonics.setLocalizedText(versionLabel, NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.versionLabel.text")); // NOI18N
+
         GroupLayout layout = new GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
@@ -401,6 +417,10 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
                     .addComponent(scriptCheckBox)
                     .addComponent(runPhpUnitOnlyCheckBox))
                 .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+            .addGroup(layout.createSequentialGroup()
+                .addComponent(versionLabel)
+                .addPreferredGap(ComponentPlacement.RELATED)
+                .addComponent(versionComboBox, 0, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         layout.linkSize(SwingConstants.HORIZONTAL, new Component[] {bootstrapBrowseButton, bootstrapGenerateButton, configurationBrowseButton, configurationGenerateButton, scriptBrowseButton, suiteBrowseButton});
@@ -447,6 +467,10 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
                 .addComponent(runTestUsingUnitCheckBox)
                 .addPreferredGap(ComponentPlacement.RELATED)
                 .addComponent(askForTestGroupsCheckBox)
+                .addPreferredGap(ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                    .addComponent(versionLabel)
+                    .addComponent(versionComboBox, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
                 .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
@@ -482,6 +506,9 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
         suiteBrowseButton.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.suiteBrowseButton.AccessibleContext.accessibleDescription")); // NOI18N
         suiteInfoLabel.getAccessibleContext().setAccessibleName(NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.suiteInfoLabel.AccessibleContext.accessibleName")); // NOI18N
         suiteInfoLabel.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.suiteInfoLabel.AccessibleContext.accessibleDescription")); // NOI18N
+        versionLabel.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.versionLabel.AccessibleContext.accessibleDescription")); // NOI18N
+        versionComboBox.getAccessibleContext().setAccessibleName(NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.versionComboBox.AccessibleContext.accessibleName")); // NOI18N
+        versionComboBox.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.versionComboBox.AccessibleContext.accessibleDescription")); // NOI18N
 
         getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.AccessibleContext.accessibleDescription")); // NOI18N
     }// </editor-fold>//GEN-END:initComponents
@@ -581,6 +608,8 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
     private JLabel suiteInfoLabel;
     private JLabel suiteLabel;
     private JTextField suiteTextField;
+    private JComboBox<PhpUnitVersion> versionComboBox;
+    private JLabel versionLabel;
     // End of variables declaration//GEN-END:variables
 
     //~ Inner classes
@@ -600,6 +629,25 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
         }
         private void processUpdate() {
             validateData();
+        }
+    }
+
+    private static class PhpUnitVersionComboBoxModel extends DefaultComboBoxModel<PhpUnitVersion> {
+
+        private static final long serialVersionUID = 5850175934190021687L;
+
+        public PhpUnitVersionComboBoxModel() {
+            this(null);
+        }
+
+        public PhpUnitVersionComboBoxModel(PhpUnitVersion preselected) {
+            super(PhpUnitVersion.values());
+
+            if (preselected != null) {
+                setSelectedItem(preselected);
+            } else {
+                setSelectedItem(PhpUnitVersion.getDefault());
+            }
         }
     }
 

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/options/PhpUnitOptionsPanel.form
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/options/PhpUnitOptionsPanel.form
@@ -45,6 +45,29 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
+          <Group type="102" attributes="0">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="errorLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="noteLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Group type="102" attributes="0">
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="phpUnitInfoLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="phpUnitPhp53InfoLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="installationInfoLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="phpUnitLearnMoreLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="skelGenLearnMoreLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="phpUnit370InfoLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                  </Group>
+              </Group>
+              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+          </Group>
+          <Group type="102" alignment="0" attributes="0">
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="skelGenAbandonedLabel" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
+          </Group>
           <Group type="102" alignment="0" attributes="0">
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="phpUnitLabel" min="-2" max="-2" attributes="0"/>
@@ -73,35 +96,13 @@
                   </Group>
                   <Group type="102" attributes="0">
                       <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="phpUnitVersionLabel" min="-2" max="-2" attributes="0"/>
                           <Component id="skelGenHintLabel" min="-2" max="-2" attributes="0"/>
                           <Component id="phpUnitHintLabel" max="-2" attributes="0"/>
                       </Group>
                       <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                   </Group>
               </Group>
-          </Group>
-          <Group type="102" attributes="0">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="errorLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                  <Component id="noteLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                  <Group type="102" attributes="0">
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="phpUnitInfoLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="phpUnitPhp53InfoLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="installationInfoLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="phpUnitLearnMoreLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="skelGenLearnMoreLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="phpUnit370InfoLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                  </Group>
-              </Group>
-              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-          </Group>
-          <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="skelGenAbandonedLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -115,8 +116,10 @@
                   <Component id="phpUnitBrowseButton" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
+              <Component id="phpUnitVersionLabel" min="-2" max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Component id="phpUnitHintLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="skelGenTextField" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="skelGenLabel" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -379,6 +382,11 @@
           <ResourceString bundle="org/netbeans/modules/php/phpunit/ui/options/Bundle.properties" key="PhpUnitOptionsPanel.errorLabel.AccessibleContext.accessibleDescription" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </AccessibilityProperties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="phpUnitVersionLabel">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="VERSION" noResource="true"/>
+      </Properties>
     </Component>
   </SubComponents>
 </Form>

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/options/PhpUnitOptionsPanel.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/options/PhpUnitOptionsPanel.java
@@ -85,6 +85,7 @@ public class PhpUnitOptionsPanel extends JPanel {
     })
     private void init() {
         errorLabel.setText(" "); // NOI18N
+        phpUnitVersionLabel.setText(" "); // NOI18N
         phpUnitHintLabel.setText(Bundle.PhpUnitOptionsPanel_phpUnit_hint(
                 PhpUnit.SCRIPT_NAME, PhpUnit.SCRIPT_NAME_LONG, PhpUnit.SCRIPT_NAME_PHAR));
         skelGenHintLabel.setText(Bundle.PhpUnitOptionsPanel_skelGen_hint(
@@ -121,6 +122,10 @@ public class PhpUnitOptionsPanel extends JPanel {
         errorLabel.setText(" "); // NOI18N
         errorLabel.setForeground(UIManager.getColor("nb.warningForeground")); // NOI18N
         errorLabel.setText(message);
+    }
+
+    public void setVersion(String version) {
+        phpUnitVersionLabel.setText(version);
     }
 
     public void addChangeListener(ChangeListener listener) {
@@ -163,6 +168,7 @@ public class PhpUnitOptionsPanel extends JPanel {
         phpUnitLearnMoreLabel = new JLabel();
         skelGenLearnMoreLabel = new JLabel();
         errorLabel = new JLabel();
+        phpUnitVersionLabel = new JLabel();
 
         phpUnitLabel.setLabelFor(phpUnitBrowseButton);
         Mnemonics.setLocalizedText(phpUnitLabel, NbBundle.getMessage(PhpUnitOptionsPanel.class, "PhpUnitOptionsPanel.phpUnitLabel.text")); // NOI18N
@@ -236,9 +242,29 @@ public class PhpUnitOptionsPanel extends JPanel {
 
         Mnemonics.setLocalizedText(errorLabel, "ERROR"); // NOI18N
 
+        Mnemonics.setLocalizedText(phpUnitVersionLabel, "VERSION"); // NOI18N
+
         GroupLayout layout = new GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
+            .addGroup(layout.createSequentialGroup()
+                .addGroup(layout.createParallelGroup(Alignment.LEADING)
+                    .addComponent(errorLabel)
+                    .addComponent(noteLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                    .addGroup(layout.createSequentialGroup()
+                        .addContainerGap()
+                        .addGroup(layout.createParallelGroup(Alignment.LEADING)
+                            .addComponent(phpUnitInfoLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                            .addComponent(phpUnitPhp53InfoLabel)
+                            .addComponent(installationInfoLabel)
+                            .addComponent(phpUnitLearnMoreLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                            .addComponent(skelGenLearnMoreLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                            .addComponent(phpUnit370InfoLabel))))
+                .addGap(0, 0, Short.MAX_VALUE))
+            .addGroup(layout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(skelGenAbandonedLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
             .addGroup(layout.createSequentialGroup()
                 .addGroup(layout.createParallelGroup(Alignment.LEADING)
                     .addComponent(phpUnitLabel)
@@ -261,27 +287,10 @@ public class PhpUnitOptionsPanel extends JPanel {
                                 .addComponent(skelGenSearchButton))))
                     .addGroup(layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(Alignment.LEADING)
+                            .addComponent(phpUnitVersionLabel)
                             .addComponent(skelGenHintLabel)
                             .addComponent(phpUnitHintLabel))
                         .addGap(0, 0, Short.MAX_VALUE))))
-            .addGroup(layout.createSequentialGroup()
-                .addGroup(layout.createParallelGroup(Alignment.LEADING)
-                    .addComponent(errorLabel)
-                    .addComponent(noteLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
-                    .addGroup(layout.createSequentialGroup()
-                        .addContainerGap()
-                        .addGroup(layout.createParallelGroup(Alignment.LEADING)
-                            .addComponent(phpUnitInfoLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
-                            .addComponent(phpUnitPhp53InfoLabel)
-                            .addComponent(installationInfoLabel)
-                            .addComponent(phpUnitLearnMoreLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
-                            .addComponent(skelGenLearnMoreLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
-                            .addComponent(phpUnit370InfoLabel))))
-                .addGap(0, 0, Short.MAX_VALUE))
-            .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
-                .addComponent(skelGenAbandonedLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         layout.linkSize(SwingConstants.HORIZONTAL, new Component[] {phpUnitBrowseButton, phpUnitSearchButton, skelGenBrowseButton, skelGenSearchButton});
@@ -294,8 +303,10 @@ public class PhpUnitOptionsPanel extends JPanel {
                     .addComponent(phpUnitSearchButton)
                     .addComponent(phpUnitBrowseButton))
                 .addPreferredGap(ComponentPlacement.RELATED)
-                .addComponent(phpUnitHintLabel)
+                .addComponent(phpUnitVersionLabel)
                 .addPreferredGap(ComponentPlacement.RELATED)
+                .addComponent(phpUnitHintLabel)
+                .addPreferredGap(ComponentPlacement.UNRELATED)
                 .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                     .addComponent(skelGenTextField, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
                     .addComponent(skelGenLabel)
@@ -488,6 +499,7 @@ public class PhpUnitOptionsPanel extends JPanel {
     private JLabel phpUnitPhp53InfoLabel;
     private JButton phpUnitSearchButton;
     private JTextField phpUnitTextField;
+    private JLabel phpUnitVersionLabel;
     private JLabel skelGenAbandonedLabel;
     private JButton skelGenBrowseButton;
     private JLabel skelGenHintLabel;


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/5790
- Add `PhpUnitVersion`
- Don't use `NetBeansSuite.php` with PHPUnit 10 because `suite()` method is invoked no longer and we have to extend `TestCase`
- See: https://github.com/sebastianbergmann/phpunit/commit/36354a9cdc69ecabd20ac505b07541cfdde50aaa

![nb-php-gh-5790-phpunit10-project-properties](https://user-images.githubusercontent.com/738383/233264912-d6f0c662-b73e-4cec-b8c1-5a3be37e20fb.png)
