### PR TITLE
update wildcard cert test case url since badssl expired

### DIFF
--- a/ide/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/impl/SecureURLResourceRetrieverTest.java
+++ b/ide/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/impl/SecureURLResourceRetrieverTest.java
@@ -56,7 +56,7 @@ public class SecureURLResourceRetrieverTest {
     @Test
     public void shouldAcceptWildcardCertificate() throws Exception {
         SecureURLResourceRetriever resourceRetriever = new SecureURLResourceRetriever();
-        resourceRetriever.retrieveDocument(null, "https://badssl.com/");
+        resourceRetriever.retrieveDocument(null, "https://wikipedia.org/");
 
         assertFalse(lookupMockDialogDisplayer().invoked);
     }


### PR DESCRIPTION
`shouldAcceptWildcardCertificate(org.netbeans.modules.xml.retriever.impl.SecureURLResourceRetrieverTest)` started failing with:

```
[junit] PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
    [junit] javax.net.ssl.SSLHandshakeException: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
    [junit] 	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:131)
...
```
https://github.com/apache/netbeans/actions/runs/4778711192/jobs/8495573338

since the cert of the test url expired. I switched it to wikipedia.org since they are using a wildcard cert too (suggestions for better options appreciated since this might not be a good test cert since it has more than just the wildcard in it).

we would get this both into master and delivery. This is based on delivery.