### PR TITLE
Schema name has to be in uppercase for Oracle ADB

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
@@ -155,7 +155,7 @@ public class DownloadWalletAction extends AbstractAction implements ContextAware
                             drivers[0], 
                             dbUrl, 
                             p.getDbUser(), 
-                            p.getDbUser(), 
+                            p.getDbUser().toUpperCase(), 
                             new String(p.getDbPassword()), 
                             true, 
                             context.getName(),


### PR DESCRIPTION
For Oracle ADM, schema name is the same as username but in uppercase. 