### PR TITLE
Add metabuild json link via netbeans.apache.org

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,6 @@ env:
 
   # note to self: don't remove the minus again
   OPTS: >-
-    -Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json
     -Dtest-unit-sys-prop.ignore.random.failures=true
 
   # what to build and test, see nbbuild/cluster.properties

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -150,7 +150,7 @@
 
     <property name="metabuild.releasejson" value="${nb_all}/nbbuild/build/netbeansrelease.json"/>
     <!-- get all json info we have on apache gitbox  -->
-    <condition property="metabuild.jsonurl" value="https://gitbox.apache.org/repos/asf?p=netbeans-jenkins-lib.git;a=blob_plain;f=meta/netbeansrelease.json">
+    <condition property="metabuild.jsonurl" value="https://netbeans.apache.org/nbbuild/netbeansrelease.json">
         <not>
             <isset property="metabuild.jsonurl"/>
         </not>


### PR DESCRIPTION
Change default metabuild URL to https://netbeans.apache.org/nbbuild/netbeansrelease.json  This currently redirects to the GitHub content link.

Removed direct link from workflows file OPTS.  Both to test this, and so that we can redirect in future without updating the CI config.