### PR TITLE
Adding inlay hints in the VS Code extension.

### DIFF
--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -51,6 +51,19 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="InlayHintsProvider">
+        <api name="LSP_API"/>
+        <summary>Adding InlayHintsProvider</summary>
+        <version major="1" minor="34"/>
+        <date day="9" month="2" year="2025"/>
+        <author login="jlahoda"/>
+        <compatibility binary="compatible" source="compatible" addition="yes" deletion="no" />
+        <description>
+            The <code>InlayHintsProvider</code> is introduced to provide inlay
+            hints for the LSP protocol.
+        </description>
+        <class package="org.netbeans.spi.lsp" name="InlayHintsProvider"/>
+    </change>
     <change id="RegisterLSPServices">
         <api name="LSP_API"/>
         <summary>Adding RegisterLSPServices annotation</summary>

--- a/ide/api.lsp/manifest.mf
+++ b/ide/api.lsp/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.lsp/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/lsp/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.33
+OpenIDE-Module-Specification-Version: 1.34
 AutoUpdate-Show-In-Client: false

--- a/ide/api.lsp/src/org/netbeans/api/lsp/InlayHint.java
+++ b/ide/api.lsp/src/org/netbeans/api/lsp/InlayHint.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.lsp;
+
+/**
+ * An inlay hint.
+ *
+ * @since 1.34
+ */
+public class InlayHint {
+    private final Position position;
+    private final String text;
+
+    /**
+     * Create a new instance of InlayHint
+     *
+     * @param position the position where the hint should appear
+     * @param text the text fo the hint
+     */
+    public InlayHint(Position position, String text) {
+        this.position = position;
+        this.text = text;
+    }
+
+    /**
+     * Returns the position of the hint
+     *
+     * @return the position of the hint
+     */
+    public Position getPosition() {
+        return position;
+    }
+
+    /**
+     * Returns the text of the hint
+     *
+     * @return the text of the hint
+     */
+
+    public String getText() {
+        return text;
+    }
+
+}

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/InlayHintsProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/InlayHintsProvider.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.spi.lsp;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.api.lsp.InlayHint;
+import org.netbeans.api.lsp.Range;
+import org.netbeans.spi.editor.mimelookup.MimeLocation;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Parameters;
+
+/**
+ * A provider for code lens for a given document.
+ *
+ * @since 1.34
+ */
+@MimeLocation(subfolderName = "CodeLensProvider")
+public interface InlayHintsProvider {
+
+    /**
+     * Return a set of types of hints supported by this provider.
+     *
+     * The {@code codeLens} method will only be called if at least one
+     * of the hint type is enabled in the settings.
+     *
+     * @return a set of the hint types supported by this provider.
+     */
+    public Set<String> supportedHintTypes();
+
+    /**
+     * Provide {@code CodeLens} for the given document.
+     *
+     * @param doc the document
+     * @return the (future) code lens.
+     */
+    public CompletableFuture<List<? extends InlayHint>> inlayHints(@NonNull Context context);
+
+    /**
+     * Context in which the inlay hints should be evaluated.
+     */
+    public static final class Context {
+        private final @NonNull FileObject file;
+        private final @NullAllowed Range range;
+        private final @NonNull Set<String> requestedHintTypes;
+
+        /**
+         * Create the Context.
+         *
+         * @param file a file in which the inlay hints should be evaluated
+         * @param range the range for which the hints should be computed
+         * @param requestedHintTypes the types of hints that should be computed
+         */
+        public Context(@NonNull FileObject file, @NullAllowed Range range, @NonNull Set<String> requestedHintTypes) {
+            Parameters.notNull("file", file);
+            Parameters.notNull("range", range);
+            Parameters.notNull("requestedHintTypes", requestedHintTypes);
+
+            this.file = file;
+            this.range = range;
+            this.requestedHintTypes = Set.copyOf(requestedHintTypes);
+        }
+
+        /**
+         * The file for which the inlay hints should be computed.
+         *
+         * @return the file for which the inlay hints should be computed
+         */
+        public @NonNull FileObject getFile() {
+            return file;
+        }
+
+        /**
+         * The range for which the inlay hints should be computed.
+         *
+         * @return the range for which the inlay hints should be computed
+         */
+        public @CheckForNull Range getRange() {
+            return range;
+        }
+
+        /**
+         * The types of hints that should be computed.
+         *
+         * @return the types of hints that should be computed
+         */
+        public @NonNull Set<String> getRequestedHintTypes() {
+            return requestedHintTypes;
+        }
+
+    }
+}

--- a/java/java.editor/src/org/netbeans/modules/java/editor/semantic/InlayHintsProviderImpl.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/semantic/InlayHintsProviderImpl.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.editor.semantic;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import javax.swing.text.Document;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.lexer.Token;
+import org.netbeans.api.lsp.InlayHint;
+import org.netbeans.api.lsp.Position;
+import org.netbeans.modules.java.editor.base.semantic.ColoringAttributes;
+import org.netbeans.modules.java.editor.base.semantic.SemanticHighlighterBase;
+import org.netbeans.spi.lsp.InlayHintsProvider;
+import org.openide.util.Pair;
+
+@MimeRegistration(mimeType="text/x-java", service=InlayHintsProvider.class)
+public class InlayHintsProviderImpl implements InlayHintsProvider {
+
+    private static final Set<String> SUPPORTED_HINT_TYPES = Set.of(
+        "parameter", "chained", "var"
+    );
+
+    @Override
+    public Set<String> supportedHintTypes() {
+        return SUPPORTED_HINT_TYPES;
+    }
+
+    @Override
+    public CompletableFuture<List<? extends InlayHint>> inlayHints(Context context) {
+        CompletableFuture<List<? extends InlayHint>> result = new CompletableFuture<>();
+        JavaSource js = JavaSource.forFileObject(context.getFile());
+
+        if (js != null) {
+            List<InlayHint> hints = new ArrayList<>();
+            try {
+                js.runUserActionTask(cc -> {
+                    cc.toPhase(JavaSource.Phase.RESOLVED);
+                    SemanticHighlighterBase.Settings settings =
+                            new SemanticHighlighterBase.Settings(context.getRequestedHintTypes().contains("parameter"),
+                                                                 context.getRequestedHintTypes().contains("chained"),
+                                                                 context.getRequestedHintTypes().contains("var"));
+                    Document doc = cc.getSnapshot().getSource().getDocument(true);
+                    int start = context.getRange().getStartOffset();
+                    int end = context.getRange().getEndOffset();
+                    new SemanticHighlighterBase() {
+                        @Override
+                        protected boolean process(CompilationInfo info, Document doc) {
+                            process(info, doc, settings, new SemanticHighlighterBase.ErrorDescriptionSetter() {
+                                @Override
+                                public void setHighlights(Document doc, Collection<Pair<int[], ColoringAttributes.Coloring>> highlights, Map<int[], String> preText) {
+                                    for (Map.Entry<int[], String> e : preText.entrySet()) {
+                                        if (e.getKey()[0] >= start && e.getKey()[0] <= end) {
+                                            InlayHint hint = new InlayHint(new PositionImpl(e.getKey()[0]), e.getValue());
+                                            hints.add(hint);
+                                        }
+                                    }
+                                }
+
+                                @Override
+                                public void setColorings(Document doc, Map<Token, ColoringAttributes.Coloring> colorings) {
+                                    //...nothing
+                                }
+                            });
+                            return true;
+                        }
+                    }.process(cc, doc);
+                }, true);
+                result.complete(hints);
+            } catch (IOException ex) {
+                result.completeExceptionally(ex);
+            }
+        }
+        return result;
+    }
+
+    private static final class PositionImpl implements Position {
+        private final int offset;
+
+        public PositionImpl(int offset) {
+            this.offset = offset;
+        }
+
+        public int getOffset() {
+            return offset;
+        }
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Element;
@@ -49,6 +50,7 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.swing.text.Document;
 import javax.swing.text.StyledDocument;
 import org.eclipse.lsp4j.CreateFile;
 import org.eclipse.lsp4j.MessageParams;
@@ -352,6 +354,17 @@ public class Utils {
         int column = offset - NbDocument.findLineOffset(doc, line);
 
         return new Position(line, column);
+    }
+
+    public static int getOffset(FileObject file, Position pos) {
+        try {
+            EditorCookie ec = file.getLookup().lookup(EditorCookie.class);
+            StyledDocument doc = ec.openDocument();
+
+            return getOffset(doc, pos);
+        } catch (IOException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     public static int getOffset(StyledDocument doc, Position pos) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -65,6 +65,7 @@ import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.FoldingRangeProviderOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InlayHintRegistrationOptions;
 import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
@@ -936,6 +937,7 @@ public final class Server {
                 capabilities.setRenameProvider(renOpt);
                 FoldingRangeProviderOptions foldingOptions = new FoldingRangeProviderOptions();
                 capabilities.setFoldingRangeProvider(foldingOptions);
+                capabilities.setInlayHintProvider(true);
                 textDocumentService.init(init.getCapabilities(), capabilities);
 
                 // register for workspace changess

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -83,6 +83,7 @@ import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionItemLabelDetails;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.ConfigurationItem;
 import org.eclipse.lsp4j.ConfigurationParams;
 import org.eclipse.lsp4j.CreateFile;
 import org.eclipse.lsp4j.DefinitionParams;
@@ -106,6 +107,8 @@ import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.ImplementationParams;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InlayHint;
+import org.eclipse.lsp4j.InlayHintParams;
 import org.eclipse.lsp4j.InsertTextFormat;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.MarkupContent;
@@ -5848,6 +5851,126 @@ public class ServerTest extends NbTestCase {
 
         assertEquals(1, mm3.size());
         assertEquals(1, mm4.size());
+    }
+
+    public void testInlayHints() throws Exception {
+        File src = new File(getWorkDir(), "Test.java");
+        src.getParentFile().mkdirs();
+        String code = "import java.util.*;\n" +
+                      "public class Test {\n" +
+                      "    public String convert(String str) {\n" +
+                      "        var v = 0;\n" +
+                      "        return Arrays.asList(str)\n" +
+                      "                     .stream()\n" +
+                      "                     .map(s -> s.length())\n" +
+                      "                     .toArray();\n" +
+                      "    }\n" +
+                      "}\n";
+        try (Writer w = new FileWriter(src)) {
+            w.write(code);
+        }
+        file2SourceLevel.put(FileUtil.toFileObject(src.getParentFile()), "11");
+        FileUtil.refreshFor(getWorkDir());
+
+        String[] settings = new String[] {
+            "[\"chained\", \"parameter\", \"var\"]"
+        };
+
+        Launcher<LanguageServer> serverLauncher = createClientLauncherWithLogging(new LspClient() {
+            @Override
+            public void telemetryEvent(Object arg0) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
+
+            @Override
+            public void publishDiagnostics(PublishDiagnosticsParams params) {
+                synchronized (diags) {
+                    diags[0] = params.getDiagnostics();
+                    diags.notifyAll();
+                }
+            }
+
+            @Override
+            public void showMessage(MessageParams arg0) {
+            }
+
+            @Override
+            public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
+
+            @Override
+            public void logMessage(MessageParams arg0) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
+
+            @Override
+            public CompletableFuture<ApplyWorkspaceEditResponse> applyEdit(ApplyWorkspaceEditParams params) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
+
+            @Override
+            public CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams) {
+                assertEquals(1, configurationParams.getItems().size());
+                ConfigurationItem item = configurationParams.getItems().get(0);
+                assertEquals("netbeans.inlay.enabled", item.getSection());
+                return CompletableFuture.completedFuture(Arrays.asList(JsonParser.parseString(settings[0])));
+            }
+
+        }, client.getInputStream(), client.getOutputStream());
+        serverLauncher.startListening();
+        LanguageServer server = serverLauncher.getRemoteProxy();
+        server.initialize(new InitializeParams()).get();
+        String uri = src.toURI().toString();
+        server.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(uri, "java", 0, code)));
+        VersionedTextDocumentIdentifier id = new VersionedTextDocumentIdentifier(src.toURI().toString(), 1);
+        Function<List<InlayHint>, Set<String>> convertHints = hints ->
+                hints.stream()
+                .map(ih -> ih.getPosition().getLine() + ":" + ih.getPosition().getCharacter() + ":" + ih.getLabel().getRight().get(0).getValue())
+                .collect(Collectors.toSet());
+        {
+            List<InlayHint> hints = server.getTextDocumentService().inlayHint(new InlayHintParams(id, new Range(new Position(0, 0), new Position(9, 1)))).get();
+            Set<String> expectedHints = new HashSet<>(Arrays.asList(
+                    "3:13: : int",
+                    "4:29:a:",
+                    "4:33:  List<String>",
+                    "5:30:  Stream<String>",
+                    "6:42:  Stream<Integer>",
+                    "7:32:  "));
+            assertEquals(expectedHints, convertHints.apply(hints));
+        }
+        {
+            List<InlayHint> hints = server.getTextDocumentService().inlayHint(new InlayHintParams(id, new Range(new Position(4, 0), new Position(5, 30)))).get();
+            Set<String> expectedHints = new HashSet<>(Arrays.asList(
+                    "4:29:a:",
+                    "4:33:  List<String>",
+                    "5:30:  Stream<String>"));
+            assertEquals(expectedHints, convertHints.apply(hints));
+        }
+        {
+            settings[0] = "[\"chained\"]";
+            List<InlayHint> hints = server.getTextDocumentService().inlayHint(new InlayHintParams(id, new Range(new Position(0, 0), new Position(9, 1)))).get();
+            Set<String> expectedHints = new HashSet<>(Arrays.asList(
+                    "4:33:  List<String>",
+                    "5:30:  Stream<String>",
+                    "6:42:  Stream<Integer>",
+                    "7:32:  "));
+            assertEquals(expectedHints, convertHints.apply(hints));
+        }
+        {
+            settings[0] = "[\"parameter\"]";
+            List<InlayHint> hints = server.getTextDocumentService().inlayHint(new InlayHintParams(id, new Range(new Position(0, 0), new Position(9, 1)))).get();
+            Set<String> expectedHints = new HashSet<>(Arrays.asList(
+                    "4:29:a:"));
+            assertEquals(expectedHints, convertHints.apply(hints));
+        }
+        {
+            settings[0] = "[\"var\"]";
+            List<InlayHint> hints = server.getTextDocumentService().inlayHint(new InlayHintParams(id, new Range(new Position(0, 0), new Position(9, 1)))).get();
+            Set<String> expectedHints = new HashSet<>(Arrays.asList(
+                    "3:13: : int"));
+            assertEquals(expectedHints, convertHints.apply(hints));
+        }
     }
 
     public void testErrorBasedCodeActionFiltering() throws Exception {

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -266,6 +266,20 @@
 					"type": "string",
 					"default": "",
 					"description": "Working directory"
+				},
+				"netbeans.inlay.enabled": {
+					"description": "Enable or disable various inline hints.",
+					"type": "array",
+					"default": [],
+                                        "items": {
+                                            "type": "string",
+                                            "enum": ["chained", "parameter", "var"],
+                                            "markdownEnumDescriptions": [
+                                                "show return types of chained methods",
+                                                "show parameter names",
+                                                "show types of `var` variables"
+                                            ]
+                                        }
 				}
 			}
 		},


### PR DESCRIPTION
Adding ability to show the inline hints (using "inlayHints" of the LSP), showing the same hints as for NetBeans. Enabled by default, but can be adjusted either in global settings (Editor/Inlay Hints), or individual Java-specific capabilities can be enabled/disabled in the extension settings.

It looks like this:
![inlay-hints](https://github.com/apache/netbeans/assets/51319204/6477004f-9173-44d6-8fb5-4e08e383cbcc)

---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
