### PR TITLE
Bugfix: Bring back singleton option when creating a new `Session Bean` and interfaceless EJBs

### DIFF
--- a/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/J2eeProjectCapabilities.java
+++ b/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/J2eeProjectCapabilities.java
@@ -29,6 +29,7 @@ import org.netbeans.modules.j2ee.deployment.devmodules.api.J2eePlatform;
 import org.netbeans.api.j2ee.core.Profile;
 import org.netbeans.modules.j2ee.api.ejbjar.Car;
 import org.netbeans.modules.j2ee.api.ejbjar.EjbJar;
+import org.netbeans.modules.j2ee.deployment.devmodules.api.J2eeModule.Type;
 import org.netbeans.modules.j2ee.deployment.devmodules.spi.J2eeModuleProvider;
 import org.netbeans.modules.javaee.specs.support.api.EjbSupport;
 import org.netbeans.modules.javaee.specs.support.api.JpaSupport;
@@ -95,9 +96,10 @@ public final class J2eeProjectCapabilities {
      */
     public boolean isEjb30Supported() {
         J2eeModule.Type moduleType = provider.getJ2eeModule().getType();
-        boolean eeOk = ejbJarProfile != null && (ejbJarProfile.equals(Profile.JAVA_EE_5) ||
-                ejbJarProfile.equals(Profile.JAVA_EE_6_FULL) || ejbJarProfile.equals(Profile.JAVA_EE_7_FULL) || ejbJarProfile.equals(Profile.JAVA_EE_8_FULL) || ejbJarProfile.equals(Profile.JAKARTA_EE_8_FULL));
-        return J2eeModule.Type.EJB.equals(moduleType) && eeOk;
+
+        return ejbJarProfile != null && (
+                (Type.EJB.equals(moduleType) && ejbJarProfile.equals(Profile.JAVA_EE_5)) ||
+                isFullProfileAtLeast(ejbJarProfile, Profile.JAVA_EE_6_FULL));
     }
 
     /**
@@ -106,10 +108,7 @@ public final class J2eeProjectCapabilities {
      * @return {@code true} if the project is targeting full Java EE 6 or newer platform
      */
     public boolean isEjb31Supported() {
-        J2eeModule.Type moduleType = provider.getJ2eeModule().getType();
-        boolean ee6or7 = ejbJarProfile != null && (ejbJarProfile.equals(Profile.JAVA_EE_6_FULL) || ejbJarProfile.equals(Profile.JAVA_EE_7_FULL) || ejbJarProfile.equals(Profile.JAVA_EE_8_FULL) || ejbJarProfile.equals(Profile.JAKARTA_EE_8_FULL));
-        return ee6or7 && (J2eeModule.Type.EJB.equals(moduleType) ||
-                J2eeModule.Type.WAR.equals(moduleType));
+        return isFullProfileAtLeast(ejbJarProfile, Profile.JAVA_EE_6_FULL);
     }
 
     /**
@@ -117,9 +116,7 @@ public final class J2eeProjectCapabilities {
      * web profile or newer and wherever full EJB 3.1 is supported.
      */
     public boolean isEjb31LiteSupported() {
-        J2eeModule.Type moduleType = provider.getJ2eeModule().getType();
-        boolean ee6or7Web = ejbJarProfile != null && (ejbJarProfile.equals(Profile.JAVA_EE_6_WEB) || ejbJarProfile.equals(Profile.JAVA_EE_7_WEB) || ejbJarProfile.equals(Profile.JAVA_EE_8_WEB) || ejbJarProfile.equals(Profile.JAKARTA_EE_8_WEB));
-        return isEjb31Supported() || (J2eeModule.Type.WAR.equals(moduleType) && ee6or7Web);
+        return ejbJarProfile.isAtLeast(Profile.JAVA_EE_6_WEB);
     }
 
     /**
@@ -130,9 +127,7 @@ public final class J2eeProjectCapabilities {
      * @since 1.76
      */
     public boolean isEjb32Supported() {
-        J2eeModule.Type moduleType = provider.getJ2eeModule().getType();
-        boolean ee7 = ejbJarProfile != null && (ejbJarProfile.equals(Profile.JAVA_EE_7_FULL) || ejbJarProfile.equals(Profile.JAVA_EE_8_FULL) || ejbJarProfile.equals(Profile.JAKARTA_EE_8_FULL));
-        return ee7 && (J2eeModule.Type.EJB.equals(moduleType) || J2eeModule.Type.WAR.equals(moduleType));
+        return isFullProfileAtLeast(ejbJarProfile, Profile.JAVA_EE_7_FULL);
     }
 
     /**
@@ -143,9 +138,7 @@ public final class J2eeProjectCapabilities {
      * @since 1.76
      */
     public boolean isEjb32LiteSupported() {
-        J2eeModule.Type moduleType = provider.getJ2eeModule().getType();
-        boolean ee7Web = ejbJarProfile != null && (ejbJarProfile.equals(Profile.JAVA_EE_7_WEB) || ejbJarProfile.equals(Profile.JAVA_EE_8_WEB) || ejbJarProfile.equals(Profile.JAKARTA_EE_8_WEB));
-        return isEjb32Supported() || (J2eeModule.Type.WAR.equals(moduleType) && ee7Web);
+        return ejbJarProfile.isAtLeast(Profile.JAVA_EE_7_WEB);
     }
 
     /**
@@ -156,11 +149,9 @@ public final class J2eeProjectCapabilities {
      * @since 1.76
      */
     public boolean isEjb40Supported() {
-        J2eeModule.Type moduleType = provider.getJ2eeModule().getType();
-        boolean ee9 = ejbJarProfile != null && (ejbJarProfile.equals(Profile.JAKARTA_EE_9_FULL) || ejbJarProfile.equals(Profile.JAKARTA_EE_9_1_FULL) || ejbJarProfile.equals(Profile.JAKARTA_EE_10_FULL));
-        return ee9 && (J2eeModule.Type.EJB.equals(moduleType) || J2eeModule.Type.WAR.equals(moduleType));
+        return isFullProfileAtLeast(ejbJarProfile, Profile.JAKARTA_EE_9_FULL);
     }
-    
+
     /**
      * EJB 4.0 Lite functionality is supported in Web project targeting Jakarta EE 9/9.1
      * web profile and wherever full EJB 4.0 is supported.
@@ -169,20 +160,17 @@ public final class J2eeProjectCapabilities {
      * @since 1.76
      */
     public boolean isEjb40LiteSupported() {
-        J2eeModule.Type moduleType = provider.getJ2eeModule().getType();
-        boolean ee9Web = ejbJarProfile != null && (ejbJarProfile.equals(Profile.JAKARTA_EE_9_WEB) || ejbJarProfile.equals(Profile.JAKARTA_EE_9_1_WEB) || ejbJarProfile.equals(Profile.JAKARTA_EE_10_WEB));
-        return isEjb40Supported() || (J2eeModule.Type.WAR.equals(moduleType) && ee9Web);
+        return ejbJarProfile.isAtLeast(Profile.JAKARTA_EE_9_WEB);
     }
-    
+
     /**
      * Is CDI 1.0 supported in this project?
      * @return {@code true} if the project targets EE6 profile, {@code false} otherwise
      * @since 1.113
      */
     public boolean isCdi10Supported() {
-        return Profile.JAVA_EE_6_FULL.equals(ejbJarProfile) ||
-            Profile.JAVA_EE_6_WEB.equals(webProfile) ||
-            Profile.JAVA_EE_6_FULL.equals(ejbJarProfile);
+        return isFullProfileAtLeast(ejbJarProfile, Profile.JAVA_EE_6_FULL)
+                || isWebProfileAtLeast(webProfile, Profile.JAVA_EE_6_WEB);
     }
     
     /**
@@ -191,15 +179,9 @@ public final class J2eeProjectCapabilities {
      * @since 1.86
      */
     public boolean isCdi11Supported() {
-        return 
-            Profile.JAKARTA_EE_9_FULL.equals(ejbJarProfile) ||
-            Profile.JAKARTA_EE_8_FULL.equals(ejbJarProfile) ||
-            Profile.JAVA_EE_8_FULL.equals(ejbJarProfile) ||
-            Profile.JAVA_EE_8_WEB.equals(webProfile) ||
-            Profile.JAVA_EE_7_FULL.equals(ejbJarProfile) ||
-            Profile.JAVA_EE_7_WEB.equals(webProfile) ||
-            Profile.JAVA_EE_7_FULL.equals(carProfile) ||
-            Profile.JAVA_EE_8_FULL.equals(carProfile);
+        return isFullProfileAtLeast(ejbJarProfile, Profile.JAVA_EE_7_FULL) || 
+                isFullProfileAtLeast(carProfile, Profile.JAVA_EE_7_FULL) ||
+                isWebProfileAtLeast(webProfile, Profile.JAVA_EE_7_WEB);
     }
     
     /**
@@ -208,12 +190,9 @@ public final class J2eeProjectCapabilities {
      * @since 1.113
      */
     public boolean isCdi20Supported() {
-        return Profile.JAVA_EE_8_FULL.equals(ejbJarProfile) ||
-            Profile.JAVA_EE_8_WEB.equals(webProfile) ||
-            Profile.JAVA_EE_8_FULL.equals(carProfile) ||
-            Profile.JAKARTA_EE_8_FULL.equals(ejbJarProfile) ||
-            Profile.JAKARTA_EE_8_WEB.equals(webProfile) ||
-            Profile.JAKARTA_EE_8_FULL.equals(carProfile);
+        return isFullProfileAtLeast(ejbJarProfile, Profile.JAVA_EE_8_FULL) ||
+                isFullProfileAtLeast(carProfile, Profile.JAVA_EE_8_FULL) ||
+                isWebProfileAtLeast(webProfile, Profile.JAVA_EE_8_WEB);
     }
     
     /**
@@ -223,12 +202,9 @@ public final class J2eeProjectCapabilities {
      * @since 1.113
      */
     public boolean isCdi30Supported() {
-        return Profile.JAKARTA_EE_9_FULL.equals(ejbJarProfile) ||
-            Profile.JAKARTA_EE_9_WEB.equals(webProfile) ||
-            Profile.JAKARTA_EE_9_FULL.equals(carProfile) ||
-            Profile.JAKARTA_EE_9_1_FULL.equals(ejbJarProfile) ||
-            Profile.JAKARTA_EE_9_1_WEB.equals(webProfile) ||
-            Profile.JAKARTA_EE_9_1_FULL.equals(carProfile);
+        return isFullProfileAtLeast(ejbJarProfile, Profile.JAKARTA_EE_9_FULL)
+                || isFullProfileAtLeast(carProfile, Profile.JAKARTA_EE_9_FULL)
+                || isWebProfileAtLeast(webProfile, Profile.JAKARTA_EE_9_WEB);
     }
 
     /**
@@ -238,9 +214,9 @@ public final class J2eeProjectCapabilities {
      * {@code false} otherwise
      */
     public boolean isCdi40Supported() {
-        return Profile.JAKARTA_EE_10_FULL.equals(ejbJarProfile)
-                || Profile.JAKARTA_EE_10_WEB.equals(webProfile)
-                || Profile.JAKARTA_EE_10_FULL.equals(carProfile);
+        return isFullProfileAtLeast(ejbJarProfile, Profile.JAKARTA_EE_10_FULL)
+                || isFullProfileAtLeast(carProfile, Profile.JAKARTA_EE_10_FULL)
+                || isWebProfileAtLeast(webProfile, Profile.JAKARTA_EE_10_WEB);
     }
 
     /**
@@ -275,5 +251,17 @@ public final class J2eeProjectCapabilities {
         }
         JpaSupport support = JpaSupport.getInstance(platform);
         return support != null && support.getDefaultProvider() != null;
+    }
+
+    private boolean isNotWebProfile(Profile profile) {
+        return profile != null && !profile.name().endsWith("_WEB");
+    }
+
+    private boolean isFullProfileAtLeast(Profile base, Profile atLeast) {
+        return base != null && base.isAtLeast(atLeast) && base.name().endsWith("_FULL");
+    }
+
+    private boolean isWebProfileAtLeast(Profile base, Profile atLeast) {
+        return base != null && base.isAtLeast(atLeast) && base.name().endsWith("_WEB");
     }
 }

--- a/enterprise/j2ee.common/test/unit/src/org/netbeans/modules/j2ee/common/J2eeProjectCapabilitiesTest.java
+++ b/enterprise/j2ee.common/test/unit/src/org/netbeans/modules/j2ee/common/J2eeProjectCapabilitiesTest.java
@@ -16,16 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.netbeans.modules.j2ee.common;
 
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.netbeans.api.j2ee.core.Profile;
 import org.netbeans.api.project.Project;
-import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.j2ee.api.ejbjar.EjbJar;
 import org.netbeans.modules.j2ee.dd.api.ejb.EjbJarMetadata;
 import org.netbeans.modules.j2ee.deployment.devmodules.api.J2eeModule;
@@ -43,46 +51,63 @@ import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.Lookups;
 
-public class J2eeProjectCapabilitiesTest extends NbTestCase {
+@RunWith(Parameterized.class)
+public class J2eeProjectCapabilitiesTest {
 
-    public J2eeProjectCapabilitiesTest(String testName) {
-        super(testName);
+    @Parameter
+    public Type type;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Parameters(name = "{0}")
+    public static Object[] parameters() {
+        return new Object[]{Type.EJB, Type.WAR};
     }
 
-    public void testIsEjbSupported() throws Exception {
-        
-        Project p = createProject(Profile.JAVA_EE_5, Type.EJB);
+    @Test
+    public void validateEjbSupport_JAVA_EE_5() throws Exception {
+        Project p = createProject(Profile.JAVA_EE_5, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
+        assertEquals( type == Type.EJB, cap.isEjb30Supported());
+        assertFalse(cap.isEjb31Supported());
+        assertFalse(cap.isEjb31LiteSupported());
+        assertFalse(cap.isEjb32Supported());
+        assertFalse(cap.isEjb32LiteSupported());
+        assertFalse(cap.isEjb40Supported());
+        assertFalse(cap.isEjb40LiteSupported());
+    }
+
+    @Test
+    public void validateEjbSupport_JAVA_EE_6_WEB() throws Exception {
+        Project p = createProject(Profile.JAVA_EE_6_WEB, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
+        assertFalse(cap.isEjb30Supported());
+        assertFalse(cap.isEjb31Supported());
+        assertTrue(cap.isEjb31LiteSupported());
+        assertFalse(cap.isEjb32Supported());
+        assertFalse(cap.isEjb32LiteSupported());
+        assertFalse(cap.isEjb40Supported());
+        assertFalse(cap.isEjb40LiteSupported());
+    }
+
+    @Test
+    public void validateEjbSupport_JAVA_EE_6_FULL() throws Exception {
+        Project p = createProject(Profile.JAVA_EE_6_FULL, type);
         J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
         assertTrue(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertFalse(cap.isEjb40LiteSupported());
-
-        p = createProject(Profile.JAVA_EE_6_FULL, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertTrue(cap.isEjb30Supported());
         assertTrue(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
         assertFalse(cap.isEjb32Supported());
         assertFalse(cap.isEjb32LiteSupported());
         assertFalse(cap.isEjb40Supported());
         assertFalse(cap.isEjb40LiteSupported());
+    }
 
-        p = createProject(Profile.JAVA_EE_6_WEB, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertTrue(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertFalse(cap.isEjb40LiteSupported());
-        
-        p = createProject(Profile.JAVA_EE_7_FULL, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
+    @Test
+    public void validateEjbSupport_JAVA_EE_7_FULL() throws Exception {
+        Project p = createProject(Profile.JAVA_EE_7_FULL, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
         assertTrue(cap.isEjb30Supported());
         assertTrue(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
@@ -90,9 +115,12 @@ public class J2eeProjectCapabilitiesTest extends NbTestCase {
         assertTrue(cap.isEjb32LiteSupported());
         assertFalse(cap.isEjb40Supported());
         assertFalse(cap.isEjb40LiteSupported());
+}
 
-        p = createProject(Profile.JAVA_EE_7_WEB, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
+    @Test
+    public void validateEjbSupport_JAVA_EE_7_WEB() throws Exception {
+        Project p = createProject(Profile.JAVA_EE_7_WEB, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
         assertFalse(cap.isEjb30Supported());
         assertFalse(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
@@ -100,9 +128,12 @@ public class J2eeProjectCapabilitiesTest extends NbTestCase {
         assertTrue(cap.isEjb32LiteSupported());
         assertFalse(cap.isEjb40Supported());
         assertFalse(cap.isEjb40LiteSupported());
-        
-        p = createProject(Profile.JAVA_EE_8_FULL, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
+}
+
+    @Test
+    public void validateEjbSupport_JAVA_EE_8_FULL() throws Exception {
+        Project p = createProject(Profile.JAVA_EE_8_FULL, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
         assertTrue(cap.isEjb30Supported());
         assertTrue(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
@@ -110,9 +141,12 @@ public class J2eeProjectCapabilitiesTest extends NbTestCase {
         assertTrue(cap.isEjb32LiteSupported());
         assertFalse(cap.isEjb40Supported());
         assertFalse(cap.isEjb40LiteSupported());
+}
 
-        p = createProject(Profile.JAVA_EE_8_WEB, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
+    @Test
+    public void validateEjbSupport_JAVA_EE_8_WEB() throws Exception {
+        Project p = createProject(Profile.JAVA_EE_8_WEB, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
         assertFalse(cap.isEjb30Supported());
         assertFalse(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
@@ -120,9 +154,12 @@ public class J2eeProjectCapabilitiesTest extends NbTestCase {
         assertTrue(cap.isEjb32LiteSupported());
         assertFalse(cap.isEjb40Supported());
         assertFalse(cap.isEjb40LiteSupported());
-        
-        p = createProject(Profile.JAKARTA_EE_8_FULL, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
+}
+
+    @Test
+    public void validateEjbSupport_JAKARTA_EE_8_FULL() throws Exception {
+        Project p = createProject(Profile.JAKARTA_EE_8_FULL, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
         assertTrue(cap.isEjb30Supported());
         assertTrue(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
@@ -130,9 +167,12 @@ public class J2eeProjectCapabilitiesTest extends NbTestCase {
         assertTrue(cap.isEjb32LiteSupported());
         assertFalse(cap.isEjb40Supported());
         assertFalse(cap.isEjb40LiteSupported());
+}
 
-        p = createProject(Profile.JAKARTA_EE_8_WEB, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
+    @Test
+    public void validateEjbSupport_JAKARTA_EE_8_WEB() throws Exception {
+        Project p = createProject(Profile.JAKARTA_EE_8_WEB, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
         assertFalse(cap.isEjb30Supported());
         assertFalse(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
@@ -140,222 +180,89 @@ public class J2eeProjectCapabilitiesTest extends NbTestCase {
         assertTrue(cap.isEjb32LiteSupported());
         assertFalse(cap.isEjb40Supported());
         assertFalse(cap.isEjb40LiteSupported());
-        
-        p = createProject(Profile.JAKARTA_EE_9_FULL, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertTrue(cap.isEjb40Supported());
-        assertTrue(cap.isEjb40LiteSupported());
+}
 
-        p = createProject(Profile.JAKARTA_EE_9_WEB, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertTrue(cap.isEjb40LiteSupported());
-        
-        p = createProject(Profile.JAKARTA_EE_9_1_FULL, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertTrue(cap.isEjb40Supported());
-        assertTrue(cap.isEjb40LiteSupported());
-
-        p = createProject(Profile.JAKARTA_EE_9_1_WEB, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertTrue(cap.isEjb40LiteSupported());
-
-        p = createProject(Profile.JAKARTA_EE_10_FULL, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertTrue(cap.isEjb40Supported());
-        assertTrue(cap.isEjb40LiteSupported());
-
-        p = createProject(Profile.JAKARTA_EE_10_WEB, Type.EJB);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertTrue(cap.isEjb40LiteSupported());
-
-        p = createProject(Profile.JAVA_EE_5, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertFalse(cap.isEjb40LiteSupported());
-        
-        p = createProject(Profile.JAVA_EE_6_WEB, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertTrue(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertFalse(cap.isEjb40LiteSupported());
-
-        p = createProject(Profile.JAVA_EE_6_FULL, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertTrue(cap.isEjb31Supported());
-        assertTrue(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertFalse(cap.isEjb40LiteSupported());
-
-        p = createProject(Profile.JAVA_EE_7_FULL, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
+    @Test
+    public void validateEjbSupport_JAKARTA_EE_9_FULL() throws Exception {
+        Project p = createProject(Profile.JAKARTA_EE_9_FULL, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
+        assertTrue(cap.isEjb30Supported());
         assertTrue(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
         assertTrue(cap.isEjb32Supported());
         assertTrue(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertFalse(cap.isEjb40LiteSupported());
-        
-        p = createProject(Profile.JAVA_EE_7_WEB, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
+        assertTrue(cap.isEjb40Supported());
+        assertTrue(cap.isEjb40LiteSupported());
+}
+
+    @Test
+    public void validateEjbSupport_JAKARTA_EE_9_WEB() throws Exception {
+        Project p = createProject(Profile.JAKARTA_EE_9_WEB, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
         assertFalse(cap.isEjb30Supported());
         assertFalse(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
         assertFalse(cap.isEjb32Supported());
         assertTrue(cap.isEjb32LiteSupported());
         assertFalse(cap.isEjb40Supported());
-        assertFalse(cap.isEjb40LiteSupported());
+        assertTrue(cap.isEjb40LiteSupported());
+}
 
-        p = createProject(Profile.JAVA_EE_8_FULL, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
+    @Test
+    public void validateEjbSupport_JAKARTA_EE_9_1_FULL() throws Exception {
+        Project p = createProject(Profile.JAKARTA_EE_9_1_FULL, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
+        assertTrue(cap.isEjb30Supported());
         assertTrue(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
         assertTrue(cap.isEjb32Supported());
         assertTrue(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertFalse(cap.isEjb40LiteSupported());
-        
-        p = createProject(Profile.JAVA_EE_8_WEB, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
+        assertTrue(cap.isEjb40Supported());
+        assertTrue(cap.isEjb40LiteSupported());
+}
+
+    @Test
+    public void validateEjbSupport_JAKARTA_EE_9_1_WEB() throws Exception {
+        Project p = createProject(Profile.JAKARTA_EE_9_1_WEB, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
         assertFalse(cap.isEjb30Supported());
         assertFalse(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
         assertFalse(cap.isEjb32Supported());
         assertTrue(cap.isEjb32LiteSupported());
         assertFalse(cap.isEjb40Supported());
-        assertFalse(cap.isEjb40LiteSupported());
+        assertTrue(cap.isEjb40LiteSupported());
+}
 
-        p = createProject(Profile.JAKARTA_EE_8_FULL, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
+    @Test
+    public void validateEjbSupport_JAKARTA_EE_10_FULL() throws Exception {
+        Project p = createProject(Profile.JAKARTA_EE_10_FULL, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
+        assertTrue(cap.isEjb30Supported());
         assertTrue(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
         assertTrue(cap.isEjb32Supported());
         assertTrue(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertFalse(cap.isEjb40LiteSupported());
+        assertTrue(cap.isEjb40Supported());
+        assertTrue(cap.isEjb40LiteSupported());
+}
 
-        p = createProject(Profile.JAKARTA_EE_8_WEB, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
+    @Test
+    public void validateEjbSupport_JAKARTA_EE_10_WEB() throws Exception {
+        Project p = createProject(Profile.JAKARTA_EE_10_WEB, type);
+        J2eeProjectCapabilities cap = J2eeProjectCapabilities.forProject(p);
         assertFalse(cap.isEjb30Supported());
         assertFalse(cap.isEjb31Supported());
         assertTrue(cap.isEjb31LiteSupported());
         assertFalse(cap.isEjb32Supported());
         assertTrue(cap.isEjb32LiteSupported());
         assertFalse(cap.isEjb40Supported());
-        assertFalse(cap.isEjb40LiteSupported());
-        
-        p = createProject(Profile.JAKARTA_EE_9_FULL, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertTrue(cap.isEjb40Supported());
         assertTrue(cap.isEjb40LiteSupported());
-
-        p = createProject(Profile.JAKARTA_EE_9_WEB, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertTrue(cap.isEjb40LiteSupported());
-        
-        p = createProject(Profile.JAKARTA_EE_9_1_FULL, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertTrue(cap.isEjb40Supported());
-        assertTrue(cap.isEjb40LiteSupported());
-
-        p = createProject(Profile.JAKARTA_EE_9_1_WEB, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertTrue(cap.isEjb40LiteSupported());
-
-        p = createProject(Profile.JAKARTA_EE_10_FULL, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertTrue(cap.isEjb40Supported());
-        assertTrue(cap.isEjb40LiteSupported());
-
-        p = createProject(Profile.JAKARTA_EE_10_WEB, Type.WAR);
-        cap = J2eeProjectCapabilities.forProject(p);
-        assertFalse(cap.isEjb30Supported());
-        assertFalse(cap.isEjb31Supported());
-        assertFalse(cap.isEjb31LiteSupported());
-        assertFalse(cap.isEjb32Supported());
-        assertFalse(cap.isEjb32LiteSupported());
-        assertFalse(cap.isEjb40Supported());
-        assertTrue(cap.isEjb40LiteSupported());
-        
     }
 
     private Project createProject(final Profile profile, final Type type) throws IOException {
         // just a fake project dir for now:
-        FileObject projDir = FileUtil.toFileObject(getWorkDir());
+        FileObject projDir = FileUtil.toFileObject(folder.newFolder());
         return new FakeProject(type, profile, projDir);
     }
 

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/devmodules/api/J2eeModule.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/devmodules/api/J2eeModule.java
@@ -384,6 +384,11 @@ public class J2eeModule {
             }
             return null;
         }
+
+        @Override
+        public String toString() {
+            return jsrType.toString();
+        }
     }
 
 }


### PR DESCRIPTION
The options shown when selecting `New > Session Bean` are based on the capabilities of the used enterprise project.

The check missed some Jakarta EE versions and so were disabled.

As EJB and CDI specs are backwards compatible the code was refactored so that only a minimal version and the profile type is checked to match that EJB or CDI version.

This fixes #4892 and fixes #4830