### PR TITLE
Fix the vendor name regex for Composer #6192

### DIFF
--- a/php/php.composer/src/org/netbeans/modules/php/composer/options/ComposerOptionsValidator.java
+++ b/php/php.composer/src/org/netbeans/modules/php/composer/options/ComposerOptionsValidator.java
@@ -29,7 +29,8 @@ import org.openide.util.NbBundle;
  */
 public final class ComposerOptionsValidator {
 
-    private static final Pattern VENDOR_REGEX = Pattern.compile("^[a-z0-9-]+$"); // NOI18N
+    // GH-6192 : https://getcomposer.org/doc/04-schema.md#name
+    private static final Pattern VENDOR_REGEX = Pattern.compile("^[a-z0-9]([_.-]?[a-z0-9]+)*$"); // NOI18N
     private static final Pattern EMAIL_REGEX = Pattern.compile("^\\w+[\\.\\w\\-]*@\\w+[\\.\\w\\-]*\\.[a-z]{2,}$", Pattern.CASE_INSENSITIVE); // NOI18N
     private static final Pattern AUTHOR_NAME_REGEX = Pattern.compile("^[^\\d]+$"); // NOI18N
 

--- a/php/php.composer/test/unit/src/org/netbeans/modules/php/composer/options/ComposerOptionsValidatorTest.java
+++ b/php/php.composer/test/unit/src/org/netbeans/modules/php/composer/options/ComposerOptionsValidatorTest.java
@@ -52,11 +52,15 @@ public class ComposerOptionsValidatorTest extends NbTestCase {
         result = new ComposerOptionsValidator()
                 .validateVendor("my.company")
                 .getResult();
-        assertTrue(result.hasWarnings());
+        assertFalse(result.hasWarnings());
         result = new ComposerOptionsValidator()
                 .validateVendor("my_company")
                 .getResult();
-        assertTrue(result.hasWarnings());
+        assertFalse(result.hasWarnings());
+        result = new ComposerOptionsValidator()
+                .validateVendor("my-company")
+                .getResult();
+        assertFalse(result.hasWarnings());
     }
 
     public void testValidAuthorEmail() {


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6192
- https://getcomposer.org/doc/04-schema.md#name
- VendorName/PackageName: `^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$`

Before:

![nb-php-gh-6192-composer-vendor-name-options-befor](https://github.com/apache/netbeans/assets/738383/e2dd6a8c-b558-47e0-b2ee-1e316afb2f81)


After:

![nb-php-gh-6192-composer-vendor-name-options-after](https://github.com/apache/netbeans/assets/738383/b50d7d85-c4ea-48b2-9b11-a434d82fbf43)

