### PR TITLE
Remove obsolete sun.zip.disableMemoryMapping JVM flag.

### DIFF
--- a/java/performance/hudson/netbeans.conf
+++ b/java/performance/hudson/netbeans.conf
@@ -43,7 +43,7 @@ netbeans_default_cachedir="${HOME}/.cache/perfdev"
 
 # Options used by NetBeans launcher by default, can be overridden by explicit
 # command line switches:
-netbeans_default_options="-J-client -J-Xss2m -J-Xms32m -J-Dnetbeans.logger.console=false -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.graphics.UseQuartz=true -J-Dsun.java2d.noddraw=true -J-Dsun.zip.disableMemoryMapping=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.keyring.no.master=true -J-DSuspendSupport.disabled=true -J-DBrokenReferencesSupport.suppressBrokenRefAlert=true -J-Dnetbeans.full.hack=true -J-Dorg.netbeans.log.startup=print -J-Dorg.netbeans.editor.linewrap=true"
+netbeans_default_options="-J-client -J-Xss2m -J-Xms32m -J-Dnetbeans.logger.console=false -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.graphics.UseQuartz=true -J-Dsun.java2d.noddraw=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.keyring.no.master=true -J-DSuspendSupport.disabled=true -J-DBrokenReferencesSupport.suppressBrokenRefAlert=true -J-Dnetbeans.full.hack=true -J-Dorg.netbeans.log.startup=print -J-Dorg.netbeans.editor.linewrap=true"
 # Note that default -Xmx is selected for you automatically.
 # You can find these values in var/log/messages.log file in your userdir.
 # The automatically selected value can be overridden by specifying -J-Xmx

--- a/nb/ide.launcher/netbeans.conf
+++ b/nb/ide.launcher/netbeans.conf
@@ -56,14 +56,7 @@ netbeans_default_cachedir="${DEFAULT_CACHEDIR_ROOT}/@@metabuild.RawVersion@@"
 # The automatically selected value can be overridden by specifying -J-Xmx
 # here or on the command line.
 #
-# JDK 11 made GTK 3 default on Linux. Unfortunately it makes
-# NetBeans ugly on Linux with the default GTK+ Look and Feel,
-# as a workaround -J-Djdk.gtk.version=2.2 has been added to the 
-# default command line arguments.
-# (see: https://issues.apache.org/jira/browse/NETBEANS-1344)
-#
-
-netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.application.appearance=system -J-Dapple.awt.graphics.UseQuartz=true -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dsun.zip.disableMemoryMapping=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions"
+netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.application.appearance=system -J-Dapple.awt.graphics.UseQuartz=true -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions"
 
 # Default location of JDK:
 # (set by installer or commented out if launcher should decide)


### PR DESCRIPTION
Java's zip implementation doesn't use mmap anymore ([JDK-8175192](https://bugs.openjdk.org/browse/JDK-8175192), [JDK-8142508](https://bugs.openjdk.org/browse/JDK-8142508)).