### PR TITLE
Micronaut 4 build plugin recognized.

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
@@ -67,7 +67,22 @@
             </folder>
         </folder>
         <folder name="org-netbeans-modules-maven">
+            <!-- For Micornaut 3.x -->
             <folder name="io.micronaut.build:micronaut-maven-plugin">
+                <folder name="Lookup">
+                    <file name="maven-project-actions.instance">
+                        <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                        <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
+                        <attr name="resource" stringvalue="nbres:/org/netbeans/modules/micronaut/resources/micronaut-actions-maven.xml"/>
+                    </file>
+                    <file name="native-image-artifacts.instance">
+                        <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                        <attr name="instanceCreate" methodvalue="org.netbeans.modules.micronaut.maven.MicronautPackagingArtifactsImpl.projectLookup"/>
+                    </file>
+                </folder>
+            </folder>
+            <!-- Micronaut 4.x -->
+            <folder name="io.micronaut.maven:micronaut-maven-plugin">
                 <folder name="Lookup">
                     <file name="maven-project-actions.instance">
                         <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>

--- a/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/.gitignore
+++ b/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/.gitignore
@@ -1,0 +1,15 @@
+Thumbs.db
+.DS_Store
+.gradle
+build/
+target/
+out/
+.micronaut/
+.idea
+*.iml
+*.ipr
+*.iws
+.project
+.settings
+.classpath
+.factorypath

--- a/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/README.md
+++ b/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/README.md
@@ -1,0 +1,24 @@
+## Micronaut 4.1.0 Documentation
+
+- [User Guide](https://docs.micronaut.io/4.1.0/guide/index.html)
+- [API Reference](https://docs.micronaut.io/4.1.0/api/index.html)
+- [Configuration Reference](https://docs.micronaut.io/4.1.0/guide/configurationreference.html)
+- [Micronaut Guides](https://guides.micronaut.io/index.html)
+---
+
+- [Micronaut Maven Plugin documentation](https://micronaut-projects.github.io/micronaut-maven-plugin/latest/)
+## Feature maven-enforcer-plugin documentation
+
+- [https://maven.apache.org/enforcer/maven-enforcer-plugin/](https://maven.apache.org/enforcer/maven-enforcer-plugin/)
+
+
+## Feature micronaut-aot documentation
+
+- [Micronaut AOT documentation](https://micronaut-projects.github.io/micronaut-aot/latest/guide/)
+
+
+## Feature serialization-jackson documentation
+
+- [Micronaut Serialization Jackson Core documentation](https://micronaut-projects.github.io/micronaut-serialization/latest/guide/)
+
+

--- a/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/aot-jar.properties
+++ b/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/aot-jar.properties
@@ -1,0 +1,34 @@
+# AOT configuration properties for jar packaging
+# Please review carefully the optimizations enabled below
+# Check https://micronaut-projects.github.io/micronaut-aot/latest/guide/ for more details
+
+# Caches environment property values: environment properties will be deemed immutable after application startup.
+cached.environment.enabled=true
+
+# Precomputes Micronaut configuration property keys from the current environment variables
+precompute.environment.properties.enabled=true
+
+# Converts YAML configuration files to Java configuration
+yaml.to.java.config.enabled=true
+
+# Scans for service types ahead-of-time, avoiding classpath scanning at startup
+serviceloading.jit.enabled=true
+
+# Scans reactive types at build time instead of runtime
+scan.reactive.types.enabled=true
+
+# Deduces the environment at build time instead of runtime
+deduce.environment.enabled=true
+
+# Checks of existence of some types at build time instead of runtime
+known.missing.types.enabled=true
+
+# Precomputes property sources at build time
+sealed.property.source.enabled=true
+
+# The list of service types to be scanned (comma separated)
+service.types=io.micronaut.context.env.PropertySourceLoader,io.micronaut.inject.BeanConfiguration,io.micronaut.inject.BeanDefinitionReference,io.micronaut.http.HttpRequestFactory,io.micronaut.http.HttpResponseFactory,io.micronaut.core.beans.BeanIntrospectionReference
+
+# A list of types that the AOT analyzer needs to check for existence (comma separated)
+known.missing.types.list=io.reactivex.Observable,reactor.core.publisher.Flux,kotlinx.coroutines.flow.Flow,io.reactivex.rxjava3.core.Flowable,io.reactivex.rxjava3.core.Observable,io.reactivex.Single,reactor.core.publisher.Mono,io.reactivex.Maybe,io.reactivex.rxjava3.core.Single,io.reactivex.rxjava3.core.Maybe,io.reactivex.Completable,io.reactivex.rxjava3.core.Completable,io.methvin.watchservice.MacOSXListeningWatchService,io.micronaut.core.async.publisher.CompletableFuturePublisher,io.micronaut.core.async.publisher.Publishers.JustPublisher,io.micronaut.core.async.subscriber.Completable
+

--- a/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/micronaut-cli.yml
+++ b/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/micronaut-cli.yml
@@ -1,0 +1,6 @@
+applicationType: default
+defaultPackage: com.example
+testFramework: junit
+sourceLanguage: java
+buildTool: maven
+features: [app-name, http-client-test, java, java-application, junit, logback, maven, maven-enforcer-plugin, micronaut-aot, netty-server, properties, readme, serialization-jackson, shade]

--- a/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/pom.xml
+++ b/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>micronaut4test</artifactId>
+  <version>0.1</version>
+  <packaging>${packaging}</packaging>
+
+  <parent>
+    <groupId>io.micronaut.platform</groupId>
+    <artifactId>micronaut-parent</artifactId>
+    <version>4.1.0</version>
+  </parent>
+  <properties>
+    <packaging>jar</packaging>
+    <jdk.version>17</jdk.version>
+    <release.version>17</release.version>
+    <micronaut.version>4.1.0</micronaut.version>
+    <micronaut.aot.enabled>false</micronaut.aot.enabled>
+    <micronaut.aot.packageName>com.example.aot.generated</micronaut.aot.packageName>
+    <micronaut.runtime>netty</micronaut.runtime>
+    <exec.mainClass>com.example.Application</exec.mainClass>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-server-netty</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.serde</groupId>
+      <artifactId>micronaut-serde-jackson</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut</groupId>
+      <artifactId>micronaut-http-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micronaut.test</groupId>
+      <artifactId>micronaut-test-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.micronaut.maven</groupId>
+        <artifactId>micronaut-maven-plugin</artifactId>
+          <configuration>
+            <configFile>aot-${packaging}.properties</configFile>
+          </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Uncomment to enable incremental compilation -->
+          <!-- <useIncrementalCompilation>false</useIncrementalCompilation> -->
+
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>io.micronaut.serde</groupId>
+              <artifactId>micronaut-serde-processor</artifactId>
+              <version>${micronaut.serialization.version}</version>
+              <exclusions>
+                <exclusion>
+                  <groupId>io.micronaut</groupId>
+                  <artifactId>micronaut-inject</artifactId>
+                </exclusion>
+              </exclusions>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Amicronaut.processing.group=com.example</arg>
+            <arg>-Amicronaut.processing.module=demoTestForSvata</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/src/main/java/com/example/Application.java
+++ b/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/src/main/java/com/example/Application.java
@@ -1,0 +1,10 @@
+package com.example;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+}

--- a/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/src/main/resources/application.properties
+++ b/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+#Wed Sep 06 13:10:29 GMT 2023
+micronaut.application.name=demoTestForSvata

--- a/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/src/main/resources/logback.xml
+++ b/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/src/test/java/com/example/DemoTestForSvataTest.java
+++ b/enterprise/micronaut/test/unit/data/maven/micronaut4/simple/src/test/java/com/example/DemoTestForSvataTest.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import jakarta.inject.Inject;
+
+@MicronautTest
+class DemoTestForSvataTest {
+
+    @Inject
+    EmbeddedApplication<?> application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}


### PR DESCRIPTION
Micronaut has changed its build plugin coordinates between version 3.x and 4.x. Formerly, its groupId was `io.micronaut.build` while now it is `io.micronaut.maven`.

The PR just duplicates the project service registrations, so both MN3 and MN4 projects are recognized. I've added some tests to check that the continuous mode configuration is / is not present for simple, MN3 and MN4 projects.