### PR TITLE
Return the highest quality from all the loaders.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
@@ -67,6 +67,7 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
 
         Boolean trust = null;
 
+        GradleProject best = null;
         GradleProject ret = null;
         for (AbstractProjectLoader loader : loaders) {
             if (loader.isEnabled()) {
@@ -88,17 +89,19 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
                     ret = loader.load();
                     LOGGER.log(Level.FINER, "Loaded with loader {0} -> {1}", new Object[] { loader, ret });
                 }
-                if ((ret != null) && ret.getQuality().atLeast(aim)) {
-                    // We have the quality we are looking for, let's be happy with that
-                    break;
+                if (ret != null) {
+                    if (best == null || best.getQuality().notBetterThan(ret.getQuality())) {
+                        best = ret;
+                    }
+                    if (ret.getQuality().atLeast(aim)) {
+                        // We have the quality we are looking for, let's be happy with that
+                        break;
+                    }
                 }
             } else {
                 LOGGER.log(Level.FINER, "Loaded disabled: {0}", loader);
             }
         }
-        if (ret == null) {
-            throw new NullPointerException("Could not load Gradle Project: " + project);
-        }
-        return ret;
+        return best;
     }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
@@ -278,7 +278,7 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
                     for (String s : info.getProblems()) {
                         reps.add(GradleProject.createGradleReport(f == null ? null : f.toPath(), s));
                     }
-                    return ctx.previous.invalidate(info.getProblems().toArray(new GradleReport[0]));
+                    return ctx.previous.invalidate(reps.toArray(new GradleReport[0]));
                 }
             }
         } catch (GradleConnectionException | IllegalStateException ex) {

--- a/extide/gradle/test/unit/data/projects/priming/broken1/build.gradle
+++ b/extide/gradle/test/unit/data/projects/priming/broken1/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id("io.micronaut.application") version "3.5.1"
+    id('java')
+    id('application')
+}
+
+repositories {
+    mavenCentral()
+}
+
+mainClassName = 'test.App'
+
+dependencies {
+    implementation("io.micronaut:micronaut-http-clientx")
+}

--- a/extide/gradle/test/unit/data/projects/priming/broken1/gradle.properties
+++ b/extide/gradle/test/unit/data/projects/priming/broken1/gradle.properties
@@ -1,0 +1,2 @@
+micronautVersion=3.6.0
+

--- a/extide/gradle/test/unit/data/projects/priming/broken1/settings.gradle
+++ b/extide/gradle/test/unit/data/projects/priming/broken1/settings.gradle
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+rootProject.name="simple"
+

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImpl2Test.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImpl2Test.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle;
+
+import java.io.IOException;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.api.project.ui.ProjectProblems;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.projectapi.nb.NbProjectManagerAccessor;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Lookup;
+
+/**
+ *
+ * @author sdedic
+ */
+public class NbGradleProjectImpl2Test extends AbstractGradleProjectTestCase {
+    private FileObject projectDir;
+    private Project project;
+    
+    
+    public NbGradleProjectImpl2Test(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        OpenProjects.getDefault().close(OpenProjects.getDefault().getOpenProjects());
+        NbProjectManagerAccessor.reset();
+        super.tearDown();
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        clearWorkDir();
+    }
+    
+    private FileObject copyProject(String relPath) throws IOException {
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+        FileObject src = FileUtil.toFileObject(getDataDir()).getFileObject(relPath);
+        
+        projectDir = src.copy(wd, src.getName(), src.getExt());
+        project = ProjectManager.getDefault().findProject(projectDir);
+        return projectDir;
+    }
+
+    
+    /**
+     * Check that an unknown project indicates priming and errors.
+     * @throws Exception 
+     */
+    public void testFirstTimeProjectNotPrimed() throws Exception {
+        copyProject("projects/priming/broken1");
+        ProjectTrust.getDefault().trustProject(project);
+        ActionProvider ap = project.getLookup().lookup(ActionProvider.class);
+        assertNotNull(ap);
+        assertTrue(ProjectProblems.isBroken(project));
+        assertTrue(ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookup.EMPTY));
+        
+        NbGradleProject gp = NbGradleProject.get(project);
+        assertEquals(NbGradleProject.Quality.FALLBACK, gp.getQuality());
+   }
+    
+    /**
+     * Check that a broken project stops indicating priming, but is still not full quality and indicates problems.
+     */
+    public void testForceLoadBrokenProject() throws Exception {
+        copyProject("projects/priming/broken1");
+        ProjectTrust.getDefault().trustProject(project);
+        
+        ActionProvider ap = project.getLookup().lookup(ActionProvider.class);
+        assertTrue("Project should require priming", ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookup.EMPTY));
+        
+        NbGradleProject gp1 = NbGradleProject.get(project);
+        GradleBaseProject gbp1 = GradleBaseProject.get(project);
+        NbGradleProject.Quality q1 = gp1.getQuality();
+        assertEquals("Project fallback expeceted", NbGradleProject.Quality.FALLBACK, q1);
+        
+        NbGradleProject gp2 = gp1.toQuality("Priming", NbGradleProject.Quality.FULL_ONLINE, false).toCompletableFuture().get();
+        assertEquals("Project should be reloaded with errors", NbGradleProject.Quality.SIMPLE, gp2.getQuality());
+
+        GradleBaseProject gbp2 = GradleBaseProject.get(project);
+        assertSame("Project API is not the same", gp1, gp2);
+        assertNotSame("Project information was not replaced", gbp1, gbp2);
+        
+        assertNotNull(ap);
+        assertFalse("Project was already primed", ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookup.EMPTY));
+        
+        assertTrue("Project has still problems", ProjectProblems.isBroken(project));
+    }
+}

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
@@ -343,3 +343,5 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         assertTrue(prjImpl.getAimedQuality().notBetterThan(aimed));
     }
 }
+
+

--- a/extide/gradle/test/unit/src/org/netbeans/modules/projectapi/nb/NbProjectManagerAccessor.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/projectapi/nb/NbProjectManagerAccessor.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.projectapi.nb;
+
+import org.netbeans.spi.project.ProjectManagerImplementation;
+import org.openide.util.Lookup;
+import org.netbeans.modules.projectapi.nb.NbProjectManager;
+
+/**
+ *
+ * @author sdedic
+ */
+public class NbProjectManagerAccessor {
+    /**
+     * Resets cached projects, new project lookups should create new project objects.
+     */
+    public static void reset() {
+        ((NbProjectManager)Lookup.getDefault().lookup(ProjectManagerImplementation.class)).reset();
+    }
+}

--- a/ide/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesCustomizer.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesCustomizer.java
@@ -257,7 +257,7 @@ public class BrokenReferencesCustomizer extends javax.swing.JPanel {
                 description.setText(s);       
                 // avoid possible scroll down/left if the text does not fit in the default window
                 description.getCaret().setDot(0);
-                fix.setEnabled(reference.problem.isResolvable());
+                fix.setEnabled(reference.problem.isResolvable() && !reference.resolved);
                 javax.swing.SwingUtilities.invokeLater(new Runnable() {
                    public void run() {
                        jScrollPane2.getVerticalScrollBar().setValue(0);
@@ -268,7 +268,7 @@ public class BrokenReferencesCustomizer extends javax.swing.JPanel {
                 // Leave the button always enabled so that user can alter 
                 // resolved reference. Especially needed for automatically
                 // resolved JAR references.
-                fix.setEnabled(reference.problem.isResolvable());
+                fix.setEnabled(reference.problem.isResolvable() && !reference.resolved);
             }
         } else {
             description.setText("");


### PR DESCRIPTION
During investigation of #6368, I found out that if a **broken project** primes - and the loading fails, the `NbGradleProject` still reports `FALLBACK` as the quality - which leaves the prime action enabled, but also may confuse the API clients.

It's because `LegacyProjectLoader` loads project with `SIMPLE` quality (some dependencies are not satisfied), but it's then overwritten by `FallbackProjectLoader`. This PR returns the highest quality, but still stops as soon as the desired quality is achieved.