### PR TITLE
Feature: Added support for Faces 4 changed xmlns namespaces

### DIFF
--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/PageIterator.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/PageIterator.java
@@ -198,6 +198,11 @@ public class PageIterator implements TemplateWizard.Iterator {
         return classpath != null && classpath.findResource("jakarta/faces/flow/Flow.class") != null; //NOI18N
     }
 
+    private static boolean isJSF40(WebModule wm) {
+        ClassPath classpath = ClassPath.getClassPath(wm.getDocumentBase(), ClassPath.COMPILE);
+        return classpath != null && classpath.findResource("jakarta/faces/lifecycle/ClientWindowScoped.class") != null; //NOI18N
+    }
+
     public Set<DataObject> instantiate(TemplateWizard wiz) throws IOException {
         // Here is the default plain behavior. Simply takes the selected
         // template (you need to have included the standard second panel
@@ -231,7 +236,9 @@ public class PageIterator implements TemplateWizard.Iterator {
                     template = templateParent.getFileObject("JSP", "xhtml"); //NOI18N
                     WebModule wm = WebModule.getWebModule(df.getPrimaryFile());
                     if (wm != null) {
-                        if (isJSF30(wm)) {
+                        if (isJSF40(wm)) {
+                            wizardProps.put("isJSF40", Boolean.TRUE);
+                        } else if (isJSF30(wm)) {
                             wizardProps.put("isJSF30", Boolean.TRUE);
                         } else if (isJSF22(wm)) {
                             wizardProps.put("isJSF22", Boolean.TRUE);

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/InjectCompositeComponent.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/InjectCompositeComponent.java
@@ -215,7 +215,7 @@ public class InjectCompositeComponent {
                 public void run(ResultIterator resultIterator) throws Exception {
                     Library lib = jsfs.getLibrary(compositeLibURL);
                     if (lib != null) {
-                        if (!LibraryUtils.importLibrary(document, lib, prefix, jsfs.isJsf22Plus())) { //XXX: fix the damned static prefix !!!
+                        if (!LibraryUtils.importLibrary(document, lib, prefix, jsfs.getJsfVersion())) { //XXX: fix the damned static prefix !!!
                             logger.log(Level.WARNING, "Cannot import composite components library {0}", compositeLibURL); //NOI18N
                         }
                     } else {
@@ -248,7 +248,7 @@ public class InjectCompositeComponent {
                             ((BaseDocument) templateInstanceDoc).runAtomic(new Runnable() {
                                 @Override
                                 public void run() {
-                                    LibraryUtils.importLibrary(templateInstanceDoc, importsMap, jsfs.isJsf22Plus());
+                                    LibraryUtils.importLibrary(templateInstanceDoc, importsMap, jsfs.getJsfVersion());
                                 }
                             });
                             try {

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/InjectCompositeComponent.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/InjectCompositeComponent.java
@@ -52,6 +52,7 @@ import org.netbeans.modules.parsing.api.indexing.IndexingManager;
 import org.netbeans.modules.parsing.spi.ParseException;
 import org.netbeans.modules.web.api.webmodule.WebModule;
 import org.netbeans.modules.web.common.api.WebUtils;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.Library;
 import org.netbeans.modules.web.jsfapi.spi.LibraryUtils;
 import org.netbeans.spi.editor.codegen.CodeGenerator;
@@ -208,7 +209,7 @@ public class InjectCompositeComponent {
             //but since the library has just been created by adding an xhtml file
             //to the resources/xxx/ folder we need to wait until the files
             //get indexed and the library is created
-            final String compositeLibURL = LibraryUtils.getCompositeLibraryURL(compFolder, jsfs.isJsf22Plus());
+            final String compositeLibURL = LibraryUtils.getCompositeLibraryURL(compFolder, jsfs.getJsfVersion().isAtLeast(JsfVersion.JSF_2_2));
             Source documentSource = Source.create(document);
             ParserManager.parseWhenScanFinished(Collections.singletonList(documentSource), new UserTask() { //NOI18N
                 @Override

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/JsfHtmlExtension.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/JsfHtmlExtension.java
@@ -45,6 +45,7 @@ import org.netbeans.modules.web.jsf.editor.facelets.AbstractFaceletsLibrary;
 import org.netbeans.modules.web.jsf.editor.facelets.CompositeComponentLibrary;
 import org.netbeans.modules.web.jsf.editor.hints.HintsRegistry;
 import org.netbeans.modules.web.jsfapi.api.DefaultLibraryInfo;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.Library;
 import org.netbeans.modules.web.jsfapi.api.LibraryComponent;
 import org.netbeans.modules.web.jsfapi.api.NamespaceUtils;
@@ -199,10 +200,10 @@ public class JsfHtmlExtension extends HtmlExtension {
                 if (declaredPrefix == null) {
                     //undeclared prefix, try to match with default library prefix
                     if (lib.getDefaultPrefix() != null && lib.getDefaultPrefix().startsWith(context.getPrefix())) {
-                        items.addAll(queryLibrary(context, lib, lib.getDefaultPrefix(), true, jsfs.isJsf22Plus()));
+                        items.addAll(queryLibrary(context, lib, lib.getDefaultPrefix(), true, jsfs.getJsfVersion()));
                     }
                 } else {
-                    items.addAll(queryLibrary(context, lib, declaredPrefix, false, jsfs.isJsf22Plus()));
+                    items.addAll(queryLibrary(context, lib, declaredPrefix, false, jsfs.getJsfVersion()));
                 }
             }
         } else {
@@ -215,7 +216,7 @@ public class JsfHtmlExtension extends HtmlExtension {
                 for (Library lib : librariesSet) {
                     if (lib.getDefaultPrefix() != null && lib.getDefaultPrefix().equals(tagNamePrefix)) {
                         //match
-                        items.addAll(queryLibrary(context, lib, tagNamePrefix, true, jsfs.isJsf22Plus()));
+                        items.addAll(queryLibrary(context, lib, tagNamePrefix, true, jsfs.getJsfVersion()));
                     }
                 }
 
@@ -227,7 +228,7 @@ public class JsfHtmlExtension extends HtmlExtension {
                     return Collections.emptyList();
                 } else {
                     //query the library
-                    items.addAll(queryLibrary(context, lib, tagNamePrefix, false, jsfs.isJsf22Plus()));
+                    items.addAll(queryLibrary(context, lib, tagNamePrefix, false, jsfs.getJsfVersion()));
                 }
             }
         }
@@ -253,11 +254,11 @@ public class JsfHtmlExtension extends HtmlExtension {
         return null;
     }
 
-    private Collection<CompletionItem> queryLibrary(CompletionContext context, Library lib, String nsPrefix, boolean undeclared, boolean isJsf22Plus) {
+    private Collection<CompletionItem> queryLibrary(CompletionContext context, Library lib, String nsPrefix, boolean undeclared, JsfVersion jsfVersion) {
         Collection<CompletionItem> items = new ArrayList<>();
         for (LibraryComponent component : lib.getComponents()) {
             if (!(component instanceof AbstractFaceletsLibrary.Function)) {
-                items.add(JsfCompletionItem.createTag(context.getCCItemStartOffset(), component, nsPrefix, undeclared, isJsf22Plus));
+                items.add(JsfCompletionItem.createTag(context.getCCItemStartOffset(), component, nsPrefix, undeclared, jsfVersion));
             }
         }
 
@@ -353,7 +354,7 @@ public class JsfHtmlExtension extends HtmlExtension {
         JsfAttributesCompletionHelper.completeFaceletsFromProject(context, items, ns, openTag);
 
         // completion for sections in cases of ui:define name attribute
-        JsfAttributesCompletionHelper.completeSectionsOfTemplate(context, items, ns, openTag);
+        JsfAttributesCompletionHelper.completeSectionsOfTemplate(context, items, ns, openTag, jsfs.getJsfVersion());
 
         // completion for java classes in <cc:attribute type="com.example.|
         JsfAttributesCompletionHelper.completeJavaClasses(context, items, ns, openTag);

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/JsfSupportImpl.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/JsfSupportImpl.java
@@ -23,6 +23,8 @@ import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.logging.Level;
@@ -40,6 +42,7 @@ import org.netbeans.modules.web.jsf.api.facesmodel.JSFVersion;
 import org.netbeans.modules.web.jsf.editor.facelets.FaceletsLibrarySupport;
 import org.netbeans.modules.web.jsf.editor.index.JsfIndex;
 import org.netbeans.modules.web.jsfapi.api.JsfSupport;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.Library;
 import org.netbeans.modules.web.jsfapi.api.NamespaceUtils;
 import org.netbeans.modules.web.jsfapi.spi.JsfSupportProvider;
@@ -57,6 +60,21 @@ import org.openide.util.lookup.InstanceContent;
 public class JsfSupportImpl implements JsfSupport {
 
 	private static final Logger LOG = Logger.getLogger(JsfSupportImpl.class.getSimpleName());
+
+    private static final Map<JSFVersion, JsfVersion> JSF_VERSION_MAPPING;
+    static {
+        Map<JSFVersion, JsfVersion> map = new HashMap<>();
+        map.put(JSFVersion.JSF_1_0, JsfVersion.JSF_1_0);
+        map.put(JSFVersion.JSF_1_1, JsfVersion.JSF_1_1);
+        map.put(JSFVersion.JSF_1_2, JsfVersion.JSF_1_2);
+        map.put(JSFVersion.JSF_2_0, JsfVersion.JSF_2_0);
+        map.put(JSFVersion.JSF_2_1, JsfVersion.JSF_2_1);
+        map.put(JSFVersion.JSF_2_2, JsfVersion.JSF_2_2);
+        map.put(JSFVersion.JSF_2_3, JsfVersion.JSF_2_3);
+        map.put(JSFVersion.JSF_3_0, JsfVersion.JSF_3_0);
+        map.put(JSFVersion.JSF_4_0, JsfVersion.JSF_4_0);
+        JSF_VERSION_MAPPING = Collections.unmodifiableMap(map);
+    }
 
     public static JsfSupportImpl findFor(Source source) {
         return getOwnImplementation(JsfSupportProvider.get(source));
@@ -265,6 +283,17 @@ public class JsfSupportImpl implements JsfSupport {
     
     public synchronized MetadataModel<org.netbeans.modules.jakarta.web.beans.api.model.WebBeansModel> getJakartaWebBeansModel() {
         return webBeansModelJakarta;
+    }
+
+    @Override
+    public JsfVersion getJsfVersion() {
+        if (wm == null) {
+            return JsfVersion.latest();
+        }
+
+        JSFVersion jsfVersion = JSFVersion.forWebModule(wm);
+
+        return JSF_VERSION_MAPPING.getOrDefault(jsfVersion, JsfVersion.latest());
     }
 
     @Override

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/JsfSupportImpl.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/JsfSupportImpl.java
@@ -189,22 +189,18 @@ public class JsfSupportImpl implements JsfSupport {
             }
         });
 
-        if(isJsf30Plus()){
-            webBeansModelJakarta = new org.netbeans.modules.jakarta.web.beans.MetaModelSupport(project).getMetaModel();
-        } else {
-            webBeansModel = new org.netbeans.modules.web.beans.MetaModelSupport(project).getMetaModel();
-        }
-        
         //init lookup
         //TODO do it lazy so it creates the web beans model lazily once looked up
         InstanceContent ic = new InstanceContent();
-        if(isJsf30Plus()){
+        if(getJsfVersion().isAtLeast(JsfVersion.JSF_3_0)){
+            webBeansModelJakarta = new org.netbeans.modules.jakarta.web.beans.MetaModelSupport(project).getMetaModel();
             ic.add(webBeansModelJakarta);
         } else {
+            webBeansModel = new org.netbeans.modules.web.beans.MetaModelSupport(project).getMetaModel();
             ic.add(webBeansModel);
         }
-        this.lookup = new AbstractLookup(ic);
 
+        this.lookup = new AbstractLookup(ic);
     }
 
     @Override
@@ -294,28 +290,6 @@ public class JsfSupportImpl implements JsfSupport {
         JSFVersion jsfVersion = JSFVersion.forWebModule(wm);
 
         return JSF_VERSION_MAPPING.getOrDefault(jsfVersion, JsfVersion.latest());
-    }
-
-    @Override
-    public boolean isJsf22Plus() {
-        if (wm != null) {
-            JSFVersion version = JSFVersion.forWebModule(wm);
-            // caching is done inside the method
-            return version != null && version.isAtLeast(JSFVersion.JSF_2_2);
-        }
-        // return the latest supported one until somebody will complain about that
-        return true;
-    }
-
-		@Override
-    public boolean isJsf30Plus() {
-        if (wm != null) {
-            JSFVersion version = JSFVersion.forWebModule(wm);
-            // caching is done inside the method
-            return version != null && version.isAtLeast(JSFVersion.JSF_3_0);
-        }
-        // return the latest supported one until somebody will complain about that
-        return true;
     }
 
     @Override

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/JsfUtils.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/JsfUtils.java
@@ -28,6 +28,7 @@ import org.netbeans.modules.parsing.api.ResultIterator;
 import org.netbeans.modules.parsing.api.Snapshot;
 import org.netbeans.modules.parsing.spi.ParseException;
 import org.netbeans.modules.parsing.spi.Parser.Result;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.LibraryInfo;
 
 /**
@@ -99,12 +100,9 @@ public class JsfUtils {
         return null;
     }
 
-    public static Node getRoot(HtmlParserResult parserResult, LibraryInfo library) {
-        Node rootNode = parserResult.root(library.getNamespace());
-        if ((rootNode == null || rootNode.children().isEmpty()) && library.getLegacyNamespace() != null) {
-            rootNode = parserResult.root(library.getLegacyNamespace());
-        }
-        return rootNode;
+    public static Node getRoot(HtmlParserResult parserResult, LibraryInfo library, JsfVersion jsfVersion) {
+        String namespace = jsfVersion.getNamespaceUri(library.getDefaultPrefix());
+        return parserResult.root(namespace);
     }
     
 }

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/actions/FixNamespacesPerformer.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/actions/FixNamespacesPerformer.java
@@ -96,7 +96,7 @@ class FixNamespacesPerformer {
 
     private void includeMissingNamespaces() {
         for (VariantItem variant : selections) {
-            LibraryUtils.importLibrary(baseDocument, variant.getLibrary(), variant.getPrefix(), importData.isJsf22);
+            LibraryUtils.importLibrary(baseDocument, variant.getLibrary(), variant.getPrefix(), importData.jsfVersion);
         }
     }
 }

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/actions/ImportData.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/actions/ImportData.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.netbeans.modules.html.editor.lib.api.elements.Attribute;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.Library;
 
 /**
@@ -31,7 +32,7 @@ import org.netbeans.modules.web.jsfapi.api.Library;
 public class ImportData {
 
     public volatile boolean shouldShowNamespacesPanel;
-    public volatile boolean isJsf22;
+    public volatile JsfVersion jsfVersion;
 
     private final List<DataItem> dataItems = new ArrayList<>();
     private final List<DataItem> dataItemsToReplace = new ArrayList<>();

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/completion/JsfAttributesCompletionHelper.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/completion/JsfAttributesCompletionHelper.java
@@ -78,6 +78,7 @@ import org.netbeans.modules.web.jsf.editor.index.CompositeComponentModel;
 import org.netbeans.modules.web.jsf.editor.index.JsfPageModelFactory;
 import org.netbeans.modules.web.jsfapi.api.Attribute;
 import org.netbeans.modules.web.jsfapi.api.DefaultLibraryInfo;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.Library;
 import org.netbeans.modules.web.jsfapi.api.LibraryComponent;
 import org.netbeans.modules.web.jsfapi.api.NamespaceUtils;
@@ -246,7 +247,7 @@ public class JsfAttributesCompletionHelper {
         }
     }
 
-    public static void completeSectionsOfTemplate(final CompletionContext context, final List<CompletionItem> items, String ns, OpenTag openTag) {
+    public static void completeSectionsOfTemplate(final CompletionContext context, final List<CompletionItem> items, String ns, OpenTag openTag, JsfVersion jsfVersion) {
         // <ui:define name="|" ...
         String tagName = openTag.unqualifiedName().toString();
         String attrName = context.getAttributeName();
@@ -254,7 +255,7 @@ public class JsfAttributesCompletionHelper {
                 && "define".equalsIgnoreCase(tagName) && "name".equalsIgnoreCase(attrName)) { //NOI18N
 
             // get the template path
-            Node root = JsfUtils.getRoot(context.getResult(), DefaultLibraryInfo.FACELETS);
+            Node root = JsfUtils.getRoot(context.getResult(), DefaultLibraryInfo.FACELETS, jsfVersion);
             final String[] template = new String[1];
             ElementUtils.visitChildren(root, new ElementVisitor() {
                 @Override
@@ -283,7 +284,7 @@ public class JsfAttributesCompletionHelper {
                         Parser.Result result = resultIterator.getParserResult(0);
                         if (result.getSnapshot().getMimeType().equals("text/html")) {
                             HtmlParserResult htmlResult = (HtmlParserResult) result;
-                            Node root = JsfUtils.getRoot(htmlResult, DefaultLibraryInfo.FACELETS);
+                            Node root = JsfUtils.getRoot(htmlResult, DefaultLibraryInfo.FACELETS, jsfVersion);
                             if (root != null) {
                                 List<OpenTag> foundNodes = findValue(root.children(OpenTag.class), getPrefixForFaceletsNs(htmlResult) + ":insert", new ArrayList<OpenTag>()); //NOI18N
                                 for (OpenTag node : foundNodes) {

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/completion/JsfAttributesCompletionHelper.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/completion/JsfAttributesCompletionHelper.java
@@ -462,7 +462,7 @@ public class JsfAttributesCompletionHelper {
     public static void completeXMLNSAttribute(CompletionContext context, List<CompletionItem> items, JsfSupportImpl jsfs) {
         if (context.getAttributeName().toLowerCase(Locale.ENGLISH).startsWith("xmlns")) { //NOI18N
             //xml namespace completion for facelets namespaces
-            Set<String> nss = NamespaceUtils.getAvailableNss(jsfs.getLibraries(), jsfs.isJsf22Plus());
+            Set<String> nss = NamespaceUtils.getAvailableNss(jsfs.getLibraries(), jsfs.getJsfVersion().isAtLeast(JsfVersion.JSF_2_2));
 
             //add also xhtml ns to the completion
             nss.add(LibraryUtils.XHTML_NS);

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/completion/JsfCompletionItem.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/completion/JsfCompletionItem.java
@@ -31,6 +31,7 @@ import org.netbeans.modules.html.editor.api.completion.HtmlCompletionItem;
 import org.netbeans.modules.html.editor.lib.api.DefaultHelpItem;
 import org.netbeans.modules.html.editor.lib.api.HelpItem;
 import org.netbeans.modules.web.jsf.editor.facelets.AbstractFaceletsLibrary;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.LibraryComponent;
 import org.netbeans.modules.web.jsfapi.api.Library;
 import org.netbeans.modules.web.jsfapi.spi.LibraryUtils;
@@ -58,8 +59,8 @@ public class JsfCompletionItem {
     private static final Pattern REPLACEMENT_PATTERN = getPattern();
 
     //----------- Factory methods --------------
-    public static JsfTag createTag(int substitutionOffset, LibraryComponent component, String declaredPrefix, boolean autoimport, boolean isJsf22Plus) {
-        return new JsfTag(substitutionOffset, component, declaredPrefix, autoimport, isJsf22Plus);
+    public static JsfTag createTag(int substitutionOffset, LibraryComponent component, String declaredPrefix, boolean autoimport, JsfVersion jsfVersion) {
+        return new JsfTag(substitutionOffset, component, declaredPrefix, autoimport, jsfVersion);
     }
 
     public static JsfTagAttribute createAttribute(String name, int substitutionOffset, Library library, org.netbeans.modules.web.jsfapi.api.Tag tag, org.netbeans.modules.web.jsfapi.api.Attribute attr) {
@@ -109,13 +110,13 @@ public class JsfCompletionItem {
         
         private LibraryComponent component;
         private boolean autoimport; //autoimport (declare) the tag namespace if set to true
-        private boolean isJsf22Plus;
+        private JsfVersion jsfVersion;
 
-        public JsfTag(int substitutionOffset, LibraryComponent component, String declaredPrefix, boolean autoimport, boolean isJsf22Plus) {
+        public JsfTag(int substitutionOffset, LibraryComponent component, String declaredPrefix, boolean autoimport, JsfVersion jsfVersion) {
             super(generateItemText(component, declaredPrefix), substitutionOffset, null, true);
             this.component = component;
             this.autoimport = autoimport;
-            this.isJsf22Plus = isJsf22Plus;
+            this.jsfVersion = jsfVersion;
         }
 
         private static String generateItemText(LibraryComponent component, String declaredPrefix) {
@@ -139,7 +140,7 @@ public class JsfCompletionItem {
         private void autoimportLibrary(JTextComponent component) {
             final BaseDocument doc = (BaseDocument) component.getDocument();
             Library lib = JsfTag.this.component.getLibrary();
-            LibraryUtils.importLibrary(doc, lib, null, isJsf22Plus);
+            LibraryUtils.importLibrary(doc, lib, null, jsfVersion);
         }
 
         //use bold font

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/JsfVariablesModel.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/JsfVariablesModel.java
@@ -32,6 +32,7 @@ import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
 import org.netbeans.modules.html.editor.lib.api.elements.*;
 import org.netbeans.modules.parsing.api.Snapshot;
 import org.netbeans.modules.web.jsf.editor.JsfSupportImpl;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.Library;
 import org.netbeans.modules.web.jsfapi.api.LibraryComponent;
 import org.netbeans.modules.web.jsfapi.api.NamespaceUtils;
@@ -93,7 +94,7 @@ public class JsfVariablesModel {
         if(sup == null) {
             return ;
         }
-        Set<String> faceletsLibsNamespaces = NamespaceUtils.getAvailableNss(sup.getLibraries(), sup.isJsf22Plus());
+        Set<String> faceletsLibsNamespaces = NamespaceUtils.getAvailableNss(sup.getLibraries(), sup.getJsfVersion().isAtLeast(JsfVersion.JSF_2_2));
         Collection<String> declaredNamespaces = result.getNamespaces().keySet();
 
         for (String namespace : declaredNamespaces) {

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/WebBeansELVariableResolver.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/WebBeansELVariableResolver.java
@@ -26,13 +26,13 @@ import java.util.List;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import org.netbeans.modules.j2ee.metadata.model.api.MetadataModel;
-import org.netbeans.modules.j2ee.metadata.model.api.MetadataModelAction;
 import org.netbeans.modules.j2ee.metadata.model.api.MetadataModelException;
 import org.netbeans.modules.parsing.api.Snapshot;
 import org.netbeans.modules.web.beans.api.model.WebBeansModel;
 import org.netbeans.modules.web.el.spi.ELVariableResolver;
 import org.netbeans.modules.web.el.spi.ResolverContext;
 import org.netbeans.modules.web.jsf.editor.JsfSupportImpl;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
 import org.openide.util.lookup.ServiceProvider;
@@ -101,7 +101,7 @@ public final class WebBeansELVariableResolver implements ELVariableResolver {
             return Collections.<WebBean>emptyList();
         } else {
             if (context.getContent(CONTENT_NAME) == null) {
-                if(jsfSupport.isJsf30Plus()){
+                if(jsfSupport.getJsfVersion().isAtLeast(JsfVersion.JSF_3_0)){
                     context.setContent(CONTENT_NAME, getJakartaNamedBeans(jsfSupport.getJakartaWebBeansModel()));
                 } else {
                     context.setContent(CONTENT_NAME, getNamedBeans(jsfSupport.getWebBeansModel()));

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/facelets/CompositeComponentLibrary.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/facelets/CompositeComponentLibrary.java
@@ -31,6 +31,7 @@ import javax.swing.event.ChangeListener;
 import org.netbeans.modules.web.jsf.editor.index.CompositeComponentModel;
 import org.netbeans.modules.web.jsf.editor.index.JsfIndex;
 import org.netbeans.modules.web.jsfapi.api.Attribute;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.LibraryType;
 import org.netbeans.modules.web.jsfapi.api.Tag;
 import org.netbeans.modules.web.jsfapi.spi.LibraryUtils;
@@ -89,7 +90,7 @@ public class CompositeComponentLibrary extends FaceletsLibrary {
 
     @Override
     public String getDefaultNamespace() {
-        return LibraryUtils.getCompositeLibraryURL(getLibraryName(), support.getJsfSupport().isJsf22Plus());
+        return LibraryUtils.getCompositeLibraryURL(getLibraryName(), support.getJsfSupport().getJsfVersion().isAtLeast(JsfVersion.JSF_2_2));
     }
 
     @Override

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/hints/FixLibDeclaration.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/hints/FixLibDeclaration.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.web.jsf.editor.hints;
 
 import javax.swing.text.Document;
 import org.netbeans.modules.csl.api.HintFix;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.Library;
 import org.netbeans.modules.web.jsfapi.spi.LibraryUtils;
 import org.openide.util.NbBundle;
@@ -34,19 +35,19 @@ public class FixLibDeclaration implements HintFix{
     private final String nsPrefix;
     private final Library lib;
     private final Document doc;
-    private final boolean isJsf22Plus;
+    private final JsfVersion jsfVersion;
 
-    public FixLibDeclaration(Document doc, String nsPrefix, Library lib, boolean isJsf22Plus) {
+    public FixLibDeclaration(Document doc, String nsPrefix, Library lib, JsfVersion jsfVersion) {
         this.doc = doc;
         this.nsPrefix = nsPrefix;
         this.lib = lib;
-        this.isJsf22Plus = isJsf22Plus;
+        this.jsfVersion = jsfVersion;
     }
 
     @Override
     public String getDescription() {
         String namespace;
-        if (isJsf22Plus || lib.getLegacyNamespace() == null) {
+        if (jsfVersion.isAtLeast(JsfVersion.JSF_2_2) || lib.getLegacyNamespace() == null) {
             namespace = lib.getNamespace();
         } else {
             namespace = lib.getLegacyNamespace();
@@ -56,7 +57,7 @@ public class FixLibDeclaration implements HintFix{
 
     @Override
     public void implement() throws Exception {
-        LibraryUtils.importLibrary(doc, lib, nsPrefix, isJsf22Plus);
+        LibraryUtils.importLibrary(doc, lib, nsPrefix, jsfVersion);
     }
 
     @Override

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/hints/LibraryDeclarationChecker.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/hints/LibraryDeclarationChecker.java
@@ -175,7 +175,7 @@ public class LibraryDeclarationChecker extends HintsProvider {
                     List<HintFix> fixes = new ArrayList<>();
                     Set<Library> libs = getLibsByPrefixes(context, getUndeclaredNamespaces(undeclaredNodes));
                     for (Library lib : libs) {
-                        FixLibDeclaration fix = new FixLibDeclaration(context.doc, lib.getDefaultPrefix(), lib, jsfSupport.isJsf22Plus());
+                        FixLibDeclaration fix = new FixLibDeclaration(context.doc, lib.getDefaultPrefix(), lib, jsfSupport.getJsfVersion());
                         fixes.add(fix);
                     }
 

--- a/enterprise/web.jsf.editor/test/unit/src/org/netbeans/modules/web/jsf/editor/facelets/FaceletsLibrarySupportTest.java
+++ b/enterprise/web.jsf.editor/test/unit/src/org/netbeans/modules/web/jsf/editor/facelets/FaceletsLibrarySupportTest.java
@@ -23,6 +23,10 @@ import java.util.Map;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.assertTrue;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.netbeans.modules.web.jsf.editor.JsfSupportImpl;
@@ -31,6 +35,7 @@ import org.netbeans.modules.web.jsf.editor.index.JsfCustomIndexer;
 import org.netbeans.modules.web.jsfapi.api.Attribute;
 import org.netbeans.modules.web.jsfapi.api.Function;
 import org.netbeans.modules.web.jsfapi.api.JsfSupport;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.Library;
 import org.netbeans.modules.web.jsfapi.api.LibraryComponent;
 import org.netbeans.modules.web.jsfapi.api.LibraryType;
@@ -66,7 +71,7 @@ public class FaceletsLibrarySupportTest extends TestBaseForTestProject {
     public void testCompositeComponentLibraryWithoutDescriptor() {
         JsfSupportImpl instance = getJsfSupportImpl();
 
-        String ezCompLibraryNS = LibraryUtils.getCompositeLibraryURL("ezcomp", instance.isJsf22Plus());
+        String ezCompLibraryNS = LibraryUtils.getCompositeLibraryURL("ezcomp", instance.getJsfVersion().isAtLeast(JsfVersion.JSF_2_2));
 
         Library ezcompLib = instance.getLibrary(ezCompLibraryNS);
         assertNotNull(String.format("Library %s not found!", ezCompLibraryNS), ezcompLib);
@@ -115,7 +120,7 @@ public class FaceletsLibrarySupportTest extends TestBaseForTestProject {
         assertEquals("ezcomp2", ezcompLib.getDefaultPrefix());
         assertSame(LibraryType.COMPOSITE, ezcompLib.getType());
 
-        String ezCompLibraryDefaultNS = LibraryUtils.getCompositeLibraryURL("ezcomp2", instance.isJsf22Plus());
+        String ezCompLibraryDefaultNS = LibraryUtils.getCompositeLibraryURL("ezcomp2", instance.getJsfVersion().isAtLeast(JsfVersion.JSF_2_2));
         assertEquals(ezCompLibraryDefaultNS, ezcompLib.getDefaultNamespace());
         assertEquals(ezCompLibraryNS, ezcompLib.getNamespace());
         Tag t = cclib.getLibraryDescriptor().getTags().get("test");
@@ -201,7 +206,7 @@ public class FaceletsLibrarySupportTest extends TestBaseForTestProject {
 
 //        debugLibraries(instance);
 
-        String libNs = LibraryUtils.getCompositeLibraryURL("cclib", instance.isJsf22Plus());
+        String libNs = LibraryUtils.getCompositeLibraryURL("cclib", instance.getJsfVersion().isAtLeast(JsfVersion.JSF_2_2));
 
         Library lib = instance.getLibrary(libNs);
         assertNotNull(String.format("Library %s not found!", libNs), lib);
@@ -240,7 +245,7 @@ public class FaceletsLibrarySupportTest extends TestBaseForTestProject {
         assertEquals("cclib2", lib.getDefaultPrefix());
         assertSame(LibraryType.COMPOSITE, lib.getType());
 
-        String ezCompLibraryDefaultNS = LibraryUtils.getCompositeLibraryURL("cclib2", instance.isJsf22Plus());
+        String ezCompLibraryDefaultNS = LibraryUtils.getCompositeLibraryURL("cclib2", instance.getJsfVersion().isAtLeast(JsfVersion.JSF_2_2));
         assertEquals(ezCompLibraryDefaultNS, lib.getDefaultNamespace());
         assertEquals(libNs, lib.getNamespace());
         Tag t = cclib.getLibraryDescriptor().getTags().get("cc2");

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/facesmodel/JSFVersion.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/facesmodel/JSFVersion.java
@@ -127,7 +127,7 @@ public enum JSFVersion {
             }, compileCP);
             compileCP.addPropertyChangeListener(listener);
             projectListenerCache.put(webModule, listener);
-            projectVersionCache.put(webModule, get(webModule, true));
+            projectVersionCache.put(webModule, version);
         }
         return version;
     }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/facelets/resources/templates/simpleFacelets.template
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/facelets/resources/templates/simpleFacelets.template
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<#if isJSF22?? || isJSF30??>
+<#if isJSF40??>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html">
+<#elseif isJSF22?? || isJSF30??>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html">
 <#elseif isJSF20??>
@@ -9,7 +12,7 @@
 <#else>
 <html xmlns="http://www.w3.org/1999/xhtml">
 </#if>
-<#if isJSF20?? || isJSF22?? || isJSF30??>
+<#if isJSF20?? || isJSF22?? || isJSF30?? || isJSF40??>
     <h:head>
         <title>Facelet Title</title>
     </h:head>

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/JsfLibrariesSupport.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/JsfLibrariesSupport.java
@@ -142,14 +142,6 @@ public class JsfLibrariesSupport {
         return limport.declaredPrefix != null ? limport.declaredPrefix : limport.lib.getDefaultPrefix();
     }
 
-    public boolean isJsf22Plus() {
-        return jsfs.isJsf22Plus();
-    }
-
-    public boolean isJsf30Plus() {
-        return jsfs.isJsf30Plus();
-    }
-
     private static class LibraryImport {
         public Library lib;
         public String declaredPrefix;

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/JsfLibrariesSupport.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/JsfLibrariesSupport.java
@@ -130,7 +130,7 @@ public class JsfLibrariesSupport {
                 toimport.put(limport.lib, null); //lets use the default prefix
             }
         }
-        LibraryUtils.importLibrary(tc.getDocument(), toimport, jsfs.isJsf22Plus());
+        LibraryUtils.importLibrary(tc.getDocument(), toimport, jsfs.getJsfVersion());
     }
 
     /** @return the library default prefix in the case it hasn't been declared yet or the declared prefix */

--- a/enterprise/web.jsfapi/nbproject/org-netbeans-modules-web-jsfapi.sig
+++ b/enterprise/web.jsfapi/nbproject/org-netbeans-modules-web-jsfapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.54
+#Version 1.55
 
 CLSS public abstract interface java.io.Serializable
 
@@ -122,13 +122,20 @@ meth public abstract java.lang.String getDescription()
 meth public abstract java.lang.String getName()
 meth public abstract java.lang.String getSignature()
 
+CLSS public final org.netbeans.modules.web.jsfapi.api.JsfNamespaces
+supr java.lang.Object
+hfds JAKARTA,JAVA_SUN_COM,XMLNS_JCP_ORG
+
 CLSS public abstract interface org.netbeans.modules.web.jsfapi.api.JsfSupport
 meth public abstract boolean isJsf22Plus()
+ anno 0 java.lang.Deprecated()
 meth public abstract boolean isJsf30Plus()
+ anno 0 java.lang.Deprecated()
 meth public abstract java.util.Map<java.lang.String,? extends org.netbeans.modules.web.jsfapi.api.Library> getLibraries()
 meth public abstract org.netbeans.api.java.classpath.ClassPath getClassPath()
 meth public abstract org.netbeans.api.project.Project getProject()
 meth public abstract org.netbeans.modules.web.api.webmodule.WebModule getWebModule()
+meth public abstract org.netbeans.modules.web.jsfapi.api.JsfVersion getJsfVersion()
 meth public abstract org.netbeans.modules.web.jsfapi.api.Library getLibrary(java.lang.String)
 meth public abstract org.openide.util.Lookup getLookup()
 
@@ -137,6 +144,23 @@ cons public init()
 fld public final static java.lang.String JSF_XHTML_FILE_MIMETYPE = "text/facelets"
 meth public static boolean isFaceletsFile(org.openide.filesystems.FileObject)
 supr java.lang.Object
+
+CLSS public final !enum org.netbeans.modules.web.jsfapi.api.JsfVersion
+fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_1_0
+fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_1_1
+fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_1_2
+fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_2_0
+fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_2_1
+fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_2_2
+fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_2_3
+fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_3_0
+fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_4_0
+meth public java.lang.String getNamespaceUri(java.lang.String)
+meth public static org.netbeans.modules.web.jsfapi.api.JsfVersion latest()
+meth public static org.netbeans.modules.web.jsfapi.api.JsfVersion valueOf(java.lang.String)
+meth public static org.netbeans.modules.web.jsfapi.api.JsfVersion[] values()
+supr java.lang.Enum<org.netbeans.modules.web.jsfapi.api.JsfVersion>
+hfds prefixUriMapping,version
 
 CLSS public abstract interface org.netbeans.modules.web.jsfapi.api.Library
 intf org.netbeans.modules.web.jsfapi.api.LibraryInfo
@@ -234,7 +258,7 @@ cons public init()
 fld public final static java.lang.String COMPOSITE_LIBRARY_LEGACY_NS = "http://java.sun.com/jsf/composite"
 fld public final static java.lang.String COMPOSITE_LIBRARY_NS = "http://xmlns.jcp.org/jsf/composite"
 fld public final static java.lang.String XHTML_NS = "http://www.w3.org/1999/xhtml"
-meth public static boolean importLibrary(javax.swing.text.Document,org.netbeans.modules.web.jsfapi.api.Library,java.lang.String,boolean)
+meth public static boolean importLibrary(javax.swing.text.Document,org.netbeans.modules.web.jsfapi.api.Library,java.lang.String,org.netbeans.modules.web.jsfapi.api.JsfVersion)
 meth public static boolean isCompositeComponentLibrary(org.netbeans.modules.web.jsfapi.api.Library)
  anno 0 java.lang.Deprecated()
 meth public static java.lang.String generateDefaultPrefix(java.lang.String)
@@ -242,7 +266,7 @@ meth public static java.lang.String generateDefaultPrefix(java.lang.String)
  anno 1 org.netbeans.api.annotations.common.NonNull()
 meth public static java.lang.String getCompositeLibraryURL(java.lang.String,boolean)
 meth public static java.util.Map<java.lang.String,org.netbeans.modules.web.jsfapi.api.Library> getDeclaredLibraries(org.netbeans.modules.html.editor.lib.api.HtmlParsingResult)
-meth public static java.util.Map<org.netbeans.modules.web.jsfapi.api.Library,java.lang.String> importLibrary(javax.swing.text.Document,java.util.Map<org.netbeans.modules.web.jsfapi.api.Library,java.lang.String>,boolean)
+meth public static java.util.Map<org.netbeans.modules.web.jsfapi.api.Library,java.lang.String> importLibrary(javax.swing.text.Document,java.util.Map<org.netbeans.modules.web.jsfapi.api.Library,java.lang.String>,org.netbeans.modules.web.jsfapi.api.JsfVersion)
 meth public static org.netbeans.api.project.Project[] getOpenedJSFProjects()
 supr java.lang.Object
 

--- a/enterprise/web.jsfapi/nbproject/org-netbeans-modules-web-jsfapi.sig
+++ b/enterprise/web.jsfapi/nbproject/org-netbeans-modules-web-jsfapi.sig
@@ -127,10 +127,6 @@ supr java.lang.Object
 hfds JAKARTA,JAVA_SUN_COM,XMLNS_JCP_ORG
 
 CLSS public abstract interface org.netbeans.modules.web.jsfapi.api.JsfSupport
-meth public abstract boolean isJsf22Plus()
- anno 0 java.lang.Deprecated()
-meth public abstract boolean isJsf30Plus()
- anno 0 java.lang.Deprecated()
 meth public abstract java.util.Map<java.lang.String,? extends org.netbeans.modules.web.jsfapi.api.Library> getLibraries()
 meth public abstract org.netbeans.api.java.classpath.ClassPath getClassPath()
 meth public abstract org.netbeans.api.project.Project getProject()
@@ -155,7 +151,9 @@ fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_2_2
 fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_2_3
 fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_3_0
 fld public final static org.netbeans.modules.web.jsfapi.api.JsfVersion JSF_4_0
+meth public boolean isAtLeast(org.netbeans.modules.web.jsfapi.api.JsfVersion)
 meth public java.lang.String getNamespaceUri(java.lang.String)
+meth public java.lang.String getVersion()
 meth public static org.netbeans.modules.web.jsfapi.api.JsfVersion latest()
 meth public static org.netbeans.modules.web.jsfapi.api.JsfVersion valueOf(java.lang.String)
 meth public static org.netbeans.modules.web.jsfapi.api.JsfVersion[] values()

--- a/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/JsfNamespaces.java
+++ b/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/JsfNamespaces.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.web.jsfapi.api;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ * @author Benjamin Asbach
+ */
+public final class JsfNamespaces {
+
+    private JsfNamespaces() {
+    }
+
+    static final Map<String, String> JAVA_SUN_COM;
+    static {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("c", "http://java.sun.com/jsp/jstl/core");
+        map.put("cc", "http://java.sun.com/jsf/composite");
+        map.put("f", "http://java.sun.com/jsf/core");
+        map.put("h", "http://java.sun.com/jsf/html");
+        map.put("ui", "http://java.sun.com/jsf/facelets");
+        map.put("mdjnm", "http://mojarra.dev.java.net/mojarra_ext");
+        JAVA_SUN_COM = Collections.unmodifiableMap(map);
+    }
+
+    static final Map<String, String> XMLNS_JCP_ORG;
+    static {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("c", "http://xmlns.jcp.org/jsp/jstl/core");
+        map.put("cc", "http://xmlns.jcp.org/jsf/composite");
+        map.put("f", "http://xmlns.jcp.org/jsf/core");
+        map.put("h", "http://xmlns.jcp.org/jsf/html");
+        map.put("ui", "http://xmlns.jcp.org/jsf/facelets");
+        map.put("mdjnm", "http://mojarra.dev.java.net/mojarra_ext");
+        XMLNS_JCP_ORG = Collections.unmodifiableMap(map);
+    }
+
+    static final Map<String, String> JAKARTA;
+    static {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("c", "jakarta.tags.core");
+        map.put("cc", "jakarta.faces.composite");
+        map.put("f", "jakarta.faces.core");
+        map.put("h", "jakarta.faces.html");
+        map.put("ui", "jakarta.faces.facelets");
+        map.put("mdjnm", "http://mojarra.dev.java.net/mojarra_ext");
+        JAKARTA = Collections.unmodifiableMap(map);
+    }
+}

--- a/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/JsfSupport.java
+++ b/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/JsfSupport.java
@@ -46,7 +46,20 @@ public interface JsfSupport {
 
     public Lookup getLookup();
 
+    public JsfVersion getJsfVersion();
+
+    /**
+     *
+     * @return
+     * @deprecated use {@link JsfSupport#getJsfVersion()}
+     */
+    @Deprecated
     public boolean isJsf22Plus();
 
+    /**
+     *
+     * @return @deprecated use {@link JsfSupport#getJsfVersion()}
+     */
+    @Deprecated
     public boolean isJsf30Plus();
 }

--- a/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/JsfSupport.java
+++ b/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/JsfSupport.java
@@ -47,19 +47,4 @@ public interface JsfSupport {
     public Lookup getLookup();
 
     public JsfVersion getJsfVersion();
-
-    /**
-     *
-     * @return
-     * @deprecated use {@link JsfSupport#getJsfVersion()}
-     */
-    @Deprecated
-    public boolean isJsf22Plus();
-
-    /**
-     *
-     * @return @deprecated use {@link JsfSupport#getJsfVersion()}
-     */
-    @Deprecated
-    public boolean isJsf30Plus();
 }

--- a/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/JsfVersion.java
+++ b/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/JsfVersion.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.web.jsfapi.api;
+
+import java.util.Map;
+
+/**
+ * Enum which represents the JSF version and with the corresponding mapping of
+ * default xhtml namespace prefix and urn.
+ *
+ * @author Benjamin Asbach
+ */
+public enum JsfVersion {
+
+    JSF_1_0("1.0", JsfNamespaces.JAVA_SUN_COM),
+    JSF_1_1("1.1", JsfNamespaces.JAVA_SUN_COM),
+    JSF_1_2("1.2", JsfNamespaces.JAVA_SUN_COM),
+    JSF_2_0("2.0", JsfNamespaces.JAVA_SUN_COM),
+    JSF_2_1("2.1", JsfNamespaces.JAVA_SUN_COM),
+    JSF_2_2("2.2", JsfNamespaces.XMLNS_JCP_ORG),
+    JSF_2_3("2.3", JsfNamespaces.XMLNS_JCP_ORG),
+    JSF_3_0("3.0", JsfNamespaces.XMLNS_JCP_ORG),
+    JSF_4_0("4.0", JsfNamespaces.JAKARTA);
+
+    private final String version;
+
+    private final Map<String, String> prefixUriMapping;
+
+    private JsfVersion(String version, Map<String, String> prefixUriMapping) {
+        this.version = version;
+        this.prefixUriMapping = prefixUriMapping;
+    }
+
+    public static JsfVersion latest() {
+        return JsfVersion.values()[JsfVersion.values().length - 1];
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getNamespaceUri(String prefix) {
+        return prefixUriMapping.get(prefix);
+    }
+
+    public boolean isAtLeast(JsfVersion jsfVersion) {
+        return this.ordinal() >= jsfVersion.ordinal();
+    }
+}

--- a/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/NamespaceUtils.java
+++ b/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/NamespaceUtils.java
@@ -39,7 +39,7 @@ public final class NamespaceUtils {
     public static final String SUN_COM_LOCATION = "http://java.sun.com";  //NOI18N
 
     /** Mapping of the new namespace to the legacy one. */
-    public static final Map<String, String> NS_MAPPING = new HashMap<String, String>(8);
+    public static final Map<String, String> NS_MAPPING = new HashMap<String, String>(16);
 
     static {
         NS_MAPPING.put("http://xmlns.jcp.org/jsf/html", "http://java.sun.com/jsf/html");                     //NOI18N
@@ -50,6 +50,15 @@ public final class NamespaceUtils {
         NS_MAPPING.put("http://xmlns.jcp.org/jsf/composite", "http://java.sun.com/jsf/composite");           //NOI18N
         NS_MAPPING.put("http://xmlns.jcp.org/jsf", "http://java.sun.com/jsf");                               //NOI18N
         NS_MAPPING.put("http://xmlns.jcp.org/jsf/passthrough", "http://java.sun.com/jsf/passthrough");       //NOI18N
+
+        NS_MAPPING.put("jakarta.faces.html", "http://java.sun.com/jsf/html");               //NOI18N
+        NS_MAPPING.put("jakarta.faces.core", "http://java.sun.com/jsf/core");               //NOI18N
+        NS_MAPPING.put("jakarta.tags.core", "http://java.sun.com/jsp/jstl/core");           //NOI18N
+        NS_MAPPING.put("jakarta.tags.functions", "http://java.sun.com/jsp/jstl/functions"); //NOI18N
+        NS_MAPPING.put("jakarta.faces.facelets", "http://java.sun.com/jsf/facelets");       //NOI18N
+        NS_MAPPING.put("jakarta.faces.composite", "http://java.sun.com/jsf/composite");     //NOI18N
+        NS_MAPPING.put("jakarta.faces", "http://java.sun.com/jsf");                         //NOI18N
+        NS_MAPPING.put("jakarta.faces.passthrough", "http://java.sun.com/jsf/passthrough"); //NOI18N
     }
 
     /**

--- a/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/spi/LibraryUtils.java
+++ b/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/spi/LibraryUtils.java
@@ -44,6 +44,7 @@ import org.netbeans.modules.parsing.spi.ParseException;
 import org.netbeans.modules.parsing.spi.Parser;
 import org.netbeans.modules.web.common.api.WebUtils;
 import org.netbeans.modules.web.jsfapi.api.JsfSupport;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.modules.web.jsfapi.api.Library;
 import org.netbeans.modules.web.jsfapi.api.LibraryType;
 import org.netbeans.modules.web.jsfapi.api.NamespaceUtils;
@@ -71,8 +72,8 @@ public class LibraryUtils {
         return library.getType() == LibraryType.COMPOSITE;
     }
 
-    public static boolean importLibrary(Document document, Library library, String prefix, boolean isJsf22Plus) {
-        return !importLibrary(document, Collections.singletonMap(library, prefix), isJsf22Plus).isEmpty();
+    public static boolean importLibrary(Document document, Library library, String prefix, JsfVersion jsfVersion) {
+        return !importLibrary(document, Collections.singletonMap(library, prefix), jsfVersion).isEmpty();
     }
 
     /**
@@ -84,7 +85,7 @@ public class LibraryUtils {
      *
      * @return a map of library2declared prefixes which contains just the imported pairs
      */
-    public static Map<Library, String> importLibrary(Document document, Map<Library, String> libraries2prefixes, final boolean isJsf22Plus) {
+    public static Map<Library, String> importLibrary(Document document, Map<Library, String> libraries2prefixes, JsfVersion jsfVersion) {
         assert document instanceof BaseDocument;
 
         final Map<Library, String> imports = new LinkedHashMap<Library, String>(libraries2prefixes);
@@ -226,8 +227,7 @@ public class LibraryUtils {
                                 String prefixToDeclare = imports.get(library);
                                 int insertPosition = originalInsertPosition + offset_shift;
 
-                                String namespace = isJsf22Plus || library.getLegacyNamespace() == null ?
-                                        library.getNamespace() : library.getLegacyNamespace();
+                                String namespace = jsfVersion.getNamespaceUri(prefixToDeclare);
                                 String text = (!noAttributes ? "\n" : "") + " xmlns:" + prefixToDeclare + //NOI18N
                                         "=\"" + namespace + "\""; //NOI18N
 


### PR DESCRIPTION
Since Jakarte EE Faces 4 the xmls namespaces were changed from `http://xmlns.jcp.org/jsf` to `jakarta.*`. (see https://github.com/jakartaee/faces/issues/1553)
    
This change adds new namespace support for:
    * Generation of new JSF pages
    * Tag suggestion in faces xhtml editor view
    * Automatic addition of missing namespace declaration when new taglib is used
    
In order to support the JSF 4.0 namespaces the `enum` `JsfVersion` in `web.jsfapi` module was introduced. It's used to map the taglib namespaces based on the projects detected JSF version.
    
Note: There's already an enum `JSFVersion` which is not part of the api. Both enums might be merged in the future.
    
Reference: #6069