### PR TITLE
Enable Micronaut HyperlinkProviders - deadlocks fixed.

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/MicronautConfigUtilities.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/MicronautConfigUtilities.java
@@ -60,6 +60,9 @@ public class MicronautConfigUtilities {
 
     private static final Pattern REGEXP = Pattern.compile("^(application|bootstrap)(-\\w*)*\\.(yml|properties)$", Pattern.CASE_INSENSITIVE);
 
+    public static final String YAML_MIME = "text/x-yaml";
+    public static final String PROPERTIES_MIME = "text/x-properties";
+
     public static boolean isMicronautConfigFile(FileObject fo) {
         return fo != null && REGEXP.matcher(fo.getNameExt()).matches();
     }
@@ -75,7 +78,7 @@ public class MicronautConfigUtilities {
                         try {
                             int lineStart = LineDocumentUtils.getLineStart(lineDocument, offset);
                             String mimeType = DocumentUtilities.getMimeType(doc);
-                            if ("text/x-yaml".equals(mimeType)) {
+                            if (YAML_MIME.equals(mimeType)) {
                                 String text = lineDocument.getText(lineStart, offset - lineStart);
                                 if (!text.startsWith("#")) {
                                     int idx = text.indexOf(':');
@@ -163,7 +166,7 @@ public class MicronautConfigUtilities {
     public static void collectUsages(FileObject fo, String propertyName, Consumer<Usage> consumer) {
         try {
             String mimeType = fo.getMIMEType();
-            if ("text/x-yaml".equals(mimeType)) {
+            if (YAML_MIME.equals(mimeType)) {
                 ParserManager.parse(Collections.singleton(Source.create(fo)), new UserTask() {
                     public @Override void run(ResultIterator resultIterator) throws Exception {
                         Parser.Result r = resultIterator.getParserResult();

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/MicronautConfigUtilities.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/MicronautConfigUtilities.java
@@ -23,7 +23,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.text.Document;
@@ -98,26 +100,7 @@ public class MicronautConfigUtilities {
                                                                     span[1] = end;
                                                                 }
                                                                 if (start <= offset && offset <= end && item.getName().equals(lineDocument.getText(start, end - start))) {
-                                                                    String propertyName = getPropertyName(context);
-                                                                    for (Map.Entry<String, ConfigurationMetadataGroup> groupEntry : MicronautConfigProperties.getGroups(project).entrySet()) {
-                                                                        String groupKey = groupEntry.getKey();
-                                                                        if (groupKey.endsWith(".*")) {
-                                                                            groupKey = groupKey.substring(0, groupKey.length() - 2);
-                                                                        }
-                                                                        if (Pattern.matches(groupKey.replaceAll("\\.", "\\\\.").replaceAll("\\*", "\\\\w*") + ".*", propertyName)) {
-                                                                            ConfigurationMetadataGroup group = groupEntry.getValue();
-                                                                            if (sources != null) {
-                                                                                sources.addAll(group.getSources().values());
-                                                                            }
-                                                                            for (Map.Entry<String, ConfigurationMetadataProperty> propertyEntry : group.getProperties().entrySet()) {
-                                                                                String propertyKey = propertyEntry.getKey();
-                                                                                if (Pattern.matches(propertyKey.replaceAll("\\.", "\\\\.").replaceAll("\\*", "\\\\w*"), propertyName)) {
-                                                                                    property[0] = propertyEntry.getValue();
-                                                                                    return;
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
+                                                                    property[0] = getProperty(MicronautConfigProperties.getGroups(project), getPropertyName(context), sources);
                                                                 }
                                                             }
                                                         }
@@ -211,6 +194,70 @@ public class MicronautConfigUtilities {
             Exceptions.printStackTrace(ex);
         }
     }
+    
+    public static List<int[]> getPropertySpans(Project project, Parser.Result r) {
+        List<int[]> spans = new ArrayList<>();
+        if (r instanceof ParserResult) {
+            Language language = LanguageRegistry.getInstance().getLanguageByMimeType(r.getSnapshot().getMimeType());
+            if (language != null) {
+                StructureScanner scanner = language.getStructure();
+                if (scanner != null) {
+                    Map<String, ConfigurationMetadataGroup> groups = MicronautConfigProperties.getGroups(project);
+                    scan(scanner.scan((ParserResult) r), new Stack<>(), context -> {
+                        if (!context.empty()) {
+                            String propertyName = getPropertyName(context);
+                            List<ConfigurationMetadataSource> sources = new ArrayList<>();
+                            ConfigurationMetadataProperty property = getProperty(groups, propertyName, sources);
+                            if (property != null || !sources.isEmpty()) {
+                                StructureItem item = context.peek();
+                                spans.add(new int[] {(int) item.getPosition(), (int) item.getPosition() + item.getName().length()});
+                            }
+                        }
+                        return true;
+                    });
+                }
+            }
+        }
+        return spans;
+    }
+    
+    private static ConfigurationMetadataProperty getProperty(Map<String, ConfigurationMetadataGroup> groups, String propertyName, List<ConfigurationMetadataSource> sources) {
+        for (Map.Entry<String, ConfigurationMetadataGroup> groupEntry : groups.entrySet()) {
+            String groupKey = groupEntry.getKey();
+            if (groupKey.endsWith(".*")) {
+                groupKey = groupKey.substring(0, groupKey.length() - 2);
+            }
+            if (Pattern.matches(groupKey.replaceAll("\\.", "\\\\.").replaceAll("\\*", "\\\\w*") + ".*", propertyName)) {
+                ConfigurationMetadataGroup group = groupEntry.getValue();
+                if (sources != null) {
+                    sources.addAll(group.getSources().values());
+                }
+                for (Map.Entry<String, ConfigurationMetadataProperty> propertyEntry : group.getProperties().entrySet()) {
+                    String propertyKey = propertyEntry.getKey();
+                    if (Pattern.matches(propertyKey.replaceAll("\\.", "\\\\.").replaceAll("\\*", "\\\\w*"), propertyName)) {
+                        return propertyEntry.getValue();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static void scan(List<? extends StructureItem> structures, Stack<StructureItem> context, Function<Stack<StructureItem>, Boolean> visitor) {
+        for (StructureItem structure : structures) {
+            if (structure != null) {
+                try {
+                    context.push(structure);
+                    if (visitor.apply(context)) {
+                        scan(structure.getNestedItems(), context, visitor);
+                    }
+                } finally {
+                    context.pop();
+                }
+            }
+        }
+    }
+
 
     private static void find(FileObject fo, String propertyName, List<? extends StructureItem> structures, CharSequence content, Consumer<Usage> consumer) {
         int idx = propertyName.indexOf('.');

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautConfigCompletionCollector.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautConfigCompletionCollector.java
@@ -38,12 +38,12 @@ import org.springframework.boot.configurationmetadata.ConfigurationMetadataPrope
  */
 public class MicronautConfigCompletionCollector implements CompletionCollector {
 
-    @MimeRegistration(mimeType = "text/x-yaml", service = CompletionCollector.class)
+    @MimeRegistration(mimeType = MicronautConfigUtilities.YAML_MIME, service = CompletionCollector.class)
     public static MicronautConfigCompletionCollector createYamlCollector() {
         return new MicronautConfigCompletionCollector();
     }
 
-    @MimeRegistration(mimeType = "text/x-properties", service = CompletionCollector.class)
+    @MimeRegistration(mimeType = MicronautConfigUtilities.PROPERTIES_MIME, service = CompletionCollector.class)
     public static MicronautConfigCompletionCollector createPropertiesCollector() {
         return new MicronautConfigCompletionCollector();
     }

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautConfigCompletionProvider.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautConfigCompletionProvider.java
@@ -55,12 +55,12 @@ public class MicronautConfigCompletionProvider implements CompletionProvider {
 
     public static final String PROPERTY_NAME_COLOR = getHTMLColor(64, 64, 217);
 
-    @MimeRegistration(mimeType = "text/x-yaml", service = CompletionProvider.class)
+    @MimeRegistration(mimeType = MicronautConfigUtilities.YAML_MIME, service = CompletionProvider.class)
     public static MicronautConfigCompletionProvider createYamlProvider() {
         return new MicronautConfigCompletionProvider();
     }
 
-    @MimeRegistration(mimeType = "text/x-properties", service = CompletionProvider.class)
+    @MimeRegistration(mimeType = MicronautConfigUtilities.PROPERTIES_MIME, service = CompletionProvider.class)
     public static MicronautConfigCompletionProvider createPropertiesProvider() {
         return new MicronautConfigCompletionProvider();
     }

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautConfigCompletionTask.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautConfigCompletionTask.java
@@ -50,6 +50,7 @@ import org.netbeans.modules.csl.core.LanguageRegistry;
 import org.netbeans.modules.csl.spi.ParserResult;
 import org.netbeans.modules.editor.indent.api.IndentUtils;
 import org.netbeans.modules.micronaut.MicronautConfigProperties;
+import org.netbeans.modules.micronaut.MicronautConfigUtilities;
 import org.netbeans.modules.parsing.api.ParserManager;
 import org.netbeans.modules.parsing.api.ResultIterator;
 import org.netbeans.modules.parsing.api.Source;
@@ -78,7 +79,7 @@ public class MicronautConfigCompletionTask {
             try {
                 String text = lineDocument.getText(lineStart, caretOffset - lineStart);
                 String mimeType = DocumentUtilities.getMimeType(doc);
-                if ("text/x-yaml".equals(mimeType)) {
+                if (MicronautConfigUtilities.YAML_MIME.equals(mimeType)) {
                     if (!text.startsWith("#")) {
                         int idx = text.indexOf(':');
                         if (idx < 0) {

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautHoverProvider.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautHoverProvider.java
@@ -31,12 +31,12 @@ import org.springframework.boot.configurationmetadata.ConfigurationMetadataPrope
  */
 public class MicronautHoverProvider implements HoverProvider {
 
-    @MimeRegistration(mimeType = "text/x-yaml", service = HoverProvider.class)
+    @MimeRegistration(mimeType = MicronautConfigUtilities.YAML_MIME, service = HoverProvider.class)
     public static MicronautHoverProvider createYamlProvider() {
         return new MicronautHoverProvider();
     }
 
-    @MimeRegistration(mimeType = "text/x-properties", service = HoverProvider.class)
+    @MimeRegistration(mimeType = MicronautConfigUtilities.PROPERTIES_MIME, service = HoverProvider.class)
     public static MicronautHoverProvider createPropertiesProvider() {
         return new MicronautHoverProvider();
     }

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/hyperlink/MicronautConfigHyperlinkProvider.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/hyperlink/MicronautConfigHyperlinkProvider.java
@@ -73,12 +73,12 @@ public class MicronautConfigHyperlinkProvider implements HyperlinkProviderExt {
 
     private static final String SPANS_PROPERTY_NAME = "MicronautConfigHyperlinkSpans";
 
-    @MimeRegistration(mimeType = "text/x-yaml", service = HyperlinkProviderExt.class, position = 1250)
+    @MimeRegistration(mimeType = MicronautConfigUtilities.YAML_MIME, service = HyperlinkProviderExt.class, position = 1250)
     public static MicronautConfigHyperlinkProvider createYamlProvider() {
         return new MicronautConfigHyperlinkProvider();
     }
 
-    @MimeRegistration(mimeType = "text/x-properties", service = HyperlinkProviderExt.class, position = 1250)
+    @MimeRegistration(mimeType = MicronautConfigUtilities.PROPERTIES_MIME, service = HyperlinkProviderExt.class, position = 1250)
     public static MicronautConfigHyperlinkProvider createPropertiesProvider() {
         return new MicronautConfigHyperlinkProvider();
     }
@@ -96,7 +96,7 @@ public class MicronautConfigHyperlinkProvider implements HyperlinkProviderExt {
     @Override
     public int[] getHyperlinkSpan(Document doc, int offset, HyperlinkType type) {
         String mimeType = DocumentUtilities.getMimeType(doc);
-        if ("text/x-yaml".equals(mimeType)) {
+        if (MicronautConfigUtilities.YAML_MIME.equals(mimeType)) {
             List<int[]> spans = null;
             synchronized (doc) {
                 spans = (List<int[]>) doc.getProperty(SPANS_PROPERTY_NAME);
@@ -240,7 +240,7 @@ public class MicronautConfigHyperlinkProvider implements HyperlinkProviderExt {
             cancel.set(true);
         }
 
-        @MimeRegistration(mimeType = "text/x-yaml", service = TaskFactory.class)
+        @MimeRegistration(mimeType = MicronautConfigUtilities.YAML_MIME, service = TaskFactory.class)
         public static final class Factory extends TaskFactory {
 
             @Override
@@ -259,12 +259,12 @@ public class MicronautConfigHyperlinkProvider implements HyperlinkProviderExt {
 
     public static class LocationProvider implements HyperlinkLocationProvider {
 
-        @MimeRegistration(mimeType = "text/x-yaml", service = HyperlinkLocationProvider.class)
+        @MimeRegistration(mimeType = MicronautConfigUtilities.YAML_MIME, service = HyperlinkLocationProvider.class)
         public static LocationProvider createYamlProvider() {
             return new LocationProvider();
         }
 
-        @MimeRegistration(mimeType = "text/x-properties", service = HyperlinkLocationProvider.class)
+        @MimeRegistration(mimeType = MicronautConfigUtilities.PROPERTIES_MIME, service = HyperlinkLocationProvider.class)
         public static LocationProvider createPropertiesProvider() {
             return new LocationProvider();
         }


### PR DESCRIPTION
Enable Micronaut HyperlinkProviders again. Deadlocks fixed - `ParserManager.parse(...)` should not be called from AWT EDT anymore.