### PR TITLE
Prevent getting an incorrect type if a return type is `static` with PHPDoc tag(`@return`) #6247

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/actions/testGH6247/testGH6247_01.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH6247/testGH6247_01.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS1;
+
+class GH6247 {}
+
+namespace Test;
+
+$test = new class extends GH6247 {
+    /**
+     * @return static Description
+     */
+    public function test(): static {
+        return $this;
+    }
+};

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH6247/testGH6247_01.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH6247/testGH6247_01.php.importData
@@ -1,0 +1,12 @@
+Caret position: 980
+Should show uses panel: true
+Defaults:
+ \NS1\GH6247
+
+Names:
+ GH6247
+
+Variants:
+ \NS1\GH6247
+ Don't import.
+

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/ImportDataCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/ImportDataCreatorTest.java
@@ -130,6 +130,10 @@ public class ImportDataCreatorTest extends PHPTestBase {
         performTest("    public function gh6039_01(): ^array {");
     }
 
+    public void testGH6247_01() throws Exception {
+        performTest("public function test(): st^atic {");
+    }
+
     private void performTest(String caretLine) throws Exception {
         performTest(caretLine, null);
     }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6247
- Ignore `static` only when a PHPDoc tag is `@method`
- Add a unit test

Before:

![nb-php-gh-6247-before](https://github.com/apache/netbeans/assets/738383/7966558f-d625-47ce-ae6a-c5d522330de5)

After:

![nb-php-gh-6247-after](https://github.com/apache/netbeans/assets/738383/6abb2fc2-344f-4e0c-b1d9-6c1cf442e364)
