### PR TITLE
PHP: removed unnecessary "Method naming style" on the Generate Constructor form

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/ui/ConstructorPanel.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/ui/ConstructorPanel.java
@@ -69,6 +69,9 @@ public class ConstructorPanel extends JPanel {
             name = properties.get(0).getName();
         }
         ComboBoxModel model = genType.getModel(name);
+        if (genType.equals(CGSGenerator.GenType.CONSTRUCTOR)) {
+            customizeMethodGeneration = false;
+        }
         if (genType.equals(CGSGenerator.GenType.METHODS)) {
             customizeMethodGeneration = false;
             Dimension preferredSize = getPreferredSize();


### PR DESCRIPTION
On the Generate Constructor form, there is a choice of method naming style that doesn't seem to affect the generation of the constructor.

Before:
![generate_constructor](https://github.com/apache/netbeans/assets/9607501/913b2aa3-75f4-490d-84c8-6c3441deb8b4)

After:
![Снимок экрана от 2023-10-03 23-33-43](https://github.com/apache/netbeans/assets/9607501/6144da77-6ac4-4006-a16f-ba49c5b18f29)
