### PR TITLE
Fix P + BR tag handling, LI is replaced by "* "

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
@@ -414,21 +414,29 @@ public class Utils {
 
         int tagStart = -1;
         StringBuilder sb = new StringBuilder();
+        String additional = null;
         for (int i = 0; i < s.length(); i++) {
             char ch = s.charAt(i);
             T: if (inTag) {
                 boolean alpha = Character.isAlphabetic(ch);
                 if (tagStart > 0 && !alpha) {
                     String t = s.substring(tagStart, i).toLowerCase(Locale.ENGLISH);
+                    // prevent entering tagstart state again
+                    tagStart = -2;
+                    if (ch == '>') { // NOI18N
+                        inTag = false;
+                    }
                     switch (t) {
                         case "br": case "p": case "hr": // NOI1N
                             ch ='\n'; // NOI18N
                             // continues to process 'ch' as if it came from the string, but `inTag` remains
                             // the same.
                             break T;
+                        case "li":
+                            ch = '\n';
+                            additional = "* ";
+                            break T;
                     }
-                    // prevent entering tagstart state again
-                    tagStart = -2;
                 }
                 if (ch == '>') { // NOI18N
                     inTag = false;
@@ -441,6 +449,11 @@ public class Utils {
                     tagStart = -1;
                     inTag = true;
                     continue;
+                } else if (ch == '&') {
+                    if ("&nbsp;".contentEquals(s.subSequence(i, Math.min(s.length(), i + 6)))) {
+                        i += 5;
+                        ch = ' ';  // NOI18N
+                    }
                 }
             }
             if (collapseWhitespaces) {
@@ -458,6 +471,10 @@ public class Utils {
                 }
             }
             sb.append(ch);
+            if (additional != null) {
+                sb.append(additional);
+                additional = null;
+            }
         }
         return collapseWhitespaces ? sb.toString().trim() : sb.toString();
     }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/UtilsTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/UtilsTest.java
@@ -82,4 +82,26 @@ public class UtilsTest {
         String result = Utils.html2plain(s, true);
         assertEquals(expResult, result);
     }
+    
+    /**
+     * LI is replaced by "* ".
+     */
+    @Test
+    public void testReplaceLiByAsterisk() {
+        String s = "<ul><li>First option<li>Next option</ul>";
+        String expResult = "* First option * Next option";
+        String result = Utils.html2plain(s, true);
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * "P" properly appends following text, it used to strip until the next tag.
+     */
+    @Test
+    public void testDontStripContentAfterTags() {
+        String s = "<html>The Java version: 19, that is selected for the project is not supported <p>Possible solutions:<ul>List content </ul>Epilog";
+        String expResult = "The Java version: 19, that is selected for the project is not supported Possible solutions:List content Epilog";
+        String result = Utils.html2plain(s, true);
+        assertEquals(expResult, result);
+    }
 }


### PR DESCRIPTION
I noted an error in `html2plain` implementation: a text like
```
"<html>The Java version: 19, that is selected for the project is not supported <p>Possible solutions:<ul>List content </ul>
```
was stripped so that the text between `p` tag and the immediately following tag was removed, so the text became:
```
The Java version: 19, that is selected for the project is not supported List content
```