### PR TITLE
For Gradle debug, the IDE should listen, and the debugee should connect to it, not the other way around, for safety reasons.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
@@ -43,37 +43,49 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
 
     private static final String RUN_SINGLE_TASK = "runSingle";
     private static final String RUN_SINGLE_MAIN = "runClassName";
-    private static final String RUN_SINGLE_ARGS = "runArgs";
-    private static final String RUN_SINGLE_JVM_ARGS = "runJvmArgs";
-    private static final String RUN_SINGLE_CWD = "runWorkingDir";
+    private static final String RUN_ARGS = "runArgs";
+    private static final String RUN_JVM_ARGS = "runJvmArgs";
+    private static final String RUN_JVM_DEBUG_ARGS = "runJvmDebugArgs";
+    private static final String RUN_CWD = "runWorkingDir";
 
     @Override
     public void apply(Project project) {
         project.afterEvaluate(p -> {
-            if (project.getPlugins().hasPlugin("java") 
-                    && (project.getTasks().findByPath(RUN_SINGLE_TASK) == null)
-                    && project.hasProperty(RUN_SINGLE_MAIN)) {
-                Set<Task> runTasks = p.getTasksByName("run", false);
-                Task r = runTasks.isEmpty() ? null : runTasks.iterator().next();
-                String mainClass = project.property(RUN_SINGLE_MAIN).toString();
+            if (project.getPlugins().hasPlugin("java")) {
+                String mainClass = project.hasProperty(RUN_SINGLE_MAIN) ? project.property(RUN_SINGLE_MAIN).toString()
+                                                                        : null;
                 p.getTasks().withType(JavaExec.class).configureEach(je -> {
-                    if (GRADLE_VERSION.compareTo(GradleVersion.version("6.4")) < 0) {
-                        // Using setMain to keep the backward compatibility before Gradle 6.4
-                        je.setMain(mainClass);
-                    } else {
-                        je.getMainClass().set(mainClass);
+                    if (mainClass != null) {
+                        if (GRADLE_VERSION.compareTo(GradleVersion.version("6.4")) < 0) {
+                            // Using setMain to keep the backward compatibility before Gradle 6.4
+                            je.setMain(mainClass);
+                        } else {
+                            je.getMainClass().set(mainClass);
+                        }
                     }
-                    if (project.hasProperty(RUN_SINGLE_ARGS)) {
-                        je.setArgs(asList(project.property(RUN_SINGLE_ARGS).toString().split(" ")));
+                    if (project.hasProperty(RUN_ARGS)) {
+                        je.setArgs(asList(project.property(RUN_ARGS).toString().split(" ")));
                     }
-                    if (p.hasProperty(RUN_SINGLE_JVM_ARGS)) {
+                    if (p.hasProperty(RUN_JVM_ARGS) || p.hasProperty(RUN_JVM_DEBUG_ARGS)) {
                         // Property jvmArgumentProviders should not be implemented as a lambda to allow execution optimizations.
                         // See https://docs.gradle.org/current/userguide/validation_problems.html#implementation_unknown
                         je.getJvmArgumentProviders().add(new CommandLineArgumentProvider() {
                             // Do not convert to lambda.
                             @Override
                             public Iterable<String> asArguments() {
-                                return asList(p.property(RUN_SINGLE_JVM_ARGS).toString().split(" "));
+                                String args = null;
+                                if (p.hasProperty(RUN_JVM_ARGS)) {
+                                    args = p.property(RUN_JVM_ARGS).toString();
+                                }
+                                if (p.hasProperty(RUN_JVM_DEBUG_ARGS)) {
+                                    String debugArgs = p.property(RUN_JVM_DEBUG_ARGS).toString();
+                                    if (args == null) {
+                                        args = debugArgs;
+                                    } else {
+                                        args = args + " " + debugArgs;
+                                    }
+                                }
+                                return asList(args.split(" "));
                             }
                         });
                     }
@@ -86,11 +98,16 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
                             LOG.info("Failed to set STDIN for Plugin: " + je.toString());
                         }
                     }
-                    if (project.hasProperty(RUN_SINGLE_CWD)) {
-                        je.setWorkingDir(project.property(RUN_SINGLE_CWD).toString());
+                    if (project.hasProperty(RUN_CWD)) {
+                        je.setWorkingDir(project.property(RUN_CWD).toString());
                     }
                 });
-                addTask(project, r);
+                if (mainClass != null
+                    && (project.getTasks().findByPath(RUN_SINGLE_TASK) == null)) {
+                    Set<Task> runTasks = p.getTasksByName("run", false);
+                    Task r = runTasks.isEmpty() ? null : runTasks.iterator().next();
+                    addTask(project, r);
+                }
             }
         });
     }

--- a/java/gradle.java/nbproject/project.properties
+++ b/java/gradle.java/nbproject/project.properties
@@ -27,3 +27,4 @@ test-unit-sys-prop.java.awt.headless=true
 test.use.jdk.javac=true
 spec.version.base=1.24.0
 
+requires.nb.javac=true

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/Utils.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/Utils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.java.platform.JavaPlatform;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.java.api.ProjectSourcesClassPathProvider;
+import org.netbeans.modules.gradle.java.execute.JavaRunUtils;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation2;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Lookup;
+
+public class Utils {
+
+    public static ClassPath getJdkSources(Project project) {
+        JavaPlatform jdk = JavaRunUtils.getActivePlatform(project).second();
+        if (jdk != null) {
+            return jdk.getSourceFolders();
+        }
+        return null;
+    }
+
+    public static ClassPath getSources(Project project) {
+        ProjectSourcesClassPathProvider pgcpp = project.getLookup().lookup(ProjectSourcesClassPathProvider.class);
+        List<SourceForBinaryQueryImplementation2> sourceQueryImpls = new ArrayList<>(2);
+        sourceQueryImpls.addAll(project.getLookup().lookupAll(SourceForBinaryQueryImplementation2.class));
+        sourceQueryImpls.addAll(Lookup.getDefault().lookupAll(SourceForBinaryQueryImplementation2.class));
+
+        Set<FileObject> srcs = new LinkedHashSet<>();
+        for (ClassPath projectSourcePath : pgcpp.getProjectClassPath(ClassPath.SOURCE)) {
+            srcs.addAll(Arrays.asList(projectSourcePath.getRoots()));
+        }
+
+        for (ClassPath cp : pgcpp.getProjectClassPath(ClassPath.EXECUTE)) {
+            for (ClassPath.Entry entry : cp.entries()) {
+                URL url = entry.getURL();
+                SourceForBinaryQueryImplementation2.Result ret;
+                for (SourceForBinaryQueryImplementation2 sourceQuery : sourceQueryImpls) {
+                    ret = sourceQuery.findSourceRoots2(url);
+                    if (ret != null) {
+                        List<FileObject> roots = Arrays.asList(ret.getRoots());
+                        if (!roots.isEmpty()) {
+                            srcs.addAll(roots);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        FileObject[] roots = srcs.toArray(new FileObject[srcs.size()]);
+        return ClassPathSupport.createClassPath(roots);
+    }
+
+}

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
@@ -29,10 +29,10 @@
             <args>"${cleanTestTaskName}" "${testTaskName}" --tests "${selectedMethod}"</args>
         </action>
         <action name="debug.single.method">
-            <args>"${cleanTestTaskName}" "${testTaskName}" --debug-jvm --tests "${selectedMethod}"</args>
+            <args>"${cleanTestTaskName}" "${testTaskName}" -PrunJvmDebugArgs=-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=${javaExec.debug.port} --tests "${selectedMethod}"</args>
         </action>
         <action name="debug.test.single">
-            <args>"${cleanTestTaskName}" "${testTaskName}" --debug-jvm --tests "${selectedClass}"</args>
+            <args>"${cleanTestTaskName}" "${testTaskName}" -PrunJvmDebugArgs=-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=${javaExec.debug.port} --tests "${selectedClass}"</args>
         </action>
 
         <action name="javadoc">
@@ -54,7 +54,7 @@
         </action>
 
         <action name="debug.single">
-            <args>-PrunClassName=${selectedClass} ${javaExec.workingDir} ${javaExec.environment} run --stacktrace --debug-jvm  ${javaExec.jvmArgs} ${javaExec.args}</args>
+            <args>-PrunClassName=${selectedClass} ${javaExec.workingDir} ${javaExec.environment} run --stacktrace -PrunJvmDebugArgs=-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=${javaExec.debug.port} ${javaExec.jvmArgs} ${javaExec.args}</args>
         </action>
     </apply-for>
 
@@ -64,7 +64,7 @@
         </action>
 
         <action name="debug">
-            <args>${javaExec.workingDir} ${javaExec.environment} run --debug-jvm  ${javaExec.jvmArgs} ${javaExec.args}</args>
+            <args>${javaExec.workingDir} ${javaExec.environment} run -PrunJvmDebugArgs=-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=${javaExec.debug.port} ${javaExec.jvmArgs} ${javaExec.args}</args>
         </action>
     </apply-for>
 

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/JPDAStart.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/JPDAStart.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.execute;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.sun.jdi.Bootstrap;
+import com.sun.jdi.connect.ListeningConnector;
+import com.sun.jdi.connect.Transport;
+import com.sun.jdi.connect.Connector;
+import java.io.PrintWriter;
+import java.util.Iterator;
+
+import org.netbeans.api.debugger.jpda.DebuggerStartException;
+
+import org.openide.util.RequestProcessor;
+import org.openide.filesystems.FileUtil;
+
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.debugger.jpda.JPDADebugger;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectUtils;
+import org.netbeans.modules.gradle.java.Utils;
+
+/**
+ * Start the JPDA debugger.
+ *
+ * @author Arunava Sinha
+ */
+public class JPDAStart implements Runnable {
+
+    private static final RequestProcessor RP = new RequestProcessor(JPDAStart.class);
+    private static final String TRANSPORT = "dt_socket"; //NOI18N
+
+    private final Object[] lock = new Object[2];
+    private final PrintWriter out;
+    private final Project project;
+
+    JPDAStart(PrintWriter out, Project project) {
+        this.out = out;
+        this.project = project;
+    }
+
+    /**
+     * returns the port that the debugger listens to..
+     */
+    public String execute() throws Exception {
+        synchronized (lock) {
+            RP.post(this);
+            lock.wait();
+            if (lock[1] != null) {
+                throw ((Exception) lock[1]); //NOI18N
+            }
+        }
+        return (String) lock[0];
+    }
+
+    @Override
+    public void run() {
+        synchronized (lock) {
+
+            try {
+
+                ListeningConnector lc = null;
+                Iterator i = Bootstrap.virtualMachineManager().
+                        listeningConnectors().iterator();
+                for (; i.hasNext();) {
+                    lc = (ListeningConnector) i.next();
+                    Transport t = lc.transport();
+                    if (t != null && t.name().equals(getTransport())) {
+                        break;
+                    }
+                }
+                if (lc == null) {
+                    throw new RuntimeException("No trasports named " + getTransport() + " found!"); //NOI18N
+                }
+
+                final Map args = lc.defaultArguments();
+                String address = lc.startListening(args);
+                try {
+                    int port = Integer.parseInt(address.substring(address.indexOf(':') + 1));
+                    Connector.IntegerArgument portArg = (Connector.IntegerArgument) args.get("port"); //NOI18N
+                    portArg.setValue(port);
+                    lock[0] = Integer.toString(port);
+                } catch (NumberFormatException e) {
+                    lock[0] = address;
+                }
+
+                final Map properties = new HashMap();
+
+                ClassPath sourcePath = Utils.getSources(project);
+                ClassPath jdkSourcePath = Utils.getJdkSources(project);
+
+                properties.put("sourcepath", sourcePath); //NOI18N
+                properties.put("jdksources", jdkSourcePath); //NOI18N
+                File baseDir = FileUtil.toFile(project.getProjectDirectory()); 
+                properties.put("baseDir", baseDir); //NOI18N
+                properties.put("name", ProjectUtils.getInformation(project).getDisplayName()); //NOI18N
+
+                final ListeningConnector flc = lc;
+                RP.post(() -> {
+                    try {
+                        JPDADebugger.startListening(flc, args,
+                                new Object[]{properties});
+                    } catch (DebuggerStartException ex) {
+                        out.println("Debugger Start Error."); //NOI18N
+                    }
+                });
+            } catch (java.io.IOException ioex) {
+                out.println("IO Error:"); //NOI18N
+//                org.openide.ErrorManager.getDefault().notify(ioex);
+                lock[1] = ioex;
+            } catch (com.sun.jdi.connect.IllegalConnectorArgumentsException icaex) {
+                out.println("Illegal Connector"); //NOI18N
+                lock[1] = icaex;
+            } finally {
+                lock.notify();
+            }
+        }
+    }
+
+    public String getTransport() {
+        return TRANSPORT;
+    }
+}

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/JavaDebugTokenProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/JavaDebugTokenProvider.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.execute;
+
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.spi.actions.BeforeBuildActionHook;
+import org.netbeans.modules.gradle.spi.actions.ReplaceTokenProvider;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ProxyLookup;
+
+/**
+ *
+ * @author sdedic
+ */
+@ProjectServiceProvider(
+        service = ReplaceTokenProvider.class,
+        projectType = NbGradleProject.GRADLE_PROJECT_TYPE
+)
+public class JavaDebugTokenProvider implements ReplaceTokenProvider {
+    /**
+     * Replaceable token for debugging port.
+     */
+    public static String TOKEN_JAVAEXEC_DEBUG_PORT = "javaExec.debug.port"; // NOI18N
+
+    private static final Set<String> TOKENS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            TOKEN_JAVAEXEC_DEBUG_PORT
+    )));
+
+    private static final Set<String> DEBUG_ACTIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            ActionProvider.COMMAND_DEBUG,
+            ActionProvider.COMMAND_DEBUG_SINGLE,
+            ActionProvider.COMMAND_DEBUG_TEST_SINGLE
+    )));
+
+    private final Project project;
+
+    public JavaDebugTokenProvider(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public Set<String> getSupportedTokens() {
+        return isEnabled() ? TOKENS : Collections.emptySet();
+    }
+
+    private boolean isEnabled() {
+        Set<String> plugins = GradleBaseProject.get(project).getPlugins();
+        return plugins.contains("java"); // NOI18N
+    }
+
+    @Override
+    public Map<String, String> createReplacements(String action, Lookup context) {
+        if (!isEnabled() || !DEBUG_ACTIONS.contains(action)) {
+            return Collections.emptyMap();
+        }
+
+        OutputHolder output = context.lookup(OutputHolder.class);
+
+        if (output == null) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> result = new HashMap<>();
+
+        try {
+            result.put(TOKEN_JAVAEXEC_DEBUG_PORT, "" + new JPDAStart(output.out, project).execute());
+        } catch (Exception ex) {
+            Exceptions.printStackTrace(ex);
+        }
+
+        return result;
+    }
+
+    private static final class OutputHolder {
+        private final PrintWriter out;
+
+        public OutputHolder(PrintWriter out) {
+            this.out = out;
+        }
+
+    }
+
+    public static final class DebugTokenHook implements BeforeBuildActionHook {
+
+        @Override
+        public Lookup beforeAction(String action, Lookup context, PrintWriter out) {
+            if (!DEBUG_ACTIONS.contains(action))
+                return context;
+            return new ProxyLookup(context, Lookups.fixed(new OutputHolder(out)));
+        }
+
+    }
+}

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/LookupProviders.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/LookupProviders.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.gradle.java.execute;
 
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.java.execute.JavaDebugTokenProvider.DebugTokenHook;
 import org.netbeans.spi.project.LookupProvider;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.Lookups;
@@ -38,6 +39,7 @@ public class LookupProviders {
                 Project project = baseContext.lookup(Project.class);
                 return Lookups.fixed(
                         new DebugFixHooks(project),
+                        new DebugTokenHook(),
                         new ShowJavadocHook(project)
                 );
             }


### PR DESCRIPTION
Currently  Gradle debugging uses `--debug-jvm` Gradle option of the application plugin(?), which lets the debugee listen on port 5005. This has two problems: a) given the port is hardcoded, the may clash with some other VM already listening at the port; b) someone might accidentally connect to the instead of the IDE.

The typical way NB is doing debugging is that the IDE listens on a random port, and the debugee attaches to it. I tried to tweak Gradle here to do that as well. But, it feels a bit tricky, so I'd be happy to know if there's an input about this.

Thanks!



---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
