### PR TITLE
Checkbox support on Markdown preview

### DIFF
--- a/ide/libs.flexmark/external/binaries-list
+++ b/ide/libs.flexmark/external/binaries-list
@@ -29,4 +29,5 @@ AE5AFA76A669E06B3A65255C2ED775EDE5CD3EB1 com.vladsch.flexmark:flexmark-util-depe
 18133DD81887C512E2F56FEB3C14A8A1210F30EA com.vladsch.flexmark:flexmark-util-misc:0.62.2
 87AF2803A63B5B07CC42D9C1D98F8ECD4F83FBCC com.vladsch.flexmark:flexmark-util-sequence:0.62.2
 CA49BD94860A5CCEDD82BDE96ECE831F16C66FF1 com.vladsch.flexmark:flexmark-util-visitor:0.62.2
+1C0FD7A70AFAC3A93459E49089E2D1B2BF72E590 com.vladsch.flexmark:flexmark-ext-gfm-tasklist:0.62.2
 36DA09A8F68484523FA2AAA100399D612B247D67 org.jsoup:jsoup:1.11.3

--- a/ide/libs.flexmark/external/flexmark-0.62.2-license.txt
+++ b/ide/libs.flexmark/external/flexmark-0.62.2-license.txt
@@ -3,7 +3,7 @@ Version: 0.62.2
 License: BSD-flexmark
 Description: FlexMark library
 Origin: https://github.com/vsch/flexmark-java
-Files: flexmark-0.62.2.jar flexmark-ext-anchorlink-0.62.2.jar flexmark-ext-emoji-0.62.2.jar flexmark-ext-tables-0.62.2.jar flexmark-html2md-converter-0.62.2.jar flexmark-util-ast-0.62.2.jar flexmark-util-builder-0.62.2.jar flexmark-util-collection-0.62.2.jar flexmark-util-data-0.62.2.jar flexmark-util-dependency-0.62.2.jar flexmark-util-format-0.62.2.jar flexmark-util-html-0.62.2.jar flexmark-util-misc-0.62.2.jar flexmark-util-sequence-0.62.2.jar flexmark-util-visitor-0.62.2.jar
+Files: flexmark-0.62.2.jar flexmark-ext-anchorlink-0.62.2.jar flexmark-ext-emoji-0.62.2.jar flexmark-ext-tables-0.62.2.jar flexmark-html2md-converter-0.62.2.jar flexmark-util-ast-0.62.2.jar flexmark-util-builder-0.62.2.jar flexmark-util-collection-0.62.2.jar flexmark-util-data-0.62.2.jar flexmark-util-dependency-0.62.2.jar flexmark-util-format-0.62.2.jar flexmark-util-html-0.62.2.jar flexmark-util-misc-0.62.2.jar flexmark-util-sequence-0.62.2.jar flexmark-util-visitor-0.62.2.jar flexmark-ext-gfm-tasklist-0.62.2.jar
 
 Copyright (c) 2015-2016, Atlassian Pty Ltd
 All rights reserved.

--- a/ide/libs.flexmark/nbproject/project.properties
+++ b/ide/libs.flexmark/nbproject/project.properties
@@ -32,4 +32,5 @@ release.external/flexmark-util-visitor-0.62.2.jar=modules/ext/flexmark-util-visi
 release.external/flexmark-ext-emoji-0.62.2.jar=modules/ext/flexmark-ext-emoji-0.62.2.jar
 release.external/flexmark-ext-anchorlink-0.62.2.jar=modules/ext/flexmark-ext-anchorlink-0.62.2.jar
 release.external/flexmark-ext-tables-0.62.2.jar=modules/ext/flexmark-ext-tables-0.62.2.jar
+release.external/flexmark-ext-gfm-tasklist-0.62.2.jar=modules/ext/flexmark-ext-gfm-tasklist-0.62.2.jar
 release.external/jsoup-1.11.3.jar=modules/ext/jsoup-1.11.3.jar

--- a/ide/libs.flexmark/nbproject/project.xml
+++ b/ide/libs.flexmark/nbproject/project.xml
@@ -93,6 +93,10 @@
                 <runtime-relative-path>ext/flexmark-0.62.2.jar</runtime-relative-path>
                 <binary-origin>external/flexmark-0.62.2.jar</binary-origin>
             </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/flexmark-ext-gfm-tasklist-0.62.2.jar</runtime-relative-path>
+                <binary-origin>external/flexmark-ext-gfm-tasklist-0.62.2.jar</binary-origin>
+            </class-path-extension>
         </data>
     </configuration>
 </project>

--- a/ide/markdown/nbproject/project.xml
+++ b/ide/markdown/nbproject/project.xml
@@ -47,7 +47,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.14</specification-version>
+                        <specification-version>1.15</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/MarkdownEditorKit.java
+++ b/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/MarkdownEditorKit.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.markdown.ui.preview;
+
+import org.netbeans.modules.markdown.ui.preview.views.MarkdownViewFactory;
+import javax.swing.text.ViewFactory;
+import javax.swing.text.html.HTMLEditorKit;
+
+/**
+ *
+ * @author moacirrf
+ */
+public class MarkdownEditorKit extends HTMLEditorKit {
+
+    private final transient ViewFactory viewFactory;
+
+    public MarkdownEditorKit() {
+        super();
+        this.viewFactory = new MarkdownViewFactory();
+    }
+
+    @Override
+    public ViewFactory getViewFactory() {
+        return viewFactory;
+    }
+}

--- a/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/views/CheckboxView.java
+++ b/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/views/CheckboxView.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.markdown.ui.preview.views;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import javax.swing.BorderFactory;
+import javax.swing.JCheckBox;
+import javax.swing.text.Element;
+import javax.swing.text.html.FormView;
+
+/**
+ *
+ * @author moacirrf
+ */
+public class CheckboxView extends FormView {
+
+    public CheckboxView(Element elem) {
+        super(elem);
+    }
+
+    @Override
+    protected Component createComponent() {
+        Component component = super.createComponent();
+        if (component instanceof JCheckBox) {
+            JCheckBox c = (JCheckBox) component;
+            c.setBorder(BorderFactory.createEmptyBorder(0, 0, -4, 0));
+            c.addActionListener((ActionEvent e) -> c.setSelected(!c.isSelected()));
+        }
+        return component;
+    }
+}

--- a/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/views/MarkdownViewFactory.java
+++ b/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/views/MarkdownViewFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.markdown.ui.preview.views;
+
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Element;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.View;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLEditorKit;
+
+/**
+ * This class creates Views for a JEditorPane, it receives and HTML element and
+ * you must create the most similar swing component to this html element. For
+ * example a HTML input type checkbox, its a JCheckBox, and image can be a
+ * JLabel and so on.
+ *
+ * @author moacirrf
+ */
+public class MarkdownViewFactory extends HTMLEditorKit.HTMLFactory {
+
+    @Override
+    public View create(Element elem) {
+
+        if (isElementOfTag(elem, HTML.Tag.INPUT)) {
+            return new CheckboxView(elem);
+        }
+
+        return super.create(elem);
+    }
+
+    public boolean isElementOfTag(Element elem, HTML.Tag tag) {
+
+        AttributeSet attrs = elem.getAttributes();
+        Object elementName
+                = attrs.getAttribute(AbstractDocument.ElementNameAttribute);
+        Object o = (elementName != null)
+                ? null : attrs.getAttribute(StyleConstants.NameAttribute);
+        HTML.Tag kind = (HTML.Tag) o;
+
+        return (o instanceof HTML.Tag) && (kind == tag);
+
+    }
+}


### PR DESCRIPTION
Added support for Checkbox on Markdown Preview and some other changes that i will explain.
![image](https://github.com/apache/netbeans/assets/950706/880348c9-a971-4193-aa1c-a81a61439d16)



### Project: Markdown Support
Added a package **ui.preview** and  **and ui.preview.views**
![image](https://github.com/apache/netbeans/assets/950706/e853a01c-7e22-44df-9b3d-fe8dec5e9c59)

- [MarkdownEditorKit.java](https://github.com/moacirrf/netbeans/blob/5836eb61945c543cd8e7d8c443e7109af7b9c3cf/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/MarkdownEditorKit.java) : Is reponsible to supply a custom ViewFactory and this class has a very interesting method called getStyleSheet that is important to deal with themes on JEditorPane, so i believe that was better extract to a new class to avoid use of Anonymous class.

- [MarkdownViewFactory](https://github.com/moacirrf/netbeans/blob/5836eb61945c543cd8e7d8c443e7109af7b9c3cf/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/views/MarkdownViewFactory.java) : Is responsible to create custom views to JEditorPane, it will receive a Html element and convert to the most similar swing component.


- [ViewUtils.java](https://github.com/moacirrf/netbeans/blob/5836eb61945c543cd8e7d8c443e7109af7b9c3cf/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/views/ViewUtils.java): Just a utility class to deal with HTML elements.


- [CheckboxView.java](https://github.com/moacirrf/netbeans/blob/5836eb61945c543cd8e7d8c443e7109af7b9c3cf/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/views/CheckboxView.java): A view of a Checkbox in this example was necessary create a custom just to preserve state checked and fix some border 

### Project: Markdown Library
Added [flexmark-ext-gfm-tasklist](https://mvnrepository.com/artifact/com.vladsch.flexmark/flexmark-ext-gfm-tasklist/0.62.2) to support of checkboxes.

Ps.: I do not have option to add a Label...