### PR TITLE
Switch CI from JDK 21-ea to 21-ga.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '11', '17', '21-ea' ]
+        java: [ '11', '17', '21' ]
       fail-fast: false
     steps:
         
@@ -120,7 +120,7 @@ jobs:
           restore-keys: ${{ runner.os }}-
 
       - name: Setup Gradle Daemon to run on JDK 11
-        if: ${{ matrix.java == '21-ea' }}
+        if: ${{ matrix.java == '21' }}
         run: |
           mkdir -p ~/.gradle
           #uses a preinstalled JDK 11 from the runner
@@ -192,7 +192,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '11', '17', '21-ea' ]
+        java: [ '11', '17', '21' ]
       fail-fast: false
     steps:
 
@@ -1771,7 +1771,7 @@ jobs:
   macos:
     name: Tests on MacOS/JDK ${{ matrix.java }}
     needs: base-build
-    runs-on: macos-11
+    runs-on: macos-latest
     timeout-minutes: 90
     strategy:
       matrix:


### PR DESCRIPTION
java-setup action doesn't work anymore since JDK 21 has just been released and it is trying to download an ea release -> lets switch to the ga release.

going to merge as soon its green.