### PR TITLE
Fix the problem that typed fields marked as deprecated are not displayed as deprecated #6310

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/api/Utils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/api/Utils.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.php.editor.parser.api;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.csl.spi.ParserResult;
@@ -27,6 +28,7 @@ import org.netbeans.modules.php.editor.parser.PHPParseResult;
 import org.netbeans.modules.php.editor.parser.astnodes.ASTNode;
 import org.netbeans.modules.php.editor.parser.astnodes.ClassDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.Comment;
+import org.netbeans.modules.php.editor.parser.astnodes.Expression;
 import org.netbeans.modules.php.editor.parser.astnodes.FunctionName;
 import org.netbeans.modules.php.editor.parser.astnodes.Identifier;
 import org.netbeans.modules.php.editor.parser.astnodes.IntersectionType;
@@ -39,6 +41,7 @@ import org.netbeans.modules.php.editor.parser.astnodes.PHPDocTypeTag;
 import org.netbeans.modules.php.editor.parser.astnodes.PHPDocVarTypeTag;
 import org.netbeans.modules.php.editor.parser.astnodes.Program;
 import org.netbeans.modules.php.editor.parser.astnodes.Scalar;
+import org.netbeans.modules.php.editor.parser.astnodes.SingleFieldDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.UnionType;
 import org.netbeans.modules.php.editor.parser.astnodes.Variable;
 import org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultTreePathVisitor;
@@ -72,7 +75,7 @@ public final class Utils {
                 }
             }
             if (possible != null && (possible.getEndOffset() + 1 < node.getStartOffset())) {
-                List<ASTNode> nodes = (new NodeRangeLocator()).locate(root, new OffsetRange(possible.getEndOffset() + 1, node.getStartOffset() - 1));
+                List<ASTNode> nodes = (new NodeRangeLocator()).locate(root, new OffsetRange(possible.getEndOffset() + 1, getNodeRangeLocatorEndOffset(node)));
                 if (!nodes.isEmpty()) {
                     if (!isConstantDeclaration(nodes, node)
                             && !isFieldDeclaration(nodes, node)) {
@@ -83,6 +86,21 @@ public final class Utils {
         }
 
         return possible;
+    }
+
+    private static int getNodeRangeLocatorEndOffset(ASTNode node) {
+        int endOffset = node.getStartOffset() - 1;
+        if (node instanceof SingleFieldDeclaration) {
+            // GH-6310 start offset of SingleFieldDeclaration is start offset of a variable name
+            // because we can declare multiple fields as one statement e.g. public int $field1, $field2;
+            // so, check a field type
+            SingleFieldDeclaration field = (SingleFieldDeclaration) node;
+            Expression fieldType = field.getFieldType();
+            if (fieldType != null) {
+                endOffset = fieldType.getStartOffset() - 1;
+            }
+        }
+        return endOffset;
     }
 
     private static boolean isConstantDeclaration(List<ASTNode> nodes, ASTNode node) {
@@ -102,16 +120,29 @@ public final class Utils {
 
     private static boolean isFieldDeclaration(List<ASTNode> nodes, ASTNode node) {
         boolean isFieldDeclaration = false;
-        if (nodes.size() == 1 && (node instanceof Identifier)) {
-            ASTNode next = nodes.iterator().next();
-            if (next instanceof NamespaceName
-                    || next instanceof NullableType
-                    || next instanceof UnionType
-                    || next instanceof IntersectionType) {
+        if (!nodes.isEmpty() && (node instanceof Identifier)) {
+            Iterator<ASTNode> iterator = nodes.iterator();
+            ASTNode next = iterator.next();
+            if (isTypeNode(next)) {
                 isFieldDeclaration = true;
+                while (iterator.hasNext()) {
+                    // e.g. public int $f1, $f2, $f3 = 0;
+                    next = iterator.next();
+                    if (!(next instanceof SingleFieldDeclaration)) {
+                        isFieldDeclaration = false;
+                        break;
+                    }
+                }
             }
         }
         return isFieldDeclaration;
+    }
+
+    private static boolean isTypeNode(ASTNode node) {
+        return node instanceof NamespaceName
+                || node instanceof NullableType
+                || node instanceof UnionType
+                || node instanceof IntersectionType;
     }
 
     public static Program getRoot(ParserResult result) {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/FieldsDeclaration.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/FieldsDeclaration.java
@@ -183,7 +183,7 @@ public class FieldsDeclaration extends BodyDeclaration {
             modifierString += " "; // NOI18N
         }
         return sbAttributes.toString()
-                + modifierString
+                + modifierString + " " // NOI18N
                 + sb.toString();
     }
 

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/csl/NavigatorDeprecatedTest/structure/deprecatedTypedFields.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/csl/NavigatorDeprecatedTest/structure/deprecatedTypedFields.pass
@@ -1,0 +1,30 @@
+|-TypedFields [821, 1760] : ESCAPED{TypedFields}
+|--$typedField [875, 885] : DEPRECATED{ESCAPED{$typedField}}<font color="#999999">:ESCAPED{int}</font>
+|--$multiField1 [927, 938] : DEPRECATED{ESCAPED{$multiField1}}<font color="#999999">:ESCAPED{int}</font>
+|--$multiField2 [941, 952] : DEPRECATED{ESCAPED{$multiField2}}<font color="#999999">:ESCAPED{int}</font>
+|--$nullableTypeField [998, 1015] : DEPRECATED{ESCAPED{$nullableTypeField}}<font color="#999999">:ESCAPED{?}ESCAPED{string}</font>
+|--$unionTypeField [1084, 1098] : DEPRECATED{ESCAPED{$unionTypeField}}<font color="#999999">:ESCAPED{string}ESCAPED{|}ESCAPED{TypedFields}</font>
+|--$intersectionTypeField [1156, 1177] : DEPRECATED{ESCAPED{$intersectionTypeField}}<font color="#999999">:ESCAPED{Foo}ESCAPED{&}ESCAPED{Bar}</font>
+|--$dnfTypeField [1241, 1253] : DEPRECATED{ESCAPED{$dnfTypeField}}<font color="#999999">:ESCAPED{(Foo}ESCAPED{&}ESCAPED{Bar)}ESCAPED{&}ESCAPED{Baz}</font>
+|--$typedStaticField [1302, 1318] : DEPRECATED{ESCAPED{$typedStaticField}}<font color="#999999">:ESCAPED{int}</font>
+|--$multiStaticField1 [1367, 1384] : DEPRECATED{ESCAPED{$multiStaticField1}}<font color="#999999">:ESCAPED{int}</font>
+|--$multiStaticField2 [1387, 1404] : DEPRECATED{ESCAPED{$multiStaticField2}}<font color="#999999">:ESCAPED{int}</font>
+|--$nullableTypeStaticField [1457, 1480] : DEPRECATED{ESCAPED{$nullableTypeStaticField}}<font color="#999999">:ESCAPED{?}ESCAPED{string}</font>
+|--$unionTypeStaticField [1556, 1576] : DEPRECATED{ESCAPED{$unionTypeStaticField}}<font color="#999999">:ESCAPED{string}ESCAPED{|}ESCAPED{TypedFields}</font>
+|--$intersectionTypeStaticField [1641, 1668] : DEPRECATED{ESCAPED{$intersectionTypeStaticField}}<font color="#999999">:ESCAPED{Foo}ESCAPED{&}ESCAPED{Bar}</font>
+|--$dnfTypeStaticField [1739, 1757] : DEPRECATED{ESCAPED{$dnfTypeStaticField}}<font color="#999999">:ESCAPED{(Foo}ESCAPED{&}ESCAPED{Bar)}ESCAPED{&}ESCAPED{Baz}</font>
+|-TypedFieldsTrait [1768, 2712] : ESCAPED{TypedFieldsTrait}
+|--$typedField [1827, 1837] : DEPRECATED{ESCAPED{$typedField}}<font color="#999999">:ESCAPED{int}</font>
+|--$multiField1 [1879, 1890] : DEPRECATED{ESCAPED{$multiField1}}<font color="#999999">:ESCAPED{int}</font>
+|--$multiField2 [1893, 1904] : DEPRECATED{ESCAPED{$multiField2}}<font color="#999999">:ESCAPED{int}</font>
+|--$nullableTypeField [1950, 1967] : DEPRECATED{ESCAPED{$nullableTypeField}}<font color="#999999">:ESCAPED{?}ESCAPED{string}</font>
+|--$unionTypeField [2036, 2050] : DEPRECATED{ESCAPED{$unionTypeField}}<font color="#999999">:ESCAPED{string}ESCAPED{|}ESCAPED{TypedFields}</font>
+|--$intersectionTypeField [2108, 2129] : DEPRECATED{ESCAPED{$intersectionTypeField}}<font color="#999999">:ESCAPED{Foo}ESCAPED{&}ESCAPED{Bar}</font>
+|--$dnfTypeField [2193, 2205] : DEPRECATED{ESCAPED{$dnfTypeField}}<font color="#999999">:ESCAPED{(Foo}ESCAPED{&}ESCAPED{Bar)}ESCAPED{&}ESCAPED{Baz}</font>
+|--$typedStaticField [2254, 2270] : DEPRECATED{ESCAPED{$typedStaticField}}<font color="#999999">:ESCAPED{int}</font>
+|--$multiStaticField1 [2319, 2336] : DEPRECATED{ESCAPED{$multiStaticField1}}<font color="#999999">:ESCAPED{int}</font>
+|--$multiStaticField2 [2339, 2356] : DEPRECATED{ESCAPED{$multiStaticField2}}<font color="#999999">:ESCAPED{int}</font>
+|--$nullableTypeStaticField [2409, 2432] : DEPRECATED{ESCAPED{$nullableTypeStaticField}}<font color="#999999">:ESCAPED{?}ESCAPED{string}</font>
+|--$unionTypeStaticField [2508, 2528] : DEPRECATED{ESCAPED{$unionTypeStaticField}}<font color="#999999">:ESCAPED{string}ESCAPED{|}ESCAPED{TypedFields}</font>
+|--$intersectionTypeStaticField [2593, 2620] : DEPRECATED{ESCAPED{$intersectionTypeStaticField}}<font color="#999999">:ESCAPED{Foo}ESCAPED{&}ESCAPED{Bar}</font>
+|--$dnfTypeStaticField [2691, 2709] : DEPRECATED{ESCAPED{$dnfTypeStaticField}}<font color="#999999">:ESCAPED{(Foo}ESCAPED{&}ESCAPED{Bar)}ESCAPED{&}ESCAPED{Baz}</font>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php
@@ -1,0 +1,155 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class TypedFields {
+
+    /** @deprecated */
+    public int $typedField;
+
+    /** @deprecated */
+    public int $multiField1, $multiField2;
+
+    /** @deprecated */
+    public ?string $nullableTypeField;
+
+    /**
+     * @deprecated
+     */
+    public string|TypedFields $unionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public Foo&Bar $intersectionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public (Foo&Bar)|Baz $dnfTypeField;
+
+    /** @deprecated */
+    public static int $typedStaticField;
+
+    /** @deprecated */
+    public static int $multiStaticField1, $multiStaticField2;
+
+    /** @deprecated */
+    public static ?string $nullableTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static string|TypedFields $unionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static Foo&Bar $intersectionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static (Foo&Bar)|Baz $dnfTypeStaticField;
+
+    public function test(): void {
+        $this->typedField;
+        $this->multiField1;
+        $this->multiField2;
+        $this->nullableTypeField;
+        $this->unionTypeField;
+        $this->intersectionTypeField;
+        $this->dnfTypeField;
+        self::$typedStaticField;
+        self::$multiStaticField1;
+        self::$multiStaticField2;
+        self::$nullableTypeStaticField;
+        self::$unionTypeStaticField;
+        self::$intersectionTypeStaticField;
+        self::$dnfTypeStaticField;
+    }
+}
+
+trait TypedFieldsTrait {
+
+    /** @deprecated */
+    public int $typedField;
+
+    /** @deprecated */
+    public int $multiField1, $multiField2;
+
+    /** @deprecated */
+    public ?string $nullableTypeField;
+
+    /**
+     * @deprecated
+     */
+    public string|TypedFields $unionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public Foo&Bar $intersectionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public (Foo&Bar)|Baz $dnfTypeField;
+
+    /** @deprecated */
+    public static int $typedStaticField;
+
+    /** @deprecated */
+    public static int $multiStaticField1, $multiStaticField2;
+
+    /** @deprecated */
+    public static ?string $nullableTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static string|TypedFields $unionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static Foo&Bar $intersectionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static (Foo&Bar)|Baz $dnfTypeStaticField;
+
+    public function test(): void {
+        $this->typedField; // trait
+        $this->multiField1; // trait
+        $this->multiField2; // trait
+        $this->nullableTypeField; // trait
+        $this->unionTypeField; // trait
+        $this->intersectionTypeField; // trait
+        $this->dnfTypeField; // trait
+        self::$typedStaticField; // trait
+        self::$multiStaticField1; // trait
+        self::$multiStaticField2; // trait
+        self::$nullableTypeStaticField; // trait
+        self::$unionTypeStaticField; // trait
+        self::$intersectionTypeStaticField; // trait
+        self::$dnfTypeStaticField; // trait
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_01.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_01.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$typedStaticFiel|d;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int $typedStaticField           [STATIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$typedStaticField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_02.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_02.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$multiStaticField1|;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int $multiStaticField1          [STATIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$multiStaticField1</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_03.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_03.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$multiStaticField2|;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int $multiStaticField2          [STATIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$multiStaticField2</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_04.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_04.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$nullableTypeStatic|Field;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ?string $nullableTypeStaticFie  [STATIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$nullableTypeStaticField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>?string</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_05.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_05.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$unionTypeStaticFiel|d;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   string|TypedFields $unionTypeS  [STATIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$unionTypeStaticField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>string | TypedFields</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_06.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedFields_06.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$intersectionTypeStat|icField;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   Foo&Bar $intersectionTypeStati  [STATIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$intersectionTypeStaticField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>Foo & Bar</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_01.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_01.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$typedStaticFiel|d; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int $typedStaticField           [STATIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$typedStaticField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_02.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_02.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$multiStaticField1|; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int $multiStaticField1          [STATIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$multiStaticField1</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_03.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_03.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$multiStaticField2|; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int $multiStaticField2          [STATIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$multiStaticField2</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_04.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_04.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$nullableTypeStatic|Field; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ?string $nullableTypeStaticFie  [STATIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$nullableTypeStaticField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>?string</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_05.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_05.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$unionTypeStaticFiel|d; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   string|TypedFields $unionTypeS  [STATIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$unionTypeStaticField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>string | TypedFields</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_06.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedStaticTypedTraitFields_06.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+self::$intersectionTypeStat|icField; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   Foo&Bar $intersectionTypeStati  [STATIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$intersectionTypeStaticField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>Foo & Bar</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_01.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_01.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->typedFiel|d;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int typedField                  [PUBLIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$typedField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_02.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_02.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->multiField1|;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int multiField1                 [PUBLIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$multiField1</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_03.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_03.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->multiField2|;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int multiField2                 [PUBLIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$multiField2</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_04.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_04.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->nullableTypeFi|eld;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ?string nullableTypeField       [PUBLIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$nullableTypeField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>?string</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_05.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_05.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->unionType|Field;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   string|TypedFields unionTypeFi  [PUBLIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$unionTypeField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>string | TypedFields</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_06.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedFields_06.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->intersectionType|Field;
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   Foo&Bar intersectionTypeField   [PUBLIC]   TypedFields
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$intersectionTypeField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>Foo & Bar</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_01.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_01.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->typedFiel|d; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int typedField                  [PUBLIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$typedField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_02.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_02.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->multiField1|; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int multiField1                 [PUBLIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$multiField1</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_03.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_03.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->multiField2|; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   int multiField2                 [PUBLIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$multiField2</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>int</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_04.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_04.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->nullableTypeFi|eld; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   ?string nullableTypeField       [PUBLIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$nullableTypeField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>?string</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_05.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_05.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->unionType|Field; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   string|TypedFields unionTypeFi  [PUBLIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$unionTypeField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>string | TypedFields</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_06.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php.testDeprecatedTypedTraitFields_06.html
@@ -1,0 +1,10 @@
+<html><body>
+<pre>Code completion result for source line:
+$this->intersectionType|Field; // trait
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+VARIABLE   Foo&Bar intersectionTypeField   [PUBLIC]   TypedFieldsTrait
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>$intersectionTypeField</b><br/><br/><br />
+<table>
+<tr><th align="left">deprecated</th><td></td></tr>
+<tr><th align="left">Type:</th><td>Foo & Bar</td></tr></table>
+</body></html>

--- a/php/php.editor/test/unit/data/testfiles/semantic/deprecatedTypedFields/deprecatedTypedFields.php
+++ b/php/php.editor/test/unit/data/testfiles/semantic/deprecatedTypedFields/deprecatedTypedFields.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class TypedFields {
+
+    /** @deprecated */
+    public int $typedField;
+
+    /** @deprecated */
+    public int $multiField1, $multiField2;
+
+    /** @deprecated */
+    public ?string $nullableTypeField;
+
+    /**
+     * @deprecated
+     */
+    public string|TypedFields $unionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public Foo&Bar $intersectionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public (Foo&Bar)|Baz $dnfTypeField;
+
+    /** @deprecated */
+    public static int $typedStaticField;
+
+    /** @deprecated */
+    public static int $multiStaticField1, $multiStaticField2;
+
+    /** @deprecated */
+    public static ?string $nullableTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static string|TypedFields $unionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static Foo&Bar $intersectionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static (Foo&Bar)|Baz $dnfTypeStaticField;
+}
+
+trait TypedFieldsTrait {
+
+    /** @deprecated */
+    public int $typedField;
+
+    /** @deprecated */
+    public int $multiField1, $multiField2;
+
+    /** @deprecated */
+    public ?string $nullableTypeField;
+
+    /**
+     * @deprecated
+     */
+    public string|TypedFields $unionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public Foo&Bar $intersectionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public (Foo&Bar)|Baz $dnfTypeField;
+
+    /** @deprecated */
+    public static int $typedStaticField;
+
+    /** @deprecated */
+    public static int $multiStaticField1, $multiStaticField2;
+
+    /** @deprecated */
+    public static ?string $nullableTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static string|TypedFields $unionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static Foo&Bar $intersectionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static (Foo&Bar)|Baz $dnfTypeStaticField;
+}

--- a/php/php.editor/test/unit/data/testfiles/semantic/deprecatedTypedFields/deprecatedTypedFields.php.semantic
+++ b/php/php.editor/test/unit/data/testfiles/semantic/deprecatedTypedFields/deprecatedTypedFields.php.semantic
@@ -1,0 +1,121 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class |>CLASS:TypedFields<| {
+
+    /** @deprecated */
+    public int $|>DEPRECATED,FIELD:typedField<|;
+
+    /** @deprecated */
+    public int $|>DEPRECATED,FIELD:multiField1<|, $|>DEPRECATED,FIELD:multiField2<|;
+
+    /** @deprecated */
+    public ?string $|>DEPRECATED,FIELD:nullableTypeField<|;
+
+    /**
+     * @deprecated
+     */
+    public string|TypedFields $|>DEPRECATED,FIELD:unionTypeField<|;
+
+    /**
+     * @deprecated
+     */
+    public Foo&Bar $|>DEPRECATED,FIELD:intersectionTypeField<|;
+
+    /**
+     * @deprecated
+     */
+    public (Foo&Bar)|Baz $|>DEPRECATED,FIELD:dnfTypeField<|;
+
+    /** @deprecated */
+    public static int $|>DEPRECATED,FIELD,STATIC:typedStaticField<|;
+
+    /** @deprecated */
+    public static int $|>DEPRECATED,FIELD,STATIC:multiStaticField1<|, $|>DEPRECATED,FIELD,STATIC:multiStaticField2<|;
+
+    /** @deprecated */
+    public static ?string $|>DEPRECATED,FIELD,STATIC:nullableTypeStaticField<|;
+
+    /**
+     * @deprecated
+     */
+    public static string|TypedFields $|>DEPRECATED,FIELD,STATIC:unionTypeStaticField<|;
+
+    /**
+     * @deprecated
+     */
+    public static Foo&Bar $|>DEPRECATED,FIELD,STATIC:intersectionTypeStaticField<|;
+
+    /**
+     * @deprecated
+     */
+    public static (Foo&Bar)|Baz $|>DEPRECATED,FIELD,STATIC:dnfTypeStaticField<|;
+}
+
+trait |>CLASS:TypedFieldsTrait<| {
+
+    /** @deprecated */
+    public int $|>DEPRECATED,FIELD:typedField<|;
+
+    /** @deprecated */
+    public int $|>DEPRECATED,FIELD:multiField1<|, $|>DEPRECATED,FIELD:multiField2<|;
+
+    /** @deprecated */
+    public ?string $|>DEPRECATED,FIELD:nullableTypeField<|;
+
+    /**
+     * @deprecated
+     */
+    public string|TypedFields $|>DEPRECATED,FIELD:unionTypeField<|;
+
+    /**
+     * @deprecated
+     */
+    public Foo&Bar $|>DEPRECATED,FIELD:intersectionTypeField<|;
+
+    /**
+     * @deprecated
+     */
+    public (Foo&Bar)|Baz $|>DEPRECATED,FIELD:dnfTypeField<|;
+
+    /** @deprecated */
+    public static int $|>DEPRECATED,FIELD,STATIC:typedStaticField<|;
+
+    /** @deprecated */
+    public static int $|>DEPRECATED,FIELD,STATIC:multiStaticField1<|, $|>DEPRECATED,FIELD,STATIC:multiStaticField2<|;
+
+    /** @deprecated */
+    public static ?string $|>DEPRECATED,FIELD,STATIC:nullableTypeStaticField<|;
+
+    /**
+     * @deprecated
+     */
+    public static string|TypedFields $|>DEPRECATED,FIELD,STATIC:unionTypeStaticField<|;
+
+    /**
+     * @deprecated
+     */
+    public static Foo&Bar $|>DEPRECATED,FIELD,STATIC:intersectionTypeStaticField<|;
+
+    /**
+     * @deprecated
+     */
+    public static (Foo&Bar)|Baz $|>DEPRECATED,FIELD,STATIC:dnfTypeStaticField<|;
+}

--- a/php/php.editor/test/unit/data/testfiles/structure/deprecatedTypedFields.php
+++ b/php/php.editor/test/unit/data/testfiles/structure/deprecatedTypedFields.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class TypedFields {
+
+    /** @deprecated */
+    public int $typedField;
+
+    /** @deprecated */
+    public int $multiField1, $multiField2;
+
+    /** @deprecated */
+    public ?string $nullableTypeField;
+
+    /**
+     * @deprecated
+     */
+    public string|TypedFields $unionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public Foo&Bar $intersectionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public (Foo&Bar)|Baz $dnfTypeField;
+
+    /** @deprecated */
+    public static int $typedStaticField;
+
+    /** @deprecated */
+    public static int $multiStaticField1, $multiStaticField2;
+
+    /** @deprecated */
+    public static ?string $nullableTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static string|TypedFields $unionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static Foo&Bar $intersectionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static (Foo&Bar)|Baz $dnfTypeStaticField;
+}
+
+trait TypedFieldsTrait {
+
+    /** @deprecated */
+    public int $typedField;
+
+    /** @deprecated */
+    public int $multiField1, $multiField2;
+
+    /** @deprecated */
+    public ?string $nullableTypeField;
+
+    /**
+     * @deprecated
+     */
+    public string|TypedFields $unionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public Foo&Bar $intersectionTypeField;
+
+    /**
+     * @deprecated
+     */
+    public (Foo&Bar)|Baz $dnfTypeField;
+
+    /** @deprecated */
+    public static int $typedStaticField;
+
+    /** @deprecated */
+    public static int $multiStaticField1, $multiStaticField2;
+
+    /** @deprecated */
+    public static ?string $nullableTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static string|TypedFields $unionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static Foo&Bar $intersectionTypeStaticField;
+
+    /**
+     * @deprecated
+     */
+    public static (Foo&Bar)|Baz $dnfTypeStaticField;
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
@@ -440,6 +440,112 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
         checkCompletionDocumentation("testfiles/completion/documentation/nullConstant.php", "$b = TestConst::TEST_CLASS_CON^ST;", false, "");
     }
 
+    public void testDeprecatedTypedFields_01() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->typedFiel^d;", false, "");
+    }
+
+    public void testDeprecatedTypedFields_02() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->multiField1^;", false, "");
+    }
+
+    public void testDeprecatedTypedFields_03() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->multiField2^;", false, "");
+    }
+
+    public void testDeprecatedTypedFields_04() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->nullableTypeFi^eld;", false, "");
+    }
+
+    public void testDeprecatedTypedFields_05() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->unionType^Field;", false, "");
+    }
+
+    public void testDeprecatedTypedFields_06() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->intersectionType^Field;", false, "");
+    }
+
+    // TODO: dnf types are not fixed yet
+//    public void testDeprecatedTypedFields_07() throws Exception {
+//        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->dnfTypeFi^eld;", false, "");
+//    }
+
+    public void testDeprecatedStaticTypedFields_01() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$typedStaticFiel^d;", false, "");
+    }
+
+    public void testDeprecatedStaticTypedFields_02() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$multiStaticField1^;", false, "");
+    }
+
+    public void testDeprecatedStaticTypedFields_03() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$multiStaticField2^;", false, "");
+    }
+
+    public void testDeprecatedStaticTypedFields_04() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$nullableTypeStatic^Field;", false, "");
+    }
+
+    public void testDeprecatedStaticTypedFields_05() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$unionTypeStaticFiel^d;", false, "");
+    }
+
+    public void testDeprecatedStaticTypedFields_06() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$intersectionTypeStat^icField;", false, "");
+    }
+
+    // TODO: dnf types are not fixed yet
+//    public void testDeprecatedStaticTypedFields_07() throws Exception {
+//        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$dnfTypeStaticFi^eld;", false, "");
+//    }
+
+    public void testDeprecatedTypedTraitFields_01() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->typedFiel^d; // trait", false, "");
+    }
+
+    public void testDeprecatedTypedTraitFields_02() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->multiField1^; // trait", false, "");
+    }
+
+    public void testDeprecatedTypedTraitFields_03() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->multiField2^; // trait", false, "");
+    }
+
+    public void testDeprecatedTypedTraitFields_04() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->nullableTypeFi^eld; // trait", false, "");
+    }
+
+    public void testDeprecatedTypedTraitFields_05() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->unionType^Field; // trait", false, "");
+    }
+
+    public void testDeprecatedTypedTraitFields_06() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "$this->intersectionType^Field; // trait", false, "");
+    }
+
+    public void testDeprecatedStaticTypedTraitFields_01() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$typedStaticFiel^d; // trait", false, "");
+    }
+
+    public void testDeprecatedStaticTypedTraitFields_02() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$multiStaticField1^; // trait", false, "");
+    }
+
+    public void testDeprecatedStaticTypedTraitFields_03() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$multiStaticField2^; // trait", false, "");
+    }
+
+    public void testDeprecatedStaticTypedTraitFields_04() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$nullableTypeStatic^Field; // trait", false, "");
+    }
+
+    public void testDeprecatedStaticTypedTraitFields_05() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$unionTypeStaticFiel^d; // trait", false, "");
+    }
+
+    public void testDeprecatedStaticTypedTraitFields_06() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/deprecatedTypedFields/deprecatedTypedFields.php", "self::$intersectionTypeStat^icField; // trait", false, "");
+    }
+
     @Override
     protected String alterDocumentationForTest(String documentation) {
         int start = documentation.indexOf("file:");

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/DeprecatedTypedFieldsSemanticAnalysisTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/DeprecatedTypedFieldsSemanticAnalysisTest.java
@@ -27,35 +27,15 @@ import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
-/**
- *
- * @author Ondrej Brejla <obrejla@netbeans.org>
- */
-public class NavigatorDeprecatedTest extends PhpNavigatorTestBase {
+public class DeprecatedTypedFieldsSemanticAnalysisTest extends DeprecatedSemanticAnalysisTestBase {
 
-    public NavigatorDeprecatedTest(String testName) {
+    public DeprecatedTypedFieldsSemanticAnalysisTest(String testName) {
         super(testName);
     }
 
-    public void testDeprecatedDeclarations() throws Exception {
-        performTest("structure/deprecatedDeclarations");
-    }
-
-    public void testDeprecatedTypes() throws Exception {
-        performTest("structure/deprecatedTypes");
-    }
-
-    public void testDeprecatedTypesForNullableTypes_01() throws Exception {
-        performTest("structure/deprecatedTypesForNullableTypes_01");
-    }
-
-    public void testDeprecatedTypesForNullableTypes_02() throws Exception {
-        performTest("structure/deprecatedTypesForNullableTypes_02");
-    }
-
-    public void testDeprecatedTypedFields() throws Exception {
+    public void testDeprecatedFieldsDeclarations() throws Exception {
         // GH-6310
-        performTest("structure/deprecatedTypedFields");
+        checkSemantic("testfiles/semantic/deprecatedTypedFields/deprecatedTypedFields.php");
     }
 
     @Override
@@ -63,7 +43,7 @@ public class NavigatorDeprecatedTest extends PhpNavigatorTestBase {
         return Collections.singletonMap(
             PhpSourcePath.SOURCE_CP,
             ClassPathSupport.createClassPath(new FileObject[] {
-                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/structure"))
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/semantic/deprecatedTypedFields"))
             })
         );
     }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6310
- Fix the `NodeRangeLocator`'s end offset when the node is the `SingleFieldDeclaration` because a start offset is the start offset of not a type but a variable name
- Add unit tests

![nb-php-gh-6310-editor](https://github.com/apache/netbeans/assets/738383/57783593-0290-43d1-93c7-86728c914607)

![nb-php-gh-6310-navigator](https://github.com/apache/netbeans/assets/738383/855146fd-2e03-4e3b-9551-9f285e0a15cd)

![nb-php-gh-6310-cc](https://github.com/apache/netbeans/assets/738383/4df6ae71-4807-452b-aa4e-b7bdff8f9cca)
