### PR TITLE
Ensure common project actions are available in Rust projects

### DIFF
--- a/rust/rust.cargo/src/org/netbeans/modules/rust/cargo/api/CargoCommand.java
+++ b/rust/rust.cargo/src/org/netbeans/modules/rust/cargo/api/CargoCommand.java
@@ -30,13 +30,26 @@ import org.openide.util.NbBundle;
     "CARGO_BENCH_DESC=Execute benchmarks", // FMT
     "CARGO_BUILD=build", // FMT
     "CARGO_BUILD_DESC=Builds the package in debug mode", // FMT
-    "CARGO_CLEAN=clean", "CARGO_CLEAN_DESC=Cleans the project", // FMT
-    "CARGO_DOC_DESC=Builds package's documentation", // FMT
+    "CARGO_CLEAN=clean", // FMT
+    "CARGO_CLEAN_DESC=Cleans the project", // FMT
     "CARGO_DOC=doc", // FMT
+    "CARGO_DOC_DESC=Builds package's documentation", // FMT
+    "CARGO_FETCH=fetch", // FMT
+    "CARGO_FETCH_DESC=Fetch dependencies of a package from the network", // FMT
+    "CARGO_FIX=fix", // FMT
+    "CARGO_FIX_DESC=Automatically fix lint warnings reported by rustc", // FMT
     "CARGO_REMOVE=remove", // FMT
     "CARGO_REMOVE_DESC=Remove dependencies", // FMT
+    "CARGO_REPORT=report", // FMT
+    "CARGO_REPORT_DESC=Generate and display various kinds of reports", // FMT
     "CARGO_RUN_DESC=Run the current package", // FMT
     "CARGO_RUN=run", // FMT
+    "CARGO_RUSTC=rustc", // FMT
+    "CARGO_RUSTC_DESC=Compile a package, and pass extra options to the compiler", // FMT
+    "CARGO_RUSTDOC=rustdoc", // FMT
+    "CARGO_RUSTDOC_DESC=Build a package's documentation, using specified custom flags", // FMT
+    "CARGO_TEST=test", // FMT
+    "CARGO_TEST_DESC=Execute all unit and integration tests and build examples of a local package", // FMT
 })
 public enum CargoCommand {
     CARGO_ADD(new String[]{"add"}), // NOI18N

--- a/rust/rust.project/nbproject/project.xml
+++ b/rust/rust.project/nbproject/project.xml
@@ -168,6 +168,24 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.masterfs</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
             <public-packages>
                 <package>org.netbeans.modules.rust.project.api</package>
             </public-packages>

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/RustProject.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/RustProject.java
@@ -72,6 +72,7 @@ public final class RustProject implements Project {
         // instanceContent.add(new RustPrivilegedTemplates());
         instanceContent.add(this);
         instanceContent.add(new RustProjectCustomizerProvider2(this));
+        instanceContent.add(new RustProjectOperations(this));
         AbstractLookup ourLookup = new AbstractLookup(instanceContent);
 
         // Mix our lookup with providers registered in the file filesystem

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/RustProjectOperations.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/RustProjectOperations.java
@@ -1,0 +1,403 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.rust.project;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.CharArrayWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.netbeans.api.project.Project;
+import org.netbeans.spi.project.CopyOperationImplementation;
+import org.netbeans.spi.project.DeleteOperationImplementation;
+import org.netbeans.spi.project.MoveOrRenameOperationImplementation;
+import org.openide.filesystems.FileLock;
+import org.openide.filesystems.FileObject;
+import org.tomlj.Toml;
+import org.tomlj.TomlParseResult;
+import org.tomlj.TomlPosition;
+
+
+public class RustProjectOperations implements
+        MoveOrRenameOperationImplementation,
+        CopyOperationImplementation,
+        DeleteOperationImplementation {
+
+    private static final String CARGOTOML = "Cargo.toml";
+
+    private final RustProject project;
+
+    public RustProjectOperations(RustProject project) {
+        assert project != null;
+        this.project = project;
+    }
+
+    @Override
+    public void notifyDeleted() throws IOException {
+    }
+
+    @Override
+    public void notifyDeleting() throws IOException {
+    }
+
+    @Override
+    public List<FileObject> getDataFiles() {
+        return Arrays.asList(project.getProjectDirectory().getChildren());
+    }
+
+    @Override
+    public List<FileObject> getMetadataFiles() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void notifyRenaming() throws IOException {
+    }
+
+    @Override
+    public void notifyRenamed(String newName) throws IOException {
+        updateProjectName(newName);
+    }
+
+    @Override
+    public void notifyMoving() throws IOException {
+    }
+
+    @Override
+    public void notifyMoved(Project original, File originalPath, String newName) throws IOException {
+        if (original != null) {
+            updateProjectName(newName);
+        }
+    }
+
+    @Override
+    public void notifyCopying() throws IOException {
+    }
+
+    @Override
+    public void notifyCopied(Project original, File originalPath, String newName) throws IOException {
+        if(original != null) {
+            updateProjectName(newName);
+        }
+    }
+
+    /**
+     * Update the project name without modifying the rest of the file
+     */
+    private  void updateProjectName(String newName) throws IOException {
+        FileObject cargotoml = project.getProjectDirectory().getFileObject(CARGOTOML);
+        updateProjectName(cargotoml, newName);
+    }
+
+    static void updateProjectName(FileObject cargotoml, String newName) throws IOException {
+        CharArrayWriter caw = new CharArrayWriter();
+        try (Reader is1 = bufferedReader(cargotoml.getInputStream());
+                Reader is2 = bufferedReader(cargotoml.getInputStream())) {
+            TomlParseResult parseResult = Toml.parse(is1);
+            TomlPosition targetPos = parseResult.inputPositionOf("package.name");
+            copyUntilPosition(targetPos, is2, caw);
+            copyUntilEquals(is2, caw);
+            copyWhitespace(is2, caw);
+            caw.write(escapeTomlString(newName));
+            skipString(is2);
+            transfer(is2, caw);
+        }
+        try(FileLock cargotomlLock = cargotoml.lock()) {
+            deleteOldCargoToml(cargotoml);
+            cargotoml.copy(cargotoml.getParent(), CARGOTOML, "old");
+            try(Writer os = bufferedWriter(cargotoml.getOutputStream(cargotomlLock))) {
+                os.write(caw.toCharArray());
+            }
+            deleteOldCargoToml(cargotoml);
+        }
+    }
+
+    private static void deleteOldCargoToml(FileObject cargotoml) throws IOException {
+        FileObject oldFile = cargotoml.getParent().getFileObject(CARGOTOML, "old");
+        if(oldFile != null) {
+            oldFile.delete();
+        }
+    }
+
+    /**
+     * Copy the data from input to output
+     */
+    @SuppressWarnings("NestedAssignment")
+    private static void transfer(Reader is, Writer os) throws IOException {
+        char[] buffer = new char[10240];
+        int read;
+        while((read = is.read(buffer)) > 0) {
+            os.write(buffer, 0, read);
+        }
+    }
+
+    /**
+     * Escape the supplied string so that it can be used as a plain string
+     */
+    static String escapeTomlString(String input) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("\"");
+        for(char c: input.toCharArray()) {
+            if(c == '\\') {
+                sb.append("\\\\");
+            } else if (c == '\b') {
+                sb.append("\\b");
+            } else if (c == '\t') {
+                sb.append("\\t");
+            } else if (c == '\n') {
+                sb.append("\\n");
+            } else if (c == '\f') {
+                sb.append("\\f");
+            } else if (c == '\r') {
+                sb.append("\\r");
+            } else if (c == '"') {
+                sb.append("\\\"");
+            } else if (c <= 0x0008 || (c >= 0x000A && c < 0x001F) || (c == 0x007F)) {
+                sb.append("\\u");
+                if(c <= 0xFFFF) {
+                    sb.append(String.format("%04X", (int) c));
+                } else {
+                    sb.append(String.format("%08X", (int) c));
+                }
+            } else {
+                sb.append(c);
+            }
+        }
+        sb.append("\"");
+        return sb.toString();
+    }
+
+    /**
+     * Copy all characters to the targetPos (excluding it)
+     */
+    private static void copyUntilPosition(TomlPosition targetPos, Reader is, Writer os) throws IOException {
+        if(targetPos.column() == 1 && targetPos.line() == 1) {
+            return;
+        }
+        int row = 1;
+        int pos = 1;
+        for (int input = is.read(); input >= 0; input = is.read()) {
+            if (input < 0) {
+                break;
+            }
+            os.write(input);
+            if (input == '\n') {
+                row++;
+                pos = 1;
+            } else {
+                pos++;
+            }
+            if(row == targetPos.line() && pos == targetPos.column()) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Copy the "key + equals" part of a TOML key-value construct
+     */
+    private static void copyUntilEquals(Reader is, Writer os) throws IOException {
+        while (true) {
+            is.mark(1);
+            int lookAhead = is.read();
+            is.reset();
+            if (lookAhead == -1) {
+                break;
+            } else if (lookAhead == '=') {
+                os.write(is.read());
+                break;
+            } else if (Character.isWhitespace(lookAhead)) {
+                copyWhitespace(is, os);
+            } else if (lookAhead == '"') {
+                copyQuotedName(is, os);
+            } else if (isNameChar(lookAhead)) {
+                copyName(is, os);
+            } else {
+                os.write(is.read());
+            }
+        }
+    }
+
+    /**
+     * Copy an unquoted TOML name
+     */
+    private static void copyName(Reader is, Writer os) throws IOException {
+        while (true) {
+            is.mark(1);
+            int read = is.read();
+            if (read < 0 || ! isNameChar(read)) {
+                is.reset();
+                break;
+            } else {
+                os.write(read);
+            }
+        }
+    }
+
+    /**
+     * Copy a quoted TOML name from input
+     */
+    private static void copyQuotedName(Reader r, Writer w) throws IOException {
+        boolean backslashRead = false;
+        for (int input = r.read(); input >= 0; input = r.read()) {
+            w.write(input);
+            if (backslashRead) {
+                backslashRead = false;
+            } else {
+                if(input == '"') {
+                    break;
+                } else if (input == '\\') {
+                    backslashRead = true;
+                }
+            }
+        }
+    }
+
+    /**
+     * Copy whitespace from inputstream to outputstream, starting at the current
+     * position.
+     */
+    private static void copyWhitespace(Reader r, Writer w) throws IOException {
+        while(true) {
+            r.mark(1);
+            int read = r.read();
+            if(read < 0 || ! Character.isWhitespace(read)) {
+                r.reset();
+                break;
+            } else {
+                w.write(read);
+            }
+        }
+    }
+
+    /**
+     * Determine if supplied character value is a valid name character in TOML
+     */
+    private static boolean isNameChar(int c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_';
+    }
+
+    /**
+     * Skip over TOML normal, multiline, literal and multiline literal strings
+     */
+    private static void skipString(Reader r) throws IOException {
+        r.mark(3);
+        char[] marker = new char[3];
+        r.read(marker);
+        r.reset();
+        if(marker[0] == '"' && marker[1] == '"' && marker[2] == '"') {
+            r.read();
+            r.read();
+            r.read();
+            int[] buffer = new int[3];
+            int pos = 0;
+            while(true) {
+                buffer[pos] = r.read();
+                if(buffer[pos] < 0) {
+                    break;
+                }
+                if( modVal(buffer, pos - 2) == '"' && modVal(buffer, pos - 1) == '"' && modVal(buffer, pos) == '"') {
+                    break;
+                }
+                pos++;
+                pos %= buffer.length;
+            }
+        } else if (marker[0] == '"') {
+            // normal string
+            r.read();
+            boolean escape = false;
+            while(true) {
+                int read = r.read();
+                if(read < 0) {
+                    break;
+                }
+                if (!escape) {
+                    if (read == '"') {
+                        break;
+                    } else if (read == '\\') {
+                        escape = true;
+                    }
+                } else {
+                    escape = false;
+                }
+            }
+        } else if (marker[0] == '\'' && marker[1] == '\'' && marker[2] == '\'') {
+            r.read();
+            r.read();
+            r.read();
+            int[] buffer = new int[3];
+            int pos = 0;
+            while(true) {
+                buffer[pos] = r.read();
+                if(buffer[pos] < 0) {
+                    break;
+                }
+                if( modVal(buffer, pos - 2) == '\'' && modVal(buffer, pos - 1) == '\'' && modVal(buffer, pos) == '\'') {
+                    break;
+                }
+                pos++;
+                pos %= buffer.length;
+            }
+        } else if (marker[0] == '\'') {
+            r.read();
+            while(true) {
+                int read = r.read();
+                if(read == '\'' || read < 0) {
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Extract value at {@code pos} from buffer. It can handle negative
+     * positions.
+     */
+    private static int modVal(int[] buffer, int pos) {
+        if(pos >= 0) {
+            return buffer[pos % buffer.length];
+        } else {
+            return buffer[(pos % 3) + buffer.length];
+        }
+    }
+
+    /**
+     * Create a buffered reader from an inputstream with UTF-8 encoding
+     */
+    private static Reader bufferedReader(InputStream is) {
+        return new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Create a buffered writer from an outputstream with UTF-8 encoding
+     */
+    private static Writer bufferedWriter(OutputStream os) {
+        return new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
+    }
+}

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/layer.xml
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/layer.xml
@@ -63,6 +63,18 @@
                 </file>
                 <file name="sep-3.instance">
                     <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
+                    <attr name="position" intvalue="2000"/>
+                </file>
+                <file name="org-openide-actions-FindAction.shadow">
+                    <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-FindAction.instance"/>
+                    <attr name="position" intvalue="2100"/>
+                </file>
+                <file name="general.shadow">
+                    <attr name="originalFile" stringvalue="Projects/Actions"/>
+                    <attr name="position" intvalue="2200"/>
+                </file>
+                <file name="sep-4.instance">
+                    <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
                     <attr name="position" intvalue="3000"/>
                 </file>
                 <file name="org-netbeans-modules-project-ui-CustomizeProject.shadow">

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/layer.xml
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/layer.xml
@@ -53,10 +53,6 @@
                     <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-RunProject.instance"/>
                     <attr name="position" intvalue="700"/>
                 </file>
-                <file name="org-netbeans-modules-debugger-ui-actions-DebugProjectAction.shadow">
-                    <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-DebugProjectAction.instance"/>
-                    <attr name="position" intvalue="800"/>
-                </file>
                 <file name="org-netbeans-modules-project-ui-TestProject.shadow">
                     <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-TestProject.instance"/>
                     <attr name="position" intvalue="1000"/>
@@ -65,21 +61,49 @@
                     <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
                     <attr name="position" intvalue="2000"/>
                 </file>
-                <file name="org-openide-actions-FindAction.shadow">
-                    <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-FindAction.instance"/>
+                <file name="org-netbeans-modules-project-ui-CloseProject.shadow">
+                    <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-CloseProject.instance"/>
                     <attr name="position" intvalue="2100"/>
                 </file>
-                <file name="general.shadow">
-                    <attr name="originalFile" stringvalue="Projects/Actions"/>
-                    <attr name="position" intvalue="2200"/>
-                </file>
-                <file name="sep-4.instance">
+               <file name="sep-4.instance">
                     <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
                     <attr name="position" intvalue="3000"/>
                 </file>
+                <file name="org-netbeans-modules-project-ui-RenameProject.shadow">
+                    <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-RenameProject.instance"/>
+                    <attr name="position" intvalue="3100"/>
+                </file>
+                <file name="org-netbeans-modules-project-ui-MoveProject.shadow">
+                    <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-MoveProject.instance"/>
+                    <attr name="position" intvalue="3200"/>
+                </file>
+                <file name="org-netbeans-modules-project-ui-CopyProject.shadow">
+                    <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-CopyProject.instance"/>
+                    <attr name="position" intvalue="3300"/>
+                </file>
+                <file name="org-netbeans-modules-project-ui-DeleteProject.shadow">
+                    <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-DeleteProject.instance"/>
+                    <attr name="position" intvalue="3400"/>
+                </file>
+                <file name="sep-5.instance">
+                    <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
+                    <attr name="position" intvalue="4000"/>
+                </file>
+                <file name="org-openide-actions-FindAction.shadow">
+                    <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-FindAction.instance"/>
+                    <attr name="position" intvalue="4100"/>
+                </file>
+                <file name="general.shadow">
+                    <attr name="originalFile" stringvalue="Projects/Actions"/>
+                    <attr name="position" intvalue="4200"/>
+                </file>
+                <file name="sep-6.instance">
+                    <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
+                    <attr name="position" intvalue="5000"/>
+                </file>
                 <file name="org-netbeans-modules-project-ui-CustomizeProject.shadow">
                     <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-CustomizeProject.instance"/>
-                    <attr name="position" intvalue="3200"/>
+                    <attr name="position" intvalue="5200"/>
                 </file>
             </folder>
         </folder>

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/CargoExecutionCommand.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/CargoExecutionCommand.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.rust.project.ui.actions;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.netbeans.modules.rust.cargo.api.Cargo;
+import org.netbeans.modules.rust.cargo.api.CargoCommand;
+import org.netbeans.modules.rust.project.RustProject;
+import org.openide.util.Lookup;
+
+public class CargoExecutionCommand extends Command {
+
+    private String commandId;
+    private CargoCommand[] commands;
+
+    public CargoExecutionCommand(RustProject project, String commandId, CargoCommand[] commands) {
+        super(project);
+        Objects.nonNull(commandId);
+        Objects.nonNull(commands);
+        if (commands.length == 0) {
+            throw new IllegalArgumentException("At least one cargo command has to be configured");
+        }
+        this.commandId = commandId;
+        this.commands = commands;
+    }
+
+    @Override
+    public String getCommandId() {
+        return commandId;
+    }
+
+    @Override
+    public boolean asyncCallRequired() {
+        return false;
+    }
+
+    @Override
+    public boolean isActionEnabledInternal(Lookup context) {
+        return Lookup.getDefault().lookup(Cargo.class) != null;
+    }
+
+    @Override
+    public void invokeActionInternal(Lookup context) {
+        Cargo build = Lookup.getDefault().lookup(Cargo.class);
+        try {
+            build.cargo(getProject().getCargoTOML(), commands);
+        } catch (IOException ioe) {
+            throw new IllegalArgumentException(ioe.getMessage(), ioe);
+        }
+    }
+
+}

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/Command.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/Command.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.rust.project.ui.actions;
+
+import java.util.logging.Logger;
+import org.netbeans.modules.rust.project.RustProject;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Lookup;
+
+
+public abstract class Command {
+
+    protected final Logger logger = Logger.getLogger(getClass().getName());
+
+    private final RustProject project;
+
+    public Command(RustProject project) {
+        assert project != null;
+        this.project = project;
+    }
+
+    public abstract String getCommandId();
+
+    public abstract boolean isActionEnabledInternal(Lookup context);
+
+    public abstract void invokeActionInternal(Lookup context);
+
+    public final boolean isActionEnabled(Lookup context) {
+        // PHP checks for terminally broken projects first, might be helpful for
+        // Rust too
+        return isActionEnabledInternal(context);
+    }
+
+    public final void invokeAction(Lookup context) {
+        if (!validateInvokeAction(context)) {
+            return;
+        }
+        invokeActionInternal(context);
+    }
+
+    protected boolean validateInvokeAction(Lookup context) {
+        // PHP checks for terminally broken projects, might be helpful for
+        // Rust too
+        return true;
+    }
+
+    public boolean asyncCallRequired() {
+        return true;
+    }
+
+    public boolean saveRequired() {
+        return true;
+    }
+
+    public boolean isFileSensitive() {
+        return false;
+    }
+
+    public final RustProject getProject() {
+        return project;
+    }
+
+    protected boolean isTestFile(FileObject fileObj) {
+        if (fileObj == null) {
+            return false;
+        }
+        if (!fileObj.isData()) {
+            return false;
+        }
+        FileObject testFolder = project
+                .getProjectDirectory()
+                .getFileObject("test");
+        if (testFolder == null) {
+            return false;
+        }
+        return  FileUtil.isParentOf(testFolder, fileObj);
+    }
+}

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/CopyCommand.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/CopyCommand.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.rust.project.ui.actions;
+
+import org.netbeans.modules.rust.project.RustProject;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ui.support.DefaultProjectOperations;
+import org.openide.util.Lookup;
+
+public class CopyCommand extends GlobalCommand {
+
+    public CopyCommand(RustProject project) {
+        super(project);
+    }
+
+    @Override
+    protected boolean validateInvokeAction(Lookup context) {
+        return true;
+    }
+
+    @Override
+    protected void invokeAction() {
+        DefaultProjectOperations.performDefaultCopyOperation(getProject());
+    }
+
+    @Override
+    public String getCommandId() {
+        return ActionProvider.COMMAND_COPY;
+    }
+}

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/DeleteCommand.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/DeleteCommand.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.rust.project.ui.actions;
+
+import org.netbeans.modules.rust.project.RustProject;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ui.support.DefaultProjectOperations;
+import org.openide.util.Lookup;
+
+public class DeleteCommand extends GlobalCommand {
+
+    public DeleteCommand(RustProject project) {
+        super(project);
+    }
+
+    @Override
+    protected boolean validateInvokeAction(Lookup context) {
+        return true;
+    }
+
+    @Override
+    protected void invokeAction() {
+        DefaultProjectOperations.performDefaultDeleteOperation(getProject());
+    }
+
+    @Override
+    public String getCommandId() {
+        return ActionProvider.COMMAND_DELETE;
+    }
+}

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/GlobalCommand.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/GlobalCommand.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.rust.project.ui.actions;
+
+import org.netbeans.modules.rust.project.RustProject;
+import org.openide.util.Lookup;
+
+public abstract class GlobalCommand extends Command {
+
+    public GlobalCommand(RustProject project) {
+        super(project);
+    }
+
+    @Override
+    public final void invokeActionInternal(Lookup context) {
+        invokeAction();
+    }
+
+    @Override
+    public final boolean isActionEnabledInternal(Lookup context) {
+        return true;
+    }
+
+    protected abstract void invokeAction();
+}

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/MoveCommand.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/MoveCommand.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.rust.project.ui.actions;
+
+import org.netbeans.modules.rust.project.RustProject;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ui.support.DefaultProjectOperations;
+import org.openide.util.Lookup;
+
+public class MoveCommand extends GlobalCommand {
+
+    public MoveCommand(RustProject project) {
+        super(project);
+    }
+
+    @Override
+    protected boolean validateInvokeAction(Lookup context) {
+        return true;
+    }
+
+    @Override
+    protected void invokeAction() {
+        DefaultProjectOperations.performDefaultMoveOperation(getProject());
+    }
+
+    @Override
+    public String getCommandId() {
+        return ActionProvider.COMMAND_MOVE;
+    }
+}

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/RenameCommand.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/ui/actions/RenameCommand.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.rust.project.ui.actions;
+
+import org.netbeans.modules.rust.project.RustProject;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ui.support.DefaultProjectOperations;
+import org.openide.util.Lookup;
+
+public class RenameCommand extends GlobalCommand {
+
+    public RenameCommand(RustProject project) {
+        super(project);
+    }
+
+    @Override
+    protected boolean validateInvokeAction(Lookup context) {
+        return true;
+    }
+
+    @Override
+    protected void invokeAction() {
+        DefaultProjectOperations.performDefaultRenameOperation(getProject(), getProject().getCargoTOML().getPackageName());
+    }
+
+    @Override
+    public String getCommandId() {
+        return ActionProvider.COMMAND_RENAME;
+    }
+}

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/RustProjectOperationsTest.java
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/RustProjectOperationsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.rust.project;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Test;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
+
+import static junit.framework.Assert.assertEquals;
+
+
+public class RustProjectOperationsTest {
+
+    public RustProjectOperationsTest() {
+    }
+
+    @Test
+    public void testEscapeString() {
+        assertEquals("\"Test\"", RustProjectOperations.escapeTomlString("Test"));
+        assertEquals("\"Te\\\"st\"", RustProjectOperations.escapeTomlString("Te\"st"));
+        assertEquals("\"Te\\nst\"", RustProjectOperations.escapeTomlString("Te\nst"));
+        assertEquals("\"Teäst\"", RustProjectOperations.escapeTomlString("Teäst"));
+        assertEquals("\"Te\\tst\"", RustProjectOperations.escapeTomlString("Te\tst"));
+        assertEquals("\"Te\\tst\"", RustProjectOperations.escapeTomlString("Te\tst"));
+        assertEquals("\"Te\\u001Est\"", RustProjectOperations.escapeTomlString("Te\u001Est"));
+    }
+
+    @Test
+    public void testUpdateProjectNameLiteralMultilineString() throws IOException {
+        testRename("Reference.Cargo.toml", "Test.Cargo.LiteralMultilineString.toml");
+    }
+
+    @Test
+    public void testUpdateProjectNameLiteralString() throws IOException {
+        testRename("Reference.Cargo.toml", "Test.Cargo.LiteralString.toml");
+    }
+
+    @Test
+    public void testUpdateProjectNameMultilineString() throws IOException {
+        testRename("Reference.Cargo.toml", "Test.Cargo.MultilineString.toml");
+    }
+
+    @Test
+    public void testUpdateProjectNameString() throws IOException {
+        testRename("Reference.Cargo.toml", "Test.Cargo.String.toml");
+    }
+
+    @Test
+    public void testUpdateProjectNameDottedName() throws IOException {
+        testRename("Reference.Cargo.DottedName.toml", "Test.Cargo.DottedName.toml");
+    }
+
+
+    private void testRename(String referenceName, String fileName) throws IOException {
+        Path tempPath = Files.createTempFile("Cargo", "toml");
+        FileObject tempFile = FileUtil.toFileObject(tempPath);
+        try {
+            try (InputStream is = RustProjectOperationsTest.class.getResourceAsStream("data/" + fileName);
+                 OutputStream os = tempFile.getOutputStream()) {
+                FileUtil.copy(is, os);
+            }
+            RustProjectOperations.updateProjectName(tempFile, "Renamed\"Test");
+            String reference = URLMapper
+                    .findFileObject(RustProjectOperationsTest.class.getResource("data/" + referenceName))
+                    .asText("UTF-8");
+            String result = tempFile.asText("UTF-8");
+            assertEquals(reference, result);
+        } finally {
+            tempFile.delete();
+        }
+    }
+
+}

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Reference.Cargo.DottedName.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Reference.Cargo.DottedName.toml
@@ -1,0 +1,7 @@
+package.name = "Renamed\"Test"
+package.version = "0.1.0"
+package.edition= "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Reference.Cargo.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Reference.Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "Renamed\"Test"
+version = "0.1.0"
+edition= "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.DottedName.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.DottedName.toml
@@ -1,0 +1,7 @@
+package.name = "MyRust\nProject"
+package.version = "0.1.0"
+package.edition= "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.LiteralMultilineString.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.LiteralMultilineString.toml
@@ -1,0 +1,9 @@
+[package]
+name = '''
+MyRust\tProject'\'''
+version = "0.1.0"
+edition= "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.LiteralString.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.LiteralString.toml
@@ -1,0 +1,8 @@
+[package]
+name = 'MyRustProject\'
+version = "0.1.0"
+edition= "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.MultilineString.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.MultilineString.toml
@@ -1,0 +1,9 @@
+[package]
+name = """
+MyRust\tProject"""
+version = "0.1.0"
+edition= "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.String.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.String.toml
@@ -1,0 +1,8 @@
+[package]
+name = "MyRust\nProject"
+version = "0.1.0"
+edition= "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]


### PR DESCRIPTION
The NetBeans infrastructure provides common actions for projects. Covered by this change are:

- Versioning
- History
- Open in Terminal
- Open in System
- Find...
- Close
- Rename
- Move
- Copy
- Delete

The Debug action was removed as it is not yet implemented.

Before:

![Bildschirmfoto vom 2023-06-16 23-56-24](https://github.com/apache/netbeans/assets/2179736/a083a97c-47a7-4e54-bc6a-faa93e23906d)

After:

![image](https://github.com/apache/netbeans/assets/2179736/7c595e4f-b354-4a8d-89cd-69c3ee4777e1)


