### PR TITLE
Various improvements to "Open in System" action

### DIFF
--- a/platform/core.ui/src/org/netbeans/core/ui/sysopen/SystemOpenAction.java
+++ b/platform/core.ui/src/org/netbeans/core/ui/sysopen/SystemOpenAction.java
@@ -51,7 +51,8 @@ import org.openide.util.WeakListeners;
 @ActionRegistration(displayName = "#CTL_SystemOpenAction", lazy=false)
 @ActionReferences ({
     @ActionReference(path = "UI/ToolActions/Files", position = 2045),
-    @ActionReference(path = "Projects/Actions", position = 101)
+    @ActionReference(path = "Projects/Actions", position = 101),
+    @ActionReference(path = "Shortcuts", name = "SO-S")
 })
 public final class SystemOpenAction extends AbstractAction implements ContextAwareAction {
 

--- a/platform/core.ui/src/org/netbeans/core/ui/sysopen/SystemOpenAction.java
+++ b/platform/core.ui/src/org/netbeans/core/ui/sysopen/SystemOpenAction.java
@@ -50,6 +50,7 @@ import org.openide.util.WeakListeners;
 @ActionID(id = "org.netbeans.core.ui.sysopen.SystemOpenAction", category = "Edit")
 @ActionRegistration(displayName = "#CTL_SystemOpenAction", lazy=false)
 @ActionReferences ({
+    @ActionReference(path = "Editors/TabActions", position = 401),
     @ActionReference(path = "UI/ToolActions/Files", position = 2045),
     @ActionReference(path = "Projects/Actions", position = 101),
     @ActionReference(path = "Shortcuts", name = "SO-S")

--- a/platform/core.ui/src/org/netbeans/core/ui/sysopen/SystemOpenAction.java
+++ b/platform/core.ui/src/org/netbeans/core/ui/sysopen/SystemOpenAction.java
@@ -106,12 +106,22 @@ public final class SystemOpenAction extends AbstractAction implements ContextAwa
         files.clear();
         for (DataObject d : result.allInstances()) {
             File f = FileUtil.toFile(d.getPrimaryFile());
-            if (f == null || /* #144575 */ Utilities.isWindows() && f.isFile() && !f.getName().contains(".")) {
-                files.clear();
-                break;
+            if (f == null || isIgnoredFile(f)) {
+                continue;
             }
             files.add(f);
         }
+    }
+
+    private boolean isIgnoredFile(File f) {
+        if (Utilities.isWindows() && f.isFile() && !f.getName().contains(".")) {
+            /* #144575 */
+            return true;
+        }
+        if (f.getName().endsWith(".shadow")) {
+            return true;
+        }
+        return false;
     }
 
 }


### PR DESCRIPTION
As discussed in #6043 , various minor improvements to `SystemOpenAction`- add a default shortcut (`SO-S`), add to editor tab actions, and filter out `.shadow` files from list.