### PR TITLE
FlatLaf: Enable Window decoration option for Linux

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.swing.laf.flatlaf;
 
+import com.formdev.flatlaf.util.SystemInfo;
 import com.formdev.flatlaf.util.UIScale;
 import java.awt.Color;
 import java.awt.Font;
@@ -26,8 +27,10 @@ import java.awt.Insets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Callable;
 import javax.swing.BorderFactory;
 import javax.swing.InputMap;
+import javax.swing.JFrame;
 import javax.swing.KeyStroke;
 import javax.swing.UIDefaults;
 import javax.swing.UIDefaults.LazyValue;
@@ -150,6 +153,10 @@ public class FlatLFCustoms extends LFCustoms {
                     result.add(new InsetsUIResource(bm.top, bm.left, bm.bottom + 1, bm.right));
                 }
             }
+        }
+        if (SystemInfo.isLinux) {
+            result.add("windowDefaultLookAndFeelDecorated");
+            result.add(FlatLafPrefs.isUseWindowDecorations());
         }
         return result.toArray();
     }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.java
@@ -19,6 +19,7 @@
 package org.netbeans.swing.laf.flatlaf;
 
 import com.formdev.flatlaf.FlatLaf;
+import com.formdev.flatlaf.FlatLightLaf;
 import com.formdev.flatlaf.util.SystemInfo;
 import java.awt.Color;
 import java.io.BufferedWriter;
@@ -52,7 +53,8 @@ import org.openide.util.RequestProcessor;
 public class FlatLafOptionsPanel extends javax.swing.JPanel {
 
     private static final Color DEFAULT = new Color(0, true);
-    private static final Color currentAccentColor = FlatLafPrefs.getAccentColor();
+    private static final Color currentAccentColor = getPrefsAccentColorOrDefault();
+    private static final boolean currentUseWindowDecorations = FlatLafPrefs.isUseWindowDecorations();
 
     private static final RequestProcessor RP = new RequestProcessor(FlatLafOptionsPanel.class);
 
@@ -108,7 +110,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
     }
 
     private void updateEnabled() {
-        boolean supportsWindowDecorations = FlatLaf.supportsNativeWindowDecorations();
+        boolean supportsWindowDecorations = FlatLaf.supportsNativeWindowDecorations() || new FlatLightLaf().getSupportsWindowDecorations();
         useWindowDecorationsCheckBox.setEnabled(supportsWindowDecorations);
         unifiedTitleBarCheckBox.setEnabled(supportsWindowDecorations && useWindowDecorationsCheckBox.isSelected());
         menuBarEmbeddedCheckBox.setEnabled(supportsWindowDecorations && useWindowDecorationsCheckBox.isSelected());
@@ -341,7 +343,8 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
         FlatLafPrefs.setUnderlineMenuSelection(underlineMenuSelectionCheckBox.isSelected());
         FlatLafPrefs.setAlwaysShowMnemonics(alwaysShowMnemonicsCheckBox.isSelected());
 
-        if (!Objects.equals(accentColor, currentAccentColor)) {
+        if (!Objects.equals(accentColor, currentAccentColor)
+                || SystemInfo.isLinux && useWindowDecorationsCheckBox.isSelected() != currentUseWindowDecorations) {
             askForRestart();
         }
         return false;
@@ -368,7 +371,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
                 NotificationDisplayer.Priority.NORMAL, NotificationDisplayer.Category.INFO);
     }
 
-    private Color getPrefsAccentColorOrDefault() {
+    private static Color getPrefsAccentColorOrDefault() {
         Color accentColor = FlatLafPrefs.getAccentColor();
         return accentColor != null ? accentColor : DEFAULT;
     }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafPrefs.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafPrefs.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.swing.laf.flatlaf;
 
+import com.formdev.flatlaf.util.SystemInfo;
 import java.awt.Color;
 import java.util.prefs.Preferences;
 import org.openide.util.NbPreferences;
@@ -36,6 +37,8 @@ class FlatLafPrefs {
     private static final String ALWAYS_SHOW_MNEMONICS = "alwaysShowMnemonics";
 
     private static final Preferences prefs = NbPreferences.forModule(FlatLafPrefs.class);
+
+    private static final boolean DEF_USE_WINDOW_DECORATIONS = SystemInfo.isWindows_10_orLater;
 
     static Color getAccentColor() {
         return parseColor(prefs.get(ACCENT_COLOR, null));
@@ -60,11 +63,11 @@ class FlatLafPrefs {
     }
 
     static boolean isUseWindowDecorations() {
-        return prefs.getBoolean(USE_WINDOW_DECORATIONS, true);
+        return prefs.getBoolean(USE_WINDOW_DECORATIONS, DEF_USE_WINDOW_DECORATIONS);
     }
 
     static void setUseWindowDecorations(boolean value) {
-        putBoolean(USE_WINDOW_DECORATIONS, value, true);
+        putBoolean(USE_WINDOW_DECORATIONS, value, DEF_USE_WINDOW_DECORATIONS);
     }
 
     static boolean isUnifiedTitleBar() {

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/Startup.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/Startup.java
@@ -334,6 +334,9 @@ public final class Startup {
             defaults.putDefaults (customs.getLookAndFeelCustomizationKeysAndValues());
         }
 
+        if (defaults.getBoolean("windowDefaultLookAndFeelDecorated")) {
+            JFrame.setDefaultLookAndFeelDecorated(true);
+        }
     }
 
     private void runPostInstall() {


### PR DESCRIPTION
Hi! This enable window decoration option for system that not support Native Window Decorations (Linux). This can be enable in Tools > Options > Appearance > FlatLaf > Window decorations.

See: https://www.formdev.com/flatlaf/window-decorations/#enable_disable_linux