### PR TITLE
LSP: Open sources from Jar files as read-only from their true locations.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -792,6 +792,7 @@ public final class Server {
                 Set<String> commands = new LinkedHashSet<>(Arrays.asList(GRAALVM_PAUSE_SCRIPT,
                         NBLS_BUILD_WORKSPACE,
                         NBLS_CLEAN_WORKSPACE,
+                        NBLS_GET_ARCHIVE_FILE_CONTENT,
                         JAVA_RUN_PROJECT_ACTION,
                         JAVA_FIND_DEBUG_ATTACH_CONFIGURATIONS,
                         JAVA_FIND_DEBUG_PROCESS_TO_ATTACH,
@@ -989,6 +990,7 @@ public final class Server {
     public static final String JAVA_SUPER_IMPLEMENTATION =  "java.super.implementation";
     public static final String GRAALVM_PAUSE_SCRIPT =  "graalvm.pause.script";
     public static final String JAVA_RUN_PROJECT_ACTION = "java.project.run.action";
+    public static final String NBLS_GET_ARCHIVE_FILE_CONTENT = "nbls.get.archive.file.content";
 
     /**
      * Enumerates project configurations.

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -272,6 +272,20 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
                 progressOfCompilation.checkStatus();
                 return progressOfCompilation.getFinishFuture();
             }
+            case Server.NBLS_GET_ARCHIVE_FILE_CONTENT: {
+                CompletableFuture<Object> future = new CompletableFuture<>();
+                try {
+                    String uri = ((JsonPrimitive) params.getArguments().get(0)).getAsString();
+                    FileObject file = Utils.fromUri(uri);
+                    if (file != null) {
+                        future.complete(file.asText("UTF-8"));
+                    }
+                    future.complete(null);
+                } catch (IOException ioe) {
+                    future.completeExceptionally(ioe);
+                }
+                return future;
+            }
             case Server.JAVA_GET_PROJECT_SOURCE_ROOTS: {
                 String uri = ((JsonPrimitive) params.getArguments().get(0)).getAsString();
                 String type = params.getArguments().size() > 1 ? ((JsonPrimitive) params.getArguments().get(1)).getAsString() : JavaProjectConstants.SOURCES_TYPE_JAVA;

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -652,6 +652,14 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
     context.subscriptions.push(commands.registerCommand('nbls.node.properties.edit',
         async (node) => await PropertiesView.createOrShow(context, node, (await client).findTreeViewService())));
 
+    const archiveFileProvider = <vscode.TextDocumentContentProvider> {
+        provideTextDocumentContent: async (uri: vscode.Uri, token: vscode.CancellationToken): Promise<string> => {
+            return await commands.executeCommand('nbls.get.archive.file.content', uri.toString());
+        }
+    };
+    context.subscriptions.push(workspace.registerTextDocumentContentProvider('jar', archiveFileProvider));
+    context.subscriptions.push(workspace.registerTextDocumentContentProvider('nbjrt', archiveFileProvider));
+
     launchConfigurations.updateLaunchConfig();
 
     // register completions:


### PR DESCRIPTION
Sources from jar files should be opened as read-only preserving their true locations. There is no need to create temporary copies of these sources being opened any more.