### PR TITLE
Fixed gap between checkboxes in php project testing settings

### DIFF
--- a/php/php.project/src/org/netbeans/modules/php/project/ui/customizer/CustomizerTesting.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/customizer/CustomizerTesting.java
@@ -133,7 +133,6 @@ public class CustomizerTesting extends JPanel {
         GroupLayout providersPanelLayout = new GroupLayout(providersPanel);
         GroupLayout.ParallelGroup horizontalGroup = providersPanelLayout.createParallelGroup(GroupLayout.Alignment.LEADING);
         GroupLayout.SequentialGroup verticalGroup = providersPanelLayout.createSequentialGroup();
-        boolean first = true;
         final Collator collator = Collator.getInstance();
         Collections.sort(allTestingProviders, new Comparator<PhpTestingProvider>() {
             @Override
@@ -150,11 +149,7 @@ public class CustomizerTesting extends JPanel {
             }
             horizontalGroup.addComponent(checkBox);
             verticalGroup.addComponent(checkBox);
-            if (first) {
-                first = false;
-            } else {
-                verticalGroup.addPreferredGap(LayoutStyle.ComponentPlacement.RELATED);
-            }
+            verticalGroup.addPreferredGap(LayoutStyle.ComponentPlacement.RELATED);
         }
         providersPanel.setLayout(providersPanelLayout);
         providersPanelLayout.setHorizontalGroup(


### PR DESCRIPTION
before:
![before](https://github.com/apache/netbeans/assets/9607501/79970eef-5004-411f-98eb-1b45a0fc6a52)


after:
![after](https://github.com/apache/netbeans/assets/9607501/5df93169-4751-41c8-85cd-05889519690d)

