### PR TITLE
[JS] Fix ConcurrentModificationException scanning export class {} with multiple members

### DIFF
--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -712,8 +712,9 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
             );
             JsObject origClassObject = parent.getProperty(className.getName());
             if (origClassObject != null) {
-                for (Entry<String, ? extends JsObject> e : origClassObject.getProperties().entrySet()) {
-                    ModelUtils.moveProperty(classObject, e.getValue());
+                List<JsObject> properties = new ArrayList<>(origClassObject.getProperties().values());
+                for (JsObject property : properties) {
+                    ModelUtils.moveProperty(classObject, property);
                 }
             }
             parent.addProperty(className.getName(), classObject);

--- a/webcommon/javascript2.model/test/unit/data/testfiles/structure/issueGH5184_03.js
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/structure/issueGH5184_03.js
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class test {
+    field1 = "Value1";
+
+    method1() {
+    }
+}

--- a/webcommon/javascript2.model/test/unit/data/testfiles/structure/issueGH5184_03.js.model
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/structure/issueGH5184_03.js.model
@@ -1,0 +1,12 @@
+FUNCTION issueGH5184_03 [ANONYMOUS: false, DECLARED: true - issueGH5184_03, MODIFIERS: PUBLIC, FILE]
+# RETURN TYPES
+undefined, RESOLVED: true
+# PROPERTIES
+test : OBJECT test [ANONYMOUS: false, DECLARED: true - test, MODIFIERS: PUBLIC, CLASS]
+     # PROPERTIES
+     field1  : OBJECT field1 [ANONYMOUS: false, DECLARED: true - field1, MODIFIERS: PUBLIC, PROPERTY]
+     method1 : FUNCTION method1 [ANONYMOUS: false, DECLARED: true - method1, MODIFIERS: PUBLIC, METHOD]
+             # RETURN TYPES
+             undefined, RESOLVED: true
+             # PROPERTIES
+             arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]

--- a/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
+++ b/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
@@ -234,6 +234,10 @@ public class ModelTest extends ModelTestBase {
         checkModel("testfiles/structure/issueGH5184_02.js");
     }
 
+    public void testIssueGH5184_03() throws Exception {
+        checkModel("testfiles/structure/issueGH5184_03.js");
+    }
+
     public void testBogusGlobalThis() throws Exception {
         checkModel("testfiles/structure/bogusGlobalThis_01.js");
         checkModel("testfiles/structure/bogusGlobalThis_02.js");


### PR DESCRIPTION
Fix applies same pattern, that is used in other places where ModelUtils#moveProperty is invoked.