### PR TITLE
maven remote index filters

### DIFF
--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/MinimalArtifactInfoRemoteIndexCreator.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/MinimalArtifactInfoRemoteIndexCreator.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.indexer;
+
+import org.apache.lucene.document.Document;
+import org.apache.maven.index.ArtifactAvailability;
+import org.apache.maven.index.ArtifactInfo;
+import org.apache.maven.index.creator.MinimalArtifactInfoIndexCreator;
+
+/**
+ * Creates compact remote repository indices by discarding less important fields,
+ * or fields which can be easily substituted by online search services.
+ * 
+ * @author mbien
+ */
+final class MinimalArtifactInfoRemoteIndexCreator extends MinimalArtifactInfoIndexCreator {
+    
+    private static final char FS = ArtifactInfo.FS.charAt(0);
+    
+    static {
+        if (ArtifactInfo.FS.length() != 1) {
+            throw new IllegalStateException("field format changed");
+        }
+    }
+
+    @Override
+    public void updateDocument(ArtifactInfo ai, Document doc) {
+        String info = ArtifactInfo.nvl(ai.getPackaging())
+                + ArtifactInfo.FS
+                + ai.getLastModified()
+                + ArtifactInfo.FS
+                + ai.getSize()
+                + ArtifactInfo.FS
+                + ai.getSourcesExists().toString()
+                + ArtifactInfo.FS
+                + ai.getJavadocExists().toString()
+                + ArtifactInfo.FS
+                + ai.getSignatureExists().toString()
+                + ArtifactInfo.FS
+                + ai.getFileExtension();
+
+        doc.add(FLD_INFO.toField(info));
+
+        doc.add(FLD_GROUP_ID_KW.toField(ai.getGroupId()));
+        doc.add(FLD_ARTIFACT_ID_KW.toField(ai.getArtifactId()));
+        doc.add(FLD_VERSION_KW.toField(ai.getVersion()));
+
+        // V3
+        doc.add(FLD_GROUP_ID.toField(ai.getGroupId()));
+        doc.add(FLD_ARTIFACT_ID.toField(ai.getArtifactId()));
+        doc.add(FLD_VERSION.toField(ai.getVersion()));
+        doc.add(FLD_EXTENSION.toField(ai.getFileExtension()));
+
+        if (ai.getName() != null) {
+            doc.add(FLD_NAME.toField(ai.getName()));
+        }
+
+//        if (ai.getDescription() != null) {
+//            doc.add(FLD_DESCRIPTION.toField(ai.getDescription()));
+//        }
+
+        if (ai.getPackaging() != null) {
+            doc.add(FLD_PACKAGING.toField(ai.getPackaging()));
+        }
+
+        if (ai.getClassifier() != null) {
+            doc.add(FLD_CLASSIFIER.toField(ai.getClassifier()));
+        }
+
+//        if (ai.getSha1() != null) {
+//            doc.add(FLD_SHA1.toField(ai.getSha1()));
+//        }
+    }
+
+    @Override
+    public boolean updateArtifactInfo(Document doc, ArtifactInfo ai) {
+        boolean res = false;
+
+        String uinfo = doc.get(ArtifactInfo.UINFO);
+
+        if (uinfo != null) {
+
+            int start = 0;
+            int end = uinfo.indexOf(FS);
+            ai.setGroupId(uinfo.substring(start, end));
+
+            start = end + 1;
+            end = uinfo.indexOf(FS, start);
+            ai.setArtifactId(uinfo.substring(start, end));
+
+            start = end + 1;
+            end = uinfo.indexOf(FS, start);
+            ai.setVersion(uinfo.substring(start, end));
+
+            start = end + 1;
+            end = uinfo.indexOf(FS, start);
+            if (end == -1) {
+                end = uinfo.length();
+            }
+            ai.setClassifier(ArtifactInfo.renvl(uinfo.substring(start, end)));
+
+            if (end < uinfo.length()) {
+                start = end + 1;
+                end = uinfo.length();
+                ai.setFileExtension(uinfo.substring(start, end));
+            }
+
+            res = true;
+        }
+
+        String info = doc.get(ArtifactInfo.INFO);
+
+        if (info != null) {
+
+            int start = 0;
+            int end = info.indexOf(FS);
+            ai.setPackaging(ArtifactInfo.renvl(info.substring(start, end)));
+
+            start = end + 1;
+            end = info.indexOf(FS, start);
+            ai.setLastModified(Long.parseLong(info.substring(start, end)));
+
+            start = end + 1;
+            end = info.indexOf(FS, start);
+            ai.setSize(Long.parseLong(info.substring(start, end)));
+
+            start = end + 1;
+            end = info.indexOf(FS, start);
+            ai.setSourcesExists(ArtifactAvailability.fromString(info.substring(start, end)));
+
+            start = end + 1;
+            end = info.indexOf(FS, start);
+            ai.setJavadocExists(ArtifactAvailability.fromString(info.substring(start, end)));
+
+            start = end + 1;
+            end = info.indexOf(FS, start);
+            if (end == -1) {
+                end = info.length();
+            }
+            ai.setSignatureExists(ArtifactAvailability.fromString(info.substring(start, end)));
+
+            if (end < info.length()) {
+                start = end + 1;
+                end = info.length();
+                ai.setFileExtension(info.substring(start, end));
+            } else {
+                if (ai.getClassifier() != null //
+                        || "pom".equals(ai.getPackaging()) //
+                        || "war".equals(ai.getPackaging()) //
+                        || "ear".equals(ai.getPackaging())) {
+                    ai.setFileExtension(ai.getPackaging());
+                } else {
+                    ai.setFileExtension("jar"); // best guess
+                }
+            }
+
+            res = true;
+        }
+
+        String name = doc.get(ArtifactInfo.NAME);
+
+        if (name != null) {
+            ai.setName(name);
+            res = true;
+        }
+
+//        String description = doc.get(ArtifactInfo.DESCRIPTION);
+//
+//        if (description != null) {
+//            ai.setDescription(description);
+//            res = true;
+//        }
+
+        // sometimes there's a pom without packaging(default to jar), but no artifact, then the value will be a "null"
+        // String
+        if ("null".equals(ai.getPackaging())) {
+            ai.setPackaging(null);
+        }
+
+//        String sha1 = doc.get(ArtifactInfo.SHA1);
+//
+//        if (sha1 != null) {
+//            ai.setSha1(sha1);
+//        }
+
+        return res;
+    }
+}

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
@@ -34,6 +34,8 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,6 +46,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.zip.ZipError;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.codehaus.plexus.PlexusConstants;
@@ -60,7 +63,10 @@ import org.apache.maven.index.context.DefaultIndexingContext;
 import org.apache.maven.index.context.IndexCreator;
 import org.apache.maven.index.context.IndexUtils;
 import org.apache.maven.index.context.IndexingContext;
-import org.apache.maven.index.creator.OsgiArtifactIndexCreator;
+import org.apache.maven.index.creator.JarFileContentsIndexCreator;
+import org.apache.maven.index.creator.MavenArchetypeArtifactInfoIndexCreator;
+import org.apache.maven.index.creator.MavenPluginArtifactInfoIndexCreator;
+import org.apache.maven.index.creator.MinimalArtifactInfoIndexCreator;
 import org.apache.maven.index.expr.StringSearchExpression;
 import org.apache.maven.index.updater.IndexUpdateRequest;
 import org.apache.maven.index.updater.IndexUpdater;
@@ -128,6 +134,8 @@ import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
 import org.openide.util.NbBundle.Messages;
 import org.netbeans.modules.maven.indexer.spi.RepositoryIndexQueryProvider;
+import static org.apache.maven.index.creator.MinimalArtifactInfoIndexCreator.FLD_LAST_MODIFIED;
+
 
 //index fields
 //https://maven.apache.org/maven-indexer-archives/maven-indexer-LATEST/indexer-core/
@@ -359,24 +367,23 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
             }
             LOGGER.log(Level.FINE, "Loading Context: {0}", info.getId());
 
-            List<IndexCreator> creators = new ArrayList<>();
-            try {
-                for (IndexCreator creator : embedder.lookupList(IndexCreator.class)) {
-                    if (OsgiArtifactIndexCreator.ID.equals(creator.getId())) {
-                        continue; //we are no interested in osgi related content in lucene documents or ArtifactInfo objects.
-                        //they take up a lot of memory and we never query them AFAIK. (import/export packages can take up to 300k
-                        //239915, 240150 + according to my knowledge we don't expose any api that would allow 3rd party plugins to query the osgi stuff
-                    }
-                    creators.add(creator);
-                }
-            } catch (ComponentLookupException x) {
-                throw new IOException(x);
-            }
-            if (info.isLocal()) { // #164593
-                creators.add(new ArtifactDependencyIndexCreator());
-                creators.add(new ClassDependencyIndexCreator());
+            List<IndexCreator> creators;
+            if (info.isLocal()) {
+                creators = List.of(
+                    new JarFileContentsIndexCreator(),
+                    new MinimalArtifactInfoIndexCreator(),
+                    new MavenArchetypeArtifactInfoIndexCreator(),
+                    new MavenPluginArtifactInfoIndexCreator(),
+                    new ArtifactDependencyIndexCreator(),
+                    new ClassDependencyIndexCreator()
+                );
             } else {
-                creators.add(new NotifyingIndexCreator());
+                creators = List.of(
+                    info.getId().equals(smo.getRepositoryId())
+                            ? new MinimalArtifactInfoRemoteIndexCreator()
+                            : new MinimalArtifactInfoIndexCreator(),
+                    new NotifyingIndexCreator()
+                );
             }
             try {
                 addIndexingContextForced(info, creators);
@@ -417,7 +424,11 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
         }
     }
 
-    private @CheckForNull IteratorSearchResponse repeatedPagedSearch(Query q, final List<IndexingContext> contexts, int count) throws IOException {
+    private @CheckForNull IteratorSearchResponse repeatedPagedSearch(Query q, IndexingContext context, int count) throws IOException {
+        return repeatedPagedSearch(q, List.of(context), count);
+    }
+
+    private @CheckForNull IteratorSearchResponse repeatedPagedSearch(Query q, List<IndexingContext> contexts, int count) throws IOException {
         IteratorSearchRequest isr = new IteratorSearchRequest(q, contexts, new NoJavadocSourceFilter());
         if (count > 0) {
             isr.setCount(count);
@@ -554,14 +565,20 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                     } else {
                         iur.setThreads(1);
                     }
-
-                    NotifyingIndexCreator nic = null;
-                    for (IndexCreator ic : indexingContext.getIndexCreators()) {
-                        if (ic instanceof NotifyingIndexCreator) {
-                            nic = (NotifyingIndexCreator) ic;
-                            break;
-                        }
+                    if (RepositoryPreferences.getIndexDateCutoffFilter() > 0) {
+                        Instant cutoff = ZonedDateTime.now()
+                                .minusYears(RepositoryPreferences.getIndexDateCutoffFilter())
+                                .toInstant();
+                        iur.setExtractionFilter(doc -> {
+                            IndexableField date = doc.getField(FLD_LAST_MODIFIED.getKey()); // usually never null
+                            return date != null && Instant.ofEpochMilli(Long.parseLong(date.stringValue())).isAfter(cutoff);
+                        });
                     }
+
+                    NotifyingIndexCreator nic = (NotifyingIndexCreator) indexingContext.getIndexCreators().stream()
+                            .filter(c -> c instanceof NotifyingIndexCreator)
+                            .findAny().orElse(null);
+
                     if (nic != null) {
                         nic.start(listener);
                     }
@@ -650,7 +667,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
         } catch (ComponentLookupException x) {
             throw new IOException("could not find protocol handler for " + repo.getRepositoryUrl(), x);
         } finally {
-            LOGGER.log(Level.INFO, "Indexing of {0} took {1} s.", new Object[]{repo.getId(), String.format("%.2f", (System.currentTimeMillis() - t)/1000.0f)});
+            LOGGER.log(Level.INFO, "Indexing of {0} took {1}s.", new Object[]{repo.getId(), String.format("%.2f", (System.currentTimeMillis() - t)/1000.0f)});
             synchronized (indexingMutexes) {
                 indexingMutexes.remove(mutex);
             }
@@ -882,7 +899,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                             BooleanQuery bq = new BooleanQuery.Builder()
                                     .add(new BooleanClause(new PrefixQuery(new Term(ArtifactInfo.UINFO, id)), BooleanClause.Occur.MUST))
                                     .build();
-                            IteratorSearchResponse response = repeatedPagedSearch(bq, Collections.singletonList(indexingContext), MAX_RESULT_COUNT);
+                            IteratorSearchResponse response = repeatedPagedSearch(bq, indexingContext, MAX_RESULT_COUNT);
                             add = response == null || response.getTotalHitsCount() == 0;
                             if (response != null) {
                                 response.close();
@@ -955,7 +972,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                 File pom = new File(pomPath);
                 if (pom.exists()) {
                     //TODO batch removal??
-                    indexer.deleteArtifactsFromIndex(Collections.singleton(contextProducer.getArtifactContext(indexingContext, pom)), indexingContext);
+                    indexer.deleteArtifactsFromIndex(List.of(contextProducer.getArtifactContext(indexingContext, pom)), indexingContext);
                     storeGroupCache(repo, indexingContext);
                 }
                 return null;
@@ -1081,7 +1098,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                 .add(new BooleanClause(new TermQuery(new Term(ArtifactInfo.PACKAGING, packaging)), BooleanClause.Occur.MUST))
                 .build();
         iterate(repos, (RepositoryInfo repo, IndexingContext context) -> {
-            IteratorSearchResponse response = repeatedPagedSearch(bq, Collections.singletonList(context), NO_CAP_RESULT_COUNT);
+            IteratorSearchResponse response = repeatedPagedSearch(bq, context, NO_CAP_RESULT_COUNT);
             if (response != null) {
                try {
                     for (ArtifactInfo ai : response) {
@@ -1118,7 +1135,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                 .add(new BooleanClause(new PrefixQuery(new Term(ArtifactInfo.UINFO, id)), BooleanClause.Occur.MUST))
                 .build();
         iterate(repos, (RepositoryInfo repo, IndexingContext context) -> {
-            IteratorSearchResponse response = repeatedPagedSearch(bq, Collections.singletonList(context), MAX_RESULT_COUNT);
+            IteratorSearchResponse response = repeatedPagedSearch(bq, context, MAX_RESULT_COUNT);
             if (response != null) {
                 try {
                     for (ArtifactInfo ai : response) {
@@ -1153,7 +1170,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                 .build();
         iterate(repos, (RepositoryInfo repo, IndexingContext context) -> {
             //mkleint: this is not capped, because only a string is collected (and collapsed), the rest gets CGed fast
-            IteratorSearchResponse response = repeatedPagedSearch(bq, Collections.singletonList(context), NO_CAP_RESULT_COUNT);
+            IteratorSearchResponse response = repeatedPagedSearch(bq, context, NO_CAP_RESULT_COUNT);
             if (response != null) {
                 try {
                     for (ArtifactInfo artifactInfo : response.getResults()) {
@@ -1183,7 +1200,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                 .add(new BooleanClause(setBooleanRewrite(new PrefixQuery(new Term(ArtifactInfo.UINFO, id))), BooleanClause.Occur.MUST))
                 .build();
         iterate(repos, (RepositoryInfo repo, IndexingContext context) -> {
-            IteratorSearchResponse response = repeatedPagedSearch(bq, Collections.singletonList(context), MAX_RESULT_COUNT);
+            IteratorSearchResponse response = repeatedPagedSearch(bq, context, MAX_RESULT_COUNT);
             if (response != null) {
                 try {
                     for (ArtifactInfo ai : response) {
@@ -1241,7 +1258,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
             }
 
             Query q = setBooleanRewrite(constructQuery(MAVEN.CLASSNAMES, clsname.toLowerCase(Locale.ENGLISH)));
-            IteratorSearchResponse response = repeatedPagedSearch(q, Collections.singletonList(context), MAX_RESULT_COUNT);
+            IteratorSearchResponse response = repeatedPagedSearch(q, context, MAX_RESULT_COUNT);
             if (response != null) {
                 try {
                     infos.addAll(postProcessClasses(response.getResults(), clsname));
@@ -1284,7 +1301,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
         final List<RepositoryQueries.ClassUsage> results = new ArrayList<>(result.getResults());
         final SkippedAction skipAction = new SkippedAction(result);
         iterate(localRepos, (RepositoryInfo repo, IndexingContext context) -> {
-            ClassDependencyIndexCreator.search(className, indexer, Collections.singletonList(context), results);
+            ClassDependencyIndexCreator.search(className, indexer, List.of(context), results);
         }, skipAction, skipUnIndexed);
         results.sort((RepositoryQueries.ClassUsage r1, RepositoryQueries.ClassUsage r2) -> r1.getArtifact().compareTo(r2.getArtifact()));
         result.setResults(results);
@@ -1303,7 +1320,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
         final List<NBVersionInfo> infos = new ArrayList<>(result.getResults());
         final SkippedAction skipAction = new SkippedAction(result);
         iterate(repos, (RepositoryInfo repo, IndexingContext context) -> {
-            IteratorSearchResponse response = repeatedPagedSearch(q, Collections.singletonList(context), MAX_RESULT_COUNT);
+            IteratorSearchResponse response = repeatedPagedSearch(q, context, MAX_RESULT_COUNT);
             if (response != null) {
                 try {
                     for (ArtifactInfo ai : response) {
@@ -1401,7 +1418,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
             BooleanQuery bq = new BooleanQuery.Builder()
                     .add(new BooleanClause((setBooleanRewrite(constructQuery(MAVEN.SHA1, sha1))), BooleanClause.Occur.SHOULD))
                     .build();
-            IteratorSearchResponse response = repeatedPagedSearch(bq, Collections.singletonList(context), MAX_RESULT_COUNT);
+            IteratorSearchResponse response = repeatedPagedSearch(bq, context, MAX_RESULT_COUNT);
             if (response != null) {
                 try {
                     for (ArtifactInfo ai : response) {
@@ -1439,7 +1456,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
             FlatSearchRequest fsr = new FlatSearchRequest(bq, ArtifactInfo.VERSION_COMPARATOR);
             fsr.setCount(MAX_RESULT_COUNT);
             */
-            IteratorSearchResponse response = repeatedPagedSearch(bq, Collections.singletonList(context), NO_CAP_RESULT_COUNT);
+            IteratorSearchResponse response = repeatedPagedSearch(bq, context, NO_CAP_RESULT_COUNT);
             if (response != null) {
                 try {
                     for (ArtifactInfo ai : response) {
@@ -1475,7 +1492,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                 .build();
         iterate(repos, (RepositoryInfo repo, IndexingContext context) -> {
             //mkleint: this is not capped, because only a string is collected (and collapsed), the rest gets CGed fast
-            IteratorSearchResponse response = repeatedPagedSearch(bq, Collections.singletonList(context), NO_CAP_RESULT_COUNT);
+            IteratorSearchResponse response = repeatedPagedSearch(bq, context, NO_CAP_RESULT_COUNT);
             if (response != null) {
                 try {
                     for (ArtifactInfo artifactInfo : response.getResults()) {
@@ -1509,7 +1526,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
         BooleanQuery bq = builder.build();
         iterate(repos, (RepositoryInfo repo, IndexingContext context) -> {
             //mkleint: this is not capped, because only a string is collected (and collapsed), the rest gets CGed fast
-            IteratorSearchResponse response = repeatedPagedSearch(bq, Collections.singletonList(context), NO_CAP_RESULT_COUNT);
+            IteratorSearchResponse response = repeatedPagedSearch(bq, context, NO_CAP_RESULT_COUNT);
             if (response != null) {
                 try {
                     for (ArtifactInfo artifactInfo : response.getResults()) {
@@ -1604,7 +1621,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                         //queries for each field.
                     }
                 }
-                IteratorSearchResponse resp = repeatedPagedSearch(bq.build(), Collections.singletonList(context), MAX_RESULT_COUNT);
+                IteratorSearchResponse resp = repeatedPagedSearch(bq.build(), context, MAX_RESULT_COUNT);
                 if (resp != null) {
                     try {
                         for (ArtifactInfo ai : resp) {
@@ -1870,7 +1887,6 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
 
         @Override
         public InputStream retrieve(String name) throws IOException, FileNotFoundException {
-
             if (isDiag()) {
                 String id = wagon.getRepository().getId();
                 if(name.endsWith(".properties") && System.getProperty("maven.diag.index.properties." + id) != null) { // NOI18N

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
@@ -79,6 +79,7 @@ public final class RepositoryPreferences {
     public static final String PROP_LAST_INDEX_UPDATE = "lastIndexUpdate"; //NOI18N
     private static final String PROP_INDEX_DOWNLOAD_PERMISSIONS = "indexDownloadPermissions"; //NOI18N
     public static final String PROP_MT_INDEX_EXTRACTION = "indexMultiThreadedExtraction"; //NOI18N
+    public static final String PROP_INDEX_DATE_CUTOFF_FILTER = "indexDateCotoffFilter"; //NOI18N
 
     public static final int FREQ_ONCE_WEEK = 0;
     public static final int FREQ_ONCE_DAY = 1;
@@ -417,6 +418,14 @@ public final class RepositoryPreferences {
      */
     public static synchronized boolean isIndexDownloadEnabledEffective() {
         return isIndexRepositories() && isIndexDownloadEnabled() && !isIndexDownloadPaused();
+    }
+
+    public static int getIndexDateCutoffFilter() {
+        return getPreferences().getInt(PROP_INDEX_DATE_CUTOFF_FILTER, 0);
+    }
+    
+    public static void setIndexDateCutoffFilter(int years) {
+        getPreferences().putInt(PROP_INDEX_DATE_CUTOFF_FILTER, years);
     }
 
     public static boolean isIndexDownloadPaused() {

--- a/java/maven/src/org/netbeans/modules/maven/options/Bundle.properties
+++ b/java/maven/src/org/netbeans/modules/maven/options/Bundle.properties
@@ -103,3 +103,7 @@ the index periodically.</html>
 SettingsPanel.appearancePanel.border.title=Appearance
 SettingsPanel.dependenciesPanel.border.title=Dependency Download Strategy
 SettingsPanel.experimentalPanel.border.title=Experimental
+SettingsPanel.lblIndexFilter.text=Index Filter:
+SettingsPanel.rb2Years.text=2 years
+SettingsPanel.rb5Years.text=5 years
+SettingsPanel.rbFullIndex.text=Full Index (no filter)

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.form
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.form
@@ -25,6 +25,8 @@
   <NonVisualComponents>
     <Component class="javax.swing.ButtonGroup" name="buttonGroup1">
     </Component>
+    <Component class="javax.swing.ButtonGroup" name="bgIndexFilter">
+    </Component>
   </NonVisualComponents>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="1"/>
@@ -49,7 +51,6 @@
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="pnlCards" max="32767" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -121,7 +122,7 @@
                           <EmptySpace type="unrelated" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
                               <Component id="txtProjectNodeNameCustomPattern" max="32767" attributes="0"/>
-                              <Component id="cbProjectNodeNameMode" pref="332" max="32767" attributes="0"/>
+                              <Component id="cbProjectNodeNameMode" pref="377" max="32767" attributes="0"/>
                           </Group>
                           <EmptySpace max="-2" attributes="0"/>
                       </Group>
@@ -225,7 +226,7 @@
                               <Group type="102" alignment="0" attributes="0">
                                   <Component id="lblJavadoc" linkSize="2" min="-2" max="-2" attributes="0"/>
                                   <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="comJavadoc" pref="339" max="32767" attributes="1"/>
+                                  <Component id="comJavadoc" pref="384" max="32767" attributes="1"/>
                               </Group>
                               <Group type="102" alignment="0" attributes="0">
                                   <Component id="lblBinaries" linkSize="2" min="-2" max="-2" attributes="0"/>
@@ -369,7 +370,7 @@
                               <Group type="102" alignment="0" attributes="0">
                                   <Component id="lblIndex" min="-2" max="-2" attributes="0"/>
                                   <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="comIndex" pref="234" max="32767" attributes="0"/>
+                                  <Component id="comIndex" max="32767" attributes="0"/>
                                   <EmptySpace type="unrelated" max="-2" attributes="0"/>
                                   <Component id="btnIndex" min="-2" max="-2" attributes="0"/>
                               </Group>
@@ -379,7 +380,14 @@
                                       <Component id="cbEnableIndexDownload" min="-2" max="-2" attributes="0"/>
                                       <Component id="cbEnableMultiThreading" alignment="0" max="32767" attributes="0"/>
                                   </Group>
-                                  <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                                  <EmptySpace type="separate" max="-2" attributes="0"/>
+                                  <Component id="lblIndexFilter" min="-2" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Group type="103" groupAlignment="0" attributes="0">
+                                      <Component id="rbFullIndex" min="-2" max="-2" attributes="0"/>
+                                      <Component id="rb5Years" min="-2" max="-2" attributes="0"/>
+                                      <Component id="rb2Years" min="-2" max="-2" attributes="0"/>
+                                  </Group>
                               </Group>
                           </Group>
                           <EmptySpace max="-2" attributes="0"/>
@@ -390,11 +398,21 @@
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Group type="102" alignment="0" attributes="0">
                           <EmptySpace max="-2" attributes="0"/>
-                          <Component id="cbEnableIndexing" min="-2" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="3" attributes="0">
+                              <Component id="cbEnableIndexing" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="lblIndexFilter" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="rbFullIndex" alignment="3" min="-2" max="-2" attributes="0"/>
+                          </Group>
                           <EmptySpace max="-2" attributes="0"/>
-                          <Component id="cbEnableIndexDownload" min="-2" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="3" attributes="0">
+                              <Component id="cbEnableIndexDownload" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="rb5Years" alignment="3" min="-2" max="-2" attributes="0"/>
+                          </Group>
                           <EmptySpace max="-2" attributes="0"/>
-                          <Component id="cbEnableMultiThreading" min="-2" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="3" attributes="0">
+                              <Component id="cbEnableMultiThreading" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="rb2Years" alignment="3" min="-2" max="-2" attributes="0"/>
+                          </Group>
                           <EmptySpace type="unrelated" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="3" attributes="0">
                               <Component id="lblIndex" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -498,6 +516,44 @@
                     </Property>
                   </Properties>
                 </Component>
+                <Component class="javax.swing.JLabel" name="lblIndexFilter">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="org/netbeans/modules/maven/options/Bundle.properties" key="SettingsPanel.lblIndexFilter.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                    </Property>
+                  </Properties>
+                </Component>
+                <Component class="javax.swing.JRadioButton" name="rbFullIndex">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="bgIndexFilter"/>
+                    </Property>
+                    <Property name="selected" type="boolean" value="true"/>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="org/netbeans/modules/maven/options/Bundle.properties" key="SettingsPanel.rbFullIndex.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                    </Property>
+                  </Properties>
+                </Component>
+                <Component class="javax.swing.JRadioButton" name="rb5Years">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="bgIndexFilter"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="org/netbeans/modules/maven/options/Bundle.properties" key="SettingsPanel.rb5Years.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                    </Property>
+                  </Properties>
+                </Component>
+                <Component class="javax.swing.JRadioButton" name="rb2Years">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="bgIndexFilter"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="org/netbeans/modules/maven/options/Bundle.properties" key="SettingsPanel.rb2Years.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                    </Property>
+                  </Properties>
+                </Component>
               </SubComponents>
             </Container>
           </SubComponents>
@@ -555,7 +611,7 @@
                                       <Component id="cbUseBestMaven" min="-2" max="-2" attributes="0"/>
                                       <Component id="cbAlternateLocation" min="-2" max="-2" attributes="0"/>
                                   </Group>
-                                  <EmptySpace min="0" pref="134" max="32767" attributes="0"/>
+                                  <EmptySpace min="0" pref="179" max="32767" attributes="0"/>
                               </Group>
                               <Group type="102" alignment="0" attributes="0">
                                   <EmptySpace min="-2" pref="29" max="-2" attributes="0"/>

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
@@ -197,6 +197,9 @@ public class SettingsPanel extends javax.swing.JPanel {
         cbOutputTabShowConfig.addActionListener(listener);
         rbOutputTabId.addActionListener(listener);
         rbOutputTabName.addActionListener(listener);
+        rbFullIndex.addActionListener(listener);
+        rb5Years.addActionListener(listener);
+        rb2Years.addActionListener(listener);
         cbEnableIndexing.addActionListener(listener);
         cbEnableMultiThreading.addActionListener(listener);
         cbEnableIndexDownload.addActionListener(listener);
@@ -350,6 +353,7 @@ public class SettingsPanel extends javax.swing.JPanel {
     private void initComponents() {
 
         buttonGroup1 = new javax.swing.ButtonGroup();
+        bgIndexFilter = new javax.swing.ButtonGroup();
         pnlCards = new javax.swing.JPanel();
         pnlAppearance = new javax.swing.JPanel();
         javax.swing.JPanel appearancePanel = new javax.swing.JPanel();
@@ -376,6 +380,10 @@ public class SettingsPanel extends javax.swing.JPanel {
         javax.swing.JScrollPane permissionsTableScrollPane = new javax.swing.JScrollPane();
         permissionsTable = new javax.swing.JTable();
         cbEnableMultiThreading = new javax.swing.JCheckBox();
+        lblIndexFilter = new javax.swing.JLabel();
+        rbFullIndex = new javax.swing.JRadioButton();
+        rb5Years = new javax.swing.JRadioButton();
+        rb2Years = new javax.swing.JRadioButton();
         plnExperimental = new javax.swing.JPanel();
         javax.swing.JPanel experimentalPanel = new javax.swing.JPanel();
         cbUseBestMaven = new javax.swing.JCheckBox();
@@ -437,7 +445,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(appearancePanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(txtProjectNodeNameCustomPattern)
-                    .addComponent(cbProjectNodeNameMode, 0, 332, Short.MAX_VALUE))
+                    .addComponent(cbProjectNodeNameMode, 0, 377, Short.MAX_VALUE))
                 .addContainerGap())
         );
         appearancePanelLayout.setVerticalGroup(
@@ -494,7 +502,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                     .addGroup(dependenciesPanelLayout.createSequentialGroup()
                         .addComponent(lblJavadoc)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(comJavadoc, 0, 339, Short.MAX_VALUE))
+                        .addComponent(comJavadoc, 0, 384, Short.MAX_VALUE))
                     .addGroup(dependenciesPanelLayout.createSequentialGroup()
                         .addComponent(lblBinaries)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -590,6 +598,18 @@ public class SettingsPanel extends javax.swing.JPanel {
 
         org.openide.awt.Mnemonics.setLocalizedText(cbEnableMultiThreading, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.cbEnableMultiThreading.text")); // NOI18N
 
+        org.openide.awt.Mnemonics.setLocalizedText(lblIndexFilter, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.lblIndexFilter.text")); // NOI18N
+
+        bgIndexFilter.add(rbFullIndex);
+        rbFullIndex.setSelected(true);
+        org.openide.awt.Mnemonics.setLocalizedText(rbFullIndex, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.rbFullIndex.text")); // NOI18N
+
+        bgIndexFilter.add(rb5Years);
+        org.openide.awt.Mnemonics.setLocalizedText(rb5Years, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.rb5Years.text")); // NOI18N
+
+        bgIndexFilter.add(rb2Years);
+        org.openide.awt.Mnemonics.setLocalizedText(rb2Years, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.rb2Years.text")); // NOI18N
+
         javax.swing.GroupLayout indexerPanelLayout = new javax.swing.GroupLayout(indexerPanel);
         indexerPanel.setLayout(indexerPanelLayout);
         indexerPanelLayout.setHorizontalGroup(
@@ -602,7 +622,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                     .addGroup(indexerPanelLayout.createSequentialGroup()
                         .addComponent(lblIndex)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(comIndex, 0, 234, Short.MAX_VALUE)
+                        .addComponent(comIndex, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                         .addComponent(btnIndex))
                     .addGroup(indexerPanelLayout.createSequentialGroup()
@@ -610,18 +630,31 @@ public class SettingsPanel extends javax.swing.JPanel {
                             .addComponent(cbEnableIndexing, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addComponent(cbEnableIndexDownload)
                             .addComponent(cbEnableMultiThreading, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                        .addGap(0, 0, Short.MAX_VALUE)))
+                        .addGap(18, 18, 18)
+                        .addComponent(lblIndexFilter)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addGroup(indexerPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(rbFullIndex)
+                            .addComponent(rb5Years)
+                            .addComponent(rb2Years))))
                 .addContainerGap())
         );
         indexerPanelLayout.setVerticalGroup(
             indexerPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(indexerPanelLayout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(cbEnableIndexing)
+                .addGroup(indexerPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(cbEnableIndexing)
+                    .addComponent(lblIndexFilter)
+                    .addComponent(rbFullIndex))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(cbEnableIndexDownload)
+                .addGroup(indexerPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(cbEnableIndexDownload)
+                    .addComponent(rb5Years))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(cbEnableMultiThreading)
+                .addGroup(indexerPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(cbEnableMultiThreading)
+                    .addComponent(rb2Years))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(indexerPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(lblIndex)
@@ -680,7 +713,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                         .addGroup(experimentalPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(cbUseBestMaven)
                             .addComponent(cbAlternateLocation))
-                        .addGap(0, 134, Short.MAX_VALUE))
+                        .addGap(0, 179, Short.MAX_VALUE))
                     .addGroup(experimentalPanelLayout.createSequentialGroup()
                         .addGap(29, 29, 29)
                         .addGroup(experimentalPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -920,8 +953,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                     .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 140, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(lblCategory))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(pnlCards, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addContainerGap())
+                .addComponent(pnlCards, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -1030,9 +1062,14 @@ public class SettingsPanel extends javax.swing.JPanel {
         comIndex.setEnabled(cbEnableIndexing.isSelected() && cbEnableIndexDownload.isSelected());
         lblIndex.setEnabled(cbEnableIndexing.isSelected() && cbEnableIndexDownload.isSelected());
         btnIndex.setEnabled(cbEnableIndexing.isSelected());
+        lblIndexFilter.setEnabled(cbEnableIndexing.isSelected() && cbEnableIndexDownload.isSelected());
+        rbFullIndex.setEnabled(cbEnableIndexing.isSelected() && cbEnableIndexDownload.isSelected());
+        rb5Years.setEnabled(cbEnableIndexing.isSelected() && cbEnableIndexDownload.isSelected());
+        rb2Years.setEnabled(cbEnableIndexing.isSelected() && cbEnableIndexDownload.isSelected());
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.ButtonGroup bgIndexFilter;
     private javax.swing.JButton btnDirectory;
     private javax.swing.JButton btnGoals;
     private javax.swing.JButton btnIndex;
@@ -1070,6 +1107,7 @@ public class SettingsPanel extends javax.swing.JPanel {
     private javax.swing.JLabel lblExternalVersion;
     private javax.swing.JLabel lblHint;
     private javax.swing.JLabel lblIndex;
+    private javax.swing.JLabel lblIndexFilter;
     private javax.swing.JLabel lblJavadoc;
     private javax.swing.JLabel lblJdkHome;
     private javax.swing.JLabel lblOptions;
@@ -1083,14 +1121,20 @@ public class SettingsPanel extends javax.swing.JPanel {
     private javax.swing.JPanel pnlDependencies;
     private javax.swing.JPanel pnlExecution;
     private javax.swing.JPanel pnlIndex;
+    private javax.swing.JRadioButton rb2Years;
+    private javax.swing.JRadioButton rb5Years;
+    private javax.swing.JRadioButton rbFullIndex;
     private javax.swing.JRadioButton rbOutputTabId;
     private javax.swing.JRadioButton rbOutputTabName;
     private javax.swing.JTextField txtDirectory;
     private javax.swing.JTextField txtOptions;
     private javax.swing.JTextField txtProjectNodeNameCustomPattern;
     // End of variables declaration//GEN-END:variables
-    
-    
+
+    private int getDateCutoffFilterValue() {
+        return rb5Years.isSelected() ? 5 : rb2Years.isSelected() ? 2 : 0;
+    }
+
     private DefaultComboBoxModel getProjectNodeModel() {
         return new javax.swing.DefaultComboBoxModel(new String[] { 
             NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.lblDefault.text"), // NOI18N
@@ -1217,11 +1261,15 @@ public class SettingsPanel extends javax.swing.JPanel {
                 });
             }
         });
-        
         comIndex.setSelectedIndex(RepositoryPreferences.getIndexUpdateFrequency());
         cbEnableIndexing.setSelected(RepositoryPreferences.isIndexRepositories());
         cbEnableIndexDownload.setSelected(RepositoryPreferences.isIndexDownloadEnabled());
         cbEnableMultiThreading.setSelected(RepositoryPreferences.isMultiThreadedIndexExtractionEnabled());
+        switch (RepositoryPreferences.getIndexDateCutoffFilter()) {
+            case 5: rb5Years.setSelected(true); break;
+            case 2: rb2Years.setSelected(true); break;
+            default: rbFullIndex.setSelected(true); break;
+        }
         comBinaries.setSelectedItem(MavenSettings.getDefault().getBinaryDownloadStrategy());
         comJavadoc.setSelectedItem(MavenSettings.getDefault().getJavadocDownloadStrategy());
         comSource.setSelectedItem(MavenSettings.getDefault().getSourceDownloadStrategy());
@@ -1306,6 +1354,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         RepositoryPreferences.setIndexRepositories(cbEnableIndexing.isSelected());
         RepositoryPreferences.setIndexDownloadEnabled(cbEnableIndexDownload.isSelected());
         RepositoryPreferences.setMultiThreadedIndexExtractionEnabled(cbEnableMultiThreading.isSelected());
+        RepositoryPreferences.setIndexDateCutoffFilter(getDateCutoffFilterValue());
         RepositoryPreferences.setIndexDownloadPermissions(((IndexDownloadPermissionTableModel)permissionsTable.getModel()).getPermissions());
         MavenSettings.getDefault().setBinaryDownloadStrategy((MavenSettings.DownloadStrategy) comBinaries.getSelectedItem());
         MavenSettings.getDefault().setJavadocDownloadStrategy((MavenSettings.DownloadStrategy) comJavadoc.getSelectedItem());
@@ -1380,6 +1429,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         isChanged |= RepositoryPreferences.isIndexRepositories() != cbEnableIndexing.isSelected();
         isChanged |= RepositoryPreferences.isIndexDownloadEnabled() != cbEnableIndexDownload.isSelected();
         isChanged |= RepositoryPreferences.isMultiThreadedIndexExtractionEnabled() != cbEnableMultiThreading.isSelected();
+        isChanged |= RepositoryPreferences.getIndexDateCutoffFilter() != getDateCutoffFilterValue();
         isChanged |= MavenSettings.getDefault().getBinaryDownloadStrategy().compareTo((MavenSettings.DownloadStrategy) comBinaries.getSelectedItem()) != 0;
         isChanged |= MavenSettings.getDefault().getJavadocDownloadStrategy().compareTo((MavenSettings.DownloadStrategy) comJavadoc.getSelectedItem()) != 0;
         isChanged |= MavenSettings.getDefault().getSourceDownloadStrategy().compareTo((MavenSettings.DownloadStrategy) comSource.getSelectedItem()) != 0;


### PR DESCRIPTION
 - index only interesting fields to reduce index size and upkeep overhead
   - this is achieved by using a custom index creator since filters can't remove fields
   - reduces central index size from 5.7 GB to 2.8 GB (single threaded)
   - reduces central index size from 6.4 GB to 3,4 GB (multi threaded)
   - reduces initial indexing time to ~300s on my system (full index)
 - artifact date cutoff filter is configurable in the options
   - shrinks the index 1.5 GB (multi threaded, 2y filter) when enabled

The filtering is implemented via a custom index creator, for inexplicable reasons I couldn't reproduce my results from a few month ago where i removed fields in the extraction filter. Removing fields there doesn't do anything so we do that one step earlier in the pipeline.

`MinimalArtifactInfoRemoteIndexCreator` extends upstream `MinimalArtifactInfoIndexCreator` and ignores two fields: sha1 and description. SH1 queries can be easily substituted by an online service like SMO, since queries like that are usually immediately followed by a download anyway, they are also rarely used within NB.

I experimented with more fields like for example uinfo, which looked promising and had great results at first, but this can't be done at the moment since uinfo is essentially used as UID during incremental index updates - removing this field would break updates.

![maven-index-filter-options](https://github.com/apache/netbeans/assets/114367/a3a8a994-dec9-4426-9486-dee1abcd0ed6)


benchmarks:

```
# sha1, desc filter, full index, JDK 20
# MT
# String split optimization (only in NB)
run 1: 321.70s
3,4 GB

# + String split optimization (NB + maven-indexer)
run 1: 293.86s
run 2: 304.06s
run 3: 305.21s
3,4 GB

# ST for comparison
run 1: 642.11s
2.8 GB

# MT again
# + 5y filter
run 1: 240.00s
run 2: 254.54s
run 3: 245.93s
2.7 GB

# + 2y filter
run 1: 210.96s
run 2: 213.93s
run 3: 222.54s
1.5 GB
```
"String split optimization" is an upstream PR https://github.com/apache/maven-indexer/pull/317

reference (NB 18):
```
# no filters, full index:
# ST
run 1: 916.25s
5.7 GB

# MT:
run 1: 383.24s
6.4 GB
```

note: time does not include the download since for testing purposes I load the gz from disk.

note2: MT causes index size inefficiencies. However, some of it is "garbage collected" by lucene automatically when the index is used a few times. (search a few artifacts + restart NB)

note3: this is an old i6700k, storage is NVMe.