### PR TITLE
Add @asbachb to collaborator/triage list.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,6 +36,8 @@ github:
   protected_branches:
     # no force push to master
     master: {}
+  collaborators:
+    - asbachb
 
 notifications:
     commits:      commits@netbeans.apache.org


### PR DESCRIPTION
This PR proposes to add Benjamin Asbach to the collaborators list.

The collaborator/triage role unlocks many github features like labels, CI or issue management which makes contributing a smoother experience.

[apache doc](https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-AssigningexternalcollaboratorswiththetriageroleonGitHub)
[github doc (triage role)](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role)

@asbachb please make sure to read the CI section on the [wiki](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide) to understand how PR labels are used for the NetBeans repo.