### PR TITLE
#6278: discard newlines, collapse and trim whitespaces.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
@@ -41,7 +41,6 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import javax.swing.text.BadLocationException;
 import javax.swing.text.StyledDocument;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -399,24 +398,34 @@ public class Utils {
 
     /**
      * Simple conversion from HTML to plaintext. Removes all html tags incl. attributes,
-     * replaces BR, P and HR tags with newlines.
+     * replaces BR, P and HR tags with newlines. The method optionally collapses whitespaces:
+     * all whitespace characters are replaced by spaces, adjacent spaces collapsed to single one, leading
+     * and trailing spaces removed.
      * @param s html text
+     * @param collapseWhitespaces to collapse 
      * @return plaintext
      */
-    public static String html2plain(String s) {
+    public static String html2plain(String s, boolean collapseWhitespaces) {
+        if (s == null) {
+            return null;
+        }
         boolean inTag = false;
+        boolean whitespace = false;
+
         int tagStart = -1;
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < s.length(); i++) {
             char ch = s.charAt(i);
-            if (inTag) {
+            T: if (inTag) {
                 boolean alpha = Character.isAlphabetic(ch);
                 if (tagStart > 0 && !alpha) {
                     String t = s.substring(tagStart, i).toLowerCase(Locale.ENGLISH);
                     switch (t) {
                         case "br": case "p": case "hr": // NOI1N
-                            sb.append("\n");
-                            break;
+                            ch ='\n'; // NOI18N
+                            // continues to process 'ch' as if it came from the string, but `inTag` remains
+                            // the same.
+                            break T;
                     }
                     // prevent entering tagstart state again
                     tagStart = -2;
@@ -426,16 +435,40 @@ public class Utils {
                 } else if (tagStart == -1 && alpha) {
                     tagStart = i;
                 }
+                continue;
             } else {
                 if (ch == '<') { // NOI18N
                     tagStart = -1;
                     inTag = true;
                     continue;
                 }
-                sb.append(ch);
             }
+            if (collapseWhitespaces) {
+                if (ch == '\n') {
+                    ch = ' ';
+                }
+                if (Character.isWhitespace(ch)) {
+                    if (whitespace) {
+                        continue;
+                    }
+                    ch = ' '; // NOI18N
+                    whitespace = true;
+                } else {
+                    whitespace = false;
+                }
+            }
+            sb.append(ch);
         }
-        return sb.toString();
+        return collapseWhitespaces ? sb.toString().trim() : sb.toString();
     }
 
+    /**
+     * Simple conversion from HTML to plaintext. Removes all html tags incl. attributes,
+     * replaces BR, P and HR tags with newlines.
+     * @param s html text
+     * @return plaintext
+     */
+    public static String html2plain(String s) {
+        return html2plain(s, false);
+    }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
@@ -50,6 +50,7 @@ import org.netbeans.api.project.SourceGroup;
 import org.netbeans.api.project.SourceGroupModifier;
 import org.netbeans.api.templates.CreateDescriptor;
 import org.netbeans.api.templates.FileBuilder;
+import org.netbeans.modules.java.lsp.server.Utils;
 import org.netbeans.modules.java.lsp.server.input.QuickPickItem;
 import org.netbeans.modules.java.lsp.server.input.ShowQuickPickParams;
 import org.netbeans.modules.java.lsp.server.input.ShowInputBoxParams;
@@ -459,23 +460,7 @@ final class LspTemplateUI {
     }
 
     static String stripHtml(String s) {
-        boolean inTag = false;
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < s.length(); i++) {
-            char ch = s.charAt(i);
-            if (inTag) {
-                if (ch == '>') {
-                    inTag = false;
-                }
-            } else {
-                if (ch == '<') {
-                    inTag = true;
-                    continue;
-                }
-                sb.append(ch);
-            }
-        }
-        return sb.toString();
+        return Utils.html2plain(s, true);
     }
 
     private static <T extends Exception> T raise(Class<T> clazz, Exception ex) throws T {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
@@ -45,6 +45,7 @@ import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.netbeans.modules.java.lsp.server.Utils;
 import org.netbeans.modules.java.lsp.server.input.InputBoxStep;
 import org.netbeans.modules.java.lsp.server.input.InputCallbackParams;
 import org.netbeans.modules.java.lsp.server.input.InputService;
@@ -372,7 +373,7 @@ class NotifyDescriptorAdapter {
             List<QuickPickItem> items = new ArrayList<>(qpItems.size());
             for (int i = 0; i < qpItems.size(); i++) {
                 NotifyDescriptor.QuickPick.Item item = qpItems.get(i);
-                items.add(new QuickPickItem(item.getLabel(), item.getDescription(), null, item.isSelected(), Integer.toString(i)));
+                items.add(new QuickPickItem(item.getLabel(), Utils.html2plain(item.getDescription(), true), null, item.isSelected(), Integer.toString(i)));
             }
             ShowQuickPickParams params = new ShowQuickPickParams(qp.getLabel(), qp.getTitle(), qp.isMultipleSelection(), items);
             CompletableFuture<List<QuickPickItem>> qpF = client.showQuickPick(params);
@@ -431,7 +432,8 @@ class NotifyDescriptorAdapter {
                                 List<QuickPickItem> items = new ArrayList<>();
                                 for (int i = 0; i < qpItems.size(); i++) {
                                     NotifyDescriptor.QuickPick.Item item = qpItems.get(i);
-                                    items.add(new QuickPickItem(item.getLabel(), item.getDescription(), null, item.isSelected(), Integer.toString(i)));
+                                    items.add(new QuickPickItem(item.getLabel(), 
+                                            Utils.html2plain(item.getDescription(), true), null, item.isSelected(), Integer.toString(i)));
                                 }
                                 QuickPickStep step = new QuickPickStep(ci.getEstimatedNumberOfInputs(), stepId,
                                         null, input.getTitle(), ((NotifyDescriptor.QuickPick) input).isMultipleSelection(),

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/UtilsTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/UtilsTest.java
@@ -50,4 +50,36 @@ public class UtilsTest {
         assertEquals("abcd", Utils.encode2JSON("abcd"));
         assertEquals("'\\\"\\b\\t\\n\\r\\\\", Utils.encode2JSON("'\"\b\t\n\r\\"));
     }
+
+    @Test
+    public void testStripHtml() {
+        String s = "<div>Pre <span>Text</span> Post</div>";
+        String expResult = "Pre Text Post";
+        String result = Utils.html2plain(s);
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * All newlines should be removed
+     */
+    @Test
+    public void testStripNewlines() {
+        String s = "\n<div>Pre <span\n>\nText</span> Post\n</div>";
+        String expResult = "Pre Text Post";
+        String result = Utils.html2plain(s, true);
+        assertEquals(expResult, result);
+    }
+    
+    
+    /**
+     * Consecutive whitespaces should be collapsed to a single space. Leading/trailing whitespaces
+     * removed.
+     */
+    @Test
+    public void testStripConsecutiveWhitespces() {
+        String s = "\t <div> Pre <span> Text\t </span>\t\t Post </div>\t";
+        String expResult = "Pre Text Post";
+        String result = Utils.html2plain(s, true);
+        assertEquals(expResult, result);
+    }
 }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUITest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUITest.java
@@ -29,4 +29,28 @@ public class LspTemplateUITest {
         String result = LspTemplateUI.stripHtml(s);
         assertEquals(expResult, result);
     }
+    
+    /**
+     * All newlines should be removed
+     */
+    @Test
+    public void testStripNewlines() {
+        String s = "\n<div>Pre <span\n>\nText</span> Post\n</div>";
+        String expResult = "Pre Text Post";
+        String result = LspTemplateUI.stripHtml(s);
+        assertEquals(expResult, result);
+    }
+    
+    
+    /**
+     * Consecutive whitespaces should be collapsed to a single space. Leading/trailing whitespaces
+     * removed.
+     */
+    @Test
+    public void testStripConsecutiveWhitespces() {
+        String s = "\t <div> Pre <span> Text\t </span>\t\t Post </div>\t";
+        String expResult = "Pre Text Post";
+        String result = LspTemplateUI.stripHtml(s);
+        assertEquals(expResult, result);
+    }
 }

--- a/java/java.lsp.server/vscode/CHANGELOG.md
+++ b/java/java.lsp.server/vscode/CHANGELOG.md
@@ -20,6 +20,17 @@
     under the License.
 
 -->
+## Version 19.0.0
+* Performance improvements in Maven projects loading and priming build
+* Navigation for Micronaut URI and Beans in Find Symbol
+* Allow for lazy computation of CodeActions 
+* Database support improvements:
+  * Generating Entity classes from database improved
+  * JDBC properties editing
+  * Display database schema tree improvements
+  * Adding OCI Autonomous database simplified
+  * Allow to reenter DB username and password
+
 ## Version 18.0.0
 * Java 8+ launch config renamed to Java+
 


### PR DESCRIPTION
NBLS `New from Template` command implementation strips HTML from description of templates, but leaves whitespaces as they were in the html source, so potentially more (white)spaces than necessary, including tab/newline control characters. vscode now (from June's releaase 1.80.2) starts to display control characters in quickpick UI - which looks ugly, see #6278. 

This PR:
- removes all newlines
- coalesces whitespaces into a single space
- kills leading/trailing whitespaces

Should apply only to description of templates.

Please do consider to include this fix in NB(LS) 19 release, the New from Tempalate looks really ugly.