### PR TITLE
Added arch arm64 to profiler library

### DIFF
--- a/profiler/lib.profiler/native/scripts/buildnative-mac.sh
+++ b/profiler/lib.profiler/native/scripts/buildnative-mac.sh
@@ -41,7 +41,7 @@ SOURCES="../src-jdk15/class_file_cache.c \
 	../src-jdk15/Stacks.c \
 	../src-jdk15/common_functions.c"
 
-DEST="../../release/lib/deployed/jdk16/mac/"
+DEST="../../release/lib/deployed/jdk16/mac"
 
 UNILIB="$DEST/libprofilerinterface.jnilib"
 
@@ -56,37 +56,8 @@ cc $CPPFLAGS ../src-jdk15/config.c -o ../build/config && ../build/config > ../bu
 echo "Content of config.h :"
 cat ../build/config.h
 
-cc $CFLAGS $SOURCES -o ../build/libprofilerinterface.x86_64.dylib
-
-
-# Now we have a library specific to 'x86_64'. However what we use in lib.profiler
-# is a so-called Universal Library (one library file which contains embedded libraries for
-# multiple architectures .. this is an Apple speciality .. also known as a 'fat library').
-#
-# At some point in the history of NetBeans someone has created a Universal Library file
-# for the Profiler Interface which as of Jan 2021 contains libraries for the following platforms: 
-#    ppc 
-#    ppc64 
-#    i386 
-#    x86_64
-# Nowadays, Jan 2021, only 'x86_64' is relevant. Apple has abandonned the PowerPC architecture.
-# Coming up is the Apple Sillicon architecture which is named 'arm64' in short form. No attempt
-# is made here to support that, yet. 
-#
-# We re-use the existing Universal Library file and simply replace its contents but only
-# for the 'x86_64' architecture. This means that libraries for other architectures will
-# continue to exist in the bundle, albeit in the older form (meaning they'll not receive bug fixes)
-#
-
-
-
-# List architecture of the produced ".dylib" file  
-# (just to be sure .. we expect it to be 'x86_64')
-lipo ../build/libprofilerinterface.x86_64.dylib -info
+# build universal libary for x86_64 and arm64
+cc $CFLAGS -arch x86_64 -arch arm64 $SOURCES -o "$UNILIB"
 
 # List content of existing universal library
 lipo "$UNILIB" -info
-
-# Update the existing universal library so that the content for x86_64 is replaced
-# with our recent build
-lipo "$UNILIB" -replace x86_64 ../build/libprofilerinterface.x86_64.dylib -output "$UNILIB"


### PR DESCRIPTION
closes 4524

The profiler is not working on the Apple Silicon platform, see Issue 4524.
These changes discard old contents of the library for Mac (ppc, i386) because these can't be any longer updated (see also remarks in original file).

Instead this build script builds a universal library for x86_64 and arm64. My tests with NB19 on Apple Silicon where successful.

---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
