### PR TITLE
Switch FlatLaf JTabbedPane tab type to card.

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -43,7 +43,8 @@ SplitPaneDivider.style = plain
 # Windows LAF is 22 pixels tall.
 TabbedPane.tabHeight=30
 TabbedPane.inactiveUnderlineColor = $TabbedContainer.editor.contentBorderColor
-
+TabbedPane.tabType=card
+TabbedPane.tabAreaInsets=4,0,0,0
 
 #---- Tree ----
 


### PR DESCRIPTION
Switch the FlatLaf tab type for standard JTabbedPane to card (from underline). Also add some top inset as that's necessary in a few places.

I've been running with this configured in local UI properties for months now.  I find the underline tab type, particularly when unfocused, difficult to discern which tab is active.  This seems to fit better with the editor / view tab changes too.  Thought I'd open this as a potential default change ...

![Screenshot from 2023-06-12 14-50-22](https://github.com/apache/netbeans/assets/3975960/771661c1-6a68-4d44-870d-0567da1965c3)

![Screenshot from 2023-06-12 14-52-12](https://github.com/apache/netbeans/assets/3975960/9d7594a8-b248-4129-a5f2-a06a708d3b7e)
