### PR TITLE
use 'parameters' to find out if createProcedureInfo() was already invoked

### DIFF
--- a/ide/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCProcedure.java
+++ b/ide/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/JDBCProcedure.java
@@ -201,7 +201,7 @@ public class JDBCProcedure extends ProcedureImplementation {
     }
 
     private Value initReturnValue() {
-        if (returnValue != null) {
+        if (parameters != null) {
             return returnValue;
         }
         createProcedureInfo();


### PR DESCRIPTION
If `returnValue` of `org.netbeans.modules.db.metadata.model.jdbc.JDBCProcedure` is `null`, `createProcedureInfo()` is invoked every time. When `returnValue` is not `null` result are properly cached and `createProcedureInfo()` are invoked only once. Use `parameters` instead of `returnValue` to find out if `createProcedureInfo()` was already invoked.