### PR TITLE
Switch graalvm CI setup to the graalvm/setup-graalvm action.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,9 @@ env:
   # see https://github.com/actions/setup-java#supported-distributions
   default_java_distribution: 'zulu'
 
+  # graalvm, graalvm-community, or mandrel
+  # see https://github.com/graalvm/setup-graalvm#options
+  default_graalvm_distribution: 'graalvm-community'
 
 jobs:
 
@@ -2525,7 +2528,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        graal: [ '20.3.0', '21.1.0' ]
+        graal: [ '11', '17.0.8' ]
       fail-fast: false
 
     steps:
@@ -2542,18 +2545,24 @@ jobs:
       - name: Extract
         run: tar --zstd -xf build.tar.zst
 
-      - name: Setup GraalVM
-        run: |
-          URL=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${{ matrix.graal }}/graalvm-ce-java8-linux-amd64-${{ matrix.graal }}.tar.gz
-          curl -L $URL | tar -xz
-          GRAALVM=`pwd`/graalvm-ce-java8-${{ matrix.graal }}
-          echo "JAVA_HOME=$GRAALVM" >> $GITHUB_ENV
+      - name: Set up GraalVM ${{ matrix.graal }}
+        uses: graalvm/setup-graalvm@v1
+        if: ${{ matrix.graal != '11' }}
+        with:
+          # in contrast to the setup-java action, this needs full version strings
+          java-version: ${{ matrix.graal }}
+          distribution: ${{ env.default_graalvm_distribution }}
+          components: 'python, ruby, js'
 
-      - name: Setup GraalVM Languages
-        run: |
-          $JAVA_HOME/bin/gu install python
-          $JAVA_HOME/bin/gu install R
-          $JAVA_HOME/bin/gu install ruby
+      # for older graal versions, remove section and if-condition once min version is at 17+
+      - name: Set up GraalVM ${{ matrix.graal }}
+        uses: graalvm/setup-graalvm@v1
+        if: ${{ matrix.graal == '11' }}
+        with:
+          version: '22.3.3'
+          java-version: 11
+          distribution: ${{ env.default_graalvm_distribution }}
+          components: 'python, ruby, js'
 
       - name: platform/core.network
         run: ant $OPTS -f platform/core.network test


### PR DESCRIPTION
GraalVM has a new versioning scheme and the URLs changed too, lets use the opportunity to switch to the [`setup-graalvm`](https://github.com/graalvm/setup-graalvm#options) action.

This will also move the minimal version to JDK 11 since graalvm CE has only support for 17 and 20.  8 and 11 appear to be already EOL and no longer [downloadable](https://www.graalvm.org/downloads/), [test showed](https://github.com/apache/netbeans/actions/runs/5937825421/job/16101701964) that the action can also not download it. The drop of JDK 8 in the test job will also unblock PRs like #6178.

Distribution is set to the community edition.

The R component seems to be no longer available:
```
graalvm-community-openjdk-17.0.8+7.1]$ bin/gu available
Downloading: Component catalog from www.graalvm.org
ComponentId              Version             Component name                Stability                     Origin 
---------------------------------------------------------------------------------------------------------------------------------
espresso                 23.0.1              Java on Truffle               Supported                     github.com
espresso-llvm            23.0.1              Java on Truffle LLVM Java librSupported                     github.com
icu4j                    23.0.1              ICU4J                         Supported                     github.com
js                       23.0.1              Graal.js                      Supported                     github.com
llvm                     23.0.1              LLVM Runtime Core             Supported                     github.com
llvm-toolchain           23.0.1              LLVM.org toolchain            Supported                     github.com
native-image-llvm-backend23.0.1              Native Image LLVM Backend     Early adopter (experimental)  github.com
nodejs                   23.0.1              Graal.nodejs                  Supported                     github.com
python                   23.0.1              GraalVM Python                Experimental                  github.com
regex                    23.0.1              TRegex                        Supported                     github.com
ruby                     23.0.1              TruffleRuby                   Experimental                  github.com
visualvm                 23.0.1              VisualVM                      Supported                     github.com
wasm                     23.0.1              GraalWasm                     Experimental                  github.com

```


Lets check if the gh action is on the apache allow list (edit: it is).