### PR TITLE
Configure regular "run" / JavaExec-style tasks for single-class execution. Retain runSingle for compatibility.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
@@ -20,14 +20,18 @@
 package org.netbeans.modules.gradle.tooling;
 
 import static java.util.Arrays.asList;
+import java.util.Set;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.tooling.BuildException;
 import org.gradle.util.GradleVersion;
 /**
  *
@@ -46,53 +50,64 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.afterEvaluate(p -> {
-            if (p.getPlugins().hasPlugin("java") 
+            if (project.getPlugins().hasPlugin("java") 
                     && (project.getTasks().findByPath(RUN_SINGLE_TASK) == null)
-                    && project.hasProperty(RUN_SINGLE_MAIN)){
-                addTask(p);
-            }
-            p.getTasks().withType(JavaExec.class).configureEach(je -> {
-                if (p.hasProperty(RUN_SINGLE_JVM_ARGS)) {
-                    // Property jvmArgumentProviders should not be implemented as a lambda to allow execution optimizations.
-                    // See https://docs.gradle.org/current/userguide/validation_problems.html#implementation_unknown
-                    je.getJvmArgumentProviders().add(new CommandLineArgumentProvider() {
-                        // Do not convert to lambda.
-                        @Override
-                        public Iterable<String> asArguments() {
-                            return asList(p.property(RUN_SINGLE_JVM_ARGS).toString().split(" "));
-                        }
-                    });
-                }
-                try {
-                    je.setStandardInput(System.in);
-                } catch (RuntimeException ex) {
-                    if(LOG.isEnabled(LogLevel.DEBUG)) {
-                        LOG.debug("Failed to set STDIN for Plugin: " + je.toString(), ex);
+                    && project.hasProperty(RUN_SINGLE_MAIN)) {
+                Set<Task> runTasks = p.getTasksByName("run", false);
+                Task r = runTasks.isEmpty() ? null : runTasks.iterator().next();
+                String mainClass = project.property(RUN_SINGLE_MAIN).toString();
+                p.getTasks().withType(JavaExec.class).configureEach(je -> {
+                    if (GRADLE_VERSION.compareTo(GradleVersion.version("6.4")) < 0) {
+                        // Using setMain to keep the backward compatibility before Gradle 6.4
+                        je.setMain(mainClass);
                     } else {
-                        LOG.info("Failed to set STDIN for Plugin: " + je.toString());
+                        je.getMainClass().set(mainClass);
                     }
-                }
-                if (project.hasProperty(RUN_SINGLE_CWD)) {
-                    je.setWorkingDir(project.property(RUN_SINGLE_CWD).toString());
-                }
-            });
+                    if (project.hasProperty(RUN_SINGLE_ARGS)) {
+                        je.setArgs(asList(project.property(RUN_SINGLE_ARGS).toString().split(" ")));
+                    }
+                    if (p.hasProperty(RUN_SINGLE_JVM_ARGS)) {
+                        // Property jvmArgumentProviders should not be implemented as a lambda to allow execution optimizations.
+                        // See https://docs.gradle.org/current/userguide/validation_problems.html#implementation_unknown
+                        je.getJvmArgumentProviders().add(new CommandLineArgumentProvider() {
+                            // Do not convert to lambda.
+                            @Override
+                            public Iterable<String> asArguments() {
+                                return asList(p.property(RUN_SINGLE_JVM_ARGS).toString().split(" "));
+                            }
+                        });
+                    }
+                    try {
+                        je.setStandardInput(System.in);
+                    } catch (RuntimeException ex) {
+                        if(LOG.isEnabled(LogLevel.DEBUG)) {
+                            LOG.debug("Failed to set STDIN for Plugin: " + je.toString(), ex);
+                        } else {
+                            LOG.info("Failed to set STDIN for Plugin: " + je.toString());
+                        }
+                    }
+                    if (project.hasProperty(RUN_SINGLE_CWD)) {
+                        je.setWorkingDir(project.property(RUN_SINGLE_CWD).toString());
+                    }
+                });
+                addTask(project, r);
+            }
         });
     }
-
-    private void addTask(Project project) {
-        SourceSetContainer sourceSets = project.getExtensions().findByType(SourceSetContainer.class);
-
-        project.getTasks().register(RUN_SINGLE_TASK, JavaExec.class, (je) -> {
-            String mainClass = project.property(RUN_SINGLE_MAIN).toString();
-            if (GRADLE_VERSION.compareTo(GradleVersion.version("6.4")) < 0) {
-                // Using setMain to keep the backward compatibility before Gradle 6.4
-                je.setMain(mainClass);
+    
+    public static class JE extends JavaExec {
+        @Override
+        public void exec() {
+        }
+    }
+    
+    private void addTask(Project project, Task runTask) {
+        project.getTasks().register(RUN_SINGLE_TASK, JE.class, (je) -> {
+            if (runTask == null) {
+                throw new BuildException("Could not find \"run\" task to execute. Please upgrade your configuration to use standard run-style tasks instead of deprecated runSingle", null);
             } else {
-                je.getMainClass().set(mainClass);
-            }
-            je.setClasspath(sourceSets.findByName("main").getRuntimeClasspath());
-            if (project.hasProperty(RUN_SINGLE_ARGS)) {
-                je.setArgs(asList(project.property(RUN_SINGLE_ARGS).toString().split(" ")));
+                LOG.warn("runSingle task is deprecated. Inspect your configuration and use just 'run' task instead of 'runSingle'");
+                je.finalizedBy(runTask);
             }
         });
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
@@ -80,7 +80,7 @@ import org.openide.windows.InputOutput;
  * @author Laszlo Kishalmi
  */
 public final class GradleDaemonExecutor extends AbstractGradleExecutor {
-
+    private static final boolean DEBUG_GRADLE_BUILD_ACTION = Boolean.getBoolean("netbeans.debug.gradle.build.action"); //NOI18N
     private CancellationTokenSource cancelTokenSource;
     private static final Logger LOGGER = Logger.getLogger(GradleDaemonExecutor.class.getName());
     private static final String JAVA_HOME = "JAVA_HOME";    // NOI18N
@@ -253,7 +253,9 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
                     throw new BuildCancelledException("Interrupted", ex);
                 }
             }
-            //buildLauncher.addJvmArguments("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5008");
+            if (DEBUG_GRADLE_BUILD_ACTION) {
+                buildLauncher.addJvmArguments("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5008");
+            }
             buildLauncher.run();
             StatusDisplayer.getDefault().setStatusText(Bundle.BUILD_SUCCESS(getProjectName()));
             gradleTask.finish(0);

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
@@ -253,6 +253,7 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
                     throw new BuildCancelledException("Interrupted", ex);
                 }
             }
+            //buildLauncher.addJvmArguments("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5008");
             buildLauncher.run();
             StatusDisplayer.getDefault().setStatusText(Bundle.BUILD_SUCCESS(getProjectName()));
             gradleTask.finish(0);

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
@@ -50,11 +50,11 @@
         </action>
 
         <action name="run.single">
-            <args>-PrunClassName=${selectedClass} ${javaExec.workingDir} ${javaExec.environment} runSingle --stacktrace ${javaExec.jvmArgs} ${javaExec.args}</args>
+            <args>-PrunClassName=${selectedClass} ${javaExec.workingDir} ${javaExec.environment} run --stacktrace ${javaExec.jvmArgs} ${javaExec.args}</args>
         </action>
 
         <action name="debug.single">
-            <args>-PrunClassName=${selectedClass} ${javaExec.workingDir} ${javaExec.environment} runSingle --stacktrace --debug-jvm  ${javaExec.jvmArgs} ${javaExec.args}</args>
+            <args>-PrunClassName=${selectedClass} ${javaExec.workingDir} ${javaExec.environment} run --stacktrace --debug-jvm  ${javaExec.jvmArgs} ${javaExec.args}</args>
         </action>
     </apply-for>
 


### PR DESCRIPTION
The `runSingle` task we use in Gradle to execute a specific class (not the one configured in the buildscript) brings some issues if frameworks that define their own execution properties are involved - e.g. Micronaut. 

Micronaut app plugin adds certain system properties to "run" task, and also injects a `developmentOnly` configuration - it's assumed that the application is run locally and not in a cloud environment, or otherwise deployed. When NB uses `runSingle`, the Java process does not get such configration, and so works differently than when run from the commandline. 

This PR changes NB to use the standard `run` action, but Netbeans tooling plugin configures the `JavaExec` tasks to run the specific class (still defined by project property). For compatibilty with customized configurations that use `runSingle` (and are persisted on user machines), the `runSingle` task chains `run` after itself - and prints a warning.
