### PR TITLE
#5987: Use the currently active dialog as the presenter parent

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/services/NbDialog.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/services/NbDialog.java
@@ -50,7 +50,15 @@ final class NbDialog extends NbPresenter {
         super (d, owner, d.isModal ());
     }
 
-    /** Geter for help.
+    /** Creates a new Dialog from specified DialogDescriptor
+    * @param d The DialogDescriptor to create the dialog from
+    * @param owner Owner of this dialog.
+    */
+    public NbDialog(DialogDescriptor d, Window owner) {
+        super(d, owner, d.isModal() ? Dialog.DEFAULT_MODALITY_TYPE : ModalityType.MODELESS);
+    }
+
+    /** Getter for help.
     */
     @Override
     protected HelpCtx getHelpCtx () {

--- a/platform/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
@@ -26,7 +26,6 @@ import java.awt.Container;
 import java.awt.DefaultKeyboardFocusManager;
 import java.awt.Dialog;
 import java.awt.Dimension;
-import java.awt.EventQueue;
 import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.awt.GraphicsDevice;
@@ -89,7 +88,6 @@ import org.openide.NotificationLineSupport;
 import org.openide.NotifyDescriptor;
 import org.openide.WizardDescriptor;
 import org.openide.awt.Mnemonics;
-import org.openide.util.ChangeSupport;
 import org.openide.util.HelpCtx;
 import org.openide.util.ImageUtilities;
 import org.openide.util.Mutex;
@@ -106,9 +104,6 @@ import org.openide.util.Utilities;
 class NbPresenter extends JDialog
 implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparator<Object> {
 
-    /** variable holding current modal dialog in the system */
-    public static NbPresenter currentModalDialog;
-    private static final ChangeSupport cs = new ChangeSupport(NbPresenter.class);
     private static Boolean isJava17 = null;
 
     protected NotifyDescriptor descriptor;
@@ -186,6 +181,21 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
      */
     public NbPresenter(NotifyDescriptor d, Dialog owner, boolean modal) {
         super(owner, d.getTitle(), modal); // modal
+        initialize(d);
+    }
+
+    /**
+     * Creates a new Dialog from the specified NotifyDescriptor and owner.
+     *
+     * @param d the non-null descriptor from which to initialize the dialog
+     * @param owner the owner of the dialog, must be a {@code Dialog} or
+     *      {@code Frame} instance or {@code null} (not recommended)
+     * @param modality specifies whether dialog blocks input to other windows
+     *      when shown. {@code null} value and unsupported modality types are
+     *      equivalent to {@code MODELESS}
+     */
+    public NbPresenter(NotifyDescriptor d, Window owner, ModalityType modality) {
+        super(owner, d.getTitle(), modality);
         initialize(d);
     }
 
@@ -1092,6 +1102,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         }
     }
 
+    @Override
     public Void run() {
         doShow();
         return null;
@@ -1108,30 +1119,21 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                     gd.setFullScreenWindow( null );
             }
         }
-        NbPresenter prev = null;
         try {
             MenuSelectionManager.defaultManager().clearSelectedPath();
         } catch( NullPointerException npE ) {
             //#216184
             LOG.log( Level.FINE, null, npE );
         }
-        if (isModal()) {
-            prev = currentModalDialog;
-            currentModalDialog = this;
-            fireChangeEvent();
-        }
 
         superShow();
 
-        if( null != fullScreenWindow )
+        if( null != fullScreenWindow ) {
             getGraphicsConfiguration().getDevice().setFullScreenWindow( fullScreenWindow );
-
-        if (currentModalDialog != prev) {
-            currentModalDialog = prev;
-            fireChangeEvent();
         }
     }
 
+    @Override
     public void propertyChange(final java.beans.PropertyChangeEvent evt) {
         if( !SwingUtilities.isEventDispatchThread() ) {
             SwingUtilities.invokeLater(new Runnable() {
@@ -1274,19 +1276,13 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
     public void windowActivated(final java.awt.event.WindowEvent p1) {
     }
 
-    // Used by JavaHelp:
+    @Deprecated
     public static void addChangeListener(ChangeListener l) {
-        cs.addChangeListener(l);
+        // Does nothing
     }
+    @Deprecated
     public static void removeChangeListener(ChangeListener l) {
-        cs.removeChangeListener(l);
-    }
-    private static void fireChangeEvent() {
-        EventQueue.invokeLater(new Runnable() {
-            public void run() {
-                cs.fireChange();
-            }
-        });
+        // Does nothing
     }
 
     private final class EscapeAction extends AbstractAction {

--- a/platform/core.windows/src/org/netbeans/core/windows/services/NodeOperationImpl.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/services/NodeOperationImpl.java
@@ -51,6 +51,7 @@ import org.openide.util.HelpCtx;
 import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
 import org.openide.util.UserCancelException;
+import org.openide.util.Utilities;
 import org.openide.util.WeakSet;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.windows.Mode;
@@ -350,12 +351,7 @@ public final class NodeOperationImpl extends NodeOperation {
 //        Mutex.EVENT.readAccess (new Runnable () { // PENDING
         javax.swing.SwingUtilities.invokeLater(new Runnable() {
                 public void run () {
-                    boolean modal;
-                    if(NbPresenter.currentModalDialog == null) {
-                        modal = false;
-                    } else {
-                        modal = true;
-                    }
+                    boolean modal = Utilities.isModalDialogOpen();
                     
                     Dialog dlg = org.openide.DialogDisplayer.getDefault().createDialog(new DialogDescriptor (
                         sheet,

--- a/platform/core.windows/test/unit/src/org/netbeans/core/windows/services/DialogDisplayerImplTest.java
+++ b/platform/core.windows/test/unit/src/org/netbeans/core/windows/services/DialogDisplayerImplTest.java
@@ -23,6 +23,7 @@ import java.awt.Component;
 import java.awt.Dialog;
 import java.awt.EventQueue;
 import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
 import java.awt.Window;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -81,10 +82,13 @@ public class DialogDisplayerImplTest extends NbTestCase {
 
     @Override
     protected void tearDown() throws Exception {
-        if (NbPresenter.currentModalDialog != null) {
-            NbPresenter.currentModalDialog.setVisible(false);
-            NbPresenter.currentModalDialog.dispose();
-            NbPresenter.currentModalDialog = null;
+        while (true) {
+            Window w = KeyboardFocusManager.getCurrentKeyboardFocusManager().getActiveWindow();
+            if (w == null) {
+                break;
+            }
+            w.setVisible(false);
+            w.dispose();
         }
         super.tearDown();
     }
@@ -347,6 +351,22 @@ public class DialogDisplayerImplTest extends NbTestCase {
         assertEquals(frame, dlg.getOwner());
     }
     
+    @RandomlyFails
+    public void testNestedDialogParent() throws Exception {
+        Frame f = null;
+        Dialog owner = new Dialog(f, true);
+        postInAwtAndWaitOutsideAwt(() -> owner.setVisible(true));
+        assertShowing("Owner is invisible", true, owner);
+
+        child = new JButton();
+        final NotifyDescriptor nd = new NotifyDescriptor.Message(child);
+        postInAwtAndWaitOutsideAwt(() -> DialogDisplayer.getDefault().notify(nd));
+
+        assertShowing("Child is invisible", true, child);
+        Window w = SwingUtilities.windowForComponent(child);
+        assertSame("Window parent is not owner", owner, w.getParent());
+    }
+
     static void postInAwtAndWaitOutsideAwt (final Runnable run) throws Exception {
         // pendig to better implementation
         SwingUtilities.invokeLater (run);
@@ -444,7 +464,7 @@ public class DialogDisplayerImplTest extends NbTestCase {
             thenApply((x) -> x);
         
         // wait for the dialog to be displayed
-        panel.displayed.await(10, TimeUnit.SECONDS);
+        assertTrue(panel.displayed.await(10, TimeUnit.SECONDS));
         
         cf.cancel(true);
         

--- a/platform/core.windows/test/unit/src/org/netbeans/core/windows/services/NbDialogTest.java
+++ b/platform/core.windows/test/unit/src/org/netbeans/core/windows/services/NbDialogTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.core.windows.services;
+
+import java.awt.Dialog;
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
+import javax.swing.JLabel;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import org.netbeans.junit.NbTestCase;
+import org.openide.DialogDescriptor;
+
+public class NbDialogTest extends NbTestCase {
+    public static Test suite() {
+        return GraphicsEnvironment.isHeadless() ? new TestSuite() : new TestSuite(NbDialogTest.class);
+    }
+
+    public NbDialogTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected boolean runInEQ() {
+        return true;
+    }
+
+    public void testModalityIsDefaultWhenModal() {
+        NbDialog d = new NbDialog(new DialogDescriptor(null, null, true, null), (Window) null);
+        assertEquals(Dialog.DEFAULT_MODALITY_TYPE, d.getModalityType());
+    }
+
+    public void testModalityIsModelessWhenNotModal() {
+        NbDialog d = new NbDialog(new DialogDescriptor(null, null, false, null), (Window) null);
+        assertEquals(Dialog.ModalityType.MODELESS, d.getModalityType());
+    }
+}

--- a/platform/core.windows/test/unit/src/org/netbeans/core/windows/services/NbPresenterTest.java
+++ b/platform/core.windows/test/unit/src/org/netbeans/core/windows/services/NbPresenterTest.java
@@ -20,6 +20,7 @@
 package org.netbeans.core.windows.services;
 
 import java.awt.Dialog;
+import java.awt.Frame;
 import java.awt.GraphicsEnvironment;
 import java.awt.Window;
 import java.util.Arrays;
@@ -31,7 +32,6 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.openide.DialogDescriptor;
 import org.netbeans.junit.NbTestCase;
-import org.netbeans.junit.RandomlyFails;
 import org.openide.NotifyDescriptor;
 import org.openide.util.HelpCtx;
 
@@ -40,6 +40,8 @@ import org.openide.util.HelpCtx;
  * @author Jiri Rechtacek
  */
 public class NbPresenterTest extends NbTestCase {
+    private static final String TITLE = "My dialog";
+    private static final DialogDescriptor DESCRIPTOR = new DialogDescriptor(new JLabel ("Something interesting"), TITLE);
 
     public static Test suite() {
         return GraphicsEnvironment.isHeadless() ? new TestSuite() : new TestSuite(NbPresenterTest.class);
@@ -49,8 +51,25 @@ public class NbPresenterTest extends NbTestCase {
         super (testName);
     }
 
+    @Override
     protected boolean runInEQ () {
         return true;
+    }
+
+    public void testOwnerIsWindow() {
+        Window owner = new Frame();
+        NbPresenter p = new NbPresenter(DESCRIPTOR, owner, Dialog.ModalityType.APPLICATION_MODAL);
+        assertSame(owner, p.getOwner());
+    }
+
+    public void testTitleIsFromDescriptor() {
+        NbPresenter p = new NbPresenter(DESCRIPTOR, null, Dialog.ModalityType.APPLICATION_MODAL);
+        assertEquals(TITLE, p.getTitle());
+    }
+
+    public void testModalityIsSet() {
+        NbPresenter p = new NbPresenter(DESCRIPTOR, null, Dialog.ModalityType.APPLICATION_MODAL);
+        assertEquals(Dialog.ModalityType.APPLICATION_MODAL, p.getModalityType());
     }
 
     public void testDialogsOptionsOnDefaultSystem () {
@@ -70,7 +89,7 @@ public class NbPresenterTest extends NbTestCase {
         JButton rescue = new JButton ("Rescue");
         JButton cancel = new JButton ("Cancel");
         JButton [] options = new JButton [] {erase, rescue, cancel};
-        DialogDescriptor dd = new DialogDescriptor (new JLabel ("Something interesting"), "My dialog", modal,
+        DialogDescriptor dd = new DialogDescriptor (new JLabel ("Something interesting"), TITLE, modal,
                 // options
                 options,
                 rescue,
@@ -123,7 +142,7 @@ public class NbPresenterTest extends NbTestCase {
         JButton rescue = new JButton ("Rescue");
         JButton cancel = new JButton ("Cancel");
         JButton [] options = new JButton [] {erase, rescue, cancel};
-        DialogDescriptor dd = new DialogDescriptor (new JLabel ("Something interesting"), "My dialog", false,
+        DialogDescriptor dd = new DialogDescriptor (new JLabel ("Something interesting"), TITLE, false,
                 // options
                 options,
                 rescue,

--- a/platform/core.windows/test/unit/src/org/netbeans/core/windows/services/NotifyLaterTest.java
+++ b/platform/core.windows/test/unit/src/org/netbeans/core/windows/services/NotifyLaterTest.java
@@ -116,7 +116,7 @@ public class NotifyLaterTest extends NbTestCase {
         assertNotNull("There is parent window", root);
         assertTrue("It is a dialog", root instanceof JDialog);
         JDialog d = (JDialog)root;
-        assertEquals("The owner of d is the same as owner of dialog without owner", new JDialog().getParent(), d.getParent());
+        assertNull("d should have no owner", d.getParent());
         
         SwingUtilities.invokeAndWait(new Runnable () {
             public void run() {

--- a/platform/openide.util.ui/apichanges.xml
+++ b/platform/openide.util.ui/apichanges.xml
@@ -27,6 +27,22 @@
     <apidef name="actions">Actions API</apidef>
 </apidefs>
 <changes>
+    <change id="findDialogParent2">
+         <api name="util"/>
+         <summary>static method Utilities.findDialogParent overloaded and isModalDialogOpen added</summary>
+         <version major="9" minor="30"/>
+         <date day="26" month="5" year="2023"/>
+         <author login="rkeen-siemens"/>
+         <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="yes"/>
+         <description>
+             <p>
+                 Updated <code>findDialogParent</code> to ensure that if a modal dialog is open the returned component is in that dialog
+                 and added an overload that allows providing a fallback component.
+                 Added <code>isModalDialogOpen</code> to determine if there is a modal dialog open.
+             </p>
+         </description>
+         <class package="org.openide.util" name="Utilities"/>
+    </change>
     <change id="actionsForPathLookup">
          <api name="util"/>
          <summary>Added variant Utilities.actionsForPath with Lookup that produces context-aware actions</summary>


### PR DESCRIPTION
As described in #5987, `DialogDisplayer.notify` won't use the active window as the parent if it is a dialog that wasn't originally shown via `NbPresenter`. This causes issues in some cases due to [JDK-8306001](https://bugs.openjdk.org/browse/JDK-8306001) because the displayed dialog does not have the previously active modal dialog as its parent.

The solution here is to use the `Dialog` overload when creating the `NbPresenter` if the currently active window is a `Dialog` instead of falling back to the main window.