### PR TITLE
Keep existing order of use type kinds(types, functions, constants) if possible #6274

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/actions/FixUsesAction.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/actions/FixUsesAction.java
@@ -283,6 +283,7 @@ public class FixUsesAction extends BaseAction {
         private final boolean startUseWithNamespaceSeparator;
         private final boolean aliasesCapitalsOfNamespaces;
         private final boolean putInPSR12Order;
+        private final boolean keepExistingUseTypeOrder;
         private final int blankLinesBetweenUseTypes;
         private final PhpVersion phpVersion;
 
@@ -294,6 +295,7 @@ public class FixUsesAction extends BaseAction {
             private boolean startUseWithNamespaceSeparator = false;
             private boolean aliasesCapitalsOfNamespaces = false;
             private boolean putInPSR12Order = false;
+            private boolean keepExistingUseTypeOrder = false;
             private int blankLinesBetweenUseTypes = 0;
             private final PhpVersion phpVersion;
 
@@ -331,6 +333,11 @@ public class FixUsesAction extends BaseAction {
                 return this;
             }
 
+            public Builder keepExistingUseTypeOrder(boolean keepExistingUseTypeOrder) {
+                this.keepExistingUseTypeOrder = keepExistingUseTypeOrder;
+                return this;
+            }
+
             public Builder setBlankLinesBetweenUseTypes(int blankLinesBetweenUseTypes) {
                 this.blankLinesBetweenUseTypes = blankLinesBetweenUseTypes;
                 return this;
@@ -348,6 +355,7 @@ public class FixUsesAction extends BaseAction {
             this.startUseWithNamespaceSeparator = builder.startUseWithNamespaceSeparator;
             this.aliasesCapitalsOfNamespaces = builder.aliasesCapitalsOfNamespaces;
             this.putInPSR12Order = builder.putInPSR12Order;
+            this.keepExistingUseTypeOrder = builder.keepExistingUseTypeOrder;
             this.blankLinesBetweenUseTypes = builder.blankLinesBetweenUseTypes;
             this.phpVersion = builder.phpVersion;
         }
@@ -360,6 +368,7 @@ public class FixUsesAction extends BaseAction {
                 boolean startUseWithNamespaceSeparator,
                 boolean aliasesCapitalsOfNamespaces,
                 boolean putInPSR12Order,
+                boolean keepExistingUseTypeOrder,
                 int blankLinesBetweenUseTypes,
                 PhpVersion phpVersion) {
             this.preferFullyQualifiedNames = preferFullyQualifiedNames;
@@ -368,6 +377,7 @@ public class FixUsesAction extends BaseAction {
             this.startUseWithNamespaceSeparator = startUseWithNamespaceSeparator;
             this.aliasesCapitalsOfNamespaces = aliasesCapitalsOfNamespaces;
             this.putInPSR12Order = putInPSR12Order;
+            this.keepExistingUseTypeOrder = keepExistingUseTypeOrder;
             this.blankLinesBetweenUseTypes = blankLinesBetweenUseTypes;
             this.phpVersion = phpVersion;
         }
@@ -379,7 +389,7 @@ public class FixUsesAction extends BaseAction {
                 boolean startUseWithNamespaceSeparator,
                 boolean aliasesCapitalsOfNamespaces,
                 PhpVersion phpVersion) {
-            this(preferFullyQualifiedNames, preferMultipleUseStatementsCombined, preferGroupUses, startUseWithNamespaceSeparator, aliasesCapitalsOfNamespaces, false, 0, phpVersion);
+            this(preferFullyQualifiedNames, preferMultipleUseStatementsCombined, preferGroupUses, startUseWithNamespaceSeparator, aliasesCapitalsOfNamespaces, false, false, 0, phpVersion);
         }
 
         // legacy, for unit tests
@@ -389,7 +399,7 @@ public class FixUsesAction extends BaseAction {
                 boolean startUseWithNamespaceSeparator,
                 boolean aliasesCapitalsOfNamespaces,
                 boolean isPhp56OrGreater) {
-            this(preferFullyQualifiedNames, preferMultipleUseStatementsCombined, false, startUseWithNamespaceSeparator, aliasesCapitalsOfNamespaces, false, 0,
+            this(preferFullyQualifiedNames, preferMultipleUseStatementsCombined, false, startUseWithNamespaceSeparator, aliasesCapitalsOfNamespaces, false, false, 0,
                     isPhp56OrGreater ? PhpVersion.PHP_56 : PhpVersion.PHP_5);
         }
 
@@ -401,7 +411,7 @@ public class FixUsesAction extends BaseAction {
                 boolean startUseWithNamespaceSeparator,
                 boolean aliasesCapitalsOfNamespaces,
                 boolean isPhp56OrGreater) {
-            this(preferFullyQualifiedNames, preferMultipleUseStatementsCombined, preferGroupUses, startUseWithNamespaceSeparator, aliasesCapitalsOfNamespaces, false, 0,
+            this(preferFullyQualifiedNames, preferMultipleUseStatementsCombined, preferGroupUses, startUseWithNamespaceSeparator, aliasesCapitalsOfNamespaces, false, false, 0,
                     isPhp56OrGreater ? PhpVersion.PHP_56 : PhpVersion.PHP_5);
         }
 
@@ -412,6 +422,7 @@ public class FixUsesAction extends BaseAction {
             this.startUseWithNamespaceSeparator = codeStyle.startUseWithNamespaceSeparator();
             this.aliasesCapitalsOfNamespaces = codeStyle.aliasesFromCapitalsOfNamespaces();
             this.putInPSR12Order = codeStyle.putInPSR12Order();
+            this.keepExistingUseTypeOrder = codeStyle.usesKeepExistingTypeOrder();
             this.blankLinesBetweenUseTypes = codeStyle.getBlankLinesBetweenUseTypes();
             this.phpVersion = CodeUtils.getPhpVersion(fileObject);
         }
@@ -438,6 +449,10 @@ public class FixUsesAction extends BaseAction {
 
         public boolean putInPSR12Order() {
             return putInPSR12Order;
+        }
+
+        public boolean keepExistingUseTypeOrder() {
+            return keepExistingUseTypeOrder;
         }
 
         public int getBlankLinesBetweenUseTypes() {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/CodeStyle.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/CodeStyle.java
@@ -753,6 +753,10 @@ public final class CodeStyle {
         return preferences.getBoolean(PUT_IN_PSR12_ORDER, getDefaultAsBoolean(PUT_IN_PSR12_ORDER));
     }
 
+    public boolean usesKeepExistingTypeOrder() {
+        return preferences.getBoolean(USES_KEEP_EXISTING_TYPE_ORDER, getDefaultAsBoolean(USES_KEEP_EXISTING_TYPE_ORDER));
+    }
+
     private static class Producer implements FmtOptions.CodeStyleProducer {
 
         @Override

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FmtOptions.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FmtOptions.java
@@ -227,6 +227,7 @@ public final class FmtOptions {
     public static final String START_USE_WITH_NAMESPACE_SEPARATOR = "startUseWithNamespaceSeparator"; //NOI18N
     public static final String ALIASES_CAPITALS_OF_NAMESPACES = "aliasesCapitalsOfNamespacesNames"; //NOI18N
     public static final String PUT_IN_PSR12_ORDER = "putInPSR12Order"; //NOI18N
+    public static final String USES_KEEP_EXISTING_TYPE_ORDER = "usesKeepExistingTypeOrder"; //NOI18N
     public static CodeStyleProducer codeStyleProducer;
 
     private FmtOptions() {
@@ -421,7 +422,8 @@ public final class FmtOptions {
             {PREFER_GROUP_USES, FALSE},
             {START_USE_WITH_NAMESPACE_SEPARATOR, FALSE},
             {ALIASES_CAPITALS_OF_NAMESPACES, FALSE},
-            {PUT_IN_PSR12_ORDER, FALSE}
+            {PUT_IN_PSR12_ORDER, FALSE},
+            {USES_KEEP_EXISTING_TYPE_ORDER, TRUE},
         };
 
         defaults = new HashMap<>();

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/Bundle.properties
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/Bundle.properties
@@ -455,3 +455,4 @@ FmtBlankLines.betweenUseTypesLabel.AccessibleContext.accessibleDescription=Betwe
 FmtBlankLines.betweenUseTypesField.text=
 FmtBlankLines.endOfFileCheckBox.text=En&d of File
 FmtUses.putInPSR12OrderCheckBox.text=Put in PSR-12 &Order
+FmtUses.keepExistingUseTypeOrderCheckBox.text=&Keep Existing Order of Use Types(types, functions, constants) If Possible

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtUses.form
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtUses.form
@@ -52,6 +52,7 @@
                   <Component id="aliasesCapitalsOfNamespacesCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="preferGroupUsesCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="putInPSR12OrderCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="keepExistingUseTypeOrderCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
@@ -72,7 +73,9 @@
               <Component id="aliasesCapitalsOfNamespacesCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="putInPSR12OrderCheckBox" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="12" max="32767" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="keepExistingUseTypeOrderCheckBox" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -121,6 +124,13 @@
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/php/editor/indent/ui/Bundle.properties" key="FmtUses.putInPSR12OrderCheckBox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="keepExistingUseTypeOrderCheckBox">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/php/editor/indent/ui/Bundle.properties" key="FmtUses.keepExistingUseTypeOrderCheckBox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtUses.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtUses.java
@@ -49,6 +49,7 @@ public class FmtUses extends JPanel {
         startUseWithNamespaceSeparatorCheckBox.putClientProperty(OPTION_ID, FmtOptions.START_USE_WITH_NAMESPACE_SEPARATOR);
         aliasesCapitalsOfNamespacesCheckBox.putClientProperty(OPTION_ID, FmtOptions.ALIASES_CAPITALS_OF_NAMESPACES);
         putInPSR12OrderCheckBox.putClientProperty(OPTION_ID, FmtOptions.PUT_IN_PSR12_ORDER);
+        keepExistingUseTypeOrderCheckBox.putClientProperty(OPTION_ID, FmtOptions.USES_KEEP_EXISTING_TYPE_ORDER);
     }
 
     public static PreferencesCustomizer.Factory getController() {
@@ -76,6 +77,7 @@ public class FmtUses extends JPanel {
         startUseWithNamespaceSeparatorCheckBox = new JCheckBox();
         aliasesCapitalsOfNamespacesCheckBox = new JCheckBox();
         putInPSR12OrderCheckBox = new JCheckBox();
+        keepExistingUseTypeOrderCheckBox = new JCheckBox();
 
         setName(NbBundle.getMessage(FmtUses.class, "LBL_Uses")); // NOI18N
         setOpaque(false);
@@ -96,6 +98,8 @@ public class FmtUses extends JPanel {
 
         Mnemonics.setLocalizedText(putInPSR12OrderCheckBox, NbBundle.getMessage(FmtUses.class, "FmtUses.putInPSR12OrderCheckBox.text")); // NOI18N
 
+        Mnemonics.setLocalizedText(keepExistingUseTypeOrderCheckBox, NbBundle.getMessage(FmtUses.class, "FmtUses.keepExistingUseTypeOrderCheckBox.text")); // NOI18N
+
         GroupLayout layout = new GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
@@ -107,7 +111,8 @@ public class FmtUses extends JPanel {
                     .addComponent(startUseWithNamespaceSeparatorCheckBox)
                     .addComponent(aliasesCapitalsOfNamespacesCheckBox)
                     .addComponent(preferGroupUsesCheckBox)
-                    .addComponent(putInPSR12OrderCheckBox))
+                    .addComponent(putInPSR12OrderCheckBox)
+                    .addComponent(keepExistingUseTypeOrderCheckBox))
                 .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
@@ -124,11 +129,14 @@ public class FmtUses extends JPanel {
                 .addComponent(aliasesCapitalsOfNamespacesCheckBox)
                 .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(putInPSR12OrderCheckBox)
-                .addContainerGap(12, Short.MAX_VALUE))
+                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(keepExistingUseTypeOrderCheckBox)
+                .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private JCheckBox aliasesCapitalsOfNamespacesCheckBox;
+    private JCheckBox keepExistingUseTypeOrderCheckBox;
     private JCheckBox preferFullyQualifiedNamesCheckBox;
     private JCheckBox preferGroupUsesCheckBox;
     private JCheckBox preferMultipleUseStatementsCombinedCheckBox;

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group01a/testKeepExistingUseTypeOrder_Group01a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group01a/testKeepExistingUseTypeOrder_Group01a.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function1;
+use function NS2\ns2Function2;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+use const NS2\NS2_CONSTANT2;
+
+NS1\ns1Function();
+NS2\ns2Function();
+NS2\ns2Function2();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group01a/testKeepExistingUseTypeOrder_Group01a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group01a/testKeepExistingUseTypeOrder_Group01a.php.fixUses
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+
+ns1Function();
+NS2\ns2Function();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group01b/testKeepExistingUseTypeOrder_Group01b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group01b/testKeepExistingUseTypeOrder_Group01b.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function1;
+use function NS2\ns2Function2;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+use const NS2\NS2_CONSTANT2;
+
+NS1\ns1Function();
+NS2\ns2Function();
+NS2\ns2Function2();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group01b/testKeepExistingUseTypeOrder_Group01b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group01b/testKeepExistingUseTypeOrder_Group01b.php.fixUses
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+NS2\ns2Function();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group02a/testKeepExistingUseTypeOrder_Group02a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group02a/testKeepExistingUseTypeOrder_Group02a.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group02a/testKeepExistingUseTypeOrder_Group02a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group02a/testKeepExistingUseTypeOrder_Group02a.php.fixUses
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group02b/testKeepExistingUseTypeOrder_Group02b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group02b/testKeepExistingUseTypeOrder_Group02b.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group02b/testKeepExistingUseTypeOrder_Group02b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group02b/testKeepExistingUseTypeOrder_Group02b.php.fixUses
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group03a/testKeepExistingUseTypeOrder_Group03a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group03a/testKeepExistingUseTypeOrder_Group03a.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group03a/testKeepExistingUseTypeOrder_Group03a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group03a/testKeepExistingUseTypeOrder_Group03a.php.fixUses
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group03b/testKeepExistingUseTypeOrder_Group03b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group03b/testKeepExistingUseTypeOrder_Group03b.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group03b/testKeepExistingUseTypeOrder_Group03b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group03b/testKeepExistingUseTypeOrder_Group03b.php.fixUses
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group04a/testKeepExistingUseTypeOrder_Group04a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group04a/testKeepExistingUseTypeOrder_Group04a.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group04a/testKeepExistingUseTypeOrder_Group04a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group04a/testKeepExistingUseTypeOrder_Group04a.php.fixUses
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group04b/testKeepExistingUseTypeOrder_Group04b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group04b/testKeepExistingUseTypeOrder_Group04b.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group04b/testKeepExistingUseTypeOrder_Group04b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group04b/testKeepExistingUseTypeOrder_Group04b.php.fixUses
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group05a/testKeepExistingUseTypeOrder_Group05a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group05a/testKeepExistingUseTypeOrder_Group05a.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group05a/testKeepExistingUseTypeOrder_Group05a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group05a/testKeepExistingUseTypeOrder_Group05a.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group05b/testKeepExistingUseTypeOrder_Group05b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group05b/testKeepExistingUseTypeOrder_Group05b.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group05b/testKeepExistingUseTypeOrder_Group05b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Group05b/testKeepExistingUseTypeOrder_Group05b.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR01a/testKeepExistingUseTypeOrder_GroupPSR01a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR01a/testKeepExistingUseTypeOrder_GroupPSR01a.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+use const NS2\NS2_CONSTANT2;
+use function NS1\ns1Function;
+use function NS2\ns2Function1;
+use function NS2\ns2Function2;
+
+NS1\ns1Function();
+NS2\ns2Function();
+NS2\ns2Function2();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR01a/testKeepExistingUseTypeOrder_GroupPSR01a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR01a/testKeepExistingUseTypeOrder_GroupPSR01a.php.fixUses
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+NS2\ns2Function();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR01b/testKeepExistingUseTypeOrder_GroupPSR01b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR01b/testKeepExistingUseTypeOrder_GroupPSR01b.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+use const NS2\NS2_CONSTANT2;
+use function NS1\ns1Function;
+use function NS2\ns2Function1;
+use function NS2\ns2Function2;
+
+NS1\ns1Function();
+NS2\ns2Function();
+NS2\ns2Function2();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR01b/testKeepExistingUseTypeOrder_GroupPSR01b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR01b/testKeepExistingUseTypeOrder_GroupPSR01b.php.fixUses
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+
+ns1Function();
+NS2\ns2Function();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR02a/testKeepExistingUseTypeOrder_GroupPSR02a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR02a/testKeepExistingUseTypeOrder_GroupPSR02a.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR02a/testKeepExistingUseTypeOrder_GroupPSR02a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR02a/testKeepExistingUseTypeOrder_GroupPSR02a.php.fixUses
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR02b/testKeepExistingUseTypeOrder_GroupPSR02b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR02b/testKeepExistingUseTypeOrder_GroupPSR02b.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR02b/testKeepExistingUseTypeOrder_GroupPSR02b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR02b/testKeepExistingUseTypeOrder_GroupPSR02b.php.fixUses
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\{
+    NS1Class,
+    NS1Enum,
+    NS1Interface,
+    NS1Trait
+};
+use NS2\{
+    NS2Class,
+    NS2Enum,
+    NS2Interface,
+    NS2Trait
+};
+use function NS1\ns1Function;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR03a/testKeepExistingUseTypeOrder_GroupPSR03a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR03a/testKeepExistingUseTypeOrder_GroupPSR03a.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR03a/testKeepExistingUseTypeOrder_GroupPSR03a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR03a/testKeepExistingUseTypeOrder_GroupPSR03a.php.fixUses
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR03b/testKeepExistingUseTypeOrder_GroupPSR03b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR03b/testKeepExistingUseTypeOrder_GroupPSR03b.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR03b/testKeepExistingUseTypeOrder_GroupPSR03b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR03b/testKeepExistingUseTypeOrder_GroupPSR03b.php.fixUses
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR04a/testKeepExistingUseTypeOrder_GroupPSR04a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR04a/testKeepExistingUseTypeOrder_GroupPSR04a.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR04a/testKeepExistingUseTypeOrder_GroupPSR04a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR04a/testKeepExistingUseTypeOrder_GroupPSR04a.php.fixUses
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR04b/testKeepExistingUseTypeOrder_GroupPSR04b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR04b/testKeepExistingUseTypeOrder_GroupPSR04b.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\{
+    NS2_CONSTANT1,
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR04b/testKeepExistingUseTypeOrder_GroupPSR04b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR04b/testKeepExistingUseTypeOrder_GroupPSR04b.php.fixUses
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR05a/testKeepExistingUseTypeOrder_GroupPSR05a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR05a/testKeepExistingUseTypeOrder_GroupPSR05a.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR05a/testKeepExistingUseTypeOrder_GroupPSR05a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR05a/testKeepExistingUseTypeOrder_GroupPSR05a.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR05b/testKeepExistingUseTypeOrder_GroupPSR05b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR05b/testKeepExistingUseTypeOrder_GroupPSR05b.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR05b/testKeepExistingUseTypeOrder_GroupPSR05b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/GroupPSR05b/testKeepExistingUseTypeOrder_GroupPSR05b.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS2\{
+    ns2Function1,
+    ns2Function2
+};
+use const NS2\{
+    NS2_CONSTANT1,
+    NS2_CONSTANT2
+};
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function1() {}
+function ns2Function2() {}
+
+const NS2_CONSTANT1 = "NS2_CONSTANT1";
+const NS2_CONSTANT2 = "NS2_CONSTANT2";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple01a/testKeepExistingUseTypeOrder_Multiple01a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple01a/testKeepExistingUseTypeOrder_Multiple01a.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function1;
+use function NS2\ns2Function2;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+use const NS2\NS2_CONSTANT2;
+
+NS1\ns1Function();
+NS2\ns2Function1();
+NS2\ns2Function2();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple01a/testKeepExistingUseTypeOrder_Multiple01a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple01a/testKeepExistingUseTypeOrder_Multiple01a.php.fixUses
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1,
+    NS2\NS2_CONSTANT2;
+
+ns1Function();
+NS2\ns2Function1();
+NS2\ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple01b/testKeepExistingUseTypeOrder_Multiple01b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple01b/testKeepExistingUseTypeOrder_Multiple01b.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function1;
+use function NS2\ns2Function2;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+use const NS2\NS2_CONSTANT2;
+
+NS1\ns1Function();
+NS2\ns2Function1();
+NS2\ns2Function2();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple01b/testKeepExistingUseTypeOrder_Multiple01b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple01b/testKeepExistingUseTypeOrder_Multiple01b.php.fixUses
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1,
+    NS2\NS2_CONSTANT2;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+
+ns1Function();
+NS2\ns2Function1();
+NS2\ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple02a/testKeepExistingUseTypeOrder_Multiple02a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple02a/testKeepExistingUseTypeOrder_Multiple02a.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple02a/testKeepExistingUseTypeOrder_Multiple02a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple02a/testKeepExistingUseTypeOrder_Multiple02a.php.fixUses
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1,
+    NS2\NS2_CONSTANT2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple02b/testKeepExistingUseTypeOrder_Multiple02b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple02b/testKeepExistingUseTypeOrder_Multiple02b.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple02b/testKeepExistingUseTypeOrder_Multiple02b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple02b/testKeepExistingUseTypeOrder_Multiple02b.php.fixUses
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1,
+    NS2\NS2_CONSTANT2;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple03a/testKeepExistingUseTypeOrder_Multiple03a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple03a/testKeepExistingUseTypeOrder_Multiple03a.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple03a/testKeepExistingUseTypeOrder_Multiple03a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple03a/testKeepExistingUseTypeOrder_Multiple03a.php.fixUses
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple03b/testKeepExistingUseTypeOrder_Multiple03b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple03b/testKeepExistingUseTypeOrder_Multiple03b.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple03b/testKeepExistingUseTypeOrder_Multiple03b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple03b/testKeepExistingUseTypeOrder_Multiple03b.php.fixUses
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple04a/testKeepExistingUseTypeOrder_Multiple04a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple04a/testKeepExistingUseTypeOrder_Multiple04a.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple04a/testKeepExistingUseTypeOrder_Multiple04a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple04a/testKeepExistingUseTypeOrder_Multiple04a.php.fixUses
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple04b/testKeepExistingUseTypeOrder_Multiple04b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple04b/testKeepExistingUseTypeOrder_Multiple04b.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple04b/testKeepExistingUseTypeOrder_Multiple04b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple04b/testKeepExistingUseTypeOrder_Multiple04b.php.fixUses
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple05a/testKeepExistingUseTypeOrder_Multiple05a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple05a/testKeepExistingUseTypeOrder_Multiple05a.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple05a/testKeepExistingUseTypeOrder_Multiple05a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple05a/testKeepExistingUseTypeOrder_Multiple05a.php.fixUses
@@ -1,0 +1,70 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple05b/testKeepExistingUseTypeOrder_Multiple05b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple05b/testKeepExistingUseTypeOrder_Multiple05b.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple05b/testKeepExistingUseTypeOrder_Multiple05b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Multiple05b/testKeepExistingUseTypeOrder_Multiple05b.php.fixUses
@@ -1,0 +1,70 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR01a/testKeepExistingUseTypeOrder_MultiplePSR01a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR01a/testKeepExistingUseTypeOrder_MultiplePSR01a.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+use const NS2\NS2_CONSTANT2;
+use function NS1\ns1Function;
+use function NS2\ns2Function1;
+use function NS2\ns2Function2;
+
+NS1\ns1Function();
+NS2\ns2Function1();
+NS2\ns2Function2();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR01a/testKeepExistingUseTypeOrder_MultiplePSR01a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR01a/testKeepExistingUseTypeOrder_MultiplePSR01a.php.fixUses
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1,
+    NS2\NS2_CONSTANT2;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+
+ns1Function();
+NS2\ns2Function1();
+NS2\ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR01b/testKeepExistingUseTypeOrder_MultiplePSR01b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR01b/testKeepExistingUseTypeOrder_MultiplePSR01b.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT1;
+use const NS2\NS2_CONSTANT2;
+use function NS1\ns1Function;
+use function NS2\ns2Function1;
+use function NS2\ns2Function2;
+
+NS1\ns1Function();
+NS2\ns2Function1();
+NS2\ns2Function2();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR01b/testKeepExistingUseTypeOrder_MultiplePSR01b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR01b/testKeepExistingUseTypeOrder_MultiplePSR01b.php.fixUses
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1,
+    NS2\NS2_CONSTANT2;
+
+ns1Function();
+NS2\ns2Function1();
+NS2\ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT1;
+$const2 = NS2\NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR02a/testKeepExistingUseTypeOrder_MultiplePSR02a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR02a/testKeepExistingUseTypeOrder_MultiplePSR02a.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR02a/testKeepExistingUseTypeOrder_MultiplePSR02a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR02a/testKeepExistingUseTypeOrder_MultiplePSR02a.php.fixUses
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1,
+    NS2\NS2_CONSTANT2;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR02b/testKeepExistingUseTypeOrder_MultiplePSR02b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR02b/testKeepExistingUseTypeOrder_MultiplePSR02b.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR02b/testKeepExistingUseTypeOrder_MultiplePSR02b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR02b/testKeepExistingUseTypeOrder_MultiplePSR02b.php.fixUses
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class,
+    NS1\NS1Enum,
+    NS1\NS1Interface,
+    NS1\NS1Trait,
+    NS2\NS2Class,
+    NS2\NS2Enum,
+    NS2\NS2Interface,
+    NS2\NS2Trait;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1,
+    NS2\NS2_CONSTANT2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR03a/testKeepExistingUseTypeOrder_MultiplePSR03a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR03a/testKeepExistingUseTypeOrder_MultiplePSR03a.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR03a/testKeepExistingUseTypeOrder_MultiplePSR03a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR03a/testKeepExistingUseTypeOrder_MultiplePSR03a.php.fixUses
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR03b/testKeepExistingUseTypeOrder_MultiplePSR03b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR03b/testKeepExistingUseTypeOrder_MultiplePSR03b.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR03b/testKeepExistingUseTypeOrder_MultiplePSR03b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR03b/testKeepExistingUseTypeOrder_MultiplePSR03b.php.fixUses
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function,
+    NS2\ns2Function1,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR04a/testKeepExistingUseTypeOrder_MultiplePSR04a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR04a/testKeepExistingUseTypeOrder_MultiplePSR04a.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR04a/testKeepExistingUseTypeOrder_MultiplePSR04a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR04a/testKeepExistingUseTypeOrder_MultiplePSR04a.php.fixUses
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR04b/testKeepExistingUseTypeOrder_MultiplePSR04b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR04b/testKeepExistingUseTypeOrder_MultiplePSR04b.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR04b/testKeepExistingUseTypeOrder_MultiplePSR04b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR04b/testKeepExistingUseTypeOrder_MultiplePSR04b.php.fixUses
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use function NS1\ns1Function,
+    NS2\ns2Function2;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR05a/testKeepExistingUseTypeOrder_MultiplePSR05a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR05a/testKeepExistingUseTypeOrder_MultiplePSR05a.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR05a/testKeepExistingUseTypeOrder_MultiplePSR05a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR05a/testKeepExistingUseTypeOrder_MultiplePSR05a.php.fixUses
@@ -1,0 +1,70 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR05b/testKeepExistingUseTypeOrder_MultiplePSR05b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR05b/testKeepExistingUseTypeOrder_MultiplePSR05b.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR05b/testKeepExistingUseTypeOrder_MultiplePSR05b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/MultiplePSR05b/testKeepExistingUseTypeOrder_MultiplePSR05b.php.fixUses
@@ -1,0 +1,70 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use const NS1\NS1_CONSTANT,
+    NS2\NS2_CONSTANT1;
+
+ns1Function();
+ns2Function1();
+ns2Function2();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT1;
+$const2 = NS2_CONSTANT2;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single01a/testKeepExistingUseTypeOrder_Single01a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single01a/testKeepExistingUseTypeOrder_Single01a.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+
+NS1\ns1Function();
+NS2\ns2Function();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single01a/testKeepExistingUseTypeOrder_Single01a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single01a/testKeepExistingUseTypeOrder_Single01a.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single01b/testKeepExistingUseTypeOrder_Single01b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single01b/testKeepExistingUseTypeOrder_Single01b.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+
+NS1\ns1Function();
+NS2\ns2Function();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single01b/testKeepExistingUseTypeOrder_Single01b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single01b/testKeepExistingUseTypeOrder_Single01b.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single02a/testKeepExistingUseTypeOrder_Single02a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single02a/testKeepExistingUseTypeOrder_Single02a.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single02a/testKeepExistingUseTypeOrder_Single02a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single02a/testKeepExistingUseTypeOrder_Single02a.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single02b/testKeepExistingUseTypeOrder_Single02b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single02b/testKeepExistingUseTypeOrder_Single02b.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single02b/testKeepExistingUseTypeOrder_Single02b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single02b/testKeepExistingUseTypeOrder_Single02b.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single03a/testKeepExistingUseTypeOrder_Single03a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single03a/testKeepExistingUseTypeOrder_Single03a.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single03a/testKeepExistingUseTypeOrder_Single03a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single03a/testKeepExistingUseTypeOrder_Single03a.php.fixUses
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single03b/testKeepExistingUseTypeOrder_Single03b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single03b/testKeepExistingUseTypeOrder_Single03b.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single03b/testKeepExistingUseTypeOrder_Single03b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single03b/testKeepExistingUseTypeOrder_Single03b.php.fixUses
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single04a/testKeepExistingUseTypeOrder_Single04a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single04a/testKeepExistingUseTypeOrder_Single04a.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single04a/testKeepExistingUseTypeOrder_Single04a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single04a/testKeepExistingUseTypeOrder_Single04a.php.fixUses
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Interface;
+use NS2\NS2Enum;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single04b/testKeepExistingUseTypeOrder_Single04b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single04b/testKeepExistingUseTypeOrder_Single04b.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single04b/testKeepExistingUseTypeOrder_Single04b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single04b/testKeepExistingUseTypeOrder_Single04b.php.fixUses
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Interface;
+use NS2\NS2Enum;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single05a/testKeepExistingUseTypeOrder_Single05a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single05a/testKeepExistingUseTypeOrder_Single05a.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single05a/testKeepExistingUseTypeOrder_Single05a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single05a/testKeepExistingUseTypeOrder_Single05a.php.fixUses
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS2\NS2_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single05b/testKeepExistingUseTypeOrder_Single05b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single05b/testKeepExistingUseTypeOrder_Single05b.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single05b/testKeepExistingUseTypeOrder_Single05b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/Single05b/testKeepExistingUseTypeOrder_Single05b.php.fixUses
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS2\NS2_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR01a/testKeepExistingUseTypeOrder_SinglePSR01a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR01a/testKeepExistingUseTypeOrder_SinglePSR01a.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+NS1\ns1Function();
+NS2\ns2Function();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR01a/testKeepExistingUseTypeOrder_SinglePSR01a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR01a/testKeepExistingUseTypeOrder_SinglePSR01a.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR01b/testKeepExistingUseTypeOrder_SinglePSR01b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR01b/testKeepExistingUseTypeOrder_SinglePSR01b.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+NS1\ns1Function();
+NS2\ns2Function();
+$const1 = NS1\NS1_CONSTANT;
+$const2 = NS2\NS2_CONSTANT;
+
+class Test implements NS1\NS1Interface, NS2\NS2Interface {
+    public const CONSTANT1 = NS1\NS1Enum::Case1;
+    public const CONSTANT2 = NS2\NS2Enum::Case1;
+    use NS1\NS1Trait;
+    use NS2\NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1\NS1Class();
+        $ns2 = new NS2\NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR01b/testKeepExistingUseTypeOrder_SinglePSR01b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR01b/testKeepExistingUseTypeOrder_SinglePSR01b.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR02a/testKeepExistingUseTypeOrder_SinglePSR02a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR02a/testKeepExistingUseTypeOrder_SinglePSR02a.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR02a/testKeepExistingUseTypeOrder_SinglePSR02a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR02a/testKeepExistingUseTypeOrder_SinglePSR02a.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR02b/testKeepExistingUseTypeOrder_SinglePSR02b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR02b/testKeepExistingUseTypeOrder_SinglePSR02b.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use const NS1\NS1_CONSTANT;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR02b/testKeepExistingUseTypeOrder_SinglePSR02b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR02b/testKeepExistingUseTypeOrder_SinglePSR02b.php.fixUses
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use NS1\NS1Enum;
+use NS1\NS1Interface;
+use NS1\NS1Trait;
+use NS2\NS2Class;
+use NS2\NS2Enum;
+use NS2\NS2Interface;
+use NS2\NS2Trait;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR03a/testKeepExistingUseTypeOrder_SinglePSR03a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR03a/testKeepExistingUseTypeOrder_SinglePSR03a.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT;
+use NS1\NS1Class;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR03a/testKeepExistingUseTypeOrder_SinglePSR03a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR03a/testKeepExistingUseTypeOrder_SinglePSR03a.php.fixUses
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+use NS1\NS1Class;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR03b/testKeepExistingUseTypeOrder_SinglePSR03b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR03b/testKeepExistingUseTypeOrder_SinglePSR03b.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use const NS1\NS1_CONSTANT;
+use NS1\NS1Class;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR03b/testKeepExistingUseTypeOrder_SinglePSR03b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR03b/testKeepExistingUseTypeOrder_SinglePSR03b.php.fixUses
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use const NS1\NS1_CONSTANT;
+use const NS2\NS2_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR04a/testKeepExistingUseTypeOrder_SinglePSR04a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR04a/testKeepExistingUseTypeOrder_SinglePSR04a.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use NS1\NS1Class;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR04a/testKeepExistingUseTypeOrder_SinglePSR04a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR04a/testKeepExistingUseTypeOrder_SinglePSR04a.php.fixUses
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS2\NS2_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR04b/testKeepExistingUseTypeOrder_SinglePSR04b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR04b/testKeepExistingUseTypeOrder_SinglePSR04b.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use NS1\NS1Class;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR04b/testKeepExistingUseTypeOrder_SinglePSR04b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR04b/testKeepExistingUseTypeOrder_SinglePSR04b.php.fixUses
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS1\NS1Class;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS2\NS2_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR05a/testKeepExistingUseTypeOrder_SinglePSR05a.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR05a/testKeepExistingUseTypeOrder_SinglePSR05a.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR05a/testKeepExistingUseTypeOrder_SinglePSR05a.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR05a/testKeepExistingUseTypeOrder_SinglePSR05a.php.fixUses
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS2\NS2_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR05b/testKeepExistingUseTypeOrder_SinglePSR05b.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR05b/testKeepExistingUseTypeOrder_SinglePSR05b.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR05b/testKeepExistingUseTypeOrder_SinglePSR05b.php.fixUses
+++ b/php/php.editor/test/unit/data/testfiles/actions/testKeepExistingUseTypeOrder/SinglePSR05b/testKeepExistingUseTypeOrder_SinglePSR05b.php.fixUses
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\Test;
+
+use NS2\NS2Class;
+use function NS1\ns1Function;
+use function NS2\ns2Function;
+use const NS2\NS2_CONSTANT;
+
+ns1Function();
+ns2Function();
+$const1 = NS1_CONSTANT;
+$const2 = NS2_CONSTANT;
+
+class Test implements NS1Interface, NS2Interface {
+    public const CONSTANT1 = NS1Enum::Case1;
+    public const CONSTANT2 = NS2Enum::Case1;
+    use NS1Trait;
+    use NS2Trait;
+    public function method(): void {
+        $ns1 = new NS1Class();
+        $ns2 = new NS2Class();
+    }
+}
+
+namespace NS1;
+
+function ns1Function() {}
+
+const NS1_CONSTANT = "NS1_CONSTANT";
+
+class NS1Class {}
+interface NS1Interface {}
+trait NS1Trait {}
+enum NS1Enum {
+    case CASE1;
+}
+
+namespace NS2;
+
+function ns2Function() {}
+
+const NS2_CONSTANT = "NS2_CONSTANT";
+
+class NS2Class {}
+interface NS2Interface {}
+trait NS2Trait {}
+enum NS2Enum {
+    case CASE1;
+}
+

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/FixUsesPerformerTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/FixUsesPerformerTest.java
@@ -1134,6 +1134,800 @@ public class FixUsesPerformerTest extends PHPTestBase {
         performTest("    class ^Test {", selections, true, options);
     }
 
+    public void testKeepExistingUseTypeOrder_Single01a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Single01b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Single02a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Single02b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Single03a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Single03b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Single04a() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Single04b() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Single05a() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Single05b() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_SinglePSR01a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_SinglePSR01b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_SinglePSR02a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_SinglePSR02b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_SinglePSR03a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_SinglePSR03b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_SinglePSR04a() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_SinglePSR04b() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_SinglePSR05a() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_SinglePSR05b() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Group01a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function2", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Group01b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function2", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Group02a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Group02b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Group03a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Group03b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Group04a() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Group04b() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Group05a() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Group05b() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_GroupPSR01a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function2", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_GroupPSR01b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function2", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_GroupPSR02a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_GroupPSR02b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_GroupPSR03a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_GroupPSR03b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_GroupPSR04a() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_GroupPSR04b() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_GroupPSR05a() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_GroupPSR05b() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferGroupUses(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Multiple01a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function2", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Multiple01b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function2", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Multiple02a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Multiple02b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Multiple03a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Multiple03b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Multiple04a() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Multiple04b() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Multiple05a() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_Multiple05b() throws Exception {
+        // default order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_MultiplePSR01a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function2", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_MultiplePSR01b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS1\\NS1Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS1\\NS1Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS1\\NS1Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS1\\NS1Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        selections.add(new Selection("\\NS2\\NS2Enum", ItemVariant.Type.ENUM));
+        selections.add(new Selection("\\NS2\\NS2Interface", ItemVariant.Type.INTERFACE));
+        selections.add(new Selection("\\NS2\\NS2Trait", ItemVariant.Type.TRAIT));
+        selections.add(new Selection("\\NS1\\ns1Function", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS2\\ns2Function2", ItemVariant.Type.FUNCTION));
+        selections.add(new Selection("\\NS1\\NS1_CONSTANT", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT1", ItemVariant.Type.CONST));
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("NS1\\ns1Functi^on();", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_MultiplePSR02a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_MultiplePSR02b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2_CONSTANT2", ItemVariant.Type.CONST));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_MultiplePSR03a() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_MultiplePSR03b() throws Exception {
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("NS2\\ns2Function1", ItemVariant.Type.FUNCTION));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_MultiplePSR04a() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_MultiplePSR04b() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_MultiplePSR05a() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(true)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
+    public void testKeepExistingUseTypeOrder_MultiplePSR05b() throws Exception {
+        // PSR-12 order is used
+        List<Selection> selections = new ArrayList<>();
+        selections.add(new Selection("\\NS2\\NS2Class", ItemVariant.Type.CLASS));
+        Options options = new Options.Builder(PhpVersion.PHP_81)
+                .preferMultipleUseStatementsCombined(true)
+                .putInPSR12Order(true)
+                .keepExistingUseTypeOrder(false)
+                .build();
+        performTest("$const1 = NS1_CONST^ANT;", selections, true, options);
+    }
+
     private String getTestResult(final String fileName, final String caretLine, final List<Selection> selections, final boolean removeUnusedUses, final Options options) throws Exception {
         FileObject testFile = getTestFile(fileName);
 


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6274
- Add the option (Keep existing order of use types(types, functions, constants) if possible)
- Add unit tests

![nb-php-gh-6274-options](https://github.com/apache/netbeans/assets/738383/2e3c0485-4eff-4297-974d-506d22b0b76b)

e.g. Add `use Vendor\Package\Type2;` to the following code
```php
<?php

use Vendor\Package\Type;
use function Vendor\Package\fnc;
use const Vendor\Package\CONSTANT;

```

Before:
```php
<?php

use Vendor\Package\Type;
use Vendor\Package\Type2;
use const Vendor\Package\CONSTANT;
use function Vendor\Package\fnc;

```

After:
```php
<?php

use Vendor\Package\Type;
use Vendor\Package\Type2;
use function Vendor\Package\fnc;
use const Vendor\Package\CONSTANT;

```


### NOTE:
If existing "uses" don't have a type kind for adding, the default order is used.

e.g. in the following case, the default order is used when `use const Vendor\Package\CONSTANT;` is added
```php

use Vendor\Package\Type;

```

```php

use Vendor\Package\Type;
use const Vendor\Package\CONSTANT;

```