### PR TITLE
Small code cleanup in extbrowser module.

### DIFF
--- a/ide/extbrowser/src/org/netbeans/modules/extbrowser/ExtBrowserImpl.java
+++ b/ide/extbrowser/src/org/netbeans/modules/extbrowser/ExtBrowserImpl.java
@@ -35,10 +35,7 @@ public abstract class ExtBrowserImpl extends HtmlBrowser.Impl {
 
     private static final RequestProcessor RP = new RequestProcessor(ExtBrowserImpl.class);
 
-    /** Lookup of this {@code HtmlBrowser.Impl}.  */
-    private Lookup lookup;
-
-    /** standart helper variable */
+    /** standard helper variable */
     protected PropertyChangeSupport pcs;
 
     /** requested URL */
@@ -82,9 +79,7 @@ public abstract class ExtBrowserImpl extends HtmlBrowser.Impl {
     @Override
     public void stopLoading() { }
     
-    protected void setTitle (String title) {
-        return;
-    }
+    protected void setTitle (String title) { }
     
     @Override
     public String getTitle() {
@@ -135,11 +130,8 @@ public abstract class ExtBrowserImpl extends HtmlBrowser.Impl {
     }
 
     protected final void loadURLInBrowser(final URL url) {
-        RP.post(new Runnable() {
-            @Override
-            public void run() {
-                loadURLInBrowserInternal(url);
-            }
+        RP.post(() -> {
+            loadURLInBrowserInternal(url);
         });
     }
 
@@ -179,6 +171,7 @@ public abstract class ExtBrowserImpl extends HtmlBrowser.Impl {
         pcs.removePropertyChangeListener (l);
     }
 
+    @Override
     public final Lookup getLookup() {
         return Lookup.EMPTY;
     }

--- a/ide/extbrowser/src/org/netbeans/modules/extbrowser/NbDdeBrowserImpl.java
+++ b/ide/extbrowser/src/org/netbeans/modules/extbrowser/NbDdeBrowserImpl.java
@@ -37,6 +37,7 @@ import org.openide.util.NbBundle;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.logging.Level;
 import org.openide.util.Exceptions;
 
@@ -413,7 +414,7 @@ public class NbDdeBrowserImpl extends ExtBrowserImpl {
             while ((f == null) && (retries > 0)) {
                 retries--;
                 try {
-                    f = File.createTempFile("extbrowser", ".html");             // NOI18N
+                    f = Files.createTempFile("extbrowser", ".html").toFile();             // NOI18N
                     logFine("file:", f); // NOI18N
                     if (f != null) { 
                         fw = new FileWriter(f);


### PR DESCRIPTION
I originally thought I could enable the `JdkBrowserImpl` by default due to #6455, but this could potentially cause feature regressions since the impl is fairly limited.

However, looking through the code I am wondering if any of the "DDE" features still work on windows for example.

Didn't want to discard the cleanup, so I opened this PR.