### PR TITLE
Apache LS does not add DB connection

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBAddConnection.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBAddConnection.java
@@ -238,16 +238,21 @@ public class DBAddConnection extends CodeActionsProvider {
                                 Either<List<QuickPickItem>,String> userData = data.get(USER_ID);
                                 int i = ((Double) driverData.getLeft().get(0).getUserData()).intValue();
                                 JDBCDriver driver = drivers[i];
+                                boolean failed = true;
+
                                 schemas.clear();
                                 DatabaseConnection dbconn = DatabaseConnection.create(driver, urlData.getRight(), userData.getRight(), null, passwordData.getRight(), true);
                                 try {
                                     ConnectionManager.getDefault().addConnection(dbconn);
                                     schemas.addAll(getSchemas(dbconn));
+                                    failed = false;
                                 } catch(DatabaseException | SQLException ex) {
                                     return CompletableFuture.completedFuture(ex.getMessage());
                                 } finally {
                                     try {
-                                        ConnectionManager.getDefault().removeConnection(dbconn);
+                                        if (failed || !schemas.isEmpty()) {
+                                            ConnectionManager.getDefault().removeConnection(dbconn);
+                                        }
                                     } catch (DatabaseException ex) {}
                                 }
                             }


### PR DESCRIPTION
VSCode only: Sometimes new DB connection is not displayed even if URL and username, password are correctly entered. This probem is caused by unconditionally removing database commection in finally block in `validate()` method. The rest of the code expects that such connection is reused if there are no schemas. The fix is to change the finally block to remove connection only in case of connection failure or non-empty list of schemas is retrieved from database.