### PR TITLE
Add nb-javac libwrapper tests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1373,6 +1373,9 @@ jobs:
       - name: lib.nbjavac
         run: ant $OPTS -f java/lib.nbjavac test
 
+      - name: libs.nbjavacapi
+        run: ant $OPTS -f java/libs.nbjavacapi test
+
 #      - name: performance
 #        run: ant $OPTS -f java/performance test
 

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/NoJavacHelperTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/NoJavacHelperTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.source;
+
+import javax.lang.model.SourceVersion;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * This test assumes nb-javac is active.
+ * 
+ * @author mbien
+ */
+public class NoJavacHelperTest {
+
+    @Test
+    public void testJavacVersionRequirement() {
+        assertEquals("'NoJavacHelper.REQUIRED_JAVAC_VERSION' should mirror the bundled javac version",
+                SourceVersion.latest().ordinal(), NoJavacHelper.REQUIRED_JAVAC_VERSION);
+    }
+
+    @Test
+    public void testHasWorkingJavac() {
+        assertTrue(NoJavacHelper.hasWorkingJavac());
+    }
+
+}

--- a/java/libs.nbjavacapi/nbproject/project.properties
+++ b/java/libs.nbjavacapi/nbproject/project.properties
@@ -20,3 +20,6 @@ javac.compilerargs=-Xlint -Xlint:-serial
 license.file.override=${nb_all}/nbbuild/licenses/GPL-2-CP
 release.external/nb-javac-jdk-21+26-api.jar=modules/ext/nb-javac-jdk-21-26-api.jar
 release.external/nb-javac-jdk-21+26.jar=modules/ext/nb-javac-jdk-21-26.jar
+
+# for tests
+requires.nb.javac=true

--- a/java/libs.nbjavacapi/nbproject/project.xml
+++ b/java/libs.nbjavacapi/nbproject/project.xml
@@ -34,6 +34,15 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>ext/nb-javac-jdk-21-26-api.jar</runtime-relative-path>

--- a/java/libs.nbjavacapi/test/unit/src/org/netbeans/modules/nbjavac/api/NBJavacBrandingTest.java
+++ b/java/libs.nbjavacapi/test/unit/src/org/netbeans/modules/nbjavac/api/NBJavacBrandingTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.nbjavac.api;
+
+import java.util.ResourceBundle;
+import javax.lang.model.SourceVersion;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ * @author mbien
+ */
+public class NBJavacBrandingTest {
+
+    @Test
+    public void testModuleDescription() {
+        String desc = ResourceBundle.getBundle("org.netbeans.modules.nbjavac.api.Bundle")
+                                    .getString("OpenIDE-Module-Long-Description");
+        String expected = "JDK-" + SourceVersion.latest().ordinal();
+        assertTrue(
+                "Wrong JDK version in module description?"
+              + "\nexpected token: " + expected
+              + "\nmodule descripton: " + desc,
+                desc.contains(expected)
+        );
+    }
+
+}


### PR DESCRIPTION
 - test min javac version requirement check
 - test module description

Should make it less likely that version increments are overlooked during javac lib wrapper updates (e.g https://github.com/apache/netbeans/pull/6206#issuecomment-1640274517).