### PR TITLE
Cleanup redundant cast warnings..

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractEntry.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractEntry.java
@@ -116,7 +116,7 @@ abstract class AbstractEntry implements ModuleEntry {
         try {
             Enumeration<JarEntry> entries = jf.entries();
             ENTRY: while (entries.hasMoreElements()) {
-                JarEntry entry = (JarEntry) entries.nextElement();
+                JarEntry entry = entries.nextElement();
                 String path = entry.getName();
                 if (!path.endsWith(".class")) { // NOI18N
                     continue;

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/DomainEditor.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/DomainEditor.java
@@ -487,7 +487,7 @@ public class DomainEditor {
 
     private Map<String,String> getPoolValues(Map<String, Node> cpMap, String poolName) {
         Map<String,String> pValues = new HashMap<>();
-        Node cpNode = (Node) cpMap.get(poolName);
+        Node cpNode = cpMap.get(poolName);
         NamedNodeMap cpAttrMap = cpNode.getAttributes();
         Node dsClassName = cpAttrMap.getNamedItem(CONST_DS_CLASS);
         Node resType = cpAttrMap.getNamedItem(CONST_RES_TYPE);

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
@@ -888,7 +888,7 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
         if (ctx.getFileObject() == null) return null;
         Enumeration<Node> en = ctx.getDocumentChildren();
         while (en.hasMoreElements()) {
-            Node next = (Node) en.nextElement();
+            Node next = en.nextElement();
             if (next.getNodeType() == Node.DOCUMENT_TYPE_NODE) {
                 return null; // null for web.xml specified by DTD
             } else if (next.getNodeType() == Node.ELEMENT_NODE) {

--- a/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ClasspathUtil.java
+++ b/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ClasspathUtil.java
@@ -250,7 +250,7 @@ public class ClasspathUtil {
                 try {
                     Enumeration<JarEntry> entries = jf.entries();
                     while (entries.hasMoreElements()) {
-                        JarEntry entry = (JarEntry) entries.nextElement();
+                        JarEntry entry = entries.nextElement();
                         if (classFilePathFirst.equals(entry.getName())) {
                             return tokenFirst;
                         }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/web/DDProvider.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/web/DDProvider.java
@@ -193,7 +193,7 @@ public final class DDProvider {
         if (wr == null) {
             return null;
         }
-        WebAppProxy webApp = (WebAppProxy) wr.get();
+        WebAppProxy webApp = wr.get();
         if (webApp == null) {
             ddMap.remove(fo.toURL());
         }
@@ -205,7 +205,7 @@ public final class DDProvider {
         if (wr == null) {
             return null;
         }        
-        WebApp webApp = (WebApp) wr.get();
+        WebApp webApp = wr.get();
         if (webApp == null) {
             baseBeanMap.remove(fo.toURL());
             errorMap.remove(fo.toURL());

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataObject.java
@@ -453,7 +453,7 @@ public class EarDataObject extends DD2beansDataObject
                     else if (options[1].equals (e.getSource ())) {
                         Enumeration<DDChangeEvent> en = connectionPanel.listModel.elements ();
                         while (en.hasMoreElements ()) {
-                            processDDChangeEvent ((DDChangeEvent)en.nextElement ());
+                            processDDChangeEvent(en.nextElement());
                         }
                         confirmChangesDialog[0].setVisible (false);
                         connectionPanel.setChanges (null);

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/client/ClientDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/client/ClientDataObject.java
@@ -345,7 +345,7 @@ public class ClientDataObject extends  DDMultiViewDataObject
                 } else if (options[1].equals(e.getSource())) {
                     Enumeration<DDChangeEvent> en = connectionPanel.listModel.elements();
                     while (en.hasMoreElements()) {
-                        processDDChangeEvent((DDChangeEvent)en.nextElement());
+                        processDDChangeEvent(en.nextElement());
                     }
                     confirmChangesDialog[0].setVisible(false);
                     connectionPanel.setChanges(null);

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EjbJarMultiViewDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EjbJarMultiViewDataObject.java
@@ -761,7 +761,7 @@ public class EjbJarMultiViewDataObject extends DDMultiViewDataObject
     }
     
     public EntityHelper getEntityHelper(Entity entity) {
-        EntityHelper entityHelper = (EntityHelper) entityHelperMap.get(entity);
+        EntityHelper entityHelper = entityHelperMap.get(entity);
         if (entityHelper == null) {
             entityHelper = new EntityHelper(this, entity);
             entityHelperMap.put(entity, entityHelper);
@@ -770,7 +770,7 @@ public class EjbJarMultiViewDataObject extends DDMultiViewDataObject
     }
     
     public SessionHelper getSessionHelper(Session session) {
-        SessionHelper sessionHelper = (SessionHelper) sessionHelperMap.get(session);
+        SessionHelper sessionHelper = sessionHelperMap.get(session);
         if (sessionHelper == null) {
             sessionHelper = new SessionHelper(this, session);
             sessionHelperMap.put(session, sessionHelper);

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EntityHelper.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EntityHelper.java
@@ -130,7 +130,7 @@ public class EntityHelper extends EntityAndSessionHelper {
         
         public CmpFieldHelper getCmpFieldHelper(int row) {
             CmpField field = getCmpField(row);
-            CmpFieldHelper cmpFieldHelper = (CmpFieldHelper) cmpFieldHelperMap.get(field);
+            CmpFieldHelper cmpFieldHelper = cmpFieldHelperMap.get(field);
             if (cmpFieldHelper == null) {
                 cmpFieldHelper = createCmpFieldHelper(field);
             }
@@ -138,7 +138,7 @@ public class EntityHelper extends EntityAndSessionHelper {
         }
         
         private CmpFieldHelper getCmpFieldHelper(String fieldName) {
-            CmpFieldHelper cmpFieldHelper = (CmpFieldHelper) cmpFieldHelperMap.get(fieldName);
+            CmpFieldHelper cmpFieldHelper = cmpFieldHelperMap.get(fieldName);
             if (cmpFieldHelper == null) {
                 CmpField[] cmpFields = entity.getCmpField();
                 for (int i = 0; i < cmpFields.length; i++) {
@@ -197,7 +197,7 @@ public class EntityHelper extends EntityAndSessionHelper {
         
         protected void firePropertyChange(PropertyChangeEvent evt) {
             for (Iterator<PropertyChangeListener> iterator = listeners.iterator(); iterator.hasNext();) {
-                ((PropertyChangeListener) iterator.next()).propertyChange(evt);
+                iterator.next().propertyChange(evt);
             }
         }
         
@@ -258,13 +258,13 @@ public class EntityHelper extends EntityAndSessionHelper {
                 Query query = queries[i];
                 if (query.getQueryMethod().getMethodName().startsWith(s)) {
                     list.add(query);
-                    final QueryMethodHelper helper = (QueryMethodHelper) queryMethodHelperMap.get(query);
+                    final QueryMethodHelper helper = queryMethodHelperMap.get(query);
                     if (helper != null) {
                         helper.init();
                     }
                 }
             }
-            return (Query[]) list.toArray(new Query[0]);
+            return list.toArray(new Query[0]);
         }
         
         public int getFinderMethodCount() {
@@ -303,7 +303,7 @@ public class EntityHelper extends EntityAndSessionHelper {
         
         protected void firePropertyChange(PropertyChangeEvent evt) {
             for (Iterator<PropertyChangeListener> iterator = listeners.iterator(); iterator.hasNext();) {
-                ((PropertyChangeListener) iterator.next()).propertyChange(evt);
+                iterator.next().propertyChange(evt);
             }
         }
         

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/common/api/SourceFileMap.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/common/api/SourceFileMap.java
@@ -111,7 +111,7 @@ public abstract class SourceFileMap {
         Project owner = FileOwnerQuery.getOwner(source);
         if (owner != null) {
             Lookup l = owner.getLookup();
-            J2eeModuleProvider projectModule = (J2eeModuleProvider) l.lookup(J2eeModuleProvider.class);
+            J2eeModuleProvider projectModule = l.lookup(J2eeModuleProvider.class);
             if (projectModule != null) {
                 return projectModule.getSourceFileMap();
             }

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/Server.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/Server.java
@@ -102,7 +102,7 @@ public class Server implements Node.Cookie {
                 return;
             }
             DataObject dobj = DataObject.find(factoryinstance);
-            InstanceCookie cookie = (InstanceCookie) dobj.getCookie(InstanceCookie.class);
+            InstanceCookie cookie = dobj.getCookie(InstanceCookie.class);
             if (cookie == null) {
                 String msg = NbBundle.getMessage(Server.class, "MSG_FactoryFailed", name);
                 LOGGER.log(Level.SEVERE, msg);
@@ -206,7 +206,7 @@ public class Server implements Node.Cookie {
             return nodeProvider;
         }
 
-        RegistryNodeFactory nodeFact = (RegistryNodeFactory) lkp.lookup(RegistryNodeFactory.class);
+        RegistryNodeFactory nodeFact = lkp.lookup(RegistryNodeFactory.class);
         if (nodeFact == null) {
             String msg = NbBundle.getMessage(Server.class, "MSG_NoInstance", name, RegistryNodeFactory.class);
             LOGGER.log(Level.INFO, msg);
@@ -216,19 +216,18 @@ public class Server implements Node.Cookie {
     }
 
     public RegistryNodeFactory getRegistryNodeFactory() {
-        return (RegistryNodeFactory) lkp.lookup(RegistryNodeFactory.class);
+        return lkp.lookup(RegistryNodeFactory.class);
     }
 
     /** returns OptionalDeploymentManagerFactory or null it is not provided by the plugin */
     public OptionalDeploymentManagerFactory getOptionalFactory () {
-        OptionalDeploymentManagerFactory o = (OptionalDeploymentManagerFactory)
-                lkp.lookup(OptionalDeploymentManagerFactory.class);
+        OptionalDeploymentManagerFactory o = lkp.lookup(OptionalDeploymentManagerFactory.class);
         return o;
     }
 
     /** returns J2eePlatformFactory or null if it is not provided by the plugin */
     public J2eePlatformFactory getJ2eePlatformFactory () {
-        J2eePlatformFactory o = (J2eePlatformFactory) lkp.lookup(J2eePlatformFactory.class);
+        J2eePlatformFactory o = lkp.lookup(J2eePlatformFactory.class);
         return o;
     }
 
@@ -237,7 +236,7 @@ public class Server implements Node.Cookie {
     }
 
     public VerifierSupport getVerifierSupport() {
-        VerifierSupport vs = (VerifierSupport) lkp.lookup(VerifierSupport.class);
+        VerifierSupport vs = lkp.lookup(VerifierSupport.class);
         return vs;
     }
 

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatProperties.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/TomcatProperties.java
@@ -394,7 +394,7 @@ public class TomcatProperties {
         JavaPlatformManager jpm = JavaPlatformManager.getDefault();
         JavaPlatform[] installedPlatforms = jpm.getPlatforms(null, new Specification("J2SE", null)); // NOI18N
         for (int i = 0; i < installedPlatforms.length; i++) {
-            String platformName = (String)installedPlatforms[i].getProperties().get(PLAT_PROP_ANT_NAME);
+            String platformName = installedPlatforms[i].getProperties().get(PLAT_PROP_ANT_NAME);
             if (platformName != null && platformName.equals(currentJvm)) {
                 return installedPlatforms[i];
             }
@@ -404,7 +404,7 @@ public class TomcatProperties {
     }
     
     public void setJavaPlatform(JavaPlatform javaPlatform) {
-        ip.setProperty(PROP_JAVA_PLATFORM, (String)javaPlatform.getProperties().get(PLAT_PROP_ANT_NAME));
+        ip.setProperty(PROP_JAVA_PLATFORM, javaPlatform.getProperties().get(PLAT_PROP_ANT_NAME));
     }
     
     public String getJavaOpts() {

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/completion/CCPaintComponent.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/completion/CCPaintComponent.java
@@ -215,7 +215,7 @@ public class CCPaintComponent extends JPanel {
     }
     
     protected int getWidth(String s) {
-        Integer i = (Integer)widths.get(s);
+        Integer i = widths.get(s);
         if (i != null) {
             return i;
         } else {

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebProjectGenerator.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebProjectGenerator.java
@@ -87,7 +87,7 @@ public class WebProjectGenerator {
         } else {
             List<Element> l = XMLUtil.findSubElements(foldersEl);
             for (int i = 0; i < l.size(); i++) {
-                Element e = (Element) l.get(i);
+                Element e = l.get(i);
                 Element te = XMLUtil.findElement(e, "type", Util.NAMESPACE);
                 if (te != null && XMLUtil.findText(te).equals(folderType)) {
                     foldersEl.removeChild(e);
@@ -108,7 +108,7 @@ public class WebProjectGenerator {
         } else {
             List<Element> l = XMLUtil.findSubElements(itemsEl);
             for (int i = 0; i < l.size(); i++) {
-                Element e = (Element) l.get(i);
+                Element e = l.get(i);
                 if (e.hasAttribute("style")) {
                     if (e.getAttribute("style").equals("tree")) {
                         // #110173

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ProjectWebModule.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ProjectWebModule.java
@@ -312,7 +312,7 @@ public final class ProjectWebModule extends J2eeModuleProvider
     }
 
     public ClassPathProvider getClassPathProvider () {
-        return (ClassPathProvider) project.getLookup ().lookup (ClassPathProvider.class);
+        return project.getLookup().lookup(ClassPathProvider.class);
     }
 
     public FileObject getArchive () {

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/UpdateProjectImpl.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/UpdateProjectImpl.java
@@ -194,7 +194,7 @@ public class UpdateProjectImpl implements UpdateImplementation {
             ReferenceHelper refHelper = new ReferenceHelper(helper, cfg, helper.getStandardPropertyEvaluator());
             ClassPathSupport cs = new ClassPathSupport(helper.getStandardPropertyEvaluator(), refHelper, helper,
                     updateHelper, new ClassPathSupportCallbackImpl(helper));
-            Iterator<ClassPathSupport.Item> items = cs.itemsIterator((String)props.get( ProjectProperties.JAVAC_CLASSPATH ), ClassPathSupportCallbackImpl.TAG_WEB_MODULE_LIBRARIES);
+            Iterator<ClassPathSupport.Item> items = cs.itemsIterator(props.get( ProjectProperties.JAVAC_CLASSPATH ), ClassPathSupportCallbackImpl.TAG_WEB_MODULE_LIBRARIES);
             ArrayList<ClassPathSupport.Item> cpItems = new ArrayList<ClassPathSupport.Item>();
             while(items.hasNext()) {
                 ClassPathSupport.Item cpti = items.next();

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/Utils.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/Utils.java
@@ -170,7 +170,7 @@ public class Utils {
             JavaPlatform[] platforms = JavaPlatformManager.getDefault().getInstalledPlatforms();
             for(int i = 0; i < platforms.length; i++) {
                 JavaPlatform platform = platforms[i];
-                String antName = (String)platform.getProperties().get(PLATFORM_ANT_NAME);
+                String antName = platform.getProperties().get(PLATFORM_ANT_NAME);
                 if (antName != null && antName.equals(platformName)) {
                     if(specFilter == null || specFilter.equalsIgnoreCase(platform.getSpecification().getName())) {
                         return platform;

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/WebPersistenceProvider.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/WebPersistenceProvider.java
@@ -128,7 +128,7 @@ public class WebPersistenceProvider implements PersistenceLocationProvider, Pers
     public PersistenceScope findPersistenceScope(FileObject fo) {
         Project proj = FileOwnerQuery.getOwner(fo);
         if (proj != null) {
-            WebPersistenceProvider provider = (WebPersistenceProvider) proj.getLookup().lookup(WebPersistenceProvider.class);
+            WebPersistenceProvider provider = proj.getLookup().lookup(WebPersistenceProvider.class);
             return provider.getPersistenceScope();
         }
         return null;
@@ -138,7 +138,7 @@ public class WebPersistenceProvider implements PersistenceLocationProvider, Pers
     public EntityClassScope findEntityClassScope(FileObject fo) {
         Project proj = FileOwnerQuery.getOwner(fo);
         if (proj != null) {
-            WebPersistenceProvider provider = (WebPersistenceProvider) proj.getLookup().lookup(WebPersistenceProvider.class);
+            WebPersistenceProvider provider = proj.getLookup().lookup(WebPersistenceProvider.class);
             return provider.getEntityClassScope();
         }
         return null;

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/WebProject.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/WebProject.java
@@ -895,7 +895,7 @@ public final class WebProject implements Project {
         protected void projectOpened() {
             evaluator().addPropertyChangeListener(WebProject.this.webModule);
 
-            WebLogicalViewProvider logicalViewProvider = (WebLogicalViewProvider) WebProject.this.getLookup().lookup (WebLogicalViewProvider.class);
+            WebLogicalViewProvider logicalViewProvider = WebProject.this.getLookup().lookup(WebLogicalViewProvider.class);
             if (logicalViewProvider != null) {
                 logicalViewProvider.initialize();
             }

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/WebProjectOperations.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/WebProjectOperations.java
@@ -186,15 +186,15 @@ public class WebProjectOperations implements DeleteOperationImplementation, Copy
 		AntProjectHelper helper = project.getAntProjectHelper();
 		EditableProperties projectProps = helper.getProperties(AntProjectHelper.PROJECT_PROPERTIES_PATH);
 
-		String warName = (String) projectProps.get(WebProjectProperties.WAR_NAME);
-		String warEarName = (String) projectProps.get(WebProjectProperties.WAR_EAR_NAME);
+		String warName = projectProps.get(WebProjectProperties.WAR_NAME);
+		String warEarName = projectProps.get(WebProjectProperties.WAR_EAR_NAME);
 		String oldName = warName.substring(0, warName.length() - 4);
 		if (warName.endsWith(".war") && oldName.equals(oldProjectName)) //NOI18N
 		    projectProps.put(WebProjectProperties.WAR_NAME, PropertyUtils.getUsablePropertyName(newName) + ".war"); //NOI18N
 		if (warEarName.endsWith(".war") && oldName.equals(oldProjectName)) //NOI18N
 		    projectProps.put(WebProjectProperties.WAR_EAR_NAME, PropertyUtils.getUsablePropertyName(newName) + ".war"); //NOI18N
                 
-                ProjectWebModule wm = (ProjectWebModule) project.getLookup ().lookup(ProjectWebModule.class);
+                ProjectWebModule wm = project.getLookup().lookup(ProjectWebModule.class);
                 if (wm != null) //should not be null
                     wm.setContextPath("/" + newName);
                 
@@ -228,15 +228,15 @@ public class WebProjectOperations implements DeleteOperationImplementation, Copy
 		EditableProperties projectProps = helper.getProperties(AntProjectHelper.PROJECT_PROPERTIES_PATH);
 		EditableProperties privateProps = helper.getProperties(AntProjectHelper.PRIVATE_PROPERTIES_PATH);
 
-		String warName = (String) projectProps.get(WebProjectProperties.WAR_NAME);
-		String warEarName = (String) projectProps.get(WebProjectProperties.WAR_EAR_NAME);
+		String warName = projectProps.get(WebProjectProperties.WAR_NAME);
+		String warEarName = projectProps.get(WebProjectProperties.WAR_EAR_NAME);
 		String oldName = warName.substring(0, warName.length() - 4);
 		if (warName.endsWith(".war") && oldName.equals(oldProjectName)) //NOI18N
 		    projectProps.put(WebProjectProperties.WAR_NAME, PropertyUtils.getUsablePropertyName(newName) + ".war"); //NOI18N
 		if (warEarName != null && warEarName.endsWith(".war") && oldName.equals(oldProjectName)) //NOI18N
 		    projectProps.put(WebProjectProperties.WAR_EAR_NAME, PropertyUtils.getUsablePropertyName(newName) + ".war"); //NOI18N
 
-		ProjectWebModule wm = (ProjectWebModule) project.getLookup().lookup(ProjectWebModule.class);
+		ProjectWebModule wm = project.getLookup().lookup(ProjectWebModule.class);
 		String serverId = privateProps.getProperty(WebProjectProperties.J2EE_SERVER_INSTANCE);
 		String oldCP = wm.getContextPath(serverId);
 		if (oldCP != null && oldName.equals(oldCP.substring(1)))

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/api/WebProjectUtilities.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/api/WebProjectUtilities.java
@@ -291,7 +291,7 @@ public class WebProjectUtilities {
                   false);
 
         WebProject p = (WebProject)ProjectManager.getDefault().findProject(h.getProjectDirectory());
-        UpdateHelper updateHelper = ((WebProject) p).getUpdateHelper();
+        UpdateHelper updateHelper = p.getUpdateHelper();
         
         // #119052
         if (sourceLevel == null) {
@@ -315,7 +315,7 @@ public class WebProjectUtilities {
             Exceptions.printStackTrace(ex.getException());
         }
         
-        ProjectWebModule pwm = (ProjectWebModule) p.getLookup().lookup(ProjectWebModule.class);
+        ProjectWebModule pwm = p.getLookup().lookup(ProjectWebModule.class);
         if (pwm != null) { //should not be null
             pwm.setContextPath(contextPath);
         }

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/classpath/ClassPathProviderImpl.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/classpath/ClassPathProviderImpl.java
@@ -101,7 +101,7 @@ public final class ClassPathProviderImpl implements ClassPathProvider, PropertyC
         return ProjectManager.mutex().readAccess(new Mutex.Action<FileObject>() {
             public FileObject run() {
                 synchronized (ClassPathProviderImpl.this) {
-                    FileObject fo = (FileObject) ClassPathProviderImpl.this.dirCache.get (propname);
+                    FileObject fo = ClassPathProviderImpl.this.dirCache.get(propname);
                     if (fo == null ||  !fo.isValid()) {
                         String prop = evaluator.getProperty(propname);
                         if (prop != null) {

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/jaxws/WebProjectJAXWSSupport.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/jaxws/WebProjectJAXWSSupport.java
@@ -410,7 +410,7 @@ public class WebProjectJAXWSSupport extends ProjectJAXWSSupport /*implements JAX
      */
     @Override
     public void serviceFromJavaRemoved(String serviceName) {
-        JaxWsModel jaxWsModel = (JaxWsModel)project.getLookup().lookup(JaxWsModel.class);
+        JaxWsModel jaxWsModel = project.getLookup().lookup(JaxWsModel.class);
         Boolean isJsr109 = jaxWsModel.getJsr109();
         if(isJsr109!=null && !isJsr109){
             try{
@@ -443,7 +443,7 @@ public class WebProjectJAXWSSupport extends ProjectJAXWSSupport /*implements JAX
             if(sunjaxwsFile != null){
                 FileLock lock = null;
                 //if there are no more services, delete the file
-                JaxWsModel jaxWsModel = (JaxWsModel)project.getLookup().lookup(JaxWsModel.class);
+                JaxWsModel jaxWsModel = project.getLookup().lookup(JaxWsModel.class);
                 if(jaxWsModel.getServices().length == 0) {
                     synchronized(this) {
                         try{
@@ -495,7 +495,7 @@ public class WebProjectJAXWSSupport extends ProjectJAXWSSupport /*implements JAX
     public void removeJsr109Entries(String serviceName) throws IOException {
         WebApp webApp = getWebApp();
         if (webApp != null) {
-            JaxWsModel jaxWsModel = (JaxWsModel)project.getLookup().lookup(JaxWsModel.class);
+            JaxWsModel jaxWsModel = project.getLookup().lookup(JaxWsModel.class);
             if (jaxWsModel != null) {
                 Service service = jaxWsModel.findServiceByName(serviceName);
                 if (service != null) {

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/LibrariesNodeFactory.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/LibrariesNodeFactory.java
@@ -64,7 +64,7 @@ public final class LibrariesNodeFactory implements NodeFactory {
     }
 
     public NodeList createNodes(Project p) {
-        WebProject project = (WebProject)p.getLookup().lookup(WebProject.class);
+        WebProject project = p.getLookup().lookup(WebProject.class);
         assert project != null;
         return new LibrariesNodeList(project);
     }
@@ -85,7 +85,7 @@ public final class LibrariesNodeFactory implements NodeFactory {
         LibrariesNodeList(WebProject proj) {
             project = proj;
             testSources = project.getTestSourceRoots();
-            WebLogicalViewProvider logView = (WebLogicalViewProvider)project.getLookup().lookup(WebLogicalViewProvider.class);
+            WebLogicalViewProvider logView = project.getLookup().lookup(WebLogicalViewProvider.class);
             assert logView != null;
             evaluator = project.evaluator();
             helper = project.getUpdateHelper();

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/SetExecutionUriAction.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/SetExecutionUriAction.java
@@ -71,7 +71,7 @@ public final class SetExecutionUriAction extends NodeAction {
     protected void performAction(Node[] activatedNodes) {
         if ((activatedNodes != null) && (activatedNodes.length == 1)) {
             if (activatedNodes[0] != null) {
-                DataObject data = (DataObject)activatedNodes[0].getLookup().lookup(DataObject.class);
+                DataObject data = activatedNodes[0].getLookup().lookup(DataObject.class);
                 if (data != null) {
                     FileObject servletFo = data.getPrimaryFile();
                     WebModule webModule = WebModule.getWebModule(servletFo);
@@ -104,7 +104,7 @@ public final class SetExecutionUriAction extends NodeAction {
     protected boolean enable (Node[] activatedNodes) {
         if ((activatedNodes != null) && (activatedNodes.length == 1)) {
             if (activatedNodes[0] != null) {
-                DataObject data = (DataObject)activatedNodes[0].getLookup().lookup(DataObject.class);
+                DataObject data = activatedNodes[0].getLookup().lookup(DataObject.class);
                 if (data != null) {
                     FileObject javaClass = data.getPrimaryFile();
                     WebModule webModule = WebModule.getWebModule(javaClass);

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/SetupDirNodeFactory.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/SetupDirNodeFactory.java
@@ -47,7 +47,7 @@ public final class SetupDirNodeFactory implements NodeFactory {
     }
 
     public NodeList createNodes(Project p) {
-        WebProject project = (WebProject) p.getLookup().lookup(WebProject.class);
+        WebProject project = p.getLookup().lookup(WebProject.class);
         assert project != null;
         return new SetupDirNodeList(project);
     }
@@ -61,7 +61,7 @@ public final class SetupDirNodeFactory implements NodeFactory {
         SetupDirNodeList(WebProject proj) {
             project = proj;
             project.getProjectDirectory().addFileChangeListener(this);
-            WebLogicalViewProvider logView = (WebLogicalViewProvider) project.getLookup().lookup(WebLogicalViewProvider.class);
+            WebLogicalViewProvider logView = project.getLookup().lookup(WebLogicalViewProvider.class);
             assert logView != null;
         }
         

--- a/enterprise/websvc.jaxwsapi/src/org/netbeans/modules/websvc/jaxws/ProjectJAXWSSupportProvider.java
+++ b/enterprise/websvc.jaxwsapi/src/org/netbeans/modules/websvc/jaxws/ProjectJAXWSSupportProvider.java
@@ -34,7 +34,7 @@ public class ProjectJAXWSSupportProvider implements JAXWSSupportProvider {
     public JAXWSSupport findJAXWSSupport(FileObject file) {
         Project project = FileOwnerQuery.getOwner(file);
         if (project != null) {
-            JAXWSSupportProvider provider = (JAXWSSupportProvider) project.getLookup().lookup(JAXWSSupportProvider.class);
+            JAXWSSupportProvider provider = project.getLookup().lookup(JAXWSSupportProvider.class);
             
             if (provider != null) {
                 return provider.findJAXWSSupport(file);

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/project/WSUtils.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/project/WSUtils.java
@@ -122,7 +122,7 @@ public class WSUtils {
                                     WSUtils.class,"ERR_retrieveResource",
                                     key.getCurrentAddress()));
                             ex.initCause(exc);
-                            throw (IOException)(ex);
+                            throw ex;
                         }
                     }
                 }

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/project/config/Endpoints.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/api/jaxws/project/config/Endpoints.java
@@ -58,11 +58,11 @@ public class Endpoints {
     }
     
     public void addEnpoint(Endpoint endpoint) {
-        endpoints.addEndpoint((org.netbeans.modules.websvc.jaxwsmodel.endpoints_config1_0.Endpoint)endpoint.getOriginal());
+        endpoints.addEndpoint(endpoint.getOriginal());
     }
     
     public void removeEndpoint(Endpoint endpoint) {
-        endpoints.removeEndpoint((org.netbeans.modules.websvc.jaxwsmodel.endpoints_config1_0.Endpoint)endpoint.getOriginal());
+        endpoints.removeEndpoint(endpoint.getOriginal());
     }
     
     public Endpoint findEndpointByName(String endpointName) {

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxws/catalog/CatalogModelFactory.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxws/catalog/CatalogModelFactory.java
@@ -47,7 +47,7 @@ public class CatalogModelFactory extends AbstractModelFactory<CatalogModel> {
             "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" prefer=\"system\"/>";
     
     public CatalogModel getModel(ModelSource source) {
-        Document doc = (Document) source.getLookup().lookup(Document.class);
+        Document doc = source.getLookup().lookup(Document.class);
         if( (doc != null) && doc.getLength() <= 5){
             //means the catalog file is empty now
             try {
@@ -58,7 +58,7 @@ public class CatalogModelFactory extends AbstractModelFactory<CatalogModel> {
             }
         }
         
-        CatalogModel cm =(CatalogModel) super.getModel(source);
+        CatalogModel cm = super.getModel(source);
         try {
             cm.sync();
         } catch (IOException ex) {

--- a/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxws/catalog/impl/CatalogComponentImpl.java
+++ b/enterprise/websvc.jaxwsmodel/src/org/netbeans/modules/websvc/jaxws/catalog/impl/CatalogComponentImpl.java
@@ -53,7 +53,7 @@ public abstract class CatalogComponentImpl extends AbstractDocumentComponent<Cat
                 org.w3c.dom.Node n = nl.item(i);
                 if (n instanceof Element) {
                     CatalogModel model = getModel();
-                    CatalogComponent comp = (CatalogComponent) model.getFactory().create((Element)n, this);
+                    CatalogComponent comp = model.getFactory().create((Element)n, this);
                     if (comp != null) {
                         children.add(comp);
                     }

--- a/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/spi/MiscUtilities.java
+++ b/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/spi/MiscUtilities.java
@@ -225,8 +225,7 @@ public class MiscUtilities {
     }
 
     public static FileObject getApplicationContextXml(Project project) {
-        J2eeModuleProvider provider = (J2eeModuleProvider) project.getLookup().
-            lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider provider = project.getLookup().lookup(J2eeModuleProvider.class);
         FileObject[] fobjs = provider.getSourceRoots();
 
         if (fobjs.length > 0) {
@@ -423,7 +422,7 @@ public class MiscUtilities {
 
 
     public static Datasource getDatasource(Project p, String jndiName) {
-        J2eeModuleProvider provider = (J2eeModuleProvider) p.getLookup().lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider provider = p.getLookup().lookup(J2eeModuleProvider.class);
 
         try {
             return provider.getConfigSupport().findDatasource(jndiName);

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/spi/CssCompletionItem.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/spi/CssCompletionItem.java
@@ -649,7 +649,7 @@ public abstract class CssCompletionItem extends DefaultCompletionProposal {
                 if (mustBeEscaped) {
                     result.append("\\");
                     if (entry > 127 || Character.isWhitespace(entry) || Character.isISOControl(entry)) {
-                        result.append(String.format("%06x", (int) entry));
+                        result.append(String.format("%06x", entry));
                     } else {
                         result.appendCodePoint(entry);
                     }

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilder.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilder.java
@@ -765,8 +765,8 @@ public class QueryBuilder extends TopComponent
             fromTables = _queryModel.getFrom().getTableList();
             for ( int i = 0; i < fromTables.size(); i++ ) {
 
-                String fromTableName = ( (JoinTable) fromTables.get(i) ).getFullTableName();
-                String fromTableSpec = ( (JoinTable) fromTables.get(i) ).getTableSpec();
+                String fromTableName = fromTables.get(i).getFullTableName();
+                String fromTableSpec = fromTables.get(i).getTableSpec();
                 String checkedFullTableName = checkFullTableName( fromTableName ) ;
 
                 if (DEBUG)
@@ -790,7 +790,7 @@ public class QueryBuilder extends TopComponent
 
                 // now check the columns in the condition if any.
                 List<Column> fromColumns = new ArrayList<>();
-                ( (JoinTable) fromTables.get(i) ).getReferencedColumns(fromColumns);
+                fromTables.get(i).getReferencedColumns(fromColumns);
                 for ( int j = 0; j < fromColumns.size(); j++ ) {
                     Column fromColumn = fromColumns.get(j);
                     if (! checkTableColumnName( fromColumn)) {
@@ -907,9 +907,9 @@ public class QueryBuilder extends TopComponent
                 List<JoinTable> fromTables = _queryModel.getFrom().getTableList();
                 boolean found=false;
                 for ( int j = 0; j < fromTables.size(); j++ ) {
-                    String fromTableName = ( (JoinTable) fromTables.get(j) ).getFullTableName();
+                    String fromTableName = fromTables.get(j).getFullTableName();
                     // this could be an alias
-                    String fromTableSpec = ( (JoinTable) fromTables.get(j) ).getTableSpec();
+                    String fromTableSpec = fromTables.get(j).getTableSpec();
 
                     if (DEBUG)
                         System.out.println(

--- a/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatTokenPositionSupport.java
+++ b/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatTokenPositionSupport.java
@@ -82,7 +82,7 @@ class FormatTokenPositionSupport {
         int cnt = posList.size();
         ExtTokenPosition etp;
         for (int i = 0; i < cnt; i++) {
-            etp = (ExtTokenPosition)posList.get(i);
+            etp = posList.get(i);
             if (etp.getOffset() == offset && etp.getBias() == bias) {
                 return etp;
             }
@@ -110,7 +110,7 @@ class FormatTokenPositionSupport {
         int len = posList.size();
         List<ExtTokenPosition> prevPosList = getPosList(prevToken);
         for (int i = 0; i < len; i++) {
-            ExtTokenPosition etp = (ExtTokenPosition)posList.get(i);
+            ExtTokenPosition etp = posList.get(i);
             if (etp.offset < startLength) { // move to prevToken
                 etp.token = prevToken;
                 posList.remove(i);
@@ -140,7 +140,7 @@ class FormatTokenPositionSupport {
         int len = posList.size();
         int offset = token.getImage().length() - endLength;
         for (int i = 0; i < len; i++) {
-            ExtTokenPosition etp = (ExtTokenPosition)posList.get(i);
+            ExtTokenPosition etp = posList.get(i);
             if (etp.offset >= offset) { // move to nextToken
                 etp.token = nextToken;
                 etp.offset -= offset;
@@ -158,7 +158,7 @@ class FormatTokenPositionSupport {
         int len = posList.size();
         // Add length to all positions after insertion point
         for (int i = 0; i < len; i++) {
-            ExtTokenPosition etp = (ExtTokenPosition)posList.get(i);
+            ExtTokenPosition etp = posList.get(i);
             if ((etp.bias == Position.Bias.Backward)
                     ? (etp.offset > offset) : (etp.offset >= offset)) {
                 etp.offset += length;
@@ -174,7 +174,7 @@ class FormatTokenPositionSupport {
             posList = getPosList(nextToken);
             len = posList.size();
             for (int i = 0; i < len; i++) {
-                ExtTokenPosition etp = (ExtTokenPosition)posList.get(i);
+                ExtTokenPosition etp = posList.get(i);
                 if (etp.bias == Position.Bias.Backward && etp.offset == 0) {
                     etp.token = token;
                     etp.offset = offset;
@@ -192,7 +192,7 @@ class FormatTokenPositionSupport {
         int newLen = token.getImage().length() - length;
         List<ExtTokenPosition> nextList = getPosList(token.getNext());
         for (int i = 0; i < len; i++) {
-            ExtTokenPosition etp = (ExtTokenPosition)posList.get(i);
+            ExtTokenPosition etp = posList.get(i);
             if (etp.offset >= offset + length) { // move to nextToken
                 etp.offset -= length;
 
@@ -223,7 +223,7 @@ class FormatTokenPositionSupport {
         List<ExtTokenPosition> posList = getPosList(token);
         int len = posList.size();
         for (int i = 0; i < len; i++) {
-            ExtTokenPosition etp = (ExtTokenPosition)posList.get(i);
+            ExtTokenPosition etp = posList.get(i);
             etp.token = nextToken;
             etp.offset = 0;
             nextPosList.add(etp);
@@ -247,7 +247,7 @@ class FormatTokenPositionSupport {
 
             int nextLen = nextPosList.size();
             for (int i = 0; i < nextLen; i++) {
-                ExtTokenPosition etp = (ExtTokenPosition)nextPosList.get(i);
+                ExtTokenPosition etp = nextPosList.get(i);
                 if (etp.offset == 0 && etp.getBias() == Position.Bias.Backward) {
                     etp.token = token; // offset will stay equal to zero
                     nextPosList.remove(i);

--- a/ide/xml.core/src/org/netbeans/modules/xml/core/lib/XSLT10PseudoDTDGrammarQueryProvider.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/core/lib/XSLT10PseudoDTDGrammarQueryProvider.java
@@ -41,7 +41,7 @@ public class XSLT10PseudoDTDGrammarQueryProvider extends GrammarQueryManager {
     public Enumeration enabled(GrammarEnvironment ctx) {
         Enumeration<Node> en = ctx.getDocumentChildren();
         while (en.hasMoreElements()) {
-            Node next = (Node) en.nextElement();
+            Node next = en.nextElement();
             if (next.getNodeType() == Node.ELEMENT_NODE) {
                 boolean xslt = false;
                 boolean version1x = false;

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
@@ -195,7 +195,7 @@ class DTDGrammar implements ExtendedGrammarQuery {
                 String prefix = ctx.getCurrentPrefix();
                 elements = new TreeSet<>();
                 while (en.hasMoreElements()) {
-                    String next = (String) en.nextElement();
+                    String next = en.nextElement();
                     if (next.startsWith(prefix)) {
                         elements.add(next);
                     }

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookieImpl.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookieImpl.java
@@ -537,7 +537,7 @@ public class TreeEditorCookieImpl implements TreeEditorCookie, UpdateDocumentCoo
         }
         
         public TreeDocumentRoot getDocumentRoot() {
-            return (TreeDocumentRoot) super.get();
+            return super.get();
         }
         
         public TreeEditorCookieImpl getEditor() {

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/parser/ParserLoader.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/parser/ParserLoader.java
@@ -63,7 +63,7 @@ public final class ParserLoader extends URLClassLoader {
     /** Creates new ParserLoader */
     private ParserLoader(URL[] locations) {
         super(locations);
-        parentLoader = (ClassLoader) Lookup.getDefault().lookup(ClassLoader.class);
+        parentLoader = Lookup.getDefault().lookup(ClassLoader.class);
     }
 
     /**

--- a/ide/xml/src/org/netbeans/modules/xml/text/TextEditorSupport.java
+++ b/ide/xml/src/org/netbeans/modules/xml/text/TextEditorSupport.java
@@ -561,7 +561,7 @@ public class TextEditorSupport extends DataEditorSupport implements EditorCookie
 
             Enumeration<CloneableTopComponent> en = allEditors.getComponents();
             while ( en.hasMoreElements() ) {
-                CloneableTopComponent editor = (CloneableTopComponent)en.nextElement();
+                CloneableTopComponent editor = en.nextElement();
                 if ( editor instanceof CloneableEditor ) {
                     editor.open();
                     ret = (CloneableEditor) editor;
@@ -762,7 +762,7 @@ public class TextEditorSupport extends DataEditorSupport implements EditorCookie
 
             synchronized (this) {
                 if ( editorRef != null ) {
-                    editorSupport = (TextEditorSupport) editorRef.get();
+                    editorSupport = editorRef.get();
                 }
                 if ( editorSupport != null ) {
                     return editorSupport;

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/IOManager.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/IOManager.java
@@ -96,7 +96,7 @@ public class IOManager {
                     synchronized (buffer) {
                         int i, k = buffer.size ();
                         for (i = 0; i < k; i++) {
-                            Text t = (Text) buffer.removeFirst ();
+                            Text t = buffer.removeFirst();
                             try {
                                 OutputWriter ow = (t.important) ? debuggerErr : debuggerOut;
                                 if (t.line != null) {

--- a/java/beans/src/org/netbeans/modules/beans/beaninfo/BIEditorSupport.java
+++ b/java/beans/src/org/netbeans/modules/beans/beaninfo/BIEditorSupport.java
@@ -670,7 +670,7 @@ public final class BIEditorSupport extends DataEditorSupport
                         if (multiviewTC == topComponent) {
                             if (en.hasMoreElements()) {
                                 // Remember next cloned top component
-                                multiviewTC = (CloneableTopComponent) en.nextElement();
+                                multiviewTC = en.nextElement();
                             } else {
                                 // All cloned top components are closed
                                 notifyClosed();

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -481,7 +481,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                     boolean all = false;
                     for (int k = 0; k < columns.size(); k++)
                         //test if the view is created over all columns and try to eliminate agregation functions
-                        if (((String) columns.get(k)).trim().endsWith("*")) {
+                        if (columns.get(k).trim().endsWith("*")) {
                             all = true;
                             break;
                         }
@@ -541,7 +541,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
 
                             keys = new UniqueKeyElement[tempList.size()];
                             for (int k = 0; k < tempList.size(); k++)
-                                keys[k] = (UniqueKeyElement) tempList.get(k);
+                                keys[k] = tempList.get(k);
                             te.setKeys(keys);
 
                             IndexElement[] indexes = new IndexElement[keys.length];
@@ -698,7 +698,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                         ke[j] = uke[j];
                     int idx = uke.length;
                     for (int j = 0; j < tempList.size(); j++)
-                        ke[j + idx] = (ForeignKeyElement) tempList.get(j);
+                        ke[j + idx] = tempList.get(j);
                     
                     te.setKeys(ke);
 

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
@@ -324,9 +324,9 @@ public class TableElementImpl extends DBElementImpl implements TableElement.Impl
                                 continue;
                             }
                             rset = bridge.getDriverSpecification().getRow();
-                            name = (String) rset.get(new Integer(6));
-                            columnName = (String) rset.get(new Integer(9));
-                            uniqueStr = (String) rset.get(new Integer(4));
+                            name = rset.get(new Integer(6));
+                            columnName = rset.get(new Integer(9));
+                            uniqueStr  = rset.get(new Integer(4));
                             if (uniqueStr == null || uniqueStr.equals("0") || uniqueStr.equalsIgnoreCase("false") || uniqueStr.equalsIgnoreCase("f"))
                                 unq = false;
                             else
@@ -469,15 +469,15 @@ public class TableElementImpl extends DBElementImpl implements TableElement.Impl
                     rset = bridge.getDriverSpecification().getRow();
                     
                     //test references between two schemas
-                    c1 = (String) rset.get(new Integer(1));
-                    s1 = (String) rset.get(new Integer(2));
-                    c2 = (String) rset.get(new Integer(5));
-                    s2 = (String) rset.get(new Integer(6));                    
+                    c1 = rset.get(new Integer(1));
+                    s1 = rset.get(new Integer(2));
+                    c2 = rset.get(new Integer(5));
+                    s2 = rset.get(new Integer(6));                    
                             
-                    name = (String) rset.get(new Integer(12));
-                    fkColName = (String) rset.get(new Integer(8));
-                    pkTableName = (String) rset.get(new Integer(3));
-                    pkColName = (String) rset.get(new Integer(4));
+                    name = rset.get(new Integer(12));
+                    fkColName = rset.get(new Integer(8));
+                    pkTableName = rset.get(new Integer(3));
+                    pkColName = rset.get(new Integer(4));
                     rset.clear();
                 } else {
                     //test references between two schemas

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Catalog.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Catalog.java
@@ -71,7 +71,7 @@ public class Catalog {
             }
         }
         
-        return (Schema[])schemas.values().toArray(new Schema[schemas.size()]);
+        return schemas.values().toArray(new Schema[schemas.size()]);
     }
     
     public synchronized Schema getSchema(String name) throws SQLException {
@@ -79,7 +79,7 @@ public class Catalog {
             getSchemas();
         }
         
-        return (Schema)schemas.get(name);
+        return schemas.get(name);
     }
     
     @Override

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/DBMetaDataProvider.java
@@ -63,7 +63,7 @@ public class DBMetaDataProvider {
      */
     public static synchronized DBMetaDataProvider get(Connection conn, String driverClass) {
         assert conn != null;
-        DBMetaDataProvider provider = (DBMetaDataProvider)CONN_TO_PROVIDER.get(conn);
+        DBMetaDataProvider provider = CONN_TO_PROVIDER.get(conn);
         if (provider == null) {
             provider = new DBMetaDataProvider(conn, driverClass);
             CONN_TO_PROVIDER.put(conn, provider);
@@ -110,22 +110,22 @@ public class DBMetaDataProvider {
             }
         }
         
-        return (Catalog[])catalogs.values().toArray(new Catalog[catalogs.size()]);
+        return catalogs.values().toArray(new Catalog[catalogs.size()]);
     }
     
     public synchronized Catalog getCatalog(String name) throws SQLException {
         if (catalogs == null) {
             getCatalogs();
         }
-        Catalog ret = (Catalog)catalogs.get(name);
+        Catalog ret = catalogs.get(name);
         if(ret == null && "".equals(name)) {
-            ret = (Catalog)catalogs.get(null);
+            ret = catalogs.get(null);
         }
         return ret;
     }
     
     Connection getConnection() {
-        return (Connection)conn.get();
+        return conn.get();
     }
     
     String getDriverClass() {
@@ -190,7 +190,7 @@ public class DBMetaDataProvider {
             }
             DBMetaDataProvider provider;
             synchronized (this) {
-                provider = (DBMetaDataProvider)CONN_TO_PROVIDER.get(conn);
+                provider = CONN_TO_PROVIDER.get(conn);
             }
             if (provider == null) {
                 return null;

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Schema.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/db/Schema.java
@@ -64,7 +64,7 @@ public class Schema {
             tableNames = getTableNamesByType("TABLE"); // NOI18N
         }
         
-        return (String[])tableNames.toArray(new String[0]);
+        return tableNames.toArray(new String[0]);
     }
     
     public TableElement getTable(String tableName) throws SQLException {

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/SourceRootsUi.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/SourceRootsUi.java
@@ -410,7 +410,7 @@ out:        for( int i = 0; i < files.length; i++ ) {
 
             // Remove the items
             for( int i = si.length - 1 ; i >= 0 ; i-- ) {
-                this.ownedFolders.remove(((Vector)rootsModel.getDataVector().elementAt(si[i])).elementAt(0));
+                this.ownedFolders.remove(rootsModel.getDataVector().elementAt(si[i]).elementAt(0));
                 rootsModel.removeRow( si[i] );
             }
 
@@ -440,7 +440,7 @@ out:        for( int i = 0; i < files.length; i++ ) {
             ListSelectionModel selectionModel = this.rootsList.getSelectionModel();
             selectionModel.clearSelection();
             for( int i = 0; i < si.length; i++ ) {
-                Vector item = (Vector)rootsModel.getDataVector().elementAt(si[i]);
+                Vector item = rootsModel.getDataVector().elementAt(si[i]);
                 int newIndex = si[i]-1;
                 rootsModel.removeRow( si[i] );
                 rootsModel.insertRow( newIndex, item );

--- a/java/maven.grammar/src/org/netbeans/modules/maven/codegen/NewPluginPanel.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/codegen/NewPluginPanel.java
@@ -127,7 +127,7 @@ public class NewPluginPanel extends javax.swing.JPanel implements ChangeListener
         Enumeration<GoalEntry> e  = listModel.elements();
         GoalEntry ge;
         while (e.hasMoreElements()) {
-            ge = (GoalEntry) e.nextElement();
+            ge = e.nextElement();
             if (ge.isSelected) {
                 goals.add(ge.name);
             }

--- a/java/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenQueryProvider.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/grammar/MavenQueryProvider.java
@@ -56,7 +56,7 @@ public final class MavenQueryProvider extends GrammarQueryManager {
         if (getGrammar(ctx) != null) {
             Enumeration<Node> en = ctx.getDocumentChildren();
             while (en.hasMoreElements()) {
-                Node next = (Node)en.nextElement();
+                Node next = en.nextElement();
                 if (next.getNodeType() == Node.ELEMENT_NODE) {
                     return Collections.enumeration(Collections.singletonList(next));
                 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/ArrayCreation.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/ArrayCreation.java
@@ -59,7 +59,7 @@ public class ArrayCreation extends Expression {
     }
 
     public ArrayCreation(int start, int end, List<ArrayElement> elements, Type type) {
-        this(start, end, elements == null ? null : (ArrayElement[]) elements.toArray(new ArrayElement[elements.size()]), type);
+        this(start, end, elements == null ? null : elements.toArray(new ArrayElement[elements.size()]), type);
     }
 
     /**

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/BackTickExpression.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/BackTickExpression.java
@@ -41,7 +41,7 @@ public class BackTickExpression extends Expression {
     }
 
     public BackTickExpression(int start, int end, List<Expression> expressions) {
-        this(start, end, expressions == null ? null : (Expression[]) expressions.toArray(new Expression[expressions.size()]));
+        this(start, end, expressions == null ? null : expressions.toArray(new Expression[expressions.size()]));
     }
 
     /**

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/DeclareStatement.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/DeclareStatement.java
@@ -46,8 +46,8 @@ public class DeclareStatement extends Statement {
 
     public DeclareStatement(int start, int end, List<Identifier> directiveNames, List<Expression> directiveValues, Statement action) {
         this(start, end,
-                directiveNames == null ? null : (Identifier[]) directiveNames.toArray(new Identifier[directiveNames.size()]),
-                directiveValues == null ? null : (Expression[]) directiveValues.toArray(new Expression[directiveValues.size()]),
+                directiveNames  == null ? null : directiveNames.toArray(new Identifier[directiveNames.size()]),
+                directiveValues == null ? null : directiveValues.toArray(new Expression[directiveValues.size()]),
                 action);
     }
 

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/EchoStatement.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/EchoStatement.java
@@ -40,7 +40,7 @@ public class EchoStatement extends Statement {
     }
 
     public EchoStatement(int start, int end, List<Exception> expressions) {
-        this(start, end, (Expression[]) expressions.toArray(new Expression[expressions.size()]));
+        this(start, end, expressions.toArray(new Expression[expressions.size()]));
     }
 
     /**

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/ForStatement.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/ForStatement.java
@@ -54,9 +54,9 @@ public class ForStatement extends Statement {
 
     public ForStatement(int start, int end, List<Expression> initializations, List<Expression> conditions, List<Expression> increasements, Statement action) {
         this(start, end,
-                initializations == null ? null : (Expression[]) initializations.toArray(new Expression[initializations.size()]),
-                conditions == null ? null : (Expression[]) conditions.toArray(new Expression[conditions.size()]),
-                increasements == null ? null : (Expression[]) increasements.toArray(new Expression[increasements.size()]),
+                initializations == null ? null : initializations.toArray(new Expression[initializations.size()]),
+                conditions == null ? null : conditions.toArray(new Expression[conditions.size()]),
+                increasements == null ? null : increasements.toArray(new Expression[increasements.size()]),
                 action);
     }
 

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/FormalParameter.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/FormalParameter.java
@@ -59,7 +59,7 @@ public class FormalParameter extends ASTNode implements Attributed {
     }
 
     public FormalParameter(int start, int end, Expression type, final Expression parameterName) {
-        this(start, end, type, (Expression) parameterName, null);
+        this(start, end, type, parameterName, null);
     }
 
     public FormalParameter(int start, int end, Expression type, final Reference parameterName) {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/FunctionInvocation.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/FunctionInvocation.java
@@ -46,7 +46,7 @@ public class FunctionInvocation extends VariableBase {
     }
 
     public FunctionInvocation(int start, int end, FunctionName functionName, List<Expression> parameters) {
-        this(start, end, functionName, parameters == null ? new Expression[0] : (Expression[]) parameters.toArray(new Expression[parameters.size()]));
+        this(start, end, functionName, parameters == null ? new Expression[0] : parameters.toArray(new Expression[parameters.size()]));
     }
 
     /**

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/GlobalStatement.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/GlobalStatement.java
@@ -43,7 +43,7 @@ public class GlobalStatement extends Statement {
     }
 
     public GlobalStatement(int start, int end, List<Variable> variables) {
-        this(start, end, variables == null ? null : (Variable[]) variables.toArray(new Variable[variables.size()]));
+        this(start, end, variables == null ? null : variables.toArray(new Variable[variables.size()]));
     }
 
     /**

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/ListVariable.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/ListVariable.java
@@ -73,7 +73,7 @@ public class ListVariable extends VariableBase {
     }
 
     public ListVariable(int start, int end, List<ArrayElement> elements, SyntaxType syntaxType) {
-        this(start, end, elements == null ? null : (ArrayElement[]) elements.toArray(new ArrayElement[elements.size()]), syntaxType);
+        this(start, end, elements == null ? null : elements.toArray(new ArrayElement[elements.size()]), syntaxType);
     }
 
     /**

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/Program.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/Program.java
@@ -40,13 +40,13 @@ public class Program extends ASTNode {
         super(start, end);
         this.statements.addAll(Arrays.asList(statements));
         for (Comment comment : commentsList) {
-            this.comments.add((Comment) comment);
+            this.comments.add(comment);
         }
 
     }
 
     public Program(int start, int end, List<Statement> statements, List<Comment> commentsList) {
-        this(start, end, (Statement[]) statements.toArray(new Statement[statements.size()]), commentsList);
+        this(start, end, statements.toArray(new Statement[statements.size()]), commentsList);
     }
 
     public List<Comment> getComments() {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/Quote.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/Quote.java
@@ -52,7 +52,7 @@ public class Quote extends Expression {
     }
 
     public Quote(int start, int end, List<Exception> expressions, Quote.Type type) {
-        this(start, end, expressions == null ? new Expression[0] : (Expression[]) expressions.toArray(new Expression[expressions.size()]), type);
+        this(start, end, expressions == null ? new Expression[0] : expressions.toArray(new Expression[expressions.size()]), type);
     }
 
     /**

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/StaticStatement.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/StaticStatement.java
@@ -46,7 +46,7 @@ public class StaticStatement extends Statement {
     }
 
     public StaticStatement(int start, int end, List<Exception> expressions) {
-        this(start, end, expressions == null ? null : (Expression[]) expressions.toArray(new Expression[expressions.size()]));
+        this(start, end, expressions == null ? null : expressions.toArray(new Expression[expressions.size()]));
     }
 
     /**
@@ -63,7 +63,7 @@ public class StaticStatement extends Statement {
                 vars.add((Variable) ass.getLeftHandSide());
             }
         }
-        return (Variable[]) vars.toArray(new Variable[vars.size()]);
+        return vars.toArray(new Variable[vars.size()]);
     }
 
     /**

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/SwitchCase.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/SwitchCase.java
@@ -53,8 +53,7 @@ public class SwitchCase extends Statement {
 
     public SwitchCase(int start, int end, Expression value, List<Statement> actions, boolean isDefault) {
         this(start, end, value,
-                actions == null ? null : (Statement[]) actions.toArray(new Statement[actions.size()]),
-                isDefault);
+                actions == null ? null : actions.toArray(new Statement[actions.size()]), isDefault);
     }
 
     /**

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/TryStatement.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/TryStatement.java
@@ -52,7 +52,7 @@ public class TryStatement extends Statement {
     }
 
     public TryStatement(int start, int end, Block tryStatement, List<CatchClause> catchClauses, FinallyClause finallyClause) {
-        this(start, end, tryStatement, catchClauses == null ? null : (CatchClause[]) catchClauses.toArray(new CatchClause[catchClauses.size()]), finallyClause);
+        this(start, end, tryStatement, catchClauses == null ? null : catchClauses.toArray(new CatchClause[catchClauses.size()]), finallyClause);
     }
 
     /**

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsSemanticAnalyzer.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsSemanticAnalyzer.java
@@ -248,7 +248,7 @@ public class JsSemanticAnalyzer extends SemanticAnalyzer<JsParserResult> {
                                     }
                                 }
                             } else if (object instanceof JsObject && !ModelUtils.ARGUMENTS.equals(object.getName())) {   // NOI18N
-                                if (object.getOccurrences().size() <= ((JsObject)object).getAssignmentCount()) {
+                                if (object.getOccurrences().size() <= object.getAssignmentCount()) {
                                     // probably is used only on the left site => is unused
                                     if (object.getDeclarationName().getOffsetRange().getLength() > 0) {
                                         highlights.put(LexUtilities.getLexerOffsets(result, object.getDeclarationName().getOffsetRange()), ColoringAttributes.UNUSED_SET);

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/wizard/SiteTemplateWizard.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/wizard/SiteTemplateWizard.java
@@ -442,7 +442,7 @@ public class SiteTemplateWizard extends JPanel {
             public void run() {
                 Enumeration<SiteTemplateImplementation> templates = onlineTemplatesListModel.elements();
                 while (templates.hasMoreElements()) {
-                    SiteTemplateImplementation template = (SiteTemplateImplementation) templates.nextElement();
+                    SiteTemplateImplementation template = templates.nextElement();
                     try {
                         template.cleanup();
                     } catch (IOException exc) {

--- a/websvccommon/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModelerFactory.java
+++ b/websvccommon/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wsdl/impl/WsdlModelerFactory.java
@@ -69,7 +69,7 @@ public class WsdlModelerFactory {
         if (wr == null) {
             return null;
         }
-        WsdlModeler modeler = (WsdlModeler) wr.get();
+        WsdlModeler modeler = wr.get();
         if (modeler == null) {
             modelers.remove(url);
         }


### PR DESCRIPTION
As a result of much of the warning cleanup work I've done over the past couple of years, the redundant cast warnings start happening more fequently.

```
   [repeat] /home/bwalker/src/netbeans/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ButtonPopupSwitcher.java:344: warning: [cast] redundant cast to Item
   [repeat]                 final Item item = ( Item ) pTable.getSelectedItem();
   [repeat]                                   ^
```

This works reduces those warnings.

