### PR TITLE
Adding ability to run a single sub-test for tests under jtreg.

### DIFF
--- a/ide/gsf.testrunner.ui/nbproject/project.xml
+++ b/ide/gsf.testrunner.ui/nbproject/project.xml
@@ -266,6 +266,7 @@
                 <friend>org.netbeans.modules.groovy.support</friend>
                 <friend>org.netbeans.modules.hudson.ui</friend>
                 <friend>org.netbeans.modules.java.lsp.server</friend>
+                <friend>org.netbeans.modules.java.openjdk.project</friend>
                 <friend>org.netbeans.modules.java.testrunner.ui</friend>
                 <friend>org.netbeans.modules.javascript.jstestdriver</friend>
                 <friend>org.netbeans.modules.javascript.karma</friend>

--- a/java/java.openjdk.project/nbproject/project.xml
+++ b/java/java.openjdk.project/nbproject/project.xml
@@ -137,6 +137,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.gsf.testrunner.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.34</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.java.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -189,12 +197,29 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.java.testrunner.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.23</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
                         <specification-version>1.66</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.parsing.api</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>9.26</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImpl.java
@@ -77,10 +77,21 @@ public class ClassPathProviderImpl implements ClassPathProvider {
                 if (javac) {
                     ClassPath langtoolsCP = ClassPath.getClassPath(keyRoot, ClassPath.COMPILE);
                     Library testngLib = LibraryManager.getDefault().getLibrary("testng");
+                    Library junit5Lib = LibraryManager.getDefault().getLibrary("junit_5");
 
-                    if (testngLib != null) {
-                        return ClassPathSupport.createProxyClassPath(ClassPathSupport.createClassPath(testngLib.getContent("classpath").toArray(new URL[0])),
-                                                                     langtoolsCP);
+                    if (testngLib != null || junit5Lib != null) {
+                        List<ClassPath> parts = new ArrayList<>();
+
+                        if (testngLib != null) {
+                            parts.add(ClassPathSupport.createClassPath(testngLib.getContent("classpath").toArray(new URL[0])));
+                        }
+                        if (junit5Lib != null) {
+                            parts.add(ClassPathSupport.createClassPath(junit5Lib.getContent("classpath").toArray(new URL[0])));
+                        }
+
+                        parts.add(langtoolsCP);
+
+                        return ClassPathSupport.createProxyClassPath(parts.toArray(new ClassPath[0]));
                     }
 
                     if (langtoolsCP == null)

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ActionProviderImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ActionProviderImpl.java
@@ -38,6 +38,7 @@ import org.netbeans.modules.java.openjdk.common.ShortcutUtils;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.netbeans.spi.project.ActionProgress;
 import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.SingleMethod;
 import org.netbeans.spi.project.ui.support.ProjectSensitiveActions;
 import org.openide.execution.ExecutorTask;
 import org.openide.filesystems.FileObject;
@@ -151,6 +152,8 @@ public class ActionProviderImpl implements ActionProvider {
                     filteredActions.retainAll(Arrays.asList(actions));
                     filteredActions.add(COMMAND_BUILD_GENERIC_FAST);
                     filteredActions.add(COMMAND_PROFILE_TEST_SINGLE);
+                    filteredActions.add(SingleMethod.COMMAND_RUN_SINGLE_METHOD);
+                    filteredActions.add(SingleMethod.COMMAND_DEBUG_SINGLE_METHOD);
                     supported = filteredActions.toArray(new String[0]);
                     break;
                 }
@@ -174,6 +177,15 @@ public class ActionProviderImpl implements ActionProvider {
             for (ActionProvider ap : Lookup.getDefault().lookupAll(ActionProvider.class)) {
                 if (new HashSet<>(Arrays.asList(ap.getSupportedActions())).contains(COMMAND_PROFILE_TEST_SINGLE) && ap.isActionEnabled(COMMAND_PROFILE_TEST_SINGLE, context)) {
                     ap.invokeAction(COMMAND_PROFILE_TEST_SINGLE, context);
+                    return ;
+                }
+            }
+        }
+        if (SingleMethod.COMMAND_RUN_SINGLE_METHOD.equals(command) ||
+            SingleMethod.COMMAND_DEBUG_SINGLE_METHOD.equals(command)) {
+            for (ActionProvider ap : Lookup.getDefault().lookupAll(ActionProvider.class)) {
+                if (new HashSet<>(Arrays.asList(ap.getSupportedActions())).contains(command) && ap.isActionEnabled(command, context)) {
+                    ap.invokeAction(command, context);
                     return ;
                 }
             }

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ClassPathProviderImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ClassPathProviderImpl.java
@@ -194,7 +194,7 @@ public class ClassPathProviderImpl implements ClassPathProvider {
         this.repository = repository;
     }
 
-    private static final String[] TEST_LIBRARIES = new String[] {"testng", "junit_4"};
+    private static final String[] TEST_LIBRARIES = new String[] {"testng", "junit_4", "junit_5"};
 
     private static URL projectDir2FakeTarget(FileObject projectDir) throws MalformedURLException {
         return FileUtil.getArchiveRoot(projectDir.toURI().resolve("fake-target.jar").toURL());

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/JDKProject.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/JDKProject.java
@@ -222,6 +222,7 @@ public class JDKProject implements Project {
                                     new Settings(this),
                                     new BinaryForSourceQueryImpl(this, cpp.getSourceCP()),
                                     CProjectConfigurationProviderImpl.create(this),
+                                    new UnitTestForSourceQueryImpl(this),
                                     this);
         this.lookup = LookupProviderSupport.createCompositeLookup(base, "Projects/" + PROJECT_KEY + "/Lookup");
         } catch (Throwable t) {

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/UnitTestForSourceQueryImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/UnitTestForSourceQueryImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.openjdk.project;
+
+import java.net.URL;
+import java.util.Arrays;
+import org.netbeans.api.java.project.JavaProjectConstants;
+import org.netbeans.api.project.ProjectUtils;
+import org.netbeans.api.project.SourceGroup;
+import org.netbeans.modules.java.openjdk.project.JDKProject;
+import org.netbeans.spi.java.queries.MultipleRootsUnitTestForSourceQueryImplementation;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+/**
+ *
+ * @author lahvac
+ */
+public class UnitTestForSourceQueryImpl implements MultipleRootsUnitTestForSourceQueryImplementation {
+
+    private final JDKProject prj;
+
+    public UnitTestForSourceQueryImpl(JDKProject prj) {
+        this.prj = prj;
+    }
+
+    @Override
+    public URL[] findUnitTests(FileObject source) {
+        SourceGroup[] groups = ProjectUtils.getSources(prj)
+                                           .getSourceGroups(SourcesImpl.SOURCES_TYPE_JDK_PROJECT_TESTS);
+        return notInReturn(source, groups);
+    }
+
+    @Override
+    public URL[] findSources(FileObject unitTest) {
+        SourceGroup[] groups = ProjectUtils.getSources(prj)
+                                           .getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA);
+        return notInReturn(unitTest, groups);
+    }
+
+    private URL[] notInReturn(FileObject file, SourceGroup[] groups) {
+        return Arrays.stream(groups)
+                     .map(sg -> sg.getRootFolder())
+                     .filter(root -> FileUtil.isParentOf(root, file) || root == file)
+                     .map(f -> f.toURL())
+                     .toArray(s -> new URL[s]);
+    }
+}

--- a/java/java.testrunner.ui/nbproject/project.xml
+++ b/java/java.testrunner.ui/nbproject/project.xml
@@ -197,6 +197,7 @@
             <friend-packages>
                 <friend>org.netbeans.modules.gradle.test</friend>
                 <friend>org.netbeans.modules.java.lsp.server</friend>
+                <friend>org.netbeans.modules.java.openjdk.project</friend>
                 <friend>org.netbeans.modules.junit.ant.ui</friend>
                 <friend>org.netbeans.modules.junit.ui</friend>
                 <friend>org.netbeans.modules.maven.junit.ui</friend>

--- a/java/testng.ui/nbproject/project.xml
+++ b/java/testng.ui/nbproject/project.xml
@@ -457,12 +457,22 @@
                         <test/>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.modules.parsing.indexing</code-name-base>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.parsing.lucene</code-name-base>
                         <compile-dependency/>
                         <test/>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.modules.parsing.nb</code-name-base>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.progress.ui</code-name-base>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.projectui</code-name-base>
@@ -498,12 +508,12 @@
                         <code-name-base>org.openide.text</code-name-base>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.openide.util.ui</code-name-base>
+                        <code-name-base>org.openide.util.lookup</code-name-base>
                         <compile-dependency/>
                         <test/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.openide.util.lookup</code-name-base>
+                        <code-name-base>org.openide.util.ui</code-name-base>
                         <compile-dependency/>
                         <test/>
                     </test-dependency>

--- a/java/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/actions/RetoucheTestBase.java
+++ b/java/testng.ui/test/unit/src/org/netbeans/modules/testng/ui/actions/RetoucheTestBase.java
@@ -74,16 +74,6 @@ public class RetoucheTestBase extends NbTestCase {
                 new String[]{},
                 new Object[]{loader, cpp});
         testFO = FileUtil.createFolder(src, "sample/pkg/").createData("Test.java");
-        TestUtilities.copyStringToFile(testFO,
-                "package sample.pkg;\n" +
-                "\n" +
-                "public class Test {\n" +
-                "\n" +
-                "    @Deprecated\n" +
-                "    void method() {\n" +
-                "    }\n" +
-                "\n" +
-                "}\n");
     }
 
     protected FileObject getTestFO() {


### PR DESCRIPTION
New versions of jtreg (the test framework for OpenJDK) support running a single test method. This patch adds support for this for junit, testng and javac's internal framework `TestRunner`, to run individual test methods. It also fixes some problems found along the way: JUnit 5 support for jtreg tests, test method inside a class marked as test are recognized for TestNG.


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
