### PR TITLE
Disaplay parameter tooltips for annotations.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -622,7 +622,9 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
             signatureInformation.setParameters(parameters);
             if (activeSignature.get() < 0 && signature.isActive()) {
                 activeSignature.set(signatures.size());
-                activeParameter.set(signatureInformation.getActiveParameter());
+                if (signatureInformation.getActiveParameter() != null) {
+                    activeParameter.set(signatureInformation.getActiveParameter());
+                }
             }
             signatures.add(signatureInformation);
         });


### PR DESCRIPTION
Parameter tooltips (signature help in LSP) should be displayed also for annotations (in addition to method/constructor invocations).