### PR TITLE
Fix code completion for fields with single line var doc #6359

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
@@ -89,6 +89,7 @@ import org.netbeans.modules.php.editor.parser.astnodes.PHPDocBlock;
 import org.netbeans.modules.php.editor.parser.astnodes.PHPDocTag;
 import org.netbeans.modules.php.editor.parser.astnodes.PHPDocTypeNode;
 import org.netbeans.modules.php.editor.parser.astnodes.PHPDocVarTypeTag;
+import org.netbeans.modules.php.editor.parser.astnodes.PHPVarComment;
 import org.netbeans.modules.php.editor.parser.astnodes.ParenthesisExpression;
 import org.netbeans.modules.php.editor.parser.astnodes.Program;
 import org.netbeans.modules.php.editor.parser.astnodes.Reference;
@@ -384,7 +385,18 @@ public final class VariousUtils {
                     break;
                 }
             }
+        } else if ((comment instanceof PHPVarComment) && PHPDocTag.Type.VAR == tagType) {
+            // GH-6359
+            // /** @var Type $field */
+            // private $field;
+            PHPVarComment varComment = (PHPVarComment) comment;
+            PHPDocVarTypeTag tag = varComment.getVariable();
+            String[] parts = WS_PATTERN.split(tag.getValue().trim(), 3); // 3: @var Type $field
+            if (parts.length > 1) {
+                return parts[1];
+            }
         }
+
         return null;
     }
 

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6359/gh6359.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6359/gh6359.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class X {
+    public function testX(): void {}
+}
+
+class Y {
+    public function testY(): void {}
+}
+
+class GH6359 {
+
+    /** @var X $testX */
+    protected $testX;
+    /** @var X|Y $testXorY */
+    protected $testXorY;
+    /** @var X&Y $testXandY */
+    protected $testXandY;
+
+    public function test(): void {
+        $this->testX->testX();
+        $this->testXorY->testX();
+        $this->testXandY->testX();
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6359/gh6359.php.testGH6359_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6359/gh6359.php.testGH6359_01.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+$this->testX->|testX();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     testX()                         [PUBLIC]   X

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6359/gh6359.php.testGH6359_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6359/gh6359.php.testGH6359_02.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+$this->testXorY->|testX();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     testX()                         [PUBLIC]   X
+METHOD     testY()                         [PUBLIC]   Y

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6359/gh6359.php.testGH6359_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6359/gh6359.php.testGH6359_03.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+$this->testXandY->|testX();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     testX()                         [PUBLIC]   X
+METHOD     testY()                         [PUBLIC]   Y

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH6359Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH6359Test.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class PHPCodeCompletionGH6359Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionGH6359Test(String testName) {
+        super(testName);
+    }
+
+    public void testGH6359_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6359/gh6359.php", "$this->testX->^testX();", false);
+    }
+
+    public void testGH6359_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6359/gh6359.php", "$this->testXorY->^testX();", false);
+    }
+
+    public void testGH6359_03() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6359/gh6359.php", "$this->testXandY->^testX();", false);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[] {
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/gh6359"))
+            })
+        );
+    }
+}


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6359
- `/** @var Type $field */` is recognized as not `PHPDocBlock` but `PHPVarComment`, so, check it
```php
// example
class X {
    public function testX(): void {}
}

class Y {
    public function testY(): void {}
}

class GH6359 {

    /** @var X $testX */
    protected $testX;
    /** @var X|Y $testXorY */
    protected $testXorY;
    /** @var X&Y $testXandY */
    protected $testXandY;

    public function test(): void {
        $this->testX->testX();
        $this->testXorY->testX();
        $this->testXandY->testX();
    }
}
```