### PR TITLE
Fix the problem that documentation for methods and properties is not shown #5881

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -335,7 +335,9 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
         // GH-4494 if query type is documentation, get a whole identifier as a prefix
         boolean upToOffset = queryType != QueryType.DOCUMENTATION;
         prefix = getPrefix(info, caretOffset, upToOffset, PrefixBreaker.WITH_NS_PARTS);
+        String prefixUntilCaret = upToOffset ? prefix : getPrefix(info, caretOffset, true, PrefixBreaker.WITH_NS_PARTS); // GH-5881
         if (prefix == null
+                || prefixUntilCaret == null
                 || (queryType == QueryType.DOCUMENTATION && prefix.isEmpty())) {
             return CodeCompletionResult.NONE;
         }
@@ -358,10 +360,11 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
         }
         request.extraPrefix = searchPrefix;
 
+        int prefixLengthForAnchor = upToOffset ? prefix.length() : prefixUntilCaret.length();
         request.anchor = caretOffset
                 // can't just use 'prefix.getLength()' here cos it might have been calculated with
                 // the 'upToOffset' flag set to false
-                - prefix.length();
+                - prefixLengthForAnchor;
 
         request.result = result;
         request.info = info;

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH5881 {
+    /**
+     * Property $prop.
+     */
+    public $prop;
+    /**
+     * Property $prop_aa.
+     */
+    public $prop_aa;
+    /**
+     * Property $prop_aa_bbb.
+     */
+    public $prop_aa_bbb;
+    /**
+     * Property $prop_aa_bb_cc.
+     */
+    public $prop_aa_bb_cc;
+
+    /**
+     * Method method().
+     *
+     * @return void
+     */
+    public function method(): void {
+    }
+
+    /**
+     * Method method_aa().
+     *
+     * @return void
+     */
+    public function method_aa(): void {
+    }
+
+    /**
+     * Method method_aa_bbb().
+     *
+     * @return void
+     */
+    public function method_aa_bbb(): void {
+    }
+
+    /**
+     * Method method_aa_bb_cc().
+     *
+     * @return void
+     */
+    public function method_aa_bb_cc(): void {
+    }
+}
+$test = new GH5881();
+$prop1 = $test->prop_aa_bbb;
+$prop2 = $test->prop_aa_bb_cc;
+$test->method_aa_bbb();
+$test->method_aa_bb_cc();

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_01a.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_01a.html
@@ -1,0 +1,9 @@
+<html><body>
+<pre>Code completion result for source line:
+$prop1 = $test->pr|op_aa_bbb;
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ? prop_aa_bbb                   [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$prop_aa_bbb</b><br/><br/>
+Property $prop_aa_bbb.
+<br />
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_01b.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_01b.html
@@ -1,0 +1,9 @@
+<html><body>
+<pre>Code completion result for source line:
+$prop1 = $test->prop_aa|_bbb;
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ? prop_aa_bbb                   [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$prop_aa_bbb</b><br/><br/>
+Property $prop_aa_bbb.
+<br />
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_01c.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_01c.html
@@ -1,0 +1,9 @@
+<html><body>
+<pre>Code completion result for source line:
+$prop1 = $test->prop_aa_bb|b;
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ? prop_aa_bbb                   [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$prop_aa_bbb</b><br/><br/>
+Property $prop_aa_bbb.
+<br />
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_01d.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_01d.html
@@ -1,0 +1,9 @@
+<html><body>
+<pre>Code completion result for source line:
+$prop1 = $test->|prop_aa_bbb;
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ? prop_aa_bbb                   [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$prop_aa_bbb</b><br/><br/>
+Property $prop_aa_bbb.
+<br />
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_02a.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_02a.html
@@ -1,0 +1,9 @@
+<html><body>
+<pre>Code completion result for source line:
+$prop2 = $test->pr|op_aa_bb_cc;
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ? prop_aa_bb_cc                 [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$prop_aa_bb_cc</b><br/><br/>
+Property $prop_aa_bb_cc.
+<br />
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_02b.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_02b.html
@@ -1,0 +1,9 @@
+<html><body>
+<pre>Code completion result for source line:
+$prop2 = $test->prop_aa|_bb_cc;
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ? prop_aa_bb_cc                 [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$prop_aa_bb_cc</b><br/><br/>
+Property $prop_aa_bb_cc.
+<br />
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_02c.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_02c.html
@@ -1,0 +1,9 @@
+<html><body>
+<pre>Code completion result for source line:
+$prop2 = $test->prop_aa_bb|_cc;
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ? prop_aa_bb_cc                 [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$prop_aa_bb_cc</b><br/><br/>
+Property $prop_aa_bb_cc.
+<br />
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_02d.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_02d.html
@@ -1,0 +1,9 @@
+<html><body>
+<pre>Code completion result for source line:
+$prop2 = $test->prop_aa_bb_cc|;
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ? prop_aa_bb_cc                 [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$prop_aa_bb_cc</b><br/><br/>
+Property $prop_aa_bb_cc.
+<br />
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_02e.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_02e.html
@@ -1,0 +1,9 @@
+<html><body>
+<pre>Code completion result for source line:
+$prop2 = $test->|prop_aa_bb_cc;
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ? prop_aa_bb_cc                 [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$prop_aa_bb_cc</b><br/><br/>
+Property $prop_aa_bb_cc.
+<br />
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_03a.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_03a.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+$test->meth|od_aa_bbb();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     method_aa_bbb()                 [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>method_aa_bbb</b><br/><br/>
+Method method_aa_bbb().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_03b.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_03b.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+$test->method_aa|_bbb();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     method_aa_bbb()                 [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>method_aa_bbb</b><br/><br/>
+Method method_aa_bbb().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_03c.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_03c.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+$test->method_aa_bb|b();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     method_aa_bbb()                 [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>method_aa_bbb</b><br/><br/>
+Method method_aa_bbb().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_03d.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_03d.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+$test->|method_aa_bbb();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     method_aa_bbb()                 [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>method_aa_bbb</b><br/><br/>
+Method method_aa_bbb().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_04a.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_04a.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+$test->me|thod_aa_bb_cc();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     method_aa_bb_cc()               [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>method_aa_bb_cc</b><br/><br/>
+Method method_aa_bb_cc().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_04b.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_04b.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+$test->method_aa|_bb_cc();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     method_aa_bb_cc()               [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>method_aa_bb_cc</b><br/><br/>
+Method method_aa_bb_cc().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_04c.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_04c.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+$test->method_aa_bb|_cc();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     method_aa_bb_cc()               [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>method_aa_bb_cc</b><br/><br/>
+Method method_aa_bb_cc().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_04d.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_04d.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+$test->method_aa_bb_cc|();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     method_aa_bb_cc()               [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>method_aa_bb_cc</b><br/><br/>
+Method method_aa_bb_cc().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_04e.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/issueGH5881.php.testIssueGH5881_04e.html
@@ -1,0 +1,11 @@
+<html><body>
+<pre>Code completion result for source line:
+$test->method_aa_bb_cc|();
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
+METHOD     method_aa_bb_cc()               [PUBLIC]   GH5881
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>method_aa_bb_cc</b><br/><br/>
+Method method_aa_bb_cc().
+<br />
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>void</td></tr></table></body></html>

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
@@ -352,6 +352,78 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
         checkCompletionDocumentation("testfiles/completion/documentation/issueGH5355.php", "testFunctio^n(null);", false, "");
     }
 
+    public void testIssueGH5881_01a() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$prop1 = $test->pr^op_aa_bbb;");
+    }
+
+    public void testIssueGH5881_01b() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$prop1 = $test->prop_aa^_bbb;");
+    }
+
+    public void testIssueGH5881_01c() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$prop1 = $test->prop_aa_bb^b;");
+    }
+
+    public void testIssueGH5881_01d() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$prop1 = $test->^prop_aa_bbb;");
+    }
+
+    public void testIssueGH5881_02a() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$prop2 = $test->pr^op_aa_bb_cc;");
+    }
+
+    public void testIssueGH5881_02b() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$prop2 = $test->prop_aa^_bb_cc;");
+    }
+
+    public void testIssueGH5881_02c() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$prop2 = $test->prop_aa_bb^_cc;");
+    }
+
+    public void testIssueGH5881_02d() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$prop2 = $test->prop_aa_bb_cc^;");
+    }
+
+    public void testIssueGH5881_02e() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$prop2 = $test->^prop_aa_bb_cc;");
+    }
+
+    public void testIssueGH5881_03a() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$test->meth^od_aa_bbb();");
+    }
+
+    public void testIssueGH5881_03b() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$test->method_aa^_bbb();");
+    }
+
+    public void testIssueGH5881_03c() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$test->method_aa_bb^b();");
+    }
+
+    public void testIssueGH5881_03d() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$test->^method_aa_bbb();");
+    }
+
+    public void testIssueGH5881_04a() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$test->me^thod_aa_bb_cc();");
+    }
+
+    public void testIssueGH5881_04b() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$test->method_aa^_bb_cc();");
+    }
+
+    public void testIssueGH5881_04c() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$test->method_aa_bb^_cc();");
+    }
+
+    public void testIssueGH5881_04d() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$test->method_aa_bb_cc^();");
+    }
+
+    public void testIssueGH5881_04e() throws Exception {
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/issueGH5881.php", "$test->method_aa_bb_cc^();");
+    }
+
     @Override
     protected String alterDocumentationForTest(String documentation) {
         int start = documentation.indexOf("file:");


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/5881
- Get also the prefix until the caret position to calculate the correct anchor

### Example
```php
class GH5881 {
    /**
     * Property $prop.
     */
    public $prop;
    /**
     * Property $prop_aa.
     */
    public $prop_aa;
    /**
     * Property $prop_aa_bbb.
     */
    public $prop_aa_bbb;
    /**
     * Property $prop_aa_bb_cc.
     */
    public $prop_aa_bb_cc;

    /**
     * Method method().
     *
     * @return void
     */
    public function method(): void {
    }

    /**
     * Method method_aa().
     *
     * @return void
     */
    public function method_aa(): void {
    }

    /**
     * Method method_aa_bbb().
     *
     * @return void
     */
    public function method_aa_bbb(): void {
    }

    /**
     * Method method_aa_bb_cc().
     *
     * @return void
     */
    public function method_aa_bb_cc(): void {
    }
}
$test = new GH5881();
$prop1 = $test->prop_aa_bbb;
$prop2 = $test->prop_aa_bb_cc;
$test->method_aa_bbb();
$test->method_aa_bb_cc();
```
![nb-php-gh-5881-cc-doc-regression-property](https://user-images.githubusercontent.com/738383/234265417-7aedffc5-9edc-4957-916d-e023b30d2148.png)

![nb-php-gh-5881-cc-doc-regression-method](https://user-images.githubusercontent.com/738383/234265454-479b1cc5-bebc-4450-9d84-8acb28eff919.png)

