### PR TITLE
Fix Javadoc formatting error when using add/remove param hint.

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
@@ -3535,6 +3535,17 @@ public final class TreeMaker {
     }
 
     /**Creates a new javadoc comment.
+     *
+     * @param fullBody the entire body of the comment
+     * @param tags the block tags of the comment (after the main body)
+     * @return newly created DocCommentTree
+     * @since 2.62
+     */
+    public DocCommentTree DocComment(List<? extends DocTree> fullBody, List<? extends DocTree> tags) {
+        return delegate.DocComment(fullBody, tags);
+    }
+
+    /**Creates a new javadoc comment.
      * 
      * @param firstSentence the javadoc comment's first sentence
      * @param body the main body of the comment

--- a/java/javadoc/src/org/netbeans/modules/javadoc/hints/AddTagFix.java
+++ b/java/javadoc/src/org/netbeans/modules/javadoc/hints/AddTagFix.java
@@ -85,7 +85,7 @@ abstract class AddTagFix extends JavaFix {
             blockTags.add(newTree);
         }
         
-        DocCommentTree newDoc = make.DocComment(docComment.getFirstSentence(), docComment.getBody(), blockTags);
+        DocCommentTree newDoc = make.DocComment(docComment.getFullBody(), blockTags);
         Tree tree = ctx.getPath().getLeaf();
         javac.rewrite(tree, docComment, newDoc);
     }

--- a/java/javadoc/src/org/netbeans/modules/javadoc/hints/RemoveTagFix.java
+++ b/java/javadoc/src/org/netbeans/modules/javadoc/hints/RemoveTagFix.java
@@ -72,7 +72,7 @@ final class RemoveTagFix extends JavaFix {
                 blockTags.add(docTree);
             }
         }
-        DocCommentTree newDoc = make.DocComment(docComment.getFirstSentence(), docComment.getBody(), blockTags);
+        DocCommentTree newDoc = make.DocComment(docComment.getFullBody(), blockTags);
         Tree tree = ctx.getPath().getLeaf();
         javac.rewrite(tree, docComment, newDoc);
     }


### PR DESCRIPTION
Fix formatting issue with Javadoc when using the add or remove param hint. Debugging shows some error in extracting the first sentence and body, then recreating the full body. Updated TreeMaker to allow the hint to pass in the existing full body whole.

For more context see users@ thread on the error at https://lists.apache.org/thread/wqq8jnxp2c2lxyf9wxk2sqqjhrz1lhhd