### PR TITLE
Configure latest released wrapper in new Gradle project

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,21 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="gradle-wrapper-version">
+            <api name="general"/>
+            <summary>Method to set the Gradle version when initalizing the wrapper</summary>
+            <version major="2" minor="34"/>
+            <date day="14" month="8" year="2023"/>
+            <author login="neilcsmith"/>
+            <compatibility semantic="compatible" addition="yes"/>
+            <description>
+                <p>
+                Added additional <a href="@TOP@/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.html#addWrapperInit-java.io.File-java.lang.String-">addWrapperInit</a>
+                method allowing to request a specific version or version label when initializing the Gradle wrapper.
+                </p>
+            </description>
+            <class package="org.netbeans.modules.gradle.spi.newproject" name="TemplateOperation"/>
+        </change>
         <change id="java-runtime-manager">
             <api name="general"/>
             <summary>Adding JavaRuntimeManager abstracting the Gradle Runtime from Java Platform</summary>

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleJavaCompatProblemsProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleJavaCompatProblemsProvider.java
@@ -77,7 +77,7 @@ public final class GradleJavaCompatProblemsProvider implements ProjectProblemsPr
         "# {1} - Supported Java Version",
         "# {2} - Required Gradle Version",
         "# {3} - Forced Gradle Version",
-        "TXT_JavaVersionMismatch=<html>The Java version: {0}, that is seletced for the project "
+        "TXT_JavaVersionMismatch=<html>The Java version: {0}, that is selected for the project "
                 + "is not supported by Gradle {2}."
                 + "The IDE will attempt to use Gradle {3} to gather the project information.<p>"
                 + "Possible solutions:"

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
@@ -149,8 +149,29 @@ public final class TemplateOperation implements Runnable {
         steps.add(new ConfigureProjectStep(projectDir, configurator));
     }
 
+    /**
+     * Initialize the Gradle wrapper in the target project. Equivalent to
+     * executing <code>gradle wrapper</code>.
+     *
+     * @param target project directory
+     */
     public void addWrapperInit(File target) {
-        steps.add(new InitGradleWrapper(target));
+        steps.add(new InitGradleWrapper(target, null));
+    }
+
+    /**
+     * Initialize the Gradle wrapper in the target project with the requested
+     * version of Gradle. Equivalent to executing
+     * <code>gradle wrapper --gradle-version $version</code>. The version may be
+     * the specific Gradle version required, or one of the labels supported by
+     * the wrapper task, eg. <code>latest</code>.
+     *
+     * @param target project directory
+     * @param version Gradle version or version label
+     * @since 2.34
+     */
+    public void addWrapperInit(File target, String version) {
+        steps.add(new InitGradleWrapper(target, version));
     }
 
     /** *  Begin creation of new project using Gradle's 
@@ -443,9 +464,11 @@ public final class TemplateOperation implements Runnable {
     private static final class InitGradleWrapper extends BaseOperationStep {
 
         final File projectDir;
+        final String version;
 
-        public InitGradleWrapper(File projectDir) {
+        public InitGradleWrapper(File projectDir, String version) {
             this.projectDir = projectDir;
+            this.version = version;
         }
 
         @Override
@@ -458,7 +481,13 @@ public final class TemplateOperation implements Runnable {
         public Set<FileObject> execute() {
             GradleConnector gconn = GradleConnector.newConnector();
             try (ProjectConnection pconn = gconn.forProjectDirectory(projectDir).connect()) {
-                pconn.newBuild().withArguments("--offline").forTasks("wrapper").run(); //NOI18N
+                List<String> args = new ArrayList<>();
+                args.add("wrapper"); //NOI18N
+                if (version != null) {
+                    args.add("--gradle-version"); //NOI18N
+                    args.add(version);
+                }
+                pconn.newBuild().withArguments("--offline").forTasks(args.toArray(new String[0])).run(); //NOI18N
             } catch (GradleConnectionException | IllegalStateException ex) {
                 // Well for some reason we were  not able to load Gradle.
                 // Ignoring that for now

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/SimpleApplicationProjectWizard.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/SimpleApplicationProjectWizard.java
@@ -71,7 +71,10 @@ public class SimpleApplicationProjectWizard extends BaseGradleWizardIterator {
 
         Boolean initWrapper = (Boolean) params.get(PROP_INIT_WRAPPER);
         if (initWrapper == null || initWrapper) {
-            ops.addWrapperInit(root);
+            // @TODO allow configuration of wrapper version
+            ops.addWrapperInit(root, "latest"); // NOI18N
+        } else {
+            // @TODO delete wrapper added by init?
         }
     }
 


### PR DESCRIPTION
So that we don't get a release candidate wrapper when running the new Gradle project wizard, configure it to use version `latest`.

This highlights an issue that the wrapper is actually created by the init task.  The wrapper checkbox currently has no effect except for running the wrapper task again.

Second commit fixes a typo in the project problems dialog.

Not sure if this is a better fallback solution for NB19 or not?