### PR TITLE
Fix tab closing when trying to select partly clipped tab.

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
@@ -168,7 +168,7 @@ public class FlatEditorTabCellRenderer extends AbstractTabCellRenderer {
         public void getCloseButtonRectangle(JComponent jc, Rectangle rect, Rectangle bounds) {
             FlatEditorTabCellRenderer ren = (FlatEditorTabCellRenderer) jc;
 
-            if (!ren.isShowCloseButton()) {
+            if (!ren.isShowCloseButton() || leftClip || rightClip) {
                 rect.x = -100;
                 rect.y = -100;
                 rect.width = 0;

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
@@ -166,7 +166,7 @@ class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
         public void getCloseButtonRectangle(JComponent jc, Rectangle rect, Rectangle bounds) {
             WinFlatEditorTabCellRenderer ren = (WinFlatEditorTabCellRenderer) jc;
 
-            if (!ren.isShowCloseButton()) {
+            if (!ren.isShowCloseButton() || leftClip || rightClip) {
                 rect.x = -100;
                 rect.y = -100;
                 rect.width = 0;


### PR DESCRIPTION
Fix FlatEditorTabCellRenderer to not return close button bounds when clipped and not painting it. This seems to be the cause of #4738 and #6143 