### PR TITLE
VSCode: Completion for annonymous inner classes improved.

### DIFF
--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -59,7 +59,7 @@
         <author login="dbalek"/>
         <compatibility binary="compatible" source="compatible" addition="yes" deletion="no"/>
         <description>
-            <a href="@TOP@/org/netbeans/api/lsp/Diagnostic.html#getCommand">Completion.getCommand</a> to get an optional command
+            <a href="@TOP@/org/netbeans/api/lsp/Completion.html#getCommand">Completion.getCommand</a> to get an optional command
             that is executed after inserting the completion.
         </description>
         <class package="org.netbeans.api.lsp" name="Completion"/>

--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -51,6 +51,19 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="Completion_getCommand">
+        <api name="LSP_API"/>
+        <summary>Added URL to diagnostic code description</summary>
+        <version major="1" minor="17"/>
+        <date day="23" month="5" year="2023"/>
+        <author login="dbalek"/>
+        <compatibility binary="compatible" source="compatible" addition="yes" deletion="no"/>
+        <description>
+            <a href="@TOP@/org/netbeans/api/lsp/Diagnostic.html#getCommand">Completion.getCommand</a> to get an optional command
+            that is executed after inserting the completion.
+        </description>
+        <class package="org.netbeans.api.lsp" name="Completion"/>
+    </change>
     <change id="DiagnosticURL">
         <api name="LSP_API"/>
         <summary>Added URL to diagnostic code description</summary>

--- a/ide/api.lsp/manifest.mf
+++ b/ide/api.lsp/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.lsp/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/lsp/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.16
+OpenIDE-Module-Specification-Version: 1.17
 AutoUpdate-Show-In-Client: false

--- a/ide/api.lsp/src/org/netbeans/api/lsp/Completion.java
+++ b/ide/api.lsp/src/org/netbeans/api/lsp/Completion.java
@@ -44,9 +44,9 @@ public final class Completion {
         CompletionAccessor.setDefault(new CompletionAccessor() {
             @Override
             public Completion createCompletion(String label, Kind kind, List<Tag> tags, CompletableFuture<String> detail, CompletableFuture<String> documentation,
-                    boolean preselect, String sortText, String filterText, String insertText, TextFormat insertTextFormat, TextEdit textEdit, CompletableFuture<List<TextEdit>> additionalTextEdits,
-                    List<Character> commitCharacters) {
-                return new Completion(label, kind, tags, detail, documentation, preselect, sortText, filterText, insertText, insertTextFormat, textEdit, additionalTextEdits, commitCharacters);
+                    boolean preselect, String sortText, String filterText, String insertText, TextFormat insertTextFormat, TextEdit textEdit, Command command,
+                    CompletableFuture<List<TextEdit>> additionalTextEdits, List<Character> commitCharacters) {
+                return new Completion(label, kind, tags, detail, documentation, preselect, sortText, filterText, insertText, insertTextFormat, textEdit, command, additionalTextEdits, commitCharacters);
             }
         });
     }
@@ -62,12 +62,13 @@ public final class Completion {
     private final String insertText;
     private final TextFormat insertTextFormat;
     private final TextEdit textEdit;
+    private final Command command;
     private final CompletableFuture<List<TextEdit>> additionalTextEdits;
     private final List<Character> commitCharacters;
 
     private Completion(String label, Kind kind, List<Tag> tags, CompletableFuture<String> detail, CompletableFuture<String> documentation,
             boolean preselect, String sortText, String filterText, String insertText, TextFormat insertTextFormat,
-            TextEdit textEdit, CompletableFuture<List<TextEdit>> additionalTextEdits, List<Character> commitCharacters) {
+            TextEdit textEdit, Command command, CompletableFuture<List<TextEdit>> additionalTextEdits, List<Character> commitCharacters) {
         this.label = label;
         this.kind = kind;
         this.tags = tags;
@@ -79,6 +80,7 @@ public final class Completion {
         this.insertText = insertText;
         this.insertTextFormat = insertTextFormat;
         this.textEdit = textEdit;
+        this.command = command;
         this.additionalTextEdits = additionalTextEdits;
         this.commitCharacters = commitCharacters;
     }
@@ -201,6 +203,16 @@ public final class Completion {
     @CheckForNull
     public TextEdit getTextEdit() {
         return textEdit;
+    }
+
+    /**
+     * An optional command that is executed after inserting this completion.
+     *
+     * @since 1.17
+     */
+    @CheckForNull
+    public Command getCommand() {
+        return command;
     }
 
     /**

--- a/ide/api.lsp/src/org/netbeans/modules/lsp/CompletionAccessor.java
+++ b/ide/api.lsp/src/org/netbeans/modules/lsp/CompletionAccessor.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.lsp;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.lsp.Command;
 import org.netbeans.api.lsp.Completion;
 import org.netbeans.api.lsp.TextEdit;
 import org.openide.util.Exceptions;
@@ -56,5 +57,5 @@ public abstract class CompletionAccessor {
 
     public abstract Completion createCompletion(String label, Completion.Kind kind, List<Completion.Tag> tags, CompletableFuture<String> detail, CompletableFuture<String> documentation,
             boolean preselect, String sortText, String filterText, String insertText, Completion.TextFormat insertTextFormat,
-            TextEdit textEdit, CompletableFuture<List<TextEdit>> additionalTextEdits, List<Character> commitCharacters);
+            TextEdit textEdit, Command command, CompletableFuture<List<TextEdit>> additionalTextEdits, List<Character> commitCharacters);
 }

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/CompletionCollector.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/CompletionCollector.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import javax.swing.text.Document;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.api.lsp.Command;
 import org.netbeans.api.lsp.Completion;
 import org.netbeans.api.lsp.TextEdit;
 import org.netbeans.modules.lsp.CompletionAccessor;
@@ -99,6 +100,7 @@ public interface CompletionCollector {
         private String insertText;
         private Completion.TextFormat insertTextFormat;
         private TextEdit textEdit;
+        private Command command;
         private CompletableFuture<List<TextEdit>> additionalTextEdits;
         private List<Character> commitCharacters;
 
@@ -274,6 +276,16 @@ public interface CompletionCollector {
         }
 
         /**
+	 * An optional command that is executed after inserting this completion.
+         *
+         * @since 1.17
+	 */
+        @NonNull
+        public Builder command(@NonNull Command command) {
+            this.command = command;
+            return this;
+        }
+        /**
          * A list of additional text edits that are applied when selecting this
          * completion. Edits must not overlap (including the same insert position)
          * with the main edit nor with themselves.
@@ -334,7 +346,7 @@ public interface CompletionCollector {
         public Completion build() {
             return CompletionAccessor.getDefault().createCompletion(label, kind,
                     tags, detail, documentation, preselect, sortText, filterText,
-                    insertText, insertTextFormat, textEdit, additionalTextEdits,
+                    insertText, insertTextFormat, textEdit, command, additionalTextEdits,
                     commitCharacters);
         }
 

--- a/java/java.editor/nbproject/project.xml
+++ b/java/java.editor/nbproject/project.xml
@@ -58,7 +58,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.9</specification-version>
+                        <specification-version>1.17</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
@@ -612,6 +612,9 @@ public class JavaCompletionCollector implements CompletionCollector {
                     .kind(Completion.Kind.Constructor)
                     .sortText(String.format("%04d%s#0", smartType ? 650 : 1650, elem.getSimpleName().toString()));
             StringBuilder insertText = new StringBuilder();
+            if (substitutionOffset < offset) {
+                insertText.append((elem.getSimpleName()));
+            }
             insertText.append(CodeStyle.getDefault(doc).spaceBeforeMethodCallParen() ? " ()" : "()");
             if (elem.getModifiers().contains(Modifier.ABSTRACT)) {
                 try {

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -128,7 +128,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.11</specification-version>
+                        <specification-version>1.17</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ImplementAllAbstractMethodsAction.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ImplementAllAbstractMethodsAction.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonPrimitive;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import javax.swing.text.Document;
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.netbeans.api.editor.document.LineDocument;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.modules.java.editor.codegen.GeneratorUtils;
+import org.netbeans.modules.java.lsp.server.Utils;
+import org.netbeans.modules.parsing.api.ResultIterator;
+import org.openide.filesystems.FileObject;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author Dusan Balek
+ */
+@ServiceProvider(service = CodeActionsProvider.class, position = 200)
+public final class ImplementAllAbstractMethodsAction extends CodeActionsProvider {
+
+    private static final String IMPLEMENT_ALL_ABSTRACT_METHODS = "java.implement.all.abstract.methods"; //NOI18N
+    private final Gson gson = new Gson();
+
+    @Override
+    public List<CodeAction> getCodeActions(ResultIterator resultIterator, CodeActionParams params) throws Exception {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return Collections.singleton(IMPLEMENT_ALL_ABSTRACT_METHODS);
+    }
+
+    @Override
+    public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        try {
+            if (arguments.size() >= 2) {
+                String uri = ((JsonPrimitive) arguments.get(0)).getAsString();
+                FileObject file = Utils.fromUri(uri);
+                JavaSource js = JavaSource.forFileObject(file);
+                if (js == null) {
+                    throw new IOException("Cannot get JavaSource for: " + uri);
+                }
+                Position position = gson.fromJson(gson.toJson(arguments.get(1)), Position.class);
+                List<TextEdit> edits = TextDocumentServiceImpl.modify2TextEdits(js, wc -> {
+                    wc.toPhase(JavaSource.Phase.RESOLVED);
+                    Document doc = wc.getSnapshot().getSource().getDocument(true);
+                    if (doc instanceof LineDocument) {
+                        int offset = Utils.getOffset((LineDocument) doc, position);
+                        GeneratorUtils.generateAllAbstractMethodImplementations(wc, wc.getTreeUtilities().pathFor(offset));
+                    }
+                });
+                client.applyEdit(new ApplyWorkspaceEditParams(new WorkspaceEdit(Collections.singletonMap(uri, edits))));
+                future.complete(true);
+            } else {
+                throw new IllegalArgumentException(String.format("Illegal number of arguments received for command: %s", command));
+            }
+        } catch (IOException | IllegalArgumentException ex) {
+            future.completeExceptionally(ex);
+        }
+        return future;
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -399,6 +399,10 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                         if (edit != null) {
                             item.setTextEdit(Either.forLeft(new TextEdit(new Range(Utils.createPosition(file, edit.getStartOffset()), Utils.createPosition(file, edit.getEndOffset())), edit.getNewText())));
                         }
+                        org.netbeans.api.lsp.Command command = completion.getCommand();
+                        if (command != null) {
+                            item.setCommand(new Command(command.getTitle(), command.getCommand(), command.getArguments()));
+                        }
                         if (completion.getAdditionalTextEdits() != null && completion.getAdditionalTextEdits().isDone()) {
                             List<org.netbeans.api.lsp.TextEdit> additionalTextEdits = completion.getAdditionalTextEdits().getNow(null);
                             if (additionalTextEdits != null && !additionalTextEdits.isEmpty()) {

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -610,6 +610,13 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
             }
         }
     }));
+    context.subscriptions.push(commands.registerCommand('java.complete.abstract.methods', async () => {
+        const active = vscode.window.activeTextEditor;
+        if (active) {
+            const position = new vscode.Position(active.selection.start.line, active.selection.start.character);
+            await commands.executeCommand('java.implement.all.abstract.methods', active.document.uri.toString(), position);
+        }
+    }));
     context.subscriptions.push(commands.registerCommand('nbls.startup.condition', async () => {
         return client;
     }));


### PR DESCRIPTION
Code completion for anonymous inner class constructor should generate default implementation for all abstract methods.
E.g. code completion for:
```
Runnable r = new Runnable|
```
should generate:
```
Runnable r = new Runnable() {
    @Override
    public void run() {
        throw new UnsupportedOperationException("Not supported yet.");
    }
}
```