### PR TITLE
rust.project missing licenses in test files

### DIFF
--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Reference.Cargo.DottedName.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Reference.Cargo.DottedName.toml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 package.name = "Renamed\"Test"
 package.version = "0.1.0"
 package.edition= "2021"

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Reference.Cargo.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Reference.Cargo.toml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [package]
 name = "Renamed\"Test"
 version = "0.1.0"

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.DottedName.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.DottedName.toml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 package.name = "MyRust\nProject"
 package.version = "0.1.0"
 package.edition= "2021"

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.LiteralMultilineString.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.LiteralMultilineString.toml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [package]
 name = '''
 MyRust\tProject'\'''

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.LiteralString.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.LiteralString.toml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [package]
 name = 'MyRustProject\'
 version = "0.1.0"

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.MultilineString.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.MultilineString.toml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [package]
 name = """
 MyRust\tProject"""

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.String.toml
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/data/Test.Cargo.String.toml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [package]
 name = "MyRust\nProject"
 version = "0.1.0"


### PR DESCRIPTION
Test files introduced in 307594e2ffe55c7e4d3d7c8f9b03774828052d0d do not have license headers. Since these will end up in the source distribution of NB19 I thought we may want to add them.

I think that our "rat" test does not currently work on the "rust" folder, as that folder is processed only when `-Dcluster.config=rust` is ran. We may want to run rat on this folder too during the release process, or exclude the "rust" folder when generating the source artifact.