### PR TITLE
Set DB environment for java+ as well as for java

### DIFF
--- a/java/java.lsp.server/vscode/src/dbConfigurationProvider.ts
+++ b/java/java.lsp.server/vscode/src/dbConfigurationProvider.ts
@@ -35,7 +35,7 @@ export async function initializeRunConfiguration(): Promise<boolean> {
 	return false;
 }
 
-export class DBConfigurationProvider implements vscode.DebugConfigurationProvider {
+class DBConfigurationProvider implements vscode.DebugConfigurationProvider {
 	resolveDebugConfiguration(_folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, _token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
 		return new Promise<vscode.DebugConfiguration>(resolve => {
 			resolve(config);
@@ -59,3 +59,5 @@ export class DBConfigurationProvider implements vscode.DebugConfigurationProvide
 		});
 	}
 }
+
+export const dBConfigurationProvider = new DBConfigurationProvider();

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -56,7 +56,7 @@ import { asRanges, StatusMessageRequest, ShowStatusMessageParams, QuickPickReque
 import * as launchConfigurations from './launchConfigurations';
 import { createTreeViewService, TreeViewService, TreeItemDecorator, Visualizer, CustomizableTreeDataProvider } from './explorer';
 import { initializeRunConfiguration, runConfigurationProvider, runConfigurationNodeProvider, configureRunSettings, runConfigurationUpdateAll } from './runConfiguration';
-import { DBConfigurationProvider } from './dbConfigurationProvider';
+import { dBConfigurationProvider } from './dbConfigurationProvider';
 import { TLSSocket } from 'tls';
 import { InputStep, MultiStepInput } from './utils';
 import { env } from 'process';
@@ -427,7 +427,8 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
     // initialize Run Configuration
     initializeRunConfiguration().then(initialized => {
 		if (initialized) {
-            context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java+', new DBConfigurationProvider()));
+            context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java+', dBConfigurationProvider));
+            context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java', dBConfigurationProvider));
 			context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java+', runConfigurationProvider));
 			context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java', runConfigurationProvider));
 			context.subscriptions.push(vscode.window.registerTreeDataProvider('run-config', runConfigurationNodeProvider));


### PR DESCRIPTION
To correctly set environment variables for database connection we need to register DBConfigurationProvider for both targets - java+ and java.