### PR TITLE
#5978: Maven/priming optimization

### DIFF
--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
@@ -21,6 +21,15 @@
 -->
 <!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
 <filesystem>
+    <folder name="Preferences">
+        <folder name="org">
+            <folder name="netbeans">
+                <folder name="modules">
+                    <file name="maven.properties" url="maven.properties"/>
+                </folder>
+            </folder>
+        </folder>
+    </folder>
     <folder name="Services">
         <folder name="NBLS">
             <file name="general-node-commands.instance">

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/maven.properties
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/maven.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+primingBuild.snapshot.goals=install
+primingBuild.regular.goals=install

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -436,6 +436,8 @@ public final class Server {
                 return CompletableFuture.completedFuture(new Project[0]);
             }
             CompletableFuture<Project[]> f = new CompletableFuture<>();
+            LOG.log(Level.FINER, "Asked to open project(s): {0}", Arrays.asList(projectCandidates));
+            LOG.log(Level.FINER, "Caller:", new Throwable());
             SERVER_INIT_RP.post(() -> {
                 asyncOpenSelectedProjects0(f, projectCandidates, addWorkspace, false);
             });
@@ -611,7 +613,7 @@ public final class Server {
             List<Project> toOpen = new ArrayList<>();
             Map<Project, CompletableFuture<Void>> local = new HashMap<>();
             synchronized (this) {
-                LOG.log(Level.FINER, "{0}: Asked to open project(s): {1}", new Object[]{ id, Arrays.asList(projects) });
+                LOG.log(Level.FINER, "{0}: Opening project(s): {1}", new Object[]{ id, Arrays.asList(projects) });
                 for (Project p : projects) {
                     CompletableFuture<Void> pending = beingOpened.get(p);
                     if (pending != null) {
@@ -623,7 +625,7 @@ public final class Server {
                 }
                 beingOpened.putAll(local);
             }
-
+            long t = System.currentTimeMillis();
             LOG.log(Level.FINER, id + ": Opening projects: {0}", Arrays.asList(toOpen));
 
             // before the projects are officialy 'opened', try to prime the projects
@@ -700,6 +702,7 @@ public final class Server {
                     }
                 }
                 f.complete(prjsRequested);
+                LOG.log(Level.INFO, "{0} projects opened in {1}ms", new Object[] { prjsRequested.length, (System.currentTimeMillis() - t) });
             }).exceptionally(e -> {
                 f.completeExceptionally(e);
                 return null;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -60,6 +60,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
@@ -329,7 +330,9 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
                 if (file == null) {
                     return CompletableFuture.completedFuture(Collections.emptyList());
                 }
+                long t = System.currentTimeMillis();
                 return server.asyncOpenFileOwner(file).thenCompose(this::getTestRoots).thenCompose(testRoots -> {
+                    LOG.log(Level.INFO, "Project {2}: {0} test roots opened in {1}ms", new Object[] { testRoots.size(), (System.currentTimeMillis() - t), file});
                     BiFunction<FileObject, Collection<TestMethodController.TestMethod>, Collection<TestSuiteInfo>> f = (fo, methods) -> {
                         String url = Utils.toUri(fo);
                         Map<String, TestSuiteInfo> suite2infos = new LinkedHashMap<>();

--- a/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
@@ -72,6 +72,7 @@ import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.lookup.Lookups;
 import org.netbeans.modules.maven.InternalActionDelegate;
+import org.openide.util.Pair;
 
 /**
  * Suggests to run priming build. Also serves as a provider for Priming Build action,
@@ -91,9 +92,13 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);
     private final Project project;
     private final AtomicBoolean projectListenerSet = new AtomicBoolean(false);
-    private final AtomicReference<Collection<ProjectProblem>> problemsCache = new AtomicReference<Collection<ProjectProblem>>();
+    private final AtomicReference<Pair<Collection<ProjectProblem>, Boolean>> problemsCache = new AtomicReference<>();
     private final PrimingActionProvider primingProvider = new PrimingActionProvider();
     private ProblemReporterImpl problemReporter;
+    /**
+     * The Maven project that has been processed already.
+     */
+    private volatile Reference<MavenProject> analysedProject = new WeakReference<>(null);
     private final PropertyChangeListener projectListener = new PropertyChangeListener() {
 
         @Override
@@ -125,6 +130,15 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
         return prbs != null ? prbs : Collections.emptyList();
     }
     
+    /**
+     * Flag set during creation of sanity build action. Usable only inside synchronized
+     * section of the problem resolver.
+     */
+    private boolean sanityBuildStatus;
+            
+    public boolean isSanityBuildNeeded() {
+        return doGetProblems1(true).second();
+    }
     
     /**
      * Compute problems. If 'sync' is true, the computation is done synchronously. Caches results,
@@ -133,9 +147,23 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
      * @return project problems.
      */
     Collection<? extends ProjectProblem> doGetProblems(boolean sync) {
-        final MavenProject prj = project.getLookup().lookup(NbMavenProject.class).getMavenProject();
+        return doGetProblems1(sync).first();
+    }
+        
+    /**
+     * Analyzes problem, returns list of problems and priming build status. The returned {@link Pair}
+     * contains the list of problems and true/false whether the priming build seems necessary. The last result
+     * is cached for the given maven model instance. If the project was reloaded, the problems will be computed
+     * again for the new project instance. The call might block waiting on the pending project reload. If `sync' 
+     * is false, the method will just post in request processor and return {@code null}.
+     * 
+     * @param sync if the call should complete synchronously
+     */
+    private Pair<Collection<ProjectProblem>, Boolean> doGetProblems1(boolean sync) {
+        final MavenProject updatedPrj = ((NbMavenProjectImpl)project).getFreshOriginalMavenProject();
+        Callable<Pair<Collection<ProjectProblem>, Boolean>> c;
+    
         synchronized (this) {
-            LOG.log(Level.FINER, "Called getProblems for {0}", project);
             //lazy adding listener only when someone asks for the problems the first time
             if (projectListenerSet.compareAndSet(false, true)) {
                 //TODO do we check only when the project is opened?
@@ -144,59 +172,87 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
                 project.getLookup().lookup(NbMavenProject.class).addPropertyChangeListener(projectListener);
             
             }
-            
+            MavenProject o = analysedProject.get();
+            LOG.log(Level.FINER, "Called getProblems for {0}, analysed = {1}, current = {2}", 
+                    new Object[] { project, o == null ? 0 : System.identityHashCode(o), System.identityHashCode(updatedPrj) });
             //for non changed project models, no need to recalculate, always return the cached value
-            Object wasprocessed = prj.getContextValue(MavenModelProblemsProvider.class.getName());
-            if (wasprocessed != null) {
-                Collection<ProjectProblem> cached = problemsCache.get();
-                LOG.log(Level.FINER, "Project was processed, cached is: {0}", cached);
+            Object wasprocessed = updatedPrj.getContextValue(MavenModelProblemsProvider.class.getName());
+            if (o == updatedPrj && wasprocessed != null) {
+                Pair<Collection<ProjectProblem>, Boolean> cached = problemsCache.get();
+                LOG.log(Level.FINER, "getProblems: Project was processed, cached is: {0}", cached);
                 if (cached != null) {
                     return cached;
                 }
             } 
-            Callable<Collection<? extends ProjectProblem>> c = new Callable<Collection<? extends ProjectProblem>>() {
+            
+            SanityBuildAction sba = cachedSanityBuild.get();
+            if (sba != null && sba.getPendingResult() == null) {
+                cachedSanityBuild.clear();
+            }
+            c = new Callable<Pair<Collection<ProjectProblem>, Boolean>>() {
                 @Override
-                public Collection<? extends ProjectProblem> call() throws Exception {
-                    Object wasprocessed = prj.getContextValue(MavenModelProblemsProvider.class.getName());
-                    if (wasprocessed != null) {
-                        Collection<ProjectProblem> cached = problemsCache.get();
-                        LOG.log(Level.FINER, "Project was processed #2, cached is: {0}", cached);
+                public Pair<Collection<ProjectProblem>, Boolean> call() throws Exception {
+                    // double check, the project may be invalidated during the time.
+                    MavenProject prj = ((NbMavenProjectImpl)project).getFreshOriginalMavenProject();
+                    Object wasprocessed = updatedPrj.getContextValue(MavenModelProblemsProvider.class.getName());
+                    if (o == updatedPrj && wasprocessed != null) {
+                        Pair<Collection<ProjectProblem>, Boolean> cached = problemsCache.get();
+                        LOG.log(Level.FINER, "getProblems: Project was processed #2, cached is: {0}", cached);
                         if (cached != null) {                            
                             return cached;
                         }
                     } 
-                    List<ProjectProblem> toRet = new ArrayList<>();
-                    MavenExecutionResult res = MavenProjectCache.getExecutionResult(prj);
-                    if (res != null && res.hasExceptions()) {
-                        toRet.addAll(reportExceptions(res));
+                    int round = 0;
+                    List<ProjectProblem> toRet = null;
+                    while (round < 3) {
+                        try {
+                            synchronized (MavenModelProblemsProvider.this) {
+                                sanityBuildStatus = false;
+                                toRet = new ArrayList<>();
+                                MavenExecutionResult res = MavenProjectCache.getExecutionResult(prj);
+                                if (res != null && res.hasExceptions()) {
+                                    toRet.addAll(reportExceptions(res));
+                                }
+                                //#217286 doArtifactChecks can call FileOwnerQuery and attempt to aquire the project mutex.
+                                toRet.addAll(doArtifactChecks(prj));
+                                //mark the project model as checked once and cached
+                                prj.setContextValue(MavenModelProblemsProvider.class.getName(), new Object());
+                                synchronized(MavenModelProblemsProvider.this) {
+                                    LOG.log(Level.FINER, "getProblems: Project {1} processing finished, result is: {0}",
+                                            new Object[] { toRet, prj });
+                                    problemsCache.set(Pair.of(toRet, sanityBuildStatus));
+                                    analysedProject = new WeakReference<>(prj);
+                                }
+                                firePropertyChange();
+                                return Pair.of(toRet, sanityBuildStatus);
+                            }
+                        } catch (ProblemReporterImpl.ArtifactFoundException ex) {
+                            round++;
+                            LOG.log(Level.FINER, "getProblems: Project {1} reported missing artifact that actually exists, restarting - {0} round",
+                                    new Object[] { round, prj });
+                            // force reload, then wait for the reload to complete
+                            NbMavenProject.fireMavenProjectReload(project);
+                            prj = ((NbMavenProjectImpl)project).getFreshOriginalMavenProject();
+                        } 
                     }
-                    //#217286 doArtifactChecks can call FileOwnerQuery and attempt to aquire the project mutex.
-                    toRet.addAll(doArtifactChecks(prj));
-                    //mark the project model as checked once and cached
-                    prj.setContextValue(MavenModelProblemsProvider.class.getName(), new Object());
-                    synchronized(MavenModelProblemsProvider.this) {
-                        LOG.log(Level.FINER, "Project processing finished, result is: {0}", toRet);
-                        problemsCache.set(toRet);
-                    }
-                    firePropertyChange();
-                    return toRet;
-                }                
-            };
-            if(sync || Boolean.getBoolean("test.reload.sync")) {
-                try {
-                    return c.call();
-                } catch (Exception ex) {
-                    Exceptions.printStackTrace(ex);
+                    return Pair.of(toRet, sanityBuildStatus);
                 }
-            } else {
-                RP.submit(c);
+            };
+        }
+        if(sync || Boolean.getBoolean("test.reload.sync")) {
+            try {
+                return c.call();
+            } catch (Exception ex) {
+                Exceptions.printStackTrace(ex);
             }
+        } else {
+            RP.submit(c);
         }
         
         // indicate that we do not know
-        return null;
+        return Pair.of(null, true);
     }
-
+    
     private void firePropertyChange() {
         support.firePropertyChange(ProjectProblemsProvider.PROP_PROBLEMS, null, null);
     }
@@ -245,6 +301,7 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
                             //a.getFile should be already normalized
                             SourceForBinaryQuery.Result2 result = SourceForBinaryQuery.findSourceRoots2(archiveUrl);
                             if (!result.preferSources() || /* SourceForBinaryQuery.EMPTY_RESULT2.preferSources() so: */ result.getRoots().length == 0) {
+                                LOG.log(Level.FINE, "Missing nonsibling artifact: {0}", art);
                                 missingNonSibling = true;
                             } // else #189442: typically a snapshot dep on another project
                         }
@@ -306,13 +363,14 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
     public SanityBuildAction createSanityBuildAction() {
         synchronized (this) {
             SanityBuildAction a = cachedSanityBuild.get();
+            sanityBuildStatus = true;
             if (a != null) {
                 Future<ProjectProblemsProvider.Result> r = a.getPendingResult();
                 if (r != null) {
                     return a;
                 }
             }
-            a = new SanityBuildAction(project);
+            a = new SanityBuildAction(project, this::isSanityBuildNeeded);
             project.getLookup().lookup(NbMavenProject.class).getMavenProject().setContextValue("org.netbeans.modules.maven.problems.primingNotDone", true);
             cachedSanityBuild = new WeakReference<>(a);
             return a;

--- a/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
@@ -103,7 +103,7 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
     /**
      * The Maven project that has been processed already.
      */
-    private volatile Reference<MavenProject> analysedProject = new WeakReference<>(null);
+    private Reference<MavenProject> analysedProject = new WeakReference<>(null);
     private final PropertyChangeListener projectListener = new PropertyChangeListener() {
 
         @Override

--- a/java/maven/src/org/netbeans/modules/maven/problems/ProblemReporterImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/problems/ProblemReporterImpl.java
@@ -195,12 +195,30 @@ public final class ProblemReporterImpl implements ProblemReporter, Comparator<Pr
             //a.getFile should be already normalized but the find() method can pull tricks on us.
             //#225008
             File f = FileUtil.normalizeFile(a.getFile());
+            if (f.exists() && f.canRead()) {
+                throw new ArtifactFoundException(a, f);
+            }
             if (missingArtifacts.add(f)) {                
                 LOG.log(Level.FINE, "listening to {0} from {1}", new Object[] {f, projectPOMFile});                
                 FileUtil.addFileChangeListener(fcl, f);
             }
         }
     }
+    
+    /**
+     * Indicates that the cached data that report a missing artifact is obsolete. 
+     */
+    public static class ArtifactFoundException extends IllegalStateException {
+        private final Artifact artifact;
+        private final File artifactFile;
+
+        public ArtifactFoundException(Artifact artifact, File artifactFile) {
+            this.artifact = artifact;
+            this.artifactFile = artifactFile;
+        }
+    }
+    
+    
 
     public Set<File> getMissingArtifactFiles() {
         synchronized (reports) {


### PR DESCRIPTION
Also see #5978.

First of all, `log4j` is not a good example. The project is set up in a way that **requires** that JDK8 is **on the PATH** while maven `toolchains.xml` define JDK 9+. The project will not compile if (e.g.) JDK11 is on PATH or JDK8 is defined in toolchains.
But the example surfaced several interesting things. Most importantly, maven processes for the parent *and subprojects* are launched in parallel. In reality, parent priming build is most likely to fetch all artifacts for all projects in the reactor - so running maven for a subproject is not necessary.  So it is worth to wait for preceding priming builds to complete before trying another one.
Next bug is that, after priming, the problem reporter does not refresh early - so `SanityBuildAction` could not even re-check the project is broken.

This PR:
- serializes maven priming builds. There will be at most 1 priming build running. It could be relaxed to allow 1 priming build for a reactor; we'll see from how this first change will affect perceived IDE performance.
- each priming build first checks, if the _updated_ maven model still reports missing artifacts. If not, it won't execute maven. It may be still reported through Progress API, but at least the costly external process (+ maven project model evaluation) will not happen
- an artifact might be reported as missing in the model, when it is, actually downloaded already. If this is detected - when the now-not-missing artifact is going to be reported, the current evaluation restarts. This is attempted 3 times at most so no endless loop should happen.

During prototyping, I've tried to avoid Java compilation - since for IDE purposes, only dependencies are important, not correctness of the project's sources. That would allow speedup of the priming process - and also better detection if the priming build fails: currently there's no failure detection, as work-in-progress sources can easily fail "priming" compilation. We would need to only report artifact download failures.
Sadly with Maven builtin goals, it does not seem possible - I tried to use `dependency` plugin, but that one treats even intra-reactor dependencies (e.g. snapshots) the same way as external ones and attempts to resolve them from an external repository (instead of the reactor contents). So I reverted back to `install`. 

There's important peculiarity: while `-SNAPSHOT` projects are `install`ed, nonsnapshot projects are just `package`d. This difference (based on top project) is applied to the whole reactor. In a case where the root project defines a non-snapshot version while the modules are actually snapshot versions, the priming fails.
The difference is IMHO negligible - so I made the goals settable through `Preferences` (although this is not exposed in the UI) and `vscode` extension makes an experiment on its users to use `install` for both situations.

Filed toolchains.xml issue separately as #5999