### PR TITLE
#6377: workaround vscode jar/nbjrt URI mangle

### DIFF
--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/UtilsTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/UtilsTest.java
@@ -20,7 +20,10 @@ package org.netbeans.modules.java.lsp.server;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import org.junit.Assume;
 import org.junit.Test;
+import org.netbeans.api.java.platform.JavaPlatform;
+import org.openide.filesystems.FileObject;
 
 /**
  *
@@ -103,5 +106,39 @@ public class UtilsTest {
         String expResult = "The Java version: 19, that is selected for the project is not supported Possible solutions:List content Epilog";
         String result = Utils.html2plain(s, true);
         assertEquals(expResult, result);
+    }
+    
+    /**
+     * Checks that mangled URI pointing into a JAR file is properly interpreted from LSP.
+     * @throws Exception 
+     */
+    @Test
+    public void testDecodeMangledJarURI() throws Exception {
+        FileObject fo = JavaPlatform.getDefault().getSourceFolders().findResource("java/util/Collections.java");
+        String uri = Utils.toUri(fo);
+        // mangle:
+        String replaced = uri.replace("file:", "file%3A").replace("!/", "%21/");
+        
+        assertEquals(uri, URITranslator.getDefault().uriFromLSP(replaced));
+        assertSame(fo, Utils.fromUri(replaced));
+    }
+
+    /**
+     * Checks that mangled URI pointing into a JDK11 module is properly interpreted from LSP.
+     * @throws Exception 
+     */
+    @Test
+    public void testDecodeMangledNbjrtURI() throws Exception {
+        String jdkVersion = System.getProperty("java.specification.version");
+        // ignore on JDK8
+        Assume.assumeTrue(!jdkVersion.startsWith("1.") && Integer.parseInt(jdkVersion) >= 9);
+        
+        FileObject fo = JavaPlatform.getDefault().getBootstrapLibraries().findResource("java/util/Collections.class");
+        String uri = Utils.toUri(fo);
+        // mangle:
+        String replaced = uri.replace("file:", "file%3A").replace("!/", "%21/");
+        
+        assertEquals(uri, URITranslator.getDefault().uriFromLSP(replaced));
+        assertSame(fo, Utils.fromUri(replaced));
     }
 }


### PR DESCRIPTION
The original commit 3fd09f3 that causes this bug changed the processing since although NBLS reported nbjrt or jar URIs in form `nbjrt:file:/space/java/17/!/modules/java.base/?CLASS#java.util.Collections`, the LSP client seems to mangle the scheme and ! by urlencoding it.  The clients sends back URIs like `nbjrt:file%3A/space/java/17/%21/modules/java.base/?CLASS#java.util.Collections`.

The original code in 3fd09f3  used URLDecoder, which demangles those parts, but also decodes other potentially URLeconded characters, such as spaces in path. 

This PR handles the specific sitiuation when there are multiple (nested) schemes like `jar:file:` or `nbjrt:file:` -- these always precede the first slash. In both cases, `!` serves as a delimiter for the inner scheme's part, followed by `/`. So only these parts are searched for and demangled.

The URI is later passed to `URI.create()` that decodes the rest.