### PR TITLE
Rust: More precise parser error markings in the Editor

### DIFF
--- a/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/ast/RustAST.java
+++ b/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/ast/RustAST.java
@@ -103,9 +103,9 @@ public final class RustAST {
             if (offendingSymbol instanceof Token) {
                 Token offendingToken = (Token) offendingSymbol;
                 errorStartIndex = offendingToken.getStartIndex();
-                errorStopIndex = offendingToken.getStopIndex();
+                errorStopIndex = offendingToken.getStopIndex() + 1;
             }
-            errors.add(new DefaultError(null, msg, null, fileObject, errorStartIndex, errorStopIndex, Severity.ERROR));
+            errors.add(new DefaultError(null, msg, null, fileObject, errorStartIndex, errorStopIndex, errorStartIndex != errorStopIndex, Severity.ERROR));
         }
     }
 
@@ -127,8 +127,8 @@ public final class RustAST {
             String msg = sb.toString();
             RecognitionException ex = new RecognitionException(msg, recognizer, recognizer.getInputStream(), recognizer.getContext());
             int start = e.getOffendingToken().getStartIndex();
-            int stop = e.getOffendingToken().getStopIndex();
-            errors.add(new DefaultError(null, msg, null, fileObject, start, stop, Severity.ERROR));
+            int stop = e.getOffendingToken().getStopIndex() + 1;
+            errors.add(new DefaultError(null, msg, null, fileObject, start, stop, false, Severity.ERROR));
         }
 
     }


### PR DESCRIPTION
It kept me bugging, why CSL support underlines the whole line on parser error even if the exact position of the error is given.

It's not very intuitive but:
https://github.com/apache/netbeans/blob/b79fd30b2e76ed070789745cabcf14bf5cf1e330/ide/csl.api/src/org/netbeans/modules/csl/spi/DefaultError.java#L67

So the constructor used here, defaults to line-error. I thought give @vieiro  a hand, and file this trivial PR.
