### PR TITLE
Add Oracle Autonomous DB - Select Compartment

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/AddADBAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/AddADBAction.java
@@ -18,7 +18,12 @@
  */
 package org.netbeans.modules.cloud.oracle.actions;
 
+import com.oracle.bmc.identity.Identity;
+import com.oracle.bmc.identity.IdentityClient;
+import com.oracle.bmc.identity.model.Compartment;
 import com.oracle.bmc.identity.model.Tenancy;
+import com.oracle.bmc.identity.requests.ListCompartmentsRequest;
+import com.oracle.bmc.identity.responses.ListCompartmentsResponse;
 import com.oracle.bmc.model.BmcException;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -28,17 +33,19 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.netbeans.api.progress.ProgressHandle;
 import org.netbeans.modules.cloud.oracle.OCIManager;
 import org.netbeans.modules.cloud.oracle.OCIProfile;
+import org.netbeans.modules.cloud.oracle.OCISessionInitiator;
 import org.netbeans.modules.cloud.oracle.actions.DownloadWalletDialog.WalletInfo;
 import org.netbeans.modules.cloud.oracle.compartment.CompartmentItem;
-import org.netbeans.modules.cloud.oracle.compartment.CompartmentNode;
 import org.netbeans.modules.cloud.oracle.database.DatabaseItem;
 import org.netbeans.modules.cloud.oracle.database.DatabaseNode;
+import org.netbeans.modules.cloud.oracle.items.OCID;
 import org.netbeans.modules.cloud.oracle.items.OCIItem;
 import org.netbeans.modules.cloud.oracle.items.TenancyItem;
 import org.openide.DialogDescriptor;
@@ -119,9 +126,16 @@ public class AddADBAction implements ActionListener {
                     }
                     String title;
                     if (profiles.size() == 1) {
-                        values.put(1, getCompartmentsAndDbs(profiles.keySet().iterator().next().getTenancy().get()));
-                        title = Bundle.SelectCompartment();
-                        return createQuickPick(values.get(1), title);
+                        h = ProgressHandle.createHandle(Bundle.MSG_CollectingItems());
+                        h.start();
+                        h.progress(Bundle.MSG_CollectingItems_Text());
+                        try {
+                            values.put(1, getFlatCompartment(profiles.keySet().iterator().next().getTenancy().get()));
+                            title = Bundle.SelectCompartment();
+                            return createQuickPick(values.get(1), title);
+                        } finally {
+                            h.finish();
+                        }
                     } else {
                         title = Bundle.SelectProfile();
                         List<Item> items = new ArrayList<>(profiles.size());
@@ -153,7 +167,11 @@ public class AddADBAction implements ActionListener {
                         h.start();
                         h.progress(Bundle.MSG_CollectingItems_Text());
                         try {
-                            values.put(number, getCompartmentsAndDbs(prevItem));
+                            if (prevItem instanceof TenancyItem) {
+                                values.put(number, getFlatCompartment((TenancyItem) prevItem));
+                            } else {
+                                values.put(number, getDbs(prevItem));
+                            }
                             input.setEstimatedNumberOfInputs(input.getEstimatedNumberOfInputs() + 1);
                             return createQuickPick(values.get(number), Bundle.SelectDatabase());
                         } finally {
@@ -194,13 +212,80 @@ public class AddADBAction implements ActionListener {
     
     private <T extends OCIItem> NotifyDescriptor.QuickPick createQuickPick(Map<String, T> ociItems, String title) {
         
-        List<Item> items = ociItems.values().stream()
-                .map(tenancy -> new Item(tenancy.getName(), tenancy.getDescription()))
+        List<Item> items = ociItems.entrySet().stream()
+                .map(entry -> new Item(entry.getKey(), entry.getValue().getDescription()))
                 .collect(Collectors.toList());
         return new NotifyDescriptor.QuickPick(title, title, items, false);
     }
     
-    private Map<String, OCIItem> getCompartmentsAndDbs(OCIItem parent) {
+    private Map<String, OCIItem> getFlatCompartment(TenancyItem tenancy) {
+        Map<OCID, FlatCompartmentItem> compartments = new HashMap<>();
+        OCISessionInitiator session = OCIManager.getDefault().getActiveSession();
+        Identity identityClient = session.newClient(IdentityClient.class);
+        String nextPageToken = null;
+
+        do {
+            ListCompartmentsResponse response
+                    = identityClient.listCompartments(
+                            ListCompartmentsRequest.builder()
+                                    .compartmentId(tenancy.getKey().getValue())
+                                    .compartmentIdInSubtree(true)
+                                    .lifecycleState(Compartment.LifecycleState.Active)
+                                    .accessLevel(ListCompartmentsRequest.AccessLevel.Accessible)
+                                    .limit(1000)
+                                    .page(nextPageToken)
+                                    .build());
+            for (Compartment comp : response.getItems()) {
+                FlatCompartmentItem ci = new FlatCompartmentItem(comp) {
+                    FlatCompartmentItem getItem(OCID compId) {
+                        return compartments.get(compId);
+                    }
+                };
+                compartments.put(ci.getKey(), ci);
+            }
+            nextPageToken = response.getOpcNextPage();
+        } while (nextPageToken != null);
+        Map<String, OCIItem> pickItems = computeFlatNames(compartments);
+        pickItems.put(tenancy.getName()+" (root)", tenancy);        // NOI18N
+        return pickItems;
+    }
+
+    private Map<String, OCIItem> computeFlatNames(Map<OCID, FlatCompartmentItem> compartments) {
+        Map<String, OCIItem> pickItems = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (FlatCompartmentItem comp : compartments.values()) {
+            pickItems.put(comp.getName(), comp);
+        }
+        return pickItems;
+    }
+
+    private abstract class FlatCompartmentItem extends CompartmentItem {
+        private final OCID parentId;
+        private String flatName;
+
+        private FlatCompartmentItem(Compartment ociComp) {
+            super(OCID.of(ociComp.getId(), "Compartment"), ociComp.getName());      // NOI18N
+            setDescription(ociComp.getDescription());
+            parentId = OCID.of(ociComp.getCompartmentId(), "Compartment");          // NOI18N
+        }
+
+        public String getName() {
+            if (parentId.getValue() == null) {
+                return "";
+            }
+            if (flatName == null) {
+                String parentFlatName = "";
+                FlatCompartmentItem parentComp = getItem(parentId);
+                if (parentComp != null) parentFlatName = parentComp.getName();
+                flatName = super.getName();
+                if (!parentFlatName.isEmpty()) flatName = parentFlatName + "/" + flatName;  // NOI18N
+            }
+            return flatName;
+        }
+
+        abstract FlatCompartmentItem getItem(OCID compId);
+    }
+
+    private Map<String, OCIItem> getDbs(OCIItem parent) {
         Map<String, OCIItem> items = new HashMap<> ();
         try {
             if (parent instanceof CompartmentItem) {
@@ -209,7 +294,6 @@ public class AddADBAction implements ActionListener {
         } catch (BmcException e) {
             LOGGER.log(Level.SEVERE, "Unable to load compartment list", e); // NOI18N
         }
-        CompartmentNode.getCompartments().apply(parent).forEach(c -> items.put(c.getName(), c));
         return items;
     }
     


### PR DESCRIPTION
If you clicked the Add Oracle Autonomous DB, selected oraclelabs tenancy & gcn-dev compartment. Select Database quick pick is now displayed, which actually shows another compartments. This view should actually show a mixed list of databases and nested compartments. There's no way to identify whether an entry represents a compartment or database. This fix displays a flat list of all compartments using fully qualified names in the Select Compartment quick pick to select the compartment in a single step, the same way as used in the GCN ext. This way the following Select Database quick pick can really display just databases.