### PR TITLE
Micronaut's lifecycle participant changed FQN in Micronaut 4.x

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
@@ -100,6 +100,10 @@
                 <folder name="io.micronaut.build.testresources.TestResourcesLifecycleExtension">
                     <attr name="ignoreOnModelLoad" boolvalue="true"/>
                 </folder>
+                <!-- For micronaut 4.x -->
+                <folder name="io.micronaut.maven.testresources.TestResourcesLifecycleExtension">
+                    <attr name="ignoreOnModelLoad" boolvalue="true"/>
+                </folder>
             </folder>
         </folder>
     </folder>


### PR DESCRIPTION
Maven support warns before using lifecycle participants as they are not going to be executed during project read - it does not warn abou the known ones (as they do not change project model so much).

Micronaut repackaged its lifecycle participant in 4.0 release, so this PR just extends the exclusion list.