### PR TITLE
Adding DB configuration provider for NBLS

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/AddADBAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/AddADBAction.java
@@ -183,7 +183,8 @@ public class AddADBAction implements ActionListener {
                         DownloadWalletDialog.getWalletsDir().getAbsolutePath(),
                         AbstractPasswordPanel.generatePassword(),
                         (String) result.get(USERNAME),
-                        ((String) result.get(PASSWORD)).toCharArray());
+                        ((String) result.get(PASSWORD)).toCharArray(),
+                        selectedDatabase.getKey().getValue());
                 action.addConnection(info);
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
@@ -27,6 +27,7 @@ import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -147,6 +148,8 @@ public class DownloadWalletAction extends AbstractAction implements ContextAware
                             return;
                         }
                     }
+                    Properties props = new Properties();
+                    props.put("OCID", p.getOcid()); //NOI18N
                     String dbUrl = MessageFormat.format(URL_TEMPLATE, connectionName, BaseUtilities.escapeParameters(new String[] { walletPath.toString() }));
                     DatabaseConnection dbConn = DatabaseConnection.create(
                             drivers[0], 
@@ -155,7 +158,8 @@ public class DownloadWalletAction extends AbstractAction implements ContextAware
                             p.getDbUser(), 
                             new String(p.getDbPassword()), 
                             true, 
-                            context.getName());
+                            context.getName(),
+                            props);
                     ConnectionManager.getDefault().addConnection(dbConn);
                 }
 

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletDialog.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletDialog.java
@@ -90,7 +90,7 @@ final class DownloadWalletDialog extends AbstractPasswordPanel {
                 String path = dlgPanel.jTextFieldLocation.getText();
                 char[] passwd = dlgPanel.jPasswordField.getPassword();
                 NbPreferences.forModule(DownloadWalletAction.class).put(LAST_USED_DIR, path); //NOI18N
-                return Optional.of(new WalletInfo(path, passwd, null, null));
+                return Optional.of(new WalletInfo(path, passwd, null, null, db.getKey().getValue()));
             }
         } else {
             try {
@@ -109,7 +109,7 @@ final class DownloadWalletDialog extends AbstractPasswordPanel {
                     return Optional.empty();
                 }
                 char[] password = inp.getInputText().toCharArray();
-                return Optional.of(new WalletInfo(walletsDir.getAbsolutePath(), generatePassword(), username, password));
+                return Optional.of(new WalletInfo(walletsDir.getAbsolutePath(), generatePassword(), username, password, db.getKey().getValue()));
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);
             }
@@ -253,12 +253,14 @@ final class DownloadWalletDialog extends AbstractPasswordPanel {
         private char[] walletPassword;
         private String dbUser;
         private char[] dbPassword;
+        private String ocid;
 
-        public WalletInfo(String path, char[] walletPassword, String dbUser, char[] dbPassword) {
+        public WalletInfo(String path, char[] walletPassword, String dbUser, char[] dbPassword, String ocid) {
             this.path = path;
             this.walletPassword = walletPassword;
             this.dbUser = dbUser;
             this.dbPassword = dbPassword;
+            this.ocid = ocid;
         }
 
         public String getPath() {
@@ -276,7 +278,10 @@ final class DownloadWalletDialog extends AbstractPasswordPanel {
         public char[] getDbPassword() {
             return dbPassword;
         }
-        
+
+        public String getOcid() {
+            return ocid;
+        }
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBConnectionProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBConnectionProvider.java
@@ -40,8 +40,8 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Jan Horvath
  */
 @ServiceProvider(service = CodeActionsProvider.class)
-public class DBConnectionsProvider extends CodeActionsProvider{
-    private static final String  GET_DB_CONNECTIONS = "java.db.connections"; //NOI18N
+public class DBConnectionProvider extends CodeActionsProvider{
+    private static final String  GET_DB_CONNECTIONS = "java.db.connection"; //NOI18N
     
     private static final Set<String> COMMANDS = new HashSet<>(Arrays.asList(
         GET_DB_CONNECTIONS
@@ -65,7 +65,7 @@ public class DBConnectionsProvider extends CodeActionsProvider{
         result.put("DATASOURCES_DEFAULT_USERNAME", conn.getUser()); //NOI18N
         result.put("DATASOURCES_DEFAULT_PASSWORD", conn.getPassword()); //NOI18N
         result.put("DATASOURCES_DEFAULT_DRIVER_CLASS_NAME", conn.getDriverClass()); //NOI18N
-        String ocid = (String) conn.getConnectionProperties().get("OCID");
+        String ocid = (String) conn.getConnectionProperties().get("OCID"); //NOI18N
         if (ocid != null && !ocid.isEmpty()) {
             result.put("DATASOURCES_DEFAULT_OCID", ocid); //NOI18N
         }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBConnectionProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBConnectionProvider.java
@@ -41,10 +41,10 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service = CodeActionsProvider.class)
 public class DBConnectionProvider extends CodeActionsProvider{
-    private static final String  GET_DB_CONNECTIONS = "java.db.connection"; //NOI18N
+    private static final String  GET_DB_CONNECTION = "java.db.connection"; //NOI18N
     
     private static final Set<String> COMMANDS = new HashSet<>(Arrays.asList(
-        GET_DB_CONNECTIONS
+        GET_DB_CONNECTION
     ));
     
 
@@ -55,7 +55,7 @@ public class DBConnectionProvider extends CodeActionsProvider{
     
     @Override
     public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
-        if (!GET_DB_CONNECTIONS.equals(command)) {
+        if (!GET_DB_CONNECTION.equals(command)) {
             return null;
         }
         Map<String, String> result = new HashMap<> ();

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBConnectionsProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBConnectionsProvider.java
@@ -26,51 +26,51 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.netbeans.api.db.explorer.ConnectionManager;
 import org.netbeans.api.db.explorer.DatabaseConnection;
 import org.netbeans.modules.java.lsp.server.protocol.CodeActionsProvider;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
-import org.netbeans.modules.java.lsp.server.protocol.UpdateConfigParams;
 import org.netbeans.modules.parsing.api.ResultIterator;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
- * Updates Run Configuratoin with Database env variables.
  * 
  * @author Jan Horvath
  */
 @ServiceProvider(service = CodeActionsProvider.class)
-public class DBSetEnvCommand extends CodeActionsProvider {
-    private static final String  COMMAND_SET_DB_ENV = "java.db.set.env"; //NOI18N
-    private static final String CONFIG_SECTION = "java+.runConfig"; //NOI18N
+public class DBConnectionsProvider extends CodeActionsProvider{
+    private static final String  GET_DB_CONNECTIONS = "java.db.connections"; //NOI18N
     
     private static final Set<String> COMMANDS = new HashSet<>(Arrays.asList(
-        COMMAND_SET_DB_ENV
+        GET_DB_CONNECTIONS
     ));
     
+
     @Override
     public List<CodeAction> getCodeActions(ResultIterator resultIterator, CodeActionParams params) throws Exception {
         return Collections.emptyList();
     }
+    
     @Override
     public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
-        if (!COMMAND_SET_DB_ENV.equals(command)) {
+        if (!GET_DB_CONNECTIONS.equals(command)) {
             return null;
         }
+        Map<String, String> result = new HashMap<> ();
         DatabaseConnection conn = ConnectionManager.getDefault().getPreferredConnection(true);
-        Map<String, String> props = new HashMap<>();
-        props.put("DATASOURCES_DEFAULT_URL", conn.getDatabaseURL()); //NOI18N
-        props.put("DATASOURCES_DEFAULT_USERNAME", conn.getUser()); //NOI18N
-        props.put("DATASOURCES_DEFAULT_PASSWORD", conn.getPassword()); //NOI18N
-        props.put("DATASOURCES_DEFAULT_DRIVER_CLASS_NAME", conn.getDriverClass()); //NOI18N
-        String values = props.entrySet().stream()
-                .map(e -> e.getKey() + "=" + e.getValue()) //NOI18N
-                .collect(Collectors.joining(",")); //NOI18N
-        client.configurationUpdate(new UpdateConfigParams(CONFIG_SECTION, "env", values)); //NOI18N
-        return CompletableFuture.completedFuture(props);
+            
+        result.put("DATASOURCES_DEFAULT_URL", conn.getDatabaseURL()); //NOI18N
+        result.put("DATASOURCES_DEFAULT_USERNAME", conn.getUser()); //NOI18N
+        result.put("DATASOURCES_DEFAULT_PASSWORD", conn.getPassword()); //NOI18N
+        result.put("DATASOURCES_DEFAULT_DRIVER_CLASS_NAME", conn.getDriverClass()); //NOI18N
+        String ocid = (String) conn.getConnectionProperties().get("OCID");
+        if (ocid != null && !ocid.isEmpty()) {
+            result.put("DATASOURCES_DEFAULT_OCID", ocid); //NOI18N
+        }
+            
+        return CompletableFuture.completedFuture(result);
     }
     
     @Override

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -597,11 +597,6 @@
 				"title": "Open Service Console"
 			},
 			{
-				"command": "java.db.set.env",
-				"title": "Set Database Environment Variables",
-				"category": "Database"
-			},
-			{
 				"command": "java.select.editor.projects",
 				"title": "Reveal active editor in Projects",
 				"category": "Project"

--- a/java/java.lsp.server/vscode/src/dbConfigurationProvider.ts
+++ b/java/java.lsp.server/vscode/src/dbConfigurationProvider.ts
@@ -44,7 +44,7 @@ export class DBConfigurationProvider implements vscode.DebugConfigurationProvide
 
 	resolveDebugConfigurationWithSubstitutedVariables?(_folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, _token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
         return new Promise<vscode.DebugConfiguration>(async resolve => {
-			let o: Object = await vscode.commands.executeCommand('java.db.connections');
+			let o: Object = await vscode.commands.executeCommand('java.db.connection');
 			if (config === undefined) {
 				config = {} as vscode.DebugConfiguration;
 			}

--- a/java/java.lsp.server/vscode/src/dbConfigurationProvider.ts
+++ b/java/java.lsp.server/vscode/src/dbConfigurationProvider.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as vscode from 'vscode';
+import { homedir } from 'os';
+
+export async function initializeRunConfiguration(): Promise<boolean> {
+	const java = await vscode.workspace.findFiles('**/*.java', '**/node_modules/**', 1);
+	if (java?.length > 0) {
+		const maven = await vscode.workspace.findFiles('pom.xml', '**/node_modules/**', 1);
+		if (maven?.length > 0) {
+			return true;
+		}
+		const gradle = await vscode.workspace.findFiles('build.gradle', '**/node_modules/**', 1);
+		if (gradle?.length > 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export class DBConfigurationProvider implements vscode.DebugConfigurationProvider {
+	resolveDebugConfiguration(_folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, _token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+		return new Promise<vscode.DebugConfiguration>(resolve => {
+			resolve(config);
+		});
+	}
+
+	resolveDebugConfigurationWithSubstitutedVariables?(_folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, _token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+        return new Promise<vscode.DebugConfiguration>(async resolve => {
+			let o: Object = await vscode.commands.executeCommand('java.db.connections');
+			if (config === undefined) {
+				config = {} as vscode.DebugConfiguration;
+			}
+			if (config.env === undefined) {
+				config.env = {};
+			}
+			for (let val of Object.keys(o) as (keyof typeof o)[]) {
+				let value = o[val];
+				config.env[val as string] = value;
+			}
+			resolve(config);
+		});
+	}
+}

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -53,6 +53,7 @@ import { asRanges, StatusMessageRequest, ShowStatusMessageParams, QuickPickReque
 import * as launchConfigurations from './launchConfigurations';
 import { createTreeViewService, TreeViewService, TreeItemDecorator, Visualizer, CustomizableTreeDataProvider } from './explorer';
 import { initializeRunConfiguration, runConfigurationProvider, runConfigurationNodeProvider, configureRunSettings, runConfigurationUpdateAll } from './runConfiguration';
+import { DBConfigurationProvider } from './dbConfigurationProvider';
 import { TLSSocket } from 'tls';
 import { InputStep, MultiStepInput } from './utils';
 import { env } from 'process';
@@ -412,6 +413,7 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
     // initialize Run Configuration
     initializeRunConfiguration().then(initialized => {
 		if (initialized) {
+            context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java+', new DBConfigurationProvider()));
 			context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java+', runConfigurationProvider));
 			context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java', runConfigurationProvider));
 			context.subscriptions.push(vscode.window.registerTreeDataProvider('run-config', runConfigurationNodeProvider));


### PR DESCRIPTION
Updating a method how Database Connection properties are provided to a running application in NBLS. Former one didn't follow best security practices. Plain text password was stored in VSCode settings json. This is now removed with DBSetEnvCommand. New implementation takes it the other way around. DB connection properties are still stored in NB, when VSCode runs an application it asks NBLS for DB connection details (including password) using DBConnectionProvider.