### PR TITLE
shell env. variable cannot contain dot

### DIFF
--- a/java/java.lsp.server/vscode/src/nbcode.ts
+++ b/java/java.lsp.server/vscode/src/nbcode.ts
@@ -75,7 +75,7 @@ export function launch(
     }
     ideArgs.push(...extraArgs);
     
-    if (env['netbeans.debug'] && extraArgs && extraArgs.find(s => s.includes("--list"))) {
+    if (env['netbeans_debug'] && extraArgs && extraArgs.find(s => s.includes("--list"))) {
         ideArgs.push(...['-J-Xdebug', '-J-Dnetbeans.logger.console=true', '-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000']);
     }
 


### PR DESCRIPTION
Shell environment variable cannot contain dot. Shells map environment variables to shell variables and in most shells, variable names are limited to ASCII alphanumerical characters and _ where the first character can't be a digit.
Dot was replaced by underscode.
