### PR TITLE
    Cleanup the use of Double primitive wrapper

### DIFF
--- a/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/validation/constraints/NumberConstraint.java
+++ b/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/validation/constraints/NumberConstraint.java
@@ -63,7 +63,7 @@ public class NumberConstraint extends ConstraintUtils
         ArrayList failed_constrained_list = new ArrayList();
         if(null != value){
             try {
-                new Double(value);
+                Double.valueOf(value);
                 return failed_constrained_list;
             } catch(NumberFormatException e) {
                 String failureMessage = formatFailureMessage(toString(), value,

--- a/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/validation/constraints/RangeConstraint.java
+++ b/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/validation/constraints/RangeConstraint.java
@@ -66,8 +66,8 @@ public class RangeConstraint extends ConstraintUtils
     /** Creates a new instance of <code>RangeConstraint</code>. */
     public RangeConstraint(String startValue, String endValue) {
         try {
-           this.startValue = new Double(startValue);
-           this.endValue = new Double(endValue);
+           this.startValue = Double.valueOf(startValue);
+           this.endValue = Double.valueOf(endValue);
         } catch(NumberFormatException e) {
             String format = 
                 BundleReader.getValue("Error_failed_to_create");        //NOI18N
@@ -102,7 +102,7 @@ public class RangeConstraint extends ConstraintUtils
         
         if((value != null) && (value.length() != 0)){
             try {
-                Double val = new Double(value);
+                Double val = Double.valueOf(value);
                 if((val.compareTo(startValue) < 0) ||
                     (val.compareTo(endValue) > 0)){
                     addFailure(failed_constrained_list, name, value);
@@ -122,7 +122,7 @@ public class RangeConstraint extends ConstraintUtils
      */
     public void setRangeStart(String value){
         try {
-           startValue = new Double(value);
+           startValue = Double.valueOf(value);
         } catch(NumberFormatException e) {
             String format = 
                 BundleReader.getValue("Error_failed_to_set");           //NOI18N
@@ -142,7 +142,7 @@ public class RangeConstraint extends ConstraintUtils
      */
     public void setRangeEnd(String value){
         try {
-           endValue = new Double(value);
+           endValue = Double.valueOf(value);
         } catch(NumberFormatException e) {
             String format = 
                 BundleReader.getValue("Error_failed_to_set");           //NOI18N

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ImportBuildfile.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ImportBuildfile.java
@@ -52,7 +52,7 @@ final class ImportBuildfile extends javax.swing.JPanel implements DocumentListen
     }
     
     private void resize() {
-        int width = (new Double(jLabelDesc.getFontMetrics(jLabelDesc.getFont()).getStringBounds(jLabelDesc.getText(), getGraphics()).getWidth() / 2.7)).intValue() + 40;
+        int width = (int)(jLabelDesc.getFontMetrics(jLabelDesc.getFont()).getStringBounds(jLabelDesc.getText(), getGraphics()).getWidth() / 2.7) + 40;
         int height = (jLabelDesc.getFont().getSize() * 5) + 100;
         if (width < 400)
             width = 400;

--- a/ide/api.debugger/src/org/netbeans/api/debugger/Properties.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/Properties.java
@@ -1480,7 +1480,7 @@ public abstract class Properties {
                 } else if (classNames[6].equals(className)) {
                     return properties.getFloat(propertyName, 0f);
                 } else if (classNames[7].equals(className)) {
-                    return new Double(properties.getDouble(propertyName, 0d));
+                    return properties.getDouble(propertyName, 0D);
                 }
                 throw new IllegalArgumentException("Class = '"+className+"'.");
             }

--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/NodeTableModel.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/NodeTableModel.java
@@ -33,6 +33,7 @@ import java.beans.PropertyChangeListener;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.TreeMap;
 
 import javax.swing.JCheckBox;
@@ -161,7 +162,7 @@ class NodeTableModel extends AbstractTableModel {
         int visibleCount = 0;
         existsComparableColumn = false;
 
-        TreeMap<Double, Integer> sort = new TreeMap<Double, Integer>();
+        Map<Double, Integer> sort = new TreeMap<>();
         int i = 0;
         int ia = 0;
 
@@ -176,9 +177,9 @@ class NodeTableModel extends AbstractTableModel {
                     Object o = props[i].getValue(ATTR_ORDER_NUMBER);
 
                     if (o instanceof Integer) {
-                        sort.put(new Double(((Integer) o).doubleValue()), Integer.valueOf(ia));
+                        sort.put(((Integer)o).doubleValue(), ia);
                     } else {
-                        sort.put(new Double(ia + 0.1), Integer.valueOf(ia));
+                        sort.put((ia + 0.1), ia);
                     }
                 } else {
                     allPropertyColumns[ia].setVisibleIndex(-1);
@@ -231,9 +232,9 @@ class NodeTableModel extends AbstractTableModel {
             int vi = allPropertyColumns[i].getVisibleIndex();
 
             if (vi == -1) {
-                sort.put(new Double(i - 0.1), Integer.valueOf(i));
+                sort.put((i - 0.1), i);
             } else {
-                sort.put(new Double(vi), Integer.valueOf(i));
+                sort.put((double)vi, i);
             }
         }
 

--- a/ide/db.dataview/src/org/netbeans/modules/db/dataview/util/DBReadWriteHelper.java
+++ b/ide/db.dataview/src/org/netbeans/modules/db/dataview/util/DBReadWriteHelper.java
@@ -441,7 +441,7 @@ public class DBReadWriteHelper {
                     }
                         
                 case Types.DOUBLE:
-                    return valueObj instanceof Double ? valueObj : new Double(valueObj.toString());
+                    return valueObj instanceof Double ? valueObj : Double.valueOf(valueObj.toString());
 
                 case Types.FLOAT:
                 case Types.REAL:

--- a/ide/db/libsrc/org/netbeans/lib/ddl/util/PListReader.java
+++ b/ide/db/libsrc/org/netbeans/lib/ddl/util/PListReader.java
@@ -185,7 +185,7 @@ public class PListReader {
             tokenizer.pushBack();
             double d = Math.rint(tokenizer.nval);
             if(d == tokenizer.nval) return Integer.valueOf((int)d);
-            return new Double(tokenizer.nval);
+            return Double.valueOf(tokenizer.nval);
         }
     }
 

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/CreateTableDialog.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/CreateTableDialog.java
@@ -471,7 +471,7 @@ public class CreateTableDialog {
                 Map cmap = ColumnItem.getColumnProperty(i);
                 col.setIdentifier(cmap.get("name")); //NOI18N
                 columnName = NbBundle.getMessage (CreateTableDialog.class, "CreateTable_" + i); //NOI18N
-                columnWidth = (new Double(getFontMetrics(getFont()).getStringBounds(columnName, getGraphics()).getWidth())).intValue() + 20;
+                columnWidth = (int)(getFontMetrics(getFont()).getStringBounds(columnName, getGraphics()).getWidth()) + 20;
                 if (cmap.containsKey("width")) { // NOI18N
                     if (((Integer)cmap.get("width")).intValue() < columnWidth)
                         col.setPreferredWidth(columnWidth);

--- a/ide/editor.completion/src/org/netbeans/modules/editor/completion/PatchedHtmlRenderer.java
+++ b/ide/editor.completion/src/org/netbeans/modules/editor/completion/PatchedHtmlRenderer.java
@@ -176,7 +176,7 @@ public final class PatchedHtmlRenderer {
                 }
 
                 double chWidth = wid / chars.length;
-                int estCharsToPaint = new Double(w / chWidth).intValue();
+                int estCharsToPaint = (int)(w / chWidth);
                 if( estCharsToPaint > chars.length )
                     estCharsToPaint = chars.length;
                 //let's correct the estimate now
@@ -841,7 +841,7 @@ public final class PatchedHtmlRenderer {
                             //Word wrap mode
                             goToNextRow = true;
 
-                            int lastChar = new Double(nextTag - estCharsOver).intValue();
+                            int lastChar = (int)(nextTag - estCharsOver);
 
                             //Unlike Swing's word wrap, which does not wrap on tag boundaries correctly, if we're out of space,
                             //we're out of space
@@ -892,7 +892,7 @@ public final class PatchedHtmlRenderer {
                                 }
                             } else if (brutalWrap) {
                                 //wrap without checking word boundaries
-                                length = (new Double((w - widthPainted) / chWidth)).intValue();
+                                length = (int)((w - widthPainted) / chWidth);
 
                                 if ((pos + length) > nextTag) {
                                     length = (nextTag - pos);
@@ -911,7 +911,7 @@ public final class PatchedHtmlRenderer {
 
                     if (strikethrough || underline) {
                         LineMetrics lm = fm.getLineMetrics(chars, pos, length - 1, g);
-                        int lineWidth = new Double(x + r.getWidth()).intValue();
+                        int lineWidth = (int)(x + r.getWidth());
 
                         if (paint) {
                             if (strikethrough) {
@@ -930,7 +930,7 @@ public final class PatchedHtmlRenderer {
 
                                 //PENDING - worth supporting with g.setStroke()? A one pixel line is most likely
                                 //good enough
-                                //int stThick = new Float (lm.getUnderlineThickness()).intValue();
+                                //int stThick = Float.valueOf(lm.getUnderlineThickness()).intValue();
                                 g.drawLine(x, y + stPos, lineWidth, y + stPos);
                             }
                         }

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/Common.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/Common.java
@@ -387,7 +387,7 @@ public class Common {
             case Common.TYPE_FLOAT:
                 return 0.0F;
             case Common.TYPE_DOUBLE:
-                return new Double(0.0);
+                return 0.0D;
             default:
                 throw new IllegalArgumentException(Common.getMessage(
                         "UnknownType_msg", Integer.valueOf(type)));

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/GraphManager.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/GraphManager.java
@@ -900,7 +900,7 @@ public class GraphManager extends Object {
 	    case Common.TYPE_FLOAT:
 		return 0.0F;
 	    case Common.TYPE_DOUBLE:
-		return new Double(0.0);
+		return 0.0D;
 	    default:
                 throw new IllegalArgumentException(Common.getMessage("UnknownType", type));
 	}

--- a/java/classfile/src/org/netbeans/modules/classfile/CPDoubleInfo.java
+++ b/java/classfile/src/org/netbeans/modules/classfile/CPDoubleInfo.java
@@ -32,7 +32,7 @@ public final class CPDoubleInfo extends CPEntry {
 
     CPDoubleInfo(ConstantPool pool, double v) {
 	super(pool);
-        value = new Double(v);
+        value = v;
     }
 
     /* The VM doesn't allow the next constant pool slot to be used

--- a/java/form/src/org/netbeans/modules/form/layoutdesign/LayoutDesigner.java
+++ b/java/form/src/org/netbeans/modules/form/layoutdesign/LayoutDesigner.java
@@ -437,8 +437,8 @@ public final class LayoutDesigner implements LayoutConstants {
             LayoutTestUtils.writeLayoutComponentArray(testCode, "comps", "lc");				    //NOI18N
             LayoutTestUtils.writeRectangleArray(testCode, "bounds", bounds);				    //NOI18N
             LayoutTestUtils.writeString(testCode, "defaultContId", defaultContId);			    //NOI18N         
-            testCode.add("Point hotspot = new Point(" + new Double(hotspot.getX()).intValue() + "," +	    //NOI18N
-			    new Double(hotspot.getY()).intValue() + ");");				    //NOI18N
+            testCode.add("Point hotspot = new Point(" + (int)(hotspot.getX()) + "," +			    //NOI18N
+			    (int)(hotspot.getY()) + ");");						    //NOI18N
             testCode.add("ld.startAdding(comps, bounds, hotspot, defaultContId);");			    //NOI18N
             testCode.add("}");										    //NOI18N
         }
@@ -463,12 +463,12 @@ public final class LayoutDesigner implements LayoutConstants {
 
         if (logTestCode()) {
             testCode.add("{"); //NOI18N
-            LayoutTestUtils.writeStringArray(testCode, "compIds", compIds); //NOI18N
-            LayoutTestUtils.writeRectangleArray(testCode, "bounds", bounds); //NOI18N
-            testCode.add("Point hotspot = new Point(" + new Double(hotspot.getX()).intValue() + "," +  //NOI18N
-		    new Double(hotspot.getY()).intValue() + ");"); //NOI18N
-            testCode.add("ld.startMoving(compIds, bounds, hotspot);"); //NOI18N
-            testCode.add("}"); //NOI18N
+            LayoutTestUtils.writeStringArray(testCode, "compIds", compIds);		//NOI18N
+            LayoutTestUtils.writeRectangleArray(testCode, "bounds", bounds);		//NOI18N
+            testCode.add("Point hotspot = new Point(" + (int)(hotspot.getX()) + "," +   //NOI18N
+		    (int)(hotspot.getY()) + ");");					//NOI18N
+            testCode.add("ld.startMoving(compIds, bounds, hotspot);");			//NOI18N
+            testCode.add("}");								//NOI18N
         }
         
         setDragTarget(comps[0].getParent(), comps, false);
@@ -517,14 +517,14 @@ public final class LayoutDesigner implements LayoutConstants {
 
         if (logTestCode()) {
             testCode.add("{"); //NOI18N
-            LayoutTestUtils.writeStringArray(testCode, "compIds", compIds); //NOI18N
-            LayoutTestUtils.writeRectangleArray(testCode, "bounds", bounds); //NOI18N
-            testCode.add("Point hotspot = new Point(" + new Double(hotspot.getX()).intValue() + "," +  //NOI18N
-		    new Double(hotspot.getY()).intValue() + ");"); //NOI18N
-            LayoutTestUtils.writeIntArray(testCode, "resizeEdges", resizeEdges); //NOI18N
-            testCode.add("boolean inLayout = " + inLayout + ";"); // NOI18N
+            LayoutTestUtils.writeStringArray(testCode, "compIds", compIds);		//NOI18N
+            LayoutTestUtils.writeRectangleArray(testCode, "bounds", bounds);		//NOI18N
+            testCode.add("Point hotspot = new Point(" + (int)(hotspot.getX()) + "," +   //NOI18N
+		    (int)(hotspot.getY()) + ");");					//NOI18N
+            LayoutTestUtils.writeIntArray(testCode, "resizeEdges", resizeEdges);	//NOI18N
+            testCode.add("boolean inLayout = " + inLayout + ";");			// NOI18N
             testCode.add("ld.startResizing(compIds, bounds, hotspot, resizeEdges, inLayout);"); //NOI18N
-            testCode.add("}"); //NOI18N
+            testCode.add("}");								//NOI18N
         }
 
         if (inLayout) {

--- a/java/j2ee.persistence/test/unit/src/org/netbeans/test/stub/api/Stub.java
+++ b/java/j2ee.persistence/test/unit/src/org/netbeans/test/stub/api/Stub.java
@@ -157,9 +157,9 @@ public final class Stub {
                 } else if (retClass == Long.TYPE) {
                     return 0L;
                 } else if (retClass == Float.TYPE) {
-                    return Float.valueOf(0);
+                    return 0F;
                 } else if (retClass == Double.TYPE) {
-                    return 0.0;
+                    return 0D;
                 } else if (retClass == Character.TYPE) {
                     return '\0';
                 } else if (retClass == Boolean.TYPE) {

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/ImportFoldersPanel.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/ImportFoldersPanel.java
@@ -86,7 +86,7 @@ class ImportFoldersPanel extends javax.swing.JPanel {
     }
 
     private void resize() {
-        int width = (new Double(message.getFontMetrics(message.getFont()).getStringBounds(message.getText(), getGraphics()).getWidth() / 2.7)).intValue() + 40;
+        int width = (int)(message.getFontMetrics(message.getFont()).getStringBounds(message.getText(), getGraphics()).getWidth() / 2.7) + 40;
         int height = (message.getFont().getSize() * 5) + 100;
         if (width < 400)
             width = 400;

--- a/javafx/javafx2.samples/SwingInterop/src/swinginterop/SampleTableModel.java
+++ b/javafx/javafx2.samples/SwingInterop/src/swinginterop/SampleTableModel.java
@@ -35,12 +35,13 @@ public class SampleTableModel extends AbstractTableModel {
     private static ObservableList<BarChart.Series> bcData;
     
     private final String[] names = {"2007", "2008", "2009"};
- 
+
+    // TOOD - helpful if these constants had a descriptive constant name 
     private Object[][] data = {
-            {new Double(567), new Double(956), new Double(1154)},
-            {new Double(1292), new Double(1665), new Double(1927)},
-            {new Double(1292), new Double(2559), new Double(2774)}
-        };
+            {567D,  956D,  1154D},
+            {1292D, 1665D, 1927D},
+            {1292D, 2559D, 2774D}
+    };
 
     public double getTickUnit() {
         return 1000;

--- a/nb/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SerParser.java
+++ b/nb/o.n.upgrader/src/org/netbeans/upgrade/systemoptions/SerParser.java
@@ -491,7 +491,7 @@ public final class SerParser implements ObjectStreamConstants {
         makeRef(aw);
         int size = readInt();
         if (size < 0) throw new NotImplementedException();
-        aw.values = new ArrayList<Object>(size);
+        aw.values = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             if (aw.classdesc.name.equals("[B")) { // NOI18N
                 aw.values.add(readByte());
@@ -504,7 +504,7 @@ public final class SerParser implements ObjectStreamConstants {
             } else if (aw.classdesc.name.equals("[F")) { // NOI18N
                 aw.values.add(Float.intBitsToFloat(readInt()));
             } else if (aw.classdesc.name.equals("[D")) { // NOI18N
-                aw.values.add(new Double(Double.longBitsToDouble(readLong())));
+                aw.values.add(Double.longBitsToDouble(readLong()));
             } else if (aw.classdesc.name.equals("[C")) { // NOI18N
                 aw.values.add(new Character((char)readShort()));
             } else if (aw.classdesc.name.equals("[Z")) { // NOI18N
@@ -568,7 +568,7 @@ public final class SerParser implements ObjectStreamConstants {
             } else if (fd.type.equals("F")) { // NOI18N
                 values.add(new NameValue(fd, Float.intBitsToFloat(readInt())));
             } else if (fd.type.equals("D")) { // NOI18N
-                values.add(new NameValue(fd, new Double(Double.longBitsToDouble(readLong()))));
+                values.add(new NameValue(fd, Double.longBitsToDouble(readLong())));
             } else if (fd.type.equals("C")) { // NOI18N
                 values.add(new NameValue(fd, new Character((char)readShort())));
             } else if (fd.type.equals("Z")) { // NOI18N

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ViewHelper.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ViewHelper.java
@@ -165,7 +165,7 @@ final class ViewHelper {
         List visibleChildren = splitSnapshot.getVisibleChildSnapshots();
         
         ArrayList<ElementAccessor> children = new ArrayList<ElementAccessor>( visibleChildren.size() );
-        ArrayList<Double> weights = new ArrayList<Double>( visibleChildren.size() );
+        List<Double> weights = new ArrayList<Double>( visibleChildren.size() );
         
         int index = 0;
         for( Iterator i=visibleChildren.iterator(); i.hasNext(); index++ ) {
@@ -183,11 +183,11 @@ final class ViewHelper {
                 double[] weightsToMerge = subSplit.getSplitWeights();
                 for( int j=0; j<childrenToMerge.length; j++ ) {
                     children.add( childrenToMerge[j] );
-                    weights.add( Double.valueOf( weightsToMerge[j] * weight ) );
+                    weights.add(weightsToMerge[j] * weight);
                 }
             } else {
                 children.add( childAccessor );
-                weights.add( Double.valueOf( weight ) );
+                weights.add(weight);
             }
         }
         
@@ -195,7 +195,7 @@ final class ViewHelper {
         double[] splitWeights = new double[children.size()];
         for( int i=0; i<children.size(); i++ ) {
             ElementAccessor ea = (ElementAccessor)children.get( i );
-            Double weight = (Double)weights.get( i );
+            Double weight = weights.get(i);
             childrenAccessors[i] = ea;
             splitWeights[i] = weight.doubleValue();
         }

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/MultiSplitPane.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/MultiSplitPane.java
@@ -189,7 +189,7 @@ public class MultiSplitPane extends JPanel
         for( int i=0; i<getCellCount(); i++ ) {
             MultiSplitCell cell = cellAt( i );
             double weight = cell.getSize() / size;
-            splitWeights.add( Double.valueOf( weight ) );
+            splitWeights.add(weight);
             visibleViews.add( cell.getViewElement() );
         }
     }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BaseTabLayoutModel.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BaseTabLayoutModel.java
@@ -123,8 +123,8 @@ class BaseTabLayoutModel implements TabLayoutModel {
             //No need to calculate for every string
             String testStr = "Zgj"; //NOI18N
             Font f = getFont();
-            textHeight = new Double(f.getStringBounds(testStr, 
-            BasicScrollingTabDisplayerUI.getOffscreenGraphics(component).getFontRenderContext()).getWidth()).intValue() + 2;
+            textHeight = (int)(f.getStringBounds(testStr, 
+            BasicScrollingTabDisplayerUI.getOffscreenGraphics(component).getFontRenderContext()).getWidth()) + 2;
         }
         return textHeight;
     }

--- a/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
@@ -352,7 +352,7 @@ public final class HtmlRenderer {
                 }
 
                 double chWidth = wid / chars.length;
-                int estCharsToPaint = new Double(w / chWidth).intValue();
+                int estCharsToPaint = (int)(w / chWidth);
                 if( estCharsToPaint > chars.length )
                     estCharsToPaint = chars.length;
                 //let's correct the estimate now
@@ -1057,7 +1057,7 @@ public final class HtmlRenderer {
                             //Word wrap mode
                             goToNextRow = true;
 
-                            int lastChar = new Double(nextTag - estCharsOver).intValue();
+                            int lastChar = (int)(nextTag - estCharsOver);
 
                             //Unlike Swing's word wrap, which does not wrap on tag boundaries correctly, if we're out of space,
                             //we're out of space
@@ -1108,7 +1108,7 @@ public final class HtmlRenderer {
                                 }
                             } else if (brutalWrap) {
                                 //wrap without checking word boundaries
-                                length = (new Double((w - widthPainted) / chWidth)).intValue();
+                                length = (int)((w - widthPainted) / chWidth);
 
                                 if ((pos + length) > nextTag) {
                                     length = (nextTag - pos);
@@ -1127,7 +1127,7 @@ public final class HtmlRenderer {
 
                     if (strikethrough || underline || link) {
                         LineMetrics lm = fm.getLineMetrics(chars, pos, length - 1, g);
-                        int lineWidth = new Double(x + r.getWidth()).intValue();
+                        int lineWidth = (int)(x + r.getWidth());
 
                         if (paint) {
                             if (strikethrough) {

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/IndexedPropertyEditor.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/IndexedPropertyEditor.java
@@ -360,11 +360,11 @@ class IndexedPropertyEditor extends Object implements ExPropertyEditor {
             }
 
             if (getConvertedType().equals(Double.class)) {
-                value = new Double(0d);
+                value = 0D;
             }
 
             if (getConvertedType().equals(Float.class)) {
-                value = 0f;
+                value = 0F;
             }
 
             if (getConvertedType().equals(Long.class)) {

--- a/platform/openide.explorer/src/org/openide/explorer/view/NodeTableModel.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/NodeTableModel.java
@@ -31,6 +31,7 @@ import java.beans.PropertyChangeListener;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.TreeMap;
 
 import javax.swing.*;
@@ -148,7 +149,7 @@ public class NodeTableModel extends AbstractTableModel {
         int visibleCount = 0;
         existsComparableColumn = false;
 
-        TreeMap<Double, Integer> sort = new TreeMap<Double, Integer>();
+        Map<Double, Integer> sort = new TreeMap<>();
         int i = 0;
         int ia = 0;
 
@@ -163,9 +164,9 @@ public class NodeTableModel extends AbstractTableModel {
                     Object o = props[i].getValue(ATTR_ORDER_NUMBER);
 
                     if (o instanceof Integer) {
-                        sort.put(new Double(((Integer) o).doubleValue()), Integer.valueOf(ia));
+                        sort.put(((Integer)o).doubleValue(), ia);
                     } else {
-                        sort.put(new Double(ia + 0.1), new Integer(ia));
+                        sort.put(ia + 0.1, ia);
                     }
                 } else {
                     allPropertyColumns[ia].setVisibleIndex(-1);
@@ -212,15 +213,15 @@ public class NodeTableModel extends AbstractTableModel {
     private void computeVisiblePorperties(int visCount) {
         propertyColumns = new int[visCount];
 
-        TreeMap<Double, Integer> sort = new TreeMap<Double, Integer>();
+        Map<Double, Integer> sort = new TreeMap<>();
 
         for (int i = 0; i < allPropertyColumns.length; i++) {
             int vi = allPropertyColumns[i].getVisibleIndex();
 
             if (vi == -1) {
-                sort.put(new Double(i - 0.1), Integer.valueOf(i));
+                sort.put((i - 0.1), i);
             } else {
-                sort.put(new Double(vi), Integer.valueOf(i));
+                sort.put((double)vi, i);
             }
         }
 

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
@@ -928,7 +928,7 @@ final class XMLMapAttr implements Map {
                     case 4:
                         return Float.valueOf(value);
                     case 5:
-                        return new Double(value);
+                        return Double.valueOf(value);
                     case 6:
                         return Boolean.valueOf(value);
                     case 7:

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ClassesListController.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ClassesListController.java
@@ -164,8 +164,7 @@ public class ClassesListController extends AbstractController {
                     else data[i][4] = (retainedSizeByClass > 0 ? "+" : "") + numberFormat.format(retainedSizeByClass); // NOI18N 
                 }
             } else {
-                data[i][1] = new Double((double) instancesCount /
-                                     (double) totalLiveInstances * 100);
+                data[i][1] = (double)instancesCount / totalLiveInstances * 100;
                 data[i][2] = numberFormat.format(instancesCount) + " (" // NOI18N
                                      + percentFormat.format((double) instancesCount /
                                      (double) totalLiveInstances) + ")"; // NOI18N

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/ParameterInfo.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/ParameterInfo.java
@@ -185,7 +185,7 @@ public class ParameterInfo {
         } else if (type == Float.class || type == Float.TYPE) {
             return 0F;
         } else if (type == Double.class || type == Double.TYPE) {
-            return new Double(0);
+            return 0D;
         } else if (type == Boolean.class || type == Boolean.TYPE) {
             return Boolean.FALSE;
         } else if (type == Character.class || type == Character.TYPE) {


### PR DESCRIPTION
        Cleanup the use of Double primitive wrapper. As of Java 9, the VM can do a better job of handling the
        coversion from a Double primitive to a Double Object or vice versa.
    
        This is an extension of the work done in #2498.
    
        No tests have been touched as those expressly need to manage the conversion.
    
        A couple of places I also cleaned up the Float.
