### PR TITLE
Update collection return encapsulation hint.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/encapsulation/ReturnEncapsulation.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/encapsulation/ReturnEncapsulation.java
@@ -34,7 +34,6 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -88,7 +87,18 @@ public class ReturnEncapsulation {
             "java.util.Collections.<$T$>unmodifiableSortedSet($any)",
             "java.util.Collections.<$T$>unmodifiableMap($any)",
             "java.util.Collections.<$T$>unmodifiableSortedMap($any)",
-            "java.util.Arrays.<$T$>asList($any$)"
+            "java.util.Collections.<$T$>unmodifiableNavigableMap($any)",
+            "java.util.Collections.<$T$>unmodifiableSequencedCollection($any)",
+            "java.util.Collections.<$T$>unmodifiableSequencedSet($any)",
+            "java.util.Collections.<$T$>unmodifiableSequencedMap($any)",
+            "java.util.Arrays.<$T$>asList($any$)",
+            "java.util.List.<$T$>of($any$)",
+            "java.util.List.<$T$>copyOf($any$)",
+            "java.util.Set.<$T$>of($any$)",
+            "java.util.Set.<$T$>copyOf($any$)",
+            "java.util.Map.<$T$>of($any$)",
+            "java.util.Map.<$T$>copyOf($any$)",
+            "java.util.Map.<$T$>ofEntries($any$)"
     );
 
     @Hint(displayName = "#DN_org.netbeans.modules.java.hints.encapsulation.ReturnEncapsulation.collection", description = "#DESC_org.netbeans.modules.java.hints.encapsulation.ReturnEncapsulation.collection", category="encapsulation",suppressWarnings="ReturnOfCollectionOrArrayField", enabled=false) //NOI18N
@@ -217,7 +227,7 @@ public class ReturnEncapsulation {
         if (enclMethod == null || enclMethod.getEnclosingElement() != exprElement.getEnclosingElement()) {
             return null;
         }
-        List<Fix> fixes = new ArrayList<Fix>(providers.length + 1);
+        List<Fix> fixes = new ArrayList<>(providers.length + 1);
         for (int i=0; i<providers.length; i++) {
             Fix f = providers[i].fixFor(ctx,(ExecutableElement) enclMethod,exprPath);
             if (f != null) {
@@ -229,7 +239,7 @@ public class ReturnEncapsulation {
             fixes.toArray(new Fix[0]));
     }
 
-    private static final TreePath findEnclosingMethod(TreePath tp) {
+    private static TreePath findEnclosingMethod(TreePath tp) {
         while (tp != null && tp.getLeaf().getKind() != Tree.Kind.COMPILATION_UNIT) {
             if (tp.getLeaf().getKind() == Tree.Kind.METHOD) {
                 return tp;
@@ -248,13 +258,18 @@ public class ReturnEncapsulation {
         private static final Map<String, String> TO_UNMODIFIABLE;
 
         static {
-            TO_UNMODIFIABLE = new LinkedHashMap<String, String>();
+            TO_UNMODIFIABLE = new LinkedHashMap<>();
             TO_UNMODIFIABLE.put("java.util.SortedMap", "unmodifiableSortedMap");
             TO_UNMODIFIABLE.put("java.util.SortedSet", "unmodifiableSortedSet");
             TO_UNMODIFIABLE.put("java.util.Map", "unmodifiableMap");
             TO_UNMODIFIABLE.put("java.util.Set", "unmodifiableSet");
             TO_UNMODIFIABLE.put("java.util.List", "unmodifiableList");
             TO_UNMODIFIABLE.put("java.util.Collection", "unmodifiableCollection");
+            TO_UNMODIFIABLE.put("java.util.NavigableMap", "unmodifiableNavigableMap");
+            TO_UNMODIFIABLE.put("java.util.NavigableSet", "unmodifiableNavigableSet");
+            TO_UNMODIFIABLE.put("java.util.SequencedCollection", "unmodifiableSequencedCollection");
+            TO_UNMODIFIABLE.put("java.util.SequencedMap", "unmodifiableSequencedMap");
+            TO_UNMODIFIABLE.put("java.util.SequencedSet", "unmodifiableSequencedSet");
         }
 
         private FixProvider() {


### PR DESCRIPTION
Small update which adds support for unmodifiable and sequenced collections.

Reduces some false positives. This hint is still of fairly limited use since it produces false positives for fields which are initialized in static blocks or constructors. (hint is off by default I believe)