### PR TITLE
Fix cycle in problem reporter with unreachable artifacts.

### DIFF
--- a/java/maven/test/unit/src/org/netbeans/modules/maven/classpath/AbstractProjectClassPathImplTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/classpath/AbstractProjectClassPathImplTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.logging.Level;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.codehaus.plexus.util.FileUtils;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.maven.embedder.EmbedderFactory;
@@ -60,7 +61,11 @@ public class AbstractProjectClassPathImplTest extends NbTestCase {
         File downloaded = new File(repo, "nbtest/grp/art/1.10-SNAPSHOT/art-1.10-20210520.222429-1.jar");
         Artifact a = EmbedderFactory.getProjectEmbedder().createArtifact("nbtest.grp", "art", "1.10-20210520.222429-1", "jar");
         assertNull(AbstractProjectClassPathImpl.getFile(a));
-        EmbedderFactory.getProjectEmbedder().resolve(a, Collections.emptyList(), EmbedderFactory.getProjectEmbedder().getLocalRepository());
+        try {
+            EmbedderFactory.getProjectEmbedder().resolve(a, Collections.emptyList(), EmbedderFactory.getProjectEmbedder().getLocalRepository());
+        } catch (ArtifactNotFoundException ex) {
+            // the downloaded artifact was not found, expected as only -SNAPSHOT is installed.
+        }
         assertEquals(installed, a.getFile());
         assertEquals(installed, AbstractProjectClassPathImpl.getFile(a));
         FileUtils.mkdir(downloaded.getParent());


### PR DESCRIPTION
There was a bug in the loop that causes the values NOT to be cached when the loop exited unsuccessfully, so the detection happened over and over again - computation intensive. This PR makes just one repeated attempt to resolve the artifacts, then reports whatever results are computed.

The reported error was made possible also because simple file-exists check is not enough: in the situation described by #6176, the artifact file physically exists locally (so priming detection evaluated that as an inconsistency and looped again), but is actually refused by Maven, as it is recorded to belong to a remote repository, but was never downloaded from there. The changes to `MavenEmbedder` use EnhancedLocalRepository that checks that thoroughly (the same way as Maven does during build). In addition `MavenEmbedder.resolve()` method never threw exceptions declared in the signature: partly they were swallowed by Maven library (in `DefaultArtifactResolver`) and partially they were ignored if present in `result.getExceptions()` - this affected existing clients that do exception hadling.