### PR TITLE
LSP: NPE from InputBoxStep fixed

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBAddConnection.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBAddConnection.java
@@ -112,19 +112,21 @@ public class DBAddConnection extends CodeActionsProvider {
             String driverClass = m != null ? (String) m.get(DRIVER) : null;
             if (dbUrl != null && driverClass != null) {
 
-                JDBCDriver[] driver = JDBCDriverManager.getDefault().getDrivers(driverClass); //NOI18N
+                JDBCDriver[] driver = JDBCDriverManager.getDefault().getDrivers(driverClass);
                 if (driver != null && driver.length > 0) {
                     if (userId == null || password == null) {
                         String inputId = inputServiceRegistry.registerInput(param -> {
                             int totalSteps = 2;
                             switch (param.getStep()) {
                                 case 1:
-                                    return CompletableFuture.completedFuture(Either.forRight(new InputBoxStep(totalSteps, USER_ID, Bundle.MSG_EnterUsername(), userId)));
+                                    String userIdVal = userId != null ? userId : "";
+                                    return CompletableFuture.completedFuture(Either.forRight(new InputBoxStep(totalSteps, USER_ID, Bundle.MSG_EnterUsername(), userIdVal)));
                                 case 2:
                                     Map<String, Either<List<QuickPickItem>, String>> data = param.getData();
                                     Either<List<QuickPickItem>, String> userData = data.get(USER_ID);
                                     if (userData != null) {
-                                        return CompletableFuture.completedFuture(Either.forRight(new InputBoxStep(totalSteps, PASSWORD, null, Bundle.MSG_EnterUsername(), password, true)));
+                                        String passwordVal = password != null ? password : "";
+                                        return CompletableFuture.completedFuture(Either.forRight(new InputBoxStep(totalSteps, PASSWORD, null, Bundle.MSG_EnterPassword(), passwordVal, true)));
                                     }
                                     return CompletableFuture.completedFuture(null);
                                 default:


### PR DESCRIPTION
Register Database for Micro/GCN stops when username should be provided. The LSP fails with:
```
WARNING [org.netbeans.modules.java.lsp.server.protocol.Server]: Error occurred during LSP message dispatch
java.lang.NullPointerException: Property must not be null: value
	at org.eclipse.lsp4j.util.Preconditions.checkNotNull(Preconditions.java:29)
	at org.netbeans.modules.java.lsp.server.input.ShowInputBoxParams.<init>(ShowInputBoxParams.java:62)
	at org.netbeans.modules.java.lsp.server.input.ShowInputBoxParams.<init>(ShowInputBoxParams.java:66)
	at org.netbeans.modules.java.lsp.server.input.InputBoxStep.<init>(InputBoxStep.java:56)
	at org.netbeans.modules.java.lsp.server.db.DBAddConnection.lambda$processCommand$0(DBAddConnection.java:127)
```
The `InputBoxStep` does not accept null for `value`, but the DBAddConnection uses null unset for username and password. This PR uses empty string instead of null.
It also fixes wrong prompt in password InputBoxStep.
