### PR TITLE
Workaround: Avoid reporting BOMs among dependencies to prevent dependency graphs explosion

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -81,6 +81,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
@@ -1337,6 +1338,12 @@ class NbProjectInfoBuilder {
         }
         
         public void walkResolutionResult(ResolvedDependencyResult node, Set<String> stack) {
+            String c = node.getResolvedVariant().getAttributes().getAttribute(Attribute.of("org.gradle.category", String.class)); 
+            if (c != null && (Category.REGULAR_PLATFORM.equals(c) || Category.ENFORCED_PLATFORM.equals(c))) {
+                // TEMPORARY FIX: do not walk children of BOMs, as they are not real dependencies, just version constraints.
+                // better project dependency API needed to handle this.
+                return;
+            }
             depth++;
             ResolvedComponentResult rcr = node.getSelected();
             String id = findNodeIdentifier(rcr.getId());

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/GradleBaseProjectTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/GradleBaseProjectTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import static junit.framework.TestCase.assertNotNull;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProjectConnection;
+import org.junit.Assume;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ui.OpenProjects;
@@ -248,21 +249,29 @@ public class GradleBaseProjectTest extends AbstractGradleProjectTestCase {
     }
     
     public void testOldGradle611ProjectLoads() throws Exception {
+        String s = System.getProperty("java.specification.version");
+        Assume.assumeTrue(s.startsWith("1.") || Integer.parseInt(s) < 17);
         Project p = makeProjectWithWrapper("projects/oldgradle/basic", "6.1.1");
         assertProjectLoadedWithNoProblems(p, "6.1.1");
     }
 
     public void testOldGradle683ProjectLoads() throws Exception {
+        String s = System.getProperty("java.specification.version");
+        Assume.assumeTrue(s.startsWith("1.") || Integer.parseInt(s) < 17);
         Project p = makeProjectWithWrapper("projects/oldgradle/basic", "6.8.3");
         assertProjectLoadedWithNoProblems(p, "6.8.3");
     }
 
     public void testOldGradle700ProjectLoads() throws Exception {
+        String s = System.getProperty("java.specification.version");
+        Assume.assumeTrue(s.startsWith("1.") || Integer.parseInt(s) < 17);
         Project p = makeProjectWithWrapper("projects/oldgradle/basic", "7.0");
         assertProjectLoadedWithNoProblems(p, "7.0");
     }
 
     public void testOldGradle710ProjectLoads() throws Exception {
+        String s = System.getProperty("java.specification.version");
+        Assume.assumeTrue(s.startsWith("1.") || Integer.parseInt(s) < 17);
         Project p = makeProjectWithWrapper("projects/oldgradle/basic", "7.1");
         assertProjectLoadedWithNoProblems(p, "7.1");
     }


### PR DESCRIPTION
Gradle NB tooling now reports BOMs as regular dependencies and its contents as dependencies. This causes dependency graph explosion as BOMs are used in many intermediate dependencies and the project API explodes the tree eagerly. 

For proper function, a change in Dependency API is probably needed, so the client is able to identify BOMs (some flag on output), or exclude them entirely (some additional filter at input) - and to allow lazy creation of dependency tree levels, so that client can avoid the explosion which now happens in project dependency core impl. 

For now, it is more safe not to return children of BOMs; it will not affect normal dependencies as BOMs just help to select version of a library.