### PR TITLE
Don't remove existing uses if they are the same as the created string for use statements

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/actions/testIssue210093/01/testIssue210093_01.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testIssue210093/01/testIssue210093_01.php.fixUses
@@ -8,7 +8,7 @@ namespace Issue\Martin {
 
 namespace {
 
-use \Issue\Martin\Pondeli;
+    use \Issue\Martin\Pondeli;
 
     function testOk(Pondeli $param) {}
 

--- a/php/php.editor/test/unit/data/testfiles/actions/testNoChanges/01/testNoChanges_01.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testNoChanges/01/testNoChanges_01.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace {
+
+    use NS1\TestClass;
+
+    class Test {
+        public function create(): TestClass {
+            return new TestClass();
+        }
+
+        public function something(\NS1\TestClass $testClass): TestClass {
+            return $testClass;
+        }
+    }
+}
+
+namespace NS1 {
+    class TestClass {}
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testNoChanges/01/testNoChanges_01.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testNoChanges/01/testNoChanges_01.php.fixUses
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace {
+
+    use NS1\TestClass;
+
+    class Test {
+        public function create(): TestClass {
+            return new TestClass();
+        }
+
+        public function something(TestClass $testClass): TestClass {
+            return $testClass;
+        }
+    }
+}
+
+namespace NS1 {
+    class TestClass {}
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/FixUsesPerformerTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/FixUsesPerformerTest.java
@@ -641,6 +641,13 @@ public void testGH4609PSR12_GroupUses() throws Exception {
         performTest("class DeclareTest1 ^{", selections, true, options);
     }
 
+    public void testNoChanges_01() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\TestClass", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81).build();
+        performTest("    class ^Test {", selections, true, options);
+    }
+
     private String getTestResult(final String fileName, final String caretLine, final List<Selection> selections, final boolean removeUnusedUses, final Options options) throws Exception {
         FileObject testFile = getTestFile(fileName);
 


### PR DESCRIPTION
- https://github.com/apache/netbeans/pull/5681
- Avoid changing the file state if the created string is the same as the existing use statements
