### PR TITLE
[NETBEANS-5719] Add option to disable tooltips for parameter completion.

### DIFF
--- a/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionSettings.java
+++ b/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionSettings.java
@@ -66,7 +66,11 @@ public final class CompletionSettings {
     boolean documentationPopupNextToCC() {
         return preferences.getBoolean(SimpleValueNames.JAVADOC_POPUP_NEXT_TO_CC, false);
     }
-    
+
+    public boolean completionDisplayTooltip() {
+        return preferences.getBoolean(SimpleValueNames.COMPLETION_PARAMETER_TOOLTIP, true);
+    }
+
     public int documentationAutoPopupDelay() {
         return preferences.getInt(SimpleValueNames.JAVADOC_AUTO_POPUP_DELAY, 200);
     }

--- a/ide/editor.settings/src/org/netbeans/api/editor/settings/SimpleValueNames.java
+++ b/ide/editor.settings/src/org/netbeans/api/editor/settings/SimpleValueNames.java
@@ -336,7 +336,13 @@ public final class SimpleValueNames {
      * @since 1.18
      */
     public static final String COMPLETION_PAIR_CHARACTERS = "pair-characters-completion"; // NOI18N
-    
+
+    /**
+     * Whether the code completion should include parameter tooltip.
+     * Values: java.lang.Boolean
+     */
+    public static final String COMPLETION_PARAMETER_TOOLTIP = "completion-parameter-tooltip"; // NOI18N
+
     /**
      * Background color of javaDoc popup window 
      *  Values: java.awt.Color

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/completion/Bundle.properties
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/completion/Bundle.properties
@@ -51,3 +51,4 @@ AN_Javadoc_Next_To_CC=Documentation Next To Completion Checkbox
 AD_Javadoc_Next_To_CC=Display Documentation Next To Completion
 GeneralCompletionOptionsPanel.AccessibleContext.accessibleName=General Completion Options
 GeneralCompletionOptionsPanel.AccessibleContext.accessibleDescription=Settings for various completion settings
+GeneralCompletionOptionsPanel.cbDisplayParameterTooltip.text=Display Parameter &Tooltip

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsPanelController.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsPanelController.java
@@ -111,6 +111,7 @@ public final class CodeCompletionOptionsPanelController extends OptionsPanelCont
                 prefs.remove(SimpleValueNames.COMPLETION_AUTO_POPUP);
                 prefs.remove(SimpleValueNames.JAVADOC_AUTO_POPUP);
                 prefs.remove(SimpleValueNames.JAVADOC_POPUP_NEXT_TO_CC);
+                prefs.remove(SimpleValueNames.COMPLETION_PARAMETER_TOOLTIP);
                 prefs.remove(SimpleValueNames.SHOW_DEPRECATED_MEMBERS);
                 prefs.remove(SimpleValueNames.COMPLETION_INSTANT_SUBSTITUTION);
                 prefs.remove(SimpleValueNames.COMPLETION_CASE_SENSITIVE);

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/completion/GeneralCompletionOptionsPanel.form
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/completion/GeneralCompletionOptionsPanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 
@@ -60,6 +60,7 @@
                   <Component id="cbAutoPopup" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="cbInsertSingleProposalsAutomatically" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="cbJavadocNextToCC" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="cbDisplayParameterTooltip" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace pref="46" max="32767" attributes="0"/>
           </Group>
@@ -75,6 +76,8 @@
               <EmptySpace max="-2" attributes="0"/>
               <Component id="cbJavadocNextToCC" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
+              <Component id="cbDisplayParameterTooltip" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="cbInsertSingleProposalsAutomatically" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="cbCaseSensitive" min="-2" max="-2" attributes="0"/>
@@ -82,7 +85,7 @@
               <Component id="cbShowDeprecated" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="cbInsertClosingBracketsAutomatically" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="40" max="32767" attributes="0"/>
+              <EmptySpace pref="13" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -212,6 +215,16 @@
       </AccessibilityProperties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cbInsertClosingBracketsAutomaticallyActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="cbDisplayParameterTooltip">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/options/editor/completion/Bundle.properties" key="GeneralCompletionOptionsPanel.cbDisplayParameterTooltip.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cbDisplayParamterTooltipActionPerformed"/>
       </Events>
     </Component>
   </SubComponents>

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/completion/GeneralCompletionOptionsPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/completion/GeneralCompletionOptionsPanel.java
@@ -47,6 +47,7 @@ public class GeneralCompletionOptionsPanel extends JPanel {
         cbAutoPopup.setSelected(preferences.getBoolean(SimpleValueNames.COMPLETION_AUTO_POPUP, true));
         cbDocsAutoPopup.setSelected(preferences.getBoolean(SimpleValueNames.JAVADOC_AUTO_POPUP, true));
         cbJavadocNextToCC.setSelected(preferences.getBoolean(SimpleValueNames.JAVADOC_POPUP_NEXT_TO_CC, false));
+        cbDisplayParameterTooltip.setSelected(preferences.getBoolean(SimpleValueNames.COMPLETION_PARAMETER_TOOLTIP, true));
         cbShowDeprecated.setSelected(preferences.getBoolean(SimpleValueNames.SHOW_DEPRECATED_MEMBERS, true));
         cbInsertSingleProposalsAutomatically.setSelected(preferences.getBoolean(SimpleValueNames.COMPLETION_INSTANT_SUBSTITUTION, true));
         cbCaseSensitive.setSelected(preferences.getBoolean(SimpleValueNames.COMPLETION_CASE_SENSITIVE, true));
@@ -54,6 +55,7 @@ public class GeneralCompletionOptionsPanel extends JPanel {
         id2Saved.put(SimpleValueNames.COMPLETION_AUTO_POPUP, cbAutoPopup.isSelected());
         id2Saved.put(SimpleValueNames.JAVADOC_AUTO_POPUP, cbDocsAutoPopup.isSelected());
         id2Saved.put(SimpleValueNames.JAVADOC_POPUP_NEXT_TO_CC, cbJavadocNextToCC.isSelected());
+        id2Saved.put(SimpleValueNames.COMPLETION_PARAMETER_TOOLTIP, cbDisplayParameterTooltip.isSelected());
         id2Saved.put(SimpleValueNames.SHOW_DEPRECATED_MEMBERS, cbShowDeprecated.isSelected());
         id2Saved.put(SimpleValueNames.COMPLETION_INSTANT_SUBSTITUTION, cbInsertSingleProposalsAutomatically.isSelected());
         id2Saved.put(SimpleValueNames.COMPLETION_CASE_SENSITIVE, cbCaseSensitive.isSelected());
@@ -78,6 +80,7 @@ public class GeneralCompletionOptionsPanel extends JPanel {
         cbCaseSensitive = new javax.swing.JCheckBox();
         cbShowDeprecated = new javax.swing.JCheckBox();
         cbInsertClosingBracketsAutomatically = new javax.swing.JCheckBox();
+        cbDisplayParameterTooltip = new javax.swing.JCheckBox();
 
         setForeground(new java.awt.Color(99, 130, 191));
 
@@ -130,6 +133,13 @@ public class GeneralCompletionOptionsPanel extends JPanel {
             }
         });
 
+        org.openide.awt.Mnemonics.setLocalizedText(cbDisplayParameterTooltip, org.openide.util.NbBundle.getMessage(GeneralCompletionOptionsPanel.class, "GeneralCompletionOptionsPanel.cbDisplayParameterTooltip.text")); // NOI18N
+        cbDisplayParameterTooltip.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                cbDisplayParamterTooltipActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -143,7 +153,8 @@ public class GeneralCompletionOptionsPanel extends JPanel {
                     .addComponent(cbDocsAutoPopup)
                     .addComponent(cbAutoPopup)
                     .addComponent(cbInsertSingleProposalsAutomatically)
-                    .addComponent(cbJavadocNextToCC))
+                    .addComponent(cbJavadocNextToCC)
+                    .addComponent(cbDisplayParameterTooltip))
                 .addContainerGap(46, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
@@ -156,6 +167,8 @@ public class GeneralCompletionOptionsPanel extends JPanel {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(cbJavadocNextToCC)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(cbDisplayParameterTooltip)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(cbInsertSingleProposalsAutomatically)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(cbCaseSensitive)
@@ -163,7 +176,7 @@ public class GeneralCompletionOptionsPanel extends JPanel {
                 .addComponent(cbShowDeprecated)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(cbInsertClosingBracketsAutomatically)
-                .addContainerGap(40, Short.MAX_VALUE))
+                .addContainerGap(13, Short.MAX_VALUE))
         );
 
         cbAutoPopup.getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(GeneralCompletionOptionsPanel.class, "AN_Auto_Popup_Completion_Window")); // NOI18N
@@ -213,9 +226,14 @@ public class GeneralCompletionOptionsPanel extends JPanel {
         preferences.putBoolean(SimpleValueNames.JAVADOC_POPUP_NEXT_TO_CC, cbJavadocNextToCC.isSelected());
     }//GEN-LAST:event_cbJavadocNextToCCActionPerformed
 
+    private void cbDisplayParamterTooltipActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cbDisplayParamterTooltipActionPerformed
+        preferences.putBoolean(SimpleValueNames.COMPLETION_PARAMETER_TOOLTIP, cbDisplayParameterTooltip.isSelected());
+    }//GEN-LAST:event_cbDisplayParamterTooltipActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JCheckBox cbAutoPopup;
     private javax.swing.JCheckBox cbCaseSensitive;
+    private javax.swing.JCheckBox cbDisplayParameterTooltip;
     private javax.swing.JCheckBox cbDocsAutoPopup;
     private javax.swing.JCheckBox cbInsertClosingBracketsAutomatically;
     private javax.swing.JCheckBox cbInsertSingleProposalsAutomatically;

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java
@@ -2091,7 +2091,7 @@ public abstract class JavaCompletionItem implements CompletionItem {
                         if (toAddText.length() > idx + 1) {
                             sb.append(toAddText.substring(idx + 1));
                         }
-                        showTooltip = true;
+                        showTooltip = Utilities.popupPrameterTooltip();
                     }
                 }
             }
@@ -2708,7 +2708,7 @@ public abstract class JavaCompletionItem implements CompletionItem {
             if (sb.length() == 0) {
                 return cs;
             }
-            showTooltip = true;
+            showTooltip = Utilities.popupPrameterTooltip();
             return sb;
         }
 
@@ -3001,7 +3001,7 @@ public abstract class JavaCompletionItem implements CompletionItem {
                 }
             }
             sb.append(toAdd);
-            showTooltip = true;
+            showTooltip = Utilities.popupPrameterTooltip();
             return sb;
         }
 

--- a/java/java.editor/src/org/netbeans/modules/editor/java/Utilities.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/Utilities.java
@@ -63,6 +63,7 @@ import javax.swing.text.JTextComponent;
 
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.api.editor.settings.SimpleValueNames;
 import org.netbeans.api.java.lexer.JavaTokenId;
 import org.netbeans.api.java.source.CodeStyle;
 import org.netbeans.api.java.source.CodeStyleUtils;
@@ -102,6 +103,7 @@ public final class Utilities {
     private static String javaCompletionSelectors = CodeCompletionPanel.JAVA_COMPLETION_SELECTORS_DEFAULT;
     private static String javadocCompletionAutoPopupTriggers = CodeCompletionPanel.JAVADOC_AUTO_COMPLETION_TRIGGERS_DEFAULT;
     private static String javadocCompletionSelectors = CodeCompletionPanel.JAVADOC_COMPLETION_SELECTORS_DEFAULT;
+    private static boolean popupParameterToolip = true;
     
     private static final AtomicBoolean inited = new AtomicBoolean(false);
     private static Preferences preferences;
@@ -126,6 +128,9 @@ public final class Utilities {
             }
             if (settingName == null || CodeCompletionPanel.JAVADOC_COMPLETION_SELECTORS.equals(settingName)) {
                 javadocCompletionSelectors = preferences.get(CodeCompletionPanel.JAVADOC_COMPLETION_SELECTORS, CodeCompletionPanel.JAVADOC_COMPLETION_SELECTORS_DEFAULT);
+            }
+            if (settingName == null || SimpleValueNames.COMPLETION_PARAMETER_TOOLTIP.equals(settingName)) {
+				popupParameterToolip = preferences.getBoolean(SimpleValueNames.COMPLETION_PARAMETER_TOOLTIP, true);
             }
         }
     };
@@ -158,6 +163,11 @@ public final class Utilities {
     public static String getJavadocCompletionSelectors() {
         lazyInit();
         return javadocCompletionSelectors;
+    }
+
+    public static boolean popupPrameterTooltip() {
+        lazyInit();
+        return popupParameterToolip;
     }
 
     private static void lazyInit() {


### PR DESCRIPTION

Here's a quick and dirty attempt at implementing an option to disable the annoying tooltips that show when completing on functions, as per [NETBEANS-5719].

---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
