### PR TITLE
Keep using Groovy DSL for Gradle

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/SimpleApplicationProjectWizard.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/SimpleApplicationProjectWizard.java
@@ -65,7 +65,7 @@ public class SimpleApplicationProjectWizard extends BaseGradleWizardIterator {
         final File loc = (File) params.get(CommonProjectActions.PROJECT_PARENT_FOLDER);
         final File root = new File(loc, name);
 
-        ops.createGradleInit(root, type).basePackage(packageBase).projectName(name).add(); // NOI18N
+        ops.createGradleInit(root, type).basePackage(packageBase).projectName(name).dsl("groovy").add(); // NOI18N
         ops.addProjectPreload(root);
         ops.addProjectPreload(new File(root, subFolder));
 


### PR DESCRIPTION

Gradle create new projects using Kotlin DSL by default from version 8.2.

That could be quite confusing. It would be nice to add a DSL Language selection option to the create project wizard. However this late in the release process, simply forcing Groovy may do it.

The change is trivial, might not need another RC even if included.