### PR TITLE
Update JDK version requirement warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1159,10 +1159,7 @@ jobs:
 
       - name: platform/uihandler
         run: ant $OPTS -Dvanilla.javac.exists=true -f platform/uihandler test
-        
-      - name: platform/o.n.bootstrap
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/o.n.bootstrap test
-        
+
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/BuildZipDistributionTest.java
+++ b/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/BuildZipDistributionTest.java
@@ -233,6 +233,7 @@ public class BuildZipDistributionTest extends TestBase {
         assertTrue("file found: " + testf, testf.exists());
         
         LinkedList<String> allArgs = new LinkedList<String>(Arrays.asList(args));
+        allArgs.addFirst("-J-Dbootstrap.disableJDKCheck=true");
         allArgs.addFirst("-J-Dnetbeans.mainclass=" + MainCallback.class.getName());
         allArgs.addFirst(getWorkDirPath());
         allArgs.addFirst("--userdir");

--- a/harness/nbjunit/src/org/netbeans/junit/NbTestCase.java
+++ b/harness/nbjunit/src/org/netbeans/junit/NbTestCase.java
@@ -79,6 +79,7 @@ import org.netbeans.junit.internal.NbModuleLogHandler;
 public abstract class NbTestCase extends TestCase implements NbTest {
     static {
         MethodOrder.initialize();
+        System.setProperty("bootstrap.disableJDKCheck", "true");
     }
     /**
      * active filter

--- a/harness/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteTest.java
+++ b/harness/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteTest.java
@@ -59,6 +59,7 @@ public class NbModuleSuiteTest extends NbTestCase {
 
         assertEquals("Doesn't exist", System.getProperty("t.userdir"));
         assertProperty("netbeans.full.hack", "true");
+        assertProperty("bootstrap.disableJDKCheck", "true");
     }
     
     public void testPreparePatches() throws URISyntaxException {

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NewClustersRebootTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NewClustersRebootTest.java
@@ -93,6 +93,7 @@ public class NewClustersRebootTest extends NbTestCase {
         assertTrue("file found: " + testf, testf.exists());
 
         LinkedList<String> allArgs = new LinkedList<String>(Arrays.asList(args));
+        allArgs.addFirst("-J-Dbootstrap.disableJDKCheck=true");
         allArgs.addFirst("-J-Dnetbeans.mainclass=" + NewClustersRebootCallback.class.getName());
         allArgs.addFirst(System.getProperty("java.home"));
         allArgs.addFirst("--jdkhome");

--- a/platform/o.n.bootstrap/src/org/netbeans/Bundle.properties
+++ b/platform/o.n.bootstrap/src/org/netbeans/Bundle.properties
@@ -42,7 +42,8 @@ OpenIDE-Module-Long-Description=\
         that loads all other parts of the application. \
         It cannot be disabled.
 
-MSG_InstallJava7=Cannot run on older versions of Java than Java 7 Standard Edition.\n\
-        Please install Java 7 Standard Edition or newer or use --jdkhome\n\
+MSG_InstallJava=Cannot run on older versions of Java than Java {0}.\n\
+        Please install Java {0} or newer or use --jdkhome\n\
         switch to point to its installation directory.
-MSG_NeedsJava7=Java 7 Standard Edition or newer required
+MSG_NeedsJava=Java {0} or newer required
+MSG_WarnJavaCheckDisabled=WARNING: JDK requirements check disabled


### PR DESCRIPTION
as previously discussed in https://github.com/apache/netbeans/pull/5852#issuecomment-1524695759, NetBeans needs to inform the user if the runtime JDK does not meet the [requirements](https://cwiki.apache.org/confluence/display/NETBEANS/Minimum+JDK+build+and+run+policy). The current warning instructed the user to install Java 7, which is a bit outdated.

![newer-java-required](https://github.com/apache/netbeans/assets/114367/6a371410-2a4d-40cd-8543-5c708d228c61)
