### PR TITLE
Defensive guards against invalid code points in preferences.

### DIFF
--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/IntrospectedInfo.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/IntrospectedInfo.java
@@ -674,22 +674,30 @@ public final class IntrospectedInfo {
             null | String[] enumTags: .enumTags=whenempty,always,never
              */
             Pattern p = Pattern.compile("(.+)\\.(supportsText|attrs\\.(.+)|subs\\.(.+)|enumTags)");
+            @Override
             public IntrospectedInfo load(Preferences node) {
                 IntrospectedInfo ii = new IntrospectedInfo();
                 try {
                     for (String k : node.keys()) {
-                        String v = node.get(k, null);
+                        String v;
+                        try {
+                            v = node.get(k, null);
+                        } catch (IllegalArgumentException ex) { // e.g invalid code point JDK-8075156
+                            LOG.log(Level.WARNING, "malformed key: {0}, pref path: {1}, msg: {2}",
+                                    new Object[] {k, node.absolutePath(), ex.getMessage()});
+                            continue;
+                        }
                         assert v != null : k;
                         String[] ss = k.split("\\.", 2);
                         if (ss.length != 2) {
-                            LOG.log(Level.WARNING, "malformed key: {0}", k);
+                            LOG.log(Level.WARNING, "malformed key: {0}, pref path: {1}", new Object[] {k, node.absolutePath()});
                             continue;
                         }
                         if (ss[0].equals("class")) {
                             Matcher m = p.matcher(ss[1]);
                             boolean match = m.matches();
                             if (!match) {
-                                LOG.log(Level.WARNING, "malformed key: {0}", k);
+                                LOG.log(Level.WARNING, "malformed key: {0}, pref path: {1}", new Object[] {k, node.absolutePath()});
                                 continue;
                             }
                             String c = m.group(1);
@@ -742,6 +750,7 @@ public final class IntrospectedInfo {
                 }
                 return ic;
             }
+            @Override
             public void store(Preferences node, IntrospectedInfo info) {
                 try {
                     node.clear();

--- a/nb/o.n.upgrader/src/org/netbeans/upgrade/CopyFiles.java
+++ b/nb/o.n.upgrader/src/org/netbeans/upgrade/CopyFiles.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map.Entry;
@@ -38,6 +39,8 @@ import javax.swing.JOptionPane;
 import org.netbeans.util.Util;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.EditableProperties;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /** Does copy of files according to include/exclude patterns.
  *
@@ -136,6 +139,14 @@ final class CopyFiles extends Object {
      * @throws java.io.IOException if copying fails
      */
     private void copyFile(File sourceFile) throws IOException {
+
+        // invalid code point check JDK-8075156
+        if (sourceFile.getName().endsWith(".properties")
+                && new String(Files.readAllBytes(sourceFile.toPath()), UTF_8).indexOf('\u0000') != -1) {
+            LOGGER.log(Level.WARNING, "{0} contains invalid code points -> skipping", sourceFile);  //NOI18N
+            return;
+        }
+
         String relativePath = getRelativePath(sourceRoot, sourceFile);
         currentProperties = null;
         boolean includeFile = false;

--- a/platform/core.windows/src/org/netbeans/core/windows/TopComponentTracker.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/TopComponentTracker.java
@@ -73,7 +73,13 @@ public final class TopComponentTracker {
         Preferences prefs = getPreferences();
         try {
             for( String key : prefs.keys() ) {
-                boolean view = prefs.getBoolean( key, false );
+                boolean view;
+                try {
+                   view = prefs.getBoolean( key, false );
+                } catch (IllegalArgumentException ex) {
+                    Logger.getLogger(TopComponentTracker.class.getName()).log(Level.INFO, "invalid preferences key", ex);
+                    continue; // e.g invalid code point JDK-8075156
+                }
                 if( view )
                     viewIds.add( key );
                 else

--- a/platform/options.api/src/org/netbeans/modules/options/export/OptionsExportModel.java
+++ b/platform/options.api/src/org/netbeans/modules/options/export/OptionsExportModel.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.options.export;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -110,19 +111,19 @@ public final class OptionsExportModel {
     ArrayList<String> getEnabledItemsDuringExport(File importSource) {
         ArrayList<String> enabledItems = null;
         if (importSource.isFile()) { // importing from .zip file
-            try {
-                ZipFile zipFile = new ZipFile(importSource);
+            try (ZipFile zipFile = new ZipFile(importSource)) {
                 // Enumerate each entry
                 Enumeration<? extends ZipEntry> entries = zipFile.entries();
                 while (entries.hasMoreElements()) {
-                    ZipEntry zipEntry = (ZipEntry) entries.nextElement();
+                    ZipEntry zipEntry = entries.nextElement();
                     if(zipEntry.getName().equals(OptionsExportModel.ENABLED_ITEMS_INFO)) {
-                        enabledItems = new ArrayList<String>();
-                        InputStream stream = zipFile.getInputStream(zipEntry);
-                        BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
-                        String strLine;
-                        while ((strLine = br.readLine()) != null) {
-                            enabledItems.add(strLine);
+                        enabledItems = new ArrayList<>();
+                        try (InputStream stream = zipFile.getInputStream(zipEntry);
+                             BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));) {
+                            String strLine;
+                            while ((strLine = br.readLine()) != null) {
+                                enabledItems.add(strLine);
+                            }
                         }
                     }
                 }
@@ -158,20 +159,20 @@ public final class OptionsExportModel {
     double getBuildNumberDuringExport(File importSource) {
         String buildNumber = null;
         if (importSource.isFile()) { // importing from .zip file
-            try {
-                ZipFile zipFile = new ZipFile(importSource);
+            try (ZipFile zipFile = new ZipFile(importSource)) {
                 // Enumerate each entry
                 Enumeration<? extends ZipEntry> entries = zipFile.entries();
                 while (entries.hasMoreElements()) {
                     ZipEntry zipEntry = (ZipEntry) entries.nextElement();
                     if (zipEntry.getName().equals(OptionsExportModel.BUILD_INFO)) {
-                        InputStream stream = zipFile.getInputStream(zipEntry);
-                        BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
-                        String strLine;
-                        while ((strLine = br.readLine()) != null) {
-                            buildNumber = parseBuildNumber(strLine);
-                            if(buildNumber != null) {
-                                break; // successfully parsed build number, no need to continue
+                        try (InputStream stream = zipFile.getInputStream(zipEntry);
+                             BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));)  {
+                            String strLine;
+                            while ((strLine = br.readLine()) != null) {
+                                buildNumber = parseBuildNumber(strLine);
+                                if(buildNumber != null) {
+                                    break; // successfully parsed build number, no need to continue
+                                }
                             }
                         }
                     }
@@ -304,24 +305,16 @@ public final class OptionsExportModel {
         try {
             ensureParent(targetZipFile);
             // Create the ZIP file
-            zipOutputStream = new ZipOutputStream(createOutputStream(targetZipFile));
-            copyFiles();
-            createEnabledItemsInfo(zipOutputStream, enabledItems);
-            createProductInfo(zipOutputStream);
-            // Complete the ZIP file
-            zipOutputStream.close();
+            try (ZipOutputStream out = new ZipOutputStream(createOutputStream(targetZipFile))) {
+                zipOutputStream = out;
+                copyFiles();
+                createEnabledItemsInfo(out, enabledItems);
+                createProductInfo(out);
+            }
         } catch (IOException ex) {
             Exceptions.attachLocalizedMessage(ex,
                     NbBundle.getMessage(OptionsExportModel.class, "OptionsExportModel.export.zip.error", targetZipFile));
             Exceptions.printStackTrace(ex);
-        } finally {
-            if (zipOutputStream != null) {
-                try {
-                    zipOutputStream.close();
-                } catch (IOException ex) {
-                    // ignore
-                }
-            }
         }
     }
 
@@ -748,21 +741,31 @@ public final class OptionsExportModel {
      */
     private void copyZipFile() throws IOException {
         // Open the ZIP file
-        ZipFile zipFile = new ZipFile(source);
-        try {
+        try (ZipFile zipFile = new ZipFile(source)) {
             // Enumerate each entry
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
             while (entries.hasMoreElements()) {
                 ZipEntry zipEntry = entries.nextElement();
-                if (!zipEntry.isDirectory()) {
+                if (!zipEntry.isDirectory() && !checkIntegrity(zipEntry)) {
                     copyFile(zipEntry.getName());
                 }
             }
-        } finally {
-            if (zipFile != null) {
-                zipFile.close();
+        }
+    }
+
+    private boolean checkIntegrity(ZipEntry entry) throws IOException {
+        if (entry.getName().endsWith(".properties")) {
+            try (ZipFile zip = new ZipFile(source);
+                 BufferedReader reader = new BufferedReader(new InputStreamReader(zip.getInputStream(entry), StandardCharsets.UTF_8))) {
+                // invalid code point check JDK-8075156
+                boolean corrupted = reader.lines().anyMatch(l -> l.indexOf('\u0000') != -1);
+                if (corrupted) {
+                    LOGGER.log(Level.WARNING, "ignoring corrupted properties file at {0}", entry.getName());
+                }
+                return corrupted;
             }
         }
+        return true;
     }
 
     /** Copy given folder to target userdir or zip file obeying include/exclude patterns.
@@ -964,18 +967,12 @@ public final class OptionsExportModel {
             // Complete the entry
             zipOutputStream.closeEntry();
         } else {  // import to userdir
-            OutputStream out = null;
             File targetFile = new File(targetUserdir, relativePath);
             LOGGER.log(Level.FINE, "Path: {0}", relativePath);  //NOI18N
             if (includeKeys.isEmpty() && excludeKeys.isEmpty()) {
                 // copy entire file
-                try {
-                    out = createOutputStream(targetFile);
+                try (OutputStream out = createOutputStream(targetFile)) {
                     copyFile(relativePath, out);
-                } finally {
-                    if (out != null) {
-                        out.close();
-                    }
                 }
             } else {
                 mergeProperties(relativePath, includeKeys, excludeKeys);
@@ -999,29 +996,17 @@ public final class OptionsExportModel {
             return;
         }
         EditableProperties targetProperties = new EditableProperties(false);
-        InputStream in = null;
         File targetFile = new File(targetUserdir, relativePath);
-        try {
-            if (targetFile.exists()) {
-                in = new FileInputStream(targetFile);
+        if (targetFile.exists()) {
+            try (InputStream in = new FileInputStream(targetFile)) {
                 targetProperties.load(in);
-            }
-        } finally {
-            if (in != null) {
-                in.close();
             }
         }
         for (Entry<String, String> entry : currentProperties.entrySet()) {
             targetProperties.put(entry.getKey(), entry.getValue());
         }
-        OutputStream out = null;
-        try {
-            out = createOutputStream(targetFile);
+        try (OutputStream out = createOutputStream(targetFile)) {
             targetProperties.store(out);
-        } finally {
-            if (out != null) {
-                out.close();
-            }
         }
     }
 
@@ -1055,14 +1040,8 @@ public final class OptionsExportModel {
      */
     private EditableProperties getProperties(String relativePath) throws IOException {
         EditableProperties properties = new EditableProperties(false);
-        InputStream in = null;
-        try {
-            in = getInputStream(relativePath);
+        try (InputStream in = getInputStream(relativePath)) {
             properties.load(in);
-        } finally {
-            if (in != null) {
-                in.close();
-            }
         }
         return properties;
     }
@@ -1075,13 +1054,25 @@ public final class OptionsExportModel {
     private InputStream getInputStream(String relativePath) throws IOException {
         if (source.isFile()) {
             //zip file
-            ZipFile zipFile = new ZipFile(source);
-            ZipEntry zipEntry = zipFile.getEntry(relativePath);
-            return zipFile.getInputStream(zipEntry);
+            return singleEntryZipStream(relativePath);
         } else {
             // userdir
             return new FileInputStream(new File(source, relativePath));
         }
+    }
+
+    private InputStream singleEntryZipStream(String relativePath) throws IOException {
+        final ZipFile zipFile = new ZipFile(source);
+        return new BufferedInputStream(zipFile.getInputStream(zipFile.getEntry(relativePath))) {
+            @Override
+            public void close() throws IOException {
+                try {
+                    super.close();
+                } finally {
+                    zipFile.close();
+                }
+            }
+        };
     }
 
     /** Copy file from relative path in zip file or userdir to target OutputStream.
@@ -1090,14 +1081,8 @@ public final class OptionsExportModel {
      * @throws java.io.IOException if copying fails
      */
     private void copyFile(String relativePath, OutputStream out) throws IOException {
-        InputStream in = null;
-        try {
-            in = getInputStream(relativePath);
+        try (InputStream in = getInputStream(relativePath)) {
             FileUtil.copy(in, out);
-        } finally {
-            if (in != null) {
-                in.close();
-            }
         }
     }
 
@@ -1117,15 +1102,16 @@ public final class OptionsExportModel {
      * @throws java.io.IOException
      */
     static List<String> listZipFile(File file) throws IOException {
-        List<String> relativePaths = new ArrayList<String>();
+        List<String> relativePaths = new ArrayList<>();
         // Open the ZIP file
-        ZipFile zipFile = new ZipFile(file);
-        // Enumerate each entry
-        Enumeration<? extends ZipEntry> entries = zipFile.entries();
-        while (entries.hasMoreElements()) {
-            ZipEntry zipEntry = (ZipEntry) entries.nextElement();
-            if (!zipEntry.isDirectory()) {
-                relativePaths.add(zipEntry.getName());
+        try (ZipFile zipFile = new ZipFile(file)) {
+            // Enumerate each entry
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry zipEntry = entries.nextElement();
+                if (!zipEntry.isDirectory()) {
+                    relativePaths.add(zipEntry.getName());
+                }
             }
         }
         return relativePaths;
@@ -1139,35 +1125,20 @@ public final class OptionsExportModel {
      */
     static void createZipFile(File targetFile, File sourceDir, List<String> relativePaths) throws IOException {
         ensureParent(targetFile);
-        ZipOutputStream out = null;
-        try {
-            // Create the ZIP file
-            out = new ZipOutputStream(createOutputStream(targetFile));
+        try (ZipOutputStream out = new ZipOutputStream(createOutputStream(targetFile))) {
             // Compress the files
             for (String relativePath : relativePaths) {
                 LOGGER.finest("Adding to zip: " + relativePath);  //NOI18N
                 // Add ZIP entry to output stream.
                 out.putNextEntry(new ZipEntry(relativePath));
                 // Transfer bytes from the file to the ZIP file
-                FileInputStream in = null;
-                try {
-                    in = new FileInputStream(new File(sourceDir, relativePath));
+                try (FileInputStream in = new FileInputStream(new File(sourceDir, relativePath))) {
                     FileUtil.copy(in, out);
-                } finally {
-                    if (in != null) {
-                        in.close();
-                    }
                 }
                 // Complete the entry
                 out.closeEntry();
             }
             createProductInfo(out);
-            // Complete the ZIP file
-            out.close();
-        } finally {
-            if (out != null) {
-                out.close();
-            }
         }
     }
 


### PR DESCRIPTION
The code point '\u0000' breaks the Preferences storage as demonstrated in https://bugs.openjdk.org/browse/JDK-8068373, as preventive measure it can't be used in keys since https://bugs.openjdk.org/browse/JDK-8084823.

There are many reports of windows users running into seemingly unrelated issues, but closer investigation showed that they all had at some point "invalid code point" exceptions in the log.

this usually happens in a code pattern like this:
```java
for (String k : pref.keys()) { // contains an invalid key
    ... = pref.get(key, null);  // throws IAE
}
```
It is not clear what causes the corruption (and why it seems to only occur on windows), this PR adds some defensive code to cover some common cases, logs it and makes sure no corrupted properties files are imported from old configs on first launch.

the jackpot rule:
```java
$pref.keys() :: $pref instanceof java.util.prefs.Preferences;;
```
had 70 hits - this PR covers only common cases + adds the import filter.

```
org.apache.tools.ant.module.bridge.impl.BridgeImpl$PostRun
java.lang.IllegalArgumentException: Key contains code point U+0000
	at java.prefs/java.util.prefs.AbstractPreferences.get(AbstractPreferences.java:296)
	at org.apache.tools.ant.module.api.IntrospectedInfo$3.load(IntrospectedInfo.java:681)
	at org.apache.tools.ant.module.AntSettings.getCustomDefs(AntSettings.java:119)
	at org.apache.tools.ant.module.bridge.impl.BridgeImpl$PostRun.run(BridgeImpl.java:443)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
```
```
java.lang.IllegalArgumentException: Key contains code point U+0000
       at java.util.prefs.AbstractPreferences.get(AbstractPreferences.java:296)
       at java.util.prefs.AbstractPreferences.getBoolean(AbstractPreferences.java:531)
       at org.netbeans.core.windows.TopComponentTracker.load(TopComponentTracker.java:99)
       at org.netbeans.core.windows.PersistenceHandler.load(PersistenceHandler.java:126)
       at org.netbeans.core.windows.WindowSystemImpl.load(WindowSystemImpl.java:81)
       at org.netbeans.core.GuiRunLevel$InitWinSys.run(GuiRunLevel.java:229)
```
```
java.lang.IllegalArgumentException: Key contains code point U+0000
      at java.prefs/java.util.prefs.AbstractPreferences.get(AbstractPreferences.java:296)
      at org.netbeans.modules.maven.queries.MavenFileOwnerQueryImpl.registerCoordinates(MavenFileOwnerQueryImpl.java:153)
      at org.netbeans.modules.maven.ProjectOpenedHookImpl.registerWithSubmodules(ProjectOpenedHookImpl.java:431)
      at org.netbeans.modules.maven.ProjectOpenedHookImpl.projectOpened(ProjectOpenedHookImpl.java:138)
      at org.netbeans.spi.project.ui.ProjectOpenedHook$1.projectOpened(ProjectOpenedHook.java:60)
  [catch] at org.netbeans.modules.project.ui.OpenProjectList.notifyOpened(OpenProjectList.java:1273)
      at org.netbeans.modules.project.ui.OpenProjectList.doOpenProject(OpenProjectList.java:1354)
      at org.netbeans.modules.project.ui.OpenProjectList.open(OpenProjectList.java:798)
      at org.netbeans.modules.project.ui.OpenProjectList$6.run(OpenProjectList.java:650)
      at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
      at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
      at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
      at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)
```


closes #6076
closes #5147
closes #5633
closes #5634
https://bz.apache.org/netbeans/show_bug.cgi?id=271652
https://issues.apache.org/jira/browse/NETBEANS-3284