### PR TITLE
bump delete-artifact action to v2 to be node 16 compatible.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 /*/build/
-/*/nbproject/private/
-/*/*/nbproject/private/
+**/nbproject/private/
 /*/*/build/
 /*/*/dist/
-/*/*/*/nbproject/private/
 /*/*/*/build/
 /*/*/*/dist/
 /*/external/*.zip
@@ -35,7 +33,6 @@
 /nbbuild/netbeansrelease.json
 /nbi/engine/native/*/*/dist/
 /nb-javac/
-/java.source.nbjavac/test/test-nb-javac/nbproject/private/
 /java/java.lsp.server/vscode/.vscode-test/
 /harness/apisupport.harness/windows-launcher-src/*.exe
 /harness/apisupport.harness/windows-launcher-src/*.res
@@ -49,13 +46,10 @@
 # Various files that may be generated if the launcher projects are opened in NetBeans 8.2.
 /harness/apisupport.harness/windows-launcher-src/nbproject/Makefile-*.mk
 /harness/apisupport.harness/windows-launcher-src/nbproject/Package-*.bash
-/harness/apisupport.harness/windows-launcher-src/nbproject/private/
 /nb/ide.launcher/windows/nbproject/Makefile-*.mk
 /nb/ide.launcher/windows/nbproject/Package-*.bash
-/nb/ide.launcher/windows/nbproject/private/
 /platform/o.n.bootstrap/launcher/windows/nbproject/Makefile-*.mk
 /platform/o.n.bootstrap/launcher/windows/nbproject/Package-*.bash
-/platform/o.n.bootstrap/launcher/windows/nbproject/private/
 
 # Database logs
 derby.log
@@ -78,16 +72,10 @@ derby.log
 /websvccommon/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/jaxb/
 /websvccommon/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/oauth/
 /websvccommon/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wadl/
-/javafx2.samples/FXML-LoginDemo/nbproject/private/
 
 # OS generated files - test related #
 #####################################
-/debugger.jpda.ui/test/qa-functional/data/debugTestProject/nbproject/private/
-/debugger.jpda.ui/test/qa-functional/data/debugTestProjectAnt/nbproject/private/
 /platform/o.n.bootstrap/test/unit/data/jars
-/xml/test/qa-functional/data/DTDActionsTestProject/nbproject/private/
-/xml/test/qa-functional/data/ActionsTestProject/nbproject/private/
-/xml/test/qa-functional/data/CoreTemplatesTestProject/nbproject/private/
 
 # Snapcraft Generated files #
 #######################


### PR DESCRIPTION
github will switch everything to Node 16 on the 18th of May:
https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/

[delete-artifact](https://github.com/GeekyEggo/delete-artifact) is the last remaining action which we haven't updated yet. We access the action via a git submodule since it is third-party. Other actions were bumped in #4770 and #5376

 + this PR moves the delete-artifact submodule to the [v2.0.0 tag](https://github.com/GeekyEggo/delete-artifact/releases/tag/v2.0.0)
 + bonus: updated git ignore to ignore all private folders by default


after that we shouldn't see any warnings of this kind anymore:

```
Cleanup Workflow Artifacts
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: ./.github/actions/delete-artifact/. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```