### PR TITLE
upgrade vsce to @vscode/vsce version 2.19

### DIFF
--- a/java/java.lsp.server/build.xml
+++ b/java/java.lsp.server/build.xml
@@ -108,9 +108,9 @@
         <exec executable="npm" failonerror="true" dir="${build.dir}/vsce">
             <arg value="install" />
             <arg value="--save" />
-            <arg value="vsce@2.6.4" />
+            <arg value="@vscode/vsce@2.19.0" />
         </exec>
-        <exec executable="${build.dir}/vsce/node_modules/vsce/vsce" failonerror="true" dir="${basedir}/vscode">
+        <exec executable="${build.dir}/vsce/node_modules/@vscode/vsce/vsce" failonerror="true" dir="${basedir}/vscode">
             <arg value="package" />
             <arg value="--baseImagesUrl" />
             <arg value="https://github.com/apache/netbeans/raw/${metabuild.hash}/java/java.lsp.server/vscode" />


### PR DESCRIPTION
Steps to reproduce:
 1. build the Visual Studio Code extension with `ant build-vscode-ext`
 2. the following warning is in the log:
```
npm WARN deprecated vsce@2.6.4: vsce has been renamed to @vscode/vsce. Install using @vscode/vsce instead.
```

This PR upgrades `vsce` to `@vscode/vsce` and uses the latest version 2.19. 


