### PR TITLE
JakartaEE: Fix more cases where jakarta namespace has to be supported

### DIFF
--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/annotation/CommonAnnotationHelper.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/annotation/CommonAnnotationHelper.java
@@ -62,11 +62,16 @@ public class CommonAnnotationHelper {
     // see JSR250
     private static final Set<String> RESOURCE_REF_TYPES = new HashSet<String>(Arrays.<String>asList(
             "javax.sql.DataSource",
+            "jakarta.jms.ConnectionFactory",
             "javax.jms.ConnectionFactory",
+            "jakarta.jms.QueueConnectionFactory",
             "javax.jms.QueueConnectionFactory",
+            "jakarta.jms.TopicConnectionFactory",
             "javax.jms.TopicConnectionFactory",
+            "jakarta.mail.Session",
             "javax.mail.Session",
             "java.net.URL",
+            "jakarta.resource.cci.ConnectionFactory",
             "javax.resource.cci.ConnectionFactory",
             "org.omg.CORBA_2_3.ORB"
             // any other connection factory defined by a resource adapter
@@ -82,12 +87,19 @@ public class CommonAnnotationHelper {
             "java.lang.Long",
             "java.lang.Float"));
     private static final Set<String> SERVICE_REF_TYPES = new HashSet<String>(Arrays.<String>asList(
+            "jakarta.xml.rpc.Service",
+            "jakarta.xml.ws.Service",
+            "jakarta.jws.WebService",
             "javax.xml.rpc.Service",
             "javax.xml.ws.Service",
-            "javax.jws.WebService"));
+            "javax.jws.WebService"
+    ));
     private static final Set<String> MESSAGE_DESTINATION_TYPES = new HashSet<String>(Arrays.<String>asList(
+            "jakarta.jms.Queue",
+            "jakarta.jms.Topic",
             "javax.jms.Queue",
-            "javax.jms.Topic"));
+            "javax.jms.Topic"
+    ));
 
     private CommonAnnotationHelper() {
     }
@@ -105,6 +117,11 @@ public class CommonAnnotationHelper {
             }
         }, null);
         try {
+            helper.getAnnotationScanner().findAnnotations("jakarta.annotation.security.DeclareRoles", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
+                public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
+                    parser.parse(annotation);
+                }
+            });
             helper.getAnnotationScanner().findAnnotations("javax.annotation.security.DeclareRoles", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
                 public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
                     parser.parse(annotation);
@@ -280,7 +297,10 @@ public class CommonAnnotationHelper {
         }
 
         Map<String, ? extends AnnotationMirror> ans = helper.getAnnotationsByType(typeElement.getAnnotationMirrors());
-        AnnotationMirror wsMirror = ans.get("javax.jws.WebService"); //NOI18N
+        AnnotationMirror wsMirror = ans.get("jakarta.jws.WebService"); //NOI18N
+        if (wsMirror == null) {
+            wsMirror = ans.get("javax.jws.WebService"); //NOI18N
+        }
         if (wsMirror != null) {
             for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : wsMirror.getElementValues().entrySet()) {
                 ExecutableElement key = entry.getKey();
@@ -302,14 +322,18 @@ public class CommonAnnotationHelper {
         
         // fields
         for (VariableElement field : ElementFilter.fieldsIn(typeElement.getEnclosedElements())) {
-            if (helper.hasAnnotation(field.getAnnotationMirrors(), "javax.annotation.Resource")) { //NOI18N
+            if (helper.hasAnnotation(field.getAnnotationMirrors(), "jakarta.annotation.Resource") //NOI18N
+                    || helper.hasAnnotation(field.getAnnotationMirrors(), "javax.annotation.Resource") //NOI18N
+            ) {
                 ResourceImpl resource = new ResourceImpl(field, typeElement, helper);
                 result.add(resource);
             }
         }
         // methods
         for (ExecutableElement method : ElementFilter.methodsIn(typeElement.getEnclosedElements())) {
-            if (helper.hasAnnotation(method.getAnnotationMirrors(), "javax.annotation.Resource")) { //NOI18N
+            if (helper.hasAnnotation(method.getAnnotationMirrors(), "jakarta.annotation.Resource") //NOI18N
+                    || helper.hasAnnotation(method.getAnnotationMirrors(), "javax.annotation.Resource") //NOI18N
+            ) {
                 ResourceImpl resource = new ResourceImpl(method, typeElement, helper);
                 result.add(resource);
             }
@@ -321,6 +345,14 @@ public class CommonAnnotationHelper {
         
         final List<ResourceImpl> result = new ArrayList<ResourceImpl>();
         try {
+            helper.getAnnotationScanner().findAnnotations(
+                    "jakarta.annotation.Resource", // NOI18N
+                    EnumSet.of(ElementKind.CLASS, ElementKind.METHOD, ElementKind.FIELD),new AnnotationHandler() {
+                        public void handleAnnotation(TypeElement typeElement, Element element, AnnotationMirror annotation) {
+                            ResourceImpl resource = new ResourceImpl(element, typeElement, helper);
+                            result.add(resource);
+                        }
+                    });
             helper.getAnnotationScanner().findAnnotations(
                     "javax.annotation.Resource", // NOI18N
                     EnumSet.of(ElementKind.CLASS, ElementKind.METHOD, ElementKind.FIELD),new AnnotationHandler() {
@@ -341,7 +373,9 @@ public class CommonAnnotationHelper {
         
         // fields
         for (VariableElement field : ElementFilter.fieldsIn(typeElement.getEnclosedElements())) {
-            if (helper.hasAnnotation(field.getAnnotationMirrors(), "javax.xml.ws.WebServiceRef")) { //NOI18N
+            if (helper.hasAnnotation(field.getAnnotationMirrors(), "jakarta.xml.ws.WebServiceRef") //NOI18N
+                    || helper.hasAnnotation(field.getAnnotationMirrors(), "javax.xml.ws.WebServiceRef") //NOI18N
+            ) { //NOI18N
                 addServiceReference(result, field, typeElement, helper);
             }
         }
@@ -352,6 +386,13 @@ public class CommonAnnotationHelper {
         
         final List<ServiceRef> result = new ArrayList<ServiceRef>();
         try {
+            helper.getAnnotationScanner().findAnnotations(
+                    "jakarta.xml.ws.WebServiceRef", // NOI18N
+                    EnumSet.of(ElementKind.FIELD),new AnnotationHandler() {
+                        public void handleAnnotation(TypeElement typeElement, Element element, AnnotationMirror annotation) {
+                            addServiceReference(result, element, typeElement, helper);
+                        }
+                    });
             helper.getAnnotationScanner().findAnnotations(
                     "javax.xml.ws.WebServiceRef", // NOI18N
                     EnumSet.of(ElementKind.FIELD),new AnnotationHandler() {

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/annotation/ServiceRefImpl.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/annotation/ServiceRefImpl.java
@@ -67,7 +67,11 @@ public class ServiceRefImpl implements ServiceRef {
         parser.expectString("wsdlLocation",null);
         parser.expectClass("value",null);
         parser.expectClass("type",null);
-        ParseResult parseResult = parser.parse(annByType.get("javax.xml.ws.WebServiceRef")); //NOI18N
+        AnnotationMirror annotationMirror = annByType.get("jakarta.xml.ws.WebServiceRef"); //NOI18N
+        if (annotationMirror == null) {
+            annotationMirror = annByType.get("javax.xml.ws.WebServiceRef"); //NOI18N
+        }
+        ParseResult parseResult = parser.parse(annotationMirror);
         serviceRefName = parseResult.get("name", String.class); // NOI18N
         wsdlFile = parseResult.get("wsdlLocation", String.class); // NOI18N
         value = parseResult.get("value", String.class); // NOI18N

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/annotation/EnterpriseBeansImpl.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/annotation/EnterpriseBeansImpl.java
@@ -44,7 +44,6 @@ import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.Annotatio
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.ObjectProvider;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.PersistentObjectManager;
 
-// @todo: Support JakartaEE
 public class EnterpriseBeansImpl implements EnterpriseBeans {
 
     private final AnnotationModelHelper helper;
@@ -121,6 +120,21 @@ public class EnterpriseBeansImpl implements EnterpriseBeans {
 
         public List<SessionImpl> createInitialObjects() throws InterruptedException {
             final List<SessionImpl> result = new ArrayList<SessionImpl>();
+            helper.getAnnotationScanner().findAnnotations("jakarta.ejb.Stateless", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
+                public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
+                    result.add(new SessionImpl(SessionImpl.Kind.STATELESS, helper, type));
+                }
+            });
+            helper.getAnnotationScanner().findAnnotations("jakarta.ejb.Stateful", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
+                public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
+                    result.add(new SessionImpl(SessionImpl.Kind.STATEFUL, helper, type));
+                }
+            });
+            helper.getAnnotationScanner().findAnnotations("jakarta.ejb.Singleton", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
+                public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
+                    result.add(new SessionImpl(SessionImpl.Kind.SINGLETON, helper, type));
+                }
+            });
             helper.getAnnotationScanner().findAnnotations("javax.ejb.Stateless", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
                 public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
                     result.add(new SessionImpl(SessionImpl.Kind.STATELESS, helper, type));
@@ -141,6 +155,15 @@ public class EnterpriseBeansImpl implements EnterpriseBeans {
 
         public List<SessionImpl> createObjects(TypeElement type) {
             final List<SessionImpl> result = new ArrayList<SessionImpl>();
+            if (helper.hasAnnotation(type.getAnnotationMirrors(), "jakarta.ejb.Stateless")) { // NOI18N
+                result.add(new SessionImpl(SessionImpl.Kind.STATELESS, helper, type));
+            }
+            if (helper.hasAnnotation(type.getAnnotationMirrors(), "jakarta.ejb.Stateful")) { // NOI18N
+                result.add(new SessionImpl(SessionImpl.Kind.STATEFUL, helper, type));
+            }
+            if (helper.hasAnnotation(type.getAnnotationMirrors(), "jakarta.ejb.Singleton")) { // NOI18N
+                result.add(new SessionImpl(SessionImpl.Kind.SINGLETON, helper, type));
+            }
             if (helper.hasAnnotation(type.getAnnotationMirrors(), "javax.ejb.Stateless")) { // NOI18N
                 result.add(new SessionImpl(SessionImpl.Kind.STATELESS, helper, type));
             }
@@ -171,6 +194,11 @@ public class EnterpriseBeansImpl implements EnterpriseBeans {
 
         public List<MessageDrivenImpl> createInitialObjects() throws InterruptedException {
             final List<MessageDrivenImpl> result = new ArrayList<MessageDrivenImpl>();
+            helper.getAnnotationScanner().findAnnotations("jakarta.ejb.MessageDriven", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
+                public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
+                    result.add(new MessageDrivenImpl(helper, type));
+                }
+            });
             helper.getAnnotationScanner().findAnnotations("javax.ejb.MessageDriven", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
                 public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
                     result.add(new MessageDrivenImpl(helper, type));
@@ -181,6 +209,9 @@ public class EnterpriseBeansImpl implements EnterpriseBeans {
 
         public List<MessageDrivenImpl> createObjects(TypeElement type) {
             final List<MessageDrivenImpl> result = new ArrayList<MessageDrivenImpl>();
+            if (helper.hasAnnotation(type.getAnnotationMirrors(), "jakarta.ejb.MessageDriven")) { // NOI18N
+                result.add(new MessageDrivenImpl(helper, type));
+            }
             if (helper.hasAnnotation(type.getAnnotationMirrors(), "javax.ejb.MessageDriven")) { // NOI18N
                 result.add(new MessageDrivenImpl(helper, type));
             }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/annotation/MessageDrivenImpl.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/annotation/MessageDrivenImpl.java
@@ -82,7 +82,12 @@ public class MessageDrivenImpl extends PersistentObject implements MessageDriven
     
     boolean refresh(TypeElement typeElement) {
         Map<String, ? extends AnnotationMirror> annByType = getHelper().getAnnotationsByType(typeElement.getAnnotationMirrors());
-        AnnotationMirror annotationMirror = annByType.get("javax.ejb.MessageDriven"); // NOI18N
+        AnnotationMirror annotationMirror = annByType.get("jakarta.ejb.MessageDriven"); // NOI18N
+        String activationConfigClass = "jakarta.ejb.ActivationConfigProperty";
+        if (annotationMirror == null) {
+            annotationMirror = annByType.get("javax.ejb.MessageDriven"); // NOI18N
+            activationConfigClass = "javax.ejb.ActivationConfigProperty";
+        }
         if (annotationMirror == null) {
             return false;
         }
@@ -92,7 +97,7 @@ public class MessageDrivenImpl extends PersistentObject implements MessageDriven
         parser.expectString("mappedName", null); // NOI18N
 
         activationConfig = new ActivationConfigImpl();
-        TypeMirror acpType = getHelper().resolveType("javax.ejb.ActivationConfigProperty");
+        TypeMirror acpType = getHelper().resolveType(activationConfigClass);
         ActivationConfigPropertyHandler handler = new ActivationConfigPropertyHandler(getHelper(), activationConfig);
         if (acpType != null) {
             parser.expectAnnotationArray("activationConfig", acpType, handler, null); //NOI18N

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/annotation/SessionImpl.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/annotation/SessionImpl.java
@@ -108,15 +108,24 @@ public class SessionImpl extends PersistentObject implements Session {
         AnnotationMirror annotationMirror = null;
         switch(kind){
             case STATELESS:
-                annotationMirror = annByType.get("javax.ejb.Stateless"); //NOI18N
+                annotationMirror = annByType.get("jakarta.ejb.Stateless"); //NOI18N
+                if (annotationMirror == null) {
+                    annotationMirror = annByType.get("javax.ejb.Stateless"); //NOI18N
+                }
                 sessionType = Session.SESSION_TYPE_STATELESS;
                 break;
             case STATEFUL:
-                annotationMirror = annByType.get("javax.ejb.Stateful"); //NOI18N
+                annotationMirror = annByType.get("jakarta.ejb.Stateful"); //NOI18N
+                if (annotationMirror == null) {
+                    annotationMirror = annByType.get("javax.ejb.Stateful"); //NOI18N
+                }
                 sessionType = Session.SESSION_TYPE_STATEFUL;
                 break;
             case SINGLETON: 
-                annotationMirror = annByType.get("javax.ejb.Singleton"); //NOI18N
+                annotationMirror = annByType.get("jakarta.ejb.Singleton"); //NOI18N
+                if (annotationMirror == null) {
+                    annotationMirror = annByType.get("javax.ejb.Singleton"); //NOI18N
+                }
                 sessionType = Session.SESSION_TYPE_SINGLETON;
                 break;
         }
@@ -136,7 +145,7 @@ public class SessionImpl extends PersistentObject implements Session {
 
         initBusinessInterfaces();
 
-        localBean = annByType.get("javax.ejb.LocalBean") != null;
+        localBean = annByType.get("jakarta.ejb.LocalBean") != null || annByType.get("javax.ejb.LocalBean") != null;
 
         return true;
     }
@@ -201,7 +210,7 @@ public class SessionImpl extends PersistentObject implements Session {
                     TypeElement interfaceTypeElement = (TypeElement) element;
                     String fqn = interfaceTypeElement.getQualifiedName().toString();
                     interfacesSet.add(fqn);
-                    if (!"java.io.Serializable".equals(fqn) && !"java.io.Externalizable".equals(fqn) && !fqn.startsWith("javax.ejb")) {
+                    if (!"java.io.Serializable".equals(fqn) && !"java.io.Externalizable".equals(fqn) && !fqn.startsWith("javax.ejb") && !fqn.startsWith("jakarta.ejb")) {
                         interfaces.add(interfaceTypeElement);
                     }
                 }
@@ -210,9 +219,15 @@ public class SessionImpl extends PersistentObject implements Session {
         
         Map<String, ? extends AnnotationMirror> annByType = getHelper().getAnnotationsByType(typeElement.getAnnotationMirrors());
 
-        AnnotationMirror beanLocalAnnotation = annByType.get("javax.ejb.Local"); // @Local at bean class
+        AnnotationMirror beanLocalAnnotation = annByType.get("jakarta.ejb.Local"); // @Local at bean class
+        if (beanLocalAnnotation == null) {
+            beanLocalAnnotation = annByType.get("javax.ejb.Local"); // @Local at bean class
+        }
         boolean isEmptyBeanLocalAnnotation = beanLocalAnnotation != null && beanLocalAnnotation.getElementValues().isEmpty();
-        AnnotationMirror beanRemoteAnnotation = annByType.get("javax.ejb.Remote"); // @Remote at beans class
+        AnnotationMirror beanRemoteAnnotation = annByType.get("jakarta.ejb.Remote"); // @Remote at beans class
+        if (beanRemoteAnnotation == null) {
+            beanRemoteAnnotation = annByType.get("javax.ejb.Remote"); // @Remote at beans class
+        }
         boolean isEmptyBeanRemoteAnnotation = beanRemoteAnnotation != null && beanRemoteAnnotation.getElementValues().isEmpty();
         
         List<String> annotatedLocalInterfaces = new ArrayList<String>();
@@ -221,16 +236,16 @@ public class SessionImpl extends PersistentObject implements Session {
         
         for (TypeElement interfaceTypeElement : interfaces) {
             Map<String, ? extends AnnotationMirror> ifaceAnnByType = getHelper().getAnnotationsByType(interfaceTypeElement.getAnnotationMirrors());
-            if (ifaceAnnByType.get("javax.ejb.Local") != null) {
+            if (ifaceAnnByType.get("jakarta.ejb.Local") != null || ifaceAnnByType.get("javax.ejb.Local") != null) {
                 annotatedLocalInterfaces.add(interfaceTypeElement.getQualifiedName().toString());
             }
-            if (ifaceAnnByType.get("javax.ejb.Remote") != null) {
+            if (ifaceAnnByType.get("jakarta.ejb.Remote") != null || ifaceAnnByType.get("javax.ejb.Remote") != null) {
                 annotatedRemoteInterfaces.add(interfaceTypeElement.getQualifiedName().toString());
             }
             allInterfaces.add(interfaceTypeElement.getQualifiedName().toString());
         }
 
-        boolean isNoIfaceView = annByType.get("javax.ejb.LocalBean") != null; //NOI18N
+        boolean isNoIfaceView = annByType.get("javax.ejb.LocalBean") != null || annByType.get("jakarta.ejb.LocalBean") != null; //NOI18N
                                      // any interface is explicitly specified
         boolean isAnyIfaceExplicit = !annotatedRemoteInterfaces.isEmpty() || !annotatedLocalInterfaces.isEmpty()
                 // annotated class with non-empty value

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/annotation/SecurityRoles.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/annotation/SecurityRoles.java
@@ -46,7 +46,10 @@ public class SecurityRoles extends PersistentObject implements Refreshable {
 
     public boolean refresh(TypeElement typeElement) {
         Map<String, ? extends AnnotationMirror> annByType = getHelper().getAnnotationsByType(typeElement.getAnnotationMirrors());
-        AnnotationMirror annotationMirror = annByType.get("javax.annotation.security.DeclareRoles"); // NOI18N
+        AnnotationMirror annotationMirror = annByType.get("jakarta.annotation.security.DeclareRoles"); // NOI18N
+        if(annotationMirror == null) {
+            annotationMirror = annByType.get("javax.annotation.security.DeclareRoles"); // NOI18N
+        }
         if (annotationMirror == null) {
             return false;
         }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/annotation/WebFilter.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/annotation/WebFilter.java
@@ -48,7 +48,10 @@ public class WebFilter extends PersistentObject implements Refreshable {
 
     public boolean refresh(TypeElement typeElement) {
         Map<String, ? extends AnnotationMirror> annByType = getHelper().getAnnotationsByType(typeElement.getAnnotationMirrors());
-        AnnotationMirror annotationMirror = annByType.get("javax.servlet.annotation.WebFilter"); // NOI18N
+        AnnotationMirror annotationMirror = annByType.get("jakarta.servlet.annotation.WebFilter"); // NOI18N
+        if(annotationMirror == null) {
+            annotationMirror = annByType.get("javax.servlet.annotation.WebFilter"); // NOI18N
+        }
         if (annotationMirror == null) {
             return false;
         }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/annotation/WebServlet.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/annotation/WebServlet.java
@@ -48,7 +48,10 @@ public class WebServlet extends PersistentObject implements Refreshable {
 
     public boolean refresh(TypeElement typeElement) {
         Map<String, ? extends AnnotationMirror> annByType = getHelper().getAnnotationsByType(typeElement.getAnnotationMirrors());
-        AnnotationMirror annotationMirror = annByType.get("javax.servlet.annotation.WebServlet"); // NOI18N
+        AnnotationMirror annotationMirror = annByType.get("jakarta.servlet.annotation.WebServlet"); // NOI18N
+        if(annotationMirror == null) {
+            annotationMirror = annByType.get("javax.servlet.annotation.WebServlet"); // NOI18N
+        }
         if (annotationMirror == null) {
             return false;
         }

--- a/enterprise/j2ee.dd/test/unit/src/org/netbeans/modules/j2ee/dd/impl/common/annotation/CommonAnnotationHelperTest.java
+++ b/enterprise/j2ee.dd/test/unit/src/org/netbeans/modules/j2ee/dd/impl/common/annotation/CommonAnnotationHelperTest.java
@@ -326,14 +326,14 @@ public class CommonAnnotationHelperTest extends CommonTestCase {
                 "import javax.annotation.Resource;" +
                 "import javax.sql.DataSource;" +
                 "" +
-                "@Resource(name=\"yourClass\", type=javax.transaction.UserTransaction)" +
+                "@Resource(name=\"yourClass\", type=javax.transaction.UserTransaction.class)" +
                 "public class YourClass {" +
                 "   @Resource" +
                 "   private void setYourDataSource(DataSource ds) {" +
                 "   }" +
                 "" +
                 "   @Resource" +
-                "   private void setYourLong(Long long) {" +
+                "   private void setYourLong(Long value) {" +
                 "   }" +
                 "" +
                 "   @Resource" +

--- a/enterprise/j2ee.dd/test/unit/src/org/netbeans/modules/j2ee/dd/impl/ejb/annotation/SessionImplTest.java
+++ b/enterprise/j2ee.dd/test/unit/src/org/netbeans/modules/j2ee/dd/impl/ejb/annotation/SessionImplTest.java
@@ -21,7 +21,9 @@ package org.netbeans.modules.j2ee.dd.impl.ejb.annotation;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.netbeans.modules.j2ee.dd.api.common.PortComponentRef;
 import org.netbeans.modules.j2ee.dd.api.common.ServiceRef;
 import org.netbeans.modules.j2ee.dd.api.common.VersionNotSupportedException;
@@ -180,8 +182,9 @@ public class SessionImplTest extends CommonTestCase {
                 Session session = (Session) getEjbByEjbName(metadata.getRoot().getEnterpriseBeans().getSession(), "Customer");
                 assertEquals(Session.SESSION_TYPE_STATELESS, session.getSessionType());
                 assertEquals(2, session.getBusinessLocal().length);
-                assertEquals("foo.CustomerLocalA", session.getBusinessLocal()[0]);
-                assertEquals("foo.CustomerLocalB", session.getBusinessLocal()[1]);
+                Set<String> ref = new HashSet<>(Arrays.asList("foo.CustomerLocalA", "foo.CustomerLocalB"));
+                Set<String> toCheck = new HashSet<>(Arrays.asList(session.getBusinessLocal()));
+                assertEquals(ref, toCheck);
                 // test Employee
                 session = (Session) getEjbByEjbName(metadata.getRoot().getEnterpriseBeans().getSession(), "SatisfiedEmployee");
                 assertEquals(Session.SESSION_TYPE_STATEFUL, session.getSessionType());

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/mdb/MdbPropertiesPanelVisual.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/mdb/MdbPropertiesPanelVisual.java
@@ -40,7 +40,6 @@ import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 import org.netbeans.modules.j2ee.common.J2eeProjectCapabilities;
 import org.netbeans.modules.j2ee.deployment.common.api.MessageDestination;
-import org.netbeans.modules.j2ee.ejbcore.api.codegeneration.JmsDestinationDefinition;
 import org.netbeans.modules.j2ee.ejbcore.ejb.wizard.mdb.ActivationConfigProperties.AcknowledgeMode;
 import org.netbeans.modules.j2ee.ejbcore.ejb.wizard.mdb.ActivationConfigProperties.ActivationConfigProperty;
 import org.netbeans.modules.j2ee.ejbcore.ejb.wizard.mdb.ActivationConfigProperties.DestinationType;
@@ -53,7 +52,6 @@ import org.openide.util.NbBundle.Messages;
  *
  * @author Martin Fousek <marfous@netbeans.org>
  */
-// @todo: Support JakartaEE
 @SuppressWarnings("serial") // not used to be serialized
 public class MdbPropertiesPanelVisual extends javax.swing.JPanel {
 

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/mdb/MessageDestinationUiSupport.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/mdb/MessageDestinationUiSupport.java
@@ -64,7 +64,6 @@ import org.openide.util.NbBundle;
  * This class contains only static methods.
  * @author Tomas Mysik
  */
-// @todo: Support JakartaEE
 public abstract class MessageDestinationUiSupport {
 
     /**
@@ -248,7 +247,13 @@ public abstract class MessageDestinationUiSupport {
                 @Override
                 public Void run(JndiResourcesModel metadata) throws Exception {
                     for (final JmsDestination jmsDestination : metadata.getJmsDestinations()) {
-                        Type type = "javax.ejb.Topic".equals(jmsDestination.getClassName()) ? Type.TOPIC : Type.QUEUE; //NOI18N
+                        Type type;
+                        if ("jakarta.ejb.Topic".equals(jmsDestination.getClassName()) //NOI18N
+                                || "javax.ejb.Topic".equals(jmsDestination.getClassName())) { //NOI18N
+                            type = Type.TOPIC;
+                        } else {
+                            type = Type.QUEUE;
+                        }
                         allDestinations.add(new JmsDestinationDefinition(jmsDestination.getName(), type, false));
                     }
                     return null;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestBmp.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestBmp.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/BmpEjbClass.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestBmpLocal.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestBmpLocal.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/BmpLocal.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestBmpLocalHome.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestBmpLocalHome.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/BmpLocalHome.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestCmp.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestCmp.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/CmpEjbClass.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestCmpLocal.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestCmpLocal.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/CmpLocal.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestCmpLocalHome.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestCmpLocalHome.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/CmpLocalHome.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestCmpRemote.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestCmpRemote.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/CmpRemote.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestCmpRemoteHome.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/EntityGeneratorTest/testGenerateJavaEE14/TestCmpRemoteHome.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/CmpRemoteHome.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE14/TestMDBQueueBean.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE14/TestMDBQueueBean.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/MessageDrivenEjbClass.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE14/TestMDBTopicBean.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE14/TestMDBTopicBean.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/MessageDrivenEjbClass.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE50/TestMDBQueueBean.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE50/TestMDBQueueBean.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/MessageDrivenBean.java to edit this template
  */
 
 package testGenerateJavaEE50;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE50/TestMDBTopicBean.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE50/TestMDBTopicBean.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/MessageDrivenBean.java to edit this template
  */
 
 package testGenerateJavaEE50;
@@ -15,17 +14,18 @@ import javax.jms.MessageListener;
  *
  * @author {user}
  */
-@MessageDriven(mappedName = "TestMessageDestination", activationConfig =  {
-        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
-        @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
+@MessageDriven(mappedName = "TestMDBTopicBean", activationConfig =  {
         @ActivationConfigProperty(propertyName = "clientId", propertyValue = "TestMDBTopicBean"),
-        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "TestMDBTopicBean")
+        @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
+        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "TestMDBTopicBean"),
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic")
     })
 public class TestMDBTopicBean implements MessageListener {
     
     public TestMDBTopicBean() {
     }
 
+    @Override
     public void onMessage(Message message) {
     }
     

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE70/TestMDBQueueBean.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE70/TestMDBQueueBean.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/MessageDrivenBean.java to edit this template
  */
 
 package testGenerateJavaEE70;
@@ -16,8 +15,8 @@ import javax.jms.MessageListener;
  * @author {user}
  */
 @MessageDriven(activationConfig =  {
-        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
-        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "TestMessageDestination")
+        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "TestMessageDestination"),
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue")
     })
 public class TestMDBQueueBean implements MessageListener {
     

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE70/TestMDBQueueBean2.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE70/TestMDBQueueBean2.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/MessageDrivenBean.java to edit this template
  */
 
 package testGenerateJavaEE70;
@@ -16,8 +15,8 @@ import javax.jms.MessageListener;
  * @author {user}
  */
 @MessageDriven(activationConfig =  {
-        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
-        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "TestMessageDestination2")
+        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "TestMessageDestination2"),
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue")
     })
 public class TestMDBQueueBean2 implements MessageListener {
     

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE70/TestMDBTopicBean.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest/testGenerateJavaEE70/TestMDBTopicBean.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/MessageDrivenBean.java to edit this template
  */
 
 package testGenerateJavaEE70;
@@ -16,13 +15,13 @@ import javax.jms.MessageListener;
  * @author {user}
  */
 @MessageDriven(activationConfig =  {
-        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
+        @ActivationConfigProperty(propertyName = "clientId", propertyValue = "TestMessageDestination"),
         @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "TestMessageDestination"),
         @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
         @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Dups-ok-acknowledge"),
-        @ActivationConfigProperty(propertyName = "connectionFactoryLookup", propertyValue = "factoryLookup"),
-        @ActivationConfigProperty(propertyName = "clientId", propertyValue = "TestMessageDestination"),
         @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "TestMessageDestination"),
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
+        @ActivationConfigProperty(propertyName = "connectionFactoryLookup", propertyValue = "factoryLookup"),
         @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "selector")
     })
 public class TestMDBTopicBean implements MessageListener {

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatefulLR.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatefulLR.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/SessionEjbClass.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatefulLRLocal.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatefulLRLocal.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/SessionLocal.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatefulLRLocalHome.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatefulLRLocalHome.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/SessionLocalHome.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatelessLR.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatelessLR.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/SessionEjbClass.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatelessLRLocal.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatelessLRLocal.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/SessionLocal.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatelessLRLocalHome.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatelessLRLocalHome.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/SessionLocalHome.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatelessLRRemote.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatelessLRRemote.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/SessionRemote.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatelessLRRemoteHome.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE14/TestStatelessLRRemoteHome.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB21/SessionRemoteHome.java to edit this template
  */
 
 package testGenerateJavaEE14;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE50/TestStateful.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE50/TestStateful.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/StatefulEjbClass.java to edit this template
  */
 
 package testGenerateJavaEE50;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE50/TestStatefulRemote.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE50/TestStatefulRemote.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/SessionRemote.java to edit this template
  */
 
 package testGenerateJavaEE50;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE50/TestStateless.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE50/TestStateless.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/StatelessEjbClass.java to edit this template
  */
 
 package testGenerateJavaEE50;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE50/TestStatelessLocal.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE50/TestStatelessLocal.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/SessionLocal.java to edit this template
  */
 
 package testGenerateJavaEE50;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE50/TestStatelessRemote.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE50/TestStatelessRemote.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/SessionRemote.java to edit this template
  */
 
 package testGenerateJavaEE50;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestSingleton.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestSingleton.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB31/SingletonEjbClass.java to edit this template
  */
 
 package testGenerateJavaEE60;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestStateful.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestStateful.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/StatefulEjbClass.java to edit this template
  */
 
 package testGenerateJavaEE60;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestStatefulRemote.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestStatefulRemote.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/SessionRemote.java to edit this template
  */
 
 package testGenerateJavaEE60;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestStateless.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestStateless.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/StatelessEjbClass.java to edit this template
  */
 
 package testGenerateJavaEE60;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestStatelessLocal.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestStatelessLocal.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/SessionLocal.java to edit this template
  */
 
 package testGenerateJavaEE60;

--- a/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestStatelessRemote.java
+++ b/enterprise/j2ee.ejbcore/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/SessionGeneratorTest/testGenerateJavaEE60/TestStatelessRemote.java
@@ -1,7 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/J2EE/EJB30/SessionRemote.java to edit this template
  */
 
 package testGenerateJavaEE60;

--- a/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/CallEjbGeneratorTest.java
+++ b/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/CallEjbGeneratorTest.java
@@ -137,7 +137,7 @@ public class CallEjbGeneratorTest extends TestBase {
         assertNull(erc.getLocalReferencingClass());
 
         final String generatedHome =
-                "@EJB()" + newline +
+                "@EJB" + newline +
                 "private StatelessLRLocalHome2 statelessLRLocalHome2";
         
         final String generatedComponent =
@@ -147,7 +147,7 @@ public class CallEjbGeneratorTest extends TestBase {
         
         final String generatedMethod =
                 newline +
-                "@PostConstruct()" + newline +
+                "@PostConstruct" + newline +
                 "private void initialize() {" + newline +
                 "    try {" + newline +
                 "        statelessLRBean2 = statelessLRLocalHome2.create();" + newline +

--- a/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest.java
+++ b/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/api/codegeneration/MessageGeneratorTest.java
@@ -170,16 +170,16 @@ public class MessageGeneratorTest extends TestBase {
                 );
 
         // Topic based MessageDriven EJB in Java EE 5 defined in annotation
-        messageDestination = new MessageDestinationImpl("TestMessageDestination", MessageDestination.Type.TOPIC);
+        messageDestination = new MessageDestinationImpl("TestMDBTopicBean", MessageDestination.Type.TOPIC);
         panel.setDefaultProperties(messageDestination);
         properties = panel.getProperties();
-        generator = new MessageGenerator(Profile.JAVA_EE_5, "TestMDBTopic", packageFileObject, messageDestination,
+        generator = new MessageGenerator(Profile.JAVA_EE_5, "TestMDBTopicBean", packageFileObject, messageDestination,
                 true, properties, JmsSupport.getInstance(null), true);
         generator.generate();
         
         assertFile(
-                FileUtil.toFile(packageFileObject.getFileObject("TestMDBQueueBean.java")), 
-                getGoldenFile("testGenerateJavaEE50/TestMDBQueueBean.java"), 
+                FileUtil.toFile(packageFileObject.getFileObject("TestMDBTopicBean.java")),
+                getGoldenFile("testGenerateJavaEE50/TestMDBTopicBean.java"),
                 FileUtil.toFile(packageFileObject)
                 );
     }

--- a/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/jpa/dao/EjbFacadeWizardIteratorTest.java
+++ b/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/jpa/dao/EjbFacadeWizardIteratorTest.java
@@ -76,9 +76,8 @@ public class EjbFacadeWizardIteratorTest extends TestBase {
 
         String golden =
         "/*\n"+
-        " * To change this license header, choose License Headers in Project Properties.\n"+
-        " * To change this template file, choose Tools | Templates\n"+
-        " * and open the template in the editor.\n"+
+        " * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license\n" +
+        " * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Interface.java to edit this template\n"+
         " */\n"+
         "\n"+
         "package " + pkgName + ";\n"+

--- a/enterprise/j2ee.ejbverification/src/org/netbeans/modules/j2ee/ejbverification/EJBAPIAnnotations.java
+++ b/enterprise/j2ee.ejbverification/src/org/netbeans/modules/j2ee/ejbverification/EJBAPIAnnotations.java
@@ -25,6 +25,7 @@ package org.netbeans.modules.j2ee.ejbverification;
  *
  * @author Sanjeeb.Sahoo@Sun.COM
  */
+// @todo: Support JakartaEE
 public interface EJBAPIAnnotations {
     String ASYNCHRONOUS = "javax.ejb.Asynchronous"; //NOI18N
 

--- a/enterprise/j2ee.ejbverification/src/org/netbeans/modules/j2ee/ejbverification/rules/AnnotationPostContruct.java
+++ b/enterprise/j2ee.ejbverification/src/org/netbeans/modules/j2ee/ejbverification/rules/AnnotationPostContruct.java
@@ -46,6 +46,7 @@ import org.openide.util.NbBundle.Messages;
  *
  * @author Martin Fousek <marfous@netbeans.org>
  */
+// @todo: Support JakartaEE
 @Hint(displayName = "#AnnotationPostContruct.display.name",
             description = "#AnnotationPostContruct.description",
             id = "o.n.m.j2ee.ejbverification.AnnotationPostContruct",

--- a/enterprise/javaee.resources/src/org/netbeans/modules/javaee/resources/api/JndiResourcesDefinition.java
+++ b/enterprise/javaee.resources/src/org/netbeans/modules/javaee/resources/api/JndiResourcesDefinition.java
@@ -34,5 +34,7 @@ public class JndiResourcesDefinition {
     //public static final String ANN_MAIL_SESSION = ".MailSessionDefinition"; //NOI18N
     public static final String ANN_CONNECTION_RESOURCE = "javax.resource.ConnectorResourceDefinition"; //NOI18N
     public static final String ANN_ADMINISTRED_OBJECT = "javax.resource.AdministeredObjectDefinition"; //NOI18N
+    public static final String ANN_JMS_DESTINATION_JAKARTA = "jakarta.jms.JMSDestinationDefinition"; //NOI18N
+    public static final String ANN_JMS_DESTINATIONS_JAKARTA = "jakarta.jms.JMSDestinationDefinitions"; //NOI18N
 
 }

--- a/enterprise/javaee.resources/src/org/netbeans/modules/javaee/resources/impl/model/JmsDestinationImpl.java
+++ b/enterprise/javaee.resources/src/org/netbeans/modules/javaee/resources/impl/model/JmsDestinationImpl.java
@@ -126,7 +126,10 @@ public final class JmsDestinationImpl extends PersistentObject implements JmsDes
     }
 
     private static AnnotationMirror getSpecificAnnotationMirror(Map<String, ? extends AnnotationMirror> types) {
-        AnnotationMirror annotationMirror = types.get(JndiResourcesDefinition.ANN_JMS_DESTINATION);
+        AnnotationMirror annotationMirror = types.get(JndiResourcesDefinition.ANN_JMS_DESTINATION_JAKARTA);
+        if (annotationMirror == null) {
+            annotationMirror = types.get(JndiResourcesDefinition.ANN_JMS_DESTINATION);
+        }
         return annotationMirror;
     }
 

--- a/enterprise/javaee.resources/src/org/netbeans/modules/javaee/resources/impl/model/JmsDestinationsImpl.java
+++ b/enterprise/javaee.resources/src/org/netbeans/modules/javaee/resources/impl/model/JmsDestinationsImpl.java
@@ -73,6 +73,18 @@ public final class JmsDestinationsImpl extends PersistentObject implements JmsDe
     private void parseAnnotation(AnnotationMirror annotationMirror) {
         destinations = new ArrayList<JmsDestination>();
         AnnotationParser parser = AnnotationParser.create(getHelper());
+        parser.expectAnnotationArray("value", getHelper().resolveType(JndiResourcesDefinition.ANN_JMS_DESTINATION_JAKARTA), new ArrayValueHandler() { //NOI18N
+            @Override
+            public Object handleArray(List<AnnotationValue> arrayMembers) {
+                for (AnnotationValue arrayMember : arrayMembers) {
+                    Object arrayMemberValue = arrayMember.getValue();
+                    if (arrayMemberValue instanceof AnnotationMirror) {
+                        destinations.add(JmsDestinationImpl.parseAnnotation(getHelper(), (AnnotationMirror) arrayMemberValue));
+                    }
+                }
+                return null;
+            }
+        }, null);
         parser.expectAnnotationArray("value", getHelper().resolveType(JndiResourcesDefinition.ANN_JMS_DESTINATION), new ArrayValueHandler() { //NOI18N
             @Override
             public Object handleArray(List<AnnotationValue> arrayMembers) {
@@ -93,7 +105,10 @@ public final class JmsDestinationsImpl extends PersistentObject implements JmsDe
     }
 
     private static AnnotationMirror getSpecificAnnotationMirror(Map<String, ? extends AnnotationMirror> types) {
-        AnnotationMirror annotationMirror = types.get(JndiResourcesDefinition.ANN_JMS_DESTINATIONS);
+        AnnotationMirror annotationMirror = types.get(JndiResourcesDefinition.ANN_JMS_DESTINATIONS_JAKARTA);
+        if (annotationMirror == null) {
+            annotationMirror = types.get(JndiResourcesDefinition.ANN_JMS_DESTINATIONS);
+        }
         return annotationMirror;
     }
 

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/actions/InterceptorFactory.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/actions/InterceptorFactory.java
@@ -43,6 +43,7 @@ import com.sun.source.util.TreePath;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public class InterceptorFactory implements Factory {
     
     static final String INTERCEPTOR_BINDING = "InterceptorBinding";         // NOI18N

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/actions/InterceptorGenerator.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/actions/InterceptorGenerator.java
@@ -67,6 +67,7 @@ import com.sun.source.tree.Tree;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 class InterceptorGenerator implements CodeGenerator {
     
     private static final Logger LOG = Logger.getLogger( 

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/analysis/analyzer/AnnotationUtil.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/analysis/analyzer/AnnotationUtil.java
@@ -36,6 +36,7 @@ import org.netbeans.modules.web.beans.api.model.WebBeansModel;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public final class AnnotationUtil {
     
     public static final String ANY = "javax.enterprise.inject.Any";                 // NOI18N

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/analysis/analyzer/type/ManagedBeansAnalizer.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/analysis/analyzer/type/ManagedBeansAnalizer.java
@@ -44,6 +44,7 @@ import org.openide.util.NbBundle;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public class ManagedBeansAnalizer implements ClassAnalyzer {
     
     private static final String EXTENSION = "javax.enterprise.inject.spi.Extension";  //NOI18N

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/hints/CreateQualifier.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/hints/CreateQualifier.java
@@ -63,6 +63,7 @@ import com.sun.source.util.TreePath;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public class CreateQualifier implements ErrorRule<Void> {
     
     private static final String INJECT_ANNOTATION = 

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/AnnotationObjectProvider.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/AnnotationObjectProvider.java
@@ -61,6 +61,7 @@ import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.ObjectPro
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public class AnnotationObjectProvider implements ObjectProvider<BindingQualifier> {
     
     private static final String SPECILIZES_ANNOTATION = 

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/BeansFilter.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/BeansFilter.java
@@ -28,6 +28,7 @@ import javax.lang.model.element.TypeElement;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 class BeansFilter extends Filter<TypeElement> {
     
     static BeansFilter get() {

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/EnableBeansFilter.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/EnableBeansFilter.java
@@ -59,6 +59,7 @@ import org.openide.util.NbBundle;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 class EnableBeansFilter {
 
     static final String DECORATOR = "javax.decorator.Decorator";            // NOI18N

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/EventInjectionPointLogic.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/EventInjectionPointLogic.java
@@ -58,6 +58,7 @@ import org.netbeans.modules.web.beans.impl.model.AbstractAssignabilityChecker.As
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 abstract class EventInjectionPointLogic extends ParameterInjectionPointLogic {
     
     public static final String EVENT_INTERFACE = 

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/FieldInjectionPointLogic.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/FieldInjectionPointLogic.java
@@ -67,6 +67,7 @@ import org.netbeans.modules.web.beans.api.model.BeanArchiveType;
 /**
  * @author ads
  */
+// @todo: Support JakartaEE
 abstract class FieldInjectionPointLogic {
 
     static final String PRODUCER_ANNOTATION = 

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/InterceptorBindingChecker.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/InterceptorBindingChecker.java
@@ -35,6 +35,7 @@ import org.netbeans.modules.web.beans.analysis.analyzer.annotation.TargetVerifie
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 class InterceptorBindingChecker extends RuntimeAnnotationChecker {
     
     static final String INTERCEPTOR_BINDING = "javax.interceptor.InterceptorBinding"; // NOI18N

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/InterceptorObject.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/InterceptorObject.java
@@ -33,6 +33,7 @@ import org.netbeans.modules.web.beans.impl.model.AbstractObjectProvider.Refresha
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 class InterceptorObject extends PersistentObject implements Refreshable {
     
     static final String INTERCEPTOR = "javax.interceptor.Interceptor";  // NOI18N

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/MemberBindingFilter.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/MemberBindingFilter.java
@@ -37,6 +37,7 @@ import javax.lang.model.type.DeclaredType;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 class MemberBindingFilter<T extends Element> extends Filter<T> {
     
     private static final String NON_BINDING_MEMBER_ANNOTATION =

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/ParameterInjectionPointLogic.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/ParameterInjectionPointLogic.java
@@ -49,6 +49,7 @@ import org.openide.util.NbBundle;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 abstract class ParameterInjectionPointLogic extends FieldInjectionPointLogic 
     implements WebBeansModelProvider 
 {

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/ScopeChecker.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/ScopeChecker.java
@@ -33,6 +33,7 @@ import org.netbeans.modules.web.beans.analysis.analyzer.annotation.TargetVerifie
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 class ScopeChecker extends RuntimeAnnotationChecker {
     
     static String SCOPE = "javax.inject.Scope";                         // NOI18N

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/StereotypeChecker.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/StereotypeChecker.java
@@ -35,6 +35,7 @@ import org.netbeans.modules.web.beans.analysis.analyzer.annotation.TargetVerifie
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public class StereotypeChecker extends RuntimeAnnotationChecker {
     
     static final String STEREOTYPE = "javax.enterprise.inject.Stereotype";  //NOI18N

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/results/InterceptorsResultImpl.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/results/InterceptorsResultImpl.java
@@ -45,6 +45,7 @@ import org.netbeans.modules.web.beans.impl.model.WebBeansModelProviderImpl;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public class InterceptorsResultImpl implements InterceptorsResult {
     
     static final String INTERCEPTORS = "javax.interceptor.Interceptors";    // NOI18N

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/results/ResultImpl.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/results/ResultImpl.java
@@ -39,6 +39,7 @@ import org.netbeans.modules.web.beans.impl.model.WebBeansModelProviderImpl;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public class ResultImpl extends BaseResult implements DependencyInjectionResult.ResolutionResult {
     
     private static final String ALTERNATIVE = 

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/BindingsPanel.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/BindingsPanel.java
@@ -54,6 +54,7 @@ import org.netbeans.modules.web.beans.navigation.actions.WebBeansActionHelper;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public class BindingsPanel extends CDIPanel {
     
     private static final long serialVersionUID = 1230555367053797509L;

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/DecoratorsPanel.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/DecoratorsPanel.java
@@ -40,6 +40,7 @@ import org.openide.util.NbBundle;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public class DecoratorsPanel extends BindingsPanel {
 
     private static final long serialVersionUID = -5097678699872215262L;

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/ObserversPanel.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/ObserversPanel.java
@@ -37,6 +37,7 @@ import org.openide.util.NbBundle;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public class ObserversPanel extends BindingsPanel {
 
     private static final long serialVersionUID = -5038408349629504998L;

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/actions/WebBeansActionHelper.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/actions/WebBeansActionHelper.java
@@ -104,6 +104,7 @@ import com.sun.source.util.TreePath;
  * @author ads
  *
  */
+// @todo: Support JakartaEE
 public class WebBeansActionHelper {
     
     private static final String WAIT_NODE = "LBL_WaitNode";     // NOI18N

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/WebInjectionTargetQueryImplementation.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/WebInjectionTargetQueryImplementation.java
@@ -46,8 +46,11 @@ public class WebInjectionTargetQueryImplementation implements InjectionTargetQue
         if (webModule != null &&
                 !Profile.J2EE_13.equals(webModule.getJ2eeProfile()) && // NOI18N
                 !Profile.J2EE_14.equals(webModule.getJ2eeProfile())) { // NOI18N
-            
-            ret = SourceUtils.isSubtype(controller, typeElement, "javax.servlet.Servlet"); // NOI18N
+            if(webModule.getJ2eeProfile().isAtLeast(Profile.JAKARTA_EE_9_WEB)) {
+                ret = SourceUtils.isSubtype(controller, typeElement, "jakarta.servlet.Servlet"); // NOI18N
+            } else {
+                ret = SourceUtils.isSubtype(controller, typeElement, "javax.servlet.Servlet"); // NOI18N
+            }
         }
         return ret;
     }

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/api/JspColoringData.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/api/JspColoringData.java
@@ -34,6 +34,7 @@ import javax.servlet.jsp.tagext.TagLibraryInfo;
  *
  * @author Petr Jiricka
  */
+// @todo: Support JakartaEE
 public final class JspColoringData extends PropertyChangeSupport {
     
     /** An property whose change is fired every time the tag library 

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/palette/JspPaletteUtilities.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/palette/JspPaletteUtilities.java
@@ -50,6 +50,7 @@ import org.openide.util.Exceptions;
  *
  * @author Libor Kotouc
  */
+// @todo: Support JakartaEE
 public final class JspPaletteUtilities {
 
     public static final String CARET = "&CARET&";// NOI18N

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/palette/items/GetProperty.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/palette/items/GetProperty.java
@@ -33,6 +33,7 @@ import org.openide.text.ActiveEditorDrop;
  *
  * @author Libor Kotouc
  */
+// @todo: Support JakartaEE
 public class GetProperty implements ActiveEditorDrop {
 
     public static final String[] implicitBeans = new String[] {  // NOI18N

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/ListenerGenerator.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/ListenerGenerator.java
@@ -45,6 +45,7 @@ import org.netbeans.modules.j2ee.core.api.support.java.GenerationUtils;
  * @author  milan.kuchtiak@sun.com
  * Created on March, 2004
  */
+// @todo: Support JakartaEE
 public class ListenerGenerator {
 
     boolean isContext;

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/ListenerPanel.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/ListenerPanel.java
@@ -43,6 +43,7 @@ import org.netbeans.modules.web.api.webmodule.WebModule;
  *
  * @author  Milan Kuchtiak
  */
+// @todo: Support JakartaEE
 public class ListenerPanel implements WizardDescriptor.Panel {
     
     /** The visual component that displays this panel.

--- a/enterprise/web.jsf/licenseinfo.xml
+++ b/enterprise/web.jsf/licenseinfo.xml
@@ -49,8 +49,11 @@
         <file>src/org/netbeans/modules/web/jsf/facelets/resources/templates/template-table-8.template</file>
         <file>src/org/netbeans/modules/web/jsf/resources/AjaxScripts.jspf</file>
         <file>src/org/netbeans/modules/web/jsf/resources/JsfCrudELResolver.java.txt</file>
+        <file>src/org/netbeans/modules/web/jsf/resources/JsfCrudELResolver.jakarta.java.txt</file>
         <file>src/org/netbeans/modules/web/jsf/resources/JsfUtil.java.txt</file>
+        <file>src/org/netbeans/modules/web/jsf/resources/JsfUtil.jakarta.java.txt</file>
         <file>src/org/netbeans/modules/web/jsf/resources/PagingInfo.java.txt</file>
+        <file>src/org/netbeans/modules/web/jsf/resources/PagingInfo.jakarta.java.txt</file>
         <file>src/org/netbeans/modules/web/jsf/resources/jsfcrud.css</file>
         <file>src/org/netbeans/modules/web/jsf/resources/jsfcrud.js</file>
         <file>src/org/netbeans/modules/web/jsf/resources/templates/JSFManagedBean.template</file>

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigUtilities.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigUtilities.java
@@ -96,7 +96,15 @@ public class JSFConfigUtilities {
             "javax.faces.validator.FacesValidator", //NOI18N
             "javax.faces.render.FacesBehaviorRenderer", //NOI18N
             "javax.faces.render.FacesRenderer", //NOI18N
-            "javax.faces.event.ListenerFor" //NOI18N
+            "javax.faces.event.ListenerFor", //NOI18N
+            "jakarta.faces.bean.ManagedBean", //NOI18N
+            "jakarta.faces.component.behavior.FacesBehavior", //NOI18N
+            "jakarta.faces.convert.FacesConverter", //NOI18N
+            "jakarta.faces.component.FacesComponent", //NOI18N
+            "jakarta.faces.validator.FacesValidator", //NOI18N
+            "jakarta.faces.render.FacesBehaviorRenderer", //NOI18N
+            "jakarta.faces.render.FacesRenderer", //NOI18N
+            "jakarta.faces.event.ListenerFor" //NOI18N
         ));
     private static List<ElementHandle> jsfResourcesElementHandles;
 

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/hints/rules/JakartaFacesBeanIsGonnaBeDeprecated.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/hints/rules/JakartaFacesBeanIsGonnaBeDeprecated.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.web.jsf.hints.rules;
+
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.source.tree.ModifiersTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.TypeElement;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.TreeMaker;
+import org.netbeans.api.java.source.WorkingCopy;
+import org.netbeans.modules.j2ee.core.api.support.java.GenerationUtils;
+import org.netbeans.modules.web.jsf.hints.JsfHintsContext;
+import org.netbeans.modules.web.jsf.hints.JsfHintsUtils;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
+import org.netbeans.spi.editor.hints.ErrorDescription;
+import org.netbeans.spi.editor.hints.Fix;
+import org.netbeans.spi.editor.hints.Severity;
+import org.netbeans.spi.java.hints.Hint;
+import org.netbeans.spi.java.hints.HintContext;
+import org.netbeans.spi.java.hints.JavaFix;
+import org.netbeans.spi.java.hints.TriggerTreeKind;
+import org.openide.util.NbBundle;
+
+/**
+ * Checks usage of the deprecated package jakarta.faces.bean.
+ *
+ * @author Martin Fousek <marfous@netbeans.org>
+ */
+@Hint(displayName = "#JakartaFacesBeanIsGonnaBeDeprecated.display.name",
+        description = "#JakartaFacesBeanIsGonnaBeDeprecated.err",
+        id = "o.n.m.web.jsf.hints.JakartaFacesBeanIsGonnaBeDeprecated",
+        category = "javaee/jsf",
+        enabled = true,
+        suppressWarnings = "JakartaFacesBeanIsGonnaBeDeprecated")
+@NbBundle.Messages({
+    "JakartaFacesBeanIsGonnaBeDeprecated.display.name=Classes of jakarta.faces.bean are deprecated",
+    "JakartaFacesBeanIsGonnaBeDeprecated.err=Annotations from the package jakarta.faces.bean are deprecated. CDI and Java EE ones are recommended instead."
+})
+public class JakartaFacesBeanIsGonnaBeDeprecated {
+
+    private static final Logger LOG = Logger.getLogger(JakartaFacesBeanIsGonnaBeDeprecated.class.getName());
+
+    private static final String JAKARTA_FACES_BEAN = "jakarta.faces.bean"; //NOI18N
+    private static final String MANAGED_BEAN = JAKARTA_FACES_BEAN + ".ManagedBean"; //NOI18N
+
+    /** Classes which can be switched to Java EE or CDI ones. */
+    private static final Map<String, String> DEPRECATED_TO_FIX = new HashMap<>();
+    static {
+        // scopes
+        DEPRECATED_TO_FIX.put(JAKARTA_FACES_BEAN + ".RequestScoped", "jakarta.enterprise.context.RequestScoped"); //NOI18N
+        DEPRECATED_TO_FIX.put(JAKARTA_FACES_BEAN + ".SessionScoped", "jakarta.enterprise.context.SessionScoped"); //NOI18N
+        DEPRECATED_TO_FIX.put(JAKARTA_FACES_BEAN + ".ApplicationScoped", "jakarta.enterprise.context.ApplicationScoped"); //NOI18N
+        DEPRECATED_TO_FIX.put(JAKARTA_FACES_BEAN + ".ViewScoped", "jakarta.faces.view.ViewScoped"); //NOI18N
+        // beans
+        DEPRECATED_TO_FIX.put(MANAGED_BEAN, "jakarta.inject.Named"); //NOI18N
+    }
+
+    @TriggerTreeKind(Tree.Kind.CLASS)
+    public static Collection<ErrorDescription> run(HintContext hintContext) {
+        List<ErrorDescription> problems = new ArrayList<>();
+        final JsfHintsContext ctx = JsfHintsUtils.getOrCacheContext(hintContext);
+
+        if (ctx.getJsfVersion() == null || !ctx.getJsfVersion().isAtLeast(JsfVersion.JSF_2_2)) {
+            return problems;
+        }
+
+        CompilationInfo info = hintContext.getInfo();
+        for (TypeElement typeElement : info.getTopLevelElements()) {
+            for (AnnotationMirror annotationMirror : typeElement.getAnnotationMirrors()) {
+                if (annotationMirror.getAnnotationType().toString().startsWith(JAKARTA_FACES_BEAN)) {
+                    // it's jakarta.faces.bean annotation
+                    Tree tree = info.getTrees().getTree(typeElement, annotationMirror);
+                    List<Fix> fixes = getFixesForType(info, typeElement, annotationMirror);
+                    problems.add(JsfHintsUtils.createProblem(
+                            tree,
+                            info,
+                            Bundle.JakartaFacesBeanIsGonnaBeDeprecated_display_name(),
+                            Severity.HINT,
+                            fixes));
+                }
+            }
+        }
+        return problems;
+    }
+
+    private static List<Fix> getFixesForType(CompilationInfo info, TypeElement typeElement, AnnotationMirror am) {
+        List<Fix> fixes = new ArrayList<>();
+        String annotationType = am.getAnnotationType().toString();
+        if (DEPRECATED_TO_FIX.containsKey(annotationType)) {
+            TreePath path = info.getTrees().getPath(typeElement, am);
+            fixes.add(new ChangeClassFix(info, path, typeElement, am, annotationType, DEPRECATED_TO_FIX.get(annotationType)).toEditorFix());
+        }
+        return fixes;
+    }
+
+    private static final class ChangeClassFix extends JavaFix {
+
+        private final TypeElement element;
+        private final AnnotationMirror annotation;
+        private final String deprecatedClass;
+        private final String replacingClass;
+
+        public ChangeClassFix(CompilationInfo info, TreePath path, TypeElement element, AnnotationMirror annotation, String deprecatedClass, String replacingClass) {
+            super(info, path);
+            this.element = element;
+            this.annotation = annotation;
+            this.deprecatedClass = deprecatedClass;
+            this.replacingClass = replacingClass;
+        }
+
+        @NbBundle.Messages({
+            "JakartaChangeClassFix.lbl.change.class.fix=Change {0} to the {1}"
+        })
+        @Override
+        public String getText() {
+            return Bundle.JakartaChangeClassFix_lbl_change_class_fix(deprecatedClass, replacingClass);
+        }
+
+        @Override
+        protected void performRewrite(TransformationContext ctx) throws Exception {
+            WorkingCopy wc = ctx.getWorkingCopy();
+            wc.toPhase(JavaSource.Phase.RESOLVED);
+            TreeMaker make = wc.getTreeMaker();
+
+            // rewrite annotations in case of ManagedBean
+            if (MANAGED_BEAN.equals(annotation.getAnnotationType().toString())) {
+                ModifiersTree modifiers = ((ClassTree) wc.getTrees().getTree(element)).getModifiers();
+                AnnotationTree annotationTree = (AnnotationTree) wc.getTrees().getTree(element, annotation);
+                List<ExpressionTree> arguments = new ArrayList<>();
+                for (ExpressionTree expressionTree : annotationTree.getArguments()) {
+                    if (expressionTree.getKind() == Tree.Kind.ASSIGNMENT) {
+                        AssignmentTree at = (AssignmentTree) expressionTree;
+                        String varName = ((IdentifierTree) at.getVariable()).getName().toString();
+                        if (varName.equals("name")) { //NOI18N
+                            ExpressionTree valueTree = make.Identifier(at.getExpression().toString());
+                            arguments.add(valueTree);
+                        }
+                    }
+                }
+                ModifiersTree newModifiersTree = make.removeModifiersAnnotation(modifiers, (AnnotationTree) wc.getTrees().getTree(element, annotation));
+                AnnotationTree newTree = GenerationUtils.newInstance(wc).createAnnotation(replacingClass, arguments);
+                newModifiersTree = make.addModifiersAnnotation(newModifiersTree, newTree);
+                wc.rewrite(modifiers, newModifiersTree);
+            }
+
+            // rewrite imports
+            List<? extends ImportTree> imports = wc.getCompilationUnit().getImports();
+            ImportTree newImportTree = make.Import(make.QualIdent(replacingClass), false);
+            for (ImportTree importTree : imports) {
+                if (deprecatedClass.equals(importTree.getQualifiedIdentifier().toString())) {
+                    wc.rewrite(importTree, newImportTree);
+                }
+            }
+
+        }
+    }
+}

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/BehaviorImpl.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/BehaviorImpl.java
@@ -64,8 +64,10 @@ class BehaviorImpl extends PersistentObject implements Behavior, Refreshable {
         Map<String, ? extends AnnotationMirror> types = 
             getHelper().getAnnotationsByType(getHelper().getCompilationController().
                     getElements().getAllAnnotationMirrors(type));
-        AnnotationMirror annotationMirror = types.get(
-                "javax.faces.component.behavior.FacesBehavior");        // NOI18N
+        AnnotationMirror annotationMirror = types.get("jakarta.faces.component.behavior.FacesBehavior"); //NOI18N
+        if (annotationMirror == null) {
+            annotationMirror = types.get("javax.faces.component.behavior.FacesBehavior"); // NOI18N
+        }
         if (annotationMirror == null) {
             return false;
         }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ClientBehaviorRendererImpl.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ClientBehaviorRendererImpl.java
@@ -74,8 +74,10 @@ class ClientBehaviorRendererImpl extends AnnotationBehaviorRenderer
         Map<String, ? extends AnnotationMirror> types = 
             getHelper().getAnnotationsByType(getHelper().getCompilationController().
                     getElements().getAllAnnotationMirrors( type ));
-        AnnotationMirror annotationMirror = types.get(
-                "javax.faces.render.FacesBehaviorRenderer");            // NOI18N
+        AnnotationMirror annotationMirror = types.get("jakarta.faces.render.FacesBehaviorRenderer"); //NOI18N
+        if (annotationMirror == null) {
+            annotationMirror = types.get("javax.faces.render.FacesBehaviorRenderer"); // NOI18N
+        }
         if (annotationMirror == null) {
             return false;
         }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ComponentImpl.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ComponentImpl.java
@@ -90,7 +90,10 @@ public class ComponentImpl extends PersistentObject implements Component,  Refre
     public boolean refresh(TypeElement typeElement) {
         Map<String, ? extends AnnotationMirror> types = getHelper().getAnnotationsByType(
                 getHelper().getCompilationController().getElements().getAllAnnotationMirrors(typeElement));
-        AnnotationMirror annotationMirror = types.get("javax.faces.component.FacesComponent"); //NOI18N
+        AnnotationMirror annotationMirror = types.get("jakarta.faces.component.FacesComponent"); //NOI18N
+        if (annotationMirror == null) {
+            annotationMirror = types.get("javax.faces.component.FacesComponent"); // NOI18N
+        }
         if (annotationMirror == null) {
             return false;
         }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ConverterImpl.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ConverterImpl.java
@@ -58,7 +58,11 @@ class ConverterImpl extends PersistentObject implements FacesConverter, Refresha
             getHelper().getAnnotationsByType(getHelper().getCompilationController().
                     getElements().getAllAnnotationMirrors(type));
         AnnotationMirror annotationMirror = types.get(
-                "javax.faces.convert.FacesConverter");              // NOI18N
+                "jakarta.faces.convert.FacesConverter");              // NOI18N
+        if (annotationMirror == null) {
+            annotationMirror = types.get(
+                    "javax.faces.convert.FacesConverter");              // NOI18N
+        }
         if (annotationMirror == null) {
             return false;
         }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ManagedBeanImpl.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ManagedBeanImpl.java
@@ -73,8 +73,10 @@ class ManagedBeanImpl extends PersistentObject  implements FacesManagedBean,
         Map<String, ? extends AnnotationMirror> types = 
             getHelper().getAnnotationsByType(getHelper().getCompilationController()
                     .getElements().getAllAnnotationMirrors(type));
-        AnnotationMirror annotationMirror = types.get(
-                "javax.faces.bean.ManagedBean");                         // NOI18N
+        AnnotationMirror annotationMirror = types.get("jakarta.faces.bean.ManagedBean"); // NOI18N
+        if (annotationMirror == null) {
+            annotationMirror = types.get("javax.faces.bean.ManagedBean"); // NOI18N
+        }
         if (annotationMirror == null) {
             return false;
         }
@@ -134,11 +136,16 @@ class ManagedBeanImpl extends PersistentObject  implements FacesManagedBean,
     private void setScope( Map<String, ? extends AnnotationMirror> types, 
             TypeElement type ) 
     {
-        boolean isCustom = getHelper().hasAnnotation(type.getAnnotationMirrors(), 
-                "javax.faces.bean.CustomScoped");           // NOI18N
+        boolean isCustom
+                = getHelper().hasAnnotation(type.getAnnotationMirrors(), "jakarta.faces.bean.CustomScoped") // NOI18N
+                || getHelper().hasAnnotation(type.getAnnotationMirrors(), "javax.faces.bean.CustomScoped"); // NOI18N
         if ( isCustom ){
             AnnotationMirror annotationMirror = types
-                    .get("javax.faces.bean.CustomScoped"); // NOI18N
+                    .get("jakarta.faces.bean.CustomScoped"); // NOI18N
+            if (annotationMirror == null) {
+                annotationMirror = types
+                        .get("javax.faces.bean.CustomScoped"); // NOI18N
+            }
             AnnotationParser parser = AnnotationParser.create(getHelper());
             parser.expectString("value", AnnotationParser.defaultValue(""));
             ParseResult parseResult = parser.parse(annotationMirror);
@@ -198,6 +205,16 @@ class ManagedBeanImpl extends PersistentObject  implements FacesManagedBean,
         SCOPES.put("javax.faces.bean.SessionScoped",        // NOI18N
                 ManagedBean.Scope.SESSION);
         SCOPES.put("javax.faces.bean.ViewScoped",           // NOI18N
+                ManagedBean.Scope.VIEW);
+        SCOPES.put("jakarta.faces.bean.ApplicationScoped",    // NOI18N
+                ManagedBean.Scope.APPLICATION);
+        SCOPES.put("jakarta.faces.bean.NoneScoped",           // NOI18N
+                ManagedBean.Scope.NONE);
+        SCOPES.put("jakarta.faces.bean.RequestScoped",        // NOI18N
+                ManagedBean.Scope.REQUEST);
+        SCOPES.put("jakarta.faces.bean.SessionScoped",        // NOI18N
+                ManagedBean.Scope.SESSION);
+        SCOPES.put("jakarta.faces.bean.ViewScoped",           // NOI18N
                 ManagedBean.Scope.VIEW);
     }
     

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/RendererImpl.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/RendererImpl.java
@@ -58,7 +58,12 @@ class RendererImpl extends AnnotationRenderer implements Refreshable {
             getHelper().getAnnotationsByType(getHelper().getCompilationController()
                     .getElements().getAllAnnotationMirrors(type));
         AnnotationMirror annotationMirror = types.get(
-                "javax.faces.render.FacesRenderer");                     // NOI18N
+                "jakarta.faces.render.FacesRenderer");                     // NOI18N
+        if (annotationMirror == null) {
+            annotationMirror = types.get(
+                    "javax.faces.render.FacesRenderer");        // NOI18N
+
+        }
         if (annotationMirror == null) {
             return false;
         }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/SystemEventListenerImpl.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/SystemEventListenerImpl.java
@@ -51,7 +51,12 @@ class SystemEventListenerImpl extends PersistentObject implements
             getHelper().getAnnotationsByType(getHelper().getCompilationController()
                     .getElements().getAllAnnotationMirrors(type));
         AnnotationMirror annotationMirror = types.get(
-                "javax.faces.event.ListenerFor");                       // NOI18N
+                "jakarta.faces.event.ListenerFor");                       // NOI18N
+        if (annotationMirror == null) {
+            annotationMirror = types.get(
+                    "javax.faces.event.ListenerFor");        // NOI18N
+
+        }
         if (annotationMirror == null || 
                 !ObjectProviders.SystemEventListenerProvider.
                 isApplicationSystemEventListener(type, getHelper())) 

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ValidatorImpl.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/metamodel/ValidatorImpl.java
@@ -65,7 +65,12 @@ class ValidatorImpl extends FacesValidatorImpl implements Validator, Refreshable
             getHelper().getAnnotationsByType(getHelper().getCompilationController()
                     .getElements().getAllAnnotationMirrors( type));
         AnnotationMirror annotationMirror = types.get(
-                "javax.faces.validator.FacesValidator");        // NOI18N
+                "jakarta.faces.validator.FacesValidator");        // NOI18N
+        if (annotationMirror == null) {
+            annotationMirror = types.get(
+                    "javax.faces.validator.FacesValidator");        // NOI18N
+
+        }
         if (annotationMirror == null) {
             return false;
         }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/EntityClass.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/EntityClass.java
@@ -122,7 +122,11 @@ public abstract class EntityClass {
     static boolean isId(ExecutableElement method, boolean isFieldAccess) {
         Element element = isFieldAccess ? JpaControllerUtil.guessField(method) : method;
         if (element != null) {
-            if (JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.Id") || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.EmbeddedId")) { // NOI18N
+            if (JpaControllerUtil.isAnnotatedWith(element, "jakarta.persistence.Id")
+                    || JpaControllerUtil.isAnnotatedWith(element, "jakarta.persistence.EmbeddedId")
+                    || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.Id")
+                    || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.EmbeddedId")
+                    ) { // NOI18N
                 return true;
             }
         }
@@ -132,7 +136,10 @@ public abstract class EntityClass {
     static String getTemporal(ExecutableElement method, boolean isFieldAccess) {
         Element element = isFieldAccess ? JpaControllerUtil.guessField(method) : method;
         if (element != null) {
-            AnnotationMirror annotationMirror = JpaControllerUtil.findAnnotation(element, "javax.persistence.Temporal"); // NOI18N
+            AnnotationMirror annotationMirror = JpaControllerUtil.findAnnotation(element, "jakarta.persistence.Temporal"); // NOI18N
+            if(annotationMirror == null) {
+                annotationMirror = JpaControllerUtil.findAnnotation(element, "javax.persistence.Temporal"); // NOI18N
+            }
             if (annotationMirror != null) {
                 Collection<? extends AnnotationValue> attributes = annotationMirror.getElementValues().values();
                 if (attributes.iterator().hasNext()) {
@@ -163,7 +170,8 @@ public abstract class EntityClass {
     }
     
     public static boolean isEntityClass(TypeElement typeElement) {
-        if (JpaControllerUtil.isAnnotatedWith(typeElement, "javax.persistence.Entity")) {
+        if (JpaControllerUtil.isAnnotatedWith(typeElement, "jakarta.persistence.Entity")
+                || JpaControllerUtil.isAnnotatedWith(typeElement, "javax.persistence.Entity")) {
             return true;
         }
         return false;

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/FromEntityBase.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/FromEntityBase.java
@@ -215,7 +215,8 @@ public abstract class FromEntityBase {
             JpaControllerUtil.EmbeddedPkSupport embeddedPkSupport = null;
             for (ExecutableElement method : methods) {
                 // filter out @Transient methods
-                if (JpaControllerUtil.findAnnotation(method, "javax.persistence.Transient") != null) { //NOI18N
+                if (JpaControllerUtil.findAnnotation(method, "jakarta.persistence.Transient") != null //NOI18N
+                        || JpaControllerUtil.findAnnotation(method, "javax.persistence.Transient") != null) { //NOI18N
                     continue;
                 }
 
@@ -593,7 +594,8 @@ public abstract class FromEntityBase {
             if (fieldElement == null) {
                 fieldElement = method;
             }
-            return JpaControllerUtil.isAnnotatedWith(fieldElement, "javax.persistence.Lob"); // NOI18N
+            return JpaControllerUtil.isAnnotatedWith(fieldElement, "jakarta.persistence.Lob") // NOI18N
+                    || JpaControllerUtil.isAnnotatedWith(fieldElement, "javax.persistence.Lob"); // NOI18N
         }
 
         @Override

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/JsfForm.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/JsfForm.java
@@ -257,7 +257,8 @@ public final class JsfForm extends EntityClass implements ActiveEditorDrop, Pale
             String temporal = controller.getTypes().isSameType(dateTypeMirror, method.getReturnType()) ? getTemporal(method, fieldAccess) : null;
             String template = temporal == null ? "<h:outputText value=\"{0}:\"/>\n" : "<h:outputText value=\"{0} ({4}):\"/>\n";
             Element fieldElement = fieldAccess ? JpaControllerUtil.guessField(method) : method;
-            boolean isLob = JpaControllerUtil.isAnnotatedWith(fieldElement, "javax.persistence.Lob");
+            boolean isLob = JpaControllerUtil.isAnnotatedWith(fieldElement, "jakarta.persistence.Lob")
+                    || JpaControllerUtil.isAnnotatedWith(fieldElement, "javax.persistence.Lob");
             template += isLob ? "<h:inputTextarea rows=\"4\" cols=\"30\"" : "<h:inputText";
             template += " id=\"{2}\" value=\"#'{'{1}.{2}'}'\" title=\"{0}\" ";
             template += requiredMessage == null ? "" : "required=\"true\" requiredMessage=\"{5}\" ";

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/ManagedBeanCustomizer.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/palette/items/ManagedBeanCustomizer.java
@@ -115,7 +115,7 @@ public class ManagedBeanCustomizer extends javax.swing.JPanel implements Cancell
         });
         this.project = project;
         JsfVersion projectJsfVersion = JsfVersionUtils.forProject(project);
-        if(projectJsfVersion != null && projectJsfVersion.isAtLeast(JsfVersion.JSF_4_0)){
+        if(projectJsfVersion != null && projectJsfVersion.isAtLeast(JsfVersion.JSF_3_0)){
             this.jakartaMetaModelSupport = new org.netbeans.modules.jakarta.web.beans.MetaModelSupport(project);
         } else {
             this.metaModelSupport = new org.netbeans.modules.web.beans.MetaModelSupport(project);
@@ -374,7 +374,7 @@ public class ManagedBeanCustomizer extends javax.swing.JPanel implements Cancell
         }
         try {
             //check web beans
-            if(JsfVersionUtils.forProject(project) == JsfVersion.JSF_4_0){
+            if(JsfVersionUtils.forProject(project).isAtLeast(JsfVersion.JSF_3_0)) {
                jakartaMetaModelSupport.getMetaModel().runReadAction(new MetadataModelAction<org.netbeans.modules.jakarta.web.beans.api.model.WebBeansModel, Void>() {
                 @Override
                 public Void run(org.netbeans.modules.jakarta.web.beans.api.model.WebBeansModel metadata) throws Exception {

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/JsfCrudELResolver.jakarta.java.txt
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/JsfCrudELResolver.jakarta.java.txt
@@ -1,0 +1,614 @@
+package __PACKAGE__;
+
+import java.beans.BeanInfo;
+import java.beans.FeatureDescriptor;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.el.ELResolver;
+
+public class JsfCrudELResolver extends ELResolver {
+    public static final String JSFCRUD_CLASS = "jsfcrud_class";
+    public static final String JSFCRUD_METHOD = "jsfcrud_method";
+    public static final String JSFCRUD_PARAMS = "jsfcrud_params";
+    public static final String JSFCRUD_INVOKE = "jsfcrud_invoke";
+    public static final String JSFCRUD_TRANSFORM = "jsfcrud_transform";
+    public static final String JSFCRUD_NULL = "jsfcrud_null";
+    
+    /**
+     * {@inheritDoc}
+     */
+    public Object getValue(ELContext context, Object base, Object property) {
+        if(context == null) {
+            throw new NullPointerException();
+        }
+        
+        String propertyName = null;
+        if (property != null) {
+            propertyName = property.toString();
+        }
+
+        if (JSFCRUD_NULL.equals(propertyName) &&
+                base == null) {
+            context.setPropertyResolved(true);
+            return JSFCRUD_NULL;
+        }
+        
+        if (JSFCRUD_NULL.equals(propertyName) &&
+                ! (base instanceof JsfCrudMethod) &&
+                ! (base instanceof JsfCrudParameterizedMethod) &&
+                ! (base instanceof JsfCrudTransform) ) {
+            throw new ELException(JSFCRUD_NULL + " expects a base of type JsfCrudMethod, JsfCrudParameterizedMethod, or JsfCrudTransform; received " + base);
+        }
+        
+        Object result = null;
+        
+        if (JSFCRUD_CLASS.equals(propertyName)) {
+            if (base != null) {
+                throw new ELException(JSFCRUD_CLASS + " expects a null base; received " + base);
+            }
+            result = new JsfCrudClass();
+            context.setPropertyResolved(true);
+            return result;
+        } else if (JSFCRUD_METHOD.equals(propertyName)) {
+            if (base == null) {
+                throw new ELException(JSFCRUD_METHOD + " expects a non-null (possibly JsfCrudClass) base; received null");
+            }
+            result = new JsfCrudMethod(base);
+            context.setPropertyResolved(true);
+            return result;
+        } else if (JSFCRUD_PARAMS.equals(propertyName)) {
+            if (! (base instanceof JsfCrudMethod)) {
+                throw new ELException(JSFCRUD_PARAMS + " expects a base of type JsfCrudMethod; received " + base);
+            }
+            result = new JsfCrudParameterizedMethod((JsfCrudMethod)base);
+            context.setPropertyResolved(true);
+            return result;
+        } else if (JSFCRUD_INVOKE.equals(propertyName)) {
+            JsfCrudParameterizedMethod parameterizedMethod = getParameterizedMethodToInvoke(base);
+            result = parameterizedMethod.invoke();
+            context.setPropertyResolved(true);
+            return result;
+        } else if (JSFCRUD_TRANSFORM.equals(propertyName)) {
+            if (base == null) {
+                throw new ELException(JSFCRUD_TRANSFORM + " expects a non-null base; received null");
+            }
+            result = new JsfCrudTransform(base);
+            context.setPropertyResolved(true);
+            return result;
+        } else if (base instanceof JsfCrudClass) {
+            ((JsfCrudClass)base).setType(propertyName);
+            result = base;
+            context.setPropertyResolved(true);
+            return result;
+        } else if (base instanceof JsfCrudMethod) {
+            JsfCrudMethod baseAsMethod = (JsfCrudMethod)base;
+            if (baseAsMethod.getMethodName() == null) {
+                baseAsMethod.setMethodName(propertyName);
+                result = base;
+                context.setPropertyResolved(true);
+                return result;
+            }
+            else {
+                //already have a method name. start adding parameters.
+                JsfCrudParameterizedMethod pMethod = new JsfCrudParameterizedMethod(baseAsMethod);
+                pMethod.addParameter(property);
+                result = pMethod;
+                context.setPropertyResolved(true);
+                return result;
+            }
+        } else if (base instanceof JsfCrudParameterizedMethod) {
+            ((JsfCrudParameterizedMethod)base).addParameter(property);
+            result = base;
+            context.setPropertyResolved(true);
+            return result;
+        } else if (base instanceof JsfCrudTransform) {
+            if (JSFCRUD_NULL.equals(propertyName)) {
+                ((JsfCrudTransform)base).addNullMethod();
+                result = base;
+                context.setPropertyResolved(true);
+                return result;
+            } else if (property instanceof JsfCrudMethod) {
+                ((JsfCrudTransform)base).addMethod((JsfCrudMethod)property);
+                result = base;
+                context.setPropertyResolved(true);
+                return result;
+            }
+            else {
+                result = ((JsfCrudTransform)base).getProperty(propertyName);
+                context.setPropertyResolved(true);
+                return result;
+            }
+        } 
+        
+        return null;
+    }
+    
+    private JsfCrudParameterizedMethod getParameterizedMethodToInvoke(Object base) {
+        JsfCrudParameterizedMethod parameterizedMethod = null;
+        if (base instanceof JsfCrudParameterizedMethod) {
+            parameterizedMethod = (JsfCrudParameterizedMethod)base;
+        } else if (base instanceof JsfCrudMethod) {
+            parameterizedMethod = new JsfCrudParameterizedMethod((JsfCrudMethod)base);
+        }
+        if (parameterizedMethod == null) {
+            throw new ELException(JSFCRUD_INVOKE + " expects a base of type JsfCrudParameterizedMethod or JsfCrudMethod; received " + base);
+        }
+        return parameterizedMethod;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public void setValue(ELContext context, Object base, Object property, Object value) {
+        if(context == null) {
+            throw new NullPointerException();
+        }
+        
+        String propertyName = null;
+        if (property != null) {
+            propertyName = property.toString();
+        }
+
+        if ( base instanceof JsfCrudClass || 
+             base instanceof JsfCrudMethod ||
+             base instanceof JsfCrudParameterizedMethod ||
+             (base instanceof JsfCrudTransform && property instanceof JsfCrudMethod) ||
+             JSFCRUD_CLASS.equals(propertyName) ||
+             JSFCRUD_METHOD.equals(propertyName) ||
+             JSFCRUD_PARAMS.equals(propertyName) ||
+             JSFCRUD_INVOKE.equals(propertyName) ||
+             JSFCRUD_TRANSFORM.equals(propertyName) ||
+             JSFCRUD_NULL.equals(propertyName) ||
+             property == null ) {
+            throw new ELException("setValue was called with base " + base + ", property " + property + ", and value " + value + "; expected a base of type JsfCrudTransform and a valid property of the JsfCrudTransform's own base");
+        }
+        
+        if (base instanceof JsfCrudTransform) {
+            ((JsfCrudTransform)base).setProperty(propertyName, value);
+            context.setPropertyResolved(true);
+        }
+    }
+    
+   /**
+     * {@inheritDoc}
+     */
+    public boolean isReadOnly(ELContext context, Object base, Object property) {
+        if(context == null) {
+            throw new NullPointerException();
+        }
+        
+        String propertyName = null;
+        if (property != null) {
+            propertyName = property.toString();
+        }
+
+        if (JSFCRUD_CLASS.equals(propertyName) && base == null) {
+            context.setPropertyResolved(true);
+        } else if (JSFCRUD_METHOD.equals(propertyName) && base != null) {
+            context.setPropertyResolved(true);
+        } else if (JSFCRUD_PARAMS.equals(propertyName) && (base instanceof JsfCrudMethod)) {
+            context.setPropertyResolved(true);
+        } else if (JSFCRUD_INVOKE.equals(propertyName) && (base instanceof JsfCrudParameterizedMethod || base instanceof JsfCrudMethod)) {
+            context.setPropertyResolved(true);
+        } else if (JSFCRUD_TRANSFORM.equals(propertyName) && base != null) {
+            context.setPropertyResolved(true);
+        } else if (base instanceof JsfCrudClass) {
+            context.setPropertyResolved(true);
+        } else if (base instanceof JsfCrudMethod) {
+            context.setPropertyResolved(true);
+        } else if (base instanceof JsfCrudParameterizedMethod) {
+            context.setPropertyResolved(true);
+        } else if (base instanceof JsfCrudTransform) {
+            if (property instanceof JsfCrudMethod) {
+                context.setPropertyResolved(true);
+            }
+            else {
+                context.setPropertyResolved(true);
+                return false;
+            }
+        } else {
+            return false;
+        }
+        
+        return true;
+    }
+    
+        /**
+     * {@inheritDoc}
+     */
+    public Class<?> getType(ELContext context, Object base, Object property) {
+        if(context == null) {
+            throw new NullPointerException();
+        }
+        
+        String propertyName = null;
+        if (property != null) {
+            propertyName = property.toString();
+        }
+
+        if (JSFCRUD_CLASS.equals(propertyName) && base == null) {
+            context.setPropertyResolved(true);
+            return JsfCrudClass.class;
+        } else if (JSFCRUD_METHOD.equals(propertyName) && base != null) {
+            context.setPropertyResolved(true);
+            return JsfCrudMethod.class;
+        } else if (JSFCRUD_PARAMS.equals(propertyName) && (base instanceof JsfCrudMethod)) {
+            context.setPropertyResolved(true);
+            return JsfCrudParameterizedMethod.class;
+        } else if (JSFCRUD_INVOKE.equals(propertyName) && (base instanceof JsfCrudParameterizedMethod || base instanceof JsfCrudMethod)) {
+            JsfCrudParameterizedMethod parameterizedMethod = getParameterizedMethodToInvoke(base);
+            Class<?> result = parameterizedMethod.getReturnType();
+            context.setPropertyResolved(true);
+            return result;
+        } else if (JSFCRUD_TRANSFORM.equals(propertyName) && base != null) {
+            context.setPropertyResolved(true);
+            return JsfCrudTransform.class;
+        } else if (base instanceof JsfCrudClass) {
+            context.setPropertyResolved(true);
+            return JsfCrudClass.class;
+        } else if (base instanceof JsfCrudMethod) {
+            JsfCrudMethod baseAsMethod = (JsfCrudMethod)base;
+            if (baseAsMethod.getMethodName() == null) {
+                context.setPropertyResolved(true);
+                return JsfCrudMethod.class;
+            }
+            else {
+                context.setPropertyResolved(true);
+                return JsfCrudParameterizedMethod.class;
+            }
+        } else if (base instanceof JsfCrudParameterizedMethod) {
+            context.setPropertyResolved(true);
+            return JsfCrudParameterizedMethod.class;
+        } else if (base instanceof JsfCrudTransform) {
+            if (property instanceof JsfCrudMethod) {
+                context.setPropertyResolved(true);
+                return JsfCrudTransform.class;
+            }
+            else {
+                Class<?> result = ((JsfCrudTransform)base).getPropertyType(propertyName);
+                context.setPropertyResolved(true);
+                return result;
+            }
+        }
+        
+        return null;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object base) {
+        //todo: implement
+        return null;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public Class getCommonPropertyType(ELContext context,
+                                                Object base) {
+        if (context == null) {
+            throw new NullPointerException();
+        }
+        
+        if (base == null || base instanceof JsfCrudClass) {
+            return String.class;
+        } else if (base instanceof JsfCrudMethod) {
+            JsfCrudMethod baseAsMethod = (JsfCrudMethod)base;
+            if (baseAsMethod.getMethodName() == null) {
+                return String.class;
+            }
+            else {
+                return Object.class; //could be a param Object, JSFCRUD_NULL, or JSFCRUD_INVOKE
+            }
+        } else if (base instanceof JsfCrudParameterizedMethod) {
+            return Object.class; //could be a param Object, JSFCRUD_NULL, or JSFCRUD_INVOKE
+        } else if (base instanceof JsfCrudTransform) {
+            JsfCrudTransform baseAsTransform = (JsfCrudTransform)base;
+            boolean[] tma = baseAsTransform.transformMethodsAssigned;
+            if (!tma[0] || !tma[1]) {
+                return Object.class; //could be a JsfCrudMethod or JSFCRUD_NULL
+            }
+            else {
+                return String.class; //the tailing propertyName
+            }
+        } else if (base != null) {
+            return String.class;    //a catch-all
+        }
+        
+        return null;
+    }
+    
+    private class JsfCrudClass {
+        private Class<?> type;
+        public Class<?> getType() {
+            return type;
+        }
+        public void setType(String typeName) {
+            try {
+                type = Class.forName(typeName);
+            } catch (ClassNotFoundException e){
+                throw new ELException(e);
+            }
+        }
+        @Override
+        public String toString() {
+            return "JsfCrudClass[" + type + "]";
+        }
+    }
+    
+    private class JsfCrudMethod {
+        private Object base;    //can be an JsfCrudClass instance, or an arbitrary Object
+        private String methodName;
+        public JsfCrudMethod(Object base) {
+            this.base = base;
+        }
+        public Object getBase() {
+            return base;
+        }
+        public String getMethodName() {
+            return methodName;
+        }
+        public void setMethodName(String methodName) {
+            this.methodName = methodName;
+        }
+        @Override
+        public String toString() {
+            return "JsfCrudMethod[base=" + base + ",methodName=" + methodName + "]";
+        }
+    }
+    
+    private class JsfCrudParameterizedMethod {
+        private JsfCrudMethod method;
+        private List<Object> actualParams;
+        private Method methodToInvoke;
+        
+        public JsfCrudParameterizedMethod(JsfCrudMethod method) {
+            this.method = method;
+            actualParams = new ArrayList<Object>();
+        }
+        public JsfCrudMethod getMethod() {
+            return method;
+        }
+        public void addParameter(Object param) {
+            if (JsfCrudELResolver.JSFCRUD_NULL.equals(param)) {
+                param = null;
+            }
+            actualParams.add(param);
+        }
+        @Override
+        public String toString() {
+            StringBuffer sb = new StringBuffer("JsfCrudParameterizedMethod[method=");
+            sb.append(method);
+            sb.append(",params=List[");
+            int i = 0;
+            for (Object param : actualParams) {
+                if (i > 0) {
+                    sb.append(",");
+                }
+                sb.append(param);
+                i++;
+            }
+            sb.append("]]");
+            return sb.toString();
+        }
+        public Object invoke() {
+            findMethodToInvoke();
+            Object methodBase = method.getBase();
+            Object instance = methodBase instanceof JsfCrudClass ? null : methodBase;
+            Object[] paramArray = actualParams.toArray();
+            try {
+                return methodToInvoke.invoke(instance, paramArray);
+            } catch (IllegalAccessException e) {
+                throw new ELException(e);
+            } catch (InvocationTargetException e) {
+                throw new ELException(e);
+            }
+        }
+        
+        public Class<?> getReturnType() {
+            findMethodToInvoke();
+            return methodToInvoke.getReturnType();
+        }
+        
+        private void findMethodToInvoke() {
+            if (methodToInvoke != null) {
+                return;
+            }
+            
+            Object methodBase = method.getBase();
+            JsfCrudClass staticMethodBase = null;
+            if (methodBase instanceof JsfCrudClass) {
+                staticMethodBase = (JsfCrudClass)methodBase;
+            }
+            Class<?> type;
+            Method[] methodsOfType;
+            if (staticMethodBase == null) {
+                type = methodBase.getClass();
+                methodsOfType = type.getMethods();
+            }
+            else {
+                type = staticMethodBase.getType();
+                methodsOfType = type.getDeclaredMethods();
+            }
+            methodsOfTypeLoop:
+            for (Method methodOfType : methodsOfType) {
+                String methodName = method.getMethodName();
+                String methodOfTypeName = methodOfType.getName();
+                if (!methodName.equals(methodOfTypeName)) {
+                    continue;
+                }
+                if (staticMethodBase == null) {
+                    if (Modifier.isStatic(methodOfType.getModifiers())) {
+                        continue;
+                    }
+                }
+                else {
+                    if (!Modifier.isStatic(methodOfType.getModifiers())) {
+                        continue;
+                    }
+                }
+                Class<?>[] methodOfTypeFormalParams = methodOfType.getParameterTypes();
+                if (methodOfTypeFormalParams.length != actualParams.size()) {
+                    continue;
+                }
+                for (int i = 0; i < methodOfTypeFormalParams.length; i++) {
+                    Object param = actualParams.get(i);
+                    if (param == null) {
+                        if (methodOfTypeFormalParams[i].isPrimitive()) {
+                            continue methodsOfTypeLoop;
+                        }
+                    } else {
+                        Class<?> paramType = param.getClass();
+                        if (!methodOfTypeFormalParams[i].isAssignableFrom(paramType)) {
+                            continue methodsOfTypeLoop;
+                        }
+                    }
+                }
+                methodToInvoke = methodOfType;
+                break;
+            }
+            if (methodToInvoke == null) {
+                throw new ELException("could not find method to invoke; no appropriate method found in type " +  type + ". JsfCrudParameterizedMethod was " + this);
+            }
+        }
+    }
+    
+    private class JsfCrudTransform {
+        private Object base;
+        private JsfCrudMethod[] transformMethods;
+        private boolean[] transformMethodsAssigned;
+        public JsfCrudTransform(Object base) {
+            this.base = base;
+            transformMethods = new JsfCrudMethod[2];
+            transformMethodsAssigned = new boolean[2];
+        }
+        @Override
+        public String toString() {
+            StringBuffer sb = new StringBuffer();
+            sb.append("JsfCrudTransform=[base=");
+            sb.append(base);
+            sb.append(",transformMethod0=");
+            sb.append(transformMethods[0]);
+            sb.append(",transformMethod1=");
+            sb.append(transformMethods[1]);
+            sb.append(",transformMethodsAssigned0=");
+            sb.append(transformMethodsAssigned[0]);
+            sb.append(",transformMethodsAssigned1=");
+            sb.append(transformMethodsAssigned[1]);
+            sb.append("]");
+            return sb.toString();
+        }
+        public Object getBase() {
+            return base;
+        }
+        public void addMethod(JsfCrudMethod method) {
+            if (!transformMethodsAssigned[0]) {
+                transformMethods[0] = method;
+                transformMethodsAssigned[0] = true;
+            }
+            else {
+                if (transformMethodsAssigned[1]) {
+                    throw new ELException("attempt to add more than two methods to a JsfCrudTransform; additional JsfCrudMethod was " + method);
+                }
+                transformMethods[1] = method;
+                transformMethodsAssigned[1] = true;
+            }
+        }
+        public void addNullMethod() {
+            if (!transformMethodsAssigned[0]) {
+                transformMethodsAssigned[0] = true;
+            }
+            else {
+                if (transformMethodsAssigned[1]) {
+                    throw new ELException("attempt to add more than two methods to a JsfCrudTransform; additional JsfCrudMethod was null");
+                }
+                transformMethodsAssigned[1] = true;
+            }
+        }
+        public Class<?> getPropertyType(String propertyName) {
+            if (transformMethods[0] == null) {
+                PropertyDescriptor pd = getPropertyDescriptor(propertyName);
+                return pd.getPropertyType();
+            }
+            JsfCrudParameterizedMethod parameterizedMethod = getParameterizedTransformationMethod(propertyName);
+            return parameterizedMethod.getReturnType();
+        }
+        private Object getUntransformedProperty(String propertyName) {
+            PropertyDescriptor pd = getPropertyDescriptor(propertyName);
+            if (pd == null) {
+                throw new ELException("could not get untransformed property " + propertyName + " of base object " + base + ": base object has no such property");
+            }
+            Method readMethod = pd.getReadMethod();
+            Object rawResult;
+            try {
+                rawResult = readMethod.invoke(base);
+            } catch (IllegalAccessException e) {
+                throw new ELException(e);
+            } catch (InvocationTargetException e) {
+                throw new ELException(e);
+            } 
+            return rawResult;
+        }
+        private JsfCrudParameterizedMethod getParameterizedTransformationMethod(String propertyName) {
+            Object rawResult = getUntransformedProperty(propertyName);
+            JsfCrudParameterizedMethod parameterizedMethod = new JsfCrudParameterizedMethod(transformMethods[0]);
+            parameterizedMethod.addParameter(rawResult);
+            return parameterizedMethod;
+        }
+        public Object getProperty(String propertyName) {
+            if (transformMethods[0] == null) {
+                return getUntransformedProperty(propertyName);
+            }
+            JsfCrudParameterizedMethod parameterizedMethod = getParameterizedTransformationMethod(propertyName);
+            return parameterizedMethod.invoke();
+        }
+        public void setProperty(String propertyName, Object value) {
+            PropertyDescriptor pd = getPropertyDescriptor(propertyName);
+            if (pd == null) {
+                throw new ELException("could not set property " + propertyName + " of base object " + base + " with raw value " + value + ": base object has no such property");
+            }
+            Object transformedOrUntransformedValue = null;
+            if (transformMethods[1] == null) {
+                transformedOrUntransformedValue = value;
+            }
+            else {
+                JsfCrudParameterizedMethod parameterizedMethod = new JsfCrudParameterizedMethod(transformMethods[1]);
+                parameterizedMethod.addParameter(value);
+                transformedOrUntransformedValue = parameterizedMethod.invoke();
+            }
+            Method writeMethod = pd.getWriteMethod();
+            try {
+                writeMethod.invoke(base, transformedOrUntransformedValue);
+            } catch (IllegalAccessException e) {
+                throw new ELException(e);
+            } catch (InvocationTargetException e) {
+                throw new ELException(e);
+            }
+        }
+        private PropertyDescriptor getPropertyDescriptor(String propertyName) {
+            Class<?> baseType = base.getClass();
+            BeanInfo info;
+            try {
+                info = Introspector.getBeanInfo(baseType);
+            } catch (IntrospectionException ie) {
+                throw new ELException(ie);
+            }
+            for (PropertyDescriptor pd : info.getPropertyDescriptors()) {
+                if (propertyName.equals(pd.getName())) {
+                    return pd;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/JsfUtil.jakarta.java.txt
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/JsfUtil.jakarta.java.txt
@@ -1,58 +1,19 @@
-<#--
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+package __PACKAGE__;
 
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
-<#if comment>
-
-  TEMPLATE DESCRIPTION:
-
-  This is Java template for 'JSF Pages From Entity Beans' PaginationHelper class. Templating
-  is performed using FreeMaker (http://freemarker.org/) - see its documentation
-  for full syntax. Variables available for templating are:
-
-    packageName - package name (String)
-    comment - always (Boolean; always FALSE)
-    jakartaJsfPackages - true if jakarta JSF is used, false if not (type: Boolean)
-
-  This template is accessible via top level menu Tools->Templates and can
-  be found in category JavaServer Faces->JSF from Entity.
-
-</#if>
-
-package ${packageName};
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-<#if jakartaJsfPackages?? && jakartaJsfPackages==true>
+import java.util.Set;
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.convert.Converter;
 import jakarta.faces.model.SelectItem;
-<#else>
-import javax.faces.application.FacesMessage;
-import javax.faces.component.UIComponent;
-import javax.faces.context.FacesContext;
-import javax.faces.convert.Converter;
-import javax.faces.model.SelectItem;
-</#if>
 
 public class JsfUtil {
-
+    
     public static SelectItem[] getSelectItems(List<?> entities, boolean selectOne) {
         int size = selectOne ? entities.size() + 1 : entities.size();
         SelectItem[] items = new SelectItem[size];
@@ -67,7 +28,7 @@ public class JsfUtil {
         return items;
     }
     
-    public static void addErrorMessage(Exception ex, String defaultMsg) {
+    public static void ensureAddErrorMessage(Exception ex, String defaultMsg) {
         String msg = ex.getLocalizedMessage();
         if (msg != null && msg.length() > 0) {
             addErrorMessage(msg);
@@ -101,4 +62,48 @@ public class JsfUtil {
         return converter.getAsObject(FacesContext.getCurrentInstance(), component, theId);
     }
     
+    public static <T> List<T> arrayToList(T[] arr) {
+        if (arr == null) {
+            return new ArrayList<T>();
+        }
+        return Arrays.asList(arr);
+    }
+
+    public static <T> Set<T> arrayToSet(T[] arr) {
+        if (arr == null) {
+            return new HashSet<T>();
+        }
+        return new HashSet(Arrays.asList(arr));
+    }
+    
+    public static Object[] collectionToArray(Collection<?> c) {
+        if (c == null) {
+            return new Object[0];
+        }
+        return c.toArray();
+    }
+
+    public static <T> List<T> setToList(Set<T> set) {
+        return new ArrayList<T>(set);
+    }
+    
+    public static String getAsConvertedString(Object object, Converter converter) {
+        return converter.getAsString(FacesContext.getCurrentInstance(), null, object);
+    }
+    
+    public static String getCollectionAsString(Collection<?> collection) {
+        if (collection == null || collection.size() == 0) {
+            return "(No Items)";
+        }
+        StringBuffer sb = new StringBuffer();
+        int i = 0;
+        for (Object item : collection) {
+            if (i > 0) {
+                sb.append("<br />");
+            }
+            sb.append(item);
+            i++;
+        }
+        return sb.toString();
+    }
 }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/PagingInfo.jakarta.java.txt
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/PagingInfo.jakarta.java.txt
@@ -1,0 +1,60 @@
+package __PACKAGE__;
+
+public class PagingInfo {
+    private int batchSize = 5;
+    private int firstItem = 0;
+    private int itemCount = -1;
+    
+    public int getBatchSize() {
+        return batchSize;
+    }
+    
+    public int getItemCount() {
+        return itemCount;
+    }
+    
+    public void setItemCount(int itemCount) {
+        this.itemCount = itemCount;
+    }
+    
+    public int getFirstItem() {
+        if (itemCount == -1) {
+            throw new IllegalStateException("itemCount must be set before invoking getFirstItem");
+        }
+        if (firstItem >= itemCount) {
+            if (itemCount == 0) {
+                firstItem = 0;
+            } else {
+                int zeroBasedItemCount = itemCount - 1;
+                double pageDouble = zeroBasedItemCount / batchSize;
+                int page = (int) Math.floor(pageDouble);
+                firstItem = page * batchSize;
+            }
+        }
+        return firstItem;
+    }
+    
+    public void setFirstItem(int firstItem) {
+        this.firstItem = firstItem;
+    }
+    
+    public int getLastItem() {
+        getFirstItem();
+        return firstItem + batchSize > itemCount ? itemCount : firstItem + batchSize;
+    }
+    
+    public void nextPage() {
+        getFirstItem();
+        if (firstItem + batchSize < itemCount) {
+            firstItem += batchSize;
+        }
+    }
+    
+    public void previousPage() {
+        getFirstItem();
+        firstItem -= batchSize;
+        if (firstItem < 0) {
+            firstItem = 0;
+        }
+    }
+}

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/templates/JSFManagedBean.template
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/templates/JSFManagedBean.template
@@ -12,6 +12,7 @@
         ScopeEntry#getClassName() - scope simple name (type: String)
         ScopeEntry#getImportEntry() - import entry for the scope (type: String)
         ScopeEntry#getParameters() - annotation parameters (type: String)
+    jakartaJsfPackages - true if jakarta JSF is used, false if not (type: Boolean)
 
   This template is accessible via top level menu Tools->Templates and can
   be found in category JavaServer Faces->JSF Managed Bean.
@@ -26,6 +27,26 @@
 package ${package};
 
 </#if>
+<#if jakartaJsfPackages?? && jakartaJsfPackages==true>
+<#if cdiEnabled?? && cdiEnabled>
+    <#if classAnnotation??>
+import jakarta.inject.Named;
+    </#if>
+    <#if scope??>
+import ${scope.getImportEntry()};
+    </#if>
+    <#if passivationCapable??>
+import java.io.Serializable;
+	</#if>
+<#else>
+    <#if classAnnotation??>
+import jakarta.faces.bean.ManagedBean;
+    </#if>
+    <#if scope??>
+import ${scope.getImportEntry()};
+    </#if>
+</#if>
+<#else>
 <#if cdiEnabled?? && cdiEnabled>
     <#if classAnnotation??>
 import javax.inject.Named;
@@ -43,6 +64,7 @@ import javax.faces.bean.ManagedBean;
     <#if scope??>
 import ${scope.getImportEntry()};
     </#if>
+</#if>
 </#if>
 
 /**

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/templates/PaginationHelper.ftl
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/templates/PaginationHelper.ftl
@@ -27,6 +27,7 @@
 
     packageName - package name (String)
     comment - always (Boolean; always FALSE)
+    jakartaJsfPackages - true if jakarta JSF is used, false if not (type: Boolean)
 
   This template is accessible via top level menu Tools->Templates and can
   be found in category JavaServer Faces->JSF from Entity.
@@ -35,7 +36,11 @@
 
 package ${packageName};
 
+<#if jakartaJsfPackages?? && jakartaJsfPackages==true>
+import jakarta.faces.model.DataModel;
+<#else>
 import javax.faces.model.DataModel;
+</#if>
 
 public abstract class PaginationHelper {
 

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/templates/controller.ftl
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/templates/controller.ftl
@@ -43,6 +43,8 @@
     embeddedIdFields - contains information about embedded primary IDs
     cdiEnabled - project contains beans.xml, so Named beans can be used
     bundle - name of the variable defined in the JSF config file for the resource bundle (type: String)
+    jakartaPersistencePackages - true if jakarta persistence is used, false if not (type: Boolean)
+    jakartaJsfPackages - true if jakarta JSF is used, false if not (type: Boolean)
 
   This template is accessible via top level menu Tools->Templates and can
   be found in category JavaServer Faces->JSF from Entity.
@@ -65,6 +67,30 @@ import ${jpaControllerFullClassName};
 
 import java.io.Serializable;
 import java.util.ResourceBundle;
+<#if jakartaJsfPackages?? && jakartaJsfPackages==true>
+<#if isInjected?? && isInjected==true>
+import jakarta.annotation.Resource;
+</#if>
+<#if ejbClassName??>
+import jakarta.ejb.EJB;
+</#if>
+<#if managedBeanName??>
+<#if cdiEnabled?? && cdiEnabled>
+import jakarta.inject.Named;
+import jakarta.enterprise.context.SessionScoped;
+<#else>
+import jakarta.faces.bean.ManagedBean;
+import jakarta.faces.bean.SessionScoped;
+</#if>
+</#if>
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.convert.Converter;
+import jakarta.faces.convert.FacesConverter;
+import jakarta.faces.model.DataModel;
+import jakarta.faces.model.ListDataModel;
+import jakarta.faces.model.SelectItem;
+<#else>
 <#if isInjected?? && isInjected==true>
 import javax.annotation.Resource;
 </#if>
@@ -87,13 +113,24 @@ import javax.faces.convert.FacesConverter;
 import javax.faces.model.DataModel;
 import javax.faces.model.ListDataModel;
 import javax.faces.model.SelectItem;
+</#if>
 <#if jpaControllerClassName??>
-<#if isInjected?? && isInjected==true>
+<#if jakartaPersistencePackages?? && jakartaPersistencePackages==true >
+<#if isInjected?? && isInjected==true >
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnit;
+import jakarta.transaction.UserTransaction;
+<#else>
+import jakarta.persistence.Persistence;
+</#if>
+<#else>
+<#if isInjected?? && isInjected==true >
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceUnit;
 import javax.transaction.UserTransaction;
 <#else>
 import javax.persistence.Persistence;
+</#if>
 </#if>
 </#if>
 

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/templates/facesComponent.template
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/resources/templates/facesComponent.template
@@ -10,11 +10,20 @@ package ${package};
 <#if sampleCode??>
 import java.io.IOException;
 </#if>
+<#if jakartaJsfPackages?? && jakartaJsfPackages==true>
+import jakarta.faces.component.FacesComponent;
+import jakarta.faces.component.UIComponentBase;
+<#if sampleCode??>
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.ResponseWriter;
+</#if>
+<#else>
 import javax.faces.component.FacesComponent;
 import javax.faces.component.UIComponentBase;
 <#if sampleCode??>
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
+</#if>
 </#if>
 
 /**

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/Bundle.properties
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/Bundle.properties
@@ -170,7 +170,7 @@ ERR_NoJSFLibraryFound=No Facelets Libraries Found
 
 LBL_JsfComponentNotValid=JSF library {0} not set up properly:
 
-ERR_UserTransactionUnavailable=The class javax.transaction.UserTransaction is unavailable. Add an appropriate JAR file in Project Properties > Libraries.
+ERR_UserTransactionUnavailable=The class jakarta.transaction.UserTransaction/javax.transaction.UserTransaction is unavailable. Add an appropriate JAR file in Project Properties > Libraries.
 ERR_JsfTargetChooser_InvalidJsfFolder=The JSF pages folder name is invalid.
 ERR_JavaTargetChooser_CantUseDefaultPackage=Provide a package name.
 ERR_JavaTargetChooser_InvalidPackage=The package name is invalid.

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/CompositeComponentWizardPanel.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/CompositeComponentWizardPanel.java
@@ -66,6 +66,7 @@ public class CompositeComponentWizardPanel implements WizardDescriptor.Panel, Ch
     SourceGroup[] folders;
     private final ChangeSupport changeSupport = new ChangeSupport(this);
     private static final String WEBAPP_RESOURCES_DIRECTORY = "javax.faces.WEBAPP_RESOURCES_DIRECTORY";
+    private static final String WEBAPP_RESOURCES_DIRECTORY_JAKARTA = "jakarta.faces.WEBAPP_RESOURCES_DIRECTORY";
     private static final String RESOURCES_FOLDER = "resources"; //NOI18N
     //TODO how to add [,] to the regular expression?
     private static final Pattern INVALID_FILENAME_CHARACTERS = Pattern.compile("[`~!@#$%^&*()=+\\|{};:'\",<>/?]"); // NOI18N
@@ -309,7 +310,8 @@ public class CompositeComponentWizardPanel implements WizardDescriptor.Panel, Ch
                 if (ddRoot != null) {
                     InitParam[] parameters = ddRoot.getContextParam();
                     for (InitParam param : parameters) {
-                        if (param.getParamName().contains(WEBAPP_RESOURCES_DIRECTORY)) {
+                        if (param.getParamName().contains(WEBAPP_RESOURCES_DIRECTORY)
+                                || param.getParamName().contains(WEBAPP_RESOURCES_DIRECTORY_JAKARTA)) {
                             relPath = param.getParamValue().trim();
                         }
                     }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/FacesComponentIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/FacesComponentIterator.java
@@ -33,6 +33,9 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.api.project.SourceGroup;
 import org.netbeans.api.project.Sources;
+import org.netbeans.modules.web.api.webmodule.WebModule;
+import org.netbeans.modules.web.jsf.api.facesmodel.JsfVersionUtils;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.netbeans.spi.java.project.support.ui.templates.JavaTemplates;
 import org.netbeans.spi.project.ui.templates.support.Templates;
 import org.openide.WizardDescriptor;
@@ -77,6 +80,18 @@ public class FacesComponentIterator implements TemplateWizard.Iterator {
         }
         if (createSampleCode) {
             templateProperties.put("sampleCode", Boolean.TRUE); //NOI18N
+        }
+        Project project = Templates.getProject(wizard);
+        WebModule webModule = WebModule.getWebModule(project.getProjectDirectory());
+        if (webModule != null) {
+            JsfVersion version = JsfVersionUtils.forWebModule(webModule);
+            if (version != null && version.isAtLeast(JsfVersion.JSF_3_0)) {
+                templateProperties.put("jakartaJsfPackages", true); //NOI18N
+            } else {
+                templateProperties.put("jakartaJsfPackages", false); //NOI18N
+            }
+        } else {
+            templateProperties.put("jakartaJsfPackages", true); //NOI18N
         }
         DataObject result = dTemplate.createFromTemplate(dataFolder, targetName, templateProperties);
         return Collections.singleton(result);

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/PersistenceClientSetupPanelVisual.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/PersistenceClientSetupPanelVisual.java
@@ -439,8 +439,12 @@ public class PersistenceClientSetupPanelVisual extends javax.swing.JPanel implem
                     Class.forName("javax.transaction.UserTransaction", false, cl);
                 }
                 catch (ClassNotFoundException cnfe) {
-                    wizard.putProperty(WizardDescriptor.PROP_ERROR_MESSAGE, NbBundle.getMessage(PersistenceClientSetupPanelVisual.class, "ERR_UserTransactionUnavailable"));
-                    return false;
+                    try {
+                        Class.forName("jakarta.transaction.UserTransaction", false, cl);
+                    } catch (ClassNotFoundException cnfe2) {
+                        wizard.putProperty(WizardDescriptor.PROP_ERROR_MESSAGE, NbBundle.getMessage(PersistenceClientSetupPanelVisual.class, "ERR_UserTransactionUnavailable"));
+                        return false;
+                    }
                 }
                 catch (UnsupportedClassVersionError ucve) {
                     Logger.getLogger(PersistenceClientSetupPanelVisual.class.getName()).log(Level.WARNING, ucve.toString());

--- a/java/j2ee.persistence/nbproject/project.properties
+++ b/java/j2ee.persistence/nbproject/project.properties
@@ -27,6 +27,7 @@ test.unit.run.cp.extra=\
     ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.12.jar:\
     ${j2ee.persistence.dir}/modules/ext/eclipselink/jakarta.persistence-2.2.3.jar:\
     ${j2eeserver.dir}/modules/ext/jsr88javax.jar:\
+    ${j2eeserver.dir}/modules/ext/javaee-api-8.0.jar:\
     ${masterfs.dir}/modules/org-netbeans-modules-masterfs.jar
 
 sigtest.gen.fail.on.error=false

--- a/java/j2ee.persistence/nbproject/project.xml
+++ b/java/j2ee.persistence/nbproject/project.xml
@@ -581,6 +581,11 @@
                         <code-name-base>org.netbeans.modules.java.editor</code-name-base>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.modules.java.j2seplatform</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.java.source</code-name-base>
                         <recursive/>
                         <compile-dependency/>
@@ -594,6 +599,9 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.modules.parsing.nb</code-name-base>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
                     </test-dependency>
                     <test-dependency>
@@ -603,17 +611,14 @@
                         <code-name-base>org.openide.filesystems</code-name-base>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.openide.util.ui</code-name-base>
-                        <compile-dependency/>
-                        <test/>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.openide.util.lookup</code-name-base>
                         <compile-dependency/>
                         <test/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.parsing.nb</code-name-base>
+                        <code-name-base>org.openide.util.ui</code-name-base>
+                        <compile-dependency/>
+                        <test/>
                     </test-dependency>
                 </test-type>
             </test-dependencies>

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategySupport.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/entitymanagergenerator/EntityManagerGenerationStrategySupport.java
@@ -261,14 +261,16 @@ public abstract class EntityManagerGenerationStrategySupport implements EntityMa
     }
     
     protected VariableTree createUserTransaction(){
-        return getTreeMaker().Variable(
+        VariableTree result = getTreeMaker().Variable(
                 getTreeMaker().Modifiers(
-                Collections.<Modifier>singleton(Modifier.PRIVATE),
-                Collections.<AnnotationTree>singletonList(getGenUtils().createAnnotation(RESOURCE_FQN))
+                        Collections.<Modifier>singleton(Modifier.PRIVATE),
+                        Collections.<AnnotationTree>singletonList(getGenUtils().createAnnotation(RESOURCE_FQN))
                 ),
                 "utx", //NOI18N
                 getTreeMaker().Identifier(USER_TX_FQN),
                 null);
+        result = (VariableTree) importFQNs(result);
+        return result;
     }
     
     protected VariableTree createEntityManagerFactory(String name){

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerUtil.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerUtil.java
@@ -156,9 +156,17 @@ public class JpaControllerUtil {
         Name qualifiedName = typeElement.getQualifiedName();
         whileloop:
         while (typeElement != null) {
-            if (isAnnotatedWith(typeElement, "javax.persistence.Entity") || isAnnotatedWith(typeElement, "javax.persistence.MappedSuperclass")) { // NOI18N
+            if (isAnnotatedWith(typeElement, "jakarta.persistence.Entity")  // NOI18N
+                    || isAnnotatedWith(typeElement, "jakarta.persistence.MappedSuperclass")  // NOI18N
+                    || isAnnotatedWith(typeElement, "javax.persistence.Entity")  // NOI18N
+                    || isAnnotatedWith(typeElement, "javax.persistence.MappedSuperclass")  // NOI18N
+            ) {
                 for (Element element : typeElement.getEnclosedElements()) {
-                    if (isAnnotatedWith(element, "javax.persistence.Id") || isAnnotatedWith(element, "javax.persistence.EmbeddedId")) {
+                    if (isAnnotatedWith(element, "jakarta.persistence.Id")
+                            || isAnnotatedWith(element, "jakarta.persistence.EmbeddedId")
+                            || isAnnotatedWith(element, "javax.persistence.Id")
+                            || isAnnotatedWith(element, "javax.persistence.EmbeddedId")
+                    ) {
                         if (ElementKind.FIELD == element.getKind()) {
                             fieldAccess = true;
                         }
@@ -277,16 +285,25 @@ public class JpaControllerUtil {
     }
     
     public static boolean isEmbeddableClass(TypeElement typeElement) {
-        return JpaControllerUtil.isAnnotatedWith(typeElement, "javax.persistence.Embeddable");
+        return JpaControllerUtil.isAnnotatedWith(typeElement, "jakarta.persistence.Embeddable")
+                || JpaControllerUtil.isAnnotatedWith(typeElement, "javax.persistence.Embeddable");
     }
     
     public static int isRelationship(ExecutableElement method, boolean isFieldAccess) {
         Element element = isFieldAccess ? JpaControllerUtil.guessField(method) : method;
         if (element != null) {
-            if (JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.OneToOne") || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.ManyToOne")) {
+            if (JpaControllerUtil.isAnnotatedWith(element, "jakarta.persistence.OneToOne")
+                    || JpaControllerUtil.isAnnotatedWith(element, "jakarta.persistence.ManyToOne")
+                    || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.OneToOne")
+                    || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.ManyToOne")
+            ) {
                 return REL_TO_ONE;
             }
-            if (JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.OneToMany") || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.ManyToMany")) {
+            if (JpaControllerUtil.isAnnotatedWith(element, "jakarta.persistence.OneToMany")
+                    || JpaControllerUtil.isAnnotatedWith(element, "jakarta.persistence.ManyToMany")
+                    || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.OneToMany")
+                    || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.ManyToMany")
+            ) {
                 return REL_TO_MANY;
             }
         }
@@ -308,7 +325,19 @@ public class JpaControllerUtil {
         //try to find a mappedBy annotation element on the possiblyAnnotatedElement
         Element possiblyAnnotatedElement = isFieldAccess ? JpaControllerUtil.guessField(executableElement) : executableElement;
         String mappedBy = null;
-        AnnotationMirror persistenceAnnotation = JpaControllerUtil.findAnnotation(possiblyAnnotatedElement, "javax.persistence.OneToOne");  //NOI18N"
+        AnnotationMirror persistenceAnnotation = JpaControllerUtil.findAnnotation(possiblyAnnotatedElement, "jakarta.persistence.OneToOne");  //NOI18N"
+        if (persistenceAnnotation == null) {
+            persistenceAnnotation = JpaControllerUtil.findAnnotation(possiblyAnnotatedElement, "jakarta.persistence.OneToMany");  //NOI18N"
+        }
+        if (persistenceAnnotation == null) {
+            persistenceAnnotation = JpaControllerUtil.findAnnotation(possiblyAnnotatedElement, "jakarta.persistence.ManyToOne");  //NOI18N"
+        }
+        if (persistenceAnnotation == null) {
+            persistenceAnnotation = JpaControllerUtil.findAnnotation(possiblyAnnotatedElement, "jakarta.persistence.ManyToMany");  //NOI18N"
+        }
+        if(persistenceAnnotation == null) {
+            persistenceAnnotation = JpaControllerUtil.findAnnotation(possiblyAnnotatedElement, "javax.persistence.OneToOne");  //NOI18N"
+        }
         if (persistenceAnnotation == null) {
             persistenceAnnotation = JpaControllerUtil.findAnnotation(possiblyAnnotatedElement, "javax.persistence.OneToMany");  //NOI18N"
         }
@@ -374,7 +403,10 @@ public class JpaControllerUtil {
         if (fieldElement == null) {
             fieldElement = method;
         }
-        String[] fieldAnnotationFqns = {"javax.persistence.ManyToOne", "javax.persistence.OneToOne", "javax.persistence.Basic"};
+        String[] fieldAnnotationFqns = {
+            "jakarta.persistence.ManyToOne", "jakarta.persistence.OneToOne", "jakarta.persistence.Basic",
+            "javax.persistence.ManyToOne", "javax.persistence.OneToOne", "javax.persistence.Basic"
+        };
         Boolean isFieldOptionalBoolean = findAnnotationValueAsBoolean(fieldElement, fieldAnnotationFqns, "optional");
         if (isFieldOptionalBoolean != null) {
             isFieldOptional = isFieldOptionalBoolean;
@@ -383,17 +415,25 @@ public class JpaControllerUtil {
             return false;
         }
         //field is optional
-        fieldAnnotationFqns = new String[]{"javax.persistence.Column", "javax.persistence.JoinColumn"};
+        fieldAnnotationFqns = new String[]{
+            "jakarta.persistence.Column", "jakarta.persistence.JoinColumn",
+            "javax.persistence.Column", "javax.persistence.JoinColumn"
+        };
         isFieldNullable = findAnnotationValueAsBoolean(fieldElement, fieldAnnotationFqns, "nullable");
         if (isFieldNullable != null) {
             return isFieldNullable;
         }
         //new ballgame
         boolean result = true;
-        AnnotationMirror fieldAnnotation = JpaControllerUtil.findAnnotation(fieldElement, "javax.persistence.JoinColumns"); //NOI18N
+        AnnotationMirror fieldAnnotation = JpaControllerUtil.findAnnotation(fieldElement, "jakarta.persistence.JoinColumns"); //NOI18N
+        if(fieldAnnotation == null) {
+            fieldAnnotation = JpaControllerUtil.findAnnotation(fieldElement, "javax.persistence.JoinColumns"); //NOI18N
+        }
         if (fieldAnnotation != null) {
             //all joinColumn annotations must indicate nullable = false to return a false result
-            List<AnnotationMirror> joinColumnAnnotations = JpaControllerUtil.findNestedAnnotations(fieldAnnotation, "javax.persistence.JoinColumn");
+            List<AnnotationMirror> joinColumnAnnotations = new ArrayList<>();
+            joinColumnAnnotations.addAll(JpaControllerUtil.findNestedAnnotations(fieldAnnotation, "jakarta.persistence.JoinColumn"));
+            joinColumnAnnotations.addAll(JpaControllerUtil.findNestedAnnotations(fieldAnnotation, "javax.persistence.JoinColumn"));
             for (AnnotationMirror joinColumnAnnotation : joinColumnAnnotations) {
                 String columnNullableValue = JpaControllerUtil.findAnnotationValueAsString(joinColumnAnnotation, "nullable"); //NOI18N
                 if (columnNullableValue != null) {
@@ -439,9 +479,17 @@ public class JpaControllerUtil {
         boolean idDetected = false;
         TypeElement typeElement = clazz;
         while (typeElement != null && !idDetected) {
-            if (isAnnotatedWith(typeElement, "javax.persistence.Entity") || isAnnotatedWith(typeElement, "javax.persistence.MappedSuperclass")) { // NOI18N
+            if (isAnnotatedWith(typeElement, "jakarta.persistence.Entity")  // NOI18N
+                    || isAnnotatedWith(typeElement, "jakarta.persistence.MappedSuperclass") // NOI18N
+                    || isAnnotatedWith(typeElement, "javax.persistence.Entity") // NOI18N
+                    || isAnnotatedWith(typeElement, "javax.persistence.MappedSuperclass") // NOI18N
+            ) {
                 for (Element element : typeElement.getEnclosedElements()) {
-                    if (isAnnotatedWith(element, "javax.persistence.Id") || isAnnotatedWith(element, "javax.persistence.EmbeddedId")) {
+                    if (isAnnotatedWith(element, "jakarta.persistence.Id") // NOI18N
+                            || isAnnotatedWith(element, "jakarta.persistence.EmbeddedId") // NOI18N
+                            || isAnnotatedWith(element, "javax.persistence.Id") // NOI18N
+                            || isAnnotatedWith(element, "javax.persistence.EmbeddedId") // NOI18N
+                    ) {
                         idDetected = true;
                     }
                 }
@@ -458,7 +506,11 @@ public class JpaControllerUtil {
             if (methodName.startsWith("get")) {
                 Element element = isFieldAccess ? JpaControllerUtil.guessField(method) : method;
                 if (element != null) {
-                    if (JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.Id") || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.EmbeddedId")) {
+                    if (JpaControllerUtil.isAnnotatedWith(element, "jakarta.persistence.Id") // NOI18N
+                            || JpaControllerUtil.isAnnotatedWith(element, "jakarta.persistence.EmbeddedId") // NOI18N
+                            || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.Id") // NOI18N
+                            || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.EmbeddedId") // NOI18N
+                    ) {
                         return method;
                     }
                 }
@@ -471,7 +523,9 @@ public class JpaControllerUtil {
     public static boolean isGenerated(ExecutableElement method, boolean isFieldAccess) {
         Element element = isFieldAccess ? JpaControllerUtil.guessField(method) : method;
         if (element != null) {
-            if (JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.GeneratedValue")) { // NOI18N
+            if (JpaControllerUtil.isAnnotatedWith(element, "jakarta.persistence.GeneratedValue") // NOI18N
+                    || JpaControllerUtil.isAnnotatedWith(element, "javax.persistence.GeneratedValue") // NOI18N
+            ) {
                 return true;
             }
         }
@@ -535,7 +589,11 @@ public class JpaControllerUtil {
         List<ExecutableElement> result = new LinkedList<>();
         TypeElement typeElement = entityTypeElement;
         while (typeElement != null) {
-            if (isAnnotatedWith(typeElement, "javax.persistence.Entity") || isAnnotatedWith(typeElement, "javax.persistence.MappedSuperclass")) { // NOI18N
+            if (isAnnotatedWith(typeElement, "jakarta.persistence.Entity") // NOI18N
+                    || isAnnotatedWith(typeElement, "jakarta.persistence.MappedSuperclass") // NOI18N
+                    || isAnnotatedWith(typeElement, "javax.persistence.Entity") // NOI18N
+                    || isAnnotatedWith(typeElement, "javax.persistence.MappedSuperclass") // NOI18N
+            ) {
                 result.addAll(ElementFilter.methodsIn(typeElement.getEnclosedElements()));
             }
             typeElement = getSuperclassTypeElement(typeElement);
@@ -714,7 +772,10 @@ public class JpaControllerUtil {
                     if (f != null) {
                         int a = -1;
                         AnnotationMirror columnAnnotation = null;
-                        String[] columnAnnotationFqns = {"javax.persistence.EmbeddedId", "javax.persistence.JoinColumns", "javax.persistence.JoinColumn", "javax.persistence.Column"}; //NOI18N
+                        String[] columnAnnotationFqns = {
+                            "jakarta.persistence.EmbeddedId", "jakarta.persistence.JoinColumns", "jakarta.persistence.JoinColumn", "jakarta.persistence.Column", //NOI18N
+                            "javax.persistence.EmbeddedId", "javax.persistence.JoinColumns", "javax.persistence.JoinColumn", "javax.persistence.Column" //NOI18N
+                        };
                         for (int i = 0; i < columnAnnotationFqns.length; i++) {
                             String columnAnnotationFqn = columnAnnotationFqns[i];
                             AnnotationMirror columnAnnotationMirror = findAnnotation(f, columnAnnotationFqn);
@@ -724,16 +785,21 @@ public class JpaControllerUtil {
                                 break;
                             }
                         }
-                        if (a == 0) {
+                        if (a == 0 || a == 4) {
                             //populate pkAccessorMethodToColumnName and columnNameToAccessorString
                             populateMapsForEmbedded(method);
                         } else if ( (a == 1 || a == 2) && 
+                                (isAnnotatedWith(f, "jakarta.persistence.OneToOne") ||
+                                isAnnotatedWith(f, "jakarta.persistence.ManyToOne")) )  {
+                            //populate joinColumnNameToRelationshipMethod, relationshipMethodToJoinColumnNames, and joinColumnNameToReferencedColumnName
+                            populateJoinColumnNameMaps(method, columnAnnotationFqns[a], columnAnnotation);
+                        } else if ( (a == 5 || a == 6) &&
                                 (isAnnotatedWith(f, "javax.persistence.OneToOne") ||
                                 isAnnotatedWith(f, "javax.persistence.ManyToOne")) )  {
                             //populate joinColumnNameToRelationshipMethod, relationshipMethodToJoinColumnNames, and joinColumnNameToReferencedColumnName
                             populateJoinColumnNameMaps(method, columnAnnotationFqns[a], columnAnnotation);
                         }
-                        else if (a == 3) {
+                        else if (a == 3 || a == 7) {
                             //populate columnNameToAccessorString
                             String columnName = findAnnotationValueAsString(columnAnnotation, "name"); //NOI18N
                             if (columnName != null) {
@@ -788,7 +854,10 @@ public class JpaControllerUtil {
             }//something is missed, may be getter name do not match variable name, see #190854
             String pkMethodName = pkMethod.getSimpleName().toString();
             String columnName = null;
-            AnnotationMirror columnAnnotation = findAnnotation(pkFieldElement, "javax.persistence.Column"); //NOI18N
+            AnnotationMirror columnAnnotation = findAnnotation(pkFieldElement, "jakarta.persistence.Column"); //NOI18N
+            if(columnAnnotation == null) {
+                columnAnnotation = findAnnotation(pkFieldElement, "javax.persistence.Column"); //NOI18N
+            }
             if (columnAnnotation != null) {
                 columnName = findAnnotationValueAsString(columnAnnotation, "name"); //NOI18N
             }
@@ -807,13 +876,21 @@ public class JpaControllerUtil {
         }
         
         private void populateJoinColumnNameMaps(ExecutableElement m, String columnAnnotationFqn, AnnotationMirror columnAnnotation) {
-            List<AnnotationMirror> joinColumnAnnotations;
-            if ("javax.persistence.JoinColumn".equals(columnAnnotationFqn)) {
-                joinColumnAnnotations = new ArrayList<AnnotationMirror>();
+            List<AnnotationMirror> joinColumnAnnotations = new ArrayList<>();
+            if ("jakarta.persistence.JoinColumn".equals(columnAnnotationFqn)) { //NOI18N
                 joinColumnAnnotations.add(columnAnnotation);
             }
-            else {  //columnAnnotation is a javax.persistence.JoinColumns
-                joinColumnAnnotations = findNestedAnnotations(columnAnnotation, "javax.persistence.JoinColumn"); //NOI18N
+            else if ("javax.persistence.JoinColumn".equals(columnAnnotationFqn)) { //NOI18N
+                joinColumnAnnotations.add(columnAnnotation);
+            }
+            else if ("jakarta.persistence.JoinColumns".equals(columnAnnotationFqn)) { //NOI18N
+                joinColumnAnnotations.addAll(findNestedAnnotations(columnAnnotation, "jakarta.persistence.JoinColumn")); //NOI18N
+            }
+            else if ("javax.persistence.JoinColumns".equals(columnAnnotationFqn)) {
+                joinColumnAnnotations.addAll(findNestedAnnotations(columnAnnotation, "javax.persistence.JoinColumn")); //NOI18N
+            }
+            else {
+                throw new IllegalStateException("Unsupported annotation: " + columnAnnotationFqn); //NOI18N
             }
             for (AnnotationMirror joinColumnAnnotation : joinColumnAnnotations) {
                 String columnName = findAnnotationValueAsString(joinColumnAnnotation, "name"); //NOI18N

--- a/java/j2ee.persistence/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/persistence/action/ContainerManagedJTANonInjectableInWebTest/testGenerate.pass
+++ b/java/j2ee.persistence/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/persistence/action/ContainerManagedJTANonInjectableInWebTest/testGenerate.pass
@@ -6,6 +6,7 @@ import java.util.logging.Logger;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.persistence.EntityManager;
+import javax.transaction.UserTransaction;
 
 public class Test {
 
@@ -22,7 +23,7 @@ public class Test {
          * </resource-ref> */
         try {
             Context ctx = new InitialContext();
-            javax.transaction.UserTransaction utx = (javax.transaction.UserTransaction) ctx.lookup("java:comp/env/UserTransaction");
+            UserTransaction utx = (UserTransaction) ctx.lookup("java:comp/env/UserTransaction");
             utx.begin();
             EntityManager em = (EntityManager) ctx.lookup("java:comp/env/persistence/LogicalName");
             em.persist(object);

--- a/java/j2ee.persistence/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/persistence/action/ContainerManagedJTANonInjectableInWebTest/testGenerateWithExistingEM.pass
+++ b/java/j2ee.persistence/test/unit/data/goldenfiles/org/netbeans/modules/j2ee/persistence/action/ContainerManagedJTANonInjectableInWebTest/testGenerateWithExistingEM.pass
@@ -7,6 +7,7 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.transaction.UserTransaction;
 
 public class Test {
 
@@ -25,7 +26,7 @@ public class Test {
          * </resource-ref> */
         try {
             Context ctx = new InitialContext();
-            javax.transaction.UserTransaction utx = (javax.transaction.UserTransaction) ctx.lookup("java:comp/env/UserTransaction");
+            UserTransaction utx = (UserTransaction) ctx.lookup("java:comp/env/UserTransaction");
             utx.begin();
             myEm.joinTransaction();
             myEm.persist(object);

--- a/java/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/sourcetestsupport/ClassPathProviderImpl.java
+++ b/java/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/sourcetestsupport/ClassPathProviderImpl.java
@@ -49,7 +49,11 @@ public class ClassPathProviderImpl implements ClassPathProvider {
         if (ClassPath.COMPILE.equals(type)){
             try {
                 URL eclipselinkJarUrl = Class.forName("javax.persistence.EntityManager").getProtectionDomain().getCodeSource().getLocation();
-                return ClassPathSupport.createClassPath(new URL[]{FileUtil.getArchiveRoot(eclipselinkJarUrl)});
+                URL javaEE8ApiJarUrl = Class.forName("javax.annotation.Resource").getProtectionDomain().getCodeSource().getLocation();
+                return ClassPathSupport.createClassPath(new URL[]{
+                    FileUtil.getArchiveRoot(eclipselinkJarUrl),
+                    FileUtil.getArchiveRoot(javaEE8ApiJarUrl)
+                });
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }

--- a/java/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceUnitDataObjectTest.java
+++ b/java/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceUnitDataObjectTest.java
@@ -52,8 +52,10 @@ public class PersistenceUnitDataObjectTest extends PersistenceEditorTestBase{
             persistenceUnit = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_1.PersistenceUnit();
         } else if(Persistence.VERSION_2_0.equals(version)) {
             persistenceUnit = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_0.PersistenceUnit();
-        } else {
+        } else if(Persistence.VERSION_1_0.equals(version)) {
             persistenceUnit = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_1_0.PersistenceUnit();
+        } else {
+            persistenceUnit = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_3_1.PersistenceUnit();
         }
         
         persistenceUnit.setName("em3");

--- a/java/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceValidatorTest.java
+++ b/java/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceValidatorTest.java
@@ -55,8 +55,10 @@ public class PersistenceValidatorTest extends PersistenceEditorTestBase {
             unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_1.PersistenceUnit();
         } else if(Persistence.VERSION_2_0.equals(version)) {
             unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_0.PersistenceUnit();
-        } else {
+        } else if(Persistence.VERSION_1_0.equals(version)) {
             unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_1_0.PersistenceUnit();
+        } else {
+            unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_3_1.PersistenceUnit();
         }
         unit1.setName("name1");
         dataObject.addPersistenceUnit(unit1);
@@ -71,8 +73,10 @@ public class PersistenceValidatorTest extends PersistenceEditorTestBase {
             unit2 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_1.PersistenceUnit();
         } else if(Persistence.VERSION_2_0.equals(version)) {
             unit2 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_0.PersistenceUnit();
-        } else {
+        } else if(Persistence.VERSION_1_0.equals(version)) {
             unit2 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_1_0.PersistenceUnit();
+        } else {
+            unit2 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_3_1.PersistenceUnit();
         }
         unit2.setName("name1");
         dataObject.addPersistenceUnit(unit2);
@@ -103,8 +107,10 @@ public class PersistenceValidatorTest extends PersistenceEditorTestBase {
             unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_1.PersistenceUnit();
         } else if(Persistence.VERSION_2_0.equals(version)) {
             unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_0.PersistenceUnit();
-        } else {
+        } else if(Persistence.VERSION_1_0.equals(version)) {
             unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_1_0.PersistenceUnit();
+        } else {
+            unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_3_1.PersistenceUnit();
         }
         unit1.setName("unit1");
         unit1.setExcludeUnlistedClasses(true);
@@ -137,8 +143,10 @@ public class PersistenceValidatorTest extends PersistenceEditorTestBase {
             unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_1.PersistenceUnit();
         } else if(Persistence.VERSION_2_0.equals(version)) {
             unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_0.PersistenceUnit();
-        } else {
+        } else if(Persistence.VERSION_1_0.equals(version)) {
             unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_1_0.PersistenceUnit();
+        } else {
+            unit1 = new org.netbeans.modules.j2ee.persistence.dd.persistence.model_3_1.PersistenceUnit();
         }
         unit1.setName("unit1");
         unit1.addJarFile("my-jar.jar");

--- a/java/j2ee.persistenceapi/nbproject/project.xml
+++ b/java/j2ee.persistenceapi/nbproject/project.xml
@@ -159,6 +159,11 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.modules.java.j2seplatform</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.masterfs</code-name-base>
                     </test-dependency>
                     <test-dependency>

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AttributesImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/AttributesImpl.java
@@ -68,7 +68,11 @@ public class AttributesImpl implements Attributes, PropertyHandler {
                 break;
             }
             Map<String, ? extends AnnotationMirror> annByType = helper.getAnnotationsByType(typeElement.getAnnotationMirrors());
-            if (annByType.get("javax.persistence.Entity") != null || annByType.get("javax.persistence.MappedSuperclass") != null) { // NOI18N
+            if (annByType.get("jakarta.persistence.Entity") != null // NOI18N
+                    || annByType.get("jakarta.persistence.MappedSuperclass") != null // NOI18N
+                    || annByType.get("javax.persistence.Entity") != null // NOI18N
+                    || annByType.get("javax.persistence.MappedSuperclass") != null) // NOI18N
+            {
                 hierarchy.add(typeElement);
             }
         }
@@ -90,24 +94,46 @@ public class AttributesImpl implements Attributes, PropertyHandler {
             return;
         }
 
-        AnnotationMirror oneToOneAnnotation = annByType.get("javax.persistence.OneToOne"); // NOI18N
-        AnnotationMirror oneToManyAnnotation = annByType.get("javax.persistence.OneToMany"); // NOI18N
-        AnnotationMirror manyToOneAnnotation = annByType.get("javax.persistence.ManyToOne"); // NOI18N
-        AnnotationMirror manyToManyAnnotation = annByType.get("javax.persistence.ManyToMany"); // NOI18N
-        AnnotationMirror embeddedIdAnnotation = annByType.get("javax.persistence.EmbeddedId"); // NOI18N
+        AnnotationMirror oneToOneAnnotation = annByType.get("jakarta.persistence.OneToOne"); // NOI18N
+        AnnotationMirror oneToManyAnnotation = annByType.get("jakarta.persistence.OneToMany"); // NOI18N
+        AnnotationMirror manyToOneAnnotation = annByType.get("jakarta.persistence.ManyToOne"); // NOI18N
+        AnnotationMirror manyToManyAnnotation = annByType.get("jakarta.persistence.ManyToMany"); // NOI18N
+        AnnotationMirror embeddedIdAnnotation = annByType.get("jakarta.persistence.EmbeddedId"); // NOI18N
+
+        if(oneToManyAnnotation == null) {
+            oneToOneAnnotation = annByType.get("javax.persistence.OneToOne"); // NOI18N
+        }
+        if(oneToManyAnnotation == null) {
+            oneToManyAnnotation = annByType.get("javax.persistence.OneToMany"); // NOI18N
+        }
+        if(manyToOneAnnotation == null) {
+            manyToOneAnnotation = annByType.get("javax.persistence.ManyToOne"); // NOI18N
+        }
+        if(manyToManyAnnotation == null) {
+            manyToManyAnnotation = annByType.get("javax.persistence.ManyToMany"); // NOI18N
+        }
+        if(embeddedIdAnnotation == null) {
+            embeddedIdAnnotation = annByType.get("javax.persistence.EmbeddedId"); // NOI18N
+        }
 
         AnnotationMirror derivedIdAnnotation = null;
 
         if (oneToOneAnnotation != null) {
             oneToOneList.add(new OneToOneImpl(helper, element, oneToOneAnnotation, propertyName, annByType));
             //it may also be part of derived id
-            derivedIdAnnotation = annByType.get("javax.persistence.Id"); // NOI18N
+            derivedIdAnnotation = annByType.get("jakarta.persistence.Id"); // NOI18N
+            if(derivedIdAnnotation == null) {
+                derivedIdAnnotation = annByType.get("javax.persistence.Id"); // NOI18N
+            }
         } else if (oneToManyAnnotation != null) {
             oneToManyList.add(new OneToManyImpl(helper, element, oneToManyAnnotation, propertyName, annByType));
         } else if (manyToOneAnnotation != null) {
             manyToOneList.add(new ManyToOneImpl(helper, element, manyToOneAnnotation, propertyName, annByType));
             //it may also be part of derived id
-            derivedIdAnnotation = annByType.get("javax.persistence.Id"); // NOI18N
+            derivedIdAnnotation = annByType.get("jakarta.persistence.Id"); // NOI18N
+            if(derivedIdAnnotation == null) {
+                derivedIdAnnotation = annByType.get("javax.persistence.Id"); // NOI18N
+            }
         } else if (manyToManyAnnotation != null) {
             manyToManyList.add(new ManyToManyImpl(helper, element, manyToManyAnnotation, propertyName, annByType));
         } else {
@@ -115,31 +141,58 @@ public class AttributesImpl implements Attributes, PropertyHandler {
             if (embeddedIdAnnotation != null) {
                 embeddedId = new EmbeddedIdImpl(propertyName);
             } else {
-                AnnotationMirror versionAnnotation = annByType.get("javax.persistence.Version"); // NOI18N
-                AnnotationMirror idAnnotation = annByType.get("javax.persistence.Id"); // NOI18N
-                AnnotationMirror columnAnnotation = annByType.get("javax.persistence.Column"); // NOI18N
-                AnnotationMirror temporalAnnotation = annByType.get("javax.persistence.Temporal"); // NOI18N
+                AnnotationMirror versionAnnotation = annByType.get("jakarta.persistence.Version"); // NOI18N
+                AnnotationMirror idAnnotation = annByType.get("jakarta.persistence.Id"); // NOI18N
+                AnnotationMirror columnAnnotation = annByType.get("jakarta.persistence.Column"); // NOI18N
+                AnnotationMirror temporalAnnotation = annByType.get("jakarta.persistence.Temporal"); // NOI18N
+                if (versionAnnotation == null) {
+                    versionAnnotation = annByType.get("javax.persistence.Version"); // NOI18N
+                }
+                if (idAnnotation == null) {
+                    idAnnotation = annByType.get("javax.persistence.Id"); // NOI18N
+                }
+                if (columnAnnotation == null) {
+                    columnAnnotation = annByType.get("javax.persistence.Column"); // NOI18N
+                }
+                if (temporalAnnotation == null) {
+                    temporalAnnotation = annByType.get("javax.persistence.Temporal"); // NOI18N
+                }
                 String temporal = temporalAnnotation != null ? EntityMappingsUtilities.getTemporalType(helper, temporalAnnotation) : null;
                 Column column = new ColumnImpl(helper, columnAnnotation, propertyName.toUpperCase()); // NOI18N
                 if (idAnnotation != null) {
-                    AnnotationMirror generatedValueAnnotation = annByType.get("javax.persistence.GeneratedValue"); // NOI18N
+                    AnnotationMirror generatedValueAnnotation = annByType.get("jakarta.persistence.GeneratedValue"); // NOI18N
+                    if(generatedValueAnnotation == null) {
+                        generatedValueAnnotation = annByType.get("javax.persistence.GeneratedValue"); // NOI18N
+                    }
                     GeneratedValue genValue = generatedValueAnnotation != null ? new GeneratedValueImpl(helper, generatedValueAnnotation) : null;
                     idList.add(new IdImpl(propertyName, genValue, column, temporal));
                 } else if (versionAnnotation != null) {
                     versionList.add(new VersionImpl(propertyName, column, temporal));
                 } else {
-                    AnnotationMirror basicAnnotation = annByType.get("javax.persistence.Basic"); // NOI18N
+                    AnnotationMirror basicAnnotation = annByType.get("jakarta.persistence.Basic"); // NOI18N
+                    if(basicAnnotation == null) {
+                        basicAnnotation = annByType.get("javax.persistence.Basic"); // NOI18N
+                    }
                     basicList.add(new BasicImpl(helper, basicAnnotation, propertyName, column, temporal));
                 }
             }
         }
         //
         if (derivedIdAnnotation != null) {
-            AnnotationMirror columnAnnotation = annByType.get("javax.persistence.Column"); // NOI18N, TODO some annotations may not be valid for derived id and it may  not be requires, also need to separate from usual id later(just like embedded ids) to find if exist
-            AnnotationMirror temporalAnnotation = annByType.get("javax.persistence.Temporal"); // NOI18N
+            AnnotationMirror columnAnnotation = annByType.get("jakarta.persistence.Column"); // NOI18N, TODO some annotations may not be valid for derived id and it may  not be requires, also need to separate from usual id later(just like embedded ids) to find if exist
+            if (columnAnnotation == null) {
+                columnAnnotation = annByType.get("javax.persistence.Column"); // NOI18N, TODO some annotations may not be valid for derived id and it may  not be requires, also need to separate from usual id later(just like embedded ids) to find if exist
+            }
+            AnnotationMirror temporalAnnotation = annByType.get("jakarta.persistence.Temporal"); // NOI18N
+            if(temporalAnnotation == null) {
+                temporalAnnotation = annByType.get("javax.persistence.Temporal"); // NOI18N
+            }
             String temporal = temporalAnnotation != null ? EntityMappingsUtilities.getTemporalType(helper, temporalAnnotation) : null;
             Column column = new ColumnImpl(helper, columnAnnotation, propertyName.toUpperCase()); // NOI18N
-            AnnotationMirror generatedValueAnnotation = annByType.get("javax.persistence.GeneratedValue"); // NOI18N
+            AnnotationMirror generatedValueAnnotation = annByType.get("jakarta.persistence.GeneratedValue"); // NOI18N
+            if(generatedValueAnnotation == null) {
+                generatedValueAnnotation = annByType.get("javax.persistence.GeneratedValue"); // NOI18N
+            }
             GeneratedValue genValue = generatedValueAnnotation != null ? new GeneratedValueImpl(helper, generatedValueAnnotation) : null;
             IdImpl id = new IdImpl(propertyName, genValue, column, temporal);
             idList.add(id);

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddableAttributesImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddableAttributesImpl.java
@@ -52,11 +52,20 @@ public class EmbeddableAttributesImpl implements EmbeddableAttributes, PropertyH
             return;
         }
 
-        AnnotationMirror columnAnnotation = annByType.get("javax.persistence.Column"); // NOI18N
-        AnnotationMirror temporalAnnotation = annByType.get("javax.persistence.Temporal"); // NOI18N
+        AnnotationMirror columnAnnotation = annByType.get("jakarta.persistence.Column"); // NOI18N
+        if (columnAnnotation == null) {
+            columnAnnotation = annByType.get("javax.persistence.Column"); // NOI18N
+        }
+        AnnotationMirror temporalAnnotation = annByType.get("jakarta.persistence.Temporal"); // NOI18N
+        if (temporalAnnotation == null) {
+            temporalAnnotation = annByType.get("javax.persistence.Temporal"); // NOI18N
+        }
         String temporal = temporalAnnotation != null ? EntityMappingsUtilities.getTemporalType(helper, temporalAnnotation) : null;
         Column column = new ColumnImpl(helper, columnAnnotation, propertyName.toUpperCase()); // NOI18N
-        AnnotationMirror basicAnnotation = annByType.get("javax.persistence.Basic"); // NOI18N
+        AnnotationMirror basicAnnotation = annByType.get("jakarta.persistence.Basic"); // NOI18N
+        if (basicAnnotation == null) {
+            basicAnnotation = annByType.get("javax.persistence.Basic"); // NOI18N
+        }
         basicList.add(new BasicImpl(helper, basicAnnotation, propertyName, column, temporal));
     }
 

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddableImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EmbeddableImpl.java
@@ -49,7 +49,10 @@ public class EmbeddableImpl extends PersistentObject implements Embeddable, Java
         class2 = typeElement.getQualifiedName().toString();
         AnnotationModelHelper helper = getHelper();
         Map<String, ? extends AnnotationMirror> annByType = helper.getAnnotationsByType(typeElement.getAnnotationMirrors());
-        AnnotationMirror embeddableAnn = annByType.get("javax.persistence.Embeddable"); // NOI18N
+        AnnotationMirror embeddableAnn = annByType.get("jakarta.persistence.Embeddable"); // NOI18N
+        if (embeddableAnn == null) {
+            embeddableAnn = annByType.get("javax.persistence.Embeddable"); // NOI18N
+        }
         return embeddableAnn != null;
     }
 

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsImpl.java
@@ -33,7 +33,6 @@ import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.ObjectPro
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.PersistentObjectManager;
 import org.netbeans.modules.j2ee.persistence.api.metadata.orm.*;
 
-// @todo: Support JakartaEE
 public class EntityMappingsImpl implements EntityMappings {
 
     private final AnnotationModelHelper helper;
@@ -380,11 +379,19 @@ public class EntityMappingsImpl implements EntityMappings {
                     result.add(new EntityImpl(helper, EntityMappingsImpl.this, type));
                 }
             });
+            helper.getAnnotationScanner().findAnnotations("jakarta.persistence.Entity", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
+                public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
+                    result.add(new EntityImpl(helper, EntityMappingsImpl.this, type));
+                }
+            });
             return result;
         }
 
         public List<EntityImpl> createObjects(TypeElement type) {
             if (helper.hasAnnotation(type.getAnnotationMirrors(), "javax.persistence.Entity")) { // NOI18N
+                return Collections.singletonList(new EntityImpl(helper, EntityMappingsImpl.this, type));
+            }
+            if (helper.hasAnnotation(type.getAnnotationMirrors(), "jakarta.persistence.Entity")) { // NOI18N
                 return Collections.singletonList(new EntityImpl(helper, EntityMappingsImpl.this, type));
             }
             return Collections.emptyList();
@@ -405,6 +412,11 @@ public class EntityMappingsImpl implements EntityMappings {
 
         public List<EmbeddableImpl> createInitialObjects() throws InterruptedException {
             final List<EmbeddableImpl> result = new ArrayList<EmbeddableImpl>();
+            helper.getAnnotationScanner().findAnnotations("jakarta.persistence.Embeddable", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
+                public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
+                    result.add(new EmbeddableImpl(helper, EntityMappingsImpl.this, type));
+                }
+            });
             helper.getAnnotationScanner().findAnnotations("javax.persistence.Embeddable", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
                 public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
                     result.add(new EmbeddableImpl(helper, EntityMappingsImpl.this, type));
@@ -414,6 +426,9 @@ public class EntityMappingsImpl implements EntityMappings {
         }
 
         public List<EmbeddableImpl> createObjects(TypeElement type) {
+            if (helper.hasAnnotation(type.getAnnotationMirrors(), "jakarta.persistence.Embeddable")) { // NOI18N
+                return Collections.singletonList(new EmbeddableImpl(helper, EntityMappingsImpl.this, type));
+            }
             if (helper.hasAnnotation(type.getAnnotationMirrors(), "javax.persistence.Embeddable")) { // NOI18N
                 return Collections.singletonList(new EmbeddableImpl(helper, EntityMappingsImpl.this, type));
             }
@@ -435,6 +450,11 @@ public class EntityMappingsImpl implements EntityMappings {
 
         public List<MappedSuperclassImpl> createInitialObjects() throws InterruptedException {
             final List<MappedSuperclassImpl> result = new ArrayList<MappedSuperclassImpl>();
+            helper.getAnnotationScanner().findAnnotations("jakarta.persistence.MappedSuperclass", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
+                public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
+                    result.add(new MappedSuperclassImpl(helper, EntityMappingsImpl.this, type));
+                }
+            });
             helper.getAnnotationScanner().findAnnotations("javax.persistence.MappedSuperclass", AnnotationScanner.TYPE_KINDS, new AnnotationHandler() { // NOI18N
                 public void handleAnnotation(TypeElement type, Element element, AnnotationMirror annotation) {
                     result.add(new MappedSuperclassImpl(helper, EntityMappingsImpl.this, type));
@@ -444,6 +464,9 @@ public class EntityMappingsImpl implements EntityMappings {
         }
 
         public List<MappedSuperclassImpl> createObjects(TypeElement type) {
+            if (helper.hasAnnotation(type.getAnnotationMirrors(), "jakarta.persistence.MappedSuperclass")) { // NOI18N
+                return Collections.singletonList(new MappedSuperclassImpl(helper, EntityMappingsImpl.this, type));
+            }
             if (helper.hasAnnotation(type.getAnnotationMirrors(), "javax.persistence.MappedSuperclass")) { // NOI18N
                 return Collections.singletonList(new MappedSuperclassImpl(helper, EntityMappingsImpl.this, type));
             }

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsUtilities.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/EntityMappingsUtilities.java
@@ -54,6 +54,44 @@ public class EntityMappingsUtilities {
     private static final Set<String> ORM_ANNOTATIONS = new HashSet<String>();
 
     static {
+        ORM_ANNOTATIONS.add("jakarta.persistence.AssociationOverride");      // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.AssociationOverrides");     // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.AttributeOverride");        // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.AttributeOverrides");       // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Basic");                    // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Column");                   // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.DiscriminatorColumn");      // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.DiscriminatorValue");       // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Embeddable");               // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Embedded");                 // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.EmbeddedId");               // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Enumerated");               // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.GeneratedValue");           // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Id");                       // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.IdClass");                  // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Inheritance");              // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.JoinColumn");               // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.JoinColumns");              // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.JoinTable");                // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Lob");                      // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.ManyToMany");               // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.ManyToOne");                // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.MapKey");                   // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.MappedSuperclass");         // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.OneToMany");                // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.OneToOne");                 // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.OrderBy");                  // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.PrimaryKeyJoinColumn");     // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.PrimaryKeyJoinColumns");    // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.SecondaryTable");           // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.SecondaryTables");          // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.SequenceGenerator");        // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Table");                    // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.TableGenerator");           // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Temporal");                 // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Transient");                // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.UniqueConstraint");         // NOI18N
+        ORM_ANNOTATIONS.add("jakarta.persistence.Version");                  // NOI18N
         ORM_ANNOTATIONS.add("javax.persistence.AssociationOverride");      // NOI18N
         ORM_ANNOTATIONS.add("javax.persistence.AssociationOverrides");     // NOI18N
         ORM_ANNOTATIONS.add("javax.persistence.AttributeOverride");        // NOI18N
@@ -95,7 +133,9 @@ public class EntityMappingsUtilities {
     }
 
     public static boolean isTransient(Map<String, ? extends AnnotationMirror> annByType, Set<Modifier> modifiers) {
-        return annByType.containsKey("javax.persistence.Transient") || modifiers.contains(Modifier.TRANSIENT); // NOI18N
+        return annByType.containsKey("jakarta.persistence.Transient")
+                || annByType.containsKey("javax.persistence.Transient")
+                || modifiers.contains(Modifier.TRANSIENT); // NOI18N
     }
 
     public static boolean hasFieldAccess(AnnotationModelHelper helper, List<? extends Element> elements) {
@@ -154,12 +194,20 @@ public class EntityMappingsUtilities {
         final List<JoinColumn> result = new ArrayList<JoinColumn>();
         AnnotationMirror joinColumnAnn = annByType.get("javax.persistence.JoinColumn"); // NOI18N
         if (joinColumnAnn != null) {
+            joinColumnAnn = annByType.get("jakarta.persistence.JoinColumn"); // NOI18N
+        }
+        if (joinColumnAnn != null) {
             result.add(new JoinColumnImpl(helper, joinColumnAnn));
         } else {
-            AnnotationMirror joinColumnsAnnotation = annByType.get("javax.persistence.JoinColumns"); // NOI18N
+            AnnotationMirror joinColumnsAnnotation = annByType.get("jakarta.persistence.JoinColumns"); // NOI18N
+            String type = "jakarta.persistence.JoinColumn"; // NOI18N
+            if (joinColumnsAnnotation == null) {
+                joinColumnsAnnotation = annByType.get("javax.persistence.JoinColumns"); // NOI18N
+                type = "javax.persistence.JoinColumn"; // NOI18N
+            }
             if (joinColumnsAnnotation != null) {
                 AnnotationParser jcParser = AnnotationParser.create(helper);
-                jcParser.expectAnnotationArray("value", helper.resolveType("javax.persistence.JoinColumn"), new ArrayValueHandler() { // NOI18N
+                jcParser.expectAnnotationArray("value", helper.resolveType(type), new ArrayValueHandler() { // NOI18N
                     public Object handleArray(List<AnnotationValue> arrayMembers) {
                         for (AnnotationValue arrayMember : arrayMembers) {
                             AnnotationMirror joinColumnAnnotation = (AnnotationMirror)arrayMember.getValue();
@@ -176,14 +224,22 @@ public class EntityMappingsUtilities {
 
     public static List<PrimaryKeyJoinColumn> getPrimaryKeyJoinColumns(final AnnotationModelHelper helper, Map<String, ? extends AnnotationMirror> annByType) {
         final List<PrimaryKeyJoinColumn> result = new ArrayList<PrimaryKeyJoinColumn>();
-        AnnotationMirror pkJoinColumnAnn = annByType.get("javax.persistence.PrimaryKeyJoinColumn"); // NOI18N
+        AnnotationMirror pkJoinColumnAnn = annByType.get("jakarta.persistence.PrimaryKeyJoinColumn"); // NOI18N
+        if (pkJoinColumnAnn == null) {
+            pkJoinColumnAnn = annByType.get("javax.persistence.PrimaryKeyJoinColumn"); // NOI18N
+        }
         if (pkJoinColumnAnn != null) {
             result.add(new PrimaryKeyJoinColumnImpl(helper, pkJoinColumnAnn));
         } else {
             AnnotationMirror pkJoinColumnsAnnotation = annByType.get("javax.persistence.PrimaryKeyJoinColumns"); // NOI18N
+            String type = "javax.persistence.PrimaryKeyJoinColumn";
+            if (pkJoinColumnsAnnotation == null) {
+                pkJoinColumnsAnnotation = annByType.get("jakarta.persistence.PrimaryKeyJoinColumns"); // NOI18N
+                type = "jakarta.persistence.PrimaryKeyJoinColumn";
+            }
             if (pkJoinColumnsAnnotation != null) {
                 AnnotationParser pkjcParser = AnnotationParser.create(helper);
-                pkjcParser.expectAnnotationArray("value", helper.resolveType("javax.persistence.PrimaryKeyJoinColumn"), new ArrayValueHandler() { // NOI18N
+                pkjcParser.expectAnnotationArray("value", helper.resolveType(type), new ArrayValueHandler() { // NOI18N
                     public Object handleArray(List<AnnotationValue> arrayMembers) {
                         for (AnnotationValue arrayMember : arrayMembers) {
                             AnnotationMirror joinColumnAnnotation = (AnnotationMirror)arrayMember.getValue();
@@ -199,13 +255,23 @@ public class EntityMappingsUtilities {
     }
 
     public static String getTemporalType(AnnotationModelHelper helper, AnnotationMirror temporalAnnotation) {
-        AnnotationParser parser = AnnotationParser.create(helper);
-        parser.expectEnumConstant("value", helper.resolveType("javax.persistence.TemporalType"), null); // NOI18N
-        return parser.parse(temporalAnnotation).get("value", String.class);
+        if(((TypeElement) temporalAnnotation.getAnnotationType().asElement()).getQualifiedName().toString().startsWith("jakarta.")) {
+            AnnotationParser parser = AnnotationParser.create(helper);
+            parser.expectEnumConstant("value", helper.resolveType("jakarta.persistence.TemporalType"), null); // NOI18N
+            return parser.parse(temporalAnnotation).get("value", String.class);
+        } else {
+            AnnotationParser parser = AnnotationParser.create(helper);
+            parser.expectEnumConstant("value", helper.resolveType("javax.persistence.TemporalType"), null); // NOI18N
+            return parser.parse(temporalAnnotation).get("value", String.class);
+        }
     }
 
     public static IdClassImpl getIdClass(AnnotationModelHelper helper, TypeElement typeElement) {
-        AnnotationMirror idClassAnn = helper.getAnnotationsByType(typeElement.getAnnotationMirrors()).get("javax.persistence.IdClass"); // NOI18N
+        Map<String, ? extends AnnotationMirror> annByType = helper.getAnnotationsByType(typeElement.getAnnotationMirrors());
+        AnnotationMirror idClassAnn = annByType.get("jakarta.persistence.IdClass"); // NOI18N
+        if (idClassAnn == null) {
+            idClassAnn = annByType.get("javax.persistence.IdClass"); // NOI18N
+        }
         if (idClassAnn == null) {
             return null;
         }

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/GeneratedValueImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/GeneratedValueImpl.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.j2ee.persistenceapi.metadata.orm.annotation;
 
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.AnnotationModelHelper;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.parser.AnnotationParser;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.parser.ParseResult;
@@ -30,10 +31,17 @@ public class GeneratedValueImpl implements GeneratedValue {
     private final ParseResult parseResult;
 
     public GeneratedValueImpl(AnnotationModelHelper helper, AnnotationMirror generatedValueAnnotation) {
-        AnnotationParser parser = AnnotationParser.create(helper);
-        parser.expectEnumConstant("strategy", helper.resolveType("javax.persistence.GenerationType"), parser.defaultValue("AUTO")); // NOI18N
-        parser.expectString("generator", parser.defaultValue("")); // NOI18N
-        parseResult = parser.parse(generatedValueAnnotation);
+        if (((TypeElement) generatedValueAnnotation.getAnnotationType().asElement()).getQualifiedName().toString().startsWith("jakarta.")) {
+            AnnotationParser parser = AnnotationParser.create(helper);
+            parser.expectEnumConstant("strategy", helper.resolveType("jakarta.persistence.GenerationType"), parser.defaultValue("AUTO")); // NOI18N
+            parser.expectString("generator", parser.defaultValue("")); // NOI18N
+            parseResult = parser.parse(generatedValueAnnotation);
+        } else {
+            AnnotationParser parser = AnnotationParser.create(helper);
+            parser.expectEnumConstant("strategy", helper.resolveType("javax.persistence.GenerationType"), parser.defaultValue("AUTO")); // NOI18N
+            parser.expectString("generator", parser.defaultValue("")); // NOI18N
+            parseResult = parser.parse(generatedValueAnnotation);
+        }
     }
 
     public void setStrategy(String value) {

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/JoinTableImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/JoinTableImpl.java
@@ -47,7 +47,10 @@ public class JoinTableImpl implements JoinTable {
                 return result;
             }
         };
-        TypeMirror joinColumnType = helper.resolveType("javax.persistence.JoinColumn"); // NOI18N
+        TypeMirror joinColumnType = helper.resolveType("jakarta.persistence.JoinColumn"); // NOI18N
+        if (joinColumnType == null) {
+            joinColumnType = helper.resolveType("javax.persistence.JoinColumn"); // NOI18N
+        }
         parser.expectAnnotationArray("joinColumn", joinColumnType, joinColumnHandler, parser.defaultValue(Collections.emptyList())); // NOI18N
         parser.expectAnnotationArray("inverseJoinColumn", joinColumnType, joinColumnHandler, parser.defaultValue(Collections.emptyList())); // NOI18N
         parseResult = parser.parse(annotation);

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToManyImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToManyImpl.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.AnnotationModelHelper;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.parser.AnnotationParser;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.parser.ArrayValueHandler;
@@ -39,22 +40,37 @@ public class ManyToManyImpl implements ManyToMany {
 
     public ManyToManyImpl(final AnnotationModelHelper helper, final Element element, AnnotationMirror manyToManyAnnotation, String name, Map<String, ? extends AnnotationMirror> annByType) {
         this.name = name;
+
+        String cascadeTypeName;
+        String fetchTypeName;
+        String joinTableName;
+
+        if (((TypeElement) manyToManyAnnotation.getAnnotationType().asElement()).getQualifiedName().toString().startsWith("jakarta.")) {
+            cascadeTypeName = "jakarta.persistence.CascadeType";
+            fetchTypeName = "jakarta.persistence.FetchType";
+            joinTableName = "jakarta.persistence.JoinTable";
+        } else {
+            cascadeTypeName = "javax.persistence.CascadeType";
+            fetchTypeName = "javax.persistence.FetchType";
+            joinTableName = "javax.persistence.JoinTable";
+        }
+
         AnnotationParser parser = AnnotationParser.create(helper);
         parser.expectClass("targetEntity", new DefaultProvider() { // NOI18N
             public Object getDefaultValue() {
                 return EntityMappingsUtilities.getCollectionArgumentTypeName(helper, element);
             }
         });
-        parser.expectEnumConstantArray("cascade", helper.resolveType("javax.persistence.CascadeType"), new ArrayValueHandler() { // NOI18N
+        parser.expectEnumConstantArray("cascade", helper.resolveType(cascadeTypeName), new ArrayValueHandler() { // NOI18N
             public Object handleArray(List<AnnotationValue> arrayMembers) {
                 return new CascadeTypeImpl(arrayMembers);
             }
         }, parser.defaultValue(new CascadeTypeImpl()));
-        parser.expectEnumConstant("fetch", helper.resolveType("javax.persistence.FetchType"), parser.defaultValue("LAZY")); // NOI18N
+        parser.expectEnumConstant("fetch", helper.resolveType(fetchTypeName), parser.defaultValue("LAZY")); // NOI18N
         parser.expectString("mappedBy", parser.defaultValue("")); // NOI18N
         parseResult = parser.parse(manyToManyAnnotation);
 
-        joinTable = new JoinTableImpl(helper, annByType.get("javax.persistence.JoinTable")); // NOI18N
+        joinTable = new JoinTableImpl(helper, annByType.get(joinTableName)); // NOI18N
     }
 
     public void setName(String value) {

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToOneImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/ManyToOneImpl.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.AnnotationModelHelper;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.parser.AnnotationParser;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.parser.ArrayValueHandler;
@@ -40,22 +41,37 @@ public class ManyToOneImpl implements ManyToOne {
 
     public ManyToOneImpl(final AnnotationModelHelper helper, final Element element, AnnotationMirror manyToOneAnnotation, String name, Map<String, ? extends AnnotationMirror> annByType) {
         this.name = name;
+
+        String cascadeTypeName;
+        String fetchTypeName;
+        String joinTableName;
+
+        if (((TypeElement) manyToOneAnnotation.getAnnotationType().asElement()).getQualifiedName().toString().startsWith("jakarta.")) {
+            cascadeTypeName = "jakarta.persistence.CascadeType";
+            fetchTypeName = "jakarta.persistence.FetchType";
+            joinTableName = "jakarta.persistence.JoinTable";
+        } else {
+            cascadeTypeName = "javax.persistence.CascadeType";
+            fetchTypeName = "javax.persistence.FetchType";
+            joinTableName = "javax.persistence.JoinTable";
+        }
+
         AnnotationParser parser = AnnotationParser.create(helper);
         parser.expectClass("targetEntity", new DefaultProvider() { // NOI18N
             public Object getDefaultValue() {
                 return EntityMappingsUtilities.getElementTypeName(element);
             }
         });
-        parser.expectEnumConstantArray("cascade", helper.resolveType("javax.persistence.CascadeType"), new ArrayValueHandler() { // NOI18N
+        parser.expectEnumConstantArray("cascade", helper.resolveType(cascadeTypeName), new ArrayValueHandler() { // NOI18N
             public Object handleArray(List<AnnotationValue> arrayMembers) {
                 return new CascadeTypeImpl(arrayMembers);
             }
         }, parser.defaultValue(new CascadeTypeImpl()));
-        parser.expectEnumConstant("fetch", helper.resolveType("javax.persistence.FetchType"), parser.defaultValue("EAGER")); // NOI18N
+        parser.expectEnumConstant("fetch", helper.resolveType(fetchTypeName), parser.defaultValue("EAGER")); // NOI18N
         parser.expectPrimitive("optional", Boolean.class, parser.defaultValue(true)); // NOI18N
         parseResult = parser.parse(manyToOneAnnotation);
 
-        joinTable = new JoinTableImpl(helper, annByType.get("javax.persistence.JoinTable")); // NOI18N
+        joinTable = new JoinTableImpl(helper, annByType.get(joinTableName)); // NOI18N
         joinColumnList = EntityMappingsUtilities.getJoinColumns(helper, annByType);
     }
 

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/MappedSuperclassImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/MappedSuperclassImpl.java
@@ -55,8 +55,14 @@ public class MappedSuperclassImpl extends PersistentObject implements MappedSupe
         class2 = typeElement.getQualifiedName().toString();
         AnnotationModelHelper helper = getHelper();
         Map<String, ? extends AnnotationMirror> annByType = helper.getAnnotationsByType(typeElement.getAnnotationMirrors());
-        AnnotationMirror embeddableAnn = annByType.get("javax.persistence.MappedSuperclass"); // NOI18N
-        AnnotationMirror entityAcc = annByType.get("javax.persistence.Access"); // NOI18N
+        AnnotationMirror embeddableAnn = annByType.get("jakarta.persistence.MappedSuperclass"); // NOI18N
+        if (embeddableAnn == null) {
+            embeddableAnn = annByType.get("javax.persistence.MappedSuperclass"); // NOI18N
+        }
+        AnnotationMirror entityAcc = annByType.get("jakarta.persistence.Access"); // NOI18N
+        if (entityAcc == null) {
+            entityAcc = annByType.get("javax.persistence.Access"); // NOI18N
+        }
         if (entityAcc != null) {
             entityAcc.getElementValues();
             AnnotationParser parser = AnnotationParser.create(helper);
@@ -101,7 +107,12 @@ public class MappedSuperclassImpl extends PersistentObject implements MappedSupe
     public String getAccess() {
         if (accessType != null && accessType.length()>0) {
             //use access type specified by annotation by default, regardless of later fields/properties annitatons
-            return accessType.equals("javax.persistence.AccessType.PROPERTY") ? PROPERTY_ACCESS : FIELD_ACCESS;
+            if (accessType.equals("jakarta.persistence.AccessType.PROPERTY")
+                    || accessType.equals("javax.persistence.AccessType.PROPERTY")) {
+                return PROPERTY_ACCESS;
+            } else {
+                return FIELD_ACCESS;
+            }
         } else {
             return getAttributes().hasFieldAccess() ? FIELD_ACCESS : PROPERTY_ACCESS;
         }

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToManyImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToManyImpl.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.AnnotationModelHelper;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.parser.AnnotationParser;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.parser.ArrayValueHandler;
@@ -40,22 +41,37 @@ public class OneToManyImpl implements OneToMany {
 
     public OneToManyImpl(final AnnotationModelHelper helper, final Element element, AnnotationMirror oneToManyAnnotation, String name, Map<String, ? extends AnnotationMirror> annByType) {
         this.name = name;
+
+        String cascadeTypeName;
+        String fetchTypeName;
+        String joinTableName;
+
+        if (((TypeElement) oneToManyAnnotation.getAnnotationType().asElement()).getQualifiedName().toString().startsWith("jakarta.")) {
+            cascadeTypeName = "jakarta.persistence.CascadeType";
+            fetchTypeName = "jakarta.persistence.FetchType";
+            joinTableName = "jakarta.persistence.JoinTable";
+        } else {
+            cascadeTypeName = "javax.persistence.CascadeType";
+            fetchTypeName = "javax.persistence.FetchType";
+            joinTableName = "javax.persistence.JoinTable";
+        }
+
         AnnotationParser parser = AnnotationParser.create(helper);
         parser.expectClass("targetEntity", new DefaultProvider() { // NOI18N
             public Object getDefaultValue() {
                 return EntityMappingsUtilities.getCollectionArgumentTypeName(helper, element);
             }
         });
-        parser.expectEnumConstantArray("cascade", helper.resolveType("javax.persistence.CascadeType"), new ArrayValueHandler() { // NOI18N
+        parser.expectEnumConstantArray("cascade", helper.resolveType(cascadeTypeName), new ArrayValueHandler() { // NOI18N
             public Object handleArray(List<AnnotationValue> arrayMembers) {
                 return new CascadeTypeImpl(arrayMembers);
             }
         }, parser.defaultValue(new CascadeTypeImpl()));
-        parser.expectEnumConstant("fetch", helper.resolveType("javax.persistence.FetchType"), parser.defaultValue("LAZY")); // NOI18N
+        parser.expectEnumConstant("fetch", helper.resolveType(fetchTypeName), parser.defaultValue("LAZY")); // NOI18N
         parser.expectString("mappedBy", parser.defaultValue("")); // NOI18N
         parseResult = parser.parse(oneToManyAnnotation);
 
-        joinTable = new JoinTableImpl(helper, annByType.get("javax.persistence.JoinTable")); // NOI18N
+        joinTable = new JoinTableImpl(helper, annByType.get(joinTableName)); // NOI18N
         joinColumnList = EntityMappingsUtilities.getJoinColumns(helper, annByType);
     }
 

--- a/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToOneImpl.java
+++ b/java/j2ee.persistenceapi/src/org/netbeans/modules/j2ee/persistenceapi/metadata/orm/annotation/OneToOneImpl.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.AnnotationModelHelper;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.parser.AnnotationParser;
 import org.netbeans.modules.j2ee.metadata.model.api.support.annotation.parser.ArrayValueHandler;
@@ -41,23 +42,38 @@ public class OneToOneImpl implements OneToOne {
 
     public OneToOneImpl(final AnnotationModelHelper helper, final Element element, AnnotationMirror oneToOneAnnotation, String name, Map<String, ? extends AnnotationMirror> annByType) {
         this.name = name;
+
+        String cascadeTypeName;
+        String fetchTypeName;
+        String joinTableName;
+
+        if (((TypeElement) oneToOneAnnotation.getAnnotationType().asElement()).getQualifiedName().toString().startsWith("jakarta.")) {
+            cascadeTypeName = "jakarta.persistence.CascadeType";
+            fetchTypeName = "jakarta.persistence.FetchType";
+            joinTableName = "jakarta.persistence.JoinTable";
+        } else {
+            cascadeTypeName = "javax.persistence.CascadeType";
+            fetchTypeName = "javax.persistence.FetchType";
+            joinTableName = "javax.persistence.JoinTable";
+        }
+
         AnnotationParser parser = AnnotationParser.create(helper);
         parser.expectClass("targetEntity", new DefaultProvider() { // NOI18N
             public Object getDefaultValue() {
                 return EntityMappingsUtilities.getElementTypeName(element);
             }
         });
-        parser.expectEnumConstantArray("cascade", helper.resolveType("javax.persistence.CascadeType"), new ArrayValueHandler() { // NOI18N
+        parser.expectEnumConstantArray("cascade", helper.resolveType(cascadeTypeName), new ArrayValueHandler() { // NOI18N
             public Object handleArray(List<AnnotationValue> arrayMembers) {
                 return new CascadeTypeImpl(arrayMembers);
             }
         }, parser.defaultValue(new CascadeTypeImpl()));
-        parser.expectEnumConstant("fetch", helper.resolveType("javax.persistence.FetchType"), parser.defaultValue("EAGER")); // NOI18N
+        parser.expectEnumConstant("fetch", helper.resolveType(fetchTypeName), parser.defaultValue("EAGER")); // NOI18N
         parser.expectPrimitive("optional", Boolean.class, parser.defaultValue(true)); // NOI18N
         parser.expectString("mappedBy", parser.defaultValue("")); // NOI18N
         parseResult = parser.parse(oneToOneAnnotation);
 
-        joinTable = new JoinTableImpl(helper, annByType.get("javax.persistence.JoinTable")); // NOI18N
+        joinTable = new JoinTableImpl(helper, annByType.get(joinTableName)); // NOI18N
         joinColumnList = EntityMappingsUtilities.getJoinColumns(helper, annByType);
         pkJoinColumnList = EntityMappingsUtilities.getPrimaryKeyJoinColumns(helper, annByType);
     }

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -123,7 +123,7 @@
         </condition>
     </target>
     <target name="-init-bootclasspath-prepend-run9" depends="-init-bootclasspath-prepend-compile" if="have-jdk-1.9">
-        <condition property="test.bootclasspath.prepend.args" value="--limit-modules=java.base,java.logging,java.xml,java.prefs,java.desktop,java.management,java.instrument,jdk.zipfs,java.scripting,java.naming,jdk.jdi,jdk.unsupported">
+        <condition property="test.bootclasspath.prepend.args" value="--limit-modules=java.base,java.logging,java.xml,java.prefs,java.desktop,java.management,java.instrument,jdk.zipfs,java.scripting,java.naming,jdk.jdi,jdk.unsupported,java.sql">
             <and>
                 <istrue value="${requires.nb.javac}"/>
                 <not>


### PR DESCRIPTION
NetBeans has partitial support for JakartaEE 9+, but several areas that provide support are still lacking support for the new package namespace "jakarta.*" instead of "javax.*".

This PR adjusts a subset of these cases and focuses on the JPA and JSF area. Further areas where identified while working on this and were marked with @todo comments.

There are two areas, that form the main picture: Code generated in the wrong package namespace and code scanning not finding classes in the new "jakarta" namespace. For the former switches were introduced, that change the generated code to the "jakarta" namespace when a compatible JSF version is detected. The code scanning was in most placed adjusted, so that both variants "javax" and "jakarta" are recognized.

Closes: #6445
Closes: #4840

