### PR TITLE
Autoupdate system must check org.openide.modules.arch as org.openide.modules.os is already handled

### DIFF
--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateUnitFactory.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/UpdateUnitFactory.java
@@ -217,13 +217,14 @@ public class UpdateUnitFactory {
         
         // XXX: it's should be moved in UI what should filter all elements w/ broken dependencies
         // #101515: Plugin Manager must filter updates by platform dependency
-        boolean passed = false;
         UpdateElementImpl elImpl = Trampoline.API.impl (element);
         if (elImpl instanceof ModuleUpdateElementImpl && elImpl.getModuleInfos () != null && elImpl.getModuleInfos ().size() == 1) {
             for (Dependency d : elImpl.getModuleInfos ().get (0).getDependencies ()) {
                 if (Dependency.TYPE_REQUIRES == d.getType ()) {
                     //log.log (Level.FINEST, "Dependency: NAME: " + d.getName () + ", TYPE: " + d.getType () + ": " + d.toString ());
                     if (d.getName ().startsWith ("org.openide.modules.os")) { // NOI18N
+                        // Filter OS specific dependencies
+                        boolean passed = false;
                         for (ModuleInfo info : InstalledModuleProvider.getInstalledModules ().values ()) {
                             if (Arrays.asList (info.getProvides ()).contains (d.getName ())) {
                                 log.log (Level.FINEST, element + " which requires OS " + d + " succeed.");
@@ -233,6 +234,20 @@ public class UpdateUnitFactory {
                         }
                         if (! passed) {
                             log.log (Level.FINE, element + " which requires OS " + d + " fails.");
+                            return ;
+                        }
+                    } else if (d.getName ().startsWith ("org.openide.modules.arch")) { // NOI18N
+                        // Filter architecture specific dependencies
+                        boolean passed = false;
+                        for (ModuleInfo info : InstalledModuleProvider.getInstalledModules ().values ()) {
+                            if (Arrays.asList (info.getProvides ()).contains (d.getName ())) {
+                                log.log (Level.FINEST, element + " which requires architecture " + d + " succeed.");
+                                passed = true;
+                                break;
+                            }
+                        }
+                        if (! passed) {
+                            log.log (Level.FINE, element + " which requires architecture " + d + " fails.");
                             return ;
                         }
                     }


### PR DESCRIPTION
With d1300be50b8864eb605cee456c4b123d768e0eca the netbeans module system was enhanced to enable modules to be filtered by architecture. Missing from that commit was adjustment to the autoupdate system, which also needs to consider the architecture when providing packages for selection.

Closes: #6460