### PR TITLE
Ensure tomcat basedirectory is configured and in a writeable location

### DIFF
--- a/ide/httpserver/src/org/netbeans/modules/httpserver/HttpServerModule.java
+++ b/ide/httpserver/src/org/netbeans/modules/httpserver/HttpServerModule.java
@@ -174,7 +174,10 @@ public class HttpServerModule extends ModuleInstall implements Externalizable {
     
 
     private static void buildServer() throws Exception {
+        File httpwork = Places.getCacheSubdirectory("httpwork");
+        File httpworkBase = Places.getCacheSubdirectory("httpwork-base");
         tomcat = new Tomcat();
+        tomcat.setBaseDir(httpworkBase.getAbsolutePath());
         tomcat.setPort(httpserverSettings().getPort());
         tomcat.getServer().setUtilityThreads(1);
         tomcat.getConnector().setXpoweredBy(false);
@@ -185,8 +188,7 @@ public class HttpServerModule extends ModuleInstall implements Externalizable {
 	ThreadPoolExecutor tf  = new ThreadPoolExecutor(0, 3, 60, TimeUnit.SECONDS, tq);
 	tomcat.getConnector().getProtocolHandler().setExecutor(tf);
 
-        File wd = Places.getCacheSubdirectory("httpwork");
-        Context ctx = tomcat.addContext("", wd.getAbsolutePath());
+        Context ctx = tomcat.addContext("", httpwork.getAbsolutePath());
 
         if(ctx instanceof StandardContext) {
             ((StandardContext) ctx).setClearReferencesRmiTargets(false);


### PR DESCRIPTION
Tomcat by default places its working directory in the current working directory. This clutters the directory tree and is problematic if the current working directory is not writeable.

Closes: #5990