### PR TITLE
HCL fix compound expression grammar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -544,6 +544,9 @@ jobs:
       - name: ide/javascript2.debug
         run: ant $OPTS -f ide/javascript2.debug test
 
+      - name: ide/languages.hcl
+        run: ant $OPTS -f ide/languages.hcl test
+
       - name: ide/languages.toml
         run: ant $OPTS -f ide/languages.toml test
 

--- a/ide/languages.hcl/nbproject/project.xml
+++ b/ide/languages.hcl/nbproject/project.xml
@@ -244,6 +244,15 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
             <public-packages/>
         </data>
     </configuration>

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/grammar/g4/HCLExpressionParser.g4
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/grammar/g4/HCLExpressionParser.g4
@@ -21,9 +21,12 @@ options { tokenVocab = HCLLexer; }
 
 expression
     : exprTerm
-    | <assoc=right> unaryOperator expression
-    | expression binaryOperator expression
-    | expression QUESTION expression COLON expression
+    | <assoc=right> op=(NOT | MINUS) right=expression
+    | left=expression op=(STAR | SLASH | PERCENT) right=expression
+    | left=expression op=(PLUS | MINUS) right=expression
+    | left=expression op=(AND | OR) right=expression
+    | left=expression op=(LTE | GTE | LT | GT | EQUALS | NOT_EQUALS) right=expression
+    | exprCond=expression QUESTION (exprTrue=expression COLON exprFalse=expression)
     ;
 
 exprTerm
@@ -148,37 +151,4 @@ attrSplat
 
 fullSplat
     : LBRACK STAR RBRACK (getAttr | index)*
-    ;
-
-unaryOperator
-    : MINUS
-    | NOT
-    ;
-
-binaryOperator
-    : compareOperator
-    | arithmeticOperator
-    | logicOperator
-    ;
-
-compareOperator
-    : EQUALS
-    | NOT_EQUALS
-    | LT
-    | GT
-    | LTE
-    | GTE
-    ;
-
-arithmeticOperator
-    : PLUS
-    | MINUS
-    | STAR
-    | SLASH
-    | PERCENT
-    ;
-
-logicOperator
-    : AND
-    | OR
     ;

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/grammar/g4/HCLExpressionParser.g4
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/grammar/g4/HCLExpressionParser.g4
@@ -21,8 +21,9 @@ options { tokenVocab = HCLLexer; }
 
 expression
     : exprTerm
-    | operation
-    | <assoc=right> expression QUESTION expression COLON expression
+    | <assoc=right> unaryOperator expression
+    | expression binaryOperator expression
+    | expression QUESTION expression COLON expression
     ;
 
 exprTerm
@@ -149,17 +150,9 @@ fullSplat
     : LBRACK STAR RBRACK (getAttr | index)*
     ;
 
-operation
-    : unaryOp
-    | binaryOp
-    ;
-
-unaryOp
-    : (MINUS | NOT) exprTerm
-    ;
-
-binaryOp
-    : exprTerm binaryOperator exprTerm
+unaryOperator
+    : MINUS
+    | NOT
     ;
 
 binaryOperator

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/grammar/HCLExpressionParserTest.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/grammar/HCLExpressionParserTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.languages.hcl.grammar;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.netbeans.modules.languages.hcl.grammar.HCLExpressionParser.ExpressionContext;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class HCLExpressionParserTest {
+
+    public HCLExpressionParserTest() {
+    }
+
+    @Test
+    public void testTerminals() {
+        assertEquals("42", parse(" 42 ").exprTerm().literalValue().NUMERIC_LIT().getText());
+    }
+
+    @Test
+    public void testCompoundExpr1() {
+        ExpressionContext expr = parse("1 + 2 / 3");
+        assertEquals("1", expr.left.getText());
+        assertEquals("+", expr.op.getText());
+        assertEquals("2/3", expr.right.getText());
+    }
+
+    @Test
+    public void testCompoundExpr2() {
+        ExpressionContext expr = parse("(1 + 2) / 3");
+        assertEquals("(1+2)", expr.left.getText());
+        assertEquals("/", expr.op.getText());
+        assertEquals("3", expr.right.getText());
+        
+        ExpressionContext left = expr.left.exprTerm().expression();
+        assertEquals("1", left.left.getText());
+        assertEquals("+", left.op.getText());
+        assertEquals("2", left.right.getText());
+    }
+
+    @Test
+    public void testCompoundExpr3() {
+        ExpressionContext expr = parse("1 + -2");
+        assertEquals("1", expr.left.getText());
+        assertEquals("+", expr.op.getText());
+        assertEquals("-2", expr.right.getText());
+
+        ExpressionContext right = expr.right;
+        assertNull(right.left);
+        assertEquals("-", right.op.getText());
+        assertEquals("2", right.right.getText());
+    }
+
+    @Test
+    public void testConditionalq() {
+        ExpressionContext expr = parse("1 == 2 ? 3 : 4");
+        assertEquals("1==2", expr.exprCond.getText());
+        assertEquals("3", expr.exprTrue.getText());
+        assertEquals("4", expr.exprFalse.getText());
+    }
+
+    @Test
+    public void testConditional2() {
+        ExpressionContext expr = parse("(a <= b) && !c ? 0 : 1");
+        assertEquals("(a<=b)&&!c", expr.exprCond.getText());
+        assertEquals("0", expr.exprTrue.getText());
+        assertEquals("1", expr.exprFalse.getText());
+
+        ExpressionContext cond = expr.exprCond;
+        assertEquals("a<=b", cond.left.exprTerm().expression().getText());
+        assertEquals("!", cond.right.op.getText());
+        assertEquals("c", cond.right.right.getText());
+
+    }
+
+    @Test
+    public void testConditional3() {
+        ExpressionContext expr = parse("a ? b ? 0 : 1 : 2");
+        assertEquals("a", expr.exprCond.getText());
+        assertEquals("b?0:1", expr.exprTrue.getText());
+        assertEquals("2", expr.exprFalse.getText());
+
+        ExpressionContext exprTrue = expr.exprTrue;
+        assertEquals("b", exprTrue.exprCond.getText());
+        assertEquals("0", exprTrue.exprTrue.getText());
+        assertEquals("1", exprTrue.exprFalse.getText());
+
+    }
+
+    private static HCLExpressionParser.ExpressionContext parse(String expr){
+        HCLLexer lexer = new HCLLexer(CharStreams.fromString(expr));
+        HCLExpressionParser parser = new HCLExpressionParser(new CommonTokenStream(lexer));
+        return parser.expression();
+    }
+}


### PR DESCRIPTION
It seems there is a bug in the HCL Grammar spec: https://github.com/hashicorp/hcl/issues/553

According to the spec an `operation` only can happen between `ExprTerm`-s not `Expression`-s making the following assignment invalid:

```
value = 1 + 2 + 3
```

This change moves the operations to the expression level, as ANTLR4 cannot handle indirect recursions, I had to move the operation rules to the expression level. I do not know if I took the left/right association directives right. That would only affect the ParserTree then the AST build up, though at the moment we do not use those that deep. 
