### PR TITLE
Fix wrong javac tree access for module information in modular maven project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,11 +162,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
             distribution: 'zulu'
-            java-version: 8
+            java-version: 11
       - name: Caching dependencies
         uses: actions/cache/restore@v3
         with:

--- a/java/maven/src/org/netbeans/modules/maven/ModuleInfoSupport.java
+++ b/java/maven/src/org/netbeans/modules/maven/ModuleInfoSupport.java
@@ -159,14 +159,14 @@ public class ModuleInfoSupport {
         return getDeclaredModules(src);
     }
     
-    private static Set<String> getDeclaredModules(final JavaSource src) {
+    static Set<String> getDeclaredModules(final JavaSource src) {
         Set<String> declaredModuleNames = new HashSet<>();
         try {
             src.runUserActionTask((cc)-> {
                 cc.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
-                final List<? extends Tree> decls = cc.getCompilationUnit().getTypeDecls();
-                final ModuleElement me =  !decls.isEmpty() && decls.get(0).getKind() == Tree.Kind.MODULE ?
-                        (ModuleElement) cc.getTrees().getElement(TreePath.getPath(cc.getCompilationUnit(), decls.get(0))) :
+                final ModuleTree moduleTree = cc.getCompilationUnit().getModule();
+                final ModuleElement me = moduleTree != null ?
+                        ((ModuleElement) cc.getTrees().getElement(TreePath.getPath(cc.getCompilationUnit(), moduleTree))) :
                         null;
                 if (me != null) {
                     for (ModuleElement.Directive d : me.getDirectives()) {
@@ -214,7 +214,7 @@ public class ModuleInfoSupport {
         });
     }
     
-    private static void addRequires(FileObject moduleInfo, List<String> newModules) {
+    static void addRequires(FileObject moduleInfo, List<String> newModules) {
         final JavaSource src = JavaSource.forFileObject(moduleInfo);
         if (src == null) {
             return;
@@ -235,7 +235,7 @@ public class ModuleInfoSupport {
                 src.runModificationTask((WorkingCopy copy) -> {
                     copy.toPhase(JavaSource.Phase.RESOLVED);
                     TreeMaker tm = copy.getTreeMaker();
-                    ModuleTree modle = (ModuleTree) copy.getCompilationUnit().getTypeDecls().get(0);
+                    ModuleTree modle = (ModuleTree) copy.getCompilationUnit().getModule();
                     ModuleTree newModle = modle;
                     for (String mName : mNames) {
                         newModle = tm.addModuleDirective(newModle, tm.Requires(false, false, tm.QualIdent(mName)));

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/ModuleInfoSupportTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/ModuleInfoSupportTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.java.platform.JavaPlatformManager;
+import org.netbeans.api.java.source.ClasspathInfo;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.test.TestFileUtils;
+
+public class ModuleInfoSupportTest extends NbTestCase {
+
+    public ModuleInfoSupportTest(String name) {
+        super(name);
+    }
+
+    protected @Override
+    void setUp() throws Exception {
+        clearWorkDir();
+    }
+
+    public void testAddRequires() throws Exception {
+        System.setProperty("test.load.sync", "true");
+        FileObject d = FileUtil.toFileObject(getWorkDir());
+        TestFileUtils.writeFile(d, "module-info.java",
+                "module Mavenproject {\n}");
+        FileObject moduleInfo = d.getFileObject("module-info.java");
+        ModuleInfoSupport.addRequires(moduleInfo, List.of("test.dummy"));
+        assertEquals("module Mavenproject {\n    requires test.dummy;\n}", moduleInfo.asText());
+    }
+
+    public void testGetDeclaredModules() throws Exception {
+        System.setProperty("test.load.sync", "true");
+        FileObject d = FileUtil.toFileObject(getWorkDir());
+        FileObject dummy = d.createFolder("dummy");
+        FileObject dummy2 = d.createFolder("dummy2");
+        TestFileUtils.writeFile(dummy, "module-info.java", "module test.dummy {}");
+        TestFileUtils.writeFile(dummy2, "module-info.java", "module test.dummy2x {}");
+        TestFileUtils.writeFile(d, "module-info.java",
+                "module Mavenproject {"
+                + "    requires test.dummy;\n"
+                + "    requires test.dummy2x;\n"
+                + "\n}");
+        FileObject moduleInfo = d.getFileObject("module-info.java");
+
+        javax.tools.ToolProvider.getSystemJavaCompiler().run(
+                System.in,
+                System.out,
+                System.err,
+                "-d", dummy.getPath(),
+                dummy.getFileObject("module-info.java").getPath()
+        );
+
+        javax.tools.ToolProvider.getSystemJavaCompiler().run(
+                System.in,
+                System.out,
+                System.err,
+                "-d", dummy2.getPath(),
+                dummy2.getFileObject("module-info.java").getPath()
+        );
+
+        ClassPath cp = org.netbeans.spi.java.classpath.support.ClassPathSupport.createClassPath(
+                dummy, dummy2
+        );
+
+        ClasspathInfo cpi = new ClasspathInfo.Builder(JavaPlatformManager.getDefault().getDefaultPlatform().getBootstrapLibraries())
+                .setModuleCompilePath(cp)
+                .build();
+
+        JavaSource js = JavaSource.create(cpi, moduleInfo);
+
+        assertEquals(Set.of("java.base", "test.dummy", "test.dummy2x"),
+                new HashSet<>(ModuleInfoSupport.getDeclaredModules(js)));
+    }
+}


### PR DESCRIPTION
I noticed, that the function "Add to Moduleinfo" that can be invoked on maven dependencies does not work. Checkin the code showed, that the access to the AST has to be updated to the current compiler interface.

![screenshot](https://github.com/apache/netbeans/assets/2179736/76754efc-28bc-4f29-99b2-ffb268321c73)
