### PR TITLE
Fix multitabs underline at top tab rendering.

### DIFF
--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabDataRenderer.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabDataRenderer.java
@@ -59,6 +59,7 @@ public class TabDataRenderer implements TableCellRenderer {
     private static final Color inactiveUnderlineColor = UIManager.getColor("nb.multitabs.inactiveUnderlineColor"); // NOI18N
     private static final Color activeBackground = UIManager.getColor("nb.multitabs.activeBackground"); // NOI18N
     private static final Color hoverBackground = UIManager.getColor("nb.multitabs.hoverBackground"); // NOI18N
+    private static final boolean underlineAtTop = UIManager.getBoolean("EditorTab.underlineAtTop");
 
     private final RendererPanel renderer = new RendererPanel();
     private final List<TabDecorator> decorators = getDecorators();
@@ -238,10 +239,18 @@ public class TabDataRenderer implements TableCellRenderer {
                 switch (tabsLocation) {
                     default:
                     case JTabbedPane.TOP:
-                        g.fillRect(0, rect.height - underlineHeight, rect.width, underlineHeight);
+                        if (underlineAtTop) {
+                            g.fillRect(0, 0, rect.width, underlineHeight);
+                        } else {
+                            g.fillRect(0, rect.height - underlineHeight, rect.width, underlineHeight);
+                        }
                         break;
                     case JTabbedPane.BOTTOM:
-                        g.fillRect(0, 0, rect.width, underlineHeight);
+                        if (underlineAtTop) {
+                            g.fillRect(0, rect.height - underlineHeight, rect.width, underlineHeight);
+                        } else {
+                            g.fillRect(0, 0, rect.width, underlineHeight);
+                        }
                         break;
                     case JTabbedPane.LEFT:
                         g.fillRect(rect.width - underlineHeight, 0, underlineHeight, rect.height);


### PR DESCRIPTION
this makes it look consistent to regular editor tabs

multitabs code is running when for example sorted-document-list is enabled in:
`tools -> options -> appearance -> document tabs -> "Sort opened documents list by default" checkbox`


![multitabs-rendering-fix](https://github.com/apache/netbeans/assets/114367/19f5463a-8ca6-4542-bc99-afb90038d561)

extracted from #4948
