### PR TITLE
Fix NBLS 3rd party licenses

### DIFF
--- a/java/java.lsp.server/build.xml
+++ b/java/java.lsp.server/build.xml
@@ -128,7 +128,7 @@
         <taskdef name="createlicensesummary" classname="org.netbeans.nbbuild.extlibs.CreateLicenseSummary" classpath="${nbantext.jar}"/>
 
         <property name="config.javadoc.all" value="" />
-        <resolvelist name="allmodules" path="modules.fullpath" dir="${nb_all}" list="${clusters.config.java.list}"/>
+        <resolvelist name="allmodules" path="modules.fullpath" dir="${nb_all}" list="${clusters.config.full.list}"/>
 
         <createlicensesummary licenseStub="${nb_all}/LICENSE"
                               noticeStub="${nb_all}/nbbuild/notice-stub.txt"


### PR DESCRIPTION
Top level LICENSE file in apache-netbeans-java-xx.x.xxx.vsix is missing some 3rd party library licenses namely for enterprise, cpplite, extra, groovy and webcommon clusters.

To fix it 'allmodules' should include all clusters not just 'java' and its dependencies, since apache-netbeans-java-xx.x.xxx.vsix contains enterprise, cpplite, extra, groovy and webcommon clusters.