### PR TITLE
Avoid needless dependency on LineDocument

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
@@ -48,8 +48,6 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.SymbolTag;
 import org.netbeans.api.annotations.common.NonNull;
-import org.netbeans.api.editor.document.LineDocument;
-import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.lsp.StructureElement;
 import org.netbeans.modules.editor.java.Utilities;
@@ -327,19 +325,15 @@ public class Utils {
         }
     }
 
-    public static Position createPosition(LineDocument doc, int offset) {
-        try {
-            int line = LineDocumentUtils.getLineIndex(doc, offset);
-            int column = offset - LineDocumentUtils.getLineStart(doc, offset);
+    public static Position createPosition(StyledDocument doc, int offset) {
+        int line = NbDocument.findLineNumber(doc, offset);
+        int column = offset - NbDocument.findLineOffset(doc, line);
 
-            return new Position(line, column);
-        } catch (BadLocationException ex) {
-            throw new IllegalStateException(ex);
-        }
+        return new Position(line, column);
     }
 
-    public static int getOffset(LineDocument doc, Position pos) {
-        return LineDocumentUtils.getLineStartFromIndex(doc, pos.getLine()) + pos.getCharacter();
+    public static int getOffset(StyledDocument doc, Position pos) {
+        return NbDocument.findLineOffset(doc,pos.getLine()) + pos.getCharacter();
     }
 
     public static synchronized String toUri(FileObject file) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/FormatterDocument.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/FormatterDocument.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.event.DocumentListener;
+import javax.swing.event.UndoableEditListener;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.Segment;
+import javax.swing.text.Style;
+import javax.swing.text.StyledDocument;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.netbeans.api.editor.document.AtomicLockDocument;
+import org.netbeans.api.editor.document.AtomicLockListener;
+import org.netbeans.api.editor.document.LineDocument;
+import org.netbeans.api.editor.document.LineDocumentUtils;
+import org.netbeans.modules.java.lsp.server.Utils;
+
+final class FormatterDocument implements StyledDocument, LineDocument, AtomicLockDocument {
+    private final StyledDocument doc;
+    private final List<TextEdit> edits = new ArrayList<>();
+    private TextEdit last = null;
+
+    FormatterDocument(StyledDocument lineDocument) {
+        this.doc = lineDocument;
+    }
+
+    List<TextEdit> getEdits() {
+        return edits;
+    }
+
+    @Override
+    public Style addStyle(String nm, Style parent) {
+        return doc.addStyle(nm, parent);
+    }
+
+    @Override
+    public void removeStyle(String nm) {
+        doc.removeStyle(nm);
+    }
+
+    @Override
+    public Style getStyle(String nm) {
+        return doc.getStyle(nm);
+    }
+
+    @Override
+    public void setCharacterAttributes(int offset, int length, AttributeSet s, boolean replace) {
+        doc.setCharacterAttributes(offset, length, s, replace);
+    }
+
+    @Override
+    public void setParagraphAttributes(int offset, int length, AttributeSet s, boolean replace) {
+        doc.setParagraphAttributes(offset, length, s, replace);
+    }
+
+    @Override
+    public void setLogicalStyle(int pos, Style s) {
+        doc.setLogicalStyle(pos, s);
+    }
+
+    @Override
+    public Style getLogicalStyle(int p) {
+        return doc.getLogicalStyle(p);
+    }
+
+    @Override
+    public javax.swing.text.Element getParagraphElement(int pos) {
+        return doc.getParagraphElement(pos);
+    }
+
+    @Override
+    public javax.swing.text.Element getCharacterElement(int pos) {
+        return doc.getCharacterElement(pos);
+    }
+
+    @Override
+    public Color getForeground(AttributeSet attr) {
+        return doc.getForeground(attr);
+    }
+
+    @Override
+    public Color getBackground(AttributeSet attr) {
+        return doc.getBackground(attr);
+    }
+
+    @Override
+    public Font getFont(AttributeSet attr) {
+        return doc.getFont(attr);
+    }
+
+    @Override
+    public int getLength() {
+        return doc.getLength();
+    }
+
+    @Override
+    public void addDocumentListener(DocumentListener listener) {
+        doc.addDocumentListener(listener);
+    }
+
+    @Override
+    public void removeDocumentListener(DocumentListener listener) {
+        doc.removeDocumentListener(listener);
+    }
+
+    @Override
+    public void addUndoableEditListener(UndoableEditListener listener) {
+        doc.addUndoableEditListener(listener);
+    }
+
+    @Override
+    public void removeUndoableEditListener(UndoableEditListener listener) {
+        doc.removeUndoableEditListener(listener);
+    }
+
+    @Override
+    public Object getProperty(Object key) {
+        return doc.getProperty(key);
+    }
+
+    @Override
+    public void putProperty(Object key, Object value) {
+    }
+
+    @Override
+    public void remove(int offs, int len) throws BadLocationException {
+        Position pos = Utils.createPosition(doc, offs);
+        if (last != null && pos.equals(last.getRange().getStart()) && pos.equals(last.getRange().getEnd())) {
+            last.getRange().setEnd(Utils.createPosition(doc, offs + len));
+        } else {
+            last = new TextEdit(new Range(pos, Utils.createPosition(doc, offs + len)), "");
+            edits.add(last);
+        }
+    }
+
+    @Override
+    public void insertString(int offset, String str, AttributeSet a) throws BadLocationException {
+        Position pos = Utils.createPosition(doc, offset);
+        if (last != null && pos.equals(last.getRange().getStart())) {
+            if (str != null) {
+                last.setNewText(last.getNewText() + str);
+            }
+        } else {
+            last = new TextEdit(new Range(pos, pos), str != null ? str : "");
+            edits.add(last);
+        }
+    }
+
+    @Override
+    public String getText(int offset, int length) throws BadLocationException {
+        return doc.getText(offset, length);
+    }
+
+    @Override
+    public void getText(int offset, int length, Segment txt) throws BadLocationException {
+        doc.getText(offset, length, txt);
+    }
+
+    @Override
+    public javax.swing.text.Position getStartPosition() {
+        return doc.getStartPosition();
+    }
+
+    @Override
+    public javax.swing.text.Position getEndPosition() {
+        return doc.getEndPosition();
+    }
+
+    @Override
+    public javax.swing.text.Position createPosition(int offs) throws BadLocationException {
+        return doc.createPosition(offs);
+    }
+
+    @Override
+    public javax.swing.text.Element[] getRootElements() {
+        return doc.getRootElements();
+    }
+
+    @Override
+    public javax.swing.text.Element getDefaultRootElement() {
+        return doc.getDefaultRootElement();
+    }
+
+    @Override
+    public void render(Runnable r) {
+        doc.render(r);
+    }
+
+    @Override
+    public javax.swing.text.Position createPosition(int offset, javax.swing.text.Position.Bias bias) throws BadLocationException {
+        LineDocument ldoc = LineDocumentUtils.as(doc, LineDocument.class);
+        return ldoc.createPosition(offset, bias);
+    }
+
+    @Override
+    public Document getDocument() {
+        return this;
+    }
+
+    @Override
+    public void atomicUndo() {
+        AtomicLockDocument bdoc = LineDocumentUtils.as(doc, AtomicLockDocument.class);
+        bdoc.atomicUndo();
+    }
+
+    @Override
+    public void runAtomic(Runnable r) {
+        AtomicLockDocument bdoc = LineDocumentUtils.as(doc, AtomicLockDocument.class);
+        bdoc.runAtomic(r);
+    }
+
+    @Override
+    public void runAtomicAsUser(Runnable r) {
+        AtomicLockDocument bdoc = LineDocumentUtils.as(doc, AtomicLockDocument.class);
+        bdoc.runAtomicAsUser(r);
+    }
+
+    @Override
+    public void addAtomicLockListener(AtomicLockListener l) {
+        AtomicLockDocument bdoc = LineDocumentUtils.as(doc, AtomicLockDocument.class);
+        bdoc.addAtomicLockListener(l);
+    }
+
+    @Override
+    public void removeAtomicLockListener(AtomicLockListener l) {
+        AtomicLockDocument bdoc = LineDocumentUtils.as(doc, AtomicLockDocument.class);
+        bdoc.removeAtomicLockListener(l);
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ImplementAllAbstractMethodsAction.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ImplementAllAbstractMethodsAction.java
@@ -26,13 +26,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.swing.text.Document;
+import javax.swing.text.StyledDocument;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
-import org.netbeans.api.editor.document.LineDocument;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.modules.java.editor.codegen.GeneratorUtils;
 import org.netbeans.modules.java.lsp.server.Utils;
@@ -74,9 +74,9 @@ public final class ImplementAllAbstractMethodsAction extends CodeActionsProvider
                 Position position = gson.fromJson(gson.toJson(arguments.get(1)), Position.class);
                 List<TextEdit> edits = TextDocumentServiceImpl.modify2TextEdits(js, wc -> {
                     wc.toPhase(JavaSource.Phase.RESOLVED);
-                    Document doc = wc.getSnapshot().getSource().getDocument(true);
-                    if (doc instanceof LineDocument) {
-                        int offset = Utils.getOffset((LineDocument) doc, position);
+                  Document doc = wc.getSnapshot().getSource().getDocument(true);
+                    if (doc instanceof StyledDocument) {
+                        int offset = Utils.getOffset((StyledDocument) doc, position);
                         GeneratorUtils.generateAllAbstractMethodImplementations(wc, wc.getTreeUtilities().pathFor(offset));
                     }
                 });

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -31,8 +31,6 @@ import com.sun.source.util.TreePath;
 import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
 import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
-import java.awt.Color;
-import java.awt.Font;
 import java.io.FileNotFoundException;
 import java.net.URI;
 import java.net.URL;
@@ -76,12 +74,8 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
-import javax.swing.event.UndoableEditListener;
-import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
-import javax.swing.text.Segment;
-import javax.swing.text.Style;
 import javax.swing.text.StyledDocument;
 import org.eclipse.lsp4j.CallHierarchyIncomingCall;
 import org.eclipse.lsp4j.CallHierarchyIncomingCallsParams;
@@ -162,10 +156,6 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.netbeans.api.annotations.common.CheckForNull;
-import org.netbeans.api.editor.document.AtomicLockDocument;
-import org.netbeans.api.editor.document.AtomicLockListener;
-import org.netbeans.api.editor.document.LineDocument;
-import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
 import org.netbeans.api.java.lexer.JavaTokenId;
@@ -1258,7 +1248,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
     public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
         String uri = params.getTextDocument().getUri();
         Document doc = server.getOpenedDocuments().getDocument(uri);
-        return format((LineDocument) doc, 0, doc.getLength());
+        return format(doc, 0, doc.getLength());
     }
 
     @Override
@@ -1275,9 +1265,8 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
 
     private CompletableFuture<List<? extends TextEdit>> format(Document doc, int startOffset, int endOffset) {
         CompletableFuture<List<? extends TextEdit>> result = new CompletableFuture<>();
-        StyledDocument sDoc = LineDocumentUtils.as(doc, StyledDocument.class);
-        if (sDoc != null) {
-            FormatterDocument formDoc = new FormatterDocument(sDoc);
+        if (doc instanceof StyledDocument) {
+            FormatterDocument formDoc = new FormatterDocument((StyledDocument) doc);
             Reformat reformat = Reformat.get(formDoc);
             if (reformat != null) {
                 reformat.lock();
@@ -2395,217 +2384,4 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
         return t.processRequest();
     }
 
-    private static class FormatterDocument implements StyledDocument, LineDocument, AtomicLockDocument {
-
-        private final StyledDocument doc;
-        private final List<TextEdit> edits = new ArrayList<>();
-        private TextEdit last = null;
-
-        private FormatterDocument(StyledDocument lineDocument) {
-            this.doc = lineDocument;
-        }
-
-        private List<TextEdit> getEdits() {
-            return edits;
-        }
-
-        @Override
-        public Style addStyle(String nm, Style parent) {
-            return doc.addStyle(nm, parent);
-        }
-
-        @Override
-        public void removeStyle(String nm) {
-            doc.removeStyle(nm);
-        }
-
-        @Override
-        public Style getStyle(String nm) {
-            return doc.getStyle(nm);
-        }
-
-        @Override
-        public void setCharacterAttributes(int offset, int length, AttributeSet s, boolean replace) {
-            doc.setCharacterAttributes(offset, length, s, replace);
-        }
-
-        @Override
-        public void setParagraphAttributes(int offset, int length, AttributeSet s, boolean replace) {
-            doc.setParagraphAttributes(offset, length, s, replace);
-        }
-
-        @Override
-        public void setLogicalStyle(int pos, Style s) {
-            doc.setLogicalStyle(pos, s);
-        }
-
-        @Override
-        public Style getLogicalStyle(int p) {
-            return doc.getLogicalStyle(p);
-        }
-
-        @Override
-        public javax.swing.text.Element getParagraphElement(int pos) {
-            return doc.getParagraphElement(pos);
-        }
-
-        @Override
-        public javax.swing.text.Element getCharacterElement(int pos) {
-            return doc.getCharacterElement(pos);
-        }
-
-        @Override
-        public Color getForeground(AttributeSet attr) {
-            return doc.getForeground(attr);
-        }
-
-        @Override
-        public Color getBackground(AttributeSet attr) {
-            return doc.getBackground(attr);
-        }
-
-        @Override
-        public Font getFont(AttributeSet attr) {
-            return doc.getFont(attr);
-        }
-
-        @Override
-        public int getLength() {
-            return doc.getLength();
-        }
-
-        @Override
-        public void addDocumentListener(DocumentListener listener) {
-            doc.addDocumentListener(listener);
-        }
-
-        @Override
-        public void removeDocumentListener(DocumentListener listener) {
-            doc.removeDocumentListener(listener);
-        }
-
-        @Override
-        public void addUndoableEditListener(UndoableEditListener listener) {
-            doc.addUndoableEditListener(listener);
-        }
-
-        @Override
-        public void removeUndoableEditListener(UndoableEditListener listener) {
-            doc.removeUndoableEditListener(listener);
-        }
-
-        @Override
-        public Object getProperty(Object key) {
-            return doc.getProperty(key);
-        }
-
-        @Override
-        public void putProperty(Object key, Object value) {
-        }
-
-        @Override
-        public void remove(int offs, int len) throws BadLocationException {
-            Position pos = Utils.createPosition(doc, offs);
-            if (last != null && pos.equals(last.getRange().getStart()) && pos.equals(last.getRange().getEnd())) {
-                last.getRange().setEnd(Utils.createPosition(doc, offs + len));
-            } else {
-                last = new TextEdit(new Range(pos, Utils.createPosition(doc, offs + len)), "");
-                edits.add(last);
-            }
-        }
-
-        @Override
-        public void insertString(int offset, String str, AttributeSet a) throws BadLocationException {
-            Position pos = Utils.createPosition(doc, offset);
-            if (last != null && pos.equals(last.getRange().getStart())) {
-                if (str != null) {
-                    last.setNewText(last.getNewText() + str);
-                }
-            } else {
-                last = new TextEdit(new Range(pos, pos), str != null ? str : "");
-                edits.add(last);
-            }
-        }
-
-        @Override
-        public String getText(int offset, int length) throws BadLocationException {
-            return doc.getText(offset, length);
-        }
-
-        @Override
-        public void getText(int offset, int length, Segment txt) throws BadLocationException {
-            doc.getText(offset, length, txt);
-        }
-
-        @Override
-        public javax.swing.text.Position getStartPosition() {
-            return doc.getStartPosition();
-        }
-
-        @Override
-        public javax.swing.text.Position getEndPosition() {
-            return doc.getEndPosition();
-        }
-
-        @Override
-        public javax.swing.text.Position createPosition(int offs) throws BadLocationException {
-            return doc.createPosition(offs);
-        }
-
-        @Override
-        public javax.swing.text.Element[] getRootElements() {
-            return doc.getRootElements();
-        }
-
-        @Override
-        public javax.swing.text.Element getDefaultRootElement() {
-            return doc.getDefaultRootElement();
-        }
-
-        @Override
-        public void render(Runnable r) {
-            doc.render(r);
-        }
-
-        @Override
-        public javax.swing.text.Position createPosition(int offset, javax.swing.text.Position.Bias bias) throws BadLocationException {
-            LineDocument ldoc = LineDocumentUtils.as(doc, LineDocument.class);
-            return ldoc.createPosition(offset, bias);
-        }
-
-        @Override
-        public Document getDocument() {
-            return this;
-        }
-
-        @Override
-        public void atomicUndo() {
-            AtomicLockDocument bdoc = LineDocumentUtils.as(doc, AtomicLockDocument.class);
-            bdoc.atomicUndo();
-        }
-
-        @Override
-        public void runAtomic(Runnable r) {
-            AtomicLockDocument bdoc = LineDocumentUtils.as(doc, AtomicLockDocument.class);
-            bdoc.runAtomic(r);
-        }
-
-        @Override
-        public void runAtomicAsUser(Runnable r) {
-            AtomicLockDocument bdoc = LineDocumentUtils.as(doc, AtomicLockDocument.class);
-            bdoc.runAtomicAsUser(r);
-        }
-
-        @Override
-        public void addAtomicLockListener(AtomicLockListener l) {
-            AtomicLockDocument bdoc = LineDocumentUtils.as(doc, AtomicLockDocument.class);
-            bdoc.addAtomicLockListener(l);
-        }
-
-        @Override
-        public void removeAtomicLockListener(AtomicLockListener l) {
-            AtomicLockDocument bdoc = LineDocumentUtils.as(doc, AtomicLockDocument.class);
-            bdoc.removeAtomicLockListener(l);
-        }
-    }
 }


### PR DESCRIPTION
I am trying to provide [structure view for Enso VSCode extension](https://github.com/enso-org/enso/tree/develop/tools/enso4igv#building-vscode-extension) via [StructureProvider](https://bits.netbeans.org/18/javadoc/org-netbeans-api-lsp/org/netbeans/spi/lsp/StructureProvider.html). While debugging why it is no working, I realized that there is an unnecessary dependency on `LineDocument` at a lot of places which prevents my implementation of `StructureProvider` to be called.

NetBeans IDE is supposed to work with any `StyledDocument`. Additional operations are abstracted into [NbDocument](https://bits.netbeans.org/18/javadoc/org-openide-text/org/openide/text/NbDocument.html) with _effective delegation_ to NetBeans editor implementation and _reasonable fallback_ for other `StyledDocument` implementations.

8063d3662809cf4cdae3c340ef962ae17028c6d2 replaces `LineDocument` usage with `NbDocument`. eb6e98ac3c74e7cff67b05338eb8c53313539589 refactors `FormatterDocument` away from `TextDocumentServiceImpl` - so we can remove `import` of `LineDocument` from the `TextDocumentServiceImpl` class.