### PR TITLE
Ability to navigate around Micronaut project by URI and beans.

### DIFF
--- a/enterprise/micronaut/nbproject/project.xml
+++ b/enterprise/micronaut/nbproject/project.xml
@@ -69,32 +69,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.maven</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>2</release-version>
-                        <specification-version>2.157</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.project.dependency</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <implementation-version/>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.maven.embedder</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>2</release-version>
-                        <specification-version>2.72</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -294,12 +268,46 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.maven</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <specification-version>2.157</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.maven.embedder</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <specification-version>2.72</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.parsing.api</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
                         <specification-version>9.18</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.parsing.indexing</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <implementation-version/>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.project.dependency</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <implementation-version/>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/symbol/MicronautSymbolFinder.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/symbol/MicronautSymbolFinder.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.micronaut.symbol;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.util.TreePathScanner;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.stream.Collectors;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.java.source.CompilationController;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.parsing.api.Snapshot;
+import org.netbeans.modules.parsing.spi.Parser;
+import org.netbeans.modules.parsing.spi.indexing.Context;
+import org.netbeans.modules.parsing.spi.indexing.EmbeddingIndexer;
+import org.netbeans.modules.parsing.spi.indexing.EmbeddingIndexerFactory;
+import org.netbeans.modules.parsing.spi.indexing.Indexable;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Exceptions;
+import org.openide.util.Pair;
+
+/**
+ *
+ * @author Dusan Balek
+ */
+public final class MicronautSymbolFinder extends EmbeddingIndexer {
+
+    public static final String NAME = "mn"; // NOI18N
+    public static final int VERSION = 1;
+    public static final MicronautSymbolFinder INSTANCE = new MicronautSymbolFinder();
+    public static final String[] META_ANNOTATIONS = new String[] {
+        "io.micronaut.http.annotation.HttpMethodMapping",
+        "io.micronaut.context.annotation.Bean",
+        "jakarta.inject.Qualifier",
+        "jakarta.inject.Scope"
+    };
+
+    private final Map<Project, Boolean> map = new WeakHashMap<>();
+
+    @Override
+    protected void index(Indexable indexable, Parser.Result parserResult, Context context) {
+        CompilationController cc = CompilationController.get(parserResult);
+        if (initialize(cc)) {
+            try {
+                cc.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
+                List<SymbolLocation> symbols = scan(cc);
+                if (!symbols.isEmpty()) {
+                    store(context.getIndexFolder(), indexable.getURL(), indexable.getRelativePath(), symbols);
+                }
+            } catch (IOException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+    }
+
+    private synchronized boolean initialize(CompilationController cc) {
+        Project p = FileOwnerQuery.getOwner(cc.getFileObject());
+        Boolean ret = map.get(p);
+        if (ret == null) {
+            ClassPath cp = ClassPath.getClassPath(p.getProjectDirectory(), ClassPath.COMPILE);
+            ret = cp.findResource("io/micronaut/http/annotation/HttpMethodMapping.class") != null;
+            map.put(p, ret);
+        }
+        return ret;
+    }
+
+    private List<SymbolLocation> scan(CompilationController cc) {
+        final List<SymbolLocation> ret = new ArrayList<>();
+        TreePathScanner<Void, String> scanner = new TreePathScanner<Void, String>() {
+            @Override
+            public Void visitClass(ClassTree node, String path) {
+                Element cls = cc.getTrees().getElement(this.getCurrentPath());
+                if (cls != null) {
+                    Pair<AnnotationMirror, AnnotationMirror> metaAnnotated = isMetaAnnotated(cls);
+                    if (metaAnnotated != null) {
+                        Element annEl = metaAnnotated.first().getAnnotationType().asElement();
+                        if ("io.micronaut.http.annotation.Controller".contentEquals(((TypeElement) annEl).getQualifiedName())) {
+                            for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : metaAnnotated.first().getElementValues().entrySet()) {
+                                if ("value".contentEquals(entry.getKey().getSimpleName())) {
+                                    path = (String) entry.getValue().getValue();
+                                }
+                            }
+                        }
+                        String name = "@+ '" + getBeanName(node.getSimpleName().toString()) + "' (@" + annEl.getSimpleName()
+                                + (metaAnnotated.second() != null ? " <: @" + metaAnnotated.second().getAnnotationType().asElement().getSimpleName() : "")
+                                + ") " + node.getSimpleName();
+                        int[] span = cc.getTreeUtilities().findNameSpan(node);
+                        ret.add(new SymbolLocation(name, span[0], span[1]));
+                    }
+                }
+                return super.visitClass(node, path);
+            }
+
+            @Override
+            public Void visitMethod(MethodTree node, String path) {
+                MthIterator it = new MthIterator(cc.getTrees().getElement(this.getCurrentPath()), cc.getElements(), cc.getTypes());
+                while (it.hasNext()) {
+                    for (AnnotationMirror ann : it.next().getAnnotationMirrors()) {
+                        String method = getEndpointMethod((TypeElement) ann.getAnnotationType().asElement());
+                        if (method != null) {
+                            for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : ann.getElementValues().entrySet()) {
+                                if ("value".contentEquals(entry.getKey().getSimpleName()) || "uri".contentEquals(entry.getKey().getSimpleName())) {
+                                    String name = '@' + (path != null ? path : "") + entry.getValue().getValue() + " -- " + method;
+                                    int[] span = cc.getTreeUtilities().findNameSpan(node);
+                                    ret.add(new SymbolLocation(name, span[0], span[1]));
+                                    return null;
+                                }
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+        };
+        scanner.scan(cc.getCompilationUnit(), null);
+        return ret;
+    }
+
+    private void store(FileObject indexFolder, URL url, String resourceName, List<SymbolLocation> symbols) {
+        File cacheRoot = FileUtil.toFile(indexFolder);
+        File output = new File(cacheRoot, resourceName + ".mn"); //NOI18N
+        if (symbols.isEmpty()) {
+            if (output.exists()) {
+                output.delete();
+            }
+        } else {
+            output.getParentFile().mkdirs();
+            try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(output), StandardCharsets.UTF_8))) {
+                pw.print("url: "); //NOI18N
+                pw.println(url.toString());
+                for (SymbolLocation symbol : symbols) {
+                    pw.print("symbol: ");
+                    pw.print(symbol.name);
+                    pw.print(':'); //NOI18N
+                    pw.print(symbol.start);
+                    pw.print('-'); //NOI18N
+                    pw.println(symbol.end);
+                }
+            } catch (IOException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+    }
+
+    private static Pair<AnnotationMirror, AnnotationMirror> isMetaAnnotated(Element el) {
+        for (AnnotationMirror ann : el.getAnnotationMirrors()) {
+            Element annEl = ann.getAnnotationType().asElement();
+            Name name = ((TypeElement) annEl).getQualifiedName();
+            String annotation = check(name);
+            if (annotation != null) {
+                return Pair.of(ann, null);
+            }
+            for (AnnotationMirror metaAnn : annEl.getAnnotationMirrors()) {
+                Element metaAnnEl = metaAnn.getAnnotationType().asElement();
+                String metaAnnotation = check(((TypeElement) metaAnnEl).getQualifiedName());
+                if (metaAnnotation != null) {
+                    return Pair.of(ann, metaAnn);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String check(Name name) {
+        for (String ann : META_ANNOTATIONS) {
+            if (ann.contentEquals(name)) {
+                return ann;
+            }
+        }
+        return null;
+    }
+
+    private static String getEndpointMethod(TypeElement te) {
+        for (AnnotationMirror ann : te.getAnnotationMirrors()) {
+            Element el = ann.getAnnotationType().asElement();
+            if ("io.micronaut.http.annotation.HttpMethodMapping".contentEquals(((TypeElement) el).getQualifiedName())) {
+                return te.getSimpleName().toString().toUpperCase();
+            }
+        }
+        return null;
+    }
+
+    public static String getBeanName(String typeName) {
+        if (typeName.length() > 0 && Character.isUpperCase(typeName.charAt(0))) {
+            if (typeName.length() == 1 || !Character.isUpperCase(typeName.charAt(1))) {
+                typeName = Character.toLowerCase(typeName.charAt(0)) + typeName.substring(1);
+            }
+        }
+        return typeName;
+    }
+
+    @MimeRegistration(mimeType="text/x-java", service=EmbeddingIndexerFactory.class) //NOI18N
+    public static class Factory extends EmbeddingIndexerFactory {
+
+        @Override
+        public EmbeddingIndexer createIndexer(Indexable indexable, Snapshot snapshot) {
+            return INSTANCE;
+        }
+
+        @Override
+        public void filesDeleted(Iterable<? extends Indexable> deleted, Context context) {
+            File cacheRoot = FileUtil.toFile(context.getIndexFolder());
+            for (Indexable indexable : deleted) {
+                File output = new File(cacheRoot, indexable.getRelativePath() + ".mn"); //NOI18N
+                if (output.exists()) {
+                    output.delete();
+                }
+            }
+        }
+
+        @Override
+        public void filesDirty(Iterable<? extends Indexable> dirty, Context context) {
+        }
+
+        @Override
+        public String getIndexerName() {
+            return NAME;
+        }
+
+        @Override
+        public int getIndexVersion() {
+            return VERSION;
+        }
+    }
+
+    private static class SymbolLocation {
+        private String name;
+        private int start;
+        private int end;
+
+        private SymbolLocation(String name, int start, int end) {
+            this.name = name;
+            this.start = start;
+            this.end = end;
+        }
+    }
+
+    private static class MthIterator implements Iterator<ExecutableElement> {
+
+        private final ExecutableElement ee;
+        private final Elements elements;
+        private final Types types;
+        private boolean createIt = false;
+        private Iterator<ExecutableElement> it = null;
+
+        private MthIterator(Element e, Elements elements, Types types) {
+            this.ee = e != null && e.getKind() == ElementKind.METHOD ? (ExecutableElement) e : null;
+            this.elements = elements;
+            this.types = types;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (ee == null) {
+                return false;
+            }
+            if (it == null) {
+                if (!createIt) {
+                    return true;
+                }
+                List<ExecutableElement> overriden = new ArrayList<>();
+                collectOverriden(ee, ee.getEnclosingElement(), overriden);
+                it = overriden.iterator();
+            }
+            return it.hasNext();
+        }
+
+        @Override
+        public ExecutableElement next() {
+            if (it == null) {
+                createIt = true;
+                return ee;
+            }
+            return it.next();
+        }
+
+        private void collectOverriden(ExecutableElement orig, Element el, List<ExecutableElement> overriden) {
+            for (TypeMirror superType : types.directSupertypes(el.asType())) {
+                if (superType.getKind() == TypeKind.DECLARED) {
+                    Element se = ((DeclaredType) superType).asElement();
+                    overriden.addAll(ElementFilter.methodsIn(se.getEnclosedElements()).stream()
+                            .filter(me -> {
+                                return orig.getSimpleName().contentEquals(me.getSimpleName()) && elements.overrides(orig, me, (TypeElement) el);
+                            })
+                            .collect(Collectors.toList()));
+                    collectOverriden(orig, se, overriden);
+                }
+            }
+        }
+    }
+}

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/symbol/MicronautSymbolSearcher.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/symbol/MicronautSymbolSearcher.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.micronaut.symbol;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import javax.swing.Icon;
+import org.netbeans.api.java.project.JavaProjectConstants;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectUtils;
+import org.netbeans.api.project.SourceGroup;
+import org.netbeans.modules.csl.api.IndexSearcher;
+import org.netbeans.modules.csl.api.Modifier;
+import org.netbeans.modules.csl.api.OffsetRange;
+import org.netbeans.modules.csl.spi.GsfUtilities;
+import org.netbeans.modules.csl.spi.ParserResult;
+import org.netbeans.modules.parsing.impl.indexing.CacheFolder;
+import org.netbeans.modules.parsing.spi.indexing.support.QuerySupport.Kind;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
+import org.openide.util.Exceptions;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author Dusan Balek
+ */
+@ServiceProvider(service=IndexSearcher.class)
+public class MicronautSymbolSearcher implements IndexSearcher {
+
+    @Override
+    public Set<? extends Descriptor> getTypes(Project project, String textForQuery, Kind searchType, Helper helper) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<? extends Descriptor> getSymbols(Project project, String textForQuery, Kind searchType, Helper helper) {
+        if (project == null || !textForQuery.startsWith("@")) {
+            return Collections.emptySet();
+        }
+        Set<Descriptor> symbols = new HashSet<>();
+        for (SourceGroup sg : ProjectUtils.getSources(project).getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA)) {
+            try {
+                FileObject cacheRoot = getCacheRoot(sg.getRootFolder().toURL());
+                if (cacheRoot != null) {
+                    Enumeration<? extends FileObject> children = cacheRoot.getChildren(true);
+                    while (children.hasMoreElements()) {
+                        FileObject child = children.nextElement();
+                        if (child.hasExt("mn")) { //NOI18N
+                            loadSymbols(child, symbols);
+                        }
+                    }
+                }
+            } catch (IOException ex) {}
+        }
+        return symbols;
+    }
+
+    private static void loadSymbols(FileObject input, Set<Descriptor> symbols) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(input.getInputStream(), StandardCharsets.UTF_8))) {
+            FileObject fo = null;
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.startsWith("url: ")) { //NOI18N
+                    String url = line.substring(5);
+                    fo = URLMapper.findFileObject(URI.create(url).toURL());
+                    if (fo == null) {
+                        return;
+                    }
+                } else if (line.startsWith("symbol: ")) { //NOI18N
+                    String info = line.substring(8);
+                    int idx = info.lastIndexOf(':');
+                    if (idx < 0) {
+                        return;
+                    }
+                    String name = info.substring(0, idx).trim();
+                    String[] range = info.substring(idx + 1).split("-");
+                    int start = range.length > 0 ? Integer.parseInt(range[0]) : 0;
+                    int end = range.length > 1 ? Integer.parseInt(range[1]) : start;
+                    symbols.add(new SymbolDescriptor(name, fo, start, end));
+                }
+            }
+        } catch (IOException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+    }
+
+    private static FileObject getCacheRoot(URL root) throws IOException {
+        final FileObject dataFolder = CacheFolder.getDataFolder(root, true);
+        return dataFolder != null ? FileUtil.createFolder(dataFolder, MicronautSymbolFinder.NAME + "/" + MicronautSymbolFinder.VERSION) : null; //NOI18N
+    }
+
+    private static class SymbolDescriptor extends IndexSearcher.Descriptor implements org.netbeans.modules.csl.api.ElementHandle {
+
+        private final String name;
+        private final FileObject fo;
+        private final Project project;
+        private final OffsetRange range;
+
+        private SymbolDescriptor(String name, FileObject fo, int start, int end) {
+            this.name = name;
+            this.fo = fo;
+            this.project = FileOwnerQuery.getOwner(fo);
+            this.range = new OffsetRange(start, end);
+        }
+
+        @Override
+        public org.netbeans.modules.csl.api.ElementHandle getElement() {
+            return this;
+        }
+
+        @Override
+        public String getSimpleName() {
+            return name;
+        }
+
+        @Override
+        public String getOuterName() {
+            return null;
+        }
+
+        @Override
+        public String getTypeName() {
+            return null;
+        }
+
+        @Override
+        public String getContextName() {
+            return null;
+        }
+
+        @Override
+        public Icon getIcon() {
+            return null;
+        }
+
+        @Override
+        public String getProjectName() {
+            return ProjectUtils.getInformation(project).getDisplayName();
+        }
+
+        @Override
+        public Icon getProjectIcon() {
+            return ProjectUtils.getInformation(project).getIcon();
+        }
+
+        @Override
+        public FileObject getFileObject() {
+            return fo;
+        }
+
+        @Override
+        public int getOffset() {
+            return range.getStart();
+        }
+
+        @Override
+        public void open() {
+            GsfUtilities.open(getFileObject(), getOffset(), null);
+        }
+
+
+        @Override
+        public String getMimeType() {
+            return getFileObject().getMIMEType();
+        }
+
+        @Override
+        public String getName() {
+            return getSimpleName();
+        }
+
+        @Override
+        public String getIn() {
+            return getOuterName();
+        }
+
+        @Override
+        public org.netbeans.modules.csl.api.ElementKind getKind() {
+            return org.netbeans.modules.csl.api.ElementKind.INTERFACE;
+        }
+
+        @Override
+        public Set<Modifier> getModifiers() {
+            return Collections.singleton(Modifier.PUBLIC);
+        }
+
+        @Override
+        public boolean signatureEquals(org.netbeans.modules.csl.api.ElementHandle handle) {
+            if (handle instanceof SymbolDescriptor) {
+                return this.getName().equals(handle.getName());
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public OffsetRange getOffsetRange(ParserResult result) {
+            return range;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 3;
+            hash = 67 * hash + Objects.hashCode(this.fo);
+            hash = 67 * hash + Objects.hashCode(this.range);
+            hash = 67 * hash + Objects.hashCode(this.name);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final SymbolDescriptor other = (SymbolDescriptor) obj;
+            if (!Objects.equals(this.name, other.name)) {
+                return false;
+            }
+            if (!Objects.equals(this.fo, other.fo)) {
+                return false;
+            }
+            return Objects.equals(this.range, other.range);
+        }
+    }
+}

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/symbol/MicronautSymbolSearcher.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/symbol/MicronautSymbolSearcher.java
@@ -40,6 +40,7 @@ import org.netbeans.modules.csl.api.Modifier;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.csl.spi.GsfUtilities;
 import org.netbeans.modules.csl.spi.ParserResult;
+import org.netbeans.modules.parsing.api.indexing.IndexingManager;
 import org.netbeans.modules.parsing.impl.indexing.CacheFolder;
 import org.netbeans.modules.parsing.spi.indexing.support.QuerySupport.Kind;
 import org.openide.filesystems.FileObject;
@@ -62,7 +63,7 @@ public class MicronautSymbolSearcher implements IndexSearcher {
 
     @Override
     public Set<? extends Descriptor> getSymbols(Project project, String textForQuery, Kind searchType, Helper helper) {
-        if (project == null || !textForQuery.startsWith("@")) {
+        if (project == null || !textForQuery.startsWith("@") || IndexingManager.getDefault().isIndexing()) {
             return Collections.emptySet();
         }
         Set<Descriptor> symbols = new HashSet<>();

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/language/GroovyTypeSearcher.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/language/GroovyTypeSearcher.java
@@ -145,7 +145,7 @@ public class GroovyTypeSearcher implements IndexSearcher {
     private String cachedString = "/";
 
     private QuerySupport.Kind adjustKind(QuerySupport.Kind kind, String text) {
-        if (text.equals(cachedString)) {
+        if (cachedKind != null && text.equals(cachedString)) {
             return cachedKind;
         }
         if (kind == QuerySupport.Kind.CASE_INSENSITIVE_PREFIX) {


### PR DESCRIPTION
Adding an ability to navigate around the Micronaut projects by URI and beans.
The keyboard short cuts for that are:
    Mac: Cmd-Shift-O (symbols in file), Cmd-T (symbols in workspace)
    Linux/Windows: Ctrl-Shift-O (symbols in file), Ctrl-T (symbols in workspace)
Examples
    @/ shows all defined request mappings (mapped path, request method, source location)
    @+ shows all defined beans (bean name, bean type, source location)