### PR TITLE
FlatLaf: fix location of drag-and-drop insert indicator lines

### DIFF
--- a/ide/spi.palette/src/org/netbeans/modules/palette/ui/DnDSupport.java
+++ b/ide/spi.palette/src/org/netbeans/modules/palette/ui/DnDSupport.java
@@ -280,8 +280,8 @@ public class DnDSupport  implements DragGestureListener, DropTargetListener {
                 p1.y += target.getHeight();
                 p2.y += target.getHeight();
             }
-            p1 = SwingUtilities.convertPoint( target, p1, palette.getRootPane() );
-            p2 = SwingUtilities.convertPoint( target, p2, palette.getRootPane() );
+            p1 = SwingUtilities.convertPoint( target, p1, dropPane );
+            p2 = SwingUtilities.convertPoint( target, p2, dropPane );
             Line2D line = new Line2D.Double( p1.x, p1.y, p2.x, p2.y );
             dropPane.setDropLine( line );
         } else {
@@ -411,8 +411,8 @@ public class DnDSupport  implements DragGestureListener, DropTargetListener {
                 p2.y += rect.height;
             }
         }
-        p1 = SwingUtilities.convertPoint( list, p1, palette.getRootPane() );
-        p2 = SwingUtilities.convertPoint( list, p2, palette.getRootPane() );
+        p1 = SwingUtilities.convertPoint( list, p1, dropPane );
+        p2 = SwingUtilities.convertPoint( list, p2, dropPane );
         Line2D line = new Line2D.Double( p1.x, p1.y, p2.x, p2.y );
         dropPane.setDropLine( line );
         targetItem = (Item)list.getModel().getElementAt( dropIndex );

--- a/platform/openide.explorer/src/org/openide/explorer/view/OutlineViewDropSupport.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/OutlineViewDropSupport.java
@@ -34,7 +34,6 @@ import java.awt.dnd.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.geom.Line2D;
-import java.awt.geom.Line2D.Double;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -290,14 +289,14 @@ final class OutlineViewDropSupport implements DropTargetListener, Runnable {
         } else {
             // line and selection of parent if any
             if (pointAt == DragDropUtilities.NODE_UP) {
-                Line2D line = new Double( 0, nodeArea.y, table.getWidth(), nodeArea.y );
+                Line2D line = new Line2D.Double( 0, nodeArea.y, table.getWidth(), nodeArea.y );
                 convertBoundsAndSetDropLine(line);
 
                 // enlagre node area with area for line
                 Rectangle lineArea = new Rectangle( 0, nodeArea.y - 5, table.getWidth(), 10 );
                 nodeArea = (Rectangle) nodeArea.createUnion(lineArea);
             } else {
-                Line2D line = new Double( 0, nodeArea.y + nodeArea.height, table.getWidth(), nodeArea.y + nodeArea.height );
+                Line2D line = new Line2D.Double( 0, nodeArea.y + nodeArea.height, table.getWidth(), nodeArea.y + nodeArea.height );
                 convertBoundsAndSetDropLine(line);
 
                 // enlagre node area with area for line
@@ -340,16 +339,16 @@ final class OutlineViewDropSupport implements DropTargetListener, Runnable {
         view.repaint(r.x - 5, r.y - 5, r.width + 10, r.height + 10);
     }
 
-    /** Converts line's bounds by the bounds of the root pane. Drop glass pane
-     * is over this root pane. After covert a given line is set to drop glass pane.
+    /** Converts line's bounds by the bounds of the drop glass pane.
+     * After covert a given line is set to drop glass pane.
      * @param line line for show in drop glass pane */
     private void convertBoundsAndSetDropLine(final Line2D line) {
         int x1 = (int) line.getX1();
         int x2 = (int) line.getX2();
         int y1 = (int) line.getY1();
         int y2 = (int) line.getY2();
-        Point p1 = SwingUtilities.convertPoint(table, x1, y1, table.getRootPane());
-        Point p2 = SwingUtilities.convertPoint(table, x2, y2, table.getRootPane());
+        Point p1 = SwingUtilities.convertPoint(table, x1, y1, dropPane);
+        Point p2 = SwingUtilities.convertPoint(table, x2, y2, dropPane);
         line.setLine(p1, p2);
         dropPane.setDropLine(line);
     }

--- a/platform/openide.explorer/src/org/openide/explorer/view/TreeViewDropSupport.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/TreeViewDropSupport.java
@@ -33,7 +33,6 @@ import java.awt.dnd.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.geom.Line2D;
-import java.awt.geom.Line2D.Double;
 import java.util.ArrayList;
 
 import java.util.Arrays;
@@ -285,7 +284,7 @@ final class TreeViewDropSupport implements DropTargetListener, Runnable {
         } else {
             // line and selection of parent if any
             if (pointAt == DragDropUtilities.NODE_UP) {
-                Line2D line = new Double(
+                Line2D line = new Line2D.Double(
                         nodeArea.x - SHIFT_LEFT, nodeArea.y + SHIFT_DOWN, endPointX, nodeArea.y + SHIFT_DOWN
                     );
                 convertBoundsAndSetDropLine(line);
@@ -296,7 +295,7 @@ final class TreeViewDropSupport implements DropTargetListener, Runnable {
                     );
                 nodeArea = (Rectangle) nodeArea.createUnion(lineArea);
             } else {
-                Line2D line = new Double(
+                Line2D line = new Line2D.Double(
                         nodeArea.x - SHIFT_LEFT, nodeArea.y + nodeArea.height + SHIFT_DOWN, endPointX,
                         nodeArea.y + nodeArea.height + SHIFT_DOWN
                     );
@@ -359,19 +358,21 @@ final class TreeViewDropSupport implements DropTargetListener, Runnable {
         tree.repaint(r.x - 5, r.y - 5, r.width + 10, r.height + 10);
     }
 
-    /** Converts line's bounds by the bounds of the root pane. Drop glass pane
-     * is over this root pane. After covert a given line is set to drop glass pane.
+    /** Converts line's bounds by the bounds of the drop glass pane.
+     * After covert a given line is set to drop glass pane.
      * @param line line for show in drop glass pane */
     private void convertBoundsAndSetDropLine(final Line2D line) {
+        if (dropPane == null)
+            return;
+
         int x1 = (int) line.getX1();
         int x2 = (int) line.getX2();
         int y1 = (int) line.getY1();
         int y2 = (int) line.getY2();
-        Point p1 = SwingUtilities.convertPoint(tree, x1, y1, tree.getRootPane());
-        Point p2 = SwingUtilities.convertPoint(tree, x2, y2, tree.getRootPane());
+        Point p1 = SwingUtilities.convertPoint(tree, x1, y1, dropPane);
+        Point p2 = SwingUtilities.convertPoint(tree, x2, y2, dropPane);
         line.setLine(p1, p2);
-        if( null != dropPane )
-            dropPane.setDropLine(line);
+        dropPane.setDropLine(line);
     }
 
     /** Removes timer and all listeners. */


### PR DESCRIPTION
When doing drag-and-drop in tree, tree-table or palette, then the insert indicator lines are painted at wrong location in NB 18 on Windows 10/11 with FlatLaf.

![image](https://github.com/apache/netbeans/assets/5604048/552df012-3101-4e62-a3cb-d994846862ab)

(red arrow indicates the correct location where the dnd lines should be painted)

The reason for this problem is that since FlatLaf 3.1 (since NB 18), glass panes are not located at location `0,0` in root pane (if FlatLaf window decorations are enabled). But NetBeans code converts locations to root pane coordinates and uses them to paint on glass pane, which is not located at `0,0` in root pane.

This PR fixes the problem for TreeView, OutlineView (e.g. used in "Search Result" view) and palette.

I've searched the NB source code for `getRootPane`, `convertPoint` and `convertRectangle` and checked results whether coordinate conversion is used for glass panes. Found only the 3 files fixed in this PR.

Fixes #6134




