### PR TITLE
Repair openjdk.project tests and add them to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1311,8 +1311,8 @@ jobs:
       - name: java.navigation
         run: ant $OPTS -f java/java.navigation test
 
-#      - name: java.openjdk.project
-#        run: ant $OPTS -f java/java.openjdk.project test
+      - name: java.openjdk.project
+        run: ant $OPTS -f java/java.openjdk.project test
 
       - name: java.platform
         run: ant $OPTS -f java/java.platform test

--- a/java/java.openjdk.project/nbproject/project.properties
+++ b/java/java.openjdk.project/nbproject/project.properties
@@ -22,3 +22,9 @@ cp.extra=${tools.jar}
 requires.nb.javac=true
 extra.module.files=\
     modules/ext/fakeJdkClasses.zip
+
+# high CI failure rate; throws exceptions even when passing
+test.config.default.excludes=**/ModulesHintTest.class
+
+# remove default compiler JMS flags to fix "WARNING: Unknown module: jdk.compiler specified to --add-opens" warnings
+jms-compiler.flags.jvm=

--- a/java/java.openjdk.project/nbproject/project.xml
+++ b/java/java.openjdk.project/nbproject/project.xml
@@ -128,6 +128,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.java.j2seplatform</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.64</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.java.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/ClassPathProviderImplTest.java
+++ b/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/ClassPathProviderImplTest.java
@@ -97,12 +97,19 @@ public class ClassPathProviderImplTest extends NbTestCase {
         FileObject src = BuildUtils.getFileObject(prj, "share/classes");
 
         Project project = FileOwnerQuery.getOwner(src);
+        ((JDKProject) project).moduleRepository.projectOpened(project);
 
-        assertNotNull(project);
+        try {
+            assertNotNull(project);
 
-        String actual = ClassPath.getClassPath(src, ClassPath.COMPILE).toString(PathConversionMode.PRINT).replace(getWorkDirPath(), "${wd}");
+            String actual = ClassPath.getClassPath(src, ClassPath.COMPILE).
+                    toString(PathConversionMode.PRINT).
+                    replace(getWorkDirPath(), "${wd}");
 
-        assertEquals(expected, actual);
+            assertEquals(expected, actual);
+        } finally {
+            ((JDKProject) project).moduleRepository.projectClosed(project);
+        }
     }
 
     private void setupModuleXMLJDK(FileObject jdkRoot) throws IOException {


### PR DESCRIPTION
while reviewing #6067 I noticed that the tests were not running. Fixing them was relatively easy since the symptom is the same as in #5166.

j2seplatform dependency fixes "java.net.MalformedURLException: unknown protocol: nbjrt"

tested on JDK 11 and 21, ran them several times, seem to be reliable. They print so many stack traces though that it is hard to figure out for me if this is intended behavior or not.

meta issue #4904

