### PR TITLE
redundant check for supported 'command' removed

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBAddConnection.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBAddConnection.java
@@ -96,9 +96,6 @@ public class DBAddConnection extends CodeActionsProvider {
 
     @Override
     public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
-        if (!DB_ADD_CONNECTION.equals(command)) {
-            return null;
-        }
         InputService.Registry inputServiceRegistry = Lookup.getDefault().lookup(InputService.Registry.class);
         if (inputServiceRegistry == null) {
             return null;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBCommandProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBCommandProvider.java
@@ -57,9 +57,6 @@ public class DBCommandProvider extends CodeActionsProvider {
 
     @Override
     public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
-        if (!COMMAND_GET_PREFERRED_CONNECTION.equals(command)) {
-            return null;
-        }
         TreeNodeRegistry r = Lookup.getDefault().lookup(TreeNodeRegistry.class);
         DatabaseConnection conn = ConnectionManager.getDefault().getPreferredConnection(true);
         if (conn == null || r == null) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBConnectionProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBConnectionProvider.java
@@ -55,9 +55,6 @@ public class DBConnectionProvider extends CodeActionsProvider{
     
     @Override
     public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
-        if (!GET_DB_CONNECTION.equals(command)) {
-            return null;
-        }
         Map<String, String> result = new HashMap<> ();
         DatabaseConnection conn = ConnectionManager.getDefault().getPreferredConnection(true);
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/NodeActionsProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/NodeActionsProvider.java
@@ -96,9 +96,6 @@ public class NodeActionsProvider extends CodeActionsProvider {
     
     @Override
     public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
-        if (!command.startsWith(NBLS_ACTION_PREFIX)) {
-            return CompletableFuture.completedFuture(false);
-        }
         JsonElement el = null;
         if (arguments.size() > 0) {
             JsonObject item = gson.fromJson(gson.toJson(arguments.get(0)), JsonObject.class);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/NodePropertiesProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/NodePropertiesProvider.java
@@ -82,9 +82,6 @@ public class NodePropertiesProvider extends CodeActionsProvider {
 
     @Override
     public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
-        if (!COMMANDS.contains(command)) {
-            return CompletableFuture.completedFuture(null);
-        }
         if (arguments == null || arguments.isEmpty()) {
             return CompletableFuture.completedFuture(null);
         }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/htmlui/WebView.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/htmlui/WebView.java
@@ -380,7 +380,7 @@ public class WebView implements Closeable {
 
         @Override
         public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
-            if (PROCESS_COMMAND.equals(command) && arguments != null && !arguments.isEmpty()) {
+            if (arguments != null && !arguments.isEmpty()) {
                 final Map m = gson.fromJson((JsonObject) arguments.get(0), Map.class);
                 final String id = (String) m.get(ID);
                 if (id != null) {

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -248,11 +248,8 @@ public class ServerTest extends NbTestCase {
 
         @Override
         public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
-            if (COMMAND_EXTRACT_LOOKUP.equals(command)) {
-                commandLookup = Lookup.getDefault();
-                return CompletableFuture.completedFuture(true);
-            }
-            return null;
+            commandLookup = Lookup.getDefault();
+            return CompletableFuture.completedFuture(true);
         }
     }
     @Override
@@ -5429,10 +5426,6 @@ public class ServerTest extends NbTestCase {
         
         @Override
         public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
-            if (!command.equals("_progressCommand")) {
-                return null;
-            }
-
             return CompletableFuture.<Object>supplyAsync(() -> {
                 ProgressHandle h = ProgressHandle.createHandle("Test Command", this::cancel);
                 try {


### PR DESCRIPTION
It is not necessarry to validity of `command` string - the infrastructure does it automatically and invokes the correct implementation of `processCommand` method.