### PR TITLE
Make Options category buttons accent colour aware in FlatLaf.

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -192,9 +192,3 @@ Nb.browser.picker.foreground.light=rgb(192,192,192)
 # search in projects
 nb.search.sandbox.highlight=@selectionBackground
 nb.search.sandbox.regexp.wrong=rgb(255, 71, 71)
-
-
-#---- OptionsPanel ----
-
-nb.options.categories.selectionBackground = @selectionBackground
-nb.options.categories.highlightBackground = $TabbedPane.hoverColor

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -165,6 +165,11 @@ Nb.MainWindow.Toolbar.Dragger=org.netbeans.swing.laf.flatlaf.ui.FlatToolbarDragg
 #---- OptionsPanel ----
 
 nb.options.categories.tabPanelForeground = @foreground
+nb.options.categories.tabPanelBackground = @background
+nb.options.categories.selectionForeground = @selectionForeground
+nb.options.categories.selectionBackground = @selectionBackground
+nb.options.categories.highlightForeground = @selectionInactiveForeground
+nb.options.categories.highlightBackground = @selectionInactiveBackground
 nb.options.categories.separatorColor = $Separator.foreground
 nb.options.categories.selectionBorderColor = $nb.options.categories.selectionBackground
 nb.options.categories.highlightBorderColor = $nb.options.categories.highlightBackground

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
@@ -80,9 +80,3 @@ nb.quicksearch.border=1,1,1,1,@background
 
 # output
 nb.output.selectionBackground=#89BCED
-
-
-#---- OptionsPanel ----
-
-nb.options.categories.selectionBackground = rgb(193, 210, 238)
-nb.options.categories.highlightBackground = rgb(224, 232, 246)

--- a/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
+++ b/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
@@ -1008,6 +1008,22 @@ public class OptionsPanel extends JPanel {
         return new Color (193, 210, 238);
     }
 
+    private Color getSelectionForeground() {
+        Color uiColor = UIManager.getColor("nb.options.categories.selectionForeground"); //NOI18N
+        if (uiColor != null) {
+            return uiColor;
+        }
+
+        if ( useUIDefaultsColors() ) {
+            Color res = UIManager.getColor("Tree.selectionForeground"); //NOI18N
+            if (null == res) {
+                return new Color(res.getRGB());
+            }
+        }
+
+        return getTabPanelForeground();
+    }
+
     private Color getHighlightBackground() {
         Color uiColor = UIManager.getColor("nb.options.categories.highlightBackground"); //NOI18N
         if (uiColor != null) {
@@ -1023,6 +1039,24 @@ public class OptionsPanel extends JPanel {
             }
         }
         return new Color (224, 232, 246);
+    }
+
+    private Color getHighlightForeground() {
+        Color uiColor = UIManager.getColor("nb.options.categories.highlightForeground"); //NOI18N
+        if (uiColor != null) {
+            return uiColor;
+        }
+
+        if( useUIDefaultsColors() ) {
+            if( !Color.white.equals( getTabPanelBackground() ) ) {
+                Color res = UIManager.getColor( "Tree.selectionForeground" ); //NOI18N
+                if( null == res )
+                    res = Color.blue;
+                return new Color( res.getRGB() );
+            }
+        }
+
+        return getTabPanelForeground();
     }
 
     /**
@@ -1190,7 +1224,7 @@ public class OptionsPanel extends JPanel {
                 ));
             }
             setBackground(selected);            
-            setForeground(getUIColorOrDefault("MenuItem.selectionForeground", getTabPanelForeground()));
+            setForeground(getSelectionForeground());
         }
         
         void setHighlighted() {
@@ -1203,7 +1237,7 @@ public class OptionsPanel extends JPanel {
                         new EmptyBorder(0, 2, 0, 2)
                         ));
                 setBackground(highlighted);
-                setForeground(getTabPanelForeground());
+                setForeground(getHighlightForeground());
             }
             if (!category.isHighlited()) {
                 if (categoryModel.getHighlitedCategoryID() != null) {
@@ -1323,6 +1357,7 @@ public class OptionsPanel extends JPanel {
 
         @Override
         void setNormal() {
+            super.setNormal();
             setBorder(normalBorder);
             status = STATUS_NORMAL;
             repaint();


### PR DESCRIPTION
Fixes the option category buttons to respond to accent colour with FlatLaf Light. Also fixes the issue with illegible foreground text mentioned in #5798 

This does change the default blue to be much darker than the existing hardcoded colour though.

This also does subtly change the behaviour on other LaFs in that `Tree.selectionForeground` is used in cases where `Tree.selectionBackground` might be - that seems to be the safer approach anyway.

![Screenshot from 2023-04-21 15-17-39](https://user-images.githubusercontent.com/3975960/233659886-08bd3e9e-d638-4c66-ab64-6980795a4ed9.png)

![Screenshot from 2023-04-21 15-18-14](https://user-images.githubusercontent.com/3975960/233659905-0d044878-03e2-42fe-9eb4-2df48faf9e62.png)

![Screenshot from 2023-04-21 15-18-47](https://user-images.githubusercontent.com/3975960/233659927-90481b4b-a887-42ba-9d91-97e500fa84f1.png)
