### PR TITLE
Replace jakartaee archetype

### DIFF
--- a/enterprise/j2ee.core/test/unit/src/org/netbeans/api/j2ee/core/ProfileTest.java
+++ b/enterprise/j2ee.core/test/unit/src/org/netbeans/api/j2ee/core/ProfileTest.java
@@ -59,9 +59,9 @@ public class ProfileTest extends NbTestCase {
         assertEquals(Profile.JAKARTA_EE_9_1_FULL, Profile.fromPropertiesString("JAKARTA_EE_9_1_FULL"));
         assertEquals(Profile.JAKARTA_EE_9_1_WEB, Profile.fromPropertiesString("9.1-web"));
         assertEquals(Profile.JAKARTA_EE_9_1_WEB, Profile.fromPropertiesString("JAKARTA_EE_9_1_WEB"));
-        assertEquals(Profile.JAKARTA_EE_10_FULL, Profile.fromPropertiesString("10.0"));
+        assertEquals(Profile.JAKARTA_EE_10_FULL, Profile.fromPropertiesString("10"));
         assertEquals(Profile.JAKARTA_EE_10_FULL, Profile.fromPropertiesString("JAKARTA_EE_10_FULL"));
-        assertEquals(Profile.JAKARTA_EE_10_WEB, Profile.fromPropertiesString("10.0-web"));
+        assertEquals(Profile.JAKARTA_EE_10_WEB, Profile.fromPropertiesString("10-web"));
         assertEquals(Profile.JAKARTA_EE_10_WEB, Profile.fromPropertiesString("JAKARTA_EE_10_WEB"));
         assertNull(Profile.fromPropertiesString("something"));
     }
@@ -228,8 +228,8 @@ public class ProfileTest extends NbTestCase {
         assertFalse(Profile.JAKARTA_EE_8_FULL.isAtLeast(Profile.JAKARTA_EE_10_WEB));
         assertFalse(Profile.JAKARTA_EE_9_WEB.isAtLeast(Profile.JAKARTA_EE_10_WEB));
         assertFalse(Profile.JAKARTA_EE_9_FULL.isAtLeast(Profile.JAKARTA_EE_10_WEB));
-        assertTrue(Profile.JAKARTA_EE_9_1_WEB.isAtLeast(Profile.JAKARTA_EE_10_WEB));
-        assertTrue(Profile.JAKARTA_EE_9_1_FULL.isAtLeast(Profile.JAKARTA_EE_10_WEB));
+        assertFalse(Profile.JAKARTA_EE_9_1_WEB.isAtLeast(Profile.JAKARTA_EE_10_WEB));
+        assertFalse(Profile.JAKARTA_EE_9_1_FULL.isAtLeast(Profile.JAKARTA_EE_10_WEB));
         assertTrue(Profile.JAKARTA_EE_10_WEB.isAtLeast(Profile.JAKARTA_EE_10_WEB));
         assertTrue(Profile.JAKARTA_EE_10_FULL.isAtLeast(Profile.JAKARTA_EE_10_WEB));
     }

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/EEWizardIterator.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/EEWizardIterator.java
@@ -103,7 +103,7 @@ public final class EEWizardIterator extends BaseWizardIterator {
         ArchetypeWizards.logUsage(archetype.getGroupId(), archetype.getArtifactId(), archetype.getVersion());
 
         File rootFile = FileUtil.normalizeFile((File) wiz.getProperty("projdir")); // NOI18N
-        ArchetypeWizards.createFromArchetype(rootFile, vi, archetype, null, true);
+        ArchetypeWizards.createFromArchetype(rootFile, vi, archetype, archetype.getProperties(), true);
 
         Set<FileObject> projects = ArchetypeWizards.openProjects(rootFile, rootFile);
         for (FileObject projectFile : projects) {

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/ServerSelectionHelper.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/ServerSelectionHelper.java
@@ -162,15 +162,14 @@ public class ServerSelectionHelper {
                 profiles.add(Profile.JAVA_EE_8_WEB);
                 profiles.add(Profile.JAVA_EE_7_WEB);
                 profiles.add(Profile.JAVA_EE_6_WEB);
-            } else {
-                profiles.add(Profile.JAKARTA_EE_10_FULL);
-                profiles.add(Profile.JAKARTA_EE_9_1_FULL);
-                profiles.add(Profile.JAKARTA_EE_9_FULL);
-                profiles.add(Profile.JAKARTA_EE_8_FULL);
-                profiles.add(Profile.JAVA_EE_8_FULL);
-                profiles.add(Profile.JAVA_EE_7_FULL);
-                profiles.add(Profile.JAVA_EE_6_FULL);
             }
+            profiles.add(Profile.JAKARTA_EE_10_FULL);
+            profiles.add(Profile.JAKARTA_EE_9_1_FULL);
+            profiles.add(Profile.JAKARTA_EE_9_FULL);
+            profiles.add(Profile.JAKARTA_EE_8_FULL);
+            profiles.add(Profile.JAVA_EE_8_FULL);
+            profiles.add(Profile.JAVA_EE_7_FULL);
+            profiles.add(Profile.JAVA_EE_6_FULL);
             profiles.add(Profile.JAVA_EE_5);
         } else {
             try {
@@ -188,10 +187,6 @@ public class ServerSelectionHelper {
 
             // We want to have Java EE 6 Full profile for all project types except Web project
             if (J2eeModule.Type.WAR.equals(projectType)) {
-                profiles.remove(Profile.JAKARTA_EE_10_FULL);
-                profiles.remove(Profile.JAKARTA_EE_9_1_FULL);
-                profiles.remove(Profile.JAKARTA_EE_9_FULL);
-                profiles.remove(Profile.JAKARTA_EE_8_FULL);
                 profiles.remove(Profile.JAVA_EE_8_FULL);
                 profiles.remove(Profile.JAVA_EE_7_FULL);
                 profiles.remove(Profile.JAVA_EE_6_FULL);

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/BaseJ2eeArchetypeProvider.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/BaseJ2eeArchetypeProvider.java
@@ -45,9 +45,6 @@ abstract class BaseJ2eeArchetypeProvider {
      *
      * It's possible to use {@link #addMojoArchetype} method for creating
      * new archetypes with groupId set to org.codehaus.mojo.archetypes or we can add archetypes directly to the map
-     *
-     * If we want to create the same archetype for all possible profiles, we can use
-     * {@link #addSameMojoArchetypeForAllProfiles} method
      */
     protected abstract void setUpProjectArchetypes();
 
@@ -67,51 +64,6 @@ abstract class BaseJ2eeArchetypeProvider {
                 NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,groupId),
                 NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,version),
                 NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,artifactId)));
-    }
-
-    protected void addSameMojoArchetypeForAllProfiles(String version, String artifactId) {
-        Archetype archetype = createMojoArchetype(version, artifactId);
-        map.put(Profile.J2EE_14, archetype);
-        map.put(Profile.JAVA_EE_5, archetype);
-        map.put(Profile.JAVA_EE_6_FULL, archetype);
-        map.put(Profile.JAVA_EE_6_WEB, archetype);
-        map.put(Profile.JAVA_EE_7_FULL, archetype);
-        map.put(Profile.JAVA_EE_7_WEB, archetype);
-        Archetype javaEE8Archetype = createArchetype(
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeGroupId.JavaEE8"),
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeVersion.JavaEE8"),
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeArtifactId.JavaEE8")
-        );
-        Archetype jakartaEE8Archetype = createArchetype(
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeGroupId.JakartaEE8"),
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeVersion.JakartaEE8"),
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeArtifactId.JakartaEE8"));
-
-        Archetype jakartaEE9Archetype = createArchetype(
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeGroupId.JakartaEE9"),
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeVersion.JakartaEE9"),
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeArtifactId.JakartaEE9"));
-
-        Archetype jakartaEE9_1Archetype = createArchetype(
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeGroupId.JakartaEE9_1"),
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeVersion.JakartaEE9_1"),
-               NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeArtifactId.JakartaEE9_1"));
-
-        Archetype jakartaEE10_0Archetype = createArchetype(
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeGroupId.JakartaEE10_0"),
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeVersion.JakartaEE10_0"),
-               NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeArtifactId.JakartaEE10_0"));
-
-        map.put(Profile.JAVA_EE_8_FULL, javaEE8Archetype);
-        map.put(Profile.JAVA_EE_8_WEB, javaEE8Archetype);
-        map.put(Profile.JAKARTA_EE_8_FULL, jakartaEE8Archetype);
-        map.put(Profile.JAKARTA_EE_8_WEB, jakartaEE8Archetype);
-        map.put(Profile.JAKARTA_EE_9_FULL, jakartaEE9Archetype);
-        map.put(Profile.JAKARTA_EE_9_WEB, jakartaEE9Archetype);
-        map.put(Profile.JAKARTA_EE_9_1_FULL, jakartaEE9_1Archetype);
-        map.put(Profile.JAKARTA_EE_9_1_WEB, jakartaEE9_1Archetype);
-        map.put(Profile.JAKARTA_EE_10_FULL, jakartaEE10_0Archetype);
-        map.put(Profile.JAKARTA_EE_10_WEB, jakartaEE10_0Archetype);
     }
 
     private Archetype createMojoArchetype(String version, String artifactId) {

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/BaseJ2eeArchetypeProvider.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/BaseJ2eeArchetypeProvider.java
@@ -25,7 +25,9 @@ import java.util.TreeMap;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.j2ee.core.Profile;
+import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.modules.maven.api.archetype.Archetype;
+import org.openide.modules.SpecificationVersion;
 import org.openide.util.NbBundle;
 
 /**
@@ -41,6 +43,8 @@ abstract class BaseJ2eeArchetypeProvider {
     private final static String JAKARTA_EE_9 = "9.0.0";
     private final static String JAKARTA_EE_9_1 = "9.1.0";
     private final static String JAKARTA_EE_10 = "10.0.0";
+
+    private final static SpecificationVersion JAVA_17_SPECIFICATION_VERSION = new SpecificationVersion("17");
 
     protected Map<Profile, Archetype> map;
 
@@ -68,9 +72,17 @@ abstract class BaseJ2eeArchetypeProvider {
         jakartaEEArchetype.setArtifactId(NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeArtifactId.JakartaEE"));
         jakartaEEArchetype.setVersion(NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeVersion.JakartaEE"));
 
-        Map<String, String> properties = new HashMap<>(2);
+        // As application servers most likely use java lts versions use 17 or 11 depending on used jdk.
+        SpecificationVersion javaSpecVersion = JavaPlatform.getDefault().getSpecification().getVersion();
+        String javaVersion = "17";
+        if (JAVA_17_SPECIFICATION_VERSION.compareTo(javaSpecVersion) < 0) {
+            javaVersion = "11";
+        }
+
+        Map<String, String> properties = new HashMap<>(3);
         properties.put("jakartaEEVariant", jakarteEEVariant);
         properties.put("jakartaEEVersion", jakartaEEVersion);
+        properties.put("javaVersion", javaVersion);
         jakartaEEArchetype.setProperties(properties);
 
         return jakartaEEArchetype;

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/BaseJ2eeArchetypeProvider.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/BaseJ2eeArchetypeProvider.java
@@ -103,14 +103,6 @@ abstract class BaseJ2eeArchetypeProvider {
     }
 
     /**
-     * Returns whole map which contains <key = Profile, value = Archetype> pairs.
-     * @return complete archetype map
-     */
-    public Map<Profile, Archetype> getArchetypeMap() {
-        return map;
-    }
-
-    /**
      * Returns any Archetype saved in the map.
      * Could be used if we want to have the same Archetype for every Profile
      *

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/BaseJ2eeArchetypeProvider.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/BaseJ2eeArchetypeProvider.java
@@ -18,6 +18,8 @@
  */
 package org.netbeans.modules.maven.j2ee.ui.wizard.archetype;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import org.netbeans.api.annotations.common.CheckForNull;
@@ -32,8 +34,51 @@ import org.openide.util.NbBundle;
  */
 abstract class BaseJ2eeArchetypeProvider {
 
+    private final static String JAKARTA_EE_WEB = "jakartaee-web";
+    private final static String JAKARTA_EE_FULL = "jakartaee";
+
+    private final static String JAKARTA_EE_8 = "8.0.0";
+    private final static String JAKARTA_EE_9 = "9.0.0";
+    private final static String JAKARTA_EE_9_1 = "9.1.0";
+    private final static String JAKARTA_EE_10 = "10.0.0";
+
     protected Map<Profile, Archetype> map;
 
+    private static final Map<Profile, Archetype> ALL_JAKARTA_EE_ARCHETYPES;
+    static {
+        Map<Profile, Archetype> map = new HashMap<>();
+        map.put(Profile.JAKARTA_EE_8_WEB, jakartaEEArchetype( JAKARTA_EE_8, JAKARTA_EE_WEB));
+        map.put(Profile.JAKARTA_EE_8_FULL, jakartaEEArchetype( JAKARTA_EE_8, JAKARTA_EE_FULL));
+
+        map.put(Profile.JAKARTA_EE_9_WEB, jakartaEEArchetype( JAKARTA_EE_9, JAKARTA_EE_WEB));
+        map.put(Profile.JAKARTA_EE_9_FULL, jakartaEEArchetype( JAKARTA_EE_9, JAKARTA_EE_FULL));
+
+        map.put(Profile.JAKARTA_EE_9_1_WEB, jakartaEEArchetype( JAKARTA_EE_9_1, JAKARTA_EE_WEB));
+        map.put(Profile.JAKARTA_EE_9_1_FULL, jakartaEEArchetype( JAKARTA_EE_9_1, JAKARTA_EE_FULL));
+
+        map.put(Profile.JAKARTA_EE_10_WEB, jakartaEEArchetype( JAKARTA_EE_10, JAKARTA_EE_WEB));
+        map.put(Profile.JAKARTA_EE_10_FULL, jakartaEEArchetype( JAKARTA_EE_10, JAKARTA_EE_FULL));
+
+        ALL_JAKARTA_EE_ARCHETYPES = Collections.unmodifiableMap(map);
+    }
+
+    private static Archetype jakartaEEArchetype(String jakartaEEVersion, String jakarteEEVariant) {
+        Archetype jakartaEEArchetype = new Archetype();
+        jakartaEEArchetype.setGroupId(NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeGroupId.JakartaEE"));
+        jakartaEEArchetype.setArtifactId(NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeArtifactId.JakartaEE"));
+        jakartaEEArchetype.setVersion(NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeVersion.JakartaEE"));
+
+        Map<String, String> properties = new HashMap<>(2);
+        properties.put("jakartaEEVariant", jakarteEEVariant);
+        properties.put("jakartaEEVersion", jakartaEEVersion);
+        jakartaEEArchetype.setProperties(properties);
+
+        return jakartaEEArchetype;
+    }
+
+    protected void importProfile(Profile profile) {
+        map.put(profile, ALL_JAKARTA_EE_ARCHETYPES.get(profile));
+    }
 
     protected BaseJ2eeArchetypeProvider() {
         map = new TreeMap<Profile, Archetype>(Profile.UI_COMPARATOR);
@@ -59,11 +104,12 @@ abstract class BaseJ2eeArchetypeProvider {
                 NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,artifactId)));
     }
 
-    protected void addJakartaEEArchetype(Profile j2eeProfile, String groupId, String version, String artifactId) {
+    protected void addJakartaEEArchetype(Profile j2eeProfile, String jakartaEEVersion, String jakartaEEVariant) {
         map.put(j2eeProfile, createArchetype(
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,groupId),
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,version),
-                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,artifactId)));
+                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeGroupId.JakartaEE"),
+                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeVersion.JakartaEE"),
+                NbBundle.getMessage(BaseJ2eeArchetypeProvider.class,"mvn.archetypeArtifactId.JakartaEE"))
+        );
     }
 
     private Archetype createMojoArchetype(String version, String artifactId) {
@@ -76,10 +122,15 @@ abstract class BaseJ2eeArchetypeProvider {
     }
 
     private Archetype createArchetype(String groupId, String version, String artifactId) {
+        return createArchetype(groupId, version, artifactId, null);
+    }
+
+    private Archetype createArchetype(String groupId, String version, String artifactId, Map<String, String> properties) {
         Archetype archetype = new Archetype();
         archetype.setGroupId(groupId); //NOI18N
         archetype.setVersion(version);
         archetype.setArtifactId(artifactId);
+        archetype.setProperties(properties);
 
         return archetype;
     }

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/Bundle.properties
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/Bundle.properties
@@ -16,18 +16,9 @@
 # under the License.
 
 # Maven Archetype Properties
-mvn.archetypeGroupId.JakartaEE10_0=io.github.juneau001
-mvn.archetypeVersion.JakartaEE10_0=1.0.0
-mvn.archetypeArtifactId.JakartaEE10_0=webapp-jakartaee10
-mvn.archetypeGroupId.JakartaEE9_1=io.github.juneau001
-mvn.archetypeVersion.JakartaEE9_1=1.1.0
-mvn.archetypeArtifactId.JakartaEE9_1=webapp-jakartaee91
-mvn.archetypeGroupId.JakartaEE9=io.github.juneau001
-mvn.archetypeVersion.JakartaEE9=1.1
-mvn.archetypeArtifactId.JakartaEE9=webapp-jakartaee9
-mvn.archetypeGroupId.JakartaEE8=io.github.juneau001
-mvn.archetypeVersion.JakartaEE8=1.0.0
-mvn.archetypeArtifactId.JakartaEE8=webapp-jakartaee8
+mvn.archetypeGroupId.JakartaEE=org.apache.netbeans.archetypes
+mvn.archetypeVersion.JakartaEE=1.0.0-SNAPSHOT
+mvn.archetypeArtifactId.JakartaEE=netbeans-jakartaee-war-archetype
 mvn.archetypeGroupId.JavaEE8=io.github.juneau001
 mvn.archetypeVersion.JavaEE8=1.3
 mvn.archetypeArtifactId.JavaEE8=webapp-javaee8

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/J2eeArchetypeFactory.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/J2eeArchetypeFactory.java
@@ -97,8 +97,6 @@ public final class J2eeArchetypeFactory {
             addJavaEE8Archetype(Profile.JAVA_EE_8_FULL,"mvn.archetypeGroupId.JavaEE8", "mvn.archetypeVersion.JavaEE8", "mvn.archetypeArtifactId.JavaEE8"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_7_FULL, "1.1", "appclient-javaee7"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_6_FULL, "1.0", "appclient-javaee6"); //NOI18N
-        //    addMojoArchetype(Profile.JAVA_EE_5, "1.0", "appclient-jee5"); //NOI18N
-        //    addMojoArchetype(Profile.J2EE_14, "1.0", "appclient-jee5"); //NOI18N
         }
     }
 
@@ -155,8 +153,6 @@ public final class J2eeArchetypeFactory {
             addJavaEE8Archetype(Profile.JAVA_EE_8_WEB,"mvn.archetypeGroupId.JavaEE8", "mvn.archetypeVersion.JavaEE8", "mvn.archetypeArtifactId.JavaEE8"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_7_WEB, "1.1", "webapp-javaee7"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_6_WEB, "1.5", "webapp-javaee6"); //NOI18N
-          //  addMojoArchetype(Profile.JAVA_EE_5, "1.3", "webapp-jee5"); //NOI18N
-          //  addMojoArchetype(Profile.J2EE_14, "1.3", "webapp-j2ee14"); //NOI18N
 
             // This need to be here! It isn't one of an options when creating Web projects, but when creating Java EE projects
             // using Java EE 6 Full profile, then the same profile applies to Ejb, Web and Parent project creation - In that case

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/J2eeArchetypeFactory.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/J2eeArchetypeFactory.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.maven.j2ee.ui.wizard.archetype;
 
-import java.util.Map;
 import org.netbeans.api.j2ee.core.Profile;
 import org.netbeans.modules.j2ee.deployment.devmodules.api.J2eeModule;
 import org.netbeans.modules.maven.api.archetype.Archetype;
@@ -86,10 +85,10 @@ public final class J2eeArchetypeFactory {
     private static class AppClientArchetypes extends BaseJ2eeArchetypeProvider {
         @Override
         protected void setUpProjectArchetypes() {
-            addJakartaEEArchetype(Profile.JAKARTA_EE_10_FULL,"mvn.archetypeGroupId.JakartaEE10_0","mvn.archetypeVersion.JakartaEE10_0","mvn.archetypeArtifactId.JakartaEE10_0");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_1_FULL,"mvn.archetypeGroupId.JakartaEE9_1","mvn.archetypeVersion.JakartaEE9_1","mvn.archetypeArtifactId.JakartaEE9_1");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_FULL,"mvn.archetypeGroupId.JakartaEE9","mvn.archetypeVersion.JakartaEE9","mvn.archetypeArtifactId.JakartaEE9");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_8_FULL,"mvn.archetypeGroupId.JakartaEE8","mvn.archetypeVersion.JakartaEE8","mvn.archetypeArtifactId.JakartaEE8");
+            importProfile(Profile.JAKARTA_EE_10_FULL);
+            importProfile(Profile.JAKARTA_EE_9_1_FULL);
+            importProfile(Profile.JAKARTA_EE_9_FULL);
+            importProfile(Profile.JAKARTA_EE_8_FULL);
             addJavaEE8Archetype(Profile.JAVA_EE_8_FULL,"mvn.archetypeGroupId.JavaEE8", "mvn.archetypeVersion.JavaEE8", "mvn.archetypeArtifactId.JavaEE8"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_7_FULL, "1.1", "appclient-javaee7"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_6_FULL, "1.0", "appclient-javaee6"); //NOI18N
@@ -99,10 +98,10 @@ public final class J2eeArchetypeFactory {
     private static class EaArchetypes extends BaseJ2eeArchetypeProvider {
         @Override
         protected void setUpProjectArchetypes() {
-            addJakartaEEArchetype(Profile.JAKARTA_EE_10_FULL,"mvn.archetypeGroupId.JakartaEE10_0","mvn.archetypeVersion.JakartaEE10_0","mvn.archetypeArtifactId.JakartaEE10_0");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_1_FULL,"mvn.archetypeGroupId.JakartaEE9_1","mvn.archetypeVersion.JakartaEE9_1","mvn.archetypeArtifactId.JakartaEE9_1");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_FULL,"mvn.archetypeGroupId.JakartaEE9","mvn.archetypeVersion.JakartaEE9","mvn.archetypeArtifactId.JakartaEE9");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_8_FULL,"mvn.archetypeGroupId.JakartaEE8","mvn.archetypeVersion.JakartaEE8","mvn.archetypeArtifactId.JakartaEE8");
+            importProfile(Profile.JAKARTA_EE_10_FULL);
+            importProfile(Profile.JAKARTA_EE_9_1_FULL);
+            importProfile(Profile.JAKARTA_EE_9_FULL);
+            importProfile(Profile.JAKARTA_EE_8_FULL);
             addJavaEE8Archetype(Profile.JAVA_EE_8_FULL,"mvn.archetypeGroupId.JavaEE8", "mvn.archetypeVersion.JavaEE8", "mvn.archetypeArtifactId.JavaEE8"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_7_FULL, "1.1", "pom-root"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_6_FULL, "1.1", "pom-root"); //NOI18N
@@ -112,10 +111,10 @@ public final class J2eeArchetypeFactory {
     private static class EarArchetypes extends BaseJ2eeArchetypeProvider {
         @Override
         protected void setUpProjectArchetypes() {
-            addJakartaEEArchetype(Profile.JAKARTA_EE_10_FULL,"mvn.archetypeGroupId.JakartaEE10_0","mvn.archetypeVersion.JakartaEE10_0","mvn.archetypeArtifactId.JakartaEE10_0");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_1_FULL,"mvn.archetypeGroupId.JakartaEE9_1","mvn.archetypeVersion.JakartaEE9_1","mvn.archetypeArtifactId.JakartaEE9_1");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_FULL,"mvn.archetypeGroupId.JakartaEE9","mvn.archetypeVersion.JakartaEE9","mvn.archetypeArtifactId.JakartaEE9");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_8_FULL,"mvn.archetypeGroupId.JakartaEE8","mvn.archetypeVersion.JakartaEE8","mvn.archetypeArtifactId.JakartaEE8");
+            importProfile(Profile.JAKARTA_EE_10_FULL);
+            importProfile(Profile.JAKARTA_EE_9_1_FULL);
+            importProfile(Profile.JAKARTA_EE_9_FULL);
+            importProfile(Profile.JAKARTA_EE_8_FULL);
             addJavaEE8Archetype(Profile.JAVA_EE_8_FULL,"mvn.archetypeGroupId.JavaEE8", "mvn.archetypeVersion.JavaEE8", "mvn.archetypeArtifactId.JavaEE8"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_7_FULL, "1.0", "ear-javaee7"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_6_FULL, "1.5", "ear-javaee6"); //NOI18N
@@ -127,10 +126,10 @@ public final class J2eeArchetypeFactory {
     private static class EjbArchetypes extends BaseJ2eeArchetypeProvider {
         @Override
         protected void setUpProjectArchetypes() {
-            addJakartaEEArchetype(Profile.JAKARTA_EE_10_FULL,"mvn.archetypeGroupId.JakartaEE10_0","mvn.archetypeVersion.JakartaEE10_0","mvn.archetypeArtifactId.JakartaEE10_0");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_1_FULL,"mvn.archetypeGroupId.JakartaEE9_1","mvn.archetypeVersion.JakartaEE9_1","mvn.archetypeArtifactId.JakartaEE9_1");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_FULL,"mvn.archetypeGroupId.JakartaEE9","mvn.archetypeVersion.JakartaEE9","mvn.archetypeArtifactId.JakartaEE9");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_8_FULL,"mvn.archetypeGroupId.JakartaEE8","mvn.archetypeVersion.JakartaEE8","mvn.archetypeArtifactId.JakartaEE8");
+            importProfile(Profile.JAKARTA_EE_10_FULL);
+            importProfile(Profile.JAKARTA_EE_9_1_FULL);
+            importProfile(Profile.JAKARTA_EE_9_FULL);
+            importProfile(Profile.JAKARTA_EE_8_FULL);
             addJavaEE8Archetype(Profile.JAVA_EE_8_FULL,"mvn.archetypeGroupId.JavaEE8", "mvn.archetypeVersion.JavaEE8", "mvn.archetypeArtifactId.JavaEE8"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_7_FULL, "1.1", "ejb-javaee7"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_6_FULL, "1.5", "ejb-javaee6"); //NOI18N
@@ -142,10 +141,10 @@ public final class J2eeArchetypeFactory {
     private static class WebArchetypes extends BaseJ2eeArchetypeProvider {
         @Override
         protected void setUpProjectArchetypes() {
-            addJakartaEEArchetype(Profile.JAKARTA_EE_10_WEB,"mvn.archetypeGroupId.JakartaEE10_0","mvn.archetypeVersion.JakartaEE10_0","mvn.archetypeArtifactId.JakartaEE10_0");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_1_WEB,"mvn.archetypeGroupId.JakartaEE9_1","mvn.archetypeVersion.JakartaEE9_1","mvn.archetypeArtifactId.JakartaEE9_1");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_WEB,"mvn.archetypeGroupId.JakartaEE9","mvn.archetypeVersion.JakartaEE9","mvn.archetypeArtifactId.JakartaEE9");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_8_WEB,"mvn.archetypeGroupId.JakartaEE8","mvn.archetypeVersion.JakartaEE8","mvn.archetypeArtifactId.JakartaEE8");
+            importProfile(Profile.JAKARTA_EE_10_WEB);
+            importProfile(Profile.JAKARTA_EE_9_1_WEB);
+            importProfile(Profile.JAKARTA_EE_9_WEB);
+            importProfile(Profile.JAKARTA_EE_8_WEB);
             addJavaEE8Archetype(Profile.JAVA_EE_8_WEB,"mvn.archetypeGroupId.JavaEE8", "mvn.archetypeVersion.JavaEE8", "mvn.archetypeArtifactId.JavaEE8"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_7_WEB, "1.1", "webapp-javaee7"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_6_WEB, "1.5", "webapp-javaee6"); //NOI18N
@@ -154,10 +153,10 @@ public final class J2eeArchetypeFactory {
             // using Java EE 6 Full profile, then the same profile applies to Ejb, Web and Parent project creation - In that case
             // application is looking for Java EE 6 Full archetype to create the Web project with it, so we need to have it here
             // or otherwise Java EE project would not be created properly
-            addJakartaEEArchetype(Profile.JAKARTA_EE_10_FULL,"mvn.archetypeGroupId.JakartaEE10_0","mvn.archetypeVersion.JakartaEE10_0","mvn.archetypeArtifactId.JakartaEE10_0");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_1_FULL,"mvn.archetypeGroupId.JakartaEE9_1","mvn.archetypeVersion.JakartaEE9_1","mvn.archetypeArtifactId.JakartaEE9_1");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_9_FULL,"mvn.archetypeGroupId.JakartaEE9","mvn.archetypeVersion.JakartaEE9","mvn.archetypeArtifactId.JakartaEE9");
-            addJakartaEEArchetype(Profile.JAKARTA_EE_8_FULL,"mvn.archetypeGroupId.JakartaEE8","mvn.archetypeVersion.JakartaEE8","mvn.archetypeArtifactId.JakartaEE8");
+            importProfile(Profile.JAKARTA_EE_10_FULL);
+            importProfile(Profile.JAKARTA_EE_9_1_FULL);
+            importProfile(Profile.JAKARTA_EE_9_FULL);
+            importProfile(Profile.JAKARTA_EE_8_FULL);
             addJavaEE8Archetype(Profile.JAVA_EE_8_FULL,"mvn.archetypeGroupId.JavaEE8", "mvn.archetypeVersion.JavaEE8", "mvn.archetypeArtifactId.JavaEE8"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_7_FULL, "1.1", "webapp-javaee7"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_6_FULL, "1.5", "webapp-javaee6"); //NOI18N

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/J2eeArchetypeFactory.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/J2eeArchetypeFactory.java
@@ -83,10 +83,6 @@ public final class J2eeArchetypeFactory {
         return getProvider(projectType).getAnyArchetype();
     }
 
-    public Map<Profile, Archetype> getArchetypeMap(J2eeModule.Type projectType) {
-        return getProvider(projectType).getArchetypeMap();
-    }
-
     private static class AppClientArchetypes extends BaseJ2eeArchetypeProvider {
         @Override
         protected void setUpProjectArchetypes() {

--- a/java/maven/src/org/netbeans/modules/maven/api/archetype/Archetype.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/archetype/Archetype.java
@@ -64,6 +64,7 @@ public final class Archetype {
     private String groupId;
     private String version;
     private String name;
+    private Map<String, String> properties;
     private String description;
     private String repository;
     public final boolean deletable;
@@ -120,6 +121,14 @@ public final class Archetype {
     
     public void setName(String name) {
         this.name = name;
+    }
+
+    public Map<String, String> getProperties() {
+        return Collections.unmodifiableMap(properties);
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
     }
     
     public String getDescription() {


### PR DESCRIPTION
This PR aims to replace the used archetypes used to generate Jakarta EE projects which a new one which should be managed within the NetBeans project.

Instead of using one archetype per Jakarta EE version there's just one configured via system properties.

In addition the newly generated projects are able to be compiled with Java 17 (see #4552 )

Before this branch can be merged the archetype needs to be migrated to NetBeans project somehow: https://github.com/asbachb/jakartaee-war-archetype/tree/netbeans-adjustments