### PR TITLE
Make SystemOpenAction dynamic in main menu

### DIFF
--- a/platform/core.ui/src/org/netbeans/core/ui/sysopen/SystemOpenAction.java
+++ b/platform/core.ui/src/org/netbeans/core/ui/sysopen/SystemOpenAction.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.netbeans.core.ui.sysopen;
 
 import java.awt.Desktop;
@@ -38,9 +37,11 @@ import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.util.ContextAwareAction;
 import org.openide.util.Lookup;
+import org.openide.util.LookupListener;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.Utilities;
+import org.openide.util.WeakListeners;
 
 /**
  * Open the selected file(s) with the system default tool.
@@ -50,63 +51,65 @@ import org.openide.util.Utilities;
 @ActionRegistration(displayName = "#CTL_SystemOpenAction", lazy=false)
 @ActionReferences ({
     @ActionReference(path = "UI/ToolActions/Files", position = 2045),
-    @ActionReference(path = "Projects/Actions", position = 101) 
+    @ActionReference(path = "Projects/Actions", position = 101)
 })
 public final class SystemOpenAction extends AbstractAction implements ContextAwareAction {
-    
+
     private static final RequestProcessor PROC = new RequestProcessor(SystemOpenAction.class);
-    
+
+    private final Lookup.Result<DataObject> result;
+    private final LookupListener resultListener;
+    private final Set<File> files;
+
     public SystemOpenAction() {
+        this(Utilities.actionsGlobalContext());
+    }
+
+    private SystemOpenAction(Lookup context) {
         super(NbBundle.getMessage(SystemOpenAction.class, "CTL_SystemOpenAction"));
+        putValue(DynamicMenuContent.HIDE_WHEN_DISABLED, true);
+        result = context.lookupResult(DataObject.class);
+        resultListener = e -> updateFileSet();
+        result.addLookupListener(WeakListeners.create(LookupListener.class, resultListener, result));
+        files = new HashSet<>();
+        updateFileSet();
     }
 
-    public @Override void actionPerformed(ActionEvent e) {
-        new ContextAction(Utilities.actionsGlobalContext()).actionPerformed(e);
-    }
-
-    public @Override Action createContextAwareInstance(Lookup context) {
-        return new ContextAction(context);
-    }
-    
-    private static final class ContextAction extends AbstractAction {
-        
-        private final Set<File> files;
-        
-        public ContextAction(Lookup context) {
-            super(NbBundle.getMessage(SystemOpenAction.class, "CTL_SystemOpenAction"));
-            putValue(DynamicMenuContent.HIDE_WHEN_DISABLED, true);
-            files = new HashSet<>();
-            for (DataObject d : context.lookupAll(DataObject.class)) {
-                File f = FileUtil.toFile(d.getPrimaryFile());
-                if (f == null || /* #144575 */Utilities.isWindows() && f.isFile() && !f.getName().contains(".")) {
-                    files.clear();
-                    break;
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        PROC.post(() -> { // #176879: asynch
+            Desktop desktop = Desktop.getDesktop();
+            for (File f : files) {
+                try {
+                    desktop.open(f);
+                } catch (IOException x) {
+                    Logger.getLogger(SystemOpenAction.class.getName()).log(Level.INFO, null, x);
+                    // XXX or perhaps notify user of problem; but not very useful on Unix at least (#6940853)
                 }
-                files.add(f);
             }
-        }
-
-        public @Override boolean isEnabled() {
-            return !files.isEmpty() && Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN);
-        }
-
-        public @Override void actionPerformed(ActionEvent e) {
-            PROC.post(new Runnable() { // #176879: asynch
-                public @Override void run() {
-                    Desktop desktop = Desktop.getDesktop();
-                    for (File f : files) {
-                        try {
-                            desktop.open(f);
-                        } catch (IOException x) {
-                            Logger.getLogger(SystemOpenAction.class.getName()).log(Level.INFO, null, x);
-                            // XXX or perhaps notify user of problem; but not very useful on Unix at least (#6940853)
-                        }
-                    }
-                }
-            });
-        }
-
+        });
     }
-    
-}
 
+    @Override
+    public Action createContextAwareInstance(Lookup context) {
+        return new SystemOpenAction(context);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return !files.isEmpty() && Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN);
+    }
+
+    private void updateFileSet() {
+        files.clear();
+        for (DataObject d : result.allInstances()) {
+            File f = FileUtil.toFile(d.getPrimaryFile());
+            if (f == null || /* #144575 */ Utilities.isWindows() && f.isFile() && !f.getName().contains(".")) {
+                files.clear();
+                break;
+            }
+            files.add(f);
+        }
+    }
+
+}


### PR DESCRIPTION
Rewrite the `Open in System` action with lookup listening so that it works dynamically with global context.

Now that SystemOpenAction is included in the main Tools menu ( #5770 ), the fact that the action doesn't enable and disable with the global context is very visible. When any item that is not a file is selected (service, pom navigator, etc.) the action remains enabled but non-operational. These changes ensure the action only appears when applicable.