### PR TITLE
The ClassLoader used to load annotation processors does not return directories from getResource/getResources methods, while normal ClassLoaders do - fixing.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/Archive.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/Archive.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.java.source.parsing;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Collections;
 import java.util.Set;
 import javax.tools.JavaFileObject;
@@ -66,6 +67,15 @@ public interface Archive {
     public JavaFileObject getFile(final @NonNull String name) throws IOException;
 
     /**
+     * Returns a {@link URI} for a directory of the given name, or null if it does
+     * not exist.
+     *
+     * @param dirName the name of the directory
+     * @return a URI if the given directory is in this archive, {@code null} otherwise.
+     */
+    public URI getDirectory(final @NonNull String dirName) throws IOException;
+
+    /**
      * Checks if the {@link Archive} is represents a multi release archive.
      * @return true if the {@link Archive} is supports multiple releases.
      */
@@ -88,6 +98,11 @@ public interface Archive {
 
         @Override
         public JavaFileObject getFile(String name) throws IOException {
+            return null;
+        }
+
+        @Override
+        public URI getDirectory(String name) throws IOException {
             return null;
         }
 

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CacheFolderArchive.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CacheFolderArchive.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.source.parsing;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Set;
 
 import javax.tools.JavaFileObject;
@@ -60,6 +61,11 @@ class CacheFolderArchive implements Archive, FileChangeListener {
     @Override
     public JavaFileObject getFile(String name) throws IOException {
         return delegate.getFile(name);
+    }
+
+    @Override
+    public URI getDirectory(String dirName) throws IOException {
+        return delegate.getDirectory(dirName);
     }
 
     @Override

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchive.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchive.java
@@ -24,6 +24,8 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,11 +47,13 @@ import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.modules.java.preprocessorbridge.spi.JavaFileFilterImplementation;
+import static org.netbeans.modules.java.source.parsing.FileObjects.getZipPathURI;
 import org.openide.filesystems.FileAttributeEvent;
 import org.openide.filesystems.FileChangeListener;
 import org.openide.filesystems.FileEvent;
 import org.openide.filesystems.FileRenameEvent;
 import org.openide.filesystems.FileUtil;
+import org.openide.util.BaseUtilities;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.Parameters;
@@ -197,6 +201,18 @@ public class CachingArchive implements Archive, FileChangeListener {
             }
             return null;
         }
+    }
+
+    @Override
+    public URI getDirectory(String dirName) throws IOException {
+        Map<String, Folder> folders = doInit();
+
+        if (folders.containsKey(dirName)) {
+            URI zipURI = BaseUtilities.toURI(this.archiveFile);
+            return getZipPathURI(zipURI, dirName);
+        }
+
+        return null;
     }
 
     @Override

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchiveClassLoader.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchiveClassLoader.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -177,6 +178,15 @@ public final class CachingArchiveClassLoader extends ClassLoader {
                             usedRoots
                                     .map((c) -> RES_PROCESSORS.equals(name) ? null : c)
                                     .ifPresent((c) -> c.accept(p.first()));
+                        } else {
+                            URI dirURI = archive.getDirectory(name);
+
+                            if (dirURI != null) {
+                                v.add(dirURI.toURL());
+                                usedRoots
+                                        .map((c) -> RES_PROCESSORS.equals(name) ? null : c)
+                                        .ifPresent((c) -> c.accept(p.first()));
+                            }
                         }
                     }
                     return v.elements();

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FileObjectArchive.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FileObjectArchive.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.java.source.parsing;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -116,6 +117,15 @@ public class FileObjectArchive implements Archive {
     public JavaFileObject getFile(String name) throws IOException {
         final FileObject file = root.getFileObject(name);
         return file == null ? null : FileObjects.sourceFileObject(file, root, null, false);
+    }
+
+    @Override
+    public URI getDirectory(String dirName) throws IOException {
+        FileObject dir = root.getFileObject(dirName);
+        if (dir != null && dir.isFolder()) {
+            return dir.toURI();
+        }
+        return null;
     }
 
     @Override

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FileObjects.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FileObjects.java
@@ -949,6 +949,34 @@ public class FileObjects {
         return null;
     }
 
+    public static URI getZipPathURI(URI zipURI, String resourceName) {
+        try {
+            //Optimistic try and see
+            return new URI ("jar:"+zipURI.toString()+"!/"+resourceName); //NOI18N
+        } catch (URISyntaxException e) {
+            //Need to encode the resName part (slower)
+            final StringBuilder sb = new StringBuilder ();
+            final String[] elements = resourceName.split("/");           //NOI18N
+            try {
+                for (int i = 0; i< elements.length; i++) {
+                    String element = elements[i];
+                    element = URLEncoder.encode(element, "UTF-8");       //NOI18N
+                    element = element.replace("+", "%20");               //NOI18N
+                    sb.append(element);
+                    if (i< elements.length - 1) {
+                        sb.append(NBFS_SEPARATOR_CHAR);
+                    }
+                }
+                return new URI("jar:"+zipURI.toString()+"!/"+sb.toString());    //NOI18N
+            } catch (final UnsupportedEncodingException e2) {
+                throw new IllegalStateException(e2);
+            }
+            catch (final URISyntaxException e2) {
+                throw new IllegalStateException(e2);
+            }
+        }
+    }
+
     // <editor-fold defaultstate="collapsed" desc="Private helper methods">
     private static CharSequence getCharContent(InputStream ins, Charset encoding, JavaFileFilterImplementation filter, long expectedLength, boolean ignoreEncodingErrors) throws IOException {
         char[] result;
@@ -1642,31 +1670,8 @@ public class FileObjects {
         @Override
         public final URI toUri () {
             URI  zdirURI = this.getArchiveURI();
-            try {
-                //Optimistic try and see
-                return new URI ("jar:"+zdirURI.toString()+"!/"+resName);  //NOI18N
-            } catch (URISyntaxException e) {
-                //Need to encode the resName part (slower)
-                final StringBuilder sb = new StringBuilder ();
-                final String[] elements = resName.split("/");                 //NOI18N
-                try {
-                    for (int i = 0; i< elements.length; i++) {
-                        String element = elements[i];
-                        element = URLEncoder.encode(element, "UTF-8");       //NOI18N
-                        element = element.replace("+", "%20");               //NOI18N
-                        sb.append(element);
-                        if (i< elements.length - 1) {
-                            sb.append(NBFS_SEPARATOR_CHAR);
-                        }
-                    }
-                    return new URI("jar:"+zdirURI.toString()+"!/"+sb.toString());    //NOI18N
-                } catch (final UnsupportedEncodingException e2) {
-                    throw new IllegalStateException(e2);
-                }
-                catch (final URISyntaxException e2) {
-                    throw new IllegalStateException(e2);
-                }
-            }
+
+            return getZipPathURI(zdirURI, resName);
         }
 
         @Override

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FolderArchive.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FolderArchive.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.java.source.parsing;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -193,6 +194,18 @@ public class FolderArchive implements Archive {
         } catch (URISyntaxException e) {
             Exceptions.printStackTrace(e);
         }
+        return null;
+    }
+
+    @Override
+    public URI getDirectory(String dirName) throws IOException {
+        final String path = dirName.replace('/', File.separatorChar);        //NOI18N
+        File dir = new File (this.root, path);
+
+        if (dir.isDirectory()) {
+            return dir.toURI();
+        }
+
         return null;
     }
 

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/PathArchive.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/PathArchive.java
@@ -85,6 +85,17 @@ public final class PathArchive extends AbstractPathArchive {
     }
 
     @Override
+    public URI getDirectory(String dirName) throws IOException {
+        if (separator != FileObjects.NBFS_SEPARATOR_CHAR) {
+            dirName = dirName.replace(FileObjects.NBFS_SEPARATOR_CHAR, separator);
+        }
+        final Path target = root.resolve(dirName);
+        return Files.isDirectory(target) ?
+                target.toUri() :
+                null;
+    }
+
+    @Override
     public JavaFileObject create(String relativeName, JavaFileFilterImplementation filter) throws UnsupportedOperationException {
         throw new UnsupportedOperationException("Write not supported");   //NOI18N
     }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ProxyArchive.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ProxyArchive.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.java.source.parsing;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,6 +54,17 @@ abstract class ProxyArchive implements Archive {
             final JavaFileObject jfo = delegate.getFile(name);
             if (jfo != null) {
                 return jfo;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public URI getDirectory(String dirName) throws IOException {
+        for (Archive delegate : delegates) {
+            final URI dirURI = delegate.getDirectory(dirName);
+            if (dirURI != null) {
+                return dirURI;
             }
         }
         return null;

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingArchiveClassLoaderTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingArchiveClassLoaderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.source.parsing;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+
+public class CachingArchiveClassLoaderTest extends NbTestCase {
+
+    public CachingArchiveClassLoaderTest(String name) {
+        super(name);
+    }
+
+
+    public void testClassLoaderGetResourcesDir() throws IOException {
+        clearWorkDir();
+
+        File wd = getWorkDir();
+        File dir1 = new File(new File(wd, "dir1"), "a");
+        assertTrue(dir1.mkdirs());
+        File dir2 = new File(new File(wd, "dir2"), "a");
+        assertTrue(dir2.mkdirs());
+        new FileOutputStream(new File(dir2, "test.txt")).close();
+
+        ClassPath cp = ClassPathSupport.createClassPath(wd.getAbsolutePath());
+        ClassLoader loader = CachingArchiveClassLoader.forClassPath(cp, null, null);
+
+        assertEquals(dir1.toURI().toURL(), loader.getResource("dir1/a"));
+        assertEquals(dir2.toURI().toURL(), loader.getResource("dir2/a"));
+
+        Enumeration<URL> resource = loader.getResources("dir1/a");
+        assertTrue(resource.hasMoreElements());
+        assertEquals(dir1.toURI().toURL(), resource.nextElement());
+        assertFalse(resource.hasMoreElements());
+    }
+
+}

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingArchiveTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingArchiveTest.java
@@ -19,8 +19,11 @@
 package org.netbeans.modules.java.source.parsing;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.jar.JarOutputStream;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -45,6 +48,7 @@ public class CachingArchiveTest extends NbTestCase {
         TestSuite suite = new NbTestSuite ();
         suite.addTest(new CachingArchiveTest("testPutName"));
         suite.addTest(new CachingArchiveTest("testJoin"));
+        suite.addTest(new CachingArchiveTest("testGetDirectory"));
         return suite;
     }
 
@@ -130,5 +134,22 @@ public class CachingArchiveTest extends NbTestCase {
                 zf.close();
             }                        
         }
+    }
+
+    public void testGetDirectory() throws Exception {
+        clearWorkDir();
+
+        File archive = new File(getWorkDir(), "rt.jar");
+
+        try (OutputStream binOut = new FileOutputStream(archive);
+             JarOutputStream out = new JarOutputStream(binOut)) {
+            out.putNextEntry(new ZipEntry(("dir1/a/")));
+            out.putNextEntry(new ZipEntry(("dir2/a/test.txt")));
+        }
+
+        Archive a = new CachingArchive(archive, false);
+
+        assertEquals("jar:" + archive.toURI().toString() + "!/dir1/a", a.getDirectory("dir1/a").toString());
+        assertEquals("jar:" + archive.toURI().toString() + "!/dir2/a", a.getDirectory("dir2/a").toString());
     }
 }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingPathArchiveTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingPathArchiveTest.java
@@ -18,6 +18,8 @@
  */
 package org.netbeans.modules.java.source.parsing;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.FileVisitResult;
@@ -39,6 +41,8 @@ import javax.tools.JavaFileObject;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.source.TestUtilities;
 import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
 import org.openide.util.BaseUtilities;
 
 /**
@@ -73,6 +77,19 @@ public final class CachingPathArchiveTest extends NbTestCase {
         } else {
             System.out.println("No JDK 9, nothing to test");
         }
+    }
+
+    public void testGetDirectory() throws IOException {
+        clearWorkDir();
+        File wd = getWorkDir();
+        File dir1 = new File(new File(wd, "dir1"), "a");
+        assertTrue(dir1.mkdirs());
+        File dir2 = new File(new File(wd, "dir2"), "a");
+        assertTrue(dir2.mkdirs());
+        new FileOutputStream(new File(dir2, "test.txt")).close();
+        Archive a = new CachingPathArchive(wd.toPath(), wd.toURI());
+        assertEquals(dir1.toURI(), a.getDirectory("dir1/a"));
+        assertEquals(dir2.toURI(), a.getDirectory("dir2/a"));
     }
 
     private static void verifyURIs(Path module) throws IOException {

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FileObjectArchiveTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FileObjectArchiveTest.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.java.source.parsing;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -28,6 +29,7 @@ import java.util.stream.StreamSupport;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
+import static junit.framework.TestCase.assertTrue;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.junit.NbTestCase;
 import org.openide.filesystems.FileUtil;
@@ -88,6 +90,17 @@ public class FileObjectArchiveTest extends NbTestCase {
                 true);
         //Explicit list of non-package returns FileObejcts with prefix
         assertEquals(Arrays.asList("non-package.org.me.X", "non-package.org.me.Y"), toInferedName(res));    //NOI18N
+    }
+
+    public void testGetDirectory() throws IOException {
+        File dir1 = new File(new File(root, "dir1"), "a");
+        assertTrue(dir1.mkdirs());
+        File dir2 = new File(new File(root, "dir2"), "a");
+        assertTrue(dir2.mkdirs());
+        new FileOutputStream(new File(dir2, "test.txt")).close();
+        final Archive a = new FileObjectArchive(FileUtil.toFileObject(root));
+        assertEquals(dir1.toURI(), a.getDirectory("dir1/a"));
+        assertEquals(dir2.toURI(), a.getDirectory("dir2/a"));
     }
 
     private static List<String> toInferedName(

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PathArchiveTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PathArchiveTest.java
@@ -18,6 +18,8 @@
  */
 package org.netbeans.modules.java.source.parsing;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
@@ -35,6 +37,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.tools.JavaFileObject;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.source.TestUtilities;
 import org.netbeans.junit.NbTestCase;
@@ -59,6 +63,21 @@ public final class PathArchiveTest extends NbTestCase {
         } else {
             System.out.println("No JDK 9, nothing to test");
         }
+    }
+
+    public void testGetDirectory() throws IOException {
+        clearWorkDir();
+
+        File root = getWorkDir();
+        File dir1 = new File(new File(root, "dir1"), "a");
+        assertTrue(dir1.mkdirs());
+        File dir2 = new File(new File(root, "dir2"), "a");
+        assertTrue(dir2.mkdirs());
+        new FileOutputStream(new File(dir2, "test.txt")).close();
+        Path rootPath = root.toPath();
+        final Archive a = new PathArchive(rootPath, rootPath.toUri());
+        assertEquals(dir1.toURI(), a.getDirectory("dir1/a"));
+        assertEquals(dir2.toURI(), a.getDirectory("dir2/a"));
     }
 
     private static void verifyModule(Path module) throws IOException {


### PR DESCRIPTION
Fixes the problem noted in the subject.

---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
