### PR TITLE
[JS] Fix handling of class constructor in classes in anonymous functions 

### DIFF
--- a/webcommon/javascript2.model/nbproject/project.xml
+++ b/webcommon/javascript2.model/nbproject/project.xml
@@ -49,7 +49,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>3</release-version>
-                        <specification-version>3.0</specification-version>
+                        <specification-version>3.2</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -920,7 +920,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
 
     @Override
     public boolean enterFunctionNode(FunctionNode functionNode) {
-        if (functionNode.isClassConstructor() && !(ModelUtils.CONSTRUCTOR.equals(functionNode.getName()) || functionNode.getName().startsWith(ModelUtils.CONSTRUCTOR))) {
+        if (isArtificialConstructor(functionNode)) {
             // don't process artificail constructors.
             return false;
         }
@@ -1023,6 +1023,18 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
         }
         removeFromPathTheLast();
         return false;
+    }
+
+    /**
+     * The parse tree for classes holds constructors for all classes. For the
+     * structure scanner it is relevent to detect whether or not this
+     * constructor is generated or defined
+     *
+     * @param functionNode to check
+     * @return true if functionNode is detected to be generated
+     */
+    private static boolean isArtificialConstructor(FunctionNode functionNode) {
+        return functionNode.isClassConstructor() && functionNode.isGenerated();
     }
 
     private void correctNameAndOffsets(JsFunctionImpl jsFunction, FunctionNode fn) {
@@ -1482,7 +1494,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
         }
     }
 
-    private void  processDeclarations(final JsFunctionImpl parentFn, final FunctionNode inNode) {
+    private void processDeclarations(final JsFunctionImpl parentFn, final FunctionNode inNode) {
         LOGGER.log(Level.FINEST, "in function: {0}, ident: {1}", new Object[]{inNode.getName(), inNode.getIdent()});
         final JsDocumentationHolder docHolder = JsDocumentationSupport.getDocumentationHolder(parserResult);
 
@@ -1601,7 +1613,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
         LOGGER.log(Level.FINEST, "       function: {0}", debugInfo(fnNode)); // NOI18N
         String name = fnNode.isAnonymous() ? modelBuilder.getFunctionName(fnNode) : fnNode.getIdent().getName();
         Identifier fnName = new Identifier(name, new OffsetRange(fnNode.getIdent().getStart(), fnNode.getIdent().getFinish()));
-        if (fnNode.isClassConstructor() && !ModelUtils.CONSTRUCTOR.equals(fnName.getName())) {
+        if (isArtificialConstructor(fnNode)) {
             // skip artifical/ syntetic constructor nodes, that are created
             // when a class extends different class
             return;

--- a/webcommon/javascript2.model/test/unit/data/testfiles/model/classConstructor.js
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/model/classConstructor.js
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function () {
+    class ClassInAnonymousFunction {
+        constructor(x, y) {
+            console.log(x, y);
+        }
+    }
+}
+)();
+
+class ClassInProgrammScope {
+    constructor(x, y) {
+        console.log(x, y);
+    }
+}
+
+class ClassInProgrammScope2 extends ClassInProgrammScope {
+    constructor(x) {
+        super(x, 2);
+        console.log(x);
+    }
+}
+
+class WithoutConstructor {
+    
+}

--- a/webcommon/javascript2.model/test/unit/data/testfiles/model/classConstructor.js.model
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/model/classConstructor.js.model
@@ -1,0 +1,51 @@
+FUNCTION classConstructor [ANONYMOUS: false, DECLARED: true - classConstructor, MODIFIERS: PUBLIC, FILE]
+# RETURN TYPES
+undefined, RESOLVED: true
+# PROPERTIES
+ClassInProgrammScope  : OBJECT ClassInProgrammScope [ANONYMOUS: false, DECLARED: true - ClassInProgrammScope, MODIFIERS: PUBLIC, CLASS]
+                      # PROPERTIES
+                      constructor : FUNCTION constructor [ANONYMOUS: false, DECLARED: true - constructor, MODIFIERS: PUBLIC, CONSTRUCTOR]
+                                  # RETURN TYPES
+                                  ClassInProgrammScope, RESOLVED: true
+                                  # PARAMETERS
+                                  OBJECT x [ANONYMOUS: false, DECLARED: true - x, MODIFIERS: PUBLIC, PARAMETER]
+                                  OBJECT y [ANONYMOUS: false, DECLARED: true - y, MODIFIERS: PUBLIC, PARAMETER]
+                                  # PROPERTIES
+                                  arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+ClassInProgrammScope2 : OBJECT ClassInProgrammScope2 [ANONYMOUS: false, DECLARED: true - ClassInProgrammScope2, MODIFIERS: PUBLIC, CLASS]
+                      # PROPERTIES
+                      constructor : FUNCTION constructor [ANONYMOUS: false, DECLARED: true - constructor, MODIFIERS: PUBLIC, CONSTRUCTOR]
+                                  # RETURN TYPES
+                                  ClassInProgrammScope2, RESOLVED: true
+                                  # PARAMETERS
+                                  OBJECT x [ANONYMOUS: false, DECLARED: true - x, MODIFIERS: PUBLIC, PARAMETER]
+                                  # PROPERTIES
+                                  arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+                      prototype   : OBJECT prototype [ANONYMOUS: false, DECLARED: true, MODIFIERS: PUBLIC, OBJECT]
+WithoutConstructor    : OBJECT WithoutConstructor [ANONYMOUS: false, DECLARED: true - WithoutConstructor, MODIFIERS: PUBLIC, CLASS]
+classConstructorL#20  : FUNCTION classConstructorL#20 [ANONYMOUS: true, DECLARED: true - classConstructorL#20, MODIFIERS: PUBLIC, FUNCTION]
+                      # RETURN TYPES
+                      undefined, RESOLVED: true
+                      # PROPERTIES
+                      ClassInAnonymousFunction : OBJECT ClassInAnonymousFunction [ANONYMOUS: false, DECLARED: true - ClassInAnonymousFunction, MODIFIERS: PUBLIC, CLASS]
+                                               # PROPERTIES
+                                               constructor : FUNCTION constructor [ANONYMOUS: false, DECLARED: true - constructor, MODIFIERS: PUBLIC, CONSTRUCTOR]
+                                                           # RETURN TYPES
+                                                           classConstructorL#20.ClassInAnonymousFunction, RESOLVED: true
+                                                           # PARAMETERS
+                                                           OBJECT x [ANONYMOUS: false, DECLARED: true - x, MODIFIERS: PUBLIC, PARAMETER]
+                                                           OBJECT y [ANONYMOUS: false, DECLARED: true - y, MODIFIERS: PUBLIC, PARAMETER]
+                                                           # PROPERTIES
+                                                           arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+                      arguments                : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+console               : OBJECT console [ANONYMOUS: false, DECLARED: false - console, MODIFIERS: PUBLIC, OBJECT]
+                      # PROPERTIES
+                      log : FUNCTION log [ANONYMOUS: false, DECLARED: false - log, MODIFIERS: PUBLIC, METHOD]
+                          # PARAMETERS
+                          OBJECT param1 [ANONYMOUS: false, DECLARED: true - param1, MODIFIERS: PUBLIC, PARAMETER]
+                          OBJECT param2 [ANONYMOUS: false, DECLARED: true - param2, MODIFIERS: PUBLIC, PARAMETER]
+                          # PROPERTIES
+                          arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+super                 : FUNCTION super [ANONYMOUS: false, DECLARED: false - super, MODIFIERS: PUBLIC, FUNCTION]
+                      # PROPERTIES
+                      arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]

--- a/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
+++ b/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
@@ -294,4 +294,8 @@ public class ModelTest extends ModelTestBase {
     public void testObjectNameMatchingNestedFunction() throws Exception {
         checkModel("testfiles/model/objectNameMatchingNestedFunction.js");
     }
+
+    public void testClassConstructor() throws Exception {
+        checkModel("testfiles/model/classConstructor.js");
+    }
 }

--- a/webcommon/libs.nashorn/manifest.mf
+++ b/webcommon/libs.nashorn/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.libs.nashorn/3
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/nashorn/Bundle.properties
-OpenIDE-Module-Specification-Version: 3.1
+OpenIDE-Module-Specification-Version: 3.2

--- a/webcommon/libs.nashorn/src/com/oracle/js/parser/Parser.java
+++ b/webcommon/libs.nashorn/src/com/oracle/js/parser/Parser.java
@@ -1412,6 +1412,7 @@ loop:
 
         function.setFlag(FunctionNode.IS_METHOD);
         function.setFlag(FunctionNode.IS_CLASS_CONSTRUCTOR);
+        function.setFlag(FunctionNode.IS_GENERATED);
         if (subclass) {
             function.setFlag(FunctionNode.IS_SUBCLASS_CONSTRUCTOR);
             function.setFlag(FunctionNode.HAS_DIRECT_SUPER);

--- a/webcommon/libs.nashorn/src/com/oracle/js/parser/ir/FunctionNode.java
+++ b/webcommon/libs.nashorn/src/com/oracle/js/parser/ir/FunctionNode.java
@@ -173,6 +173,9 @@ public final class FunctionNode extends LexicalContextExpression implements Flag
     /** Does this function have nested declarations? */
     public static final int HAS_FUNCTION_DECLARATIONS = 1 << 10;
 
+    /** The function entry is generated (for example default constructor) */
+    public static final int IS_GENERATED = 1 << 11;
+
     /** Are we vararg, but do we just pass the arguments along to apply or call */
     public static final int HAS_APPLY_TO_CALL_SPECIALIZATION = 1 << 12;
 
@@ -779,5 +782,9 @@ public final class FunctionNode extends LexicalContextExpression implements Flag
 
     public boolean isAsync() {
         return getFlag(IS_ASYNC);
+    }
+
+    public boolean isGenerated() {
+        return getFlag(IS_GENERATED);
     }
 }

--- a/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/DumpingVisitor.java
+++ b/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/DumpingVisitor.java
@@ -93,7 +93,9 @@ class DumpingVisitor extends NodeVisitor {
             System.out.println(indent() + node.getClass().getName() + " [" + cn.isOptional() + "]");
         } else if (node instanceof PropertyNode) {
             PropertyNode pn = (PropertyNode) node;
-            System.out.println(indent() + node.getClass().getName() + " [static=" + pn.isStatic() + "]");
+            System.out.printf("%s%s [%d-%d, static=%b]%n", indent(),
+                    node.getClass().getName(), node.getStart(),
+                    node.getFinish(), pn.isStatic());
         } else if (node instanceof JsxElementNode) {
             JsxElementNode jen = (JsxElementNode) node;
             System.out.printf("%s%s [%d-%d, name=%s]%n", indent(),


### PR DESCRIPTION
Before this fix, constructors in classes declared in anonymous
functions were not correctly handled as functions:

![image](https://github.com/apache/netbeans/assets/2179736/ab4c9296-b872-4395-8bd4-1ba4045b08fe)

One noticeable problem was, that the parameters were reported as
unused, although being accessed in the constructor.