### PR TITLE
Stabilize some unreliable tests for smoother CI operation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -934,7 +934,7 @@ jobs:
         run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.ui test
 
       - name: platform/core.windows
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.windows test
+        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/core.windows test
 
       - name: platform/editor.mimelookup
         run: ant $OPTS -Dvanilla.javac.exists=true -f platform/editor.mimelookup test
@@ -943,7 +943,7 @@ jobs:
         run: ant $OPTS -Dvanilla.javac.exists=true -f platform/editor.mimelookup.impl test
 
       - name: platform/favorites
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/favorites test
+        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/favorites test
 
       - name: platform/javahelp
         run: ant $OPTS -Dvanilla.javac.exists=true -f platform/javahelp test-unit
@@ -1143,7 +1143,7 @@ jobs:
         run: ant $OPTS -Dvanilla.javac.exists=true -f platform/sendopts test
 
       - name: platform/settings
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/settings test
+        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/settings test
 
       - name: platform/spi.actions
         run: ant $OPTS -Dvanilla.javac.exists=true -f platform/spi.actions test
@@ -2234,7 +2234,11 @@ jobs:
       # longest step (~40min)
       - name: php.editor
         if: env.test_php == 'true' && success()
-        run: ant $OPTS -f php/php.editor test
+        run: ant $OPTS -Dtest.config=stable -f php/php.editor test
+
+      - name: php.editor (unreliable tests)
+        if: env.test_php == 'true' && success()
+        run: .github/retry.sh ant $OPTS -Dtest.config=unreliable -f php/php.editor test
 
       - name: php.latte
         run: ant $OPTS -f php/php.latte test

--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -30,9 +30,15 @@ test.config.uicommit.includes=\
 #  org/netbeans/test/php/Commit.class,\
 #  org/netbeans/test/php/project/test*.class
 
-test.config.stable.includes=\
-  org/netbeans/test/php/*/test*.class
+# known to fail sporadically, should be tested separately in CI, ideally with retry script until stabilized
+test.config.unreliable.includes=\
+  org/netbeans/modules/php/editor/verification/IntroduceSuggestionTest.class,\
+  org/netbeans/modules/php/editor/csl/GotoDeclarationPHP81Test.class,\
+  org/netbeans/modules/php/editor/csl/FoldingTest.class
+test.config.unreliable.excludes=
 
+test.config.stable.includes=**/*Test.class
+test.config.stable.excludes=${test.config.unreliable.includes}
 
 test.config.normal.includes=\
   org/netbeans/test/php/Commit.class,\


### PR DESCRIPTION
I checked the last 10 merges to master and all of them failed on first attempt. Most failures were caused by the issue described in #5955

last 10 merge failures including test restarts till green:
```
BeforeFirstTest: org.netbeans.core.windows.awt.ValidateLayerMenuTest
BeforeFirstTest: org.netbeans.core.windows.awt.ValidateLayerToolbarTest

BeforeFirstTest: org.netbeans.modules.favorites.AddToFavoritesTest
BeforeFirstTest: org.netbeans.modules.favorites.AddToFavoritesTest
BeforeFirstTest: org.netbeans.modules.favorites.HomeFolderTest
BeforeFirstTest: org.netbeans.modules.favorites.RemoveFromFavoritesTest
BeforeFirstTest: org.netbeans.modules.favorites.RemoveFromFavoritesTest
BeforeFirstTest: org.netbeans.modules.favorites.RemoveFromFavoritesTest

BeforeFirstTest: org.netbeans.modules.settings.convertors.MimeTypeTest
BeforeFirstTest: org.netbeans.modules.settings.convertors.MimeTypeTest

testEnumCaseFix_02b: org.netbeans.modules.php.editor.verification.IntroduceSuggestionTest
testEnumCaseFix_02b: org.netbeans.modules.php.editor.verification.IntroduceSuggestionTest
testEnumCaseFix_02b: org.netbeans.modules.php.editor.verification.IntroduceSuggestionTest

testEnumerations_43: org.netbeans.modules.php.editor.csl.GotoDeclarationPHP81Test
testMarkAsRead: org.netbeans.modules.notifications.center.NotificationCenterManagerTest
testPHPTags: org.netbeans.modules.php.editor.csl.FoldingTest
```


~The javafx modules wouldn't load anyway -> lets turn off the javafx cluster for those tests.~ didn't work

failure:

```
java.lang.AssertionError: Should have found a nonproblematic provider of needs org.openide.modules.jre.JavaFX among
StandardModule:org.netbeans.libs.javafx.linux jarFile: /home/runner/work/netbeans/netbeans/nbbuild/netbeans/extra/modules/org-netbeans-libs-javafx-linux.jar,  ... long list of jars
```


fixes #5955 