### PR TITLE
UpdateDependencyHint should work on plugins with default maven group id

### DIFF
--- a/java/maven.hints/manifest.mf
+++ b/java/maven.hints/manifest.mf
@@ -4,3 +4,4 @@ OpenIDE-Module-Specification-Version: 1.62
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/hints/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/maven/hints/layer.xml
 AutoUpdate-Show-In-Client: false
+OpenIDE-Module-Java-Dependencies: Java > 11

--- a/java/maven.hints/nbproject/project.properties
+++ b/java/maven.hints/nbproject/project.properties
@@ -16,10 +16,10 @@
 # under the License.
 
 is.eager=true
-javac.source=1.8
+javac.source=11
+javac.target=11
 #javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class
-requires.nb.javac=true
 
 test-unit-sys-prop.test.netbeans.dest.dir=${netbeans.dest.dir}

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/UseReleaseOptionHint.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/UseReleaseOptionHint.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.maven.hints.pom;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.prefs.Preferences;
@@ -78,7 +77,7 @@ public class UseReleaseOptionHint implements POMErrorFixProvider {
     public List<ErrorDescription> getErrorsForDocument(POMModel model, Project prj) {
 
         if (prj == null) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         // no hints if plugin was downgraded
@@ -87,7 +86,7 @@ public class UseReleaseOptionHint implements POMErrorFixProvider {
             // note: this is the embedded plugin version, only useful for downgrade checks
             String pluginVersion = PluginPropertyUtils.getPluginVersion(nbproject.getMavenProject(), Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER);
             if (pluginVersion != null && new ComparableVersion(pluginVersion).compareTo(COMPILER_PLUGIN_VERSION) <= 0) {
-                return Collections.emptyList();
+                return List.of();
             }
         }
 
@@ -99,7 +98,7 @@ public class UseReleaseOptionHint implements POMErrorFixProvider {
 
         if (build != null && build.getPlugins() != null) {
             Optional<Plugin> compilerPlugin = build.getPlugins().stream()
-                    .filter((p) -> "maven-compiler-plugin".equals(p.getArtifactId()))
+                    .filter((p) -> Constants.PLUGIN_COMPILER.equals(p.getArtifactId()))
                     .filter(this::isPluginCompatible)
                     .findFirst();
 
@@ -118,7 +117,7 @@ public class UseReleaseOptionHint implements POMErrorFixProvider {
         if (!releaseSupportedByDeclaredPlugin) {
             ComparableVersion mavenVersion = PomModelUtils.getActiveMavenVersion();
             if (mavenVersion == null || mavenVersion.compareTo(MAVEN_VERSION) <= 0) {
-                return Collections.emptyList();
+                return List.of();
             }
         }
 
@@ -133,7 +132,7 @@ public class UseReleaseOptionHint implements POMErrorFixProvider {
     private List<ErrorDescription> createHintsForParent(String prefix, POMComponent parent) {
 
         if (parent == null) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         int source;
@@ -162,7 +161,7 @@ public class UseReleaseOptionHint implements POMErrorFixProvider {
             }
         } catch (NumberFormatException ignored) {
             // if source or target is invalid or missing
-            return Collections.emptyList();
+            return List.of();
         }
 
         if (source == target && source >= 9) {
@@ -175,12 +174,12 @@ public class UseReleaseOptionHint implements POMErrorFixProvider {
             }
             return hints;
         }
-        return Collections.emptyList();
+        return List.of();
     }
 
     private ErrorDescription createHintForComponent(String prefix, POMComponent component, POMModel model, String release) {
         Line line = NbEditorUtilities.getLine(model.getBaseDocument(), component.findPosition(), false);
-        List<Fix> fix = Collections.singletonList(new ConvertToReleaseOptionFix(prefix, release, component));
+        List<Fix> fix = List.of(new ConvertToReleaseOptionFix(prefix, release, component));
         return ErrorDescriptionFactory.createErrorDescription(Severity.HINT, FIX_UseReleaseVersionHint(), fix, model.getBaseDocument(), line.getLineNumber()+1);
     }
 

--- a/java/maven.hints/test/unit/src/org/netbeans/modules/maven/hints/pom/StatusProviderTest.java
+++ b/java/maven.hints/test/unit/src/org/netbeans/modules/maven/hints/pom/StatusProviderTest.java
@@ -23,7 +23,6 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.netbeans.junit.NbTestCase;
-import org.openide.filesystems.FileUtil;
 import org.openide.modules.DummyInstalledFileLocator;
 import org.openide.util.test.MockLookup;
 
@@ -52,16 +51,9 @@ public class StatusProviderTest extends NbTestCase {
         MockLookup.setLayersAndInstances(new InstalledFileLocator());
         // new File(StatusProviderTest.class.getResource(...).toURI()) may not work in all environments, e.g. testdist
         File pom = new File(getWorkDir(), "pom.xml");
-        InputStream is = StatusProviderTest.class.getResourceAsStream("pom-with-warnings.xml");
-        try {
-            OutputStream os = new FileOutputStream(pom); 
-            try {
-                FileUtil.copy(is, os);
-            } finally {
-                os.close();
-            }
-        } finally {
-            is.close();
+        try (InputStream is = StatusProviderTest.class.getResourceAsStream("pom-with-warnings.xml");
+             OutputStream os = new FileOutputStream(pom)) {
+            is.transferTo(os);
         }
         String warnings = PomModelUtils.runMavenValidationImpl(pom, null).toString().replace(pom.getAbsolutePath(), "pom.xml");
         assertEquals("["

--- a/java/maven.hints/test/unit/src/org/netbeans/modules/maven/hints/pom/UseReleaseOptionHintTest.java
+++ b/java/maven.hints/test/unit/src/org/netbeans/modules/maven/hints/pom/UseReleaseOptionHintTest.java
@@ -141,6 +141,16 @@ public class UseReleaseOptionHintTest extends NbTestCase {
         assertEquals(6, hints.size());
     }
 
+    public void testCompilerPluginWithNoGroupID() throws Exception {
+        FileObject pom = TestFileUtils.writeFile(work, "pom.xml", COMPILER_POM.replaceFirst("<groupId>org.apache.maven.plugins</groupId>", ""));
+
+        POMModel model = POMModelFactory.getDefault().getModel(Utilities.createModelSource(pom));
+        Project project = ProjectManager.getDefault().findProject(pom.getParent());
+
+        List<ErrorDescription> hints = new UseReleaseOptionHint().getErrorsForDocument(model, project);
+        assertEquals(6, hints.size());
+    }
+
     public void testOldCompilerPlugin() throws Exception {
         FileObject pom = TestFileUtils.writeFile(work, "pom.xml", COMPILER_POM.replaceFirst("3.10.1", "3.5"));
 


### PR DESCRIPTION
 - default plugins can omit the group ID, the hint should still check their versions
 - made hint aware of the reporting plugin section (thanks @matthiasblaesing for noticing this)
 - moved module to JDK 11 since it already has JDK 11 dependencies
 
 example:
 
![image](https://github.com/apache/netbeans/assets/114367/4c3f083e-8199-433f-a9f4-b486636d0a0a)
