### PR TITLE
Micronaut: Add missing path variable parameter fix.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1957,7 +1957,7 @@ jobs:
 
 
   enterprise-test:
-    name: Enterprise on Linux/JDK ${{ matrix.java }} (some on 8)
+    name: Enterprise on Linux/JDK ${{ matrix.java }} (some on 8 and 17)
     needs: base-build
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -2065,9 +2065,6 @@ jobs:
 
       - name: maven.j2ee
         run: ant $OPTS -f enterprise/maven.j2ee test
-
-      - name: micronaut
-        run: .github/retry.sh ant $OPTS -f enterprise/micronaut test
 
 # Fails
 #      - name: enterpirse/payara.common
@@ -2197,6 +2194,15 @@ jobs:
 
       - name: j2ee.dd.webservice
         run: ant $OPTS -f enterprise/j2ee.dd.webservice test
+
+      - name: Set up JDK 17 for tests that are not compatible with JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: ${{ env.default_java_distribution }}
+
+      - name: micronaut
+        run: .github/retry.sh ant $OPTS -f enterprise/micronaut test
 
       - name: Create Test Summary
         uses: test-summary/action@v2

--- a/enterprise/micronaut/nbproject/project.xml
+++ b/enterprise/micronaut/nbproject/project.xml
@@ -215,6 +215,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.java.hints.legacy.spi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.39</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.java.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -334,6 +343,23 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>1.58</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.spi.editor.hints</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>0-1</release-version>
+                        <specification-version>1.64</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.spi.java.hints</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.56</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/hints/AddArgForRouteVar.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/hints/AddArgForRouteVar.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.micronaut.hints;
+
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.TreeMaker;
+import org.netbeans.api.java.source.WorkingCopy;
+import org.netbeans.modules.java.hints.spi.ErrorRule;
+import org.netbeans.spi.editor.hints.Fix;
+import org.netbeans.spi.java.hints.JavaFix;
+import org.openide.util.NbBundle;
+
+/**
+ *
+ * @author Dusan Balek
+ */
+public class AddArgForRouteVar implements ErrorRule<String> {
+
+    private static Pattern PATTERN = Pattern.compile("The route declares a uri variable named \\[(\\S*)\\]");
+
+    @Override
+    public Set<String> getCodes() {
+        return Collections.singleton("compiler.err.proc.messager");
+    }
+
+    @Override
+    public List<Fix> run(CompilationInfo compilationInfo, String diagnosticKey, int offset, TreePath treePath, Data<String> data) {
+        Matcher matcher = PATTERN.matcher(data.getData());
+        if (matcher.find() && matcher.groupCount() == 1) {
+            return Collections.singletonList(new AddArgForRouteVarFix(compilationInfo, offset, matcher.group(1)).toEditorFix());
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getId() {
+        return AddArgForRouteVar.class.getName();
+    }
+
+    @NbBundle.Messages("LBL_AddPathVarParam=Add Path Variable Parameter Fix")
+    @Override
+    public String getDisplayName() {
+        return Bundle.LBL_AddPathVarParam();
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    private static class AddArgForRouteVarFix extends JavaFix {
+
+        private final String name;
+
+        private AddArgForRouteVarFix(CompilationInfo info, int offset, String name) {
+            super(info, info.getTreeUtilities().pathFor(offset));
+            this.name = name;
+        }
+
+        @NbBundle.Messages("LBL_FIX_AddPathVarParam=Add path variable parameter \"{0}\"")
+        @Override
+        protected String getText() {
+            return Bundle.LBL_FIX_AddPathVarParam(name);
+        }
+
+        @Override
+        protected void performRewrite(TransformationContext ctx) throws Exception {
+            WorkingCopy working = ctx.getWorkingCopy();
+            TreeMaker make = working.getTreeMaker();
+            TreePath tp = ctx.getPath();
+            if (tp.getLeaf().getKind() == Tree.Kind.METHOD) {
+                MethodTree targetTree = (MethodTree) tp.getLeaf();
+                int index = targetTree.getParameters().size();
+                Element el = working.getTrees().getElement(tp);
+                if (el != null && el.getKind() == ElementKind.METHOD) {
+                    ExecutableElement ee = (ExecutableElement) el;
+                    if (ee.isVarArgs()) {
+                        index = ee.getParameters().size() - 1;
+                    }
+                    MethodTree result = make.insertMethodParameter(targetTree, index, make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), name, make.QualIdent("java.lang.String"), null));
+                    working.rewrite(targetTree, result);
+                }
+            }
+        }
+    }
+}

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
@@ -159,4 +159,11 @@
             </file>
         </folder>
     </folder>
+    <folder name="org-netbeans-modules-java-hints">
+        <folder name="rules">
+            <folder name="errors">
+                <file name="org-netbeans-modules-micronaut-hints-AddArgForRouteVar.instance"/>
+            </folder>
+        </folder>
+    </folder>
 </filesystem>

--- a/java/java.hints.legacy.spi/nbproject/project.properties
+++ b/java/java.hints.legacy.spi/nbproject/project.properties
@@ -17,6 +17,6 @@
 is.autoload=true
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=1.38.0
+spec.version.base=1.39.0
 javadoc.arch=${basedir}/arch.xml
 requires.nb.javac=true

--- a/java/java.hints.legacy.spi/nbproject/project.xml
+++ b/java/java.hints.legacy.spi/nbproject/project.xml
@@ -127,13 +127,14 @@
             <friend-packages>
                 <friend>org.netbeans.modules.ant.hints</friend>
                 <friend>org.netbeans.modules.apisupport.ant</friend>
-                <friend>org.netbeans.modules.java.lsp.server</friend>
                 <friend>org.netbeans.modules.jakarta.web.beans</friend>
+                <friend>org.netbeans.modules.java.lsp.server</friend>
                 <friend>org.netbeans.modules.javadoc</friend>
                 <friend>org.netbeans.modules.javahints</friend>
                 <friend>org.netbeans.modules.jshell.support</friend>
                 <friend>org.netbeans.modules.maven.hints</friend>
                 <friend>org.netbeans.modules.maven.j2ee</friend>
+                <friend>org.netbeans.modules.micronaut</friend>
                 <friend>org.netbeans.modules.web.beans</friend>
                 <package>org.netbeans.modules.java.hints.spi</package>
                 <package>org.netbeans.modules.java.hints.spi.preview</package>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/CreatorBasedLazyFixList.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/CreatorBasedLazyFixList.java
@@ -28,7 +28,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Logger;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.modules.java.hints.spi.ErrorRule;
 import org.netbeans.modules.java.hints.spi.ErrorRule.Data;
@@ -49,15 +48,17 @@ public class CreatorBasedLazyFixList implements LazyFixList {
     
     private FileObject file;
     private String diagnosticKey;
+    private String diagnosticMessage;
     private int offset;
     private final Collection<ErrorRule> c;
     private final Map<Class, Data> class2Data;
     
     /** Creates a new instance of CreatorBasedLazyFixList */
-    public CreatorBasedLazyFixList(FileObject file, String diagnosticKey, int offset, Collection<ErrorRule> c, Map<Class, Data> class2Data) {
+    public CreatorBasedLazyFixList(FileObject file, String diagnosticKey, String diagnosticMessage, int offset, Collection<ErrorRule> c, Map<Class, Data> class2Data) {
         this.pcs = new PropertyChangeSupport(this);
         this.file = file;
         this.diagnosticKey = diagnosticKey;
+        this.diagnosticMessage = diagnosticMessage;
         this.offset = offset;
         this.c = c;
         this.class2Data = class2Data;
@@ -118,6 +119,10 @@ public class CreatorBasedLazyFixList implements LazyFixList {
                 
                 if (data == null) {
                     class2Data.put(rule.getClass(), data = new Data());
+                }
+
+                if ("compiler.err.proc.messager".equals(diagnosticKey)) { //NOI18N
+                    data.setData(diagnosticMessage);
                 }
                 
                 List<Fix> currentRuleFixes = rule.run(info, diagnosticKey, offset, path, data);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProvider.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProvider.java
@@ -165,7 +165,7 @@ public final class ErrorHintsProvider extends JavaParserResultTask {
             }
         }
         if (messageRuleCount < allRules.size()) {
-            ehm = new CreatorBasedLazyFixList(info.getFileObject(), code, pos, allRules, data);
+            ehm = new CreatorBasedLazyFixList(info.getFileObject(), code, desc, pos, allRules, data);
         } else if (processDefault) {
             ehm = ErrorDescriptionFactory.lazyListForFixes(Collections.<Fix>emptyList());
         } else {

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/CreatorBasedLazyFixListTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/CreatorBasedLazyFixListTest.java
@@ -54,7 +54,7 @@ public class CreatorBasedLazyFixListTest extends HintsTestBase {
         final AtomicBoolean[] cancel = new AtomicBoolean[1];
         final CreatorBasedLazyFixList[] list = new CreatorBasedLazyFixList[1];
         
-        list[0] = new CreatorBasedLazyFixList(null, "", 0, Collections.singleton((ErrorRule) new ErrorRule() {
+        list[0] = new CreatorBasedLazyFixList(null, "", "", 0, Collections.singleton((ErrorRule) new ErrorRule() {
             public Set getCodes() {
                 throw new UnsupportedOperationException("Not supported yet.");
             }

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/LazyHintComputationTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/LazyHintComputationTest.java
@@ -128,7 +128,7 @@ public class LazyHintComputationTest extends NbTestCase {
         private final Runnable cancelCallback;
         
         public CreatorBasedLazyFixListImpl(FileObject file, boolean[] marker, Runnable callback, Runnable cancelCallback) {
-            super(file, null, -1, null, null);
+            super(file, null, null, -1, null, null);
             this.marker = marker;
             this.callback = callback;
             this.cancelCallback = cancelCallback;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -958,7 +958,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
         Range range = params.getRange();
         int startOffset = Utils.getOffset(doc, range.getStart());
         int endOffset = Utils.getOffset(doc, range.getEnd());
-        if (startOffset == endOffset) {
+        if (startOffset == endOffset || !params.getContext().getDiagnostics().isEmpty()) {
             final javax.swing.text.Element elem = NbDocument.findLineRootElement(doc);
             int lineStartOffset = elem.getStartOffset();
             int lineEndOffset = elem.getEndOffset();


### PR DESCRIPTION
Micronaut reports error if a path variable is declared the URL path and the corresponding parameter is missing in a method signature. The quick-fix adds the missing parameter.
```
  @Get("/path/{variable}/")
  public String handle(String name_not_equal_to_variable) {
    ...
  }
```