### PR TITLE
LSP: Prevent errors written to log on workspace symbol open.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -281,7 +281,7 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
                 try {
                     String uri = ((JsonPrimitive) params.getArguments().get(0)).getAsString();
                     FileObject file = Utils.fromUri(uri);
-                    if (file != null) {
+                    if (file != null && file.isData() && file.canRead()) {
                         future.complete(file.asText("UTF-8"));
                     }
                     future.complete(null);
@@ -1174,8 +1174,7 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
                         sdp.setSelection(new Range(position, position));
                         client.showDocument(sdp).thenAccept(res -> {
                             if (res.isSuccess()) {
-                                workspaceSymbol.setLocation(Either.forLeft(new Location(Utils.toUri(loc.getFileObject()), new Range(position, position))));
-                                result.complete(workspaceSymbol);
+                                result.complete(null);
                             } else {
                                 result.completeExceptionally(new IllegalStateException("Cannot open source for: " + typeHandle.getQualifiedName()));
                             }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -1851,10 +1851,11 @@ public class ServerTest extends NbTestCase {
         indexingComplete.await();
         Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>> symbols = server.getWorkspaceService().symbol(new WorkspaceSymbolParams("Tes")).get();
         List<String> actual = symbols.getRight().stream().map(symbol -> {
-            WorkspaceSymbol ws;
+            WorkspaceSymbol ws = null;
             try {
                 ws = server.getWorkspaceService().resolveWorkspaceSymbol(symbol).get();
-            } catch (Exception ex) {
+            } catch (Exception ex) {}
+            if (ws == null) {
                 ws = symbol;
             }
             return ws.getKind() + ":" + ws.getName() + ":" + ws.getContainerName() + ":" + (ws.getLocation().isLeft() ? toString(ws.getLocation().getLeft()) : toString(ws.getLocation().getRight()));
@@ -1862,8 +1863,8 @@ public class ServerTest extends NbTestCase {
         assertEquals(Arrays.asList("Constructor:Test():Test:Test.java:0:7-0:7",
                                    "Method:testMethod():Test:Test.java:2:4-2:38",
                                    "Constructor:TestNested():Test.TestNested:Test.java:1:18-1:18",
-                                   "Class:Test:null:Test.java:0:13-0:13",
-                                   "Class:TestNested:Test:Test.java:1:24-1:24"),
+                                   "Class:Test:null:?CLASS#Test",
+                                   "Class:TestNested:Test:?CLASS#Test$TestNested"),
                      actual);
     }
 


### PR DESCRIPTION
Modified to prevent errors written to log while opening workspace symbols (classes) that come from jar files.