### PR TITLE
Remove obsolete UseQuartz JVM flag.

### DIFF
--- a/nb/ide.launcher/netbeans.conf
+++ b/nb/ide.launcher/netbeans.conf
@@ -56,7 +56,7 @@ netbeans_default_cachedir="${DEFAULT_CACHEDIR_ROOT}/@@metabuild.RawVersion@@"
 # The automatically selected value can be overridden by specifying -J-Xmx
 # here or on the command line.
 #
-netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.application.appearance=system -J-Dapple.awt.graphics.UseQuartz=true -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions"
+netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.application.appearance=system -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions"
 
 # Default location of JDK:
 # (set by installer or commented out if launcher should decide)


### PR DESCRIPTION
The `quartz` renderer doesn't exist anymore since java 7, on java 19+ the new `metal` renderer is used for MacOS systems.

closes #6316 (see comment for details)