### PR TITLE
Fix unit test on single file being reported as integration test GH4587

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.java.project.JavaProjectConstants;
 import org.netbeans.api.java.queries.UnitTestForSourceQuery;
@@ -359,13 +360,9 @@ public class DefaultReplaceTokenProvider implements ReplaceTokenProvider, Action
     }
 
     private boolean isIntegrationTestTarget(Lookup lookup) {
-        final SingleMethod targetMethod = lookup.lookup(SingleMethod.class); //JavaDataObject
-        if (targetMethod != null) {
-            return isIntegrationTestFile(targetMethod.getFile());
-        } 
-        final Collection<? extends FileObject> targetFiles = lookup.lookupAll(FileObject.class);
-        if (targetFiles != null) {
-            return targetFiles.stream().allMatch(file -> isIntegrationTestFile(file));
+        FileObject[] targetFiles = extractFileObjectsfromLookup(lookup);
+        if (targetFiles.length > 0) {
+            return Stream.of(targetFiles).allMatch(file -> isIntegrationTestFile(file));
         }
         return false;
     }


### PR DESCRIPTION
Fix unit test on single file being reported as integration test in some cases.

Change isIntegrationTestTarget to use extractFileObjectsfromLookup() as missing DataObject conversion, and make sure an empty list returns false (due to use of allMatch on empty stream).

Fixes #4587 

