### PR TITLE
Navigator Support for HCL Files

### DIFF
--- a/ide/languages.hcl/build.xml
+++ b/ide/languages.hcl/build.xml
@@ -40,7 +40,6 @@
             <arg value="org.netbeans.modules.languages.hcl.grammar"/>
             <arg value="HCLLexer.g4"/>
             <arg value="TerraformLexer.g4"/>
-            <arg value="HCLExpressionParser.g4"/>
             <arg value="HCLParser.g4"/>
         </java>
 

--- a/ide/languages.hcl/nbproject/project.xml
+++ b/ide/languages.hcl/nbproject/project.xml
@@ -251,7 +251,49 @@
                         <code-name-base>org.netbeans.libs.junit4</code-name-base>
                         <compile-dependency/>
                     </test-dependency>
-                </test-type>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.csl.api</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.editor.mimelookup</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.editor.mimelookup.impl</code-name-base>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.editor.util</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.lexer</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.masterfs</code-name-base>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.parsing.nb</code-name-base>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.openide.util.lookup</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+            </test-type>
             </test-dependencies>
             <public-packages/>
         </data>

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/BasicHCLLexer.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/BasicHCLLexer.java
@@ -106,7 +106,7 @@ public final class BasicHCLLexer extends AbstractHCLLexer {
                 return groupToken(INTERPOLATION, INTERPOLATION_CONTENT);
 
             case TEMPLATE_CONTENT:
-                return groupToken(ERROR, TEMPLATE_CONTENT);
+                return groupToken(INTERPOLATION, TEMPLATE_CONTENT);
             case WS:
             case NL:
                 return token(WHITESPACE);

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/HCLParserResult.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/HCLParserResult.java
@@ -118,6 +118,14 @@ public class HCLParserResult  extends ParserResult {
         return errors;
     }
 
+    public final HCLDocument getDocument() {
+        return document;
+    }
+
+    public final SourceRef getReferences() {
+        return references;
+    }
+
     @Override
     protected void invalidate() {
     }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/HCLParserResult.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/HCLParserResult.java
@@ -40,6 +40,7 @@ import org.netbeans.modules.csl.spi.DefaultError;
 import org.netbeans.modules.csl.spi.ParserResult;
 import org.netbeans.modules.languages.hcl.ast.ASTBuilderListener;
 import org.netbeans.modules.languages.hcl.ast.HCLDocument;
+import org.netbeans.modules.languages.hcl.ast.SourceRef;
 import org.netbeans.modules.languages.hcl.grammar.HCLLexer;
 import org.netbeans.modules.languages.hcl.grammar.HCLParser;
 import org.netbeans.modules.languages.hcl.grammar.HCLParserBaseListener;
@@ -59,6 +60,7 @@ public class HCLParserResult  extends ParserResult {
     public final Map<String,List<OffsetRange>> folds = new HashMap<>();
 
     private HCLDocument document;
+    private SourceRef references;
 
     public HCLParserResult(Snapshot snapshot) {
         super(snapshot);
@@ -84,7 +86,7 @@ public class HCLParserResult  extends ParserResult {
             lexer.reset();
             
         }
-        processDocument(document);
+        processDocument(document, references);
 
         finished = true;
     }
@@ -126,13 +128,14 @@ public class HCLParserResult  extends ParserResult {
 
         parser.addParseListener(createFoldListener());
 
-        ASTBuilderListener astListener = new ASTBuilderListener();
+        ASTBuilderListener astListener = new ASTBuilderListener(getSnapshot());
         parser.addParseListener(astListener);
 
         document = astListener.getDocument();
+        references = astListener.getReferences();
     }
 
-    protected void processDocument(HCLDocument doc) {
+    protected void processDocument(HCLDocument doc, SourceRef references) {
     }
 
     private void addFold(FoldType ft, Token token) {

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/HCLStructureItem.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/HCLStructureItem.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.languages.hcl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.swing.ImageIcon;
+import org.netbeans.modules.csl.api.ElementHandle;
+import org.netbeans.modules.csl.api.ElementKind;
+import org.netbeans.modules.csl.api.HtmlFormatter;
+import org.netbeans.modules.csl.api.Modifier;
+import org.netbeans.modules.csl.api.OffsetRange;
+import org.netbeans.modules.csl.api.StructureItem;
+import org.netbeans.modules.csl.spi.ParserResult;
+import org.netbeans.modules.languages.hcl.ast.HCLAttribute;
+import org.netbeans.modules.languages.hcl.ast.HCLBlock;
+import org.netbeans.modules.languages.hcl.ast.HCLContainer;
+import org.netbeans.modules.languages.hcl.ast.HCLElement;
+import org.netbeans.modules.languages.hcl.ast.SourceRef;
+import org.openide.filesystems.FileObject;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class HCLStructureItem implements ElementHandle, StructureItem {
+
+    final HCLElement element;
+    final SourceRef references;
+
+    public HCLStructureItem(HCLElement element, SourceRef references) {
+        this.element = element;
+        this.references = references;
+    }
+
+    @Override
+    public FileObject getFileObject() {
+        return references.getFileObject();
+    }
+
+    @Override
+    public String getMimeType() {
+        return getFileObject().getMIMEType();
+    }
+
+    @Override
+    public String getName() {
+        return element.id();
+    }
+
+    @Override
+    public String getIn() {
+        return null;
+    }
+
+
+    @Override
+    public Set<Modifier> getModifiers() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public boolean signatureEquals(ElementHandle handle) {
+        return false;
+    }
+
+    @Override
+    public OffsetRange getOffsetRange(ParserResult result) {
+        Optional<OffsetRange> range = references.getOffsetRange(element);
+        return range.isPresent() ? range.get(): OffsetRange.NONE;
+    }
+
+    @Override
+    public String getSortText() {
+        return getName();
+    }
+
+    @Override
+    public String getHtml(HtmlFormatter formatter) {
+        return getName();
+    }
+
+    @Override
+    public ElementHandle getElementHandle() {
+        return this;
+    }
+
+    @Override
+    public boolean isLeaf() {
+        return element instanceof HCLAttribute;
+    }
+
+    @Override
+    public List<? extends StructureItem> getNestedItems() {
+        if (element instanceof HCLContainer) {
+            HCLContainer c = (HCLContainer) element;
+            List<HCLStructureItem> nested = new ArrayList<>();
+            for (HCLBlock block : c.getBlocks()) {
+                nested.add(new HCLStructureItem(block, references));
+            }
+            for (HCLAttribute attribute : c.getAttributes()) {
+                nested.add(new HCLStructureItem(attribute, references));
+            }
+            return nested;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public long getPosition() {
+        return getOffsetRange(null).getStart();
+    }
+
+    @Override
+    public long getEndPosition() {
+        return getOffsetRange(null).getEnd();
+    }
+
+    @Override
+    public ImageIcon getCustomIcon() {
+        return null;
+    }
+
+    @Override
+    public ElementKind getKind() {
+        return element instanceof HCLAttribute ? ElementKind.ATTRIBUTE : ElementKind.TAG;
+    }
+
+    
+}

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/HCLStructureItem.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/HCLStructureItem.java
@@ -120,7 +120,7 @@ public class HCLStructureItem implements ElementHandle, StructureItem {
                 for (HCLAttribute attribute : c.getAttributes()) {
                     nested.add(new HCLStructureItem(attribute, references));
                 }
-                nestedCache = Collections.unmodifiableList(nested);
+                nestedCache = nested;
             } else {
                 nestedCache = Collections.emptyList();
             }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/HCLStructureScanner.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/HCLStructureScanner.java
@@ -18,28 +18,25 @@
  */
 package org.netbeans.modules.languages.hcl;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.netbeans.api.editor.fold.FoldType;
-import org.netbeans.api.editor.mimelookup.MimeRegistration;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.csl.api.StructureItem;
 import org.netbeans.modules.csl.api.StructureScanner;
 import org.netbeans.modules.csl.spi.ParserResult;
-import org.netbeans.modules.languages.hcl.HCLParserResult;
-import org.netbeans.spi.editor.fold.FoldTypeProvider;
 
 /**
  *
  * @author Laszlo Kishalmi
  */
-public class HCLStructureScanner implements StructureScanner{
+public class HCLStructureScanner implements StructureScanner {
     @Override
     public List<? extends StructureItem> scan(ParserResult info) {
-        return Collections.emptyList();
+        HCLParserResult hclInfo = (HCLParserResult) info;
+
+        HCLStructureItem root = new HCLStructureItem(hclInfo.getDocument(), hclInfo.getReferences());
+        return root.getNestedItems();
     }
 
     @Override

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/ASTBuilderListener.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/ASTBuilderListener.java
@@ -92,7 +92,7 @@ public class ASTBuilderListener extends HCLParserBaseListener {
             HCLAttribute attr = new HCLAttribute(current);
             attr.name = new HCLIdentifier.SimpleId(attr, actx.IDENTIFIER().getText());
             addReference(attr.name, actx.IDENTIFIER().getSymbol());
-            addReference(attr, ctx);
+            addReference(attr, actx);
             current.add(attr);
         }
     }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/ASTBuilderListener.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/ASTBuilderListener.java
@@ -19,11 +19,12 @@
 package org.netbeans.modules.languages.hcl.ast;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.netbeans.modules.languages.hcl.grammar.HCLParser;
 import org.netbeans.modules.languages.hcl.grammar.HCLParserBaseListener;
+import org.netbeans.modules.parsing.api.Snapshot;
 
 /**
  *
@@ -32,48 +33,72 @@ import org.netbeans.modules.languages.hcl.grammar.HCLParserBaseListener;
 public class ASTBuilderListener extends HCLParserBaseListener {
 
     final HCLDocument document = new HCLDocument();
+    final SourceRef references;
+
+    private HCLContainer current = document;
+    
+    public ASTBuilderListener(Snapshot source) {
+        this.references = new SourceRef(source);
+    }
 
     public HCLDocument getDocument() {
         return document;
     }
 
-    int blockDepth = 0;
+    public SourceRef getReferences() {
+        return references;
+    }
+
+    
+    private void addReference(HCLElement e, Token token) {
+        references.add(e, token.getStartIndex(), token.getStopIndex() + 1);
+    }
+
+    private void addReference(HCLElement e, ParserRuleContext ctx) {
+        
+        references.add(e, ctx.start.getStartIndex(), ctx.stop.getStopIndex() + 1);
+    }
+
 
     @Override
     public void exitBlock(HCLParser.BlockContext ctx) {
-        if (blockDepth == 1) {
-            ArrayList<HCLIdentifier> decl = new ArrayList<>(4);
-            for (TerminalNode idn : ctx.IDENTIFIER()) {
-                Token token = idn.getSymbol();
-                SourceRef src = new SourceRef(null, token.getStartIndex(), token.getStopIndex());
-                HCLIdentifier id = new HCLIdentifier.SimpleId(src, token.getText());
-                decl.add(id);
-            }
-            for (HCLParser.StringLitContext idn : ctx.stringLit()) {
-                String sid = idn.getText();
-                sid = sid.substring(1, sid.length() - (sid.endsWith("\"") ? 1 : 0));
-                SourceRef src = new SourceRef(null, idn.getStart().getStartIndex(), idn.getStop().getStopIndex());
-                /*
-                StringBuilder sb = new StringBuilder(idn.getStop().getStopIndex() - idn.getStart().getStartIndex());
-                for (HCLParser.StringContentContext scontent : idn.stringContent()) {
-                    for (TerminalNode tn : scontent.STRING_CONTENT()) {
-                        sb.append(tn.getText());
-                    }
-                }
-                HCLIdentifier id = new HCLIdentifier.StringId(src, sb.toString());
-                */
-                HCLIdentifier id = new HCLIdentifier.StringId(src, sid);
-                decl.add(id);
-            }
-            Collections.sort(decl, HCLElement.SOURCE_ORDER);
-            document.add(new HCLBlock(decl));
+        HCLBlock block = (HCLBlock) current;
+
+        ArrayList<HCLIdentifier> decl = new ArrayList<>(4);
+
+        for (TerminalNode idn : ctx.IDENTIFIER()) {
+            Token token = idn.getSymbol();
+            HCLIdentifier id = new HCLIdentifier.SimpleId(block, token.getText());
+            addReference(id, token);
+            decl.add(id);
         }
-        blockDepth--;
+        for (HCLParser.StringLitContext idn : ctx.stringLit()) {
+            String sid = idn.getText();
+            sid = sid.substring(1, sid.length() - (sid.endsWith("\"") ? 1 : 0));
+            HCLIdentifier id = new HCLIdentifier.StringId(block, sid);
+            addReference(id, idn);
+            decl.add(id);
+        }
+        block.setDeclaration(references.sortBySource(decl));
+
+        current = current.getContainer();
+        current.add(block);
+    }
+
+    @Override
+    public void exitBody(HCLParser.BodyContext ctx) {
+        for (HCLParser.AttributeContext actx : ctx.attribute()) {
+            HCLAttribute attr = new HCLAttribute(current);
+            attr.name = new HCLIdentifier.SimpleId(attr, actx.IDENTIFIER().getText());
+            addReference(attr.name, actx.IDENTIFIER().getSymbol());
+            addReference(attr, ctx);
+            current.add(attr);
+        }
     }
 
     @Override
     public void enterBlock(HCLParser.BlockContext ctx) {
-        blockDepth++;
+        current = new HCLBlock(current);
     }
 
     

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/ASTBuilderListener.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/ASTBuilderListener.java
@@ -83,6 +83,7 @@ public class ASTBuilderListener extends HCLParserBaseListener {
 
         current = current.getContainer();
         current.add(block);
+        addReference(block, ctx);
     }
 
     @Override

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLAttribute.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLAttribute.java
@@ -24,16 +24,19 @@ package org.netbeans.modules.languages.hcl.ast;
  */
 public final class HCLAttribute extends HCLElement {
 
-    final HCLIdentifier name;
+    HCLIdentifier name;
 
-    public HCLAttribute(HCLIdentifier name) {
-        this.name = name;
+    public HCLAttribute(HCLContainer parent) {
+        super(parent);
     }
-    
+ 
     @Override
     public String id() {
         return name.id();
     }
 
+    public HCLIdentifier getName() {
+        return name;
+    }
 
 }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLBlock.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLBlock.java
@@ -28,11 +28,14 @@ import java.util.stream.Collectors;
  */
 public class HCLBlock extends HCLContainer {
 
-    final List<HCLIdentifier> declaration;
-    final String id;
+    List<HCLIdentifier> declaration;
+    String id;
 
+    public HCLBlock(HCLContainer parent) {
+        super(parent);
+    }
 
-    public HCLBlock(List<HCLIdentifier> declaration) {
+    public void setDeclaration(List<HCLIdentifier> declaration) {
         this.declaration = Collections.unmodifiableList(declaration);
         id = declaration.stream().map(d -> d.id()).collect(Collectors.joining("."));
     }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLContainer.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLContainer.java
@@ -20,11 +20,8 @@ package org.netbeans.modules.languages.hcl.ast;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 /**
  *
@@ -36,19 +33,34 @@ public abstract class HCLContainer extends HCLElement {
     final List<HCLBlock> blocks = new LinkedList<>();
     final List<HCLAttribute> attributes = new LinkedList<>();
 
+    public HCLContainer(HCLContainer parent) {
+        super(parent);
+    }
+
     public void add(HCLBlock block) {
-        block.parent = this;
         elements.add(block);
         blocks.add(block);
     }
 
     public void add(HCLAttribute attr) {
-        attr.parent = this;
         elements.add(attr);
         attributes.add(attr);
     }
 
+    @Override
+    public HCLContainer getContainer() {
+        return (HCLContainer) parent;
+    }
+
     public Collection<? extends HCLBlock> getBlocks() {
         return Collections.unmodifiableCollection(blocks);
+    }
+
+    public Collection<? extends HCLAttribute> getAttributes() {
+        return Collections.unmodifiableCollection(attributes);
+    }
+
+    public boolean hasAttributes() {
+        return !attributes.isEmpty();
     }
 }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLDocument.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLDocument.java
@@ -22,8 +22,11 @@ package org.netbeans.modules.languages.hcl.ast;
  *
  * @author Laszlo Kishalmi
  */
-public class HCLDocument extends HCLContainer {
+public final class HCLDocument extends HCLContainer {
 
+    public HCLDocument() {
+        super(null);
+    }
 
     @Override
     public String id() {

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLElement.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLElement.java
@@ -18,36 +18,28 @@
  */
 package org.netbeans.modules.languages.hcl.ast;
 
-import java.util.Comparator;
-import java.util.Optional;
-
 /**
  *
  * @author Laszlo Kishalmi
  */
 public abstract class HCLElement {
 
-    public static final Comparator<HCLElement> SOURCE_ORDER = (HCLElement h1, HCLElement h2) -> {
-        if (h1.sourceRef.isPresent() && h2.sourceRef.isPresent()) {
-            return h1.sourceRef.get().startOffset - h2.sourceRef.get().startOffset;
+    final HCLElement parent;
+
+    public HCLElement(HCLElement parent) {
+        this.parent = parent;
+    }
+
+    public final HCLElement getParent() {
+        return parent;
+    }
+
+    public HCLContainer getContainer() {
+        HCLElement e = parent;
+        while (e != null && !(e instanceof HCLContainer)) {
+            e = e.parent;
         }
-        return 0;
-    };
-
-    HCLElement parent;
-    final Optional<SourceRef> sourceRef;
-
-    public HCLElement() {
-        this(null);
-    }
-
-    
-    public HCLElement(SourceRef sourceRef) {
-        this.sourceRef = Optional.ofNullable(sourceRef);
-    }
-
-    public Optional<SourceRef> getSourceRef() {
-        return sourceRef;
+        return (HCLContainer) e;
     }
 
     public abstract String id();

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLIdentifier.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLIdentifier.java
@@ -26,8 +26,8 @@ public abstract class HCLIdentifier extends HCLElement {
 
     final String id;
 
-    public HCLIdentifier(SourceRef src, String id) {
-        super(src);
+    public HCLIdentifier(HCLElement parent, String id) {
+        super(parent);
         this.id = id;
     }
 
@@ -38,8 +38,8 @@ public abstract class HCLIdentifier extends HCLElement {
 
     public final static class SimpleId extends HCLIdentifier {
 
-        public SimpleId(SourceRef src, String id) {
-            super(src, id);
+        public SimpleId(HCLElement parent, String id) {
+            super(parent, id);
         }
 
         @Override
@@ -50,8 +50,8 @@ public abstract class HCLIdentifier extends HCLElement {
 
     public final static class StringId extends HCLIdentifier {
 
-        public StringId(SourceRef src, String id) {
-            super(src, id);
+        public StringId(HCLElement parent, String id) {
+            super(parent, id);
         }
 
         @Override

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/SourceRef.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/SourceRef.java
@@ -18,6 +18,14 @@
  */
 package org.netbeans.modules.languages.hcl.ast;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.parsing.api.Snapshot;
 
 /**
@@ -26,12 +34,28 @@ import org.netbeans.modules.parsing.api.Snapshot;
  */
 public class SourceRef {
     public final Snapshot source;
-    public final int startOffset;
-    public final int endOffset;
+    private Map<HCLElement, OffsetRange> elementOffsets = new HashMap<>();
+    private final Comparator<HCLElement> sourceOrder = Comparator.comparing((HCLElement e) -> elementOffsets.get(e));
 
-    public SourceRef(Snapshot source, int startOffset, int endOffset) {
+    public SourceRef(Snapshot source) {
         this.source = source;
-        this.startOffset = startOffset;
-        this.endOffset = endOffset;
+    }
+
+    void add(HCLElement e, OffsetRange r) {
+        elementOffsets.put(e, r);
+    }
+
+    void add(HCLElement e, int startOffset, int endOffset) {
+        add(e, new OffsetRange(startOffset, endOffset));
+    }
+
+    public Optional<OffsetRange> getOffsetRange(HCLElement e) {
+        return Optional.ofNullable(elementOffsets.get(e));
+    }
+    
+    <E extends HCLElement> List<E> sortBySource(List<? extends E> elements) {
+        List<E> ret = new ArrayList<>(elements);
+        Collections.sort(ret, sourceOrder);
+        return ret;
     }
 }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/SourceRef.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/SourceRef.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.parsing.api.Snapshot;
+import org.openide.filesystems.FileObject;
 
 /**
  *
@@ -49,6 +50,9 @@ public class SourceRef {
         add(e, new OffsetRange(startOffset, endOffset));
     }
 
+    public FileObject getFileObject() {
+        return source.getSource().getFileObject();
+    }
     public Optional<OffsetRange> getOffsetRange(HCLElement e) {
         return Optional.ofNullable(elementOffsets.get(e));
     }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/grammar/g4/HCLExpressionParser.g4
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/grammar/g4/HCLExpressionParser.g4
@@ -85,16 +85,28 @@ stringContent
     : STRING_CONTENT+
     ;
 
+interpolationContent
+    : INTERPOLATION_CONTENT+
+    ;
+
 interpolation
-    : INTERPOLATION_START ( INTERPOLATION_CONTENT | quotedTemplate) * INTERPOLATION_END
+    : INTERPOLATION_START ( interpolationContent | quotedTemplate)* INTERPOLATION_END
+    ;
+
+templateContent
+    : TEMPLATE_CONTENT+
     ;
 
 template
-    : TEMPLATE_START TEMPLATE_CONTENT* TEMPLATE_END
+    : TEMPLATE_START ( templateContent | quotedTemplate)* TEMPLATE_END
+    ;
+
+heredocContent
+    : HEREDOC_CONTENT+
     ;
 
 heredocTemplate
-    : HEREDOC_START HEREDOC_CONTENT* HEREDOC_END
+    : HEREDOC_START (heredocContent | interpolation | template)* HEREDOC_END
     ;
 
 variableExpr

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/terraform/TerraformHCLLexer.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/terraform/TerraformHCLLexer.java
@@ -126,7 +126,7 @@ public final class TerraformHCLLexer extends AbstractHCLLexer {
                 return groupToken(INTERPOLATION, INTERPOLATION_CONTENT);
 
             case TEMPLATE_CONTENT:
-                return groupToken(ERROR, TEMPLATE_CONTENT);
+                return groupToken(INTERPOLATION, TEMPLATE_CONTENT);
             case WS:
             case NL:
                 return token(WHITESPACE);

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/terraform/TerraformLanguage.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/terraform/TerraformLanguage.java
@@ -24,6 +24,7 @@ import org.netbeans.api.lexer.InputAttributes;
 import org.netbeans.api.lexer.Language;
 import org.netbeans.api.lexer.LanguagePath;
 import org.netbeans.api.lexer.Token;
+import org.netbeans.modules.csl.api.StructureScanner;
 import org.netbeans.modules.csl.spi.LanguageRegistration;
 import org.netbeans.modules.languages.hcl.HCLLanguage;
 import org.netbeans.modules.languages.hcl.HCLTokenId;
@@ -72,6 +73,16 @@ public final class TerraformLanguage extends HCLLanguage {
     @Override
     public Parser getParser() {
         return new NbHCLParser<TerraformParserResult>(TerraformParserResult::new);
+    }
+
+    @Override
+    public StructureScanner getStructureScanner() {
+        return super.getStructureScanner();
+    }
+
+    @Override
+    public boolean hasStructureScanner() {
+        return true;
     }
 
     private static final Language<HCLTokenId> language = new LanguageHierarchy<HCLTokenId>() {

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/terraform/TerraformParserResult.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/terraform/TerraformParserResult.java
@@ -23,10 +23,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.csl.api.Severity;
 import org.netbeans.modules.csl.spi.DefaultError;
 import org.netbeans.modules.languages.hcl.HCLParserResult;
+import org.netbeans.modules.languages.hcl.ast.HCLAttribute;
 import org.netbeans.modules.languages.hcl.ast.HCLBlock;
+import org.netbeans.modules.languages.hcl.ast.HCLContainer;
 import org.netbeans.modules.languages.hcl.ast.HCLDocument;
 import org.netbeans.modules.languages.hcl.ast.HCLIdentifier;
 import org.netbeans.modules.languages.hcl.ast.SourceRef;
@@ -75,6 +78,7 @@ public class TerraformParserResult extends HCLParserResult {
         super(snapshot);
     }
 
+
     @Override
     @Messages({
         "# {0} - Block type name",
@@ -83,31 +87,56 @@ public class TerraformParserResult extends HCLParserResult {
         "# {0} - Block type name",
         "UNKNOWN_BLOCK=Unknown block: {0}",
         "# {0} - Block ID",
-        "DUPLICATE_BLOCK=Duplicate Block Definition: {0}"
+        "DUPLICATE_BLOCK=Duplicate Block Definition: {0}",
+        "# {0} - Attribute name",
+        "DUPLICATE_ATTRIBUTE=Attribute {0} has already defined"
     })
-    protected void processDocument(HCLDocument doc) {
+    protected void processDocument(HCLDocument doc, SourceRef references) {
         Set<String> defined = new HashSet<>();
         for (HCLBlock block : doc.getBlocks()) {
             List<HCLIdentifier> decl = block.getDeclaration();
             HCLIdentifier type = decl.get(0);
 
             BlockType bt = BlockType.get(type.id());
-            SourceRef src = type.getSourceRef().get();
             if (bt != null) {
                 if (decl.size() != bt.definitionLength) {
-                    DefaultError error = new DefaultError(null, Bundle.INVALID_BLOCK_DECLARATION(bt.type, bt.definitionLength - 1), null, getFileObject(), src.startOffset , src.endOffset, Severity.ERROR);
-                    errors.add(error);
+                    references.getOffsetRange(type).ifPresent((range) -> addError(Bundle.INVALID_BLOCK_DECLARATION(bt.type, bt.definitionLength - 1), range));
                 } else {
-                    if ((bt.definitionLength > 1) && !defined.add(block.id())) {
-                        errors.add(new DefaultError(null, Bundle.DUPLICATE_BLOCK(block.id()), null, getFileObject(), src.startOffset , src.endOffset, Severity.ERROR));
+                    if (!defined.add(block.id())) {
+                        switch (bt) {
+                            case DATA:
+                            case MODULE:
+                            case OUTPUT:
+                            case RESOURCE:
+                            case VARIABLE:
+                                references.getOffsetRange(type).ifPresent((range) -> addError(Bundle.DUPLICATE_BLOCK(block.id()), range));
+                        }
                     }
                 }
             } else {
-                DefaultError error = new DefaultError(null, Bundle.UNKNOWN_BLOCK(type.id()), null, getFileObject(), src.startOffset , src.endOffset, Severity.ERROR);
-                errors.add(error);
+                references.getOffsetRange(type).ifPresent((range) -> addError(Bundle.UNKNOWN_BLOCK(type.id()), range));
             }
-
         }
+        checkDuplicateAttribute(doc, references);
+    }
+
+    private void checkDuplicateAttribute(HCLContainer c, SourceRef references) {
+        for (HCLBlock block : c.getBlocks()) {
+            checkDuplicateAttribute(block, references);
+        }
+        if (c.hasAttributes()) {
+            Set<String> defined = new HashSet<>();
+            for (HCLAttribute attr : c.getAttributes()) {
+                if (!defined.add(attr.id())) {
+                    references.getOffsetRange(attr.getName()).ifPresent((range) -> addError(Bundle.DUPLICATE_ATTRIBUTE(attr.id()), range));
+                }
+            }
+        }
+    }
+
+    private void addError(String message, OffsetRange range) {
+        DefaultError error = new DefaultError(null, message, null, getFileObject(), range.getStart() , range.getEnd(), Severity.ERROR);
+        errors.add(error);
     }
 
 }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/tfvars/TFVarsLanguage.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/tfvars/TFVarsLanguage.java
@@ -24,6 +24,7 @@ import org.netbeans.api.lexer.InputAttributes;
 import org.netbeans.api.lexer.Language;
 import org.netbeans.api.lexer.LanguagePath;
 import org.netbeans.api.lexer.Token;
+import org.netbeans.modules.csl.api.StructureScanner;
 import org.netbeans.modules.csl.spi.LanguageRegistration;
 import org.netbeans.modules.languages.hcl.HCLTokenId;
 import org.netbeans.modules.languages.hcl.BasicHCLLexer;
@@ -69,6 +70,16 @@ public final class TFVarsLanguage extends HCLLanguage {
     @Override
     public String getPreferredExtension() {
         return "tfvars";
+    }
+
+    @Override
+    public boolean hasStructureScanner() {
+        return true;
+    }
+
+    @Override
+    public StructureScanner getStructureScanner() {
+        return super.getStructureScanner();
     }
 
     @Override

--- a/ide/languages.hcl/test/unit/data/testfiles/attributes.hcl
+++ b/ide/languages.hcl/test/unit/data/testfiles/attributes.hcl
@@ -1,0 +1,3 @@
+name = "John Doe"
+age  = 42
+properties = [ "car", "house" ]

--- a/ide/languages.hcl/test/unit/data/testfiles/attributes.hcl.structure
+++ b/ide/languages.hcl/test/unit/data/testfiles/attributes.hcl.structure
@@ -1,0 +1,3 @@
+name:ATTRIBUTE:[]:name:0,17:
+age:ATTRIBUTE:[]:age:18,27:
+properties:ATTRIBUTE:[]:properties:28,59:

--- a/ide/languages.hcl/test/unit/data/testfiles/blocks.hcl
+++ b/ide/languages.hcl/test/unit/data/testfiles/blocks.hcl
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {}
+}
+
+variable name {}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [local.vpc_id]
+  }
+
+  tags = {
+    Reach = "private"
+  }
+}

--- a/ide/languages.hcl/test/unit/data/testfiles/blocks.hcl.structure
+++ b/ide/languages.hcl/test/unit/data/testfiles/blocks.hcl.structure
@@ -1,0 +1,8 @@
+terraform:TAG:[]:terraform:0,37:
+  required_providers:TAG:[]:required_providers:14,35:
+variable.name:TAG:[]:variable.name:39,55:
+data.aws_subnets.private:TAG:[]:data.aws_subnets.private:57,192:
+  filter:TAG:[]:filter:90,152:
+    name:ATTRIBUTE:[]:name:103,120:
+    values:ATTRIBUTE:[]:values:125,148:
+  tags:ATTRIBUTE:[]:tags:156,190:

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/HCLStructureTest.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/HCLStructureTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.languages.hcl;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class HCLStructureTest extends HCLTestBase {
+
+    public HCLStructureTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    public void testEmpty() throws Exception {
+        checkStructure("testfiles/empty.hcl");
+    }
+
+    public void testAttributes() throws Exception {
+        checkStructure("testfiles/attributes.hcl");
+    }
+
+    public void testBlocks() throws Exception {
+        checkStructure("testfiles/blocks.hcl");
+    }
+}

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/HCLTestBase.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/HCLTestBase.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.languages.hcl;
+
+import org.netbeans.modules.csl.api.Formatter;
+import org.netbeans.modules.csl.api.test.CslTestBase;
+import org.netbeans.modules.csl.spi.DefaultLanguageConfig;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class HCLTestBase extends CslTestBase {
+
+    public HCLTestBase(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected DefaultLanguageConfig getPreferredLanguage() {
+        return new HCLLanguage();
+    }
+
+    @Override
+    protected String getPreferredMimeType() {
+        return HCLLanguage.MIME_TYPE;
+    }
+
+    @Override
+    protected Formatter getFormatter(IndentPrefs preferences) {
+        return null;
+    }
+
+    @Override
+    protected void checkStructure(String relFilePath) throws Exception {
+        super.checkStructure(relFilePath, false, false, true);
+    }
+
+    
+}

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/grammar/HCLExpressionParserTest.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/grammar/HCLExpressionParserTest.java
@@ -108,7 +108,7 @@ public class HCLExpressionParserTest {
 
     }
 
-    private static HCLParser.ExpressionContext parse(String expr){
+    private static ExpressionContext parse(String expr){
         HCLLexer lexer = new HCLLexer(CharStreams.fromString(expr));
         HCLParser parser = new HCLParser(new CommonTokenStream(lexer));
         return parser.expression();

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/grammar/HCLExpressionParserTest.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/grammar/HCLExpressionParserTest.java
@@ -22,7 +22,7 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import org.netbeans.modules.languages.hcl.grammar.HCLExpressionParser.ExpressionContext;
+import org.netbeans.modules.languages.hcl.grammar.HCLParser.ExpressionContext;
 
 /**
  *
@@ -108,9 +108,9 @@ public class HCLExpressionParserTest {
 
     }
 
-    private static HCLExpressionParser.ExpressionContext parse(String expr){
+    private static HCLParser.ExpressionContext parse(String expr){
         HCLLexer lexer = new HCLLexer(CharStreams.fromString(expr));
-        HCLExpressionParser parser = new HCLExpressionParser(new CommonTokenStream(lexer));
+        HCLParser parser = new HCLParser(new CommonTokenStream(lexer));
         return parser.expression();
     }
 }

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/grammar/HCLParserTest.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/grammar/HCLParserTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.languages.hcl.grammar;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.junit.Test;
+import static org.netbeans.modules.languages.hcl.grammar.HCLParser.*;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class HCLParserTest {
+
+    @Test
+    public void testHereDoc1() {
+        BodyContext ctx = parse("a = <<EOT\ntext\nEOT");
+        assertEquals(1, ctx.attribute().size());
+
+        AttributeContext attr = ctx.attribute(0);
+        assertEquals("a", attr.IDENTIFIER().getText());
+        HeredocTemplateContext heredoc = attr.expression().exprTerm().templateExpr().heredocTemplate();
+        assertEquals("text\n", heredoc.heredocContent(0).getText());
+    }
+
+    @Test
+    public void testHereDocInterpolation() {
+        BodyContext ctx = parse("a = <<EOT\nfoo-${a}-bar\nEOT");
+        assertEquals(1, ctx.attribute().size());
+
+        AttributeContext attr = ctx.attribute(0);
+        assertEquals("a", attr.IDENTIFIER().getText());
+        HeredocTemplateContext heredoc = attr.expression().exprTerm().templateExpr().heredocTemplate();
+        assertEquals("foo-",  heredoc.heredocContent(0).getText());
+        assertEquals("${a}",  heredoc.interpolation(0).getText());
+        assertEquals("-bar\n",  heredoc.heredocContent(1).getText());
+    }
+
+    @Test
+    public void testHereDocTemplate() {
+        BodyContext ctx = parse("a = <<EOT\n%{if a != \"\"}\n${a}\n%{ end }\nEOT");
+        assertEquals(1, ctx.attribute().size());
+
+        AttributeContext attr = ctx.attribute(0);
+        assertEquals("a", attr.IDENTIFIER().getText());
+        HeredocTemplateContext heredoc = attr.expression().exprTerm().templateExpr().heredocTemplate();
+        assertEquals("if a != ",  heredoc.template(0).templateContent(0).getText());
+        assertEquals("\"\"",  heredoc.template(0).quotedTemplate(0).getText());
+        assertEquals("${a}",  heredoc.interpolation(0).getText());
+        assertEquals(" end ",  heredoc.template(1).templateContent(0).getText());
+    }
+
+    private BodyContext parse(String text) {
+        HCLLexer lexer = new HCLLexer(CharStreams.fromString(text));
+        HCLParser parser = new HCLParser(new CommonTokenStream(lexer));
+        return parser.configFile().body();
+        
+    }
+}


### PR DESCRIPTION
Well, this one is a bit more than the Navogator.

The AST is kind of ready till Attribute level. Beyond that there is the HCL Expression sub-language which AST still has to be done.

That makes possible to implement the structure scanner part for Navigator.

I've realized that the HCL Expression language can be parsed by the HCL parser itself, no need to generate a separate HCLExpressionParser. That would just duplicate a lot of internal context classes, and so it would needed a duplicate implementation of the expression AST builder.

I plan to remove the Terraform specific Lexer in the future, as that is a duplicate + small addition to the HCLLexer. That is used in the basic syntax Highlight only. It would be better to replace that with parser assisted depending on HCL language flavors.

