### PR TITLE
Update FlatLaf from 3.1 to 3.2

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-8F25A1EB4CCE2F4C08BBD3AD99FD2A43A8E69FBB com.formdev:flatlaf:3.1
+EDBAFE4090211B2742C877D4D1C64C720387E2D2 com.formdev:flatlaf:3.2

--- a/platform/libs.flatlaf/external/flatlaf-3.2-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-3.2-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 3.1
-Files: flatlaf-3.1.jar
+Version: 3.2
+Files: flatlaf-3.2.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/manifest.mf
+++ b/platform/libs.flatlaf/manifest.mf
@@ -4,4 +4,4 @@ OpenIDE-Module: org.netbeans.libs.flatlaf/1
 OpenIDE-Module-Install: org/netbeans/libs/flatlaf/Installer.class
 OpenIDE-Module-Specification-Version: 1.16
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Implementation-Version: 3.1
+OpenIDE-Module-Implementation-Version: 3.2

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -31,12 +31,14 @@ spec.version.base.fatal.warning=false
 #
 # So when FlatLaf is updated, the OpenIDE-Module-Implementation-Version entry
 # in manifest.mf needs to be updated to match the new FlatLaf version.
-release.external/flatlaf-3.1.jar=modules/ext/flatlaf-3.1.jar
+release.external/flatlaf-3.2.jar=modules/ext/flatlaf-3.2.jar
 
-release.external/flatlaf-3.1.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
-release.external/flatlaf-3.1.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
-release.external/flatlaf-3.1.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
+release.external/flatlaf-3.2.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
+release.external/flatlaf-3.2.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
+release.external/flatlaf-3.2.jar!/com/formdev/flatlaf/natives/flatlaf-windows-arm64.dll=modules/lib/flatlaf-windows-arm64.dll
+release.external/flatlaf-3.2.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
 jnlp.verify.excludes=\
     modules/lib/flatlaf-windows-x86.dll,\
     modules/lib/flatlaf-windows-x86_64.dll,\
+    modules/lib/flatlaf-windows-arm64.dll,\
     modules/lib/libflatlaf-linux-x86_64.so

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -48,8 +48,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-3.1.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-3.1.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-3.2.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-3.2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -45,6 +45,7 @@ TabbedPane.tabHeight=30
 TabbedPane.inactiveUnderlineColor = $TabbedContainer.editor.contentBorderColor
 TabbedPane.tabType=card
 TabbedPane.tabAreaInsets=4,0,0,0
+TabbedPane.cardTabArc = 0
 
 #---- Tree ----
 


### PR DESCRIPTION
This is a simple upgrade of the FlatLaf library from version 3.1 to 3.2, modeled after the previous version bump at https://github.com/apache/netbeans/pull/5818 .

Changes: https://github.com/JFormDesigner/FlatLaf/releases/tag/3.2

The new Windows ARM support DLL was added the list of native libraries automatically extracted from the JAR.

(I needed the update in my own NetBeans build, so offered @DevCharly to prepare the version bump PR this time.)