### PR TITLE
Make NP Dereference hint aware of Objects.requireNonNull().

### DIFF
--- a/java/java.hints.test/src/org/netbeans/modules/java/hints/test/api/HintTest.java
+++ b/java/java.hints.test/src/org/netbeans/modules/java/hints/test/api/HintTest.java
@@ -823,17 +823,23 @@ public class HintTest {
         }
 
         /**Assert that the hint(s) produced warnings do not include the given warnings. The provided strings
-         * should match {@code toString()} results of {@link ErrorDescription}s produced
+         * should match {@code getDescription()} results of {@link ErrorDescription}s produced
          * by the hint(s).
          *
-         * @param warnings expected {@code toString()} results of {@link ErrorDescription}s produced
+         * @param warnings expected {@code getDescription()} results of {@link ErrorDescription}s produced
          *                 by the hint
          * @return itself
-         * @throws AssertionError if the given warnings do not match the actual warnings
+         * @throws AssertionError if the given warnings contain the actual warnings
          */
         public HintOutput assertNotContainsWarnings(String... warnings) {
             Set<String> goldenSet = new HashSet<String>(Arrays.asList(warnings));
             List<String> errorsNames = new LinkedList<String>();
+            
+            for (String warning : goldenSet) {
+                if (warning.split(":").length >= 5) {
+                    assertFalse("this method expects hint descriptions, not toString()! errors found: "+errors, true);
+                }
+            }
 
             boolean fail = false;
             for (ErrorDescription d : errors) {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/NPECheck.java
@@ -1068,12 +1068,16 @@ public class NPECheck {
                 State targetState = null;
 
                 switch (e.getSimpleName().toString()) {
-                    case "assertNotNull": targetState = State.NOT_NULL; break;
+                    case "assertNotNull":
+                    case "requireNonNull":
+                    case "requireNonNullElse":
+                    case "requireNonNullElseGet": targetState = State.NOT_NULL; break;
                     case "assertNull": targetState = State.NULL; break;
                 }
 
                 switch (ownerFQN) {
-                    case "org.testng.Assert": argument = node.getArguments().get(0); break;
+                    case "org.testng.Assert":
+                    case "java.util.Objects": argument = node.getArguments().get(0); break;
                     case "junit.framework.Assert":
                     case "org.junit.Assert": 
                     case "org.junit.jupiter.api.Assertions": argument = node.getArguments().get(node.getArguments().size() - 1); break;

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/NPECheckTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/NPECheckTest.java
@@ -1798,6 +1798,38 @@ public class NPECheckTest extends NbTestCase {
                                 "9:7-9:15:verifier:Possibly Dereferencing null");
     }
 
+    public void testObjectsRequireNonNull() throws Exception {
+        HintTest.create()
+                .input("package test;\n"
+                     + "import java.util.Objects;\n"
+                     + "public class Test {\n"
+                     + "  public String test(Object obj) {\n"
+                     + "    Objects.requireNonNull(obj);\n"
+                     + "    if (obj instanceof Number)\n"
+                     + "        return \"\";\n"
+                     + "    return obj.toString();\n"
+                     + "  }\n"
+                     + "}")
+                .run(NPECheck.class)
+                .assertNotContainsWarnings("Possibly Dereferencing null");
+    }
+
+    public void testObjectsRequireNonNullElse() throws Exception {
+        HintTest.create()
+                .input("package test;\n"
+                     + "import java.util.Objects;\n"
+                     + "public class Test {\n"
+                     + "  public String test(Object obj) {\n"
+                     + "    Objects.requireNonNullElse(obj, \"\");\n"
+                     + "    if (obj instanceof Number)\n"
+                     + "        return \"\";\n"
+                     + "    return obj.toString();\n"
+                     + "  }\n"
+                     + "}")
+                .run(NPECheck.class)
+                .assertNotContainsWarnings("Possibly Dereferencing null");
+    }
+
     private void performAnalysisTest(String fileName, String code, String... golden) throws Exception {
         HintTest.create()
                 .input(fileName, code)

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToSwitchPatternInstanceOfTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToSwitchPatternInstanceOfTest.java
@@ -105,7 +105,7 @@ public class ConvertToSwitchPatternInstanceOfTest extends NbTestCase {
                 .sourceLevel("17")
                 .options("--enable-preview")
                 .run(ConvertToSwitchPatternInstanceOf.class)
-                .assertNotContainsWarnings("3:8-3:10:verifier:" + Bundle.ERR_ConvertToSwitchPatternInstanceOf());
+                .assertNotContainsWarnings(Bundle.ERR_ConvertToSwitchPatternInstanceOf());
     }
     
     @Test
@@ -184,7 +184,7 @@ public class ConvertToSwitchPatternInstanceOfTest extends NbTestCase {
                 .sourceLevel(SourceVersion.latest().name())
                 .options("--enable-preview")
                 .run(ConvertToSwitchPatternInstanceOf.class)
-                .assertNotContainsWarnings("4:8-4:10:verifier:" + Bundle.ERR_ConvertToSwitchPatternInstanceOf());
+                .assertNotContainsWarnings(Bundle.ERR_ConvertToSwitchPatternInstanceOf());
     }
 
     @Test
@@ -278,7 +278,7 @@ public class ConvertToSwitchPatternInstanceOfTest extends NbTestCase {
                 .sourceLevel(SourceVersion.latest().name())
                 .options("--enable-preview")
                 .run(ConvertToSwitchPatternInstanceOf.class)
-                .assertNotContainsWarnings("4:8-4:24:verifier:" + Bundle.ERR_ConvertToSwitchPatternInstanceOf());
+                .assertNotContainsWarnings(Bundle.ERR_ConvertToSwitchPatternInstanceOf());
     }
 
     @Test

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/mapreduce/ForLoopToFunctionalHintTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/mapreduce/ForLoopToFunctionalHintTest.java
@@ -1406,7 +1406,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .assertNotContainsWarnings("23:8-23:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint());
+                .assertNotContainsWarnings(Bundle.ERR_ForLoopToFunctionalHint());
     }
 
     public void testNoHintDueToNEF() throws Exception {
@@ -1789,7 +1789,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .assertNotContainsWarnings("23:8-23:11:hint:Can use functional operation");
+                .assertNotContainsWarnings("Can use functional operation");
 
     }
 
@@ -1832,7 +1832,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .assertNotContainsWarnings("23:8-23:11:hint:Can use functional operation");
+                .assertNotContainsWarnings("Can use functional operation");
 
     }
 
@@ -1873,7 +1873,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .assertNotContainsWarnings("23:8-23:11:hint:Can use functional operation");
+                .assertNotContainsWarnings("Can use functional operation");
 
     }
     


### PR DESCRIPTION
The first commit is fixing the test framework itself since some tests were using the `assertNotContainsWarnings` wrong.

`assertContainsWarnings` checks against `toString()` which is the full error state, including line number and position.
`assertNotContainsWarnings` is only checking `getDescription()`, but the doc was copied from `assertContainsWarnings` which means that all tests which actually followed the doc, didn't verify anything.

second commit makes the NPECheck hint `Objects.requireNonNull` aware.

fixes #6149