### PR TITLE
Tomcat 11 increased min supported Java version to 21

### DIFF
--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/AntDeploymentProviderImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/AntDeploymentProviderImpl.java
@@ -66,16 +66,13 @@ public class AntDeploymentProviderImpl implements AntDeploymentProvider {
                 name = "resources/tomcat-ant-deploy.xml";
         }
         
-        InputStream is = AntDeploymentProviderImpl.class.getResourceAsStream(name); // NOI18N
-        if (is == null) {
-            // this should never happen, but better make sure
-            LOGGER.log(Level.SEVERE, "Missing resource {0}.", name); // NOI18N
-            return;
-        }
-        try {
+        try (InputStream is = AntDeploymentProviderImpl.class.getResourceAsStream(name)) {
+            if (is == null) {
+                // this should never happen, but better make sure
+                LOGGER.log(Level.SEVERE, "Missing resource {0}.", name); // NOI18N
+                return;
+            }
             FileUtil.copy(is, os);
-        } finally {
-            is.close();
         }
     }
 

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -552,10 +552,10 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
         if (manager.isTomEE()) {
             switch (manager.getTomEEVersion()) {
                 case TOMEE_90:
-                    versions = versionRange(11, 21);
+                    versions = versionRange(11, 22);
                     break;
                 case TOMEE_80:
-                    versions = versionRange(8, 21);
+                    versions = versionRange(8, 22);
                     break;
                 case TOMEE_71:
                 case TOMEE_70:
@@ -572,20 +572,20 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
         } else {
             switch (manager.getTomcatVersion()) {
                 case TOMCAT_110:
-                    versions = versionRange(17, 21);
+                    versions = versionRange(21, 22);
                     break;
                 case TOMCAT_101:
-                    versions = versionRange(11, 21);
+                    versions = versionRange(11, 22);
                     break;
                 case TOMCAT_100:
                 case TOMCAT_90:
-                    versions = versionRange(8, 21);
+                    versions = versionRange(8, 22);
                     break;
                 case TOMCAT_80:
-                    versions = versionRange(7, 21);
+                    versions = versionRange(7, 22);
                     break;
                 case TOMCAT_70:
-                    versions = versionRange(6, 21);
+                    versions = versionRange(6, 22);
                     break;
                 case TOMCAT_60:
                     versions = versionRange(5, 8);


### PR DESCRIPTION
Library Notes:
- Tomcat 11 increased min supported Java version to 21
- Add support for Java 22
- Use try-with-resources

Testing:
- Full build done
- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Sigtests
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Test Tomcat and TomEE and successfully:
  - Register it
  - Check correct Java SE support for Java 22
  - Check correct Java/Jakarta EE support from JEE 7 to JakartaEE 10
  - Create Web App Project
  - Deploy and run a servlet

![Screenshot from 2023-06-09 16-46-16](https://github.com/apache/netbeans/assets/9832133/eeaab9b6-28e4-4dd1-a383-65781328b370)
