### PR TITLE
JS: Fix handling of classes declared in anonymous functions

### DIFF
--- a/webcommon/javascript2.editor/test/unit/data/testfiles/structure/classInAnonymousFunction.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/structure/classInAnonymousFunction.js
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function () {
+
+    class Directory {
+        constructor(displayName) {
+            this.displayName = displayName;
+        }
+    }
+
+    class ImageFile{
+        constructor(displayName){
+            this.displayName = displayName;
+        }
+    }
+})();

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/structure/classInAnonymousFunction.js.structure
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/structure/classInAnonymousFunction.js.structure
@@ -1,0 +1,6 @@
+Directory:CLASS:[PUBLIC]:ESCAPED{Directory}:
+  constructor:CONSTRUCTOR:[PUBLIC]:ESCAPED{constructor}ESCAPED{(}ESCAPED{displayName}ESCAPED{)}<font color="#999999">ESCAPED{ : }Directory</font>:
+  displayName:FIELD:[PUBLIC]:ESCAPED{displayName}:
+ImageFile:CLASS:[PUBLIC]:ESCAPED{ImageFile}:
+  constructor:CONSTRUCTOR:[PUBLIC]:ESCAPED{constructor}ESCAPED{(}ESCAPED{displayName}ESCAPED{)}<font color="#999999">ESCAPED{ : }ImageFile</font>:
+  displayName:FIELD:[PUBLIC]:ESCAPED{displayName}:

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/structure/classInAnonymousFunction2.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/structure/classInAnonymousFunction2.js
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function () {
+    class Directory {
+        constructor(displayName) {
+            this.displayName = displayName;
+        }
+    }
+
+    class ImageFile{
+        constructor(displayName){
+            this.displayName = displayName;
+        }
+    }
+
+    function getJsonData(folderURL) {
+        const body = folderURL;
+    }
+})();

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/structure/classInAnonymousFunction2.js.structure
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/structure/classInAnonymousFunction2.js.structure
@@ -1,0 +1,7 @@
+Directory:CLASS:[PUBLIC]:ESCAPED{Directory}:
+  constructor:CONSTRUCTOR:[PUBLIC]:ESCAPED{constructor}ESCAPED{(}ESCAPED{displayName}ESCAPED{)}<font color="#999999">ESCAPED{ : }Directory</font>:
+  displayName:FIELD:[PUBLIC]:ESCAPED{displayName}:
+ImageFile:CLASS:[PUBLIC]:ESCAPED{ImageFile}:
+  constructor:CONSTRUCTOR:[PUBLIC]:ESCAPED{constructor}ESCAPED{(}ESCAPED{displayName}ESCAPED{)}<font color="#999999">ESCAPED{ : }ImageFile</font>:
+  displayName:FIELD:[PUBLIC]:ESCAPED{displayName}:
+getJsonData:METHOD:[PRIVATE]:ESCAPED{getJsonData}ESCAPED{(}ESCAPED{folderURL}ESCAPED{)}<font color="#999999">ESCAPED{ : }undefined</font>:

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsStructureScannerTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsStructureScannerTest.java
@@ -766,4 +766,12 @@ public class JsStructureScannerTest extends JsTestBase {
     public void testObjectNameMatchingNestedFunction() throws Exception {
         checkStructure("testfiles/structure/objectNameMatchingNestedFunction.js");
     }
+
+    public void testClassInAnonymousFunction() throws Exception {
+        checkStructure("testfiles/structure/classInAnonymousFunction.js");
+    }
+
+    public void testClassInAnonymousFunction2() throws Exception {
+        checkStructure("testfiles/structure/classInAnonymousFunction2.js");
+    }
 }

--- a/webcommon/javascript2.model/test/unit/data/testfiles/model/classInAnonymousFunction.js
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/model/classInAnonymousFunction.js
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function () {
+
+    class Directory {
+        constructor(displayName) {
+            this.displayName = displayName;
+        }
+    }
+
+    class ImageFile{
+        constructor(displayName){
+            this.displayName = displayName;
+        }
+    }
+})();

--- a/webcommon/javascript2.model/test/unit/data/testfiles/model/classInAnonymousFunction.js.model
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/model/classInAnonymousFunction.js.model
@@ -1,0 +1,29 @@
+FUNCTION classInAnonymousFunction [ANONYMOUS: false, DECLARED: true - classInAnonymousFunction, MODIFIERS: PUBLIC, FILE]
+# RETURN TYPES
+undefined, RESOLVED: true
+# PROPERTIES
+classInAnonymousFunctionL#20 : FUNCTION classInAnonymousFunctionL#20 [ANONYMOUS: true, DECLARED: true - classInAnonymousFunctionL#20, MODIFIERS: PUBLIC, FUNCTION]
+                             # RETURN TYPES
+                             undefined, RESOLVED: true
+                             # PROPERTIES
+                             Directory : OBJECT Directory [ANONYMOUS: false, DECLARED: true - Directory, MODIFIERS: PUBLIC, CLASS]
+                                       # PROPERTIES
+                                       constructor : FUNCTION constructor [ANONYMOUS: false, DECLARED: true - constructor, MODIFIERS: PUBLIC, CONSTRUCTOR]
+                                                   # RETURN TYPES
+                                                   classInAnonymousFunctionL#20.Directory, RESOLVED: true
+                                                   # PARAMETERS
+                                                   OBJECT displayName [ANONYMOUS: false, DECLARED: true - displayName, MODIFIERS: PUBLIC, PARAMETER]
+                                                   # PROPERTIES
+                                                   arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+                                       displayName : OBJECT displayName [ANONYMOUS: false, DECLARED: true - displayName, MODIFIERS: PUBLIC, PROPERTY]
+                             ImageFile : OBJECT ImageFile [ANONYMOUS: false, DECLARED: true - ImageFile, MODIFIERS: PUBLIC, CLASS]
+                                       # PROPERTIES
+                                       constructor : FUNCTION constructor [ANONYMOUS: false, DECLARED: true - constructor, MODIFIERS: PUBLIC, CONSTRUCTOR]
+                                                   # RETURN TYPES
+                                                   classInAnonymousFunctionL#20.ImageFile, RESOLVED: true
+                                                   # PARAMETERS
+                                                   OBJECT displayName [ANONYMOUS: false, DECLARED: true - displayName, MODIFIERS: PUBLIC, PARAMETER]
+                                                   # PROPERTIES
+                                                   arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+                                       displayName : OBJECT displayName [ANONYMOUS: false, DECLARED: true - displayName, MODIFIERS: PUBLIC, PROPERTY]
+                             arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]

--- a/webcommon/javascript2.model/test/unit/data/testfiles/model/classInAnonymousFunction2.js
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/model/classInAnonymousFunction2.js
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+(function () {
+    class Directory {
+        constructor(displayName) {
+            this.displayName = displayName;
+        }
+    }
+
+    class ImageFile{
+        constructor(displayName){
+            this.displayName = displayName;
+        }
+    }
+
+    function getJsonData(folderURL) {
+        const body = folderURL;
+    }
+})();

--- a/webcommon/javascript2.model/test/unit/data/testfiles/model/classInAnonymousFunction2.js.model
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/model/classInAnonymousFunction2.js.model
@@ -1,0 +1,37 @@
+FUNCTION classInAnonymousFunction2 [ANONYMOUS: false, DECLARED: true - classInAnonymousFunction2, MODIFIERS: PUBLIC, FILE]
+# RETURN TYPES
+undefined, RESOLVED: true
+# PROPERTIES
+classInAnonymousFunction2L#20 : FUNCTION classInAnonymousFunction2L#20 [ANONYMOUS: true, DECLARED: true - classInAnonymousFunction2L#20, MODIFIERS: PUBLIC, FUNCTION]
+                              # RETURN TYPES
+                              undefined, RESOLVED: true
+                              # PROPERTIES
+                              Directory   : OBJECT Directory [ANONYMOUS: false, DECLARED: true - Directory, MODIFIERS: PUBLIC, CLASS]
+                                          # PROPERTIES
+                                          constructor : FUNCTION constructor [ANONYMOUS: false, DECLARED: true - constructor, MODIFIERS: PUBLIC, CONSTRUCTOR]
+                                                      # RETURN TYPES
+                                                      classInAnonymousFunction2L#20.Directory, RESOLVED: true
+                                                      # PARAMETERS
+                                                      OBJECT displayName [ANONYMOUS: false, DECLARED: true - displayName, MODIFIERS: PUBLIC, PARAMETER]
+                                                      # PROPERTIES
+                                                      arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+                                          displayName : OBJECT displayName [ANONYMOUS: false, DECLARED: true - displayName, MODIFIERS: PUBLIC, PROPERTY]
+                              ImageFile   : OBJECT ImageFile [ANONYMOUS: false, DECLARED: true - ImageFile, MODIFIERS: PUBLIC, CLASS]
+                                          # PROPERTIES
+                                          constructor : FUNCTION constructor [ANONYMOUS: false, DECLARED: true - constructor, MODIFIERS: PUBLIC, CONSTRUCTOR]
+                                                      # RETURN TYPES
+                                                      classInAnonymousFunction2L#20.ImageFile, RESOLVED: true
+                                                      # PARAMETERS
+                                                      OBJECT displayName [ANONYMOUS: false, DECLARED: true - displayName, MODIFIERS: PUBLIC, PARAMETER]
+                                                      # PROPERTIES
+                                                      arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+                                          displayName : OBJECT displayName [ANONYMOUS: false, DECLARED: true - displayName, MODIFIERS: PUBLIC, PROPERTY]
+                              arguments   : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+                              getJsonData : FUNCTION getJsonData [ANONYMOUS: false, DECLARED: true - getJsonData, MODIFIERS: PRIVATE, METHOD]
+                                          # RETURN TYPES
+                                          undefined, RESOLVED: true
+                                          # PARAMETERS
+                                          OBJECT folderURL [ANONYMOUS: false, DECLARED: true - folderURL, MODIFIERS: PUBLIC, PARAMETER]
+                                          # PROPERTIES
+                                          arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+                                          body      : OBJECT body [ANONYMOUS: false, DECLARED: true - body, MODIFIERS: PRIVATE, CONSTANT]

--- a/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
+++ b/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
@@ -298,4 +298,12 @@ public class ModelTest extends ModelTestBase {
     public void testClassConstructor() throws Exception {
         checkModel("testfiles/model/classConstructor.js");
     }
+
+    public void testClassInAnonymousFunction() throws Exception {
+        checkModel("testfiles/model/classInAnonymousFunction.js");
+    }
+
+    public void testClassInAnonymousFunction2() throws Exception {
+        checkModel("testfiles/model/classInAnonymousFunction2.js");
+    }
 }


### PR DESCRIPTION
Consider this construct:

```javascript
  (function () {
      class Directory {
          constructor(displayName) {
              this.displayName = displayName;
          }
      }

      class ImageFile{
          constructor(displayName){
            this.displayName = displayName;
          }
      }
  })();
```

Before this change this construct was not correctly parsed and the constructor was not cleanly recognised, leading to missing usage marks (i.e. the displayName above was marked as unused).

A different fallout of that problem is visible with this:

```javascript
  (function () {
      class Directory {
          constructor(displayName) {
              this.displayName = displayName;
          }
      }

      class ImageFile{
          constructor(displayName){
              this.displayName = displayName;
          }
      }

      function getJsonData(folderURL) {
          const body = folderURL;
      }
  })();
```

Fixed Problems:

- `constructor` from `ImageFile` is shown as a toplevel function
- `ImageFile` is listed without its constructor and without its `displayName` property
