### PR TITLE
Update profiler native binaries to released 1-24aefa9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,6 @@ derby.log
 /ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/parser/Token.java
 /ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/parser/TokenMgrError.java
 /profiler/lib.profiler/release/lib/
-/profiler/lib.profiler/release/BUILDINFO.txt
 /websvccommon/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/jaxb/
 /websvccommon/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/oauth/
 /websvccommon/websvc.saas.api/src/org/netbeans/modules/websvc/saas/model/wadl/

--- a/profiler/lib.profiler/build.xml
+++ b/profiler/lib.profiler/build.xml
@@ -30,10 +30,14 @@
         <unzip src="external/profiler-external-binaries-8.2.zip" 
                overwrite="false"
                dest="${profiler.cluster}"/>
-        <!-- AL2 licensed binaries, build from ASF code (overwrites CDDL binaries) -->
-        <unzip src="external/profiler-external-binaries-ASF-5273a10f9471d5cf60ed894dc26ec0e59e71cc24.zip"
+        <!-- AL2 licensed binaries from ASF code -->
+        <unzip src="external/profiler-external-binaries-1-24aefa9.zip"
                overwrite="true"
-               dest="${profiler.cluster}"/>
+               dest="${profiler.cluster}">
+          <patternset>
+            <include name="lib/**"/>
+          </patternset>
+        </unzip>
     </target>
 
   <!-- Compile the JFluid engine system library, that depends on JDK version - so there are two libraries -->

--- a/profiler/lib.profiler/external/binaries-list
+++ b/profiler/lib.profiler/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 45225DCFC94A9782419E95C70957822A0C44612D profiler-external-binaries-8.2.zip
-B1C1B951F79716EFFAB9BEC96A611844B038E2E2 profiler-external-binaries-ASF-5273a10f9471d5cf60ed894dc26ec0e59e71cc24.zip
+AD1F88D2B35874756A192ACD033A17AAD8C6535C https://archive.apache.org/dist/netbeans/native/netbeans-profiler/1-24aefa9/profiler-external-binaries-1-24aefa9.zip profiler-external-binaries-1-24aefa9.zip

--- a/profiler/lib.profiler/external/profiler-external-binaries-1-24aefa9-license.txt
+++ b/profiler/lib.profiler/external/profiler-external-binaries-1-24aefa9-license.txt
@@ -1,9 +1,9 @@
 Name: Profiler Binaries
-Description: Profiler Binaries for a large variety of platforms, superseds older CDDL binaries where applicable.
-Version: 5273a10f9471d5cf60ed894dc26ec0e59e71cc24
+Description: Profiler Binaries for variety of platforms, supersedes older CDDL binaries where applicable.
+Version: 1-24aefa9
 License: Apache-2.0-ASF
 Source: https://netbeans.apache.org
-Origin: Apache NetBeans (version is commit hash)
+Origin: Apache NetBeans (version includes commit hash)
 
 Licensed to the Apache Software Foundation (ASF) under one or more contributor
 license agreements.  See the NOTICE file distributed with this work for


### PR DESCRIPTION
~~Work-in-progress update to staged profiler binaries `1-r2196e46` with fix for Apple Silicon. Built in workflow https://github.com/apache/netbeans/actions/runs/6351527745~~ This is a follow up to #6496 and part of fixing #4524

This PR is for testing and voting purposes.  The native binaries must be voted on and moved to release, and this PR updated, before merging to master.

The previous ASF binaries are kept for now, besides being entirely overwritten for testing purposes.  We might just decide to use the mac binaries in a pattern set?

We need a versioning strategy for external native binaries - intention here is to use strictly incrementing version number plus short hash - eg. next will be `2-r<hash>` then `3-r<hash>`.

We should perhaps consider adding OS into the matrix for profiler tests? 

~~UPDATE : this PR has been updated to the new staged voting artefacts, 1-24aefa9.~~

UPDATE : this PR has been updated to the released artefacts, 1-24aefa9.