### PR TITLE
Avoid getting all types with an empty type name #6039

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/actions/ImportDataCreator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/actions/ImportDataCreator.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 import org.netbeans.modules.php.api.PhpVersion;
+import org.netbeans.modules.php.api.util.StringUtils;
 import org.netbeans.modules.php.editor.CodeUtils;
 import org.netbeans.modules.php.editor.actions.FixUsesAction.Options;
 import org.netbeans.modules.php.editor.actions.ImportData.DataItem;
@@ -87,6 +88,10 @@ public class ImportDataCreator {
     }
 
     private void processFQElementName(final String fqElementName) {
+        // GH-6039: avoid getting all types
+        if (!StringUtils.hasText(fqElementName)) {
+            return;
+        }
         // GH-6075
         String fqeName = CodeUtils.removeNullableTypePrefix(fqElementName);
         Collection<FullyQualifiedElement> possibleFQElements = fetchPossibleFQElements(fqeName);

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParser.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParser.java
@@ -263,6 +263,7 @@ public class PHPDocCommentParser {
         List<PHPDocTypeNode> result = new ArrayList<>();
         for (String stype : getTypes(description, isReturnTag)) {
             stype = removeHTMLTags(stype);
+            stype = sanitizeShapes(stype);
             int startDocNode = findStartOfDocNode(originalComment, originalCommentStart, stype, startDescription);
             if (startDocNode == -1) {
                 continue;
@@ -377,15 +378,31 @@ public class PHPDocCommentParser {
 
     private String removeHTMLTags(String text) {
         String value = text;
-        int index = value.indexOf('>');
-        if (index > -1) {
-            value = value.substring(index + 1);
-            index = value.indexOf('<');
-            if (index > -1) {
-                value = value.substring(0, index);
-            }
+        int startTagIndex = value.indexOf('<');
+        if (startTagIndex > -1) {
+            value = value.substring(0, startTagIndex).trim();
         }
         return value;
+    }
+
+    /**
+     * Remove `{'key': type}`.
+     *
+     * e.g. {@code array{'foo': int}}, {@code object{'foo': int, "bar": string}}
+     *
+     * @see https://phpstan.org/writing-php-code/phpdoc-types#array-shapes
+     * @see https://phpstan.org/writing-php-code/phpdoc-types#object-shapes
+     *
+     * @param type the type
+     * @return the sanitized type
+     */
+    private String sanitizeShapes(String type) {
+        String sanitizedType = type;
+        int startIndex = sanitizedType.indexOf("{"); // NOI18N
+        if (startIndex > -1) {
+            sanitizedType = sanitizedType.substring(0, startIndex).trim();
+        }
+        return sanitizedType;
     }
 
     /**

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeArrayShapes01.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeArrayShapes01.pass
@@ -1,0 +1,9 @@
+<PHPDocBlock start='3' end='39'>
+    <Tags>
+        <PHPDocTypeTag start='3' end='42' kind='return'>
+            <Types>
+                <PHPDocTypeNode start='14' end='19' value='array' isArray='false'/>
+            </Types>
+        </PHPDocTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeArrayShapes02.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeArrayShapes02.pass
@@ -1,0 +1,9 @@
+<PHPDocBlock start='3' end='54'>
+    <Tags>
+        <PHPDocTypeTag start='3' end='57' kind='return'>
+            <Types>
+                <PHPDocTypeNode start='14' end='19' value='array' isArray='false'/>
+            </Types>
+        </PHPDocTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeGenerics01.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeGenerics01.pass
@@ -1,0 +1,9 @@
+<PHPDocBlock start='3' end='33'>
+    <Tags>
+        <PHPDocTypeTag start='3' end='36' kind='return'>
+            <Types>
+                <PHPDocTypeNode start='14' end='19' value='array' isArray='false'/>
+            </Types>
+        </PHPDocTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeGenerics02.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeGenerics02.pass
@@ -1,0 +1,9 @@
+<PHPDocBlock start='3' end='39'>
+    <Tags>
+        <PHPDocTypeTag start='3' end='42' kind='return'>
+            <Types>
+                <PHPDocTypeNode start='14' end='19' value='array' isArray='false'/>
+            </Types>
+        </PHPDocTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeGenerics03.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeGenerics03.pass
@@ -1,0 +1,9 @@
+<PHPDocBlock start='3' end='32'>
+    <Tags>
+        <PHPDocTypeTag start='3' end='35' kind='return'>
+            <Types>
+                <PHPDocTypeNode start='14' end='18' value='list' isArray='false'/>
+            </Types>
+        </PHPDocTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeGenerics04.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeGenerics04.pass
@@ -1,0 +1,9 @@
+<PHPDocBlock start='3' end='32'>
+    <Tags>
+        <PHPDocTypeTag start='3' end='35' kind='return'>
+            <Types>
+                <PHPDocTypeNode start='14' end='18' value='Test' isArray='false'/>
+            </Types>
+        </PHPDocTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeGenerics05.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeGenerics05.pass
@@ -1,0 +1,9 @@
+<PHPDocBlock start='3' end='32'>
+    <Tags>
+        <PHPDocTypeTag start='3' end='35' kind='return'>
+            <Types>
+                <PHPDocTypeNode start='14' end='18' value='Test' isArray='false'/>
+            </Types>
+        </PHPDocTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeObjectShapes01.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeObjectShapes01.pass
@@ -1,0 +1,9 @@
+<PHPDocBlock start='3' end='40'>
+    <Tags>
+        <PHPDocTypeTag start='3' end='43' kind='return'>
+            <Types>
+                <PHPDocTypeNode start='14' end='20' value='object' isArray='false'/>
+            </Types>
+        </PHPDocTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeObjectShapes02.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/ReturnTypeObjectShapes02.pass
@@ -1,0 +1,9 @@
+<PHPDocBlock start='3' end='55'>
+    <Tags>
+        <PHPDocTypeTag start='3' end='58' kind='return'>
+            <Types>
+                <PHPDocTypeNode start='14' end='20' value='object' isArray='false'/>
+            </Types>
+        </PHPDocTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH6039/testGH6039_01.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH6039/testGH6039_01.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace NS\GH6039;
+
+class TestClass1{};
+class TestClass2{};
+class TestClass3{};
+class TestClass4{};
+
+namespace Test;
+
+class Example {
+    /**
+     * @return array<int> Description
+     */
+    public function gh6039_01(): array {
+        return [];
+    }
+
+    /**
+     * @return array<int, string> Description
+     */
+    public function gh6039_02(): array {
+        return [];
+    }
+
+    /**
+     * @return Example<int> Description
+     */
+    public function gh6039_03(): Example {
+        return $this;
+    }
+
+    /**
+     * @return int<0, 100> Description
+     */
+    public function gh6039_04(): Example {
+        return 1;
+    }
+
+    /**
+     * @return array{int, int} Description
+     */
+    public function gh6039_05(): array {
+        return [];
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH6039/testGH6039_01.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH6039/testGH6039_01.php.importData
@@ -1,0 +1,7 @@
+Caret position: 1037
+Should show uses panel: false
+Defaults:
+
+Names:
+
+Variants:

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/ImportDataCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/ImportDataCreatorTest.java
@@ -126,6 +126,10 @@ public class ImportDataCreatorTest extends PHPTestBase {
         performTest("function test(): void ^{");
     }
 
+    public void testGH6039_01() throws Exception {
+        performTest("    public function gh6039_01(): ^array {");
+    }
+
     private void performTest(String caretLine) throws Exception {
         performTest(caretLine, null);
     }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest.java
@@ -385,6 +385,51 @@ public class PHPDocCommentParserTest extends PHPTestBase {
         perform(comment, "MethodStatic03");
     }
 
+    public void testReturnTypeGenerics01() throws Exception {
+        String comment = " * @return array<int> description";
+        perform(comment, "ReturnTypeGenerics01");
+    }
+
+    public void testReturnTypeGenerics02() throws Exception {
+        String comment = " * @return array<int, Test> description";
+        perform(comment, "ReturnTypeGenerics02");
+    }
+
+    public void testReturnTypeGenerics03() throws Exception {
+        String comment = " * @return list<int> description";
+        perform(comment, "ReturnTypeGenerics03");
+    }
+
+    public void testReturnTypeGenerics04() throws Exception {
+        String comment = " * @return Test<int> description";
+        perform(comment, "ReturnTypeGenerics04");
+    }
+
+    public void testReturnTypeGenerics05() throws Exception {
+        String comment = " * @return Test<max> description";
+        perform(comment, "ReturnTypeGenerics05");
+    }
+
+    public void testReturnTypeArrayShapes01() throws Exception {
+        String comment = " * @return array{'foo':int} description";
+        perform(comment, "ReturnTypeArrayShapes01");
+    }
+
+    public void testReturnTypeArrayShapes02() throws Exception {
+        String comment = " * @return array{'foo':int, \"bar\": string} description";
+        perform(comment, "ReturnTypeArrayShapes02");
+    }
+
+    public void testReturnTypeObjectShapes01() throws Exception {
+        String comment = " * @return object{'foo':int} description";
+        perform(comment, "ReturnTypeObjectShapes01");
+    }
+
+    public void testReturnTypeObjectShapes02() throws Exception {
+        String comment = " * @return object{'foo':int, \"bar\": string} description";
+        perform(comment, "ReturnTypeObjectShapes02");
+    }
+
     public void perform(String comment, String filename) throws Exception {
         PHPDocCommentParser parser = new PHPDocCommentParser();
         PHPDocBlock block = parser.parse(0, comment.length(), comment);


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6039
- Remove `<>` and `{}` from type name
- Ignore an empty type name to avoid getting all types
- Add unit tests