### PR TITLE
Use extended mouse buttons for back / forward actions (GH5728)

### DIFF
--- a/ide/editor.lib2/nbproject/project.xml
+++ b/ide/editor.lib2/nbproject/project.xml
@@ -123,7 +123,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.3</specification-version>
+                        <specification-version>9.31</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
@@ -30,6 +30,7 @@ import java.awt.RenderingHints;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.awt.font.FontRenderContext;
@@ -72,6 +73,7 @@ import org.netbeans.modules.editor.lib2.EditorPreferencesDefaults;
 import org.openide.util.Lookup;
 import org.openide.util.LookupEvent;
 import org.openide.util.LookupListener;
+import org.openide.util.Utilities;
 import org.openide.util.WeakListeners;
 
 /**
@@ -1512,17 +1514,21 @@ public final class DocumentViewOp
         Keymap keymap = textComponent.getKeymap();
         double wheelRotation = evt.getPreciseWheelRotation();
         if (wheelRotation < 0) {
-            Action action = keymap.getAction(KeyStroke.getKeyStroke(0x290, modifiers)); //WHEEL_UP constant
+            int mouseUpKeyCode = Utilities.mouseWheelUpKeyCode();
+            Action action = mouseUpKeyCode == KeyEvent.VK_UNDEFINED ? null
+                    : keymap.getAction(KeyStroke.getKeyStroke(mouseUpKeyCode, modifiers));
             if (action != null) {
-                action.actionPerformed(new ActionEvent(docView.getTextComponent(),0,""));
+                action.actionPerformed(new ActionEvent(docView.getTextComponent(), 0, ""));
                 textComponent.repaint(); // Consider repaint triggering elsewhere
             } else {
                 delegator.delegateToOriginalListener(evt, activeScrollPane);
             }
         } else if (wheelRotation > 0) {
-            Action action = keymap.getAction(KeyStroke.getKeyStroke(0x291, modifiers)); //WHEEL_DOWN constant
+            int mouseDownKeyCode = Utilities.mouseWheelDownKeyCode();
+            Action action = mouseDownKeyCode == KeyEvent.VK_UNDEFINED ? null
+                    : keymap.getAction(KeyStroke.getKeyStroke(mouseDownKeyCode, modifiers));
             if (action != null) {
-                action.actionPerformed(new ActionEvent(docView.getTextComponent(),0,""));
+                action.actionPerformed(new ActionEvent(docView.getTextComponent(), 0, ""));
                 textComponent.repaint(); // Consider repaint triggering elsewhere
             } else {
                 delegator.delegateToOriginalListener(evt, activeScrollPane);

--- a/ide/editor/nbproject/project.xml
+++ b/ide/editor/nbproject/project.xml
@@ -239,7 +239,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.3</specification-version>
+                        <specification-version>9.31</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/editor/src/org/netbeans/modules/editor/MainMenuAction.java
+++ b/ide/editor/src/org/netbeans/modules/editor/MainMenuAction.java
@@ -138,7 +138,7 @@ public abstract class MainMenuAction implements Presenter.Menu, ChangeListener, 
             if (keys != null && keys.length > 0) {
                 for (KeyStroke key : keys) {
                     // filter out synthetic mouse keycodes
-                    if (key.getKeyCode() >= 0x290 && key.getKeyCode() <= 0x29F) {
+                    if (org.openide.util.Utilities.isMouseKeyCode(key.getKeyCode())) {
                         continue;
                     }
                     if (itemAccelerator==null || !itemAccelerator.equals(key)){

--- a/ide/editor/src/org/netbeans/modules/editor/MainMenuAction.java
+++ b/ide/editor/src/org/netbeans/modules/editor/MainMenuAction.java
@@ -136,8 +136,15 @@ public abstract class MainMenuAction implements Presenter.Menu, ChangeListener, 
             KeyStroke itemAccelerator = item.getAccelerator();
             
             if (keys != null && keys.length > 0) {
-                if (itemAccelerator==null || !itemAccelerator.equals(keys[0])){
-                    item.setAccelerator(keys[0]);
+                for (KeyStroke key : keys) {
+                    // filter out synthetic mouse keycodes
+                    if (key.getKeyCode() >= 0x290 && key.getKeyCode() <= 0x29F) {
+                        continue;
+                    }
+                    if (itemAccelerator==null || !itemAccelerator.equals(key)){
+                        item.setAccelerator(key);
+                        break;
+                    }
                 }
             }else{
                 if (itemAccelerator!=null && kitAction!=null){

--- a/ide/editor/src/org/netbeans/modules/editor/resources/NetBeans-keybindings.xml
+++ b/ide/editor/src/org/netbeans/modules/editor/resources/NetBeans-keybindings.xml
@@ -96,8 +96,12 @@
     <bind actionName="jump-list-last-edit" key="D-Q"/>
     <bind actionName="jump-list-next" key="O-RIGHT"/>
     <bind actionName="jump-list-next" key="O-KP_RIGHT"/>
+    <bind actionName="jump-list-next" key="MOUSE_BUTTON5"/>
+    <bind actionName="jump-list-next" key="MOUSE_BUTTON7"/>
     <bind actionName="jump-list-prev" key="O-LEFT"/>
     <bind actionName="jump-list-prev" key="O-KP_LEFT"/>
+    <bind actionName="jump-list-prev" key="MOUSE_BUTTON4"/>
+    <bind actionName="jump-list-prev" key="MOUSE_BUTTON6"/>
     <bind actionName="page-down" key="PAGE_DOWN"/>
     <bind actionName="page-up" key="PAGE_UP"/>
     <bind actionName="paste-formated" key="DS-V"/>

--- a/platform/core.windows/nbproject/project.xml
+++ b/platform/core.windows/nbproject/project.xml
@@ -133,7 +133,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.3</specification-version>
+                        <specification-version>9.31</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/core.windows/src/org/netbeans/core/windows/ShortcutAndMenuKeyEventProcessor.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/ShortcutAndMenuKeyEventProcessor.java
@@ -314,7 +314,6 @@ final class ShortcutAndMenuKeyEventProcessor implements KeyEventDispatcher, KeyE
     private void processMouseEvent(MouseEvent mev) {
         if (mev.getID() != MouseEvent.MOUSE_PRESSED
                 || mev.getButton() <= MouseEvent.BUTTON3
-                || mev.getButton() > 10
                 || mev.isPopupTrigger()
                 || mev.isConsumed()) {
             return;
@@ -323,7 +322,10 @@ final class ShortcutAndMenuKeyEventProcessor implements KeyEventDispatcher, KeyE
         if (NbLifecycleManager.isExiting()) {
             return;
         }
-        int keycode = 0x292 + (mev.getButton() - 1);
+        int keycode = Utilities.mouseButtonKeyCode(mev.getButton());
+        if (keycode == KeyEvent.VK_UNDEFINED) {
+            return;
+        }
         int modifiers = 0;
         if (mev.isControlDown()) {
             modifiers |= InputEvent.CTRL_DOWN_MASK;

--- a/platform/core.windows/src/org/netbeans/core/windows/ShortcutAndMenuKeyEventProcessor.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/ShortcutAndMenuKeyEventProcessor.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.core.windows;
 
+import java.awt.AWTEvent;
 import java.awt.AWTKeyStroke;
 import java.awt.Component;
 import java.awt.Container;
@@ -26,10 +27,13 @@ import java.awt.Dialog;
 import java.awt.KeyEventDispatcher;
 import java.awt.KeyEventPostProcessor;
 import java.awt.KeyboardFocusManager;
+import java.awt.Toolkit;
 import java.awt.Window;
+import java.awt.event.AWTEventListener;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Set;
@@ -42,6 +46,7 @@ import javax.swing.KeyStroke;
 import javax.swing.MenuElement;
 import javax.swing.MenuSelectionManager;
 import javax.swing.SwingUtilities;
+import javax.swing.text.JTextComponent;
 import javax.swing.text.Keymap;
 import org.netbeans.core.NbKeymap;
 import org.netbeans.core.NbLifecycleManager;
@@ -58,7 +63,7 @@ import org.openide.util.Utilities;
  * 
  * @author Tran Duc Trung
  */
-final class ShortcutAndMenuKeyEventProcessor implements KeyEventDispatcher, KeyEventPostProcessor {
+final class ShortcutAndMenuKeyEventProcessor implements KeyEventDispatcher, KeyEventPostProcessor, AWTEventListener {
     
     private static ShortcutAndMenuKeyEventProcessor defaultInstance;
     
@@ -107,7 +112,8 @@ final class ShortcutAndMenuKeyEventProcessor implements KeyEventDispatcher, KeyE
         keyboardFocusManager.setDefaultFocusTraversalKeys(
             KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS,
             Collections.singleton(AWTKeyStroke.getAWTKeyStroke(KeyEvent.VK_TAB, KeyEvent.SHIFT_DOWN_MASK))
-        );                
+        );
+        Toolkit.getDefaultToolkit().addAWTEventListener(instance, AWTEvent.MOUSE_EVENT_MASK);
     }
     
     public static synchronized void uninstall() {
@@ -129,6 +135,7 @@ final class ShortcutAndMenuKeyEventProcessor implements KeyEventDispatcher, KeyE
         );                
         defaultBackward = null;
         defaultForward = null;
+        Toolkit.getDefaultToolkit().removeAWTEventListener(instance);
     }
 
     private boolean wasPopupDisplayed;
@@ -136,6 +143,13 @@ final class ShortcutAndMenuKeyEventProcessor implements KeyEventDispatcher, KeyE
     private char lastKeyChar;
     private boolean lastSampled = false;
     private boolean skipNextTyped = false;
+
+    @Override
+    public void eventDispatched(AWTEvent event) {
+        if (event instanceof MouseEvent) {
+            processMouseEvent((MouseEvent) event);
+        }
+    }
     
     public boolean postProcessKeyEvent(KeyEvent ev) {
         if (ev.isConsumed())
@@ -295,6 +309,71 @@ final class ShortcutAndMenuKeyEventProcessor implements KeyEventDispatcher, KeyE
             return true;
         }
         return false;
+    }
+
+    private void processMouseEvent(MouseEvent mev) {
+        if (mev.getID() != MouseEvent.MOUSE_PRESSED
+                || mev.getButton() <= MouseEvent.BUTTON3
+                || mev.getButton() > 10
+                || mev.isPopupTrigger()
+                || mev.isConsumed()) {
+            return;
+        }
+        //ignore when the IDE is shutting down
+        if (NbLifecycleManager.isExiting()) {
+            return;
+        }
+        int keycode = 0x292 + (mev.getButton() - 1);
+        int modifiers = 0;
+        if (mev.isControlDown()) {
+            modifiers |= InputEvent.CTRL_DOWN_MASK;
+        }
+        if (mev.isAltDown()) {
+            modifiers |= InputEvent.ALT_DOWN_MASK;
+        }
+        if (mev.isShiftDown()) {
+            modifiers |= InputEvent.SHIFT_DOWN_MASK;
+        }
+        if (mev.isMetaDown()) {
+            modifiers |= InputEvent.META_DOWN_MASK;
+        }
+
+        KeyStroke ks = KeyStroke.getKeyStroke(keycode, modifiers);
+        Window w = SwingUtilities.windowForComponent(mev.getComponent());
+
+        // don't process shortcuts if this is a help frame
+        if ((w instanceof JFrame) && ((JFrame) w).getRootPane().getClientProperty("netbeans.helpframe") != null) { // NOI18N
+            return;
+        }
+
+        // don't let action keystrokes to propagate from both
+        // modal and nonmodal dialogs, but propagate from separate floating windows,
+        // even if they are backed by JDialog
+        if ((w instanceof Dialog)
+                && !WindowManagerImpl.isSeparateWindow(w)
+                && !isTransmodalAction(ks)) {
+            return;
+        }
+
+        // Provide a reasonably useful action event that identifies what was focused
+        // when the key was pressed, as well as what keystroke ran the action.
+        ActionEvent aev = new ActionEvent(
+                mev.getSource(), ActionEvent.ACTION_PERFORMED, Utilities.keyToString(ks));
+
+        Action action = null;
+        Component focused = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
+        if (focused instanceof JTextComponent) {
+            action = ((JTextComponent) focused).getKeymap().getAction(ks);
+        }
+        if (action == null) {
+            Keymap km = Lookup.getDefault().lookup(Keymap.class);
+            action = (km != null) ? km.getAction(ks) : null;
+        }
+
+        if (action != null && action.isEnabled()) {
+            action.actionPerformed(aev);
+            mev.consume();
+        }
     }
 
     private static boolean invokeProcessKeyBindingsForAllComponents(

--- a/platform/openide.util.ui/apichanges.xml
+++ b/platform/openide.util.ui/apichanges.xml
@@ -27,6 +27,21 @@
     <apidef name="actions">Actions API</apidef>
 </apidefs>
 <changes>
+    <change id="mouseKeyCodes">
+      <api name="util"/>
+      <summary>Added methods to query mouse event pseudo-keycodes</summary>
+      <version major="9" minor="31"/>
+      <date day="25" month="9" year="2023"/>
+      <author login="neilcsmith"/>
+      <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="yes"/>
+      <description>
+            <p>
+               Added methods to query the existing pseudo-keycodes assigned to mouse wheel events, and new pseudo-keycodes added
+               for extended mouse buttons.
+            </p>
+       </description>
+       <class package="org.openide.util" name="Utilities"/>
+    </change>
     <change id="findDialogParent2">
          <api name="util"/>
          <summary>static method Utilities.findDialogParent overloaded and isModalDialogOpen added</summary>

--- a/platform/openide.util.ui/src/org/openide/util/Utilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/Utilities.java
@@ -802,6 +802,60 @@ public final class Utilities {
         return nav;
     }
 
+    /**
+     * Check whether the provided keycode is within the range reserved for mouse
+     * event pseudo-keycodes. Note that not all keycodes in the range may be
+     * mapped.
+     *
+     * @param keycode keycode to check
+     * @return true if in mouse range
+     * @since 9.31
+     */
+    public static boolean isMouseKeyCode(int keycode) {
+        return keycode >= 0x290 && keycode <= 0x29F;
+    }
+
+    /**
+     * Get the pseudo-keycode used for mouse wheel up events. May return
+     * {@link KeyEvent#VK_UNDEFINED} if not available.
+     *
+     * @return mouse wheel up keycode if defined
+     * @since 9.31
+     */
+    public static int mouseWheelUpKeyCode() {
+        return 0x290;
+    }
+
+    /**
+     * Get the pseudo-keycode used for mouse wheel up events. May return
+     * {@link KeyEvent#VK_UNDEFINED} if not available.
+     *
+     * @return mouse wheel down keycode if defined
+     * @since 9.31
+     */
+    public static int mouseWheelDownKeyCode() {
+        return 0x291;
+    }
+
+    /**
+     * Get the pseudo-keycode used for the provided mouse button. Returns
+     * {@link KeyEvent#VK_UNDEFINED} if not available.
+     * <p>
+     * Implementation note : only extended mouse buttons in the range BUTTON4 to
+     * BUTTON9 are currently mapped to keycodes.
+     *
+     * @param button mouse button
+     * @return keycode if defined
+     * @since 9.31
+     */
+    public static int mouseButtonKeyCode(int button) {
+        if (button >= 4 && button < 10) {
+            return 0x292 + (button - 1);
+        } else {
+            return KeyEvent.VK_UNDEFINED;
+        }
+    }
+
     /** Converts a Swing key stroke descriptor to a familiar Emacs-like name.
     * @param stroke key description
     * @return name of the key (e.g. <code>CS-F1</code> for control-shift-function key one)

--- a/platform/openide.util.ui/src/org/openide/util/Utilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/Utilities.java
@@ -790,6 +790,13 @@ public final class Utilities {
         values.put(0x290,"MOUSE_WHEEL_UP");
         values.put(0x291,"MOUSE_WHEEL_DOWN");
 
+        for (int button = 4; button < 10; button++) {
+            String name = "MOUSE_BUTTON" + button; // NOI18N
+            int code = 0x292 + (button - 1);
+            names.put(name, code);
+            values.put(code, name);
+        }
+
         NamesAndValues nav = new NamesAndValues(values, names);
         namesAndValues = new SoftReference<NamesAndValues>(nav);
         return nav;

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/Bundle.properties
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/Bundle.properties
@@ -161,6 +161,12 @@ SpecialkeyPanel.upButton.text=
 SpecialkeyPanel.enterButton.text=
 SpecialkeyPanel.leftButton.text_1=
 SpecialkeyPanel.rightButton.text=
+SpecialkeyPanel.mouseButton4.text=Mouse 4
+SpecialkeyPanel.mouseButton5.text=Mouse 5
+SpecialkeyPanel.mouseButton6.text=Mouse 6
+SpecialkeyPanel.mouseButton7.text=Mouse 7
+SpecialkeyPanel.mouseButton8.text=Mouse 8
+SpecialkeyPanel.mouseButton9.text=Mouse 9
 
 # Keymap Options Export
 Keymaps.Options.Export.Category.displayName=Keymaps

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/SpecialkeyPanel.form
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/SpecialkeyPanel.form
@@ -44,7 +44,7 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
+          <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="tabButton" max="32767" attributes="1"/>
@@ -53,28 +53,41 @@
                           <Component id="escButton" linkSize="4" min="-2" pref="64" max="-2" attributes="1"/>
                           <Component id="leftButton" linkSize="4" alignment="1" min="-2" pref="50" max="-2" attributes="1"/>
                       </Group>
-                      <EmptySpace max="-2" attributes="0"/>
+                      <EmptySpace min="-2" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Component id="downButton" linkSize="4" min="-2" pref="50" max="-2" attributes="0"/>
                           <Component id="upButton" linkSize="4" min="-2" pref="50" max="-2" attributes="0"/>
                       </Group>
                       <EmptySpace min="-2" max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                      <Group type="103" groupAlignment="0" attributes="0">
                           <Group type="102" attributes="0">
                               <Component id="rightButton" linkSize="4" min="-2" pref="53" max="-2" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Component id="wheelDownButton" min="-2" max="-2" attributes="0"/>
+                              <EmptySpace min="-2" max="-2" attributes="0"/>
+                              <Component id="wheelDownButton" max="32767" attributes="0"/>
                           </Group>
                           <Group type="102" attributes="0">
                               <Component id="enterButton" linkSize="4" min="-2" pref="53" max="-2" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
+                              <EmptySpace min="-2" max="-2" attributes="0"/>
                               <Component id="wheelUpButton" max="32767" attributes="0"/>
                           </Group>
                       </Group>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                  </Group>
+                  <Group type="102" attributes="0">
+                      <Component id="mouseButton4" max="32767" attributes="0"/>
+                      <EmptySpace min="-2" max="-2" attributes="0"/>
+                      <Component id="mouseButton5" max="32767" attributes="0"/>
+                      <EmptySpace min="-2" max="-2" attributes="0"/>
+                      <Component id="mouseButton6" max="32767" attributes="0"/>
+                  </Group>
+                  <Group type="102" attributes="0">
+                      <Component id="mouseButton7" max="32767" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="mouseButton8" max="32767" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="mouseButton9" max="32767" attributes="0"/>
                   </Group>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -91,11 +104,27 @@
                   <Component id="wheelUpButton" min="-2" pref="30" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" max="-2" attributes="0">
+              <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="rightButton" linkSize="5" max="32767" attributes="0"/>
                   <Component id="downButton" linkSize="5" min="-2" pref="30" max="-2" attributes="0"/>
                   <Component id="leftButton" linkSize="5" max="32767" attributes="0"/>
                   <Component id="wheelDownButton" min="-2" pref="30" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" attributes="0">
+                      <Component id="mouseButton4" min="-2" pref="30" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="3" attributes="0">
+                          <Component id="mouseButton7" alignment="3" min="-2" pref="30" max="-2" attributes="0"/>
+                          <Component id="mouseButton8" alignment="3" min="-2" pref="30" max="-2" attributes="0"/>
+                          <Component id="mouseButton9" alignment="3" min="-2" pref="30" max="-2" attributes="0"/>
+                      </Group>
+                  </Group>
+                  <Group type="103" alignment="0" groupAlignment="3" attributes="0">
+                      <Component id="mouseButton6" alignment="3" min="-2" pref="30" max="-2" attributes="0"/>
+                      <Component id="mouseButton5" alignment="3" min="-2" pref="30" max="-2" attributes="0"/>
+                  </Group>
               </Group>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
@@ -176,6 +205,48 @@
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/options/keymap/Bundle.properties" key="SpecialkeyPanel.wheelDownButton.text_1" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JButton" name="mouseButton4">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/options/keymap/Bundle.properties" key="SpecialkeyPanel.mouseButton4.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JButton" name="mouseButton5">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/options/keymap/Bundle.properties" key="SpecialkeyPanel.mouseButton5.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JButton" name="mouseButton6">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/options/keymap/Bundle.properties" key="SpecialkeyPanel.mouseButton6.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JButton" name="mouseButton7">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/options/keymap/Bundle.properties" key="SpecialkeyPanel.mouseButton7.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JButton" name="mouseButton8">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/options/keymap/Bundle.properties" key="SpecialkeyPanel.mouseButton8.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JButton" name="mouseButton9">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/options/keymap/Bundle.properties" key="SpecialkeyPanel.mouseButton9.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/SpecialkeyPanel.java
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/SpecialkeyPanel.java
@@ -67,6 +67,12 @@ public class SpecialkeyPanel extends javax.swing.JPanel implements ActionListene
         upButton.addActionListener(this);
         wheelUpButton.addActionListener(this);
         wheelDownButton.addActionListener(this);
+        mouseButton4.addActionListener(this);
+        mouseButton5.addActionListener(this);
+        mouseButton6.addActionListener(this);
+        mouseButton7.addActionListener(this);
+        mouseButton8.addActionListener(this);
+        mouseButton9.addActionListener(this);
     }
 
     /** This method is called from within the constructor to
@@ -87,6 +93,12 @@ public class SpecialkeyPanel extends javax.swing.JPanel implements ActionListene
         rightButton = new javax.swing.JButton();
         wheelUpButton = new javax.swing.JButton();
         wheelDownButton = new javax.swing.JButton();
+        mouseButton4 = new javax.swing.JButton();
+        mouseButton5 = new javax.swing.JButton();
+        mouseButton6 = new javax.swing.JButton();
+        mouseButton7 = new javax.swing.JButton();
+        mouseButton8 = new javax.swing.JButton();
+        mouseButton9 = new javax.swing.JButton();
 
         setBorder(javax.swing.BorderFactory.createEtchedBorder());
 
@@ -115,6 +127,18 @@ public class SpecialkeyPanel extends javax.swing.JPanel implements ActionListene
 
         wheelDownButton.setText(org.openide.util.NbBundle.getMessage(SpecialkeyPanel.class, "SpecialkeyPanel.wheelDownButton.text_1")); // NOI18N
 
+        mouseButton4.setText(org.openide.util.NbBundle.getMessage(SpecialkeyPanel.class, "SpecialkeyPanel.mouseButton4.text")); // NOI18N
+
+        mouseButton5.setText(org.openide.util.NbBundle.getMessage(SpecialkeyPanel.class, "SpecialkeyPanel.mouseButton5.text")); // NOI18N
+
+        mouseButton6.setText(org.openide.util.NbBundle.getMessage(SpecialkeyPanel.class, "SpecialkeyPanel.mouseButton6.text")); // NOI18N
+
+        mouseButton7.setText(org.openide.util.NbBundle.getMessage(SpecialkeyPanel.class, "SpecialkeyPanel.mouseButton7.text")); // NOI18N
+
+        mouseButton8.setText(org.openide.util.NbBundle.getMessage(SpecialkeyPanel.class, "SpecialkeyPanel.mouseButton8.text")); // NOI18N
+
+        mouseButton9.setText(org.openide.util.NbBundle.getMessage(SpecialkeyPanel.class, "SpecialkeyPanel.mouseButton9.text")); // NOI18N
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -132,16 +156,27 @@ public class SpecialkeyPanel extends javax.swing.JPanel implements ActionListene
                             .addComponent(downButton, javax.swing.GroupLayout.PREFERRED_SIZE, 50, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(upButton, javax.swing.GroupLayout.PREFERRED_SIZE, 50, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addGroup(layout.createSequentialGroup()
                                 .addComponent(rightButton, javax.swing.GroupLayout.PREFERRED_SIZE, 53, javax.swing.GroupLayout.PREFERRED_SIZE)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(wheelDownButton))
+                                .addComponent(wheelDownButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                             .addGroup(layout.createSequentialGroup()
                                 .addComponent(enterButton, javax.swing.GroupLayout.PREFERRED_SIZE, 53, javax.swing.GroupLayout.PREFERRED_SIZE)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(wheelUpButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
-                        .addGap(0, 0, Short.MAX_VALUE)))
+                                .addComponent(wheelUpButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(mouseButton4, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(mouseButton5, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(mouseButton6, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(mouseButton7, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(mouseButton8, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(mouseButton9, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
                 .addContainerGap())
         );
 
@@ -159,11 +194,23 @@ public class SpecialkeyPanel extends javax.swing.JPanel implements ActionListene
                     .addComponent(escButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(wheelUpButton, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(rightButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(downButton, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(leftButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(wheelDownButton, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(mouseButton4, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                            .addComponent(mouseButton7, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(mouseButton8, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(mouseButton9, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                    .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                        .addComponent(mouseButton6, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addComponent(mouseButton5, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
@@ -177,6 +224,12 @@ public class SpecialkeyPanel extends javax.swing.JPanel implements ActionListene
     private javax.swing.JButton enterButton;
     private javax.swing.JButton escButton;
     private javax.swing.JButton leftButton;
+    private javax.swing.JButton mouseButton4;
+    private javax.swing.JButton mouseButton5;
+    private javax.swing.JButton mouseButton6;
+    private javax.swing.JButton mouseButton7;
+    private javax.swing.JButton mouseButton8;
+    private javax.swing.JButton mouseButton9;
     private javax.swing.JButton rightButton;
     private javax.swing.JButton tabButton;
     private javax.swing.JButton upButton;
@@ -207,6 +260,18 @@ public class SpecialkeyPanel extends javax.swing.JPanel implements ActionListene
                 text = "MOUSE_WHEEL_UP"; // NOI18N
             } else if (source == wheelDownButton) {
                 text = "MOUSE_WHEEL_DOWN"; // NOI18N
+            } else if (source == mouseButton4) {
+                text = "MOUSE_BUTTON4"; // NOI18N
+            } else if (source == mouseButton5) {
+                text = "MOUSE_BUTTON5"; // NOI18N
+            } else if (source == mouseButton6) {
+                text = "MOUSE_BUTTON6"; // NOI18N
+            } else if (source == mouseButton7) {
+                text = "MOUSE_BUTTON7"; // NOI18N
+            } else if (source == mouseButton8) {
+                text = "MOUSE_BUTTON8"; // NOI18N
+            } else if (source == mouseButton9) {
+                text = "MOUSE_BUTTON9"; // NOI18N
             } else {
                 text = ((JButton) source).getText().toUpperCase().replace(" ", "_"); // NOI18N
             }


### PR DESCRIPTION
This PR adds support for binding the back and forward buttons on a mouse to the back and forward code navigation actions, as requested in #5728 (and https://bz.apache.org/netbeans/show_bug.cgi?id=70961 )

This PR also allows binding extended mouse buttons, with or without modifiers, to any action in the keymap editor.

Both mouse buttons 4 and 6 are bound to back, and 5 and 7 to forwards, due to platform differences.  Triggering a dev build so we can get some testing.

Yes, treating mouse buttons as keycodes might seem slightly odd, but as we're already doing that for the mouse wheel editor zoom actions, which seems even odder ...

EDIT : screenshot of the updated special key panel, accessible from the dropdown when editing shortcuts 

![Screenshot from 2023-09-12 09-11-18](https://github.com/apache/netbeans/assets/3975960/5b15cdcf-c749-487a-a31c-2ce4a0334641)
