### PR TITLE
Bugfix: Bring back singleton option when creating a new Session Bean and interfaceless EJBs

### DIFF
--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/annotation/EnterpriseBeansImpl.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/annotation/EnterpriseBeansImpl.java
@@ -44,6 +44,7 @@ import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.Annotatio
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.ObjectProvider;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.PersistentObjectManager;
 
+// @todo: Support JakartaEE
 public class EnterpriseBeansImpl implements EnterpriseBeans {
 
     private final AnnotationModelHelper helper;

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/annotation/AnnotationHelpers.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/annotation/AnnotationHelpers.java
@@ -33,6 +33,7 @@ import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.Persisten
 /**
  * @author Petr Slechta
  */
+// @todo: Support JakartaEE
 public class AnnotationHelpers {
 
     private AnnotationModelHelper helper;

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/action/SendJMSGenerator.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/action/SendJMSGenerator.java
@@ -79,6 +79,7 @@ import org.openide.util.Exceptions;
  *
  * @author Martin Adamek
  */
+// @todo: Support JakartaEE
 public final class SendJMSGenerator {
 
     private static final Logger LOG = Logger.getLogger(SendJMSGenerator.class.getName());

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/api/methodcontroller/EjbMethodController.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/api/methodcontroller/EjbMethodController.java
@@ -72,7 +72,7 @@ public abstract class EjbMethodController {
                 Project project = FileOwnerQuery.getOwner(ejbClassFO);
                 if (project != null){
                     J2eeProjectCapabilities projectCap = J2eeProjectCapabilities.forProject(project);
-                    allowsNoInterface = projectCap != null ? projectCap.isEjb31LiteSupported() : false;
+                    allowsNoInterface = (projectCap != null && (projectCap.isEjb31LiteSupported() || projectCap.isEjb40LiteSupported()));
                 }
 
                 controller = new SessionMethodController(className, model, allowsNoInterface);

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/jpa/dao/EjbFacadeVisualPanel2.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/jpa/dao/EjbFacadeVisualPanel2.java
@@ -381,8 +381,9 @@ public final class EjbFacadeVisualPanel2 extends JPanel implements DocumentListe
     // End of variables declaration//GEN-END:variables
 
     private void updateCheckboxes() {
+        J2eeProjectCapabilities projectCap = J2eeProjectCapabilities.forProject(project);
         //by default for ejb 3.1 no interfaces will be created
-        localCheckBox.setSelected(!J2eeProjectCapabilities.forProject(project).isEjb31LiteSupported());
+        localCheckBox.setSelected(!(projectCap.isEjb31LiteSupported() || projectCap.isEjb40LiteSupported()));
         changeSupport.fireChange();
     }
     

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/jpa/dao/EjbFacadeWizardPanel2.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/jpa/dao/EjbFacadeWizardPanel2.java
@@ -90,7 +90,8 @@ public class EjbFacadeWizardPanel2 implements WizardDescriptor.Panel, ChangeList
             return false;
         }
         if (!(component.isRemote() || component.isLocal())) {
-            if(J2eeProjectCapabilities.forProject(project).isEjb31LiteSupported()) {
+            J2eeProjectCapabilities projectCap = J2eeProjectCapabilities.forProject(project);
+            if(projectCap.isEjb31LiteSupported() || projectCap.isEjb40LiteSupported()) {
                 //if it's jee6 project, ejb 3.1 allow to omit any interfaces
             } else {
                 wizardDescriptor.putProperty(WizardDescriptor.PROP_ERROR_MESSAGE, NbBundle.getMessage(EjbFacadeWizardPanel2.class, "ERR_ChooseInterface")); // NOI18N

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/mdb/MdbPropertiesPanelVisual.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/mdb/MdbPropertiesPanelVisual.java
@@ -53,6 +53,7 @@ import org.openide.util.NbBundle.Messages;
  *
  * @author Martin Fousek <marfous@netbeans.org>
  */
+// @todo: Support JakartaEE
 @SuppressWarnings("serial") // not used to be serialized
 public class MdbPropertiesPanelVisual extends javax.swing.JPanel {
 

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/mdb/MessageDestinationUiSupport.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/mdb/MessageDestinationUiSupport.java
@@ -64,6 +64,7 @@ import org.openide.util.NbBundle;
  * This class contains only static methods.
  * @author Tomas Mysik
  */
+// @todo: Support JakartaEE
 public abstract class MessageDestinationUiSupport {
 
     /**

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/session/SessionEJBWizardDescriptor.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/session/SessionEJBWizardDescriptor.java
@@ -79,7 +79,8 @@ public class SessionEJBWizardDescriptor implements WizardDescriptor.FinishablePa
         }
         boolean isLocal = wizardPanel.isLocal();
         boolean isRemote = wizardPanel.isRemote();
-        if (!isLocal && !isRemote && !J2eeProjectCapabilities.forProject(project).isEjb31LiteSupported()) {
+        J2eeProjectCapabilities projectCap = J2eeProjectCapabilities.forProject(project);
+        if (!isLocal && !isRemote && !projectCap.isEjb31LiteSupported() && !projectCap.isEjb40LiteSupported()) {
             wizardDescriptor.putProperty(WizardDescriptor.PROP_ERROR_MESSAGE, NbBundle.getMessage(SessionEJBWizardDescriptor.class,"ERR_RemoteOrLocal_MustBeSelected")); //NOI18N
             return false;
         }

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/session/SessionEJBWizardPanel.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/session/SessionEJBWizardPanel.java
@@ -476,15 +476,15 @@ public class SessionEJBWizardPanel extends javax.swing.JPanel {
     }
 
     private boolean isSingletonSupported(J2eeProjectCapabilities projectCap) {
-        return projectCap.isEjb31LiteSupported();
+        return projectCap.isEjb31LiteSupported() || projectCap.isEjb40LiteSupported();
     }
 
     private boolean isNoInterfaceViewSupported(J2eeProjectCapabilities projectCap) {
-        return projectCap.isEjb31LiteSupported();
+        return projectCap.isEjb31LiteSupported() || projectCap.isEjb40LiteSupported();
     }
 
     private boolean isTimerSupported(J2eeProjectCapabilities projectCap) {
-        return projectCap.isEjb31Supported() || projectCap.isEjb32LiteSupported();
+        return projectCap.isEjb31Supported() || projectCap.isEjb32LiteSupported() || projectCap.isEjb40LiteSupported();
     }
 
     private boolean isRemoteInterfaceSupported() {

--- a/enterprise/j2ee.ejbverification/src/org/netbeans/modules/j2ee/ejbverification/rules/AsynchronousMethodInvocation.java
+++ b/enterprise/j2ee.ejbverification/src/org/netbeans/modules/j2ee/ejbverification/rules/AsynchronousMethodInvocation.java
@@ -53,6 +53,7 @@ import org.openide.util.NbBundle.Messages;
     "AsynchronousMethodInvocation.description=Checks usage of @Asynchronous. Tests whether it's used within supported project and interface type.",
     "AsynchronousMethodInvocation.err.asynchronous.in.ejb31=Asynchronous method invocation is not allowed in project targeting JavaEE 6 Lite profile"
 })
+// @todo: Support JakartaEE
 public final class AsynchronousMethodInvocation {
 
     private AsynchronousMethodInvocation() { }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ObjectProviders.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ObjectProviders.java
@@ -46,6 +46,7 @@ import org.netbeans.modules.web.jsf.api.metamodel.SystemEventListener;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 class ObjectProviders {
     
     /**

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsImpl.java
@@ -33,6 +33,7 @@ import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.ObjectPro
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.PersistentObjectManager;
 import org.netbeans.modules.j2ee.persistence.api.metadata.orm.*;
 
+// @todo: Support JakartaEE
 public class EntityMappingsImpl implements EntityMappings {
 
     private final AnnotationModelHelper helper;


### PR DESCRIPTION
The options shown when selecting New > Session Bean are based on the capabilities of the used enterprise project.

The check missed some Jakarta EE versions and so were disabled.

Analysis done by @asbachb

Closes: #4892
Closes: #4830