### PR TITLE
Copy fake icons before JAR is created

### DIFF
--- a/java/java.lsp.server/nbcode/integration/build.xml
+++ b/java/java.lsp.server/nbcode/integration/build.xml
@@ -58,5 +58,5 @@
         <copy file="${src.dir}/org/netbeans/modules/nbcode/integration/resources/empty.png" tofile="${build.classes.dir}/org/netbeans/modules/nbcode/integration/resources/uidefaults/${copy.icon.name}.png"/>
     </target>
     
-    <target name="-pre-release" depends="projectized-common.-pre-release, copy-icon-files"/>
+    <target name="-pre-jar" depends="projectized-common.-pre-jar, copy-icon-files"/>
 </project>


### PR DESCRIPTION
The build process is broken: the build creates fake icons for these for long time, but creates them after the jar is packaged. It works OK on dev machines, where ant clean is not routinely executed on whole nbcode project, but the build produced by apache CI is broken.
This PR hook to `-pre-jar` target, so the icons appear early enough to get packaged during 1st build as well.