### PR TITLE
Quickpick title for database fixed

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/AddADBAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/AddADBAction.java
@@ -79,7 +79,8 @@ import org.openide.util.NbBundle;
     "# {1} - region id",
     "SelectProfile_Description={0} (region: {1})",
     "SelectCompartment=Select Compartment",
-    "SelectDatabase=Select Compartment or Database",
+    "SelectDatabase=Select Database",
+    "NoDatabase=No Database available in this Compartment",
     "EnterUsername=Enter Username",
     "EnterPassword=Enter Password"
 })
@@ -167,13 +168,17 @@ public class AddADBAction implements ActionListener {
                         h.start();
                         h.progress(Bundle.MSG_CollectingItems_Text());
                         try {
+                            String title;
                             if (prevItem instanceof TenancyItem) {
                                 values.put(number, getFlatCompartment((TenancyItem) prevItem));
+                                title = Bundle.SelectCompartment();
                             } else {
-                                values.put(number, getDbs(prevItem));
+                                Map<String, OCIItem> dbs = getDbs(prevItem);
+                                values.put(number, dbs);
+                                title = dbs.isEmpty() ? Bundle.NoDatabase() : Bundle.SelectDatabase();
                             }
                             input.setEstimatedNumberOfInputs(input.getEstimatedNumberOfInputs() + 1);
-                            return createQuickPick(values.get(number), Bundle.SelectDatabase());
+                            return createQuickPick(values.get(number), title);
                         } finally {
                             h.finish();
                         }


### PR DESCRIPTION
FIxed the hint should be displayed according to the current step:

1.  Select Compartment when selecting a compartment
2. Select Database when selecting a database

When a compartment without a database is selected, the hint is 'No database available in this Compartment'