### PR TITLE
Improve WildFly support for jakarta ee and java ee javadocs

### DIFF
--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
@@ -104,6 +104,8 @@ public class WildflyPluginUtils {
     public static final Version WILDFLY_26_0_0 = new Version("26.0.0", true); // NOI18N
 
     public static final Version WILDFLY_27_0_0 = new Version("27.0.0", true); // NOI18N
+    
+    public static final Version WILDFLY_28_0_0 = new Version("28.0.0", true); // NOI18N
 
     private static final Logger LOGGER = Logger.getLogger(WildflyPluginUtils.class.getName());
 
@@ -412,6 +414,21 @@ public class WildflyPluginUtils {
             }
         }
         return false;
+    }
+    
+    /**
+     * Check if the jakarta directory exists in the module base. If the
+     * directory exists then WildFly support Jakarta EE.
+     *
+     * @param serverPath path to the server directory
+     * @return true if the jakarta directory exists, {@code false} otherwise
+     */
+    @CheckForNull
+    public static boolean isWildFlyJakartaEE(File serverPath) {
+        assert serverPath != null : "Can't determine jakarta directory with null server path"; // NOI18N
+
+        File jakartaDir = new File(serverPath, getModulesBase(serverPath.getAbsolutePath()) + "jakarta");
+        return jakartaDir.exists();
     }
 
     private static class VersionJarFileFilter implements FilenameFilter {


### PR DESCRIPTION
- Add wildfly version 28 field

Testing:

- Full build done
- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of `ant check-sigtests`
- Register different WildFly versions and verify that the correct javadoc is assigned

Jakarta EE 10 with WildFly 28 beta
![Screenshot from 2023-04-21 16-09-34](https://user-images.githubusercontent.com/9832133/233742168-ae26065c-d3a1-45d5-b5ea-f021a51156c8.png)
Jakarta EE 9 with WildFly 22 preview
![Screenshot from 2023-04-21 16-10-44](https://user-images.githubusercontent.com/9832133/233742239-d4e7da3f-a1b5-4411-a558-531ff1ddbfa0.png)
Jakarta EE 8 with WildFly 26
![Screenshot from 2023-04-21 16-10-19](https://user-images.githubusercontent.com/9832133/233742225-bf9526e0-8846-4f72-8fc8-f64b9562cc81.png)
Java EE 8 with WildFly 20
![Screenshot from 2023-04-21 16-11-14](https://user-images.githubusercontent.com/9832133/233742706-5522b0d8-e476-4c25-b7eb-464cb6ddfa6c.png)
