### PR TITLE
Rearrange commit validation job.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,10 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}-${{ github.base_ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 env:
 
   # note to self: don't remove the minus again
@@ -96,7 +100,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '11', '17', '21' ]
+        java: [ '11', '21' ]
       fail-fast: false
     steps:
         
@@ -107,10 +111,11 @@ jobs:
           distribution: ${{ env.default_java_distribution }}
           
       - name: Checkout ${{ github.ref }} ( ${{ github.sha }} )
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: false
+          show-progress: false
 
       - name: Caching dependencies
         uses: actions/cache@v3
@@ -161,11 +166,18 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'nb-javac') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+
+      - name: Checkout ${{ github.ref }} ( ${{ github.sha }} )
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: false
+          show-progress: false
+
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-            distribution: 'zulu'
+            distribution: ${{ env.default_java_distribution }}
             java-version: 11
       - name: Caching dependencies
         uses: actions/cache/restore@v3
@@ -186,13 +198,17 @@ jobs:
 
 # secondary jobs
   linux-commit-validation:
-    name: Commit Validation on Linux/JDK ${{ matrix.java }}
+    name: CV on ${{ matrix.os }}/JDK ${{ matrix.java }}
     needs: base-build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }} 
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '11', '17', '21' ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        java: [ 11 ]
+        include:
+          - os: ubuntu-latest
+            java: 21
       fail-fast: false
     steps:
 
@@ -203,6 +219,7 @@ jobs:
           distribution: ${{ env.default_java_distribution }}
 
       - name: Setup Xvfb
+        if: contains(matrix.os, 'ubuntu') && success()
         run: |
           echo "DISPLAY=:99.0" >> $GITHUB_ENV
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
@@ -212,8 +229,23 @@ jobs:
         with:
           name: build
 
-      - name: Extract
+      # tar on MacOS is not aware of zstd "tar --zstd -xf build.tar.zst" doesn't work
+      - name: Extract on MacOS
+        if: contains(matrix.os, 'macos') && success()
+        run: unzstd -c build.tar.zst | tar -x
+
+      - name: Extract on Linux/Windows
+        if: contains(matrix.os, 'macos') == false && success()
         run: tar --zstd -xf build.tar.zst
+
+      - name: platform/masterfs.macosx
+        if: contains(matrix.os, 'macos') && success()
+        run: ant $OPTS -f platform/masterfs.macosx test
+
+      # fails on 17+
+      - name: platform/core.network
+        if: matrix.java == 11 && success()
+        run: ant $OPTS -f platform/core.network test
 
       - name: Commit Validation tests
         run: ant $OPTS -Dcluster.config=$CLUSTER_CONFIG commit-validation
@@ -222,8 +254,9 @@ jobs:
         uses: test-summary/action@v2
         if: failure()
         with:
-          paths: "./nbbuild/build/test/commit-validation/results/TEST-*.xml"
-
+          paths: |
+            ./*/*/build/test/*/results/TEST-*.xml
+            ./nbbuild/build/test/commit-validation/results/TEST-*.xml
 
   # commit related checks - some steps run even when the build is dissabled
   paperwork:
@@ -247,10 +280,11 @@ jobs:
 
       - name: Checkout ${{ github.ref }} ( ${{ github.sha }} )
         if: ${{ !cancelled() }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: false
+          show-progress: false
           fetch-depth: 10
 
       - name: Print last 10 Commits
@@ -915,9 +949,6 @@ jobs:
       - name: platform/core.netigso
         run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.netigso test
 
-      - name: platform/core.network
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.network test
-
       - name: platform/core.osgi
         run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.osgi test
 
@@ -986,7 +1017,7 @@ jobs:
 
       # use cache so that the platform build doesn't have to download dependencies again
       - name: Caching dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ~/.hgexternalcache
           key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
@@ -1768,49 +1799,6 @@ jobs:
           paths: "./*/*/build/test/*/results/TEST-*.xml"
 
 
-  macos:
-    name: Tests on MacOS/JDK ${{ matrix.java }}
-    needs: base-build
-    runs-on: macos-latest
-    timeout-minutes: 90
-    strategy:
-      matrix:
-        java: [ '11' ]
-    steps:
-
-      - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.java }} 
-          distribution: ${{ env.default_java_distribution }}
-
-      - name: Download Build
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-
-      # tar on MacOS is not aware of zstd "tar --zstd -xf build.tar.zst" isn't working
-      - name: Extract
-        run: unzstd -c build.tar.zst | tar -x
-
-      - name: Test platform/masterfs.macosx
-        run: ant $OPTS -f platform/masterfs.macosx test
-
-      - name: Test platform/core.network
-        run: ant $OPTS -f platform/core.network test
-
-      - name: Commit Validation tests
-        run: ant $OPTS -Dcluster.config=$CLUSTER_CONFIG commit-validation
-
-      - name: Create Test Summary
-        uses: test-summary/action@v2
-        if: failure()
-        with:
-          paths: |
-            "./*/*/build/test/*/results/TEST-*.xml"
-            "./nbbuild/build/test/commit-validation/results/TEST-*.xml"
-
-
   javafx-test:
     name: JavaFX on Linux/JDK ${{ matrix.java }}
     needs: base-build
@@ -2332,15 +2320,12 @@ jobs:
     needs: base-build
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
-    defaults:
-      run:
-        shell: bash
     env:
       DISPLAY: ":99.0"
     strategy:
       matrix:
         java: [ '11' ]
-        os: [ 'windows-2022', 'ubuntu-20.04' ]
+        os: [ 'windows-latest', 'ubuntu-latest' ]
       fail-fast: false
     steps:
 
@@ -2372,9 +2357,6 @@ jobs:
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
-
-      - name: Test Platform Core Network
-        run: ant $OPTS -f platform/core.network test
 
       - name: hudson.php
         run: ant $OPTS -f php/hudson.php test
@@ -2571,7 +2553,7 @@ jobs:
         run: ant $OPTS -f java/nashorn.execution test
 
       - name: java/debugger.jpda.truffle
-        run: ant $OPTS -f java/debugger.jpda.truffle test
+        run: .github/retry.sh ant $OPTS -f java/debugger.jpda.truffle test
 
       - name: Create Test Summary
         uses: test-summary/action@v2
@@ -2647,7 +2629,6 @@ jobs:
       - apisupport-modules-test
       - build-tools
       - webcommon-test
-      - macos
       - php
       - javafx-test
       - groovy-test
@@ -2668,10 +2649,11 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: true
+          show-progress: false
 
       - name: Delete Workspace Artifact
         uses: ./.github/actions/delete-artifact/

--- a/.github/workflows/native-binary-build-lib.profiler.yml
+++ b/.github/workflows/native-binary-build-lib.profiler.yml
@@ -47,10 +47,7 @@
 # ----------------------
 
 
-
-
-name: Profiler native binary build
-
+name: NetBeans Profiler Libraries
 
 
 on:
@@ -69,23 +66,27 @@ on:
   # Allows you to run this workflow manually from the Actions tab in GitHub UI
   workflow_dispatch:
 
-
+# cancel other PR workflow run in the same head-base group if it exists (e.g. during PR syncs)
+# if this is not a PR run (no github.head_ref and github.base_ref defined), use an UID as group
+concurrency: 
+  group: profiler-${{ github.head_ref || github.run_id }}-${{ github.base_ref }}
+  cancel-in-progress: true
 
 jobs:
   
   source:
 
     name: Build source zip
-
     runs-on: ubuntu-latest
 
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: false
+          show-progress: false
 
       - name: Caching dependencies
         uses: actions/cache@v3
@@ -123,8 +124,8 @@ jobs:
 
   build-linux:
 
+    name: Build on Linux
     runs-on: ubuntu-latest
-    
     needs: source
     
     steps:
@@ -184,8 +185,8 @@ jobs:
 
   build-windows:
 
+    name: Build on Windows
     runs-on: windows-latest
-
     needs: source
     
     steps:
@@ -257,8 +258,8 @@ jobs:
 
   build-macos:
 
+    name: Build on MacOS
     runs-on: macos-latest
-    
     needs: source
 
     steps:
@@ -297,6 +298,7 @@ jobs:
 
   build-zip-with-build-artifacts:
 
+    name: Package Profiler Libraries
     runs-on: ubuntu-latest
 
     # Only run when the platform specific builds are finished


### PR DESCRIPTION
after merging the macos job into the cv job and adding a windows config, the cv job would produce the following runs:

```
 linux   JDK [11, 21]
 windows JDK [11]  <-- new
 macos   JDK [11]
```

 - improves windows coverage and removes a job
 - removes JDK 17 from the matrix since if it works on 11 and 21, it likely will also work on 17

other updates:
 - add retry wrapper for debugger.jpda.truffle tests again
 - bumped checkout action to v4 and download/upload actions to v3
 - renamed a few jobs in the profiler yaml to align with the main yaml
 - use cache/restore action for read only cache access in platform job
