### PR TITLE
Update the PHP sample project for PHPUnit

### DIFF
--- a/php/php.samples/samples_src/Calculator-PHPUnit/composer.json
+++ b/php/php.samples/samples_src/Calculator-PHPUnit/composer.json
@@ -11,7 +11,7 @@
 
     },
     "require-dev": {
-        "phpunit/phpunit": "~8"
+        "phpunit/phpunit": "~10"
     },
     "autoload": {
         "classmap": ["src/"]

--- a/php/php.samples/samples_src/Calculator-PHPUnit/readme.html
+++ b/php/php.samples/samples_src/Calculator-PHPUnit/readme.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
 
     Licensed to the Apache Software Foundation (ASF) under one
@@ -18,12 +19,11 @@
     under the License.
 
 -->
-<!DOCTYPE html>
 <html>
 <head>
     <title>Calculator (PHPUnit) - sample application for NetBeans IDE</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <style type="text/css">
+    <style>
         /** general **/
         * {
             margin: 0;
@@ -234,11 +234,21 @@
                             <li>Play futher with the sample :)</li>
                         </ol>
 
+                        <h3 id="coverage">Coverage</h3>
+                        <p class="p">
+                            To get the result of code coverage, please set the following to the ini file. e.g. <i>php.ini, xdebug.ini</i>
+                        </p>
+                        <pre>
+<code>xdebug.mode=coverage
+xdebug.client_host=localhost
+xdebug.client_port=9003
+xdebug.idekey="netbeans-xdebug"</code>
+                        </pre>
+
                         <h3 id="debugging">Debugging</h3>
                         <p class="p">
                             These steps should enable you the debugging option at the sample project,
-                            <a href="http://wiki.netbeans.org/HowToConfigureXDebug" target="_blank">if you already have PHP debugger (Xdebug)
-                            installed and configured</a>.<br>
+                            if you already have PHP debugger (Xdebug) installed and configured.<br>
                             For demonstrating the PHP debugger in NetBeans, try the following:
                         </p>
                         <ol class="p">
@@ -254,7 +264,7 @@
         <!-- footer -->
         <div id="footer">
             <div class="indent">
-                <div class="fleft">2019 &copy; Copyright The Apache Software Foundation, All rights reserved</div>
+                <div class="fleft">2023 &copy; Copyright The Apache Software Foundation, All rights reserved</div>
             </div>
         </div>
     </div>

--- a/php/php.samples/samples_src/Calculator-PHPUnit/test/phpunit.xml
+++ b/php/php.samples/samples_src/Calculator-PHPUnit/test/phpunit.xml
@@ -20,9 +20,9 @@
 
 -->
 <phpunit bootstrap="../vendor/autoload.php">
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage>
+        <include>
             <directory suffix=".php">../src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
- Update the version to PHPUnit 10
- Remove the unavailable URL from readme.html
- Add setting for code coverage to readme.html
- Fix the phpunit.xml (the `filter` element is available no longer. Instead, use the `coverage` element.)
- See: https://docs.phpunit.de/en/10.1/configuration.html (https://phpunit.de/documentation.html)
