### PR TITLE
Update bouncycastle to jdk18on-1.76.

### DIFF
--- a/ide/bcpg/external/bcpg-jdk18on-1.76-license.txt
+++ b/ide/bcpg/external/bcpg-jdk18on-1.76-license.txt
@@ -1,5 +1,5 @@
 Name: Bouncy Castle Java OpenPGP/BCPG
-Version: 1.70
+Version: 1.76
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcpg/external/binaries-list
+++ b/ide/bcpg/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-062F72EC06F31A6C31A3F3355FCE0384B21126D7 org.bouncycastle:bcpg-jdk15on:1.70
+D5C23D0470261254D0E84DDE1D4237D228540298 org.bouncycastle:bcpg-jdk18on:1.76

--- a/ide/bcpg/nbproject/project.properties
+++ b/ide/bcpg/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcpg-jdk15on-1.70.jar=modules/bcpg.jar
+release.external/bcpg-jdk18on-1.76.jar=modules/bcpg.jar
 is.autoload=true

--- a/ide/bcpg/nbproject/project.xml
+++ b/ide/bcpg/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcpg.jar</runtime-relative-path>
-                <binary-origin>external/bcpg-jdk15on-1.70.jar</binary-origin>
+                <binary-origin>external/bcpg-jdk18on-1.76.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcpkix/external/bcpkix-jdk18on-1.76-license.txt
+++ b/ide/bcpkix/external/bcpkix-jdk18on-1.76-license.txt
@@ -1,5 +1,5 @@
 Name: Bouncy Castle Java Provider
-Version: 1.70
+Version: 1.76
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcpkix/external/binaries-list
+++ b/ide/bcpkix/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-F81E5AF49571A9D5A109A88F239A73CE87055417 org.bouncycastle:bcpkix-jdk15on:1.70
+10C9CF5C1B4D64ABEDA28EE32FBADE3B74373622 org.bouncycastle:bcpkix-jdk18on:1.76

--- a/ide/bcpkix/nbproject/project.properties
+++ b/ide/bcpkix/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcpkix-jdk15on-1.70.jar=modules/bcpkix.jar
+release.external/bcpkix-jdk18on-1.76.jar=modules/bcpkix.jar
 is.autoload=true

--- a/ide/bcpkix/nbproject/project.xml
+++ b/ide/bcpkix/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcpkix.jar</runtime-relative-path>
-                <binary-origin>external/bcpkix-jdk15on-1.70.jar</binary-origin>
+                <binary-origin>external/bcpkix-jdk18on-1.76.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcprov/external/bcprov-jdk18on-1.76-license.txt
+++ b/ide/bcprov/external/bcprov-jdk18on-1.76-license.txt
@@ -1,5 +1,5 @@
-Name: Bouncy Castle ASN.1 Extension and Utility APIs
-Version: 1.70
+Name: Bouncy Castle Java Provider
+Version: 1.76
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcprov/external/binaries-list
+++ b/ide/bcprov/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-4636A0D01F74ACAF28082FB62B317F1080118371 org.bouncycastle:bcprov-jdk15on:1.70
+3A785D0B41806865AD7E311162BFA3FA60B3965B org.bouncycastle:bcprov-jdk18on:1.76

--- a/ide/bcprov/nbproject/project.properties
+++ b/ide/bcprov/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcprov-jdk15on-1.70.jar=modules/bcprov.jar
+release.external/bcprov-jdk18on-1.76.jar=modules/bcprov.jar
 is.autoload=true

--- a/ide/bcprov/nbproject/project.xml
+++ b/ide/bcprov/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcprov.jar</runtime-relative-path>
-                <binary-origin>external/bcprov-jdk15on-1.70.jar</binary-origin>
+                <binary-origin>external/bcprov-jdk18on-1.76.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcutil/external/bcutil-jdk18on-1.76-license.txt
+++ b/ide/bcutil/external/bcutil-jdk18on-1.76-license.txt
@@ -1,5 +1,5 @@
-Name: Bouncy Castle Java Provider
-Version: 1.70
+Name: Bouncy Castle ASN.1 Extension and Utility APIs
+Version: 1.76
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcutil/external/binaries-list
+++ b/ide/bcutil/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-54280E7195A7430D7911DED93FC01E07300B9526 org.bouncycastle:bcutil-jdk15on:1.70
+8C7594E651A278BCDE18E038D8AB55B1F97F4D31 org.bouncycastle:bcutil-jdk18on:1.76

--- a/ide/bcutil/nbproject/project.properties
+++ b/ide/bcutil/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcutil-jdk15on-1.70.jar=modules/bcutil.jar
+release.external/bcutil-jdk18on-1.76.jar=modules/bcutil.jar
 is.autoload=true

--- a/ide/bcutil/nbproject/project.xml
+++ b/ide/bcutil/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcutil.jar</runtime-relative-path>
-                <binary-origin>external/bcutil-jdk15on-1.70.jar</binary-origin>
+                <binary-origin>external/bcutil-jdk18on-1.76.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
 - switches from `jdk15on` to `jdk18on` (which is for JDK 8+, see [page](https://www.bouncycastle.org/latest_releases.html))
 - updates from 1.70 to 1.76

we might need this update for #6500, lets see if everything is green