### PR TITLE
add gradle JDK compatibility notice to readme build section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ $ ant -q clean
 
 #### Notes:
 * You can also use `php`, `enterprise`, etc. See the [cluster.properties](https://github.com/apache/netbeans/blob/master/nbbuild/cluster.properties) file.
-* once built, you can simply open individual modules of interest with NetBeans and run/rebuild/debug them like any other project
+* Once built, you can simply open individual modules of interest with NetBeans and run/rebuild/debug them like any other project
+* Building the gradle modules on recent JDKs might fail with "Unsupported class file major version" errors. In that case the gradle daemon must be
+  configured to run on a compatible JDK (for example add `org.gradle.java.home=/home/duke/jdk17` to your `~/.gradle/gradle.properties`, see [gradle doc](https://docs.gradle.org/current/userguide/build_environment.html)).
 
 #### Generating Javadoc
 


### PR DESCRIPTION
fixes #5836

the gradle daemon is a bit of a mystery to me. I tried -D, env vars etc, the only way to make this work was to put it into the gradle.properties ([that is also how we set up CI](https://github.com/apache/netbeans/blob/fc4a7d4b04e09bb4c50f70b858fe558cf042cb7d/.github/workflows/main.yml#L123-L128)). The most confusing aspect: once it works, you can remove the properties again and it will keep working until you remove the whole `.gradle` folder. (yes I did kill the daemon manually between retries)