### PR TITLE
[JS] Improve resolving this in ClassElements and in arrow functions 

### DIFF
--- a/webcommon/html.angular/nbproject/project.xml
+++ b/webcommon/html.angular/nbproject/project.xml
@@ -147,7 +147,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.0</specification-version>
+                        <specification-version>1.27</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/editor/AngularJsCodeCompletion.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/editor/AngularJsCodeCompletion.java
@@ -175,7 +175,10 @@ public class AngularJsCodeCompletion implements CompletionProvider {
         if (jsIndex != null) {
             Collection<IndexedElement> globalVars = jsIndex.getGlobalVar(ccContext.getPrefix());
             for (IndexedElement variable : globalVars) {
-                if (!variable.isAnonymous() && (variable.getJSKind() == JsElement.Kind.FUNCTION || variable.getJSKind() == JsElement.Kind.CONSTRUCTOR) && variable instanceof IndexedElement.FunctionIndexedElement) {
+                if (!variable.isAnonymous() 
+                        && (variable.getJSKind() == JsElement.Kind.FUNCTION || variable.getJSKind() == JsElement.Kind.CONSTRUCTOR || variable.getJSKind() == JsElement.Kind.ARROW_FUNCTION)
+                        && variable instanceof IndexedElement.FunctionIndexedElement
+                    ) {
                     IndexedElement.FunctionIndexedElement function = (IndexedElement.FunctionIndexedElement)variable;
                     // pick up all functions that has at least one parameter and one of the paramets is $scope
                     if (!function.isAnonymous() && function.getParameters().size() > 0 && function.getParameters().containsKey("$scope")) {

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/model/AngularWhenInterceptor.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/model/AngularWhenInterceptor.java
@@ -74,7 +74,8 @@ public class AngularWhenInterceptor implements FunctionInterceptor {
                         String controllerName = getStringValueAt(content, controller.getOffsetRange().getStart());
                         if (controllerName.isEmpty()
                                 && (controller.getJSKind() == JsElement.Kind.METHOD
-                                || controller.getJSKind() == JsElement.Kind.FUNCTION)) {
+                                || controller.getJSKind() == JsElement.Kind.FUNCTION
+                                || controller.getJSKind() == JsElement.Kind.ARROW_FUNCTION)) {
                             // probably anonymous function as a controller
                             controllerName = controller.getFullyQualifiedName();
                             if (controllerName != null && !controllerName.isEmpty()) {

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/model/ModelUtils.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/model/ModelUtils.java
@@ -38,9 +38,14 @@ public class ModelUtils {
             result = jsObject;
             for (JsObject property : jsObject.getProperties().values()) {
                 JsElement.Kind kind = property.getJSKind();
-                if (kind == JsElement.Kind.OBJECT || kind == JsElement.Kind.ANONYMOUS_OBJECT || kind == JsElement.Kind.OBJECT_LITERAL
-                        || kind == JsElement.Kind.FUNCTION || kind == JsElement.Kind.METHOD || kind == JsElement.Kind.CONSTRUCTOR
-                        || kind == JsElement.Kind.WITH_OBJECT) {
+                if (kind == JsElement.Kind.OBJECT
+                        || kind == JsElement.Kind.ANONYMOUS_OBJECT
+                        || kind == JsElement.Kind.OBJECT_LITERAL
+                        || kind == JsElement.Kind.FUNCTION
+                        || kind == JsElement.Kind.METHOD
+                        || kind == JsElement.Kind.CONSTRUCTOR
+                        || kind == JsElement.Kind.WITH_OBJECT
+                        || kind == JsElement.Kind.ARROW_FUNCTION) {
                     tmpObject = findJsObject(property, offset);
                 }
                 if (tmpObject != null) {

--- a/webcommon/javascript2.editor/nbproject/project.xml
+++ b/webcommon/javascript2.editor/nbproject/project.xml
@@ -242,7 +242,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.2</specification-version>
+                        <specification-version>1.27</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsCompletionItem.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsCompletionItem.java
@@ -700,6 +700,7 @@ public class JsCompletionItem implements CompletionProposal {
                         case FUNCTION:
                         case METHOD:
                         case GENERATOR:
+                        case ARROW_FUNCTION:
                             Set<String> returnTypes = new HashSet<>();
                             HashMap<String, Set<String>> allParameters = new LinkedHashMap<>();
                             if (element instanceof JsFunction) {

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsSemanticAnalyzer.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsSemanticAnalyzer.java
@@ -135,6 +135,7 @@ public class JsSemanticAnalyzer extends SemanticAnalyzer<JsParserResult> {
                     case METHOD:
                     case FUNCTION:
                     case GENERATOR:
+                    case ARROW_FUNCTION:
                         if(object.isDeclared() && !object.isAnonymous() && !object.getDeclarationName().getOffsetRange().isEmpty()) {
                             EnumSet<ColoringAttributes> coloring = ColoringAttributes.METHOD_SET;
                             if (object.getModifiers().contains(Modifier.PRIVATE)) {

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/doc/JsDocumentationCompleter.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/doc/JsDocumentationCompleter.java
@@ -343,8 +343,11 @@ public class JsDocumentationCompleter {
             for (JsObject property : jsObject.getProperties().values()) {
                 JsElement.Kind kind = property.getJSKind();
                 if (kind == JsElement.Kind.OBJECT
-                        || kind == JsElement.Kind.FUNCTION || kind == JsElement.Kind.METHOD || kind == JsElement.Kind.CONSTRUCTOR
-                        || kind == JsElement.Kind.VARIABLE) {
+                        || kind == JsElement.Kind.FUNCTION
+                        || kind == JsElement.Kind.METHOD
+                        || kind == JsElement.Kind.CONSTRUCTOR
+                        || kind == JsElement.Kind.VARIABLE
+                        || kind == JsElement.Kind.ARROW_FUNCTION) {
                     tmpObject = findJsObjectFunctionVariable(property, offset);
                 }
                 if (tmpObject != null) {

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/index/JsIndexer.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/index/JsIndexer.java
@@ -345,7 +345,7 @@ public class JsIndexer extends EmbeddingIndexer {
     public static final class Factory extends EmbeddingIndexerFactory {
 
         public static final String NAME = "js"; // NOI18N
-        public static final int VERSION = 16;
+        public static final int VERSION = 17;
         private static final int PRIORITY = 100;
 
         private static final ThreadLocal<Collection<Runnable>> postScanTasks = new ThreadLocal<>();

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/hints/issueGH5740.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/hints/issueGH5740.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class Test {
+	var1 = 123;
+	var2 = this.var1;
+}

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/indexer/SelfreferencingFunction.js.indexed
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/indexer/SelfreferencingFunction.js.indexed
@@ -9,7 +9,7 @@ Searchable Keys:
 
 Not Searchable Keys:
   assign : 
-  flag : 4289
+  flag : 33554625
   param : action:
   return : 
 

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH4376.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH4376.js
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class Foo {
+	bar = {}; //Line 2
+
+	test(someArray) {
+		this.bar = {};  //Line 5
+		someArray.forEach((val) => {
+			this.bar[val] = 1;  //Line 7
+		});
+	}
+}

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH4376.js.structure
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH4376.js.structure
@@ -1,0 +1,3 @@
+Foo:CLASS:[PUBLIC]:ESCAPED{Foo}:
+  bar:CLASS:[PUBLIC]:ESCAPED{bar}:
+  test:METHOD:[PUBLIC]:ESCAPED{test}ESCAPED{(}ESCAPED{someArray}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH4376.js.testIssueGH4376_01.occurrences
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH4376.js.testIssueGH4376_01.occurrences
@@ -1,0 +1,3 @@
+	|>MARK_OCCURRENCES:bar<| = {}; //Line 2
+		this.|>MARK_OCCURRENCES:b^ar<| = {};  //Line 5
+			this.|>MARK_OCCURRENCES:bar<|[val] = 1;  //Line 7

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH4376.js.testIssueGH4376_02.occurrences
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issueGH4376.js.testIssueGH4376_02.occurrences
@@ -1,0 +1,3 @@
+	|>MARK_OCCURRENCES:bar<| = {}; //Line 2
+		this.|>MARK_OCCURRENCES:bar<| = {};  //Line 5
+			this.|>MARK_OCCURRENCES:ba^r<|[val] = 1;  //Line 7

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/hint/JsGlobalIsNotDeclaredTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/hint/JsGlobalIsNotDeclaredTest.java
@@ -26,7 +26,6 @@ import junit.framework.TestSuite;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.modules.csl.api.HintSeverity;
 import org.netbeans.modules.csl.api.Rule;
-import org.netbeans.modules.csl.api.test.CslTestBase;
 import org.netbeans.modules.javascript2.editor.classpath.ClasspathProviderImplAccessor;
 import org.netbeans.modules.javascript2.editor.hints.GlobalIsNotDefined;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
@@ -44,13 +43,13 @@ public class JsGlobalIsNotDeclaredTest extends HintTestBase {
     public JsGlobalIsNotDeclaredTest(String testName) {
         super(testName);
     }
-    
+
     private static class GlobalIsNotDefinedHint extends GlobalIsNotDefined {
         @Override
         public HintSeverity getDefaultSeverity() {
             return HintSeverity.WARNING;
         }
-        
+
     }
 
     private Rule createRule() {
@@ -66,39 +65,39 @@ public class JsGlobalIsNotDeclaredTest extends HintTestBase {
     public void testSimple01() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/globalIsNotDeclared.js", null);
     }
-    
+
     public void testIssue224040() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/issue224040.js", null);
     }
-    
+
     public void testIssue224041() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/issue224041.js", null);
     }
-    
+
     public void testIssue224035() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/issue224035.js", null);
     }
-    
+
     public void testIssue225048() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/issue225048.js", null);
     }
-    
+
     public void testIssue225048_01() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/issue225048_01.js", null);
     }
-    
+
     public void testIssue250372() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/issue250372.js", null);
     }
-    
+
     public void testIssue248696_01() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/issue248696_01.js", null);
     }
-    
+
     public void testIssue248696_02() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/issue248696_02.js", null);
     }
-    
+
     public void testIssue252022() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/issue252022.js", null);
     }
@@ -106,11 +105,11 @@ public class JsGlobalIsNotDeclaredTest extends HintTestBase {
     public void testIssue249487() throws Exception {
         checkHints(this, createRule(), "testfiles/markoccurences/issue249487.js", null);
     }
-    
+
     public void testIssue255494() throws Exception {
         checkHints(this, createRule(), "testfiles/coloring/issue255494.js", null);
     }
-    
+
     public void testIssue268384() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/issue268384.js", null);
     }
@@ -125,6 +124,10 @@ public class JsGlobalIsNotDeclaredTest extends HintTestBase {
 
     public void testIssueGH4568() throws Exception {
         checkHints(this, createRule(), "testfiles/hints/issueGH4568.js", null);
+    }
+
+    public void testIssueGH5740() throws Exception {
+        checkHints(this, createRule(), "testfiles/hints/issueGH5740.js", null);
     }
 
     @Override

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/navigation/MarkOccurrenceTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/navigation/MarkOccurrenceTest.java
@@ -2248,6 +2248,18 @@ public class MarkOccurrenceTest extends JsTestBase {
         checkOccurrences("testfiles/markoccurences/issueGH5184_01.js", "export {te^st2};", true);
     }
 
+    public void testIssueGH4376() throws Exception {
+        checkStructure("testfiles/markoccurences/issueGH4376.js");
+    }
+
+    public void testIssueGH4376_01() throws Exception {
+        checkOccurrences("testfiles/markoccurences/issueGH4376.js", "		this.b^ar = {};  //Line 5", true);
+    }
+
+    public void testIssueGH4376_02() throws Exception {
+        checkOccurrences("testfiles/markoccurences/issueGH4376.js", "			this.ba^r[val] = 1;  //Line 7", true);
+    }
+
     private String getTestName() {
         String name = getName();
         int indexOf = name.indexOf("_");

--- a/webcommon/javascript2.knockout/nbproject/project.xml
+++ b/webcommon/javascript2.knockout/nbproject/project.xml
@@ -49,7 +49,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.0</specification-version>
+                        <specification-version>1.27</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript2.knockout/src/org/netbeans/modules/javascript2/knockout/model/ModelUtils.java
+++ b/webcommon/javascript2.knockout/src/org/netbeans/modules/javascript2/knockout/model/ModelUtils.java
@@ -38,9 +38,14 @@ public class ModelUtils {
             result = jsObject;
             for (JsObject property : jsObject.getProperties().values()) {
                 JsElement.Kind kind = property.getJSKind();
-                if (kind == JsElement.Kind.OBJECT || kind == JsElement.Kind.ANONYMOUS_OBJECT || kind == JsElement.Kind.OBJECT_LITERAL
-                        || kind == JsElement.Kind.FUNCTION || kind == JsElement.Kind.METHOD || kind == JsElement.Kind.CONSTRUCTOR
-                        || kind == JsElement.Kind.WITH_OBJECT) {
+                if (kind == JsElement.Kind.OBJECT
+                        || kind == JsElement.Kind.ANONYMOUS_OBJECT
+                        || kind == JsElement.Kind.OBJECT_LITERAL
+                        || kind == JsElement.Kind.FUNCTION
+                        || kind == JsElement.Kind.METHOD
+                        || kind == JsElement.Kind.CONSTRUCTOR
+                        || kind == JsElement.Kind.WITH_OBJECT
+                        || kind == JsElement.Kind.ARROW_FUNCTION) {
                     tmpObject = findJsObject(property, offset);
                 }
                 if (tmpObject != null) {

--- a/webcommon/javascript2.model/manifest.mf
+++ b/webcommon/javascript2.model/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.javascript2.model/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/javascript2/model/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.26
+OpenIDE-Module-Specification-Version: 1.27
 

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsElementImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsElementImpl.java
@@ -39,6 +39,7 @@ import static org.netbeans.modules.javascript2.model.api.JsElement.Kind.CONSTRUC
 import static org.netbeans.modules.javascript2.model.api.JsElement.Kind.FIELD;
 import static org.netbeans.modules.javascript2.model.api.JsElement.Kind.FUNCTION;
 import static org.netbeans.modules.javascript2.model.api.JsElement.Kind.METHOD;
+import static org.netbeans.modules.javascript2.model.api.JsElement.Kind.ARROW_FUNCTION;
 import static org.netbeans.modules.javascript2.model.api.JsElement.Kind.OBJECT;
 import static org.netbeans.modules.javascript2.model.api.JsElement.Kind.OBJECT_LITERAL;
 import static org.netbeans.modules.javascript2.model.api.JsElement.Kind.PROPERTY;
@@ -214,6 +215,7 @@ public abstract class JsElementImpl implements JsElement {
             case PROPERTY_GETTER:
             case PROPERTY_SETTER:
             case GENERATOR:
+            case ARROW_FUNCTION:
                 result = ElementKind.METHOD;
                 break;
             case OBJECT:

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsFunctionImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsFunctionImpl.java
@@ -137,9 +137,6 @@ public class JsFunctionImpl extends DeclarationScopeImpl implements JsFunction {
                 return JsElement.Kind.CONSTRUCTOR;
             }
         }
-//        if (getParent() != null && !getParent().isDeclared()) {
-//
-//        }
 
         JsElement.Kind result = JsElement.Kind.FUNCTION;
 

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -1115,6 +1115,11 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
             }
         }
 
+        if (fn.getKind() == FunctionNode.Kind.ARROW) {
+            // marking the function as an arrow function
+            jsFunction.setJsKind(JsElement.Kind.ARROW_FUNCTION);
+        }
+
         if (fn.getKind() == FunctionNode.Kind.GENERATOR) {
             // marking the function as generator
             jsFunction.setJsKind(JsElement.Kind.GENERATOR);

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/IndexedElement.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/IndexedElement.java
@@ -322,6 +322,7 @@ public class IndexedElement implements JsElement {
         private static final int CALLBACK = 1 << 22;
         private static final int GENERATOR = 1 << 23;
         private static final int CONSTANT = 1 << 24;
+        private static final int ARROW_FUNCTION = 1 << 25;
 
         private static final int PLATFORM = 1 << 20;
 
@@ -359,6 +360,7 @@ public class IndexedElement implements JsElement {
             if (kind == JsElement.Kind.CALLBACK) value |= CALLBACK;
             if (kind == JsElement.Kind.GENERATOR) value |= GENERATOR;
             if (kind == JsElement.Kind.CONSTANT) value |= CONSTANT;
+            if (kind == JsElement.Kind.ARROW_FUNCTION) value |= ARROW_FUNCTION;
 
             if (object.isPlatform()) value |= PLATFORM;
 
@@ -409,6 +411,7 @@ public class IndexedElement implements JsElement {
             else if ((flag & CALLBACK) != 0) result = JsElement.Kind.CALLBACK;
             else if ((flag & GENERATOR) != 0) result = JsElement.Kind.GENERATOR;
             else if ((flag & CONSTANT) != 0) result = JsElement.Kind.CONSTANT;
+            else if ((flag & ARROW_FUNCTION) != 0) result = JsElement.Kind.ARROW_FUNCTION;
             return result;
         }
     }

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/JsElement.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/JsElement.java
@@ -51,7 +51,8 @@ public interface JsElement extends ElementHandle {
         CLASS(17),
         GENERATOR(18),
         CONSTANT(19),
-        BLOCK(20);
+        BLOCK(20),
+        ARROW_FUNCTION(21);
 
         private final int id;
         private static final Map<Integer, Kind> LOOKUP = new HashMap<>();
@@ -77,7 +78,8 @@ public interface JsElement extends ElementHandle {
         public boolean isFunction() {
             return this == FUNCTION || this == METHOD || this == CONSTRUCTOR
                     || this == PROPERTY_GETTER || this == PROPERTY_SETTER
-                    || this == CALLBACK || this == GENERATOR;
+                    || this == CALLBACK || this == GENERATOR
+                    || this == ARROW_FUNCTION;
         }
 
         public boolean isPropertyGetterSetter() {

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/ModelUtils.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/ModelUtils.java
@@ -197,7 +197,7 @@ public class ModelUtils {
                 JsElement.Kind kind = property.getJSKind();
                 if (kind == JsElement.Kind.OBJECT || kind == JsElement.Kind.ANONYMOUS_OBJECT || kind == JsElement.Kind.OBJECT_LITERAL
                         || kind == JsElement.Kind.FUNCTION || kind == JsElement.Kind.METHOD || kind == JsElement.Kind.CONSTRUCTOR
-                        || kind == JsElement.Kind.WITH_OBJECT) {
+                        || kind == JsElement.Kind.WITH_OBJECT || kind == JsElement.Kind.ARROW_FUNCTION) {
                     if (!visited.contains(property.getFullyQualifiedName())) {
                         tmpObject = findJsObject(property, offset, visited);
                     }
@@ -637,6 +637,7 @@ public class ModelUtils {
                 parent = object;
             }
         }
+        // @todo: Handle Arrow Function
         if (parent != null && (parent.getJSKind() == JsElement.Kind.FUNCTION || parent.getJSKind() == JsElement.Kind.METHOD)) {
             if (parent.getParent().getJSKind() != JsElement.Kind.FILE) {
                 JsObject grandParent = parent.getParent();


### PR DESCRIPTION
Inside initialisation statements:

```javascript
class Test {
	var1 = 123;
	var2 = this.var1;
}
```

this needs to evaluate to the surrounding class, to handle this
correctly, search for the right definition of "this" needs to start
at the surrounding object, not the declaration scope of the wrapping
function.

Before:
![image](https://github.com/apache/netbeans/assets/2179736/a64c5b32-4cf2-4ab5-aa1e-4a9006ca8cc4)

After:
![image](https://github.com/apache/netbeans/assets/2179736/b3a7f85f-3c6a-4664-97ff-bea568a3f90e)


In arrow functions this is not redefined, but inherited from the outer
scope. In this sample:

```javascript
class Foo {
	bar = {};
	
	test(someArray) {
		this.bar = {}; // Mark
		someArray.forEach((val) => {
			this.bar[val] = 1;  // Mark
		});
	}
}
```

this in the lines with the "Mark" comment is an instance of `Foo` and
thus it is always the same bar. The this scanning needs to skip arrow
functions.

Before (notice, that only property under the cursor is highlighted):
![image](https://github.com/apache/netbeans/assets/2179736/9b074089-52bc-4721-992a-57ed9d6ab491)

After (notice, that now all occurences are marked):
![image](https://github.com/apache/netbeans/assets/2179736/5f19f847-6dae-45d6-8752-c02143913dc4)


After:



Closes: https://github.com/apache/netbeans/issues/5740
Closes: https://github.com/apache/netbeans/issues/4376