### PR TITLE
Fix 'Cannot call invokeAndWait' when invoking DatabaseConnection.showConnectionDialog

### DIFF
--- a/ide/db/src/org/netbeans/modules/db/explorer/action/ConnectAction.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/action/ConnectAction.java
@@ -223,27 +223,24 @@ public class ConnectAction extends AbstractAction implements ContextAwareAction,
 
                 dbcon.addPropertyChangeListener(connectionListener);
 
-                try {
-                    if (headless) {
-                        connectWithNewInfo(dbcon, input);
-                    } else {
-                        ActionListener actionListener = new ActionListener() {
-                            @Override
-                            public void actionPerformed(ActionEvent event) {
-                                if (event.getSource() == DialogDescriptor.OK_OPTION) {
-                                    connectWithNewInfo(dbcon, input);
-                                }
+                if (headless) {
+                    connectWithNewInfo(dbcon, input);
+                } else {
+                    ActionListener actionListener = new ActionListener() {
+                        @Override
+                        public void actionPerformed(ActionEvent event) {
+                            if (event.getSource() == DialogDescriptor.OK_OPTION) {
+                                connectWithNewInfo(dbcon, input);
                             }
-                        };
-                
-                        SwingUtilities.invokeAndWait(() -> {
-                            ConnectPanel basePanel = input.getConnectPanel();
-                            dlg = new ConnectionDialog(this, basePanel, basePanel.getTitle(), CONNECT_ACTION_HELPCTX, actionListener);
-                            dlg.setVisible(true);
-                        });
-                    }
-                } catch (InterruptedException | InvocationTargetException ex) {
-                    Exceptions.printStackTrace(ex);
+                        }
+                    };
+
+                    Mutex.EVENT.writeAccess((Mutex.Action<Void>) () -> {
+                        ConnectPanel basePanel = input.getConnectPanel();
+                        dlg = new ConnectionDialog(this, basePanel, basePanel.getTitle(), CONNECT_ACTION_HELPCTX, actionListener);
+                        dlg.setVisible(true);
+                        return null;
+                    });
                 }
                 dbcon.removeExceptionListener(excListener);
             } else { // without dialog with connection data (username, password), just with progress dlg


### PR DESCRIPTION
As of NetBeans 18, the API method DatabaseConnection.showConnectionDialog no longer works when called from the EDT. It now gives the following exception:

```
java.lang.Error: Cannot call invokeAndWait from the event dispatcher thread
	at java.desktop/java.awt.EventQueue.invokeAndWait(EventQueue.java:1351)
	at java.desktop/java.awt.EventQueue.invokeAndWait(EventQueue.java:1344)
	at java.desktop/javax.swing.SwingUtilities.invokeAndWait(SwingUtilities.java:1480)
	at org.netbeans.modules.db.explorer.action.ConnectAction$ConnectionDialogDisplayer.showDialog(ConnectAction.java:254)
	at org.netbeans.modules.db.explorer.DatabaseConnection$5.run(DatabaseConnection.java:1230)
	at org.netbeans.modules.openide.util.NbMutexEventProvider$Event.doEvent(NbMutexEventProvider.java:97)
	at org.netbeans.modules.openide.util.NbMutexEventProvider$Event.readAccess(NbMutexEventProvider.java:72)
	at org.netbeans.modules.openide.util.LazyMutexImplementation.readAccess(LazyMutexImplementation.java:66)
	at org.openide.util.Mutex.readAccess(Mutex.java:242)
	at org.netbeans.modules.db.explorer.DatabaseConnection.showConnectionDialog(DatabaseConnection.java:1227)
	at org.netbeans.api.db.explorer.ConnectionManager.showConnectionDialog(ConnectionManager.java:343)
```

The problem is that invokeAndWait is not permitted to be called on the EDT. The invokeAndWait call was introduced when ConnectAction was made asynchronous in an [earlier commit](https://github.com/apache/netbeans/pull/5361).

The fix is to use "Mutex.EVENT.writeAccess((Mutex.Action) () -> { ... })" instead of invokeAndWait, which works from either the EDT or not, but block in either case until the operation has completed.

I'm not sure if this bug affects the NetBeans IDE; I found it in my NetBeans Platform application (Ultorg, a database UI).