### PR TITLE
Add javadoc support for the 2nd jdk early release

### DIFF
--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
@@ -67,11 +67,24 @@ public final class J2SEPlatformDefaultJavadocImpl implements J2SEPlatformDefault
 
         if (now.isAfter(jdk9)) { // time traveler -> only java 8 doc for you
             int jdk = 9;
-            for (LocalDate t = jdk9; t.isBefore(now); t = t.plusMonths(6)) {
+            LocalDate jdkEarly = jdk9;
+            for (LocalDate t = jdk9 ; t.isBefore(now); t = t.plusMonths(6)) {
                 OFFICIAL_JAVADOC.put(String.valueOf(jdk), "https://docs.oracle.com/en/java/javase/" + jdk + "/docs/api/"); // NOI18N
+                jdkEarly = t;
                 jdk++;
             }
-            OFFICIAL_JAVADOC.put(String.valueOf(jdk), "https://download.java.net/java/early_access/jdk" + jdk + "/docs/api/"); // NOI18N Early access
+            
+            jdkEarly = jdkEarly.minusDays(12);
+            
+            if (now.isAfter(jdkEarly)) {
+                OFFICIAL_JAVADOC.put(String.valueOf(jdk), "https://download.java.net/java/early_access/jdk" + jdk + "/docs/api/"); // NOI18N Early access
+                jdkEarly = jdkEarly.plusMonths(3);
+                jdk++;
+            }
+            // there is a 2nd jdk early release after 3 months
+            if (now.isAfter(jdkEarly)) {
+                OFFICIAL_JAVADOC.put(String.valueOf(jdk), "https://download.java.net/java/early_access/jdk" + jdk + "/docs/api/"); // NOI18N Early access
+            }
         }
     }
 


### PR DESCRIPTION
NetBeans Notes:
- Add javadoc support for the 2nd jdk early release that happens 3 months after
the 1st jdk early release (usually the 9th day of the month).

Start of release updates for the last 5 JDK's:

|  JDK 18  | JDK 19 | JDK 20 | JDK 21 | JDK 22 |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| 2021-06-10 | 2021-12-09 | 2022-06-09 | 2022-12-08 | 2023-06-08 |

Testing:
- Full build done
- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Sigtests
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Register JDK's and verify that the javadoc is correct.
![Screenshot from 2023-06-14 15-28-57](https://github.com/apache/netbeans/assets/9832133/02158d73-4537-47c0-b116-90e15fbccfe8)
![Screenshot from 2023-06-14 15-28-35](https://github.com/apache/netbeans/assets/9832133/4e230f86-10ec-4013-889d-36121389a1cd)
![Screenshot from 2023-06-14 15-29-13](https://github.com/apache/netbeans/assets/9832133/75040a2a-5f9e-440e-bcb6-c56d4852cad5)
