### PR TITLE
Markdown viewer links

### DIFF
--- a/ide/libs.flexmark/external/binaries-list
+++ b/ide/libs.flexmark/external/binaries-list
@@ -14,9 +14,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-9B6A3169E240EE48800EA215DDF033EBFB221097 com.vladsch.flexmark:flexmark:0.50.36
-4C77069222E80816F73B6277F09F742382E14E30 com.vladsch.flexmark:flexmark-html2md-converter:0.50.36
-FF0452A9FF56D164C9FA1B880562ED1FC8F93F57 com.vladsch.flexmark:flexmark-util:0.50.36
-983105CC5A42FF82979C742FB6BE525AB1FED8E9 com.vladsch.flexmark:flexmark-ext-emoji:0.50.36
-A01A46E369E0C4A271A519481C422206D54A60D1 com.vladsch.flexmark:flexmark-formatter:0.50.36
+606A88E1D15AA8DEBD97CB5DFDF788DDC6FB5B5E com.vladsch.flexmark:flexmark:0.62.2
+55631AD20431C090D404C3945B692EACEEDB6FC5 com.vladsch.flexmark:flexmark-html2md-converter:0.62.2
+C0B998D5570295F104A4FFEE4F8EEC305D7DB327 com.vladsch.flexmark:flexmark-util-ast:0.62.2
+22C85EFB51D4AA25540B8B0D880BE7AD4A8BAEC1 com.vladsch.flexmark:flexmark-util-builder:0.62.2
+85253A62761533CE7709F81B0C581C8473F825EC com.vladsch.flexmark:flexmark-util-collection:0.62.2
+2DF8CE1ABAB2E40EDC7D340962025EE1DD09FE02 com.vladsch.flexmark:flexmark-util-data:0.62.2
+AE5AFA76A669E06B3A65255C2ED775EDE5CD3EB1 com.vladsch.flexmark:flexmark-util-dependency:0.62.2
+058548BE1FC0682698721C0C278451A41F361D3A com.vladsch.flexmark:flexmark-util-format:0.62.2
+6D830CB37E48FD9DCA44BF15FBC3A86AA7D82C5A com.vladsch.flexmark:flexmark-util-html:0.62.2
+18133DD81887C512E2F56FEB3C14A8A1210F30EA com.vladsch.flexmark:flexmark-util-misc:0.62.2
+87AF2803A63B5B07CC42D9C1D98F8ECD4F83FBCC com.vladsch.flexmark:flexmark-util-sequence:0.62.2
+CA49BD94860A5CCEDD82BDE96ECE831F16C66FF1 com.vladsch.flexmark:flexmark-util-visitor:0.62.2
+C1F1B1909BFB6C0F4301A9227745A3AB33B0D08F com.vladsch.flexmark:flexmark-ext-emoji:0.62.2
+3AA453B87258A448DFD8D01010D94E3A2832884D com.vladsch.flexmark:flexmark-ext-anchorlink:0.62.2
 36DA09A8F68484523FA2AAA100399D612B247D67 org.jsoup:jsoup:1.11.3

--- a/ide/libs.flexmark/external/binaries-list
+++ b/ide/libs.flexmark/external/binaries-list
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 606A88E1D15AA8DEBD97CB5DFDF788DDC6FB5B5E com.vladsch.flexmark:flexmark:0.62.2
+3AA453B87258A448DFD8D01010D94E3A2832884D com.vladsch.flexmark:flexmark-ext-anchorlink:0.62.2
+C1F1B1909BFB6C0F4301A9227745A3AB33B0D08F com.vladsch.flexmark:flexmark-ext-emoji:0.62.2
+C95068A1450835C2695750ECE82C996A7B57BBD3 com.vladsch.flexmark:flexmark-ext-tables:0.62.2
 55631AD20431C090D404C3945B692EACEEDB6FC5 com.vladsch.flexmark:flexmark-html2md-converter:0.62.2
 C0B998D5570295F104A4FFEE4F8EEC305D7DB327 com.vladsch.flexmark:flexmark-util-ast:0.62.2
 22C85EFB51D4AA25540B8B0D880BE7AD4A8BAEC1 com.vladsch.flexmark:flexmark-util-builder:0.62.2
@@ -26,6 +29,4 @@ AE5AFA76A669E06B3A65255C2ED775EDE5CD3EB1 com.vladsch.flexmark:flexmark-util-depe
 18133DD81887C512E2F56FEB3C14A8A1210F30EA com.vladsch.flexmark:flexmark-util-misc:0.62.2
 87AF2803A63B5B07CC42D9C1D98F8ECD4F83FBCC com.vladsch.flexmark:flexmark-util-sequence:0.62.2
 CA49BD94860A5CCEDD82BDE96ECE831F16C66FF1 com.vladsch.flexmark:flexmark-util-visitor:0.62.2
-C1F1B1909BFB6C0F4301A9227745A3AB33B0D08F com.vladsch.flexmark:flexmark-ext-emoji:0.62.2
-3AA453B87258A448DFD8D01010D94E3A2832884D com.vladsch.flexmark:flexmark-ext-anchorlink:0.62.2
 36DA09A8F68484523FA2AAA100399D612B247D67 org.jsoup:jsoup:1.11.3

--- a/ide/libs.flexmark/external/flexmark-0.62.2-license.txt
+++ b/ide/libs.flexmark/external/flexmark-0.62.2-license.txt
@@ -1,14 +1,14 @@
 Name: FlexMark-java
-Version: 0.50.36
+Version: 0.62.2
 License: BSD-flexmark
 Description: FlexMark library
 Origin: https://github.com/vsch/flexmark-java
-Files: flexmark-0.50.36.jar flexmark-ext-emoji-0.50.36.jar flexmark-formatter-0.50.36.jar flexmark-html2md-converter-0.50.36.jar flexmark-util-0.50.36.jar
+Files: flexmark-*0.62.2.jar
 
 Copyright (c) 2015-2016, Atlassian Pty Ltd
 All rights reserved.
 
-Copyright (c) 2016-2018, Vladimir Schneider,
+Copyright (c) 2016-2020, Vladimir Schneider,
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/ide/libs.flexmark/external/flexmark-0.62.2-license.txt
+++ b/ide/libs.flexmark/external/flexmark-0.62.2-license.txt
@@ -3,7 +3,7 @@ Version: 0.62.2
 License: BSD-flexmark
 Description: FlexMark library
 Origin: https://github.com/vsch/flexmark-java
-Files: flexmark-0.62.2.jar flexmark-ext-anchorlink-0.62.2.jar flexmark-ext-emoji-0.62.2.jar flexmark-html2md-converter-0.62.2.jar flexmark-util-0.62.2.jar flexmark-util-ast-0.62.2.jar flexmark-util-builder-0.62.2.jar flexmark-util-collection-0.62.2.jar flexmark-util-data-0.62.2.jar flexmark-util-dependency-0.62.2.jar flexmark-util-format-0.62.2.jar flexmark-util-html-0.62.2.jar flexmark-util-misc-0.62.2.jar flexmark-util-sequence-0.62.2.jar flexmark-util-visitor-0.62.2.jar
+Files: flexmark-0.62.2.jar flexmark-ext-anchorlink-0.62.2.jar flexmark-ext-emoji-0.62.2.jar flexmark-ext-tables-0.62.2.jar flexmark-html2md-converter-0.62.2.jar flexmark-util-ast-0.62.2.jar flexmark-util-builder-0.62.2.jar flexmark-util-collection-0.62.2.jar flexmark-util-data-0.62.2.jar flexmark-util-dependency-0.62.2.jar flexmark-util-format-0.62.2.jar flexmark-util-html-0.62.2.jar flexmark-util-misc-0.62.2.jar flexmark-util-sequence-0.62.2.jar flexmark-util-visitor-0.62.2.jar
 
 Copyright (c) 2015-2016, Atlassian Pty Ltd
 All rights reserved.

--- a/ide/libs.flexmark/external/flexmark-0.62.2-license.txt
+++ b/ide/libs.flexmark/external/flexmark-0.62.2-license.txt
@@ -3,7 +3,7 @@ Version: 0.62.2
 License: BSD-flexmark
 Description: FlexMark library
 Origin: https://github.com/vsch/flexmark-java
-Files: flexmark-*0.62.2.jar
+Files: flexmark-0.62.2.jar flexmark-ext-anchorlink-0.62.2.jar flexmark-ext-emoji-0.62.2.jar flexmark-html2md-converter-0.62.2.jar flexmark-util-0.62.2.jar flexmark-util-ast-0.62.2.jar flexmark-util-builder-0.62.2.jar flexmark-util-collection-0.62.2.jar flexmark-util-data-0.62.2.jar flexmark-util-dependency-0.62.2.jar flexmark-util-format-0.62.2.jar flexmark-util-html-0.62.2.jar flexmark-util-misc-0.62.2.jar flexmark-util-sequence-0.62.2.jar flexmark-util-visitor-0.62.2.jar
 
 Copyright (c) 2015-2016, Atlassian Pty Ltd
 All rights reserved.

--- a/ide/libs.flexmark/nbproject/project.properties
+++ b/ide/libs.flexmark/nbproject/project.properties
@@ -31,4 +31,5 @@ release.external/flexmark-util-sequence-0.62.2.jar=modules/ext/flexmark-util-seq
 release.external/flexmark-util-visitor-0.62.2.jar=modules/ext/flexmark-util-visitor-0.62.2.jar
 release.external/flexmark-ext-emoji-0.62.2.jar=modules/ext/flexmark-ext-emoji-0.62.2.jar
 release.external/flexmark-ext-anchorlink-0.62.2.jar=modules/ext/flexmark-ext-anchorlink-0.62.2.jar
+release.external/flexmark-ext-tables-0.62.2.jar=modules/ext/flexmark-ext-tables-0.62.2.jar
 release.external/jsoup-1.11.3.jar=modules/ext/jsoup-1.11.3.jar

--- a/ide/libs.flexmark/nbproject/project.properties
+++ b/ide/libs.flexmark/nbproject/project.properties
@@ -17,9 +17,18 @@
 
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-release.external/flexmark-0.50.36.jar=modules/ext/flexmark-0.50.36.jar
-release.external/flexmark-html2md-converter-0.50.36.jar=modules/ext/flexmark-html2md-converter-0.50.36.jar
-release.external/flexmark-util-0.50.36.jar=modules/ext/flexmark-util-0.50.36.jar
-release.external/flexmark-ext-emoji-0.50.36.jar=modules/ext/flexmark-ext-emoji-0.50.36.jar
-release.external/flexmark-formatter-0.50.36.jar=modules/ext/flexmark-formatter-0.50.36.jar
+release.external/flexmark-0.62.2.jar=modules/ext/flexmark-0.62.2.jar
+release.external/flexmark-html2md-converter-0.62.2.jar=modules/ext/flexmark-html2md-converter-0.62.2.jar
+release.external/flexmark-util-ast-0.62.2.jar=modules/ext/flexmark-util-ast-0.62.2.jar
+release.external/flexmark-util-builder-0.62.2.jar=modules/ext/flexmark-util-builder-0.62.2.jar
+release.external/flexmark-util-collection-0.62.2.jar=modules/ext/flexmark-util-collection-0.62.2.jar
+release.external/flexmark-util-data-0.62.2.jar=modules/ext/flexmark-util-data-0.62.2.jar
+release.external/flexmark-util-dependency-0.62.2.jar=modules/ext/flexmark-util-dependency-0.62.2.jar
+release.external/flexmark-util-format-0.62.2.jar=modules/ext/flexmark-util-format-0.62.2.jar
+release.external/flexmark-util-html-0.62.2.jar=modules/ext/flexmark-util-html-0.62.2.jar
+release.external/flexmark-util-misc-0.62.2.jar=modules/ext/flexmark-util-misc-0.62.2.jar
+release.external/flexmark-util-sequence-0.62.2.jar=modules/ext/flexmark-util-sequence-0.62.2.jar
+release.external/flexmark-util-visitor-0.62.2.jar=modules/ext/flexmark-util-visitor-0.62.2.jar
+release.external/flexmark-ext-emoji-0.62.2.jar=modules/ext/flexmark-ext-emoji-0.62.2.jar
+release.external/flexmark-ext-anchorlink-0.62.2.jar=modules/ext/flexmark-ext-anchorlink-0.62.2.jar
 release.external/jsoup-1.11.3.jar=modules/ext/jsoup-1.11.3.jar

--- a/ide/libs.flexmark/nbproject/project.xml
+++ b/ide/libs.flexmark/nbproject/project.xml
@@ -86,6 +86,10 @@
                 <binary-origin>external/flexmark-ext-anchorlink-0.62.2.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
+                <runtime-relative-path>ext/flexmark-ext-tables-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-ext-tables-0.62.2.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
                 <runtime-relative-path>ext/flexmark-0.62.2.jar</runtime-relative-path>
                 <binary-origin>external/flexmark-0.62.2.jar</binary-origin>
             </class-path-extension>

--- a/ide/libs.flexmark/nbproject/project.xml
+++ b/ide/libs.flexmark/nbproject/project.xml
@@ -30,28 +30,64 @@
                 <subpackages>org.jsoup</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flexmark-html2md-converter-0.50.36.jar</runtime-relative-path>
-                <binary-origin>external/flexmark-html2md-converter-0.50.36.jar</binary-origin>
+                <runtime-relative-path>ext/flexmark-html2md-converter-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-html2md-converter-0.62.2.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/jsoup-1.11.3.jar</runtime-relative-path>
                 <binary-origin>external/jsoup-1.11.3.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/flexmark-util-0.50.36.jar</runtime-relative-path>
-                <binary-origin>external/flexmark-util-0.50.36.jar</binary-origin>
+                <runtime-relative-path>ext/flexmark-util-ast-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-util-ast-0.62.2.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/flexmark-formatter-0.50.36.jar</runtime-relative-path>
-                <binary-origin>external/flexmark-formatter-0.50.36.jar</binary-origin>
+                <runtime-relative-path>ext/flexmark-util-builder-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-util-builder-0.62.2.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/flexmark-ext-emoji-0.50.36.jar</runtime-relative-path>
-                <binary-origin>external/flexmark-ext-emoji-0.50.36.jar</binary-origin>
+                <runtime-relative-path>ext/flexmark-util-collection-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-util-collection-0.62.2.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/flexmark-0.50.36.jar</runtime-relative-path>
-                <binary-origin>external/flexmark-0.50.36.jar</binary-origin>
+                <runtime-relative-path>ext/flexmark-util-data-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-util-data-0.62.2.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/flexmark-util-dependency-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-util-dependency-0.62.2.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/flexmark-util-format-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-util-format-0.62.2.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/flexmark-util-html-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-util-html-0.62.2.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/flexmark-util-misc-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-util-misc-0.62.2.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/flexmark-util-sequence-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-util-sequence-0.62.2.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/flexmark-util-visitor-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-util-visitor-0.62.2.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/flexmark-ext-emoji-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-ext-emoji-0.62.2.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/flexmark-ext-anchorlink-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-ext-anchorlink-0.62.2.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/flexmark-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-0.62.2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/markdown/nbproject/project.xml
+++ b/ide/markdown/nbproject/project.xml
@@ -47,7 +47,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.12</specification-version>
+                        <specification-version>1.14</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/markdown/src/org/netbeans/modules/markdown/MarkdownViewerElement.java
+++ b/ide/markdown/src/org/netbeans/modules/markdown/MarkdownViewerElement.java
@@ -61,7 +61,7 @@ import org.openide.windows.TopComponent;
         mimeType = "text/x-markdown",
         persistenceType = TopComponent.PERSISTENCE_NEVER,
         preferredID = "MarkdownViewer",
-        position = 900
+        position = 2000
 )
 @Messages("LBL_MarkdownViewer=Preview")
 public class MarkdownViewerElement implements MultiViewElement {

--- a/nbbuild/licenses/BSD-flexmark
+++ b/nbbuild/licenses/BSD-flexmark
@@ -1,7 +1,7 @@
 Copyright (c) 2015-2016, Atlassian Pty Ltd
 All rights reserved.
 
-Copyright (c) 2016-2018, Vladimir Schneider,
+Copyright (c) 2016-2020, Vladimir Schneider,
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Well, this one is just another low hanging fruit.

First, I've upgraded the flexmark-java library to 0.62.2 (the last which supported Java 8), that might not have been necessary, but 0.50.x is getting dated.


I moved the Preview tab to the first in multiview. I think the generic use case with Markdown files is more read than write oriented.

Then I've added a hyperlink listener to handle the internal and external links.

Added `LSP` label as previosly to markdown only the LSP modules had dependenct on the flexmark-java libraries.