### PR TITLE
Build with dependencies before main action

### DIFF
--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
@@ -123,4 +123,49 @@
         </folder>
         <folder name="Persistence_hidden"/>
     </folder>
+    <folder name="Projects">
+        <folder name="org-netbeans-modules-maven">
+            <folder name="Lookup">
+                <file name="maven-actions-override.instance">
+                    <attr name="position" intvalue="10000"/>
+                    <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                    <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
+                    <attr name="resource" stringvalue="nbres:/org/netbeans/modules/nbcode/integration/maven-actions-override.xml"/>
+                </file>
+            </folder>
+
+            <!-- For Micornaut 3.x -->
+            <folder name="io.micronaut.build:micronaut-maven-plugin">
+                <folder name="Lookup">
+                    <file name="maven-project-actions.instance">
+                        <attr name="position" intvalue="10000"/>
+                        <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                        <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
+                        <attr name="resource" stringvalue="nbres:/org/netbeans/modules/micronaut/resources/micronaut-actions-override.xml"/>
+                    </file>
+                </folder>
+            </folder>
+            <!-- Micronaut 4.x -->
+            <folder name="io.micronaut.maven:micronaut-maven-plugin">
+                <folder name="Lookup">
+                    <file name="maven-project-actions.instance">
+                        <attr name="position" intvalue="10000"/>
+                        <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                        <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
+                        <attr name="resource" stringvalue="nbres:/org/netbeans/modules/micronaut/resources/micronaut-actions-override.xml"/>
+                    </file>
+                </folder>
+            </folder>
+            <folder name="org.springframework.boot:spring-boot-maven-plugin">
+                <folder name="Lookup">
+                    <file name="maven-project-actions.instance">
+                        <attr name="position" intvalue="10000"/>
+                        <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                        <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
+                        <attr name="resource" stringvalue="nbres:/org/netbeans/modules/micronaut/resources/spring-actions-override.xml"/>
+                    </file>
+                </folder>
+            </folder>
+        </folder>
+    </folder>
 </filesystem>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/maven-actions-override.xml
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/maven-actions-override.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<actions>
+    <action>
+        <actionName>build</actionName>
+        <packagings>
+            <packaging>*</packaging>
+        </packagings>
+        <goals>
+            <goal>install</goal>
+        </goals>
+        <reactor>also-make</reactor>
+    </action>
+    <action>
+        <actionName>rebuild</actionName>
+        <packagings>
+            <packaging>*</packaging>
+        </packagings>
+        <goals>
+            <goal>clean</goal>
+            <goal>install</goal>
+        </goals>
+        <reactor>also-make</reactor>
+    </action>
+    <action>
+        <actionName>test.single</actionName>
+        <packagings>
+            <packaging>*</packaging>
+        </packagings>
+        <goals>
+            <goal>process-test-classes</goal>
+            <goal>surefire:test</goal>
+        </goals>
+        <properties>
+            <test>${packageClassName}</test>
+        </properties>
+    </action>
+
+    <action>
+        <actionName>run</actionName>
+        <packagings>
+            <packaging>jar</packaging>
+        </packagings>
+        <goals>
+            <goal>process-classes</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
+        </goals>
+        <properties>
+            <exec.vmArgs></exec.vmArgs>
+            <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+            <exec.appArgs></exec.appArgs>
+            <exec.mainClass>${packageClassName}</exec.mainClass>
+            <exec.executable>java</exec.executable>
+        </properties>
+        <preAction>build-with-dependencies</preAction>
+    </action>
+    <action>
+        <actionName>debug</actionName>
+        <packagings>
+            <packaging>jar</packaging>
+        </packagings>
+        <goals>
+            <goal>process-classes</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
+        </goals>
+        <properties>
+            <exec.vmArgs>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address}</exec.vmArgs>
+            <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+            <exec.appArgs></exec.appArgs>
+            <exec.mainClass>${packageClassName}</exec.mainClass>
+            <exec.executable>java</exec.executable>
+            <jpda.listen>true</jpda.listen>
+        </properties>
+        <preAction>build-with-dependencies</preAction>
+    </action>
+    <action>
+        <actionName>run.single.main</actionName>
+        <packagings>
+            <packaging>*</packaging>
+        </packagings>
+        <goals>
+            <goal>process-classes</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
+        </goals>
+        <properties>
+            <exec.vmArgs></exec.vmArgs>
+            <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+            <exec.executable>java</exec.executable>
+            <exec.mainClass>${packageClassName}</exec.mainClass>
+            <exec.classpathScope>${classPathScope}</exec.classpathScope>
+        </properties>
+        <preAction>build-with-dependencies</preAction>
+    </action>
+
+    <action>
+        <actionName>debug.single.main</actionName>
+        <packagings>
+            <packaging>*</packaging>
+        </packagings>
+        <goals>
+            <goal>process-test-classes</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
+        </goals>
+        <properties>
+            <exec.vmArgs>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address}</exec.vmArgs>
+            <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+            <exec.executable>java</exec.executable>
+            <exec.mainClass>${packageClassName}</exec.mainClass>
+            <exec.classpathScope>${classPathScope}</exec.classpathScope>
+            <jpda.listen>true</jpda.listen>
+        </properties>
+        <preAction>build-with-dependencies</preAction>
+    </action>
+</actions>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/micronaut-actions-override.xml
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/micronaut-actions-override.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<actions>
+    <profiles>
+        <profile>
+            <id>micronaut-auto</id>
+            <displayName>Micronaut: dev mode</displayName>
+            <actions>
+                <action>
+                    <actionName>run</actionName>
+                    <packagings>
+                        <packaging>jar</packaging>
+                    </packagings>
+                    <goals>
+                        <goal>mn:run</goal>
+                    </goals>
+                    <properties>
+                        <exec.vmArgs></exec.vmArgs>
+                        <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                        <exec.appArgs></exec.appArgs>
+                        <exec.mainClass>${packageClassName}</exec.mainClass>
+                    </properties>
+                    <preAction>build-with-dependencies</preAction>
+                </action>
+                <action>
+                    <actionName>run.single.main</actionName>
+                    <packagings>
+                        <packaging>*</packaging>
+                    </packagings>
+                    <goals>
+                        <goal>mn:run</goal>
+                    </goals>
+                    <properties>
+                        <exec.vmArgs></exec.vmArgs>
+                        <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                        <exec.mainClass>${packageClassName}</exec.mainClass>
+                        <exec.classpathScope>${classPathScope}</exec.classpathScope>
+                    </properties>
+                    <preAction>build-with-dependencies</preAction>
+                </action>
+
+                <action>
+                    <actionName>debug</actionName>
+                    <packagings>
+                        <packaging>jar</packaging>
+                    </packagings>
+                </action>
+
+                <action>
+                    <actionName>debug.single.main</actionName>
+                    <packagings>
+                        <packaging>*</packaging>
+                    </packagings>
+                </action>
+
+
+                <action>
+                    <actionName>debug.test.single</actionName>
+                    <packagings>
+                        <packaging>*</packaging>
+                    </packagings>
+                </action>
+
+                <action>
+                    <actionName>debug.integration-test.single</actionName>
+                    <packagings>
+                        <packaging>*</packaging>
+                    </packagings>
+                </action>
+
+                <action>
+                    <actionName>debug.fix</actionName>
+                    <packagings>
+                        <packaging>*</packaging>
+                    </packagings>
+                    <goals>
+                        <goal>compile</goal>
+                    </goals>
+                </action>
+            </actions>
+        </profile>
+    </profiles>
+</actions>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/spring-actions-override.xml
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/spring-actions-override.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<actions>
+    <action>
+        <actionName>native-build</actionName>
+        <packagings>
+            <packaging>*</packaging>
+        </packagings>
+        <goals>
+            <goal>native:compile</goal>
+        </goals>
+        <activatedProfiles>
+            <activatedProfile>native</activatedProfile>
+        </activatedProfiles>
+        <preAction>build-with-dependencies</preAction>
+    </action>
+</actions>


### PR DESCRIPTION
Unlike NB IDE, vscode has a different workflow. The NBLS extension provides Projects view with Compile-Run actions that should build dependent projects before the main work. 
The `build` action can go with `<reactor>also-make</reactor>` but Run action may not be available on the root project, so we need to `<preAction>build-with-dependencies</preAction>`.

For the case that action is executed on the reactor root itself, I've adjusted the `ReactorChecker` - it will clear preAction for reactor root.