### PR TITLE
A very minimal, but functional viewer for Markdown files.

### DIFF
--- a/ide/markdown/nbproject/project.xml
+++ b/ide/markdown/nbproject/project.xml
@@ -43,6 +43,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.libs.flexmark</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.12</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.textmate.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/ide/markdown/src/org/netbeans/modules/markdown/MarkdownDataObject.java
+++ b/ide/markdown/src/org/netbeans/modules/markdown/MarkdownDataObject.java
@@ -41,7 +41,7 @@ import org.openide.windows.TopComponent;
 @MIMEResolver.ExtensionRegistration(
         displayName = "#LBL_Markdown_LOADER",
         mimeType = MarkdownDataObject.MIME_TYPE,
-        extension = {"md"},
+        extension = {"md", "MD", "markdown"},
         position = 20367
 )
 @DataObject.Registration(

--- a/ide/markdown/src/org/netbeans/modules/markdown/MarkdownViewerElement.java
+++ b/ide/markdown/src/org/netbeans/modules/markdown/MarkdownViewerElement.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.markdown;
+
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.Action;
+import javax.swing.JComponent;
+import javax.swing.JEditorPane;
+import javax.swing.JScrollPane;
+import javax.swing.JToolBar;
+import org.netbeans.core.spi.multiview.CloseOperationState;
+import org.netbeans.core.spi.multiview.MultiViewElement;
+import org.netbeans.core.spi.multiview.MultiViewElementCallback;
+import org.openide.awt.UndoRedo;
+import org.openide.filesystems.FileChangeAdapter;
+import org.openide.filesystems.FileChangeListener;
+import org.openide.filesystems.FileEvent;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle.Messages;
+import org.openide.windows.TopComponent;
+
+/**
+ *
+ * @author lkishalmi
+ */
+@MultiViewElement.Registration(
+        displayName = "#LBL_MarkdownViewer",
+        iconBase = "org/netbeans/modules/markdown/markdown.png",
+        mimeType = "text/x-markdown",
+        persistenceType = TopComponent.PERSISTENCE_NEVER,
+        preferredID = "MarkdownViewer",
+        position = 1100
+)
+@Messages("LBL_MarkdownViewer=Preview")
+public class MarkdownViewerElement implements MultiViewElement {
+
+    private static final Logger LOG = Logger.getLogger(MarkdownViewerElement.class.getName());
+
+    private final MarkdownDataObject dataObject;
+    private transient JToolBar toolbar;
+
+    private transient JComponent component;
+    private transient JEditorPane viewer;
+
+    private final FileChangeListener fcl = new FileChangeAdapter() {
+        @Override
+        public void fileChanged(FileEvent fe) {
+            updateView();
+        }
+    
+    };
+
+    public MarkdownViewerElement(Lookup lookup) {
+        dataObject = lookup.lookup(MarkdownDataObject.class);
+    }
+
+    @Override
+    public JComponent getVisualRepresentation() {
+        if (component == null) {
+            viewer = new JEditorPane();
+            viewer.setContentType("text/html");
+            viewer.setEditable(false);
+            component = new JScrollPane(viewer);
+        }
+        return component;
+    }
+
+    @Override
+    public JComponent getToolbarRepresentation() {
+        if (toolbar == null) {
+            toolbar = new JToolBar();
+        }
+        return toolbar;
+    }
+
+    @Override
+    public Action[] getActions() {
+        return new Action[0];
+    }
+
+    @Override
+    public Lookup getLookup() {
+        return dataObject.getLookup();
+    }
+
+    @Override
+    public void componentOpened() {
+        dataObject.getPrimaryFile().addFileChangeListener(fcl);
+        updateView();
+    }
+
+    @Override
+    public void componentClosed() {
+        dataObject.getPrimaryFile().removeFileChangeListener(fcl);
+    }
+
+    @Override
+    public void componentShowing() {
+    }
+
+    @Override
+    public void componentHidden() {
+    }
+
+    @Override
+    public void componentActivated() {
+    }
+
+    @Override
+    public void componentDeactivated() {
+    }
+
+    @Override
+    public UndoRedo getUndoRedo() {
+        return UndoRedo.NONE;
+    }
+
+    @Override
+    public void setMultiViewCallback(MultiViewElementCallback callback) {
+    }
+
+    @Override
+    public CloseOperationState canCloseElement() {
+        return CloseOperationState.STATE_OK;
+    }
+
+    @Messages("TXT_MarkdownViewerElement_Error=<html>Something happened during markdown parsing.")
+    private void updateView() {
+        FileObject fo = dataObject.getPrimaryFile();
+        if ((fo != null) && (viewer != null)) {
+            MutableDataSet options = new MutableDataSet();
+            Parser parser = Parser.builder(options).build();
+            HtmlRenderer renderer = HtmlRenderer.builder(options).build();
+            try {
+                String html = renderer.render(parser.parse(fo.asText("UTF-8")));
+                viewer.setText(html);
+            } catch (IOException ex) {
+                viewer.setText(Bundle.TXT_MarkdownViewerElement_Error());
+                LOG.log(Level.WARNING, "Could not parse markdown!", ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Well, I was missing the Preview functionality for Markdown files. I used some plugins a few years ago. I think the plugin portal is down at the moment, so I could not find that. I came up with something very basic. It uses the existing flexmark library we ship with the IDE. I do not think it's bulletproof, but better than nothing. Regarding that the implementation so simple, its a shame I have not done it earlier, so it could be in NB18. 


![image](https://user-images.githubusercontent.com/1381701/234736753-c854cbf4-413e-4cda-91d9-660854e0e96e.png)
