### PR TITLE
Use ex.printStackTrace(StringWriter) to avoid no message NPE

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -38,6 +38,8 @@ import java.net.URI;
 import java.net.URL;
 import java.time.Instant;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -1069,8 +1071,11 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                     }
                 });
             } catch (ParseException ex) {
-                //TODO: include stack trace:
-                client.logMessage(new MessageParams(MessageType.Error, ex.getMessage()));
+                StringWriter w = new StringWriter();
+                try (PrintWriter pw = new PrintWriter(w)) {
+                  ex.printStackTrace(pw);
+                }
+                client.logMessage(new MessageParams(MessageType.Error, w.toString()));
             } finally {
                 resultFuture.complete(result);
             }


### PR DESCRIPTION
While working on https://github.com/enso-org/enso/pull/7054#issuecomment-1632751826 I got following exception:
```
java.lang.NullPointerException: Property must not be null: message
        at org.eclipse.lsp4j.util.Preconditions.checkNotNull(Preconditions.java:29)
        at org.eclipse.lsp4j.MessageParams.<init>(MessageParams.java:45)
        at org.netbeans.modules.java.lsp.server.protocol.TextDocumentServiceImpl.lambda$codeAction$24(TextDocumentServiceImpl.java:1058)
```
This PR avoids the `NullPointerException` and also addresses the comment that asked for delivering the stack trace.