### PR TITLE
Allow to select 'Add Database Connection' or 'Add Oracle Autonomous DB' from database view toolbar

### DIFF
--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -491,10 +491,14 @@
 				"title": "Delete"
 			},
 			{
-				"command": "db.add.connection",
+				"command": "db.add.all.connection",
 				"title": "Add Database Connection",
 				"category": "Database",
 				"icon": "$(add)"
+			},
+			{
+				"command": "db.add.connection",
+				"title": "Add JDBC Database Connection"
 			},
 			{
 				"command": "nbls:Database:netbeans.db.explorer.action.Connect",
@@ -726,6 +730,10 @@
 					"when": "false"
 				},
 				{
+					"command": "db.add.all.connection",
+					"when": "false"
+				},
+				{
 					"command": "nbls.addEventListener",
 					"when": "false"
 				}
@@ -757,7 +765,7 @@
 					"when": "nbJavaLSReady && view == foundProjects && config.netbeans.javaSupport.enabled"
 				},
 				{
-					"command": "db.add.connection",
+					"command": "db.add.all.connection",
 					"when": "view == database.connections",
 					"group": "navigation@3"
 				}

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -538,6 +538,16 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
             await commands.executeCommand(selected.userData.command.command, ...(selected.userData.command.arguments || []));
         }
     }));
+    context.subscriptions.push(commands.registerCommand('db.add.all.connection', async () => {
+        const ADD_JDBC = 'Add Database Connection';
+        const ADD_ADB = 'Add Oracle Autonomous DB';
+        const selected: any = await window.showQuickPick([ADD_JDBC, ADD_ADB], { placeHolder: 'Select type...' });
+        if (selected == ADD_JDBC) {
+            await commands.executeCommand('db.add.connection');
+        } else if (selected == ADD_ADB) {
+            await commands.executeCommand('nbls:Tools:org.netbeans.modules.cloud.oracle.actions.AddADBAction');
+        }
+    }));
     const mergeWithLaunchConfig = (dconfig : vscode.DebugConfiguration) => {
         const folder = vscode.workspace.workspaceFolders?.[0];
         const uri = folder?.uri;


### PR DESCRIPTION
Add sign in database toolbar was changed to include selection of 'Add Oracle Autonomous DB' wizard or original 'Add Database Connection' wizard. This will provide same functionality when no database is configured and database panel contains two buttons. This way it is possible to add 'Oracle Autonomous DB' when some database is configured and those buttons are not there anymore.