### PR TITLE
Add support for Wildfly 28

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1985,6 +1985,9 @@ jobs:
       - name: enterprise/j2ee.core
         run: ant $OPTS -f enterprise/j2ee.core test
 
+      - name: enterprise/javaee.wildfly
+        run: .github/retry.sh ant $OPTS -f enterprise/javaee.wildfly test
+
       - name: enterprise/micronaut
         run: .github/retry.sh ant $OPTS -f enterprise/micronaut test
 

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyClassLoader.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyClassLoader.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javaee.wildfly;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.security.AllPermission;
+import java.security.CodeSource;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+/**
+ *
+ * @author Petr Hejl
+ */
+public class WildflyClassLoader extends URLClassLoader {
+
+    private static final Logger LOGGER = Logger.getLogger(WildflyDeploymentFactory.class.getName());
+
+    /**
+     * Patching the xnio code to avoid bug #249135
+     *
+     * @see https://netbeans.org/bugzilla/show_bug.cgi?id=249135
+     */
+    private final boolean patchXnio;
+
+    public WildflyClassLoader(URL[] urls, ClassLoader parent, boolean patchXnio) throws MalformedURLException, RuntimeException {
+        super(urls, parent);
+        this.patchXnio = patchXnio;
+    }
+
+    public static WildflyClassLoader createWildFlyClassLoader(String serverRoot) {
+        try {
+            List<URL> urlList = new ArrayList<>(2);
+
+            Path serverRootPath = Paths.get(serverRoot);
+            Path jbossCliClientJar = Paths.get(serverRootPath.toString(), "bin", "client", "jboss-cli-client.jar");
+            urlList.add(jbossCliClientJar.toUri().toURL());
+
+            Path modulePath = serverRootPath.resolve("modules");
+            findJarAddUrl(urlList, modulePath, "glob:**/*/controller/main/wildfly-controller-*.jar");
+
+            WildflyPluginUtils.Version version = WildflyPluginUtils.getServerVersion(new File(serverRoot));
+            boolean shouldPatchXnio = WildflyPluginUtils.WILDFLY_8_0_0.compareToIgnoreUpdate(version) <= 0;
+
+            return new WildflyClassLoader(
+                    urlList.toArray(new URL[]{}),
+                    WildflyDeploymentFactory.class.getClassLoader(),
+                    shouldPatchXnio
+            );
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, null, e);
+        }
+        return null;
+    }
+
+    private static void findJarAddUrl(List<URL> urlList, Path folder, String pathMatcherRaw) {
+        PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher(pathMatcherRaw);
+
+        Stream<Path> walk = null;
+        try {
+            walk = Files.walk(folder);
+            Optional<Path> firstJarMatching = walk
+                    .filter(pathMatcher::matches)
+                    .findFirst();
+
+            if (firstJarMatching.isPresent()) {
+                LOGGER.log(Level.INFO, "Adding {0} to the classpath", firstJarMatching.get().toString());
+                urlList.add(firstJarMatching.get().toUri().toURL());
+            }
+        } catch (IOException ex) {
+            LOGGER.log(Level.INFO, null, ex);
+        } finally {
+            if (walk != null) {
+                walk.close();
+            }
+        }
+    }
+
+    @Override
+    protected PermissionCollection getPermissions(CodeSource codeSource) {
+        Permissions p = new Permissions();
+        p.add(new AllPermission());
+        return p;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        // get rid of annoying warnings
+        if (name.contains("jndi.properties")) { // NOI18N
+            return Collections.enumeration(Collections.<URL>emptyList());
+        }
+
+        return super.getResources(name);
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        // see issue #249135
+        if (patchXnio && "org.xnio.nio.WorkerThread".equals(name)) { // NOI18N
+            try {
+                LOGGER.log(Level.INFO, "Patching the issue #249135");
+                String path = name.replace('.', '/').concat(".class"); // NOI18N
+                try (InputStream is = super.getResourceAsStream(path)) {
+                    ClassReader cr = new ClassReader(is);
+                    final ClassLoader ld = this;
+                    ClassWriter cw = new ClassWriter(cr, ClassWriter.COMPUTE_FRAMES) {
+
+                        @Override
+                        protected String getCommonSuperClass(String string, String string1) {
+                            if ("org/xnio/nio/NioHandle".equals(string) // NOI18N
+                                    || "org/xnio/nio/NioHandle".equals(string1)) { // NOI18N
+                                return "java/lang/Object"; // NOI18N
+                            }
+                            return super.getCommonSuperClass(string, string1);
+                        }
+
+                        @Override
+                        protected ClassLoader getClassLoader() {
+                            return ld;
+                        }
+
+                    };
+                    ClassNode node = new ClassNode(Opcodes.ASM9);
+                    cr.accept(node, 0);
+
+                    for (MethodNode m : (Collection<MethodNode>) node.methods) {
+                        if ("execute".equals(m.name) // NOI18N
+                                && "(Ljava/lang/Runnable;)V".equals(m.desc)) { // NOI18N
+                            InsnList list = m.instructions;
+                            for (ListIterator it = list.iterator(); it.hasNext();) {
+                                AbstractInsnNode n = (AbstractInsnNode) it.next();
+                                if (n instanceof MethodInsnNode) {
+                                    MethodInsnNode mn = (MethodInsnNode) n;
+                                    if ("org/xnio/nio/Log".equals(mn.owner) // NOI18N
+                                            && "threadExiting".equals(mn.name) // NOI18N
+                                            && "()Ljava/util/concurrent/RejectedExecutionException;".equals(mn.desc)) { // NOI18N
+                                        if (it.hasNext()) {
+                                            AbstractInsnNode possibleThrow = (AbstractInsnNode) it.next();
+                                            if (possibleThrow.getOpcode() == Opcodes.ATHROW) {
+                                                it.set(new InsnNode(Opcodes.POP));
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            break;
+                        }
+                    }
+
+                    node.accept(cw);
+                    byte[] newBytecode = cw.toByteArray();
+                    return super.defineClass(name, newBytecode, 0, newBytecode.length);
+                }
+            } catch (Exception ex) {
+                // just fallback to original behavior
+                LOGGER.log(Level.INFO, null, ex);
+            }
+        }
+        return super.findClass(name);
+    }
+}

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentFactory.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentFactory.java
@@ -19,46 +19,17 @@
 package org.netbeans.modules.javaee.wildfly;
 
 import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.security.AllPermission;
-import java.security.CodeSource;
-import java.security.PermissionCollection;
-import java.security.Permissions;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import javax.enterprise.deploy.shared.factories.DeploymentFactoryManager;
 import javax.enterprise.deploy.spi.DeploymentManager;
 import javax.enterprise.deploy.spi.exceptions.DeploymentManagerCreationException;
 import javax.enterprise.deploy.spi.factories.DeploymentFactory;
 import org.netbeans.modules.j2ee.deployment.plugins.api.InstanceProperties;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties;
-import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils;
-import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils.Version;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.tree.AbstractInsnNode;
-import org.objectweb.asm.tree.ClassNode;
-import org.objectweb.asm.tree.InsnList;
-import org.objectweb.asm.tree.InsnNode;
-import org.objectweb.asm.tree.MethodInsnNode;
-import org.objectweb.asm.tree.MethodNode;
 import org.openide.util.NbBundle;
-import org.openide.util.Utilities;
 
 /**
  *
@@ -86,8 +57,8 @@ public class WildflyDeploymentFactory implements DeploymentFactory {
     private final Map<InstanceProperties, WildflyDeploymentManager> managerCache =
             new WeakHashMap<InstanceProperties, WildflyDeploymentManager>();
 
-    private final Map<InstanceProperties, WildflyDeploymentFactory.WildFlyClassLoader> classLoaderCache =
-            new WeakHashMap<InstanceProperties, WildflyDeploymentFactory.WildFlyClassLoader>();
+    private final Map<InstanceProperties, WildflyClassLoader> classLoaderCache =
+            new WeakHashMap<InstanceProperties, WildflyClassLoader>();
 
     private static WildflyDeploymentFactory instance;
 
@@ -103,199 +74,19 @@ public class WildflyDeploymentFactory implements DeploymentFactory {
         return instance;
     }
 
-    public static class WildFlyClassLoader extends URLClassLoader {
-
-        /**
-         * Patching the xnio code to avoid bug #249135
-         * @see https://netbeans.org/bugzilla/show_bug.cgi?id=249135
-         */
-        private final boolean patchXnio;
-
-        public WildFlyClassLoader(URL[] urls, ClassLoader parent, boolean patchXnio) throws MalformedURLException, RuntimeException {
-            super(urls, parent);
-            this.patchXnio = patchXnio;
-        }
-
-        @Override
-        protected PermissionCollection getPermissions(CodeSource codeSource) {
-            Permissions p = new Permissions();
-            p.add(new AllPermission());
-            return p;
-        }
-
-        @Override
-        public Enumeration<URL> getResources(String name) throws IOException {
-            // get rid of annoying warnings
-            if (name.contains("jndi.properties")) { // NOI18N
-                return Collections.enumeration(Collections.<URL>emptyList());
-            }
-
-            return super.getResources(name);
-        }
-
-        @Override
-        protected Class<?> findClass(String name) throws ClassNotFoundException {
-            // see issue #249135
-            if (patchXnio && "org.xnio.nio.WorkerThread".equals(name)) { // NOI18N
-                try {
-                    LOGGER.log(Level.INFO, "Patching the issue #249135");
-                    String path = name.replace('.', '/').concat(".class"); // NOI18N
-                    try (InputStream is = super.getResourceAsStream(path)) {
-                        ClassReader cr = new ClassReader(is);
-                        final ClassLoader ld = this;
-                        ClassWriter cw = new ClassWriter(cr, ClassWriter.COMPUTE_FRAMES) {
-
-                            @Override
-                            protected String getCommonSuperClass(String string, String string1) {
-                                if ("org/xnio/nio/NioHandle".equals(string) // NOI18N
-                                        || "org/xnio/nio/NioHandle".equals(string1)) { // NOI18N
-                                    return "java/lang/Object"; // NOI18N
-                                }
-                                return super.getCommonSuperClass(string, string1);
-                            }
-
-                            @Override
-                            protected ClassLoader getClassLoader() {
-                                return ld;
-                            }
-                            
-                            
-                        };
-                        ClassNode node = new ClassNode(Opcodes.ASM9);
-                        cr.accept(node, 0);
-
-                        for (MethodNode m : (Collection<MethodNode>) node.methods) {
-                            if ("execute".equals(m.name) // NOI18N
-                                    && "(Ljava/lang/Runnable;)V".equals(m.desc)) { // NOI18N
-                                InsnList list = m.instructions;
-                                for (ListIterator it = list.iterator(); it.hasNext(); ) {
-                                    AbstractInsnNode n = (AbstractInsnNode) it.next();
-                                    if (n instanceof MethodInsnNode) {
-                                        MethodInsnNode mn = (MethodInsnNode) n;
-                                        if ("org/xnio/nio/Log".equals(mn.owner) // NOI18N
-                                                && "threadExiting".equals(mn.name) // NOI18N
-                                                && "()Ljava/util/concurrent/RejectedExecutionException;".equals(mn.desc)) { // NOI18N
-                                            if (it.hasNext()) {
-                                                AbstractInsnNode possibleThrow = (AbstractInsnNode) it.next();
-                                                if (possibleThrow.getOpcode() == Opcodes.ATHROW) {
-                                                    it.set(new InsnNode(Opcodes.POP));
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                break;
-                            }
-                        }
-
-                        node.accept(cw);
-                        byte[] newBytecode = cw.toByteArray();
-                        return super.defineClass(name, newBytecode, 0, newBytecode.length);
-                    }
-                } catch (Exception ex) {
-                    // just fallback to original behavior
-                    LOGGER.log(Level.INFO, null, ex);
-                }
-            }
-            return super.findClass(name);
-        }
-    }
-
-    public synchronized WildFlyClassLoader getWildFlyClassLoader(InstanceProperties ip) {
-        WildFlyClassLoader cl = classLoaderCache.get(ip);
+    public synchronized WildflyClassLoader getWildFlyClassLoader(InstanceProperties ip) {
+        WildflyClassLoader cl = classLoaderCache.get(ip);
         if (cl == null) {
             DeploymentFactory factory = factoryCache.get(ip);
-            if (factory != null && factory.getClass().getClassLoader() instanceof WildFlyClassLoader) {
-                cl = (WildFlyClassLoader) factory.getClass().getClassLoader();
+            if (factory != null && factory.getClass().getClassLoader() instanceof WildflyClassLoader) {
+                cl = (WildflyClassLoader) factory.getClass().getClassLoader();
             }
             if (cl == null) {
-                cl = createWildFlyClassLoader(ip.getProperty(WildflyPluginProperties.PROPERTY_ROOT_DIR));
+                cl = WildflyClassLoader.createWildFlyClassLoader(ip.getProperty(WildflyPluginProperties.PROPERTY_ROOT_DIR));
             }
             classLoaderCache.put(ip, cl);
         }
         return cl;
-    }
-
-    public static WildFlyClassLoader createWildFlyClassLoader(String serverRoot) {
-        try {
-            String sep = File.separator;
-            List<URL> urlList = new ArrayList<>(20);
-            File org = new File(serverRoot, WildflyPluginUtils.getModulesBase(serverRoot) + "org");
-            addUrl(urlList, org, "dom4j" + sep + "main", Pattern.compile("dom4j-.*.jar"));
-            if (urlList.isEmpty()) {
-                LOGGER.log(Level.INFO, "No dom4j.jar availabale on classpath"); // NOI18N
-            }
-            File jboss = new File(org, "jboss");
-            File wildfly = new File(org, "wildfly");
-            File as = new File(jboss, "as");
-
-            final File jbossModules = new File(serverRoot, "jboss-modules.jar");
-            if(jbossModules.exists()) {
-                urlList.add(Utilities.toURI(jbossModules).toURL());
-            }
-            final File jbossClient = new File(serverRoot, "bin" + sep + "client" + sep + "jboss-client.jar");
-            if(jbossClient.exists()) {
-                urlList.add(Utilities.toURI(jbossClient).toURL());
-            }
-            addUrl(urlList, jboss, "dmr" + sep + "main", Pattern.compile("jboss-dmr-.*.jar"));
-            addUrl(urlList, jboss, "logging" + sep + "main", Pattern.compile("jboss-logging-.*.jar"));
-            addUrl(urlList, jboss, "marshalling" + sep + "main", Pattern.compile("jboss-marshalling-.*.jar"));
-            addUrl(urlList, jboss, "marshalling" + sep + "river" + sep + "main", Pattern.compile("jboss-marshalling-river-.*.jar"));
-            addUrl(urlList, jboss, "remoting" + sep + "main", Pattern.compile("jboss-remoting-.*.jar"));
-            addUrl(urlList, jboss, "sasl" + sep + "main", Pattern.compile("jboss-sasl-.*.jar"));
-            addUrl(urlList, jboss, "threads" + sep + "main", Pattern.compile("jboss-threads-.*.jar"));
-            addUrl(urlList, jboss, "xnio" + sep + "main", Pattern.compile("xnio-api-.*.jar"));
-            addUrl(urlList, jboss, "xnio" + sep + "nio" + sep + "main", Pattern.compile("xnio-nio-.*.jar"));
-            addUrl(urlList, as, "controller" + sep + "main", Pattern.compile("wildfly-controller-.*.jar"));
-            addUrl(urlList, as, "controller" + sep + "main", Pattern.compile("jboss-as-controller-.*.jar"));
-            addUrl(urlList, as, "controller-client" + sep + "main", Pattern.compile("jboss-as-controller-client-.*.jar"));
-            addUrl(urlList, as, "controller-client" + sep + "main", Pattern.compile("wildfly-controller-client-.*.jar"));
-            addUrl(urlList, as, "protocol" + sep + "main", Pattern.compile("wildfly-protocol-.*.jar"));
-            addUrl(urlList, as, "protocol" + sep + "main", Pattern.compile("jboss-as-protocol-.*.jar"));
-            //CLI GUI
-//            addUrl(urlList, jboss, "aesh" + sep + "main", Pattern.compile("aesh-.*.jar"));
-//            addUrl(urlList, jboss, "staxmapper" + sep + "main", Pattern.compile("staxmapper-.*.jar"));
-//            addUrl(urlList, wildfly, "security" + sep + "manager" + sep + "main", Pattern.compile("wildfly-security-manager-.*.jar"));
-//            addUrl(urlList, jboss, "remoting-jmx" + sep + "main", Pattern.compile("remoting-jmx-.*.jar"));
-//            addUrl(urlList, jboss, "vfs" + sep + "main", Pattern.compile("jboss-vfs-.*.jar"));
-//            addUrl(urlList, org, "picketbox" + sep + "main", Pattern.compile("picketbox-.*.jar"));
-//            addUrl(urlList, as, "cli" + sep + "main", Pattern.compile("wildfly-cli-.*.jar"));
-            File serverPath = new File(serverRoot);
-            Version version = WildflyPluginUtils.getServerVersion(serverPath);
-            if (WildflyPluginUtils.WILDFLY_10_0_0.compareToIgnoreUpdate(version) >= 0) {
-                addUrl(urlList, wildfly, "common" + sep + "main", Pattern.compile("wildfly-common-.*.jar"));
-            }
-            boolean shouldPatchXnio = WildflyPluginUtils.WILDFLY_8_0_0.compareToIgnoreUpdate(version) <= 0;
-            WildFlyClassLoader loader = new WildFlyClassLoader(urlList.toArray(new URL[] {}),
-                    WildflyDeploymentFactory.class.getClassLoader(), shouldPatchXnio);
-            return loader;
-        } catch (Exception e) {
-            LOGGER.log(Level.WARNING, null, e);
-        }
-        return null;
-    }
-
-    private static void addUrl(List<URL> result, File root, String path, final Pattern pattern) {
-        File folder = new File(root, path);
-        if(folder.exists() && folder.isDirectory()) {
-            File[] children = folder.listFiles(new FilenameFilter() {
-                @Override
-                public boolean accept(File dir, String name) {
-                    return pattern.matcher(name).matches();
-                }
-            });
-            if (children != null) {
-                for (File child : children) {
-                    try {
-                        result.add(child.toURI().toURL());
-                        LOGGER.log(Level.INFO, "Adding {0} to the classpath", child.getAbsolutePath());
-                    } catch (MalformedURLException ex) {
-                        LOGGER.log(Level.INFO, null, ex);
-                    }
-                }
-            }
-        }
     }
 
     @Override

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/commands/WildflyClient.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/commands/WildflyClient.java
@@ -72,7 +72,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.security.auth.callback.CallbackHandler;
 import org.netbeans.modules.j2ee.deployment.common.api.Datasource;
-import org.netbeans.modules.j2ee.deployment.common.api.MessageDestination;
 import org.netbeans.modules.j2ee.deployment.common.api.MessageDestination.Type;
 import org.netbeans.modules.j2ee.deployment.plugins.api.InstanceProperties;
 import org.netbeans.modules.j2ee.deployment.plugins.spi.DeploymentContext;
@@ -122,6 +121,7 @@ import static org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils.WILD
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.netbeans.modules.javaee.wildfly.WildflyClassLoader;
 import org.netbeans.modules.javaee.wildfly.config.WildflyJaxrsResource;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginProperties;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils.Version;
@@ -185,14 +185,14 @@ public class WildflyClient {
      * @return the value of serverPort
      */
     public String getServerLog() throws IOException {
-        WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+        WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
         LinkedHashMap<Object, Object> values = new LinkedHashMap<>();
         values.put(SUBSYSTEM, "logging");
         values.put("periodic-rotating-file-handler", "FILE");
         return resolvePath(cl, values);
     }
 
-    private String resolvePath(WildflyDeploymentFactory.WildFlyClassLoader cl, LinkedHashMap<Object, Object> values) throws IOException {
+    private String resolvePath(WildflyClassLoader cl, LinkedHashMap<Object, Object> values) throws IOException {
         try {
             final Object readPathOperation = createModelNode(cl);
             setModelNodeChildString(cl, getModelNodeChild(cl, readPathOperation, OP), RESOLVE_PATH);
@@ -237,7 +237,7 @@ public class WildflyClient {
     }
 
     // ModelControllerClient
-    private synchronized Object getClient(WildflyDeploymentFactory.WildFlyClassLoader cl) {
+    private synchronized Object getClient(WildflyClassLoader cl) {
         if (client == null) {
             try {
                 this.client = createClient(cl, version, serverAddress, serverPort, handler);
@@ -262,7 +262,7 @@ public class WildflyClient {
 
     public synchronized void shutdownServer(int timeout) throws IOException, InterruptedException, TimeoutException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             // ModelNode
             Object shutdownOperation = createModelNode(cl);
             setModelNodeChildString(cl, getModelNodeChild(cl, shutdownOperation, OP), SHUTDOWN);
@@ -279,7 +279,7 @@ public class WildflyClient {
 
     public synchronized boolean isServerRunning(String homeDir, String configFile) {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             // ModelNode
             Object statusOperation = createModelNode(cl);
             setModelNodeChildString(cl, getModelNodeChild(cl, statusOperation, OP), READ_ATTRIBUTE_OPERATION);
@@ -312,7 +312,7 @@ public class WildflyClient {
     }
 
     // ModelNode
-    private synchronized Object executeOnModelNode(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws IOException, ClassNotFoundException, NoSuchMethodException,
+    private synchronized Object executeOnModelNode(WildflyClassLoader cl, Object modelNode) throws IOException, ClassNotFoundException, NoSuchMethodException,
             InvocationTargetException, IllegalAccessException {
         Class modelClazz = cl.loadClass("org.jboss.dmr.ModelNode"); // NOI18N
         Object clientLocal = getClient(cl);
@@ -324,7 +324,7 @@ public class WildflyClient {
     }
 
     // ModelNode
-    private synchronized Object executeOnOperation(WildflyDeploymentFactory.WildFlyClassLoader cl, Object operation) throws IOException, ClassNotFoundException, NoSuchMethodException,
+    private synchronized Object executeOnOperation(WildflyClassLoader cl, Object operation) throws IOException, ClassNotFoundException, NoSuchMethodException,
             InvocationTargetException, IllegalAccessException {
         Class operationClazz = cl.loadClass("org.jboss.as.controller.client.Operation"); // NOI18N
         Object clientLocal = getClient(cl);
@@ -335,7 +335,7 @@ public class WildflyClient {
         return method.invoke(clientLocal, operation);
     }
 
-    private synchronized Future<?> executeAsync(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, Object operationMessageHandler) throws IOException, ClassNotFoundException, NoSuchMethodException,
+    private synchronized Future<?> executeAsync(WildflyClassLoader cl, Object modelNode, Object operationMessageHandler) throws IOException, ClassNotFoundException, NoSuchMethodException,
             InvocationTargetException, IllegalAccessException {
         Class modelClazz = cl.loadClass("org.jboss.dmr.ModelNode"); // NOI18N
         Class handlerClazz = cl.loadClass("org.jboss.as.controller.client.OperationMessageHandler"); // NOI18N
@@ -349,7 +349,7 @@ public class WildflyClient {
 
     public Collection<WildflyModule> listAvailableModules() throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyModule> modules = new ArrayList<>();
             // ModelNode
             Object deploymentAddressModelNode = createDeploymentPathAddressAsModelNode(cl, null);
@@ -382,7 +382,7 @@ public class WildflyClient {
 
     public Collection<WildflyWebModuleNode> listWebModules(Lookup lookup) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyWebModuleNode> modules = new ArrayList<>();
             // ModelNode
             Object deploymentAddressModelNode = createDeploymentPathAddressAsModelNode(cl, null);
@@ -417,7 +417,7 @@ public class WildflyClient {
 
     public String getWebModuleURL(String webModuleName) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             // ModelNode
             Object deploymentAddressModelNode = createDeploymentPathAddressAsModelNode(cl, webModuleName);
             // ModelNode
@@ -459,7 +459,7 @@ public class WildflyClient {
 
     public Collection<WildflyEjbModuleNode> listEJBModules(Lookup lookup) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyEjbModuleNode> modules = new ArrayList<>();
             // ModelNode
             Object deploymentAddressModelNode = createDeploymentPathAddressAsModelNode(cl, null);
@@ -494,7 +494,7 @@ public class WildflyClient {
 
     public boolean startModule(WildflyTargetModuleID tmid) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             // ModelNode
             Object deploymentAddressModelNode = createDeploymentPathAddressAsModelNode(cl, tmid.getModuleID());
             // ModelNode
@@ -512,7 +512,7 @@ public class WildflyClient {
 
     public boolean startModule(String moduleName) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             // ModelNode
             Object deploymentAddressModelNode = createDeploymentPathAddressAsModelNode(cl, moduleName);
             // ModelNode
@@ -526,7 +526,7 @@ public class WildflyClient {
 
     public boolean stopModule(String moduleName) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             // ModelNode
             Object deploymentAddressModelNode = createDeploymentPathAddressAsModelNode(cl, moduleName);
             // ModelNode
@@ -539,7 +539,7 @@ public class WildflyClient {
 
     public boolean undeploy(String fileName) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             // ModelNode
             Object deploymentAddressModelNode = createDeploymentPathAddressAsModelNode(cl, fileName);
 
@@ -559,7 +559,7 @@ public class WildflyClient {
 
     public boolean deploy(DeploymentContext deployment) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             String fileName = deployment.getModuleFile().getName();
             undeploy(fileName);
 
@@ -602,7 +602,7 @@ public class WildflyClient {
 
     private Set<Datasource> listDatasources() throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             Set<Datasource> listedDatasources = new HashSet<>();
             // ModelNode
             final Object readDatasources = createModelNode(cl);
@@ -631,7 +631,7 @@ public class WildflyClient {
         }
     }
 
-    private WildflyDatasource getDatasource(WildflyDeploymentFactory.WildFlyClassLoader cl, String name) throws IOException {
+    private WildflyDatasource getDatasource(WildflyClassLoader cl, String name) throws IOException {
         try {
             // ModelNode
             final Object readDatasource = createModelNode(cl);
@@ -662,7 +662,7 @@ public class WildflyClient {
 
     public boolean removeDatasource(String name) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             LinkedHashMap<Object, Object> values = new LinkedHashMap<>();
             values.put(SUBSYSTEM, DATASOURCES_SUBSYSTEM);
             values.put(DATASOURCE_TYPE, name);
@@ -677,7 +677,7 @@ public class WildflyClient {
         }
     }
 
-    private Pair<String, String> getServerPaths(WildflyDeploymentFactory.WildFlyClassLoader cl) {
+    private Pair<String, String> getServerPaths(WildflyClassLoader cl) {
         try {
             // ModelNode
             final Object readEnvironment = createModelNode(cl);
@@ -728,7 +728,7 @@ public class WildflyClient {
 
     public List<WildflyMessageDestination> listDestinationForDeployment(String deployment) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyMessageDestination> destinations = new ArrayList<>();
             // ModelNode
             final Object readMessagingServers = createModelNode(cl);
@@ -762,7 +762,7 @@ public class WildflyClient {
 
     public List<WildflyMessageDestination> listDestinations() throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyMessageDestination> destinations = new ArrayList<>();
             // ModelNode
             final Object readMessagingServers = createModelNode(cl);
@@ -795,7 +795,7 @@ public class WildflyClient {
 
     private List<WildflyMessageDestination> getJMSDestinationForServerDeployment(String deployment, String serverName, Type messageType) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyMessageDestination> listedDestinations = new ArrayList<>();
             // ModelNode
             final Object readQueues = createModelNode(cl);
@@ -841,7 +841,7 @@ public class WildflyClient {
 
     private List<WildflyMessageDestination> getJMSDestinationForServer(String serverName, Type messageType) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyMessageDestination> listedDestinations = new ArrayList<>();
             // ModelNode
             final Object readQueues = createModelNode(cl);
@@ -896,7 +896,7 @@ public class WildflyClient {
 
     public boolean addMessageDestination(WildflyMessageDestination destination) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             LinkedHashMap<Object, Object> values = new LinkedHashMap<>();
             values.put(SUBSYSTEM, getMessagingSubsystem());
             values.put(getMessagingServerType(), "default");
@@ -922,7 +922,7 @@ public class WildflyClient {
 
     public boolean removeMessageDestination(WildflyMessageDestination destination) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             LinkedHashMap<Object, Object> values = new LinkedHashMap<>();
             values.put(SUBSYSTEM, getMessagingSubsystem());
             values.put(getMessagingServerType(), "default");
@@ -951,7 +951,7 @@ public class WildflyClient {
 
     private Collection<WildflyJaxrsResource> listJaxrsResources(String deployment) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             Map<String, WildflyJaxrsResource> jaxrsResources = new HashMap<>();
             // ModelNode
             final Object readJaxrsResources = createModelNode(cl);
@@ -991,7 +991,7 @@ public class WildflyClient {
 
     public Collection<WildflyMailSessionResource> listMailSessions() throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyMailSessionResource> modules = new ArrayList<>();
             LinkedHashMap<Object, Object> values = new LinkedHashMap<>();
             values.put(SUBSYSTEM, MAIL_SUBSYSTEM);
@@ -1021,7 +1021,7 @@ public class WildflyClient {
 
     public Collection listEarApplications(Lookup lookup) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyEarApplicationNode> modules = new ArrayList<>();
             Object deploymentAddressModelNode = createDeploymentPathAddressAsModelNode(cl, null);
             Object readDeployments = createReadResourceOperation(cl, deploymentAddressModelNode, true, true);
@@ -1044,7 +1044,7 @@ public class WildflyClient {
 
     public Collection listEarSubModules(Lookup lookup, String jeeApplicationName) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List modules = new ArrayList();
             Object deploymentAddressModelNode = createDeploymentPathAddressAsModelNode(cl, jeeApplicationName);
             Object readDeployments = createReadResourceOperation(cl, deploymentAddressModelNode, true, true);
@@ -1087,7 +1087,7 @@ public class WildflyClient {
 
     public Collection listEJBForDeployment(Lookup lookup, String applicationName) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List modules = new ArrayList();
             Object deploymentAddressModelNode = createDeploymentPathAddressAsModelNode(cl, applicationName);
             Object readDeployments = createReadResourceOperation(cl, deploymentAddressModelNode, true, true);
@@ -1112,7 +1112,7 @@ public class WildflyClient {
         }
     }
 
-    private List<WildflyEjbComponentNode> listEJBs(WildflyDeploymentFactory.WildFlyClassLoader cl,
+    private List<WildflyEjbComponentNode> listEJBs(WildflyClassLoader cl,
             Object deployment, WildflyEjbComponentNode.Type type) throws IllegalAccessException, NoSuchMethodException,
             InvocationTargetException {
         List<WildflyEjbComponentNode> modules = new ArrayList<>();
@@ -1128,7 +1128,7 @@ public class WildflyClient {
     private WildflySocket fillSocket(String name, boolean outBound) throws
             ClassNotFoundException, NoSuchMethodException,
             InvocationTargetException, IllegalAccessException, InstantiationException, IOException {
-        WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+        WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
         WildflySocket socket = new WildflySocket();
         LinkedHashMap<Object, Object> values = new LinkedHashMap<>();
         values.put("socket-binding-group", "standard-sockets");
@@ -1162,7 +1162,7 @@ public class WildflyClient {
 
     public Collection<WildflyConnectionFactory> listConnectionFactories() throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyConnectionFactory> connectionFactories = new ArrayList<>();
             // ModelNode
             final Object readMessagingServers = createModelNode(cl);
@@ -1194,7 +1194,7 @@ public class WildflyClient {
 
     private Collection<? extends WildflyConnectionFactory> getConnectionFactoriesForServer(String messagingServerName) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyConnectionFactory> listedConnectionFactories = new ArrayList<>();
             // ModelNode
             final Object readConnectionFactories = createModelNode(cl);
@@ -1232,7 +1232,7 @@ public class WildflyClient {
     private WildflyConnectionFactory fillConnectionFactory(String name, Object configuration) throws
             ClassNotFoundException, NoSuchMethodException,
             InvocationTargetException, IllegalAccessException, InstantiationException, IOException {
-        WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+        WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
         List properties = modelNodeAsPropertyList(cl, configuration);
         Map<String, String> attributes = new HashMap<>(properties.size());
         for (Object property : properties) {
@@ -1248,7 +1248,7 @@ public class WildflyClient {
     private WildflyMailSessionResource fillMailSession(String name, Object mailSession) throws
             ClassNotFoundException, NoSuchMethodException,
             InvocationTargetException, IllegalAccessException, InstantiationException, IOException {
-        WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+        WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
 
         Object configuration = modelNodeAsPropertyForValue(cl, mailSession);
         List properties = modelNodeAsPropertyList(cl, configuration);
@@ -1280,7 +1280,7 @@ public class WildflyClient {
     }
 
     public String getDeploymentDirectory() throws IOException {
-        WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+        WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
         LinkedHashMap<Object, Object> values = new LinkedHashMap<>();
         values.put(SUBSYSTEM, "deployment-scanner");
         values.put("scanner", "default");
@@ -1289,7 +1289,7 @@ public class WildflyClient {
 
     private String resolveExpression(String unresolvedString) throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             final Object resolveExpression = createModelNode(cl);
             setModelNodeChildString(cl, getModelNodeChild(cl, resolveExpression, OP), RESOLVE_EXPRESSION);
             Object rootAddress = createPathAddressAsModelNode(cl, new LinkedHashMap<>());
@@ -1314,7 +1314,7 @@ public class WildflyClient {
 
     public Collection<WildflyResourceAdapter> listResourceAdapters() throws IOException {
         try {
-            WildflyDeploymentFactory.WildFlyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
+            WildflyClassLoader cl = WildflyDeploymentFactory.getInstance().getWildFlyClassLoader(ip);
             List<WildflyResourceAdapter> resourceAdapters = new ArrayList<>();
             // ModelNode
             final Object readResourceAdapters = createModelNode(cl);

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/commands/WildflyManagementAPI.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/commands/WildflyManagementAPI.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
-import org.netbeans.modules.javaee.wildfly.WildflyDeploymentFactory;
+import org.netbeans.modules.javaee.wildfly.WildflyClassLoader;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils;
 import org.netbeans.modules.javaee.wildfly.ide.ui.WildflyPluginUtils.Version;
 
@@ -48,7 +48,7 @@ public class WildflyManagementAPI {
     private static final Map<String, String> ENABLED_LOCAL_AUTH = Collections.emptyMap();
     private static final int TIMEOUT = 1000;
 
-    static Object createClient(WildflyDeploymentFactory.WildFlyClassLoader cl, Version version, final String serverAddress, final int serverPort,
+    static Object createClient(WildflyClassLoader cl, Version version, final String serverAddress, final int serverPort,
             final CallbackHandler handler) throws ClassNotFoundException, NoSuchMethodException,
             IllegalAccessException, InvocationTargetException, NoSuchAlgorithmException, InstantiationException {
         Class<?> clazz = cl.loadClass("org.jboss.as.controller.client.ModelControllerClient$Factory"); // NOI18N
@@ -71,14 +71,14 @@ public class WildflyManagementAPI {
         return method.invoke(null, serverAddress, serverPort, handler, SSLContext.getDefault(), TIMEOUT);
     }
 
-    static void closeClient(WildflyDeploymentFactory.WildFlyClassLoader cl, Object client) throws ClassNotFoundException, NoSuchMethodException,
+    static void closeClient(WildflyClassLoader cl, Object client) throws ClassNotFoundException, NoSuchMethodException,
             IllegalAccessException, InvocationTargetException {
         Method method = client.getClass().getMethod("close", new Class[]{});
         method.invoke(client, (Object[]) null);
     }
 
     // ModelNode
-    static Object createDeploymentPathAddressAsModelNode(WildflyDeploymentFactory.WildFlyClassLoader cl, String name)
+    static Object createDeploymentPathAddressAsModelNode(WildflyClassLoader cl, String name)
             throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         Class paClazz = cl.loadClass("org.jboss.as.controller.PathAddress"); // NOI18N
         Class peClazz = cl.loadClass("org.jboss.as.controller.PathElement"); // NOI18N
@@ -98,7 +98,7 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static Object createPathAddressAsModelNode(WildflyDeploymentFactory.WildFlyClassLoader cl, LinkedHashMap<Object, Object> elements)
+    static Object createPathAddressAsModelNode(WildflyClassLoader cl, LinkedHashMap<Object, Object> elements)
             throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         Class paClazz = cl.loadClass("org.jboss.as.controller.PathAddress"); // NOI18N
         Class peClazz = cl.loadClass("org.jboss.as.controller.PathElement"); // NOI18N
@@ -119,7 +119,7 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static Object createOperation(WildflyDeploymentFactory.WildFlyClassLoader cl, Object name, Object modelNode)
+    static Object createOperation(WildflyClassLoader cl, Object name, Object modelNode)
             throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         Class<?> clazz = cl.loadClass("org.jboss.as.controller.client.helpers.Operations"); // NOI18N
         Class modelClazz = cl.loadClass("org.jboss.dmr.ModelNode"); // NOI18N
@@ -128,7 +128,7 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static Object createReadResourceOperation(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, boolean recursive, boolean runtime)
+    static Object createReadResourceOperation(WildflyClassLoader cl, Object modelNode, boolean recursive, boolean runtime)
             throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Class clazz = cl.loadClass("org.jboss.as.controller.client.helpers.Operations"); // NOI18N
         Class modelClazz = cl.loadClass("org.jboss.dmr.ModelNode"); // NOI18N
@@ -139,7 +139,7 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static Object createRemoveOperation(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws ClassNotFoundException,
+    static Object createRemoveOperation(WildflyClassLoader cl, Object modelNode) throws ClassNotFoundException,
             NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         Class<?> clazz = cl.loadClass("org.jboss.as.controller.client.helpers.Operations"); // NOI18N
         Class modelClazz = cl.loadClass("org.jboss.dmr.ModelNode"); // NOI18N
@@ -148,7 +148,7 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static Object createAddOperation(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws ClassNotFoundException,
+    static Object createAddOperation(WildflyClassLoader cl, Object modelNode) throws ClassNotFoundException,
             NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         Class<?> clazz = cl.loadClass("org.jboss.as.controller.client.helpers.Operations"); // NOI18N
         Class modelClazz = cl.loadClass("org.jboss.dmr.ModelNode"); // NOI18N
@@ -157,7 +157,7 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static Object readResult(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws ClassNotFoundException,
+    static Object readResult(WildflyClassLoader cl, Object modelNode) throws ClassNotFoundException,
             NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         Class<?> clazz = cl.loadClass("org.jboss.as.controller.client.helpers.Operations"); // NOI18N
         Class modelClazz = cl.loadClass("org.jboss.dmr.ModelNode"); // NOI18N
@@ -166,21 +166,21 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static Object getModelNodeChild(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, Object name) throws IllegalAccessException,
+    static Object getModelNodeChild(WildflyClassLoader cl, Object modelNode, Object name) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("get", String.class);
         return method.invoke(modelNode, name);
     }
 
     // ModelNode
-    static Object getModelNodeChildAtIndex(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, int index) throws IllegalAccessException,
+    static Object getModelNodeChildAtIndex(WildflyClassLoader cl, Object modelNode, int index) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("get", int.class);
         return method.invoke(modelNode, index);
     }
 
     // ModelNode
-    static Object getModelNodeChildAtPath(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, Object[] path) throws IllegalAccessException,
+    static Object getModelNodeChildAtPath(WildflyClassLoader cl, Object modelNode, Object[] path) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("get", String[].class);
         Object array = Array.newInstance(String.class, path.length);
@@ -191,27 +191,27 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static boolean modelNodeHasChild(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, String child) throws IllegalAccessException,
+    static boolean modelNodeHasChild(WildflyClassLoader cl, Object modelNode, String child) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("has", String.class);
         return (Boolean) method.invoke(modelNode, child);
     }
 
     // ModelNode
-    static boolean modelNodeHasDefinedChild(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, String child) throws IllegalAccessException,
+    static boolean modelNodeHasDefinedChild(WildflyClassLoader cl, Object modelNode, String child) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("hasDefined", String.class);
         return (Boolean) method.invoke(modelNode, child);
     }
 
     // ModelNode
-    static Object createModelNode(WildflyDeploymentFactory.WildFlyClassLoader cl) throws IllegalAccessException, ClassNotFoundException, InstantiationException {
+    static Object createModelNode(WildflyClassLoader cl) throws IllegalAccessException, ClassNotFoundException, InstantiationException {
         Class modelClazz = cl.loadClass("org.jboss.dmr.ModelNode"); // NOI18N
         return modelClazz.newInstance();
     }
 
     // ModelNode
-    static Object setModelNodeChildString(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, Object value) throws IllegalAccessException,
+    static Object setModelNodeChildString(WildflyClassLoader cl, Object modelNode, Object value) throws IllegalAccessException,
             ClassNotFoundException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         assert value != null;
         Method method = modelNode.getClass().getMethod("set", String.class);
@@ -219,7 +219,7 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static Object setModelNodeChild(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, Object value) throws IllegalAccessException,
+    static Object setModelNodeChild(WildflyClassLoader cl, Object modelNode, Object value) throws IllegalAccessException,
             ClassNotFoundException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         assert value != null;
         Class modelClazz = cl.loadClass("org.jboss.dmr.ModelNode"); // NOI18N
@@ -228,21 +228,21 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static Object setModelNodeChild(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, int value) throws IllegalAccessException,
+    static Object setModelNodeChild(WildflyClassLoader cl, Object modelNode, int value) throws IllegalAccessException,
             ClassNotFoundException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("set", int.class);
         return method.invoke(modelNode, value);
     }
 
     // ModelNode
-    static Object setModelNodeChild(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, boolean value) throws IllegalAccessException,
+    static Object setModelNodeChild(WildflyClassLoader cl, Object modelNode, boolean value) throws IllegalAccessException,
             ClassNotFoundException, InstantiationException, NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("set", boolean.class);
         return method.invoke(modelNode, value);
     }
 
     // ModelNode
-    static Object setModelNodeChildEmptyList(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws IllegalAccessException,
+    static Object setModelNodeChildEmptyList(WildflyClassLoader cl, Object modelNode) throws IllegalAccessException,
             ClassNotFoundException, InstantiationException, NoSuchMethodException, InvocationTargetException {
 
         Method method = modelNode.getClass().getMethod("setEmptyList", (Class<?>[]) null);
@@ -250,7 +250,7 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static Object setModelNodeChildBytes(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, byte[] value) throws IllegalAccessException,
+    static Object setModelNodeChildBytes(WildflyClassLoader cl, Object modelNode, byte[] value) throws IllegalAccessException,
             ClassNotFoundException, InstantiationException, NoSuchMethodException, InvocationTargetException {
 
         Method method = modelNode.getClass().getMethod("set", byte[].class);
@@ -258,52 +258,52 @@ public class WildflyManagementAPI {
     }
 
     // ModelNode
-    static Object addModelNodeChild(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, Object toAddModelNode) throws IllegalAccessException,
+    static Object addModelNodeChild(WildflyClassLoader cl, Object modelNode, Object toAddModelNode) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException, ClassNotFoundException {
         Class modelClazz = cl.loadClass("org.jboss.dmr.ModelNode"); // NOI18N
         Method method = modelNode.getClass().getMethod("add", modelClazz);
         return method.invoke(modelNode, toAddModelNode);
     }
 
-    static Object addModelNodeChildString(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode, String toAddModelNode) throws IllegalAccessException,
+    static Object addModelNodeChildString(WildflyClassLoader cl, Object modelNode, String toAddModelNode) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException, ClassNotFoundException {
         Method method = modelNode.getClass().getMethod("add", String.class);
         return method.invoke(modelNode, toAddModelNode);
     }
 
-    static boolean modelNodeIsDefined(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws IllegalAccessException,
+    static boolean modelNodeIsDefined(WildflyClassLoader cl, Object modelNode) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("isDefined", (Class<?>[]) null);
         return (Boolean) method.invoke(modelNode, (Object[]) null);
     }
 
-    static String modelNodeAsString(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws IllegalAccessException,
+    static String modelNodeAsString(WildflyClassLoader cl, Object modelNode) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("asString", (Class<?>[]) null);
         return (String) method.invoke(modelNode, (Object[]) null);
     }
 
-    static String modelNodeAsPropertyForName(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws IllegalAccessException,
+    static String modelNodeAsPropertyForName(WildflyClassLoader cl, Object modelNode) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("asProperty", (Class<?>[]) null);
         Object property = method.invoke(modelNode, (Object[]) null);
         return getPropertyName(cl, property);
     }
 
-    static Object modelNodeAsPropertyForValue(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws IllegalAccessException,
+    static Object modelNodeAsPropertyForValue(WildflyClassLoader cl, Object modelNode) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("asProperty", (Class<?>[]) null);
         Object property = method.invoke(modelNode, (Object[]) null);
         return getPropertyValue(cl, property);
     }
 
-    static String getPropertyName(WildflyDeploymentFactory.WildFlyClassLoader cl, Object property) throws IllegalAccessException,
+    static String getPropertyName(WildflyClassLoader cl, Object property) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = property.getClass().getMethod("getName", (Class<?>[]) null);
         return (String) method.invoke(property, (Object[]) null);
     }
 
-    static Object getPropertyValue(WildflyDeploymentFactory.WildFlyClassLoader cl, Object property) throws IllegalAccessException,
+    static Object getPropertyValue(WildflyClassLoader cl, Object property) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = property.getClass().getMethod("getValue", (Class<?>[]) null);
         return method.invoke(property, (Object[]) null);
@@ -311,31 +311,31 @@ public class WildflyManagementAPI {
 
 
     // List<ModelNode>
-    static List modelNodeAsList(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws IllegalAccessException,
+    static List modelNodeAsList(WildflyClassLoader cl, Object modelNode) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("asList", (Class<?>[]) null);
         return (List) method.invoke(modelNode, (Object[]) null);
     }
 
-    static List modelNodeAsPropertyList(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws IllegalAccessException,
+    static List modelNodeAsPropertyList(WildflyClassLoader cl, Object modelNode) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("asPropertyList", (Class<?>[]) null);
         return (List) method.invoke(modelNode, (Object[]) null);
     }
 
-    static boolean modelNodeAsBoolean(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws IllegalAccessException,
+    static boolean modelNodeAsBoolean(WildflyClassLoader cl, Object modelNode) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("asBoolean", (Class<?>[]) null);
         return (boolean) method.invoke(modelNode, (Object[]) null);
     }
 
-    static int modelNodeAsInt(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws IllegalAccessException,
+    static int modelNodeAsInt(WildflyClassLoader cl, Object modelNode) throws IllegalAccessException,
             NoSuchMethodException, InvocationTargetException {
         Method method = modelNode.getClass().getMethod("asInt", (Class<?>[]) null);
         return (int) method.invoke(modelNode, (Object[]) null);
     }
 
-    static boolean isSuccessfulOutcome(WildflyDeploymentFactory.WildFlyClassLoader cl, Object modelNode) throws ClassNotFoundException,
+    static boolean isSuccessfulOutcome(WildflyClassLoader cl, Object modelNode) throws ClassNotFoundException,
             NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         Class<?> clazz = cl.loadClass("org.jboss.as.controller.client.helpers.Operations"); // NOI18N
         Class modelClazz = cl.loadClass("org.jboss.dmr.ModelNode"); // NOI18N


### PR DESCRIPTION
NetBeans communicates to Wildfly via management api. This functionality depends
on several Wildfly classes which are pulled from the Wildfly installation.

It seems that in 28.0.1 some classes and jars were moved which prevents NetBeans
from communicating to Wildfly.

This change simplify the current logic gathering different jars and just use
`jboss-cli-client` which should contain all necessary classes which are needed
to connect to Wildflys management interface.


I did some manual testing:
* Start / Stop /Deploy Wildfly 28.0.1
* Start / Stop / Deploy Wildfly 27.0.1
* I checked for classes loaded by plugin
* Downloaded all available Wildfly & JBoss EAP servers
* Created a test file which creates a Classloader per server and try to load the found classes

```java
/*
 * Licensed to the Apache Software Foundation (ASF) under one
 * or more contributor license agreements.  See the NOTICE file
 * distributed with this work for additional information
 * regarding copyright ownership.  The ASF licenses this file
 * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing,
 * software distributed under the License is distributed on an
 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 * KIND, either express or implied.  See the License for the
 * specific language governing permissions and limitations
 * under the License.
 */
package org.netbeans.modules.javaee.wildfly;

import java.io.IOException;
import java.nio.file.FileVisitResult;
import java.nio.file.Files;
import java.nio.file.Path;
import java.nio.file.Paths;
import java.nio.file.SimpleFileVisitor;
import java.nio.file.attribute.BasicFileAttributes;
import java.util.Collections;
import org.junit.Test;
import org.netbeans.junit.NbTestCase;
import org.openide.util.Exceptions;

/**
 *
 * @author Benjamin Asbach
 */
public class WildflyClassLoaderTest extends NbTestCase {

    public WildflyClassLoaderTest(String name) {
        super(name);
    }

    @Test
    public void testSomeMethod() throws IOException {
        String[] classesUsedByModule = new String[]{
            "org.jboss.dmr.ModelNode",
            "org.jboss.as.controller.client.Operation",
            "org.jboss.as.controller.client.OperationMessageHandler",
            "org.jboss.as.controller.client.ModelControllerClient$Factory",
            "org.jboss.as.controller.client.ModelControllerClientConfiguration$Builder",
            "org.jboss.as.controller.client.ModelControllerClientConfiguration",
            "org.jboss.as.controller.PathAddress",
            "org.jboss.as.controller.PathElement",
            "org.jboss.as.controller.client.helpers.Operations"
        };

        Path wildflyInstallations = Paths.get("/home/asbachb/dev/tmp/wildfly");
        Files.walkFileTree(wildflyInstallations, Collections.emptySet(), 1, new SimpleFileVisitor<Path>(){
            @Override
            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                WildflyClassLoader classloader = WildflyClassLoader.createWildFlyClassLoader(file.toString());

                System.out.print("Testing " + file.toString() + "...");
                for (String classUsedByModule : classesUsedByModule) {
                    try {
                        classloader.loadClass(classUsedByModule);
                    } catch (ClassNotFoundException ex) {
                        System.out.println("FAILED!");
                        System.out.println("Could not load " + classUsedByModule);
                        
                        Exceptions.printStackTrace(ex);

                        return FileVisitResult.CONTINUE;
                    }
                }

                System.out.println("OK!");

                return FileVisitResult.CONTINUE;
            }
        });
    }
}
```

Results:
```
Testing /home/asbachb/dev/tmp/wildfly/wildfly-10.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-10.1.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-11.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-12.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-13.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-14.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-14.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-15.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-15.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-16.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-17.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-17.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-18.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-18.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-19.1.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-20.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-20.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-21.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-21.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-21.0.2.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-22.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-22.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-23.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-23.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-23.0.2.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-24.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-24.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-25.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-25.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-26.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-26.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-26.1.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-26.1.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-26.1.2.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-26.1.3.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-27.0.0.Alpha5...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-27.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-27.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-28.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-28.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-8.0.0.Final...FAILED!
Could not load org.jboss.as.controller.client.ModelControllerClientConfiguration$Builder
Testing /home/asbachb/dev/tmp/wildfly/wildfly-8.1.0.Final...FAILED!
Could not load org.jboss.as.controller.client.ModelControllerClientConfiguration$Builder
Testing /home/asbachb/dev/tmp/wildfly/wildfly-8.2.0.Final...FAILED!
Could not load org.jboss.as.controller.client.ModelControllerClientConfiguration$Builder
Testing /home/asbachb/dev/tmp/wildfly/wildfly-8.2.1.Final...FAILED!
Could not load org.jboss.as.controller.client.ModelControllerClientConfiguration$Builder
Testing /home/asbachb/dev/tmp/wildfly/wildfly-9.0.0.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-9.0.1.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/wildfly-9.0.2.Final...OK!
Testing /home/asbachb/dev/tmp/wildfly/jboss-eap-6.1...FAILED!
Could not load org.jboss.as.controller.client.ModelControllerClientConfiguration$Builder
Testing /home/asbachb/dev/tmp/wildfly/jboss-eap-6.2...FAILED!
Could not load org.jboss.as.controller.client.ModelControllerClientConfiguration$Builder
Testing /home/asbachb/dev/tmp/wildfly/jboss-eap-6.3...FAILED!
Could not load org.jboss.as.controller.client.ModelControllerClientConfiguration$Builder
Testing /home/asbachb/dev/tmp/wildfly/jboss-eap-6.4...FAILED!
Could not load org.jboss.as.controller.client.ModelControllerClientConfiguration$Builder
Testing /home/asbachb/dev/tmp/wildfly/jboss-eap-7.0...OK!
Testing /home/asbachb/dev/tmp/wildfly/jboss-eap-7.1...OK!
Testing /home/asbachb/dev/tmp/wildfly/jboss-eap-7.2...OK!
Testing /home/asbachb/dev/tmp/wildfly/jboss-eap-7.3...OK!
Testing /home/asbachb/dev/tmp/wildfly/jboss-eap-7.4...OK!
Testing /home/asbachb/dev/tmp/wildfly/jboss-eap-8.0...OK!
```

I assume this would be ok as `org.jboss.as.controller.client.ModelControllerClientConfiguration$Builder` seems to be not available on the servers classpath and so the module shouldn't be compatible with these servers anyways.

Fixes #5947 