### PR TITLE
Fix the Maven Compile on Save UI.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.maven.customizer;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
+import java.awt.EventQueue;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
@@ -100,6 +101,7 @@ public class CompilePanel extends javax.swing.JPanel implements HelpCtx.Provider
         comJavaPlatform.setRenderer(new PlatformsRenderer());
 
         origComPlatformFore = comJavaPlatform.getForeground();
+        /* @TODO reinstate if a new link created, or remove
         btnLearnMore.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         btnLearnMore.addActionListener(new ActionListener() {
             @Override
@@ -111,6 +113,8 @@ public class CompilePanel extends javax.swing.JPanel implements HelpCtx.Provider
                 }
             }
         });
+        */
+        btnLearnMore.setVisible(false);
         initValues();
     }
 
@@ -162,15 +166,18 @@ public class CompilePanel extends javax.swing.JPanel implements HelpCtx.Provider
             public void setValue(Boolean v) {
                 handle.removePOMModification(operation);
                 modifiedValue = null;
-                String value = v != null ? (v ? "all" : "none") : "all";
+                boolean cosEnabled = v != null ? v : getDefaultValue();
+                String value = cosEnabled ? "all" : "none";
                 if ("all".equals(value)) {
                     if (!warningShown && DontShowAgainSettings.getDefault().showWarningAboutApplicationCoS()) {
-                        WarnPanel panel = new WarnPanel(NbBundle.getMessage(CompilePanel.class, "HINT_ApplicationCoS"));
-                        NotifyDescriptor dd = new NotifyDescriptor.Message(panel, NotifyDescriptor.PLAIN_MESSAGE);
-                        DialogDisplayer.getDefault().notify(dd);
-                        if (panel.disabledWarning()) {
-                            DontShowAgainSettings.getDefault().dontshowWarningAboutApplicationCoSAnymore();
-                        }
+                        EventQueue.invokeLater(() -> {
+                            WarnPanel panel = new WarnPanel(NbBundle.getMessage(CompilePanel.class, "HINT_ApplicationCoS"));
+                            NotifyDescriptor dd = new NotifyDescriptor.Message(panel, NotifyDescriptor.PLAIN_MESSAGE);
+                            DialogDisplayer.getDefault().notify(dd);
+                            if (panel.disabledWarning()) {
+                                DontShowAgainSettings.getDefault().dontshowWarningAboutApplicationCoSAnymore();
+                            }
+                        });
                         warningShown = true;
                     }
                 }


### PR DESCRIPTION
Most importantly, make sure the Compile-on-Save feature can still be turned off via the UI following #5826 .  No longer having it enabled by default is great; no longer being (easily) able to disable it less so! :smile: 

The problem is that the value `v` is `null` when the default, as seen in CheckBoxUpdater.

I also moved the warning dialog into an invokeLater to make sure checkbox UI gets updated (at least on my system the tick doesn't show after the dialog opens). And I also temporarily hid the non-working help link - we can follow up to remove or point it at something more useful later.