### PR TITLE
Add support for GlassFish 7.0.4

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/Bundle.properties
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/Bundle.properties
@@ -170,6 +170,7 @@ STR_700_SERVER_NAME=GlassFish Server 7.0.0
 STR_701_SERVER_NAME=GlassFish Server 7.0.1
 STR_702_SERVER_NAME=GlassFish Server 7.0.2
 STR_703_SERVER_NAME=GlassFish Server 7.0.3
+STR_704_SERVER_NAME=GlassFish Server 7.0.4
 
 # CommonServerSupport.java
 MSG_FLAKEY_NETWORK=<html>Network communication problem<br/>Could not establish \

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
@@ -334,6 +334,17 @@ public enum ServerDetails {
         "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.3/glassfish-7.0.3.zip", // NOI18N
         "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.3/glassfish-7.0.3.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
+    ),
+
+    /**
+     * details for an instance of GlassFish Server 7.0.4
+     */
+    GLASSFISH_SERVER_7_0_4(NbBundle.getMessage(ServerDetails.class, "STR_704_SERVER_NAME", new Object[]{}), // NOI18N
+        "deployer:gfv700ee10", // NOI18N
+        704,
+        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.4/glassfish-7.0.4.zip", // NOI18N
+        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.4/glassfish-7.0.4.zip", // NOI18N
+        "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     );
 
     /**
@@ -345,6 +356,7 @@ public enum ServerDetails {
     public static WizardDescriptor.InstantiatingIterator
             getInstantiatingIterator() {
         return new ServerWizardIterator(new ServerDetails[]{
+                    GLASSFISH_SERVER_7_0_4,
                     GLASSFISH_SERVER_7_0_3,
                     GLASSFISH_SERVER_7_0_2,
                     GLASSFISH_SERVER_7_0_1,
@@ -372,6 +384,7 @@ public enum ServerDetails {
                     GLASSFISH_SERVER_3_0_1,
                     GLASSFISH_SERVER_3},
                 new ServerDetails[]{
+                    GLASSFISH_SERVER_7_0_4,
                     GLASSFISH_SERVER_7_0_3,
                     GLASSFISH_SERVER_7_0_2,
                     GLASSFISH_SERVER_7_0_1,
@@ -438,6 +451,7 @@ public enum ServerDetails {
                 case GF_7_0_1:   return GLASSFISH_SERVER_7_0_1.getVersion();
                 case GF_7_0_2:   return GLASSFISH_SERVER_7_0_2.getVersion();
                 case GF_7_0_3:   return GLASSFISH_SERVER_7_0_3.getVersion();
+                case GF_7_0_4:   return GLASSFISH_SERVER_7_0_4.getVersion();
                 default:         return -1;
             }
         }

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/AdminFactory.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/AdminFactory.java
@@ -96,6 +96,7 @@ public abstract class AdminFactory {
             case GF_7_0_1:
             case GF_7_0_2:
             case GF_7_0_3:
+            case GF_7_0_4:
                 return AdminFactoryRest.getInstance();
             // Anything else is not unknown.
             default:

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
@@ -104,7 +104,9 @@ public enum GlassFishVersion {
     /** GlassFish 7.0.2 */
     GF_7_0_2       ((short) 7, (short) 0, (short) 2, (short) 0, GlassFishVersion.GF_7_0_2_STR),
     /** GlassFish 7.0.3 */
-    GF_7_0_3       ((short) 7, (short) 0, (short) 3, (short) 0, GlassFishVersion.GF_7_0_3_STR);
+    GF_7_0_3       ((short) 7, (short) 0, (short) 3, (short) 0, GlassFishVersion.GF_7_0_3_STR),
+    /** GlassFish 7.0.4 */
+    GF_7_0_4       ((short) 7, (short) 0, (short) 4, (short) 0, GlassFishVersion.GF_7_0_4_STR);
     ////////////////////////////////////////////////////////////////////////////
     // Class attributes                                                       //
     ////////////////////////////////////////////////////////////////////////////
@@ -275,6 +277,11 @@ public enum GlassFishVersion {
     /** Additional {@code String} representations of GF_7_0_3 value. */
     static final String GF_7_0_3_STR_NEXT[] = {"7.0.3", "7.0.3.0"};
 
+    /** A {@code String} representation of GF_7_0_4 value. */
+    static final String GF_7_0_4_STR = "7.0.4";
+    /** Additional {@code String} representations of GF_7_0_4 value. */
+    static final String GF_7_0_4_STR_NEXT[] = {"7.0.4", "7.0.4.0"};
+
     /**
      * Stored <code>String</code> values for backward <code>String</code>
      * conversion.
@@ -315,6 +322,7 @@ public enum GlassFishVersion {
         initStringValuesMapFromArray(GF_7_0_1, GF_7_0_1_STR_NEXT);
         initStringValuesMapFromArray(GF_7_0_2, GF_7_0_2_STR_NEXT);
         initStringValuesMapFromArray(GF_7_0_3, GF_7_0_3_STR_NEXT);
+        initStringValuesMapFromArray(GF_7_0_4, GF_7_0_4_STR_NEXT);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/ConfigBuilderProvider.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/ConfigBuilderProvider.java
@@ -134,6 +134,11 @@ public class ConfigBuilderProvider {
             = new Config.Next(GlassFishVersion.GF_7_0_3,
                     ConfigBuilderProvider.class.getResource("GlassFishV7_0_1.xml"));
 
+    /** Library builder configuration since GlassFish 7.0.4. */
+    private static final Config.Next CONFIG_V7_0_4
+            = new Config.Next(GlassFishVersion.GF_7_0_4,
+                    ConfigBuilderProvider.class.getResource("GlassFishV7_0_1.xml"));
+
     /** Library builder configuration for GlassFish cloud. */
     private static final Config config
             = new Config(CONFIG_V3, CONFIG_V4, CONFIG_V4_1, CONFIG_V5, 
@@ -141,7 +146,7 @@ public class ConfigBuilderProvider {
                          CONFIG_V6_2_0, CONFIG_V6_2_1, CONFIG_V6_2_2, 
                          CONFIG_V6_2_3, CONFIG_V6_2_4, CONFIG_V6_2_5,
                          CONFIG_V7_0_0, CONFIG_V7_0_1, CONFIG_V7_0_2,
-                         CONFIG_V7_0_3);
+                         CONFIG_V7_0_3, CONFIG_V7_0_4);
 
     /** Builders array for each server instance. */
     private static final Map<GlassFishServer, ConfigBuilder> builders

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/utils/ServerUtils.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/utils/ServerUtils.java
@@ -206,7 +206,7 @@ public class ServerUtils {
     public static final String GF_JAVAHELP_JAR = "javahelp.jar";
 
     /** GlassFish Version class name (including package). */
-    private static String VERSION_CLASS = "com.sun.appserv.server.util.Version";
+    private static final String VERSION_CLASS = "com.sun.appserv.server.util.Version";
 
     /** GlassFish VerifierMain class name (including package). */
     public static String VERIFIER_MAIN_CLASS
@@ -216,8 +216,8 @@ public class ServerUtils {
      *  full version string. */
     private static String FULL_VERSION_PATTERN = "[0-9]+(\\.[0-9]+){1,3}";
 
-    /** GlassFish full version string getter method name. */
-    private static String FULL_VERSION_METHOD = "getFullVersion";
+    /** GlassFish version string getter method name. */
+    private static final String VERSION_METHOD = "getVersionNumber";
 
     /** GlassFish Basic Authorization user and password separator. */
     private static String AUTH_BASIC_FIELD_SEPARATPR = ":";
@@ -568,7 +568,7 @@ public class ServerUtils {
                 Class c = cl.loadClass(VERSION_CLASS);
                 // Try to get version from com.sun.appserv.server.util.Version.
                 try {
-                    Method mGetFullVersion = c.getMethod(FULL_VERSION_METHOD);
+                    Method mGetFullVersion = c.getMethod(VERSION_METHOD);
                     System.getProperties().put(GF_HOME_PROPERTY, serverHome);
                     String fullVersionString
                             = (String)mGetFullVersion.invoke(c);
@@ -581,13 +581,13 @@ public class ServerUtils {
                 } catch (IllegalAccessException | IllegalArgumentException
                         | InvocationTargetException | NoSuchMethodException
                         | SecurityException | NoClassDefFoundError ex) {
-                    Logger.log(Level.WARNING, "Cannot retrieve Glassfish version: "
-                            + commonUtilJar.getAbsolutePath() + ": ", ex);
+                    Logger.log(Level.WARNING, "Cannot retrieve Glassfish version from: "
+                            + commonUtilJar.getAbsolutePath() + ". "
+                            + "Using Manifest Bundle-Version as fallback option:", ex);
                 }
                 // Use Manifest Bundle-Version as fallback option.
                 if (version == null) {
-                    try {
-                        JarFile jar = new JarFile(commonUtilJar);
+                    try (JarFile jar = new JarFile(commonUtilJar)) {
                         Manifest manifest = jar.getManifest();
                         String versionString = getVersionString(manifest
                                 .getMainAttributes().getValue(BUNDLE_VERSION));
@@ -595,7 +595,7 @@ public class ServerUtils {
                             version = GlassFishVersion.toValue(versionString);
                         }
                     } catch (IOException ioe) {
-                        Logger.log(Level.WARNING, "Cannot retrieve Glassfish version: "
+                        Logger.log(Level.WARNING, "Cannot retrieve Glassfish version from Manifest: "
                             + commonUtilJar.getAbsolutePath() + ": ", ioe);
                     }
                 }

--- a/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/admin/AdminFactoryTest.java
+++ b/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/admin/AdminFactoryTest.java
@@ -168,7 +168,7 @@ public class AdminFactoryTest extends CommandTest {
     }
     
     /**
-     * Test factory functionality for GlassFish v. 7.0.3
+     * Test factory functionality for GlassFish v. 7.0.4
      * <p/>
      * Factory should initialize REST {@code Runner} and point it to
      * provided {@code Command} instance.
@@ -176,7 +176,7 @@ public class AdminFactoryTest extends CommandTest {
     @Test
     public void testGetInstanceforVersionGF7() {
         GlassFishServerEntity srv = new GlassFishServerEntity();
-        srv.setVersion(GlassFishVersion.GF_7_0_3);
+        srv.setVersion(GlassFishVersion.GF_7_0_4);
         AdminFactory af = AdminFactory.getInstance(srv.getVersion());
         assertTrue(af instanceof AdminFactoryRest);
         Command cmd = new CommandVersion();

--- a/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersionTest.java
+++ b/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersionTest.java
@@ -105,6 +105,8 @@ public class GlassFishVersionTest {
                 GlassFishVersion.GF_7_0_2_STR_NEXT);
         verifyToValueFromAdditionalArray(GlassFishVersion.GF_7_0_3,
                 GlassFishVersion.GF_7_0_3_STR_NEXT);
+        verifyToValueFromAdditionalArray(GlassFishVersion.GF_7_0_4,
+                GlassFishVersion.GF_7_0_4_STR_NEXT);
     }
 
     /**
@@ -127,7 +129,8 @@ public class GlassFishVersionTest {
             GlassFishVersion.GF_6_2_2, GlassFishVersion.GF_6_2_3,
             GlassFishVersion.GF_6_2_4, GlassFishVersion.GF_6_2_5,
             GlassFishVersion.GF_7_0_0, GlassFishVersion.GF_7_0_1,
-            GlassFishVersion.GF_7_0_2, GlassFishVersion.GF_7_0_3
+            GlassFishVersion.GF_7_0_2, GlassFishVersion.GF_7_0_3,
+            GlassFishVersion.GF_7_0_4
         };
         String strings[] = {
             "1.0.1.4", "2.0.1.5", "2.1.0.3", "2.1.1.7",
@@ -137,7 +140,7 @@ public class GlassFishVersionTest {
             "5.0.1.0", "5.1.0.0", "6.0.0.0", "6.1.0.0",
             "6.2.0.0", "6.2.1.0", "6.2.2.0", "6.2.3.0",
             "6.2.4.0", "6.2.5.0", "7.0.0.0", "7.0.1.0",
-            "7.0.2.0", "7.0.3.0"
+            "7.0.2.0", "7.0.3.0", "7.0.4.0"
         };
         for (int i = 0; i < versions.length; i++) {
             GlassFishVersion version = GlassFishVersion.toValue(strings[i]);

--- a/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/utils/EnumUtilsTest.java
+++ b/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/utils/EnumUtilsTest.java
@@ -21,7 +21,7 @@ package org.netbeans.modules.glassfish.tooling.utils;
 import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_3;
 import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_4;
 import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_6_2_5;
-import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_7_0_3;
+import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_7_0_4;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
@@ -47,8 +47,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testEq() {
-        assertFalse(EnumUtils.eq(GF_7_0_3, GF_6_2_5), "Equals for a > b shall be false.");
-        assertTrue(EnumUtils.eq(GF_7_0_3, GF_7_0_3), "Equals for a == b shall be true.");
+        assertFalse(EnumUtils.eq(GF_7_0_4, GF_6_2_5), "Equals for a > b shall be false.");
+        assertTrue(EnumUtils.eq(GF_7_0_4, GF_7_0_4), "Equals for a == b shall be true.");
         assertFalse(EnumUtils.eq(GF_4, GF_3), "Equals for a > b shall be false.");
         assertTrue(EnumUtils.eq(GF_4, GF_4), "Equals for a == b shall be true.");
         assertFalse(EnumUtils.eq(GF_3, GF_4), "Equals for a < b shall be false.");
@@ -69,8 +69,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testNe() {
-        assertTrue(EnumUtils.ne(GF_7_0_3, GF_6_2_5), "Not equals for a > b shall be true.");
-        assertFalse(EnumUtils.ne(GF_7_0_3, GF_7_0_3), "Not equals for a == b shall be false.");
+        assertTrue(EnumUtils.ne(GF_7_0_4, GF_6_2_5), "Not equals for a > b shall be true.");
+        assertFalse(EnumUtils.ne(GF_7_0_4, GF_7_0_4), "Not equals for a == b shall be false.");
         assertTrue(EnumUtils.ne(GF_4, GF_3), "Not equals for a > b shall be true.");
         assertFalse(EnumUtils.ne(GF_4, GF_4), "Not equals for a == b shall be false.");
         assertTrue(EnumUtils.ne(GF_3, GF_4), "Not equals for a < b shall be true.");
@@ -91,8 +91,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testLt() {
-        assertFalse(EnumUtils.lt(GF_7_0_3, GF_6_2_5), "Less than for a > b shall be false.");
-        assertFalse(EnumUtils.lt(GF_7_0_3, GF_7_0_3), "Less than for a == b shall be false.");
+        assertFalse(EnumUtils.lt(GF_7_0_4, GF_6_2_5), "Less than for a > b shall be false.");
+        assertFalse(EnumUtils.lt(GF_7_0_4, GF_7_0_4), "Less than for a == b shall be false.");
         assertFalse(EnumUtils.lt(GF_4, GF_3), "Less than for a > b shall be false.");
         assertFalse(EnumUtils.lt(GF_4, GF_4), "Less than for a == b shall be false.");
         assertTrue(EnumUtils.lt(GF_3, GF_4), "Less than for a < b shall be true.");
@@ -113,8 +113,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testLe() {
-        assertFalse(EnumUtils.le(GF_7_0_3, GF_6_2_5), "Less than or equal for a > b shall be false.");
-        assertTrue(EnumUtils.le(GF_7_0_3, GF_7_0_3), "Less than or equal for a == b shall be true.");
+        assertFalse(EnumUtils.le(GF_7_0_4, GF_6_2_5), "Less than or equal for a > b shall be false.");
+        assertTrue(EnumUtils.le(GF_7_0_4, GF_7_0_4), "Less than or equal for a == b shall be true.");
         assertFalse(EnumUtils.le(GF_4, GF_3), "Less than or equal for a > b shall be false.");
         assertTrue(EnumUtils.le(GF_4, GF_4), "Less than or equal for a == b shall be true.");
         assertTrue(EnumUtils.le(GF_3, GF_4), "Less than or equal for a < b shall be true.");
@@ -135,8 +135,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testGt() {
-        assertTrue(EnumUtils.gt(GF_7_0_3, GF_6_2_5), "Greater than for a > b shall be true.");
-        assertFalse(EnumUtils.gt(GF_7_0_3, GF_7_0_3), "Greater than for a == b shall be false.");
+        assertTrue(EnumUtils.gt(GF_7_0_4, GF_6_2_5), "Greater than for a > b shall be true.");
+        assertFalse(EnumUtils.gt(GF_7_0_4, GF_7_0_4), "Greater than for a == b shall be false.");
         assertTrue(EnumUtils.gt(GF_4, GF_3), "Greater than for a > b shall be true.");
         assertFalse(EnumUtils.gt(GF_4, GF_4), "Greater than for a == b shall be false.");
         assertFalse(EnumUtils.gt(GF_3, GF_4), "Greater than for a < b shall be false.");
@@ -157,8 +157,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testGe() {
-        assertTrue(EnumUtils.ge(GF_7_0_3, GF_6_2_5), "Greater than or equal for a > b shall be true.");
-        assertTrue(EnumUtils.ge(GF_7_0_3, GF_7_0_3), "Greater than or equal for a == b shall be true.");
+        assertTrue(EnumUtils.ge(GF_7_0_4, GF_6_2_5), "Greater than or equal for a > b shall be true.");
+        assertTrue(EnumUtils.ge(GF_7_0_4, GF_7_0_4), "Greater than or equal for a == b shall be true.");
         assertTrue(EnumUtils.ge(GF_4, GF_3), "Greater than or equal for a > b shall be true.");
         assertTrue(EnumUtils.ge(GF_4, GF_4), "Greater than or equal for a == b shall be true.");
         assertFalse(EnumUtils.ge(GF_3, GF_4), "Greater than or equal for a < b shall be false.");


### PR DESCRIPTION
- This is mainly a maintenance release that contains bug fixes and updates of various components.
- Bump the GlassFish version in some tests
- Change method name that retrieve the version from the common-util.jar, from `getFullVersion` to `getVersionNumber`, method `getFullVersion` was removed since GlassFish version 6.1.0. This change will break the method detection for GlassFish 3.x.y but the Manifest fallback option to retrieve the GlassFish version still work for all versions. This change will remove an annoying warning.

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of unit tests for modules glassfish.common, glassfish.javaee, glassfish.tooling and glassfish.eecommon
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Successfully register GlassFish 7.0.4, create a web app and verify that it works.
- Successfully register GlassFish versions from 4 to 7.0.4 and verify that the version was retrieved by the `getVersionNumber` method and for version 3.1.2 the Manifest fallback option was used.
