### PR TITLE
Use ConcurrentMap/ConcurrentHashMap.newKeySet instead of Map/Collections.synchronizedSet

### DIFF
--- a/platform/o.n.bootstrap/src/org/netbeans/ProxyClassLoader.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ProxyClassLoader.java
@@ -31,6 +31,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -62,7 +64,7 @@ public class ProxyClassLoader extends ClassLoader {
     /** All known packages 
      * @GuardedBy("packages")
      */
-    private final Map<String, Package> packages = new HashMap<String, Package>();
+    private final ConcurrentMap<String, Package> packages = new ConcurrentHashMap<>();
 
     /** keeps information about parent classloaders, system classloader, etc.*/
     volatile ProxyClassParents parents;
@@ -107,7 +109,6 @@ public class ProxyClassLoader extends ClassLoader {
             if (cl == null) throw new IllegalArgumentException("null parent: " + Arrays.asList(nueparents)); // NOI18N
         }
         
-        ProxyClassLoader[] resParents = null;
         ModuleFactory moduleFactory = Lookup.getDefault().lookup(ModuleFactory.class);
         if (moduleFactory != null && moduleFactory.removeBaseClassLoader()) {
             // this hack is here to prevent having the application classloader
@@ -232,7 +233,6 @@ public class ProxyClassLoader extends ClassLoader {
     }
     
     private String diagnosticCNFEMessage(String base, Set<ProxyClassLoader> del) {
-        String parentSetS;
         int size = parents.size();
         // Too big to show in its entirety - overwhelms the log file.
         StringBuilder b = new StringBuilder();
@@ -250,7 +250,7 @@ public class ProxyClassLoader extends ClassLoader {
         b.append(']');
         return b.toString();
     }
-    private static final Set<String> arbitraryLoadWarnings = Collections.synchronizedSet(new HashSet<String>());
+    private static final Set<String> arbitraryLoadWarnings = ConcurrentHashMap.newKeySet();
 
     /** May return null */ 
     private synchronized Class<?> selfLoadClass(String pkg, String name) { 
@@ -266,7 +266,7 @@ public class ProxyClassLoader extends ClassLoader {
             }
             if (LOG_LOADING && !name.startsWith("java.")) LOGGER.log(Level.FINEST, "{0} loaded {1}",
                         new Object[] {this, name});
-        }
+            }
         return cls; 
     }
 
@@ -468,20 +468,24 @@ public class ProxyClassLoader extends ClassLoader {
      * @return located package, or null
      */
     protected Package getPackageFast(String name, boolean recurse) {
-        synchronized (packages) {
-            Package pkg = packages.get(name);
-            if (pkg != null) {
-                return pkg;
-            }
-            if (!recurse) {
-                return null;
-            }
+        Package pkg = packages.get(name);
+        if (pkg != null) {
+            return pkg;
+        }
+        if (!recurse) {
+            return null;
+        }
+        synchronized(packages) {
+            pkg = packages.get(name);
             String path = name.replace('.', '/');
             for (ProxyClassLoader par : this.parents.loaders()) {
-                if (!shouldDelegateResource(path, par))
+                if (!shouldDelegateResource(path, par)) {
                     continue;
+                }
                 pkg = par.getPackageFast(name, false);
-                if (pkg != null) break;
+                if (pkg != null) {
+                    break;
+                }
             }
             // pretend the resource ends with "/". This works better with hidden package and
             // prefix-based checks.
@@ -489,7 +493,7 @@ public class ProxyClassLoader extends ClassLoader {
                 // Cannot access either Package.getSystemPackages nor ClassLoader.getPackage
                 // from here, so do the best we can though it will cause unnecessary
                 // duplication of the package cache (PCL.packages vs. CL.packages):
-                pkg = super.getPackage(name);
+                    pkg = super.getPackage(name);
             }
             if (pkg != null) {
                 packages.put(name, pkg);
@@ -508,12 +512,10 @@ public class ProxyClassLoader extends ClassLoader {
                 String specVersion, String specVendor, String implTitle,
 		String implVersion, String implVendor, URL sealBase )
 		throws IllegalArgumentException {
-        synchronized (packages) {
-            Package pkg = super.definePackage(name, specTitle, specVersion, specVendor, implTitle,
+        Package pkg = super.definePackage(name, specTitle, specVersion, specVendor, implTitle,
                 implVersion, implVendor, sealBase);
-            packages.put(name, pkg);
-            return pkg;
-        }
+        packages.put(name, pkg);
+        return pkg;
     }
 
     /**
@@ -585,7 +587,7 @@ public class ProxyClassLoader extends ClassLoader {
     // System Class Loader Packages Support
     //
     
-    private static Map<String,Boolean> sclPackages = Collections.synchronizedMap(new HashMap<String,Boolean>());  
+    private static ConcurrentMap<String,Boolean> sclPackages = new ConcurrentHashMap<>();
     private static Boolean isSystemPackage(String pkg) {
         return sclPackages.get(pkg);
     }


### PR DESCRIPTION
NetBeans Notes:

For ProxyClassLoader class:
- Use ConcurrentMap for `packages` map and remove some synchronized blocks
- Use ConcurrentHashMap.newKeySet() instead of Collections.synchronizedSet for `ARBITRARY_LOAD_WARNINGS` set
- Remove unused variables

For ProxyClassPackages class:
- Use ConcurrentMap for `PACKAGE_COVERAGE` map and remove the synchronized methods for get and remove operations
- Use synchronized on the `PACKAGE_COVERAGE` map for the add operation. It needs to be linearizable.

Testing:
- Full build done
- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of unit tests for module `platform.o.n.bootstrap`
- Verify successful execution of sigtests
- Verify successful execution of commit-validation
- Worked normally with various projects.