### PR TITLE
Fixes "error starting modern compiler" issue on JDK 21.

### DIFF
--- a/nbbuild/jms-config/tools.flags
+++ b/nbbuild/jms-config/tools.flags
@@ -3,4 +3,5 @@
 --add-exports=jdk.jdeps/com.sun.tools.classfile=ALL-UNNAMED
 --add-exports=jdk.jdeps/com.sun.tools.javap=ALL-UNNAMED
 --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
+--add-exports=jdk.internal.opt/jdk.internal.opt=ALL-UNNAMED
 --add-exports=java.management/sun.management=ALL-UNNAMED


### PR DESCRIPTION
When NB is run on JDK 21, building/running NB modules fails with:

```
Error starting modern compiler
	at org.apache.tools.ant.taskdefs.compilers.Javac13.execute(Javac13.java:64)
	at org.apache.tools.ant.taskdefs.Javac.compile(Javac.java:1388)
	at org.netbeans.nbbuild.CustomJavac.compile(CustomJavac.java:131)
...
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:118)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.apache.tools.ant.taskdefs.compilers.Javac13.execute(Javac13.java:57)
	... 21 more
Caused by: java.lang.IllegalAccessError: class com.sun.tools.javac.main.Main (in unnamed module @0x50ba363b) cannot access class jdk.internal.opt.CommandLine$UnmatchedQuote (in module jdk.internal.opt) because module jdk.internal.opt does not export jdk.internal.opt to unnamed module @0x50ba363b
	at com.sun.tools.javac.main.Main.compile(Main.java:224)
...
BUILD FAILED (total time: 0 seconds)
```
(set ant log level to debug for stack trace)

adding `jdk.internal.opt` to the java module flags list fixes this.

For NB 19, simply add `-J--add-exports=jdk.internal.opt/jdk.internal.opt=ALL-UNNAMED` to the JVM options.