### PR TITLE
Ignore setTrace requests

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -67,6 +67,7 @@ import org.eclipse.lsp4j.RenameOptions;
 import org.eclipse.lsp4j.SemanticTokensCapabilities;
 import org.eclipse.lsp4j.SemanticTokensParams;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.SetTraceParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
@@ -953,6 +954,12 @@ public final class Server {
             ((LanguageClientAware) getTextDocumentService()).connect(client);
             ((LanguageClientAware) getWorkspaceService()).connect(client);
             ((LanguageClientAware) treeService).connect(client);
+        }
+
+        @Override
+        public void setTrace(SetTraceParams params) {
+            // no op: there's already a lot of noise in the log, and the console log
+            // can be controlled by a commandline parameter to the NBLS.
         }
     }
 


### PR DESCRIPTION
NBLS currently throws `UnsupportedOperationException` when vscode option `java.trace.server` is set to `verbose'. The LSP client sends a `setTrace` notification to the client which was unimplemented.

After discusson with @dbalek, I've decided to just trash the reques: log verbosity can be (and is) controlled by `-J-Dnetbeans.console.logger=true` by the vscode extension client and the number of protocol messages that appear in the client's output is quite high already. 
