### PR TITLE
update npm module debug (moderate severity vulnerability)

### DIFF
--- a/java/java.lsp.server/vscode/package-lock.json
+++ b/java/java.lsp.server/vscode/package-lock.json
@@ -959,9 +959,10 @@
 			}
 		},
 		"node_modules/https-proxy-agent/node_modules/debug": {
-			"version": "3.2.6",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -2166,7 +2167,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"


### PR DESCRIPTION
moderate severity vulnerability fixed by upgrading debug module.

```
# npm audit report

debug  3.2.0 - 3.2.6
Severity: moderate
Regular Expression Denial of Service in debug - https://github.com/advisories/GHSA-gxpj-cx7g-858c
fix available via `npm audit fix`
node_modules/https-proxy-agent/node_modules/debug

1 moderate severity vulnerability
```