### PR TITLE
Fix: Java completion parameter tooltip is not shown if previous parameter is TypeVariable

### DIFF
--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaTooltipTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaTooltipTask.java
@@ -275,7 +275,7 @@ public final class JavaTooltipTask extends BaseTask {
                             ret.add(paramStrings);
                             break;
                         }
-                        if (argTypes[i] == null || argTypes[i].getKind() != TypeKind.ERROR && !types.isAssignable(argTypes[i], param)) {
+                        if (argTypes[i] == null || argTypes[i].getKind() != TypeKind.ERROR && !isAssignable(types, argTypes[i], param)) {
                             break;
                         }
                     }
@@ -283,5 +283,15 @@ public final class JavaTooltipTask extends BaseTask {
             }
         }
         return ret.isEmpty() ? null : ret;
+    }
+
+    private static boolean isAssignable(Types types, TypeMirror arg, TypeMirror parameter) {
+        if(types.isAssignable(arg, parameter)) {
+            return true;
+        } else if (parameter instanceof TypeVariable) {
+            TypeMirror requiredTypes = ((TypeVariable) parameter).getUpperBound();
+            return types.isAssignable(arg, requiredTypes);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Testsetup:

```java
  public class TestParamResolution {
    public static void main(String[] args) {
      List.of("Hallo", "World");
      testMethod("Hello", "World", "Test");
      testMethod(1, "Hello", "World");
    }

    public static <S extends String & Comparable<String> & Serializable> void testMethod(S genericParam, String dummy1_1, String dummy1_2) {}
    public static <S extends Integer> void testMethod(S genericParam, String dummy2_1, String dummy2_2) {}

    public static <T extends Integer & Externalizable> void testArgumentTypeVariableParameter(T genericParam, List<? super String> x) {
	  testMethod(genericParam, "x", "dfd");
    }
  }
```

Inside main the problem can be demonstrated with all demonstrated calls. When the caret is placed in the first argument (before first comma), the parameter popup (CTRL+P) can be opened for all case. If the caret is placed in the second argument (after first comma), it does not work anymore.

Investigation shows that `javax.lang.model.util.Types#isAssignable` returns false if the target type is a TypeVariable. To fix this the upper bound of the TypeMirror is unwrapped and the check is repeated. This also works if the argument is a TypeVariable itself.

With this fix applied all places (main and
testArgumentTypeVariableParameter) allow to invoke the parameter popup.

Visualization (none of these were shown before the patch):

![image](https://github.com/apache/netbeans/assets/2179736/c58ef1b9-c3f3-401c-9740-61bb8950f0d9)
![image](https://github.com/apache/netbeans/assets/2179736/440a7dea-0ae9-4fae-b555-4cc0b6c0437c)
![image](https://github.com/apache/netbeans/assets/2179736/f1347c4e-1f2e-4c13-b1ce-1642fbc53928)
![image](https://github.com/apache/netbeans/assets/2179736/6df5caec-ad30-48a7-a739-5840a6995c7d)
