### PR TITLE
Update JavaFX wizard names and move DukeScript wizard to a better position.

### DIFF
--- a/javafx/javafx2.kit/src/org/netbeans/modules/javafx2/kit/JavaFXWizardIterator.java
+++ b/javafx/javafx2.kit/src/org/netbeans/modules/javafx2/kit/JavaFXWizardIterator.java
@@ -39,22 +39,19 @@ public class JavaFXWizardIterator {
 //        return ArchetypeWizards.definedArchetype("org.codehaus.mojo.archetypes", "sample-javafx", "0.5", null, LBL_Maven_JavaFx_Sample_Archetype());
 //    }
     @TemplateRegistration(folder = ArchetypeWizards.TEMPLATE_FOLDER, position = 925, displayName = "#LBL_Maven_FXML_Archetype", iconBase = "org/netbeans/modules/javafx2/kit/resources/jaricon.png", description = "javafx.html")
-    @Messages("LBL_Maven_FXML_Archetype=FXML JavaFX Maven Archetype (Gluon)")
+    @Messages("LBL_Maven_FXML_Archetype=FXML JavaFX Maven Archetype")
     public static WizardDescriptor.InstantiatingIterator<?> openJFXFML() {
         return definedFXArchetype("com.raelity.jfx", "javafx-archetype-fxml-netbeans", "0.0.4", Bundle.LBL_Maven_FXML_Archetype());
     }
 
     @TemplateRegistration(folder = ArchetypeWizards.TEMPLATE_FOLDER, position = 926, displayName = "#LBL_Maven_Simple_Archetype", iconBase = "org/netbeans/modules/javafx2/kit/resources/jaricon.png", description = "javafx.html")
-    @Messages("LBL_Maven_Simple_Archetype=Simple JavaFX Maven Archetype (Gluon)")
+    @Messages("LBL_Maven_Simple_Archetype=Simple JavaFX Maven Archetype")
     public static WizardDescriptor.InstantiatingIterator<?> openJFXSimple() {
         return definedFXArchetype("com.raelity.jfx", "javafx-archetype-simple-netbeans", "0.0.4", Bundle.LBL_Maven_Simple_Archetype());
     }
 
     private static WizardDescriptor.InstantiatingIterator<?> definedFXArchetype(String g, String a, String v, String name) {
         Map<String, String> props = new HashMap<>();
-        if (System.getProperty("java.version").startsWith("1.8")) {
-            props.put("javafx-version", "1.8");
-        }
         props.put("add-debug-configuration", "Y");
         return ArchetypeWizards.definedArchetype(g, a, v, null, name, props);
     }

--- a/javafx/maven.htmlui/src/org/netbeans/modules/maven/htmlui/DukeScriptWizard.java
+++ b/javafx/maven.htmlui/src/org/netbeans/modules/maven/htmlui/DukeScriptWizard.java
@@ -57,7 +57,7 @@ import org.openide.util.Utilities;
 })
 public class DukeScriptWizard {
     @TemplateRegistration(
-            position = 120,
+            position = 955,
             page = "dukeScriptWizard.html",
             content = "dukescript.archetype",
             folder = "Project/Maven2",
@@ -66,7 +66,7 @@ public class DukeScriptWizard {
             description = "description.html"
     )
     
-    @Messages("DukeScriptWizard_displayName=Java Frontend Application")
+    @Messages("DukeScriptWizard_displayName=DukeScript Frontend Application")
     public static WizardData javafxWebViewAppWizard() {
         WizardData data = new WizardData();
         data.init(Boolean.TRUE, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE);


### PR DESCRIPTION
 - Its now closer to other frontend templates, like JavaFX, and has a more specific name
 - Remove the "(Gluon)" postfix from the JavaFX templates since they don't seem to use anything from gluon

![image](https://github.com/apache/netbeans/assets/114367/b09d8022-15aa-407e-8d2b-429226704a46)
