### PR TITLE
Remove little black line from new-project wizard.

### DIFF
--- a/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
+++ b/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
@@ -3180,6 +3180,7 @@ public class WizardDescriptor extends DialogDescriptor {
         public FixedHeightPane () {
             super ();
             setEditable(false);
+            setFocusable(false);
             putClientProperty( JEditorPane.HONOR_DISPLAY_PROPERTIES, Boolean.TRUE);
             HTMLEditorKit htmlkit = new HTMLEditorKit();
             // override the Swing default CSS to make the HTMLEditorKit use the


### PR DESCRIPTION
It turned out that the little black line was the caret of a focused, 0-width JTextPane. It was mostly only visible during "loading" panels when no other component requested focus.

-> make the `messagepane` not focusable by default

The existing logic is enabling focus automatically if the text String is not empty.
https://github.com/apache/netbeans/blob/eaf1858c81b180c04a795dca0e8abf6b8080082c/platform/openide.dialogs/src/org/openide/WizardDescriptor.java#L2825

![evilcaret](https://github.com/apache/netbeans/assets/114367/52304cff-1cd3-4325-8a6a-f8bcf27dc24c)
