### PR TITLE
Fix: Committing SQL files does not change blue color on the file tab in editor

### DIFF
--- a/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLCloneableEditor.java
+++ b/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLCloneableEditor.java
@@ -106,16 +106,18 @@ public final class SQLCloneableEditor extends CloneableEditor implements MultiVi
     private MultiViewElementCallback callback;
 
     public SQLCloneableEditor() {
+        // Constructor used for deserialization/persistence
         super(null);
         putClientProperty("oldInitialize", Boolean.TRUE); // NOI18N
     }
 
     public SQLCloneableEditor(Lookup context) {
+        // Normally used constructor
         super(context.lookup(SQLEditorSupport.class));
-        SQLEditorSupport support = context.lookup(SQLEditorSupport.class);
-        setActivatedNodes(new Node[] {support.getDataObject().getNodeDelegate()});
         putClientProperty("oldInitialize", Boolean.TRUE); // NOI18N
-        initialize();
+        SQLEditorSupport support = context.lookup(SQLEditorSupport.class);
+        setActivatedNodes(new Node[]{support.getDataObject().getNodeDelegate()});
+        support.initializeCloneableEditor(this);
     }
 
     void setResults(List<Component> results) {

--- a/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLEditorSupport.java
+++ b/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLEditorSupport.java
@@ -144,6 +144,8 @@ public class SQLEditorSupport extends DataEditorSupport
 
     @Override
     protected void initializeCloneableEditor(CloneableEditor editor) {
+        // Invoked when SQLCloneableEditor is deserialized and from the 
+        // SQLCloneableEditor(Lookup) constructor.
         super.initializeCloneableEditor(editor);
         ((SQLCloneableEditor) editor).initialize();
     }


### PR DESCRIPTION
The construction of the editor panel for SQL is a bit special to support both using it as SQL console and file editor and allow it to execute sql statements.

In normal editors multiview elements are initialized by the infrastructure and #initializeCloneableEditor is called by it to connect the DataNode and the editor. This was missing for the SQLEditor.

Closes: #6224