### PR TITLE
parserResult can be null

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1006,9 +1006,10 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                                 client.logMessage(new MessageParams(MessageType.Error, ex.getMessage()));
                             }
                         }
-                        if (client.getNbCodeCapabilities().wantsJavaSupport()) {
+                        Parser.Result parserResult = resultIterator.getParserResult();
+                        if (parserResult != null && client.getNbCodeCapabilities().wantsJavaSupport()) {
                             //introduce hints:
-                            CompilationController cc = CompilationController.get(resultIterator.getParserResult());
+                            CompilationController cc = CompilationController.get(parserResult);
                             if (cc != null) {
                                 cc.toPhase(JavaSource.Phase.RESOLVED);
                                 if (!range.getStart().equals(range.getEnd())) {


### PR DESCRIPTION
I am working on https://github.com/enso-org/enso/pull/7054 and I got `StructureProvider` working. But now it seems that this "java only" code in NetBeans is also invoked for `.enso` files - which don't have any parser registered in NetBeans.

Adding defensive `NullPointerException` check.