### PR TITLE
Do not attempt to remove unused binding variables for now.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
@@ -87,7 +87,10 @@ public class Unused {
             case NOT_WRITTEN: message = Bundle.ERR_NotWritten(name);
                 break;
             case NOT_READ: message = Bundle.ERR_NotRead(name);
-                fix = JavaFixUtilities.safelyRemoveFromParent(ctx, Bundle.FIX_RemoveUsedElement(name), ud.unusedElementPath);
+                //unclear what can be done with unused binding variables currently (before "_"):
+                if (ud.unusedElementPath.getParentPath().getLeaf().getKind() != Kind.BINDING_PATTERN) {
+                    fix = JavaFixUtilities.safelyRemoveFromParent(ctx, Bundle.FIX_RemoveUsedElement(name), ud.unusedElementPath);
+                }
                 break;
             case NOT_USED:
                 if (ud.unusedElement.getKind() == ElementKind.CONSTRUCTOR) {

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnusedTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnusedTest.java
@@ -50,4 +50,19 @@ public class UnusedTest extends NbTestCase {
                                 "5:26-5:37:verifier:" + Bundle.ERR_NotRead("unusedParam"),
                                 "7:12-7:16:verifier:" + Bundle.ERR_NotUsedConstructor());
     }
+
+    public void testNoFixForBindings() throws Exception {
+        HintTest
+                .create()
+                .sourceLevel("17")
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    boolean test(Object o) {\n" +
+                       "        return o instanceof String s;\n" +
+                       "    }\n" +
+                       "}\n")
+                .run(Unused.class)
+                .findWarning("3:35-3:36:verifier:Variable s is never read")
+                .assertFixes();
+    }
 }


### PR DESCRIPTION
When there's an unused binding, the unused hint with provide a fix suggesting to remove the variable from parent. This patch currently only prevents that fix, as it is not clear what removal from parent means here. That may need some deeper thought. Also, after `_` is implemented, we might reconsider and replace with `_` on appropriate places.


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
