### PR TITLE
[PHP] FixUsesPerformer and AddUseImportSuggestion improvement

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix01/testAppendUse_existPrefix01.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix01/testAppendUse_existPrefix01.php
@@ -16,28 +16,37 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return new D;
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix01/testAppendUse_existPrefix01.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix01/testAppendUse_existPrefix01.php.fixUses
@@ -16,28 +16,38 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\D;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return new D;
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix02/testAppendUse_existPrefix02.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix02/testAppendUse_existPrefix02.php
@@ -16,28 +16,42 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+use const O\P;
+
+use function G\K;
+use function G\M;
+
+class B {
+        public function x () {
+            return L();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix02/testAppendUse_existPrefix02.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix02/testAppendUse_existPrefix02.php.fixUses
@@ -16,28 +16,43 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+use const O\P;
+
+use function G\K;
+use function G\L;
+use function G\M;
+
+class B {
+        public function x () {
+            return L();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix03/testAppendUse_existPrefix03.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix03/testAppendUse_existPrefix03.php
@@ -16,28 +16,42 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+use function G\K;
+use function G\M;
+
+use const O\P;
+
+class B {
+        public function x () {
+            return Q;
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix03/testAppendUse_existPrefix03.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/existPrefix03/testAppendUse_existPrefix03.php.fixUses
@@ -16,28 +16,43 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+use function G\K;
+use function G\M;
+
+use const O\P;
+use const O\Q;
+
+class B {
+        public function x () {
+            return Q;
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix01/testAppendUse_newPrefix01.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix01/testAppendUse_newPrefix01.php
@@ -16,28 +16,37 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return F();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix01/testAppendUse_newPrefix01.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix01/testAppendUse_newPrefix01.php.fixUses
@@ -16,28 +16,38 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
+use function C\F;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return F();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix02/testAppendUse_newPrefix02.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix02/testAppendUse_newPrefix02.php
@@ -16,28 +16,39 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
+use function X\Y;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return P;
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    class H {}
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix02/testAppendUse_newPrefix02.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix02/testAppendUse_newPrefix02.php.fixUses
@@ -16,28 +16,40 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
+use const O\P;
+use function X\Y;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return P;
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    class H {}
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix03/testAppendUse_newPrefix03.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix03/testAppendUse_newPrefix03.php
@@ -16,28 +16,42 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
+use function C\F;
+use X\Z;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return new H;
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+    class H {}
+}
+
+namespace G {
+    class H {}
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+    class Z {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix03/testAppendUse_newPrefix03.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix03/testAppendUse_newPrefix03.php.fixUses
@@ -16,28 +16,43 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
+use C\H;
+use function C\F;
+use X\Z;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return new H;
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+    class H {}
+}
+
+namespace G {
+    class H {}
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+    class Z {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix04/testAppendUse_newPrefix04.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix04/testAppendUse_newPrefix04.php
@@ -16,28 +16,42 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
 
-            new B;
-        ?>
-    </body>
-</html>
+
+
+
+class B {
+        public function x () {
+            return new H;
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+    class H {}
+}
+
+namespace G {
+    class H {}
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+    class Z {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix04/testAppendUse_newPrefix04.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPrefix04/testAppendUse_newPrefix04.php.fixUses
@@ -16,28 +16,40 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\H;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return new H;
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+    class H {}
+}
+
+namespace G {
+    class H {}
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+    class Z {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix01/testAppendUse_newPsr12Prefix01.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix01/testAppendUse_newPsr12Prefix01.php
@@ -16,28 +16,35 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+class B {
+        public function x () {
+            return new E;
+        }
+    }
+}
 
-            new B;
-        ?>
-    </body>
-</html>
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix01/testAppendUse_newPsr12Prefix01.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix01/testAppendUse_newPsr12Prefix01.php.fixUses
@@ -16,28 +16,37 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return new E;
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix02/testAppendUse_newPsr12Prefix02.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix02/testAppendUse_newPsr12Prefix02.php
@@ -16,28 +16,37 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return L();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix02/testAppendUse_newPsr12Prefix02.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix02/testAppendUse_newPsr12Prefix02.php.fixUses
@@ -16,28 +16,39 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+use function G\L;
+
+class B {
+        public function x () {
+            return L();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix03/testAppendUse_newPsr12Prefix03.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix03/testAppendUse_newPsr12Prefix03.php
@@ -16,28 +16,39 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+use const O\P;
+
+class B {
+        public function x () {
+            return L();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix03/testAppendUse_newPsr12Prefix03.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/newPsr12Prefix03/testAppendUse_newPsr12Prefix03.php.fixUses
@@ -16,28 +16,41 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+use function G\L;
+
+use const O\P;
+
+class B {
+        public function x () {
+            return L();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/regroupPrefix01/testAppendUse_regroupPrefix01.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/regroupPrefix01/testAppendUse_regroupPrefix01.php
@@ -16,28 +16,42 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+use const O\P;
+
+use function G\M;
+use function G\K;
+
+class B {
+        public function x () {
+            return L();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/regroupPrefix01/testAppendUse_regroupPrefix01.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/regroupPrefix01/testAppendUse_regroupPrefix01.php.fixUses
@@ -16,28 +16,45 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
 
-            new B;
-        ?>
-    </body>
-</html>
+use const O\P;
+
+use function G\{
+    K,
+    L,
+    M
+};
+
+class B {
+        public function x () {
+            return L();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/regroupPrefix02/testAppendUse_regroupPrefix02.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/regroupPrefix02/testAppendUse_regroupPrefix02.php
@@ -16,28 +16,40 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
+use function G\M;
+use const O\P;
+use function G\K;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return L();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/regroupPrefix02/testAppendUse_regroupPrefix02.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testAppendUse/regroupPrefix02/testAppendUse_regroupPrefix02.php.fixUses
@@ -16,28 +16,43 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
-// test
-?>
+ */
 
-<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title></title>
-    </head>
-    <body>
-        <?php 
-            declare(ticks=1);
-        
-            /** 
-             * this is phpDoc block which go after declare
-             * and use statement should go after docBlock
-             */
+namespace A {
 
-use NS1\B;
+use C\E;
+use function G\{
+    K,
+    L,
+    M
+};
+use const O\P;
 
-            new B;
-        ?>
-    </body>
-</html>
+class B {
+        public function x () {
+            return L();
+        }
+    }
+}
+
+namespace C {
+    class D {}
+    class E {}
+    function F() {}
+}
+
+namespace G {
+    function K() {}
+    function L() {}
+    function M() {}
+}
+
+namespace O {
+    const P = 1;
+    const Q = 1;
+    const R = 1;
+}
+
+namespace X {
+    function Y() {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH5578/02/testGH5578_02.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH5578/02/testGH5578_02.php.fixUses
@@ -29,8 +29,8 @@
     <body>
         <?php
 
-
 use NS1\B;
+
             new B;
         ?>
     </body>

--- a/php/php.editor/test/unit/data/testfiles/verification/testIssue258480_2.php.testIssue258480_2.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/testIssue258480_2.php.testIssue258480_2.hints
@@ -2,5 +2,5 @@ $x = date2();^
      -----
 HINT:Fix Name To "\TestMe\date2"
 FIX:Fix Name To "\TestMe\date2"
-HINT:Fix Name To "\TestMe\date2"
-FIX:Fix Name To "\TestMe\date2"
+HINT:Generate "use TestMe\date2;"
+FIX:Generate "use TestMe\date2;"

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/FixUsesPerformerTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/FixUsesPerformerTest.java
@@ -611,7 +611,91 @@ public class FixUsesPerformerTest extends PHPTestBase {
         performTest("class Exam^ple {", selections, true, true, options);
     }
 
-    private String getTestResult(final String fileName, final String caretLine, final List<Selection> selections, final boolean removeUnusedUses, final boolean putInPSR12Order, final Options options) throws Exception {
+    public void testAppendUse_existPrefix01() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\C\\D", ItemVariant.Type.CLASS));
+        Options options = new Options(false, false, false, false, false, PhpVersion.PHP_81);
+        performAppendTest("return new D^", selections, false, options);
+    }
+
+    public void testAppendUse_existPrefix02() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\G\\L", ItemVariant.Type.FUNCTION));
+        Options options = new Options(false, false, false, false, false, PhpVersion.PHP_81);
+        performAppendTest("return L^", selections, false, options);
+    }
+
+    public void testAppendUse_existPrefix03() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\O\\Q", ItemVariant.Type.CONST));
+        Options options = new Options(false, false, false, false, false, PhpVersion.PHP_81);
+        performAppendTest("return Q^", selections, false, options);
+    }
+
+    public void testAppendUse_newPrefix01() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\C\\F", ItemVariant.Type.FUNCTION));
+        Options options = new Options(false, false, false, false, false, PhpVersion.PHP_81);
+        performAppendTest("return F^", selections, false, options);
+    }
+
+    public void testAppendUse_newPrefix02() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\O\\P", ItemVariant.Type.CONST));
+        Options options = new Options(false, false, false, false, false, PhpVersion.PHP_81);
+        performAppendTest("return P^", selections, false, options);
+    }
+
+    public void testAppendUse_newPrefix03() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\C\\H", ItemVariant.Type.CLASS));
+        Options options = new Options(false, false, false, false, false, PhpVersion.PHP_81);
+        performAppendTest("return new H^", selections, false, options);
+    }
+
+    public void testAppendUse_newPrefix04() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\C\\H", ItemVariant.Type.CLASS));
+        Options options = new Options(false, false, false, false, false, PhpVersion.PHP_81);
+        performAppendTest("return new H^", selections, false, options);
+    }
+
+    public void testAppendUse_newPsr12Prefix01() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\C\\E", ItemVariant.Type.CLASS));
+        Options options = new Options(false, false, false, false, false, PhpVersion.PHP_81);
+        performAppendTest("return new E^", selections, true, options);
+    }
+
+    public void testAppendUse_newPsr12Prefix02() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\G\\L", ItemVariant.Type.FUNCTION));
+        Options options = new Options(false, false, false, false, false, PhpVersion.PHP_81);
+        performAppendTest("return L^", selections, true, options);
+    }
+
+    public void testAppendUse_newPsr12Prefix03() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\G\\L", ItemVariant.Type.FUNCTION));
+        Options options = new Options(false, false, false, false, false, PhpVersion.PHP_81);
+        performAppendTest("return L^", selections, true, options);
+    }
+
+    public void testAppendUse_regroupPrefix01() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\G\\L", ItemVariant.Type.FUNCTION));
+        Options options = new Options(false, false, true, false, false, PhpVersion.PHP_81);
+        performAppendTest("return L^", selections, false, options);
+    }
+
+    public void testAppendUse_regroupPrefix02() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\G\\L", ItemVariant.Type.FUNCTION));
+        Options options = new Options(false, false, true, false, false, PhpVersion.PHP_81);
+        performAppendTest("return L^", selections, false, options);
+    }
+
+    private String getTestResult(final String fileName, final String caretLine, final List<Selection> selections, final boolean removeUnusedUses, final boolean putInPSR12Order, final boolean append, final Options options) throws Exception {
         FileObject testFile = getTestFile(fileName);
 
         Source testSource = getTestSource(testFile);
@@ -664,7 +748,11 @@ public class FixUsesPerformerTest extends PHPTestBase {
                     }
                     importData.caretPosition = caretOffset;
                     FixUsesPerformer fixUsesPerformer = new FixUsesPerformer(phpResult, importData, properSelections, removeUnusedUses, putInPSR12Order, currentOptions);
-                    fixUsesPerformer.perform();
+                    if (append) {
+                        fixUsesPerformer.performAppend();
+                    } else {
+                        fixUsesPerformer.perform();
+                    }
                     result[0] = document.getText(0, document.getLength());
                 }
             }
@@ -686,7 +774,13 @@ public class FixUsesPerformerTest extends PHPTestBase {
 
     private void performTest(final String caretLine, final List<Selection> selections, final boolean removeUnusedUses, boolean putInPSR12Order, final Options options) throws Exception {
         String exactFileName = getTestPath();
-        String result = getTestResult(exactFileName, caretLine, selections, removeUnusedUses, putInPSR12Order, options);
+        String result = getTestResult(exactFileName, caretLine, selections, removeUnusedUses, putInPSR12Order, false, options);
+        assertDescriptionMatches(exactFileName, result, false, ".fixUses");
+    }
+
+    private void performAppendTest(final String caretLine, final List<Selection> selections, boolean putInPSR12Order, final Options options) throws Exception {
+        String exactFileName = getTestPath();
+        String result = getTestResult(exactFileName, caretLine, selections, false, putInPSR12Order, true, options);
         assertDescriptionMatches(exactFileName, result, false, ".fixUses");
     }
 


### PR DESCRIPTION
Hi,
This PR adds "append uses" logic (import use one by one) for FixUsesPerformer to have ability to use the same logic (classes) for inline "use import" like in AddUseImportSuggestion. Also it includes refactoring for AddUseImportSuggestion to use FixUsesPerformer instead of its own logic. I know that implementation is not an ideal, but I believe it would be more convenient and much easier to maintain same logic in one place, and such changes could allow to implement, for instance, something like PhpStorm auto import in the feature if needed. 

Changes are pretty complex and I think there weren't much people using AddUseImportSuggestion logic (because it was useless for a long time due to wrong class detection, ignoring traits, types, return types, functions etc.), but I hope now it's more useful, however I am still not sure that changes will be approved, so I committed final logic (only with initial tests) and decided to discuss my changes and additional change to previously committed logic here:

- While I was working on the PR there was added PSR12 formatting and it's fine, I aligned the logic due to it, but I'd like to suggest moving the "psr12 sorting checkbox" to the editor general uses options (where "prefer grouping" and other such option are situated) and change it to something like "Sort uses radiobutton - Alphabetical/PSR12", what do you think? Such change needed to have ability using the same option globally (like prefereGroupings etc) for AddUseImportSuggestion as well. 
 
If it is approved I am going to add more tests for both classes FixUsesPerformer and AddUseImportSuggestion. 