### PR TITLE
LSP: Scan for projects on server init.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1987,7 +1987,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                 return file;
             }
             missingFileDiscovered(uri);
-        } catch (MalformedURLException ex) {
+        } catch (MalformedURLException | IllegalArgumentException ex) {
             if (!uri.startsWith("untitled:") && !uri.startsWith("jdt:")) {
                 LOG.log(Level.WARNING, "Invalid file URL: " + uri, ex);
             }


### PR DESCRIPTION
Workspace folder(s) should be scanned for projects the server initialization.
In case the workspace folder represents a project, it is immediately opened (together with its sub-projects), as it was done while searching for test methods.
In case the workspace folder does not represent a project, the folder is scanned to find all projects contained in its sub-folders.