### PR TITLE
VSCode: Prevent unnecessary Java parsing when Java support if off.

### DIFF
--- a/java/java.lsp.server/nbcode/integration.java/src/META-INF/services/org.netbeans.modules.java.lsp.server.protocol.CodeActionsProvider
+++ b/java/java.lsp.server/nbcode/integration.java/src/META-INF/services/org.netbeans.modules.java.lsp.server.protocol.CodeActionsProvider
@@ -24,6 +24,7 @@
 #-org.netbeans.modules.java.lsp.server.protocol.ImplementOverrideMethodGenerator
 #-org.netbeans.modules.java.lsp.server.protocol.SurroundWithHint
 #-org.netbeans.modules.java.lsp.server.protocol.OrganizeImportsCodeAction
+#-org.netbeans.modules.java.lsp.server.protocol.TestClassGenerator
 #-org.netbeans.modules.java.lsp.server.refactoring.MoveRefactoring
 #-org.netbeans.modules.java.lsp.server.refactoring.ExtractSuperclassOrInterfaceRefactoring
 #-org.netbeans.modules.java.lsp.server.refactoring.PullUpRefactoring


### PR DESCRIPTION
Modified to prevent unnecessary parsing of Java sources invoked by Java editor features when Java support if off in Language Server settings.
