### PR TITLE
Avoid double quoting extra path

### DIFF
--- a/java/java.lsp.server/vscode/src/nbcode.ts
+++ b/java/java.lsp.server/vscode/src/nbcode.ts
@@ -69,7 +69,7 @@ export function launch(
     if (info.verbose) {
         ideArgs.push('-J-Dnetbeans.logger.console=true');
     }
-    ideArgs.push(`-J-Dnetbeans.extra.dirs="${clusterPath}"`)
+    ideArgs.push(`-J-Dnetbeans.extra.dirs=${clusterPath}`)
     if (env['netbeans.extra.options']) {
         ideArgs.push(env['netbeans.extra.options']);
     }
@@ -78,6 +78,8 @@ export function launch(
     if (env['netbeans_debug'] && extraArgs && extraArgs.find(s => s.includes("--list"))) {
         ideArgs.push(...['-J-Xdebug', '-J-Dnetbeans.logger.console=true', '-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000']);
     }
+
+    console.log(`Launching NBLS with arguments: ` + ideArgs);
 
     let process: ChildProcessByStdio<any, Readable, Readable> = spawn(nbcodePath, ideArgs, {
         cwd : userDir,


### PR DESCRIPTION
When the extension resides in a directory with path in space, NBLS does not start properly. It does in a basic configuration, but when another extension contributes an additional module, the passed parameter, `-J-Dnetbeans.extra.dirs=` will not be passed properly.

During testing, the arguments passed to the `nbcode` launcher are (logged from `nbcode.ts`)
```
[Extension Host] Launching NBLS with arguments: --userdir,/space/tmp/test mezera 8/user/User/workspaceStorage/bb81367d8526610b14dd61e6f4fb379f/asf.apache-netbeans-java/userdir,--jdkhome,/space/java/current,-J-Dnetbeans.extra.dirs="/space/tmp/test mezera 8/ext/oracle-labs-graalvm.micronaut-tools-0.6.0-208/nbcode/graalvmextra",--modules,--list,-J-XX:PerfMaxStringConstLength=10240,--laf,com.formdev.flatlaf.FlatDarkLaf,--direct-disable,org.netbeans.modules.nbcode.integration.java
```

But when the launcher invokes `nbexec`, the arguments are:
```
Using args:   "--jdkhome" "/space/java/current" "-J-Dnetbeans.extra.dirs="/space/tmp/test mezera 8/ext/oracle-labs-graalvm.micronaut-tools-0.6.0-208/nbcode/graalvmextra"" "--modules" "--list" "-J-XX:PerfMaxStringConstLength=10240" "--laf" "com.formdev.flatlaf.FlatDarkLaf" "--direct-disable" "org.netbeans.modules.nbcode.integration.java"
```
Note the double quoting: Entire parameter is enclosed in quotes, then part of the parameter is. After this point, the unquoting will split the parameters in 3 parts.

The fix is simple: as the arguments are passed to system call, rather than some shell thing, parameters do not need to be quoted ... so I've removed the quotes.

Seems to work OK on Windows, too.