### PR TITLE
Stabilize CPPLite: Discard STDERR

### DIFF
--- a/cpplite/cpplite.editor/nbproject/project.properties
+++ b/cpplite/cpplite.editor/nbproject/project.properties
@@ -15,5 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.source=11
+javac.target=11
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/LanguageServerImpl.java
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/LanguageServerImpl.java
@@ -124,6 +124,8 @@ public class LanguageServerImpl implements LanguageServerProvider {
                         ProcessBuilder builder = new ProcessBuilder(command);
                         if (LOG.isLoggable(Level.FINEST)) {
                             builder.redirectError(Redirect.INHERIT);
+                        } else {
+                            builder.redirectError(Redirect.DISCARD);
                         }
                         Process process = builder.start();
                         InputStream in = process.getInputStream();


### PR DESCRIPTION
There are currently two problems in CPPLite:

**STDERR is not drained and can cause LSP to block**

The language server ccls and clangd both output debugging information
to STDERR. This works while the output buffer of the language server
is not yet filled and fails when the buffer is full.

Closes: #6297