### PR TITLE
Update issue report template for NB18

### DIFF
--- a/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
@@ -27,8 +27,8 @@ body:
         Latest releases are always available from https://netbeans.apache.org/download/
       multiple: false
       options:
-        - "Apache NetBeans 17"
-        - "Apache NetBeans 18 release candidate"
+        - "Apache NetBeans 18"
+#        - "Apache NetBeans 19 release candidate"
         - "Apache NetBeans latest daily build"
     validations:
       required: true


### PR DESCRIPTION
Update the issue report form for release of Apache NetBeans 18. Can be merged as soon as the announcement and webpage are done.