### PR TITLE
fail proxy pac on windows if no URL

### DIFF
--- a/platform/core.network/src/org/netbeans/core/network/proxy/ProxyAutoConfig.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/ProxyAutoConfig.java
@@ -96,6 +96,9 @@ public class ProxyAutoConfig {
             } catch (MalformedURLException ex) {
                 LOGGER.log(Level.INFO, "PAC URL is malformed : ", ex);
                 return;
+            } catch (UnknownHostException ex) {
+                LOGGER.log(Level.INFO, "PAC script {0} unavailable, proxy disabled", pacURI);
+                return;
             } catch (IOException ex) {
                 LOGGER.log(Level.INFO, "InputStream for " + pacURI + " throws ", ex);
                 return;


### PR DESCRIPTION
This is a "fix" to get rid of an annoying exception thrown on every launchd as info during windows autoproxy.
I'm not sure this is right approach but "to me" as no URL are set I don't get why it should use http://wdap/wdap.dat.
So exiting early.

That the exception scaring user :p :
INFO [org.netbeans.core.network.proxy.ProxyAutoConfig]: InputStream for http://wpad/wpad.dat throws 
java.net.UnknownHostException: wpad
	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:567)
	at java.base/java.net.Socket.connect(Socket.java:633)
	at java.base/java.net.Socket.connect(Socket.java:583)
	at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:183)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:531)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:636)
	at java.base/sun.net.www.http.HttpClient.<init>(HttpClient.java:279)
	at java.base/sun.net.www.http.HttpClient.New(HttpClient.java:384)
	at java.base/sun.net.www.http.HttpClient.New(HttpClient.java:406)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1309)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1287)
	at java.base/sun.net.www.protocol.http.HttpURLConnection$6.run(HttpURLConnection.java:1118)
	at java.base/sun.net.www.protocol.http.HttpURLConnection$6.run(HttpURLConnection.java:1116)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.base/java.security.AccessController.doPrivilegedWithCombiner(AccessController.java:962)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1115)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:1057)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1665)
	at java.base/sun.net.www.protocol.http.HttpURLConnection$9.run(HttpURLConnection.java:1581)
	at java.base/sun.net.www.protocol.http.HttpURLConnection$9.run(HttpURLConnection.java:1579)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.base/java.security.AccessController.doPrivilegedWithCombiner(AccessController.java:962)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1578)
	at org.netbeans.core.network.proxy.ProxyAutoConfig.downloadPAC(ProxyAutoConfig.java:155)
[catch] at org.netbeans.core.network.proxy.ProxyAutoConfig.initEngine(ProxyAutoConfig.java:94)
	at org.netbeans.core.network.proxy.ProxyAutoConfig$1.run(ProxyAutoConfig.java:82)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)
