### PR TITLE
LSP: cleanup of CodeActionsProvider.getCommands()

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBCommandProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBCommandProvider.java
@@ -18,9 +18,7 @@
  */
 package org.netbeans.modules.java.lsp.server.db;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -29,7 +27,6 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.netbeans.api.db.explorer.ConnectionManager;
 import org.netbeans.api.db.explorer.DatabaseConnection;
-import org.netbeans.modules.java.lsp.server.explorer.TreeItem;
 import org.netbeans.modules.java.lsp.server.explorer.TreeNodeRegistry;
 import org.netbeans.modules.java.lsp.server.protocol.CodeActionsProvider;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
@@ -45,10 +42,6 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CodeActionsProvider.class)
 public class DBCommandProvider extends CodeActionsProvider {
     private static final String  COMMAND_GET_PREFERRED_CONNECTION = "java.db.preferred.connection";
-    
-    private static final Set<String> COMMANDS = new HashSet<>(Arrays.asList(
-        COMMAND_GET_PREFERRED_CONNECTION
-    ));
     
     @Override
     public List<CodeAction> getCodeActions(ResultIterator resultIterator, CodeActionParams params) throws Exception {
@@ -76,6 +69,6 @@ public class DBCommandProvider extends CodeActionsProvider {
 
     @Override
     public Set<String> getCommands() {
-        return COMMANDS;
+        return Collections.singleton(COMMAND_GET_PREFERRED_CONNECTION);
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBConnectionProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBConnectionProvider.java
@@ -18,10 +18,8 @@
  */
 package org.netbeans.modules.java.lsp.server.db;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,11 +40,6 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CodeActionsProvider.class)
 public class DBConnectionProvider extends CodeActionsProvider{
     private static final String  GET_DB_CONNECTION = "java.db.connection"; //NOI18N
-    
-    private static final Set<String> COMMANDS = new HashSet<>(Arrays.asList(
-        GET_DB_CONNECTION
-    ));
-    
 
     @Override
     public List<CodeAction> getCodeActions(ResultIterator resultIterator, CodeActionParams params) throws Exception {
@@ -74,6 +67,6 @@ public class DBConnectionProvider extends CodeActionsProvider{
     
     @Override
     public Set<String> getCommands() {
-        return COMMANDS;
+        return Collections.singleton(GET_DB_CONNECTION);
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TestClassGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TestClassGenerator.java
@@ -77,8 +77,6 @@ public final class TestClassGenerator extends CodeActionsProvider {
 
     private static final String GENERATE_TEST_CLASS_COMMAND = "java.generate.testClass";
 
-    private final Set<String> commands = Collections.singleton(GENERATE_TEST_CLASS_COMMAND);
-
     @Override
     @NbBundle.Messages({
         "# {0} - the testing framework to be used, e.g. JUnit, TestNG,...",
@@ -133,7 +131,7 @@ public final class TestClassGenerator extends CodeActionsProvider {
 
     @Override
     public Set<String> getCommands() {
-        return commands;
+        return Collections.singleton(GENERATE_TEST_CLASS_COMMAND);
     }
 
     @Override

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ChangeMethodParametersRefactoring.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ChangeMethodParametersRefactoring.java
@@ -25,7 +25,6 @@ import com.sun.source.util.Trees;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.EnumSet;
@@ -80,7 +79,6 @@ public final class ChangeMethodParametersRefactoring extends CodeRefactoring {
     private static final String CHANGE_METHOD_PARAMS_REFACTORING_KIND = "refactor.change.method.params";
     private static final String CHANGE_METHOD_PARAMS_REFACTORING_COMMAND =  "java.refactor.change.method.params";
 
-    private final Set<String> commands = Collections.singleton(CHANGE_METHOD_PARAMS_REFACTORING_COMMAND);
     private final Gson gson = new Gson();
 
     @Override
@@ -132,7 +130,7 @@ public final class ChangeMethodParametersRefactoring extends CodeRefactoring {
 
     @Override
     public Set<String> getCommands() {
-        return commands;
+        return Collections.singleton(CHANGE_METHOD_PARAMS_REFACTORING_COMMAND);
     }
 
     @Override

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/MoveRefactoring.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/MoveRefactoring.java
@@ -102,7 +102,6 @@ public final class MoveRefactoring extends CodeRefactoring {
     private static final String MOVE_REFACTORING_COMMAND =  "java.refactor.move";
     private static final ClassPath EMPTY_PATH = ClassPathSupport.createClassPath(new URL[0]);
 
-    private final Set<String> commands = Collections.singleton(MOVE_REFACTORING_COMMAND);
     private final Gson gson = new Gson();
 
     @Override
@@ -136,7 +135,7 @@ public final class MoveRefactoring extends CodeRefactoring {
 
     @Override
     public Set<String> getCommands() {
-        return commands;
+        return Collections.singleton(MOVE_REFACTORING_COMMAND);
     }
 
     @Override

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/PullUpRefactoring.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/PullUpRefactoring.java
@@ -78,7 +78,6 @@ public final class PullUpRefactoring extends CodeRefactoring {
     private static final String PULL_UP_REFACTORING_KIND = "refactor.pull.up";
     private static final String PULL_UP_REFACTORING_COMMAND =  "java.refactor.pull.up";
 
-    private final Set<String> commands = Collections.singleton(PULL_UP_REFACTORING_COMMAND);
     private final Gson gson = new Gson();
 
     @Override
@@ -131,7 +130,7 @@ public final class PullUpRefactoring extends CodeRefactoring {
 
     @Override
     public Set<String> getCommands() {
-        return commands;
+        return Collections.singleton(PULL_UP_REFACTORING_COMMAND);
     }
 
     @Override

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/PushDownRefactoring.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/PushDownRefactoring.java
@@ -74,7 +74,6 @@ public final class PushDownRefactoring extends CodeRefactoring {
     private static final String PUSH_DOWN_REFACTORING_KIND = "refactor.push.down";
     private static final String PUSH_DOWN_REFACTORING_COMMAND =  "java.refactor.push.down";
 
-    private final Set<String> commands = Collections.singleton(PUSH_DOWN_REFACTORING_COMMAND);
     private final Gson gson = new Gson();
 
     @Override
@@ -142,7 +141,7 @@ public final class PushDownRefactoring extends CodeRefactoring {
 
     @Override
     public Set<String> getCommands() {
-        return commands;
+        return Collections.singleton(PUSH_DOWN_REFACTORING_COMMAND);
     }
 
     @Override


### PR DESCRIPTION
cleanup of implenetation of CodeActionsProvider.getCommands() method. Use `Collections.singleton()` for single command poviders.