### PR TITLE
Enable previously disabled tests for the java.hints module.

### DIFF
--- a/java/java.hints/nbproject/project.properties
+++ b/java/java.hints/nbproject/project.properties
@@ -58,21 +58,6 @@ test.unit.run.cp.extra=\
 # requires nb.javac for compiling of tests on Mac
 requires.nb.javac=true
 
-test.config.jet-main.excludes=**/jackpot/*Test.class
-test.config.stableBTD.includes=\
-    org/netbeans/modules/java/hints/AnnotationAsSuperInterfaceTest.class,\
-    org/netbeans/modules/java/hints/OverridableMethodCallInConstructorTest.class,\
-    org/netbeans/modules/java/hints/errors/CreateClass183980Test.class,\
-    org/netbeans/modules/java/hints/finalize/FinalizeDeclaredTest.class,\
-    org/netbeans/modules/java/hints/infrastructure/CreatorBasedLazyFixListTest.class,\
-    org/netbeans/modules/java/hints/infrastructure/LazyHintComputationTest.class,\
-    org/netbeans/modules/java/hints/jackpot/code/*Test.class,\
-    org/netbeans/modules/java/hints/jackpot/impl/batch/ProgressHandleWrapperTest.class
-
-test.config.commit.includes=\
-    org/netbeans/modules/java/hints/errors/CreateMethodTest.class,\
-    org/netbeans/modules/java/hints/bugs/CollectionRemoveTest.class
-
 test.runner=junit
 
 test-unit-sys-prop.hints-tools.jar.location=${tools.jar}
@@ -86,34 +71,6 @@ test.config.batch1.excludes=\
 test.config.batch2.includes=\
     **/errors/*Test.class,\
     **/jdk/*Test.class
-
-#XXX: remove the vanilla javac excludes!
-#ExtraCatchTest - requires fix in javac
-#ConvertToDiamondBulkHintTest - warnings from javac missing
-#ConvertToLambdaTest, AnnotationProcessorsTest - needs fixes to JackpotJavacParser
-#ConvertToPatternInstanceOfTest - will be fixed separately
-vanilla-javac.excludes=\
-    **/AnnotationProcessorsTest.class,\
-    **/ExtraCatchTest.class,\
-    **/ConvertToDiamondBulkHintTest.class,\
-    **/ConvertToLambdaTest.class,\
-    **/ConvertToPatternInstanceOfTest.class
-
-test.config.batch1-vanilla-javac.includes=\
-    **/*Test.class
-test.config.batch1-vanilla-javac.excludes=\
-    **/bugs/*Test.class,\
-    **/errors/*Test.class,\
-    **/jdk/*Test.class,\
-    ${vanilla-javac.excludes}
-
-test.config.batch2-vanilla-javac.includes=\
-    **/bugs/*Test.class,\
-    **/errors/*Test.class,\
-    **/jdk/*Test.class
-
-test.config.batch2-vanilla-javac.excludes=\
-    ${vanilla-javac.excludes}
 
 test.jms.flags=\
  --add-opens=java.base/java.net=ALL-UNNAMED \

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/AssignResultToVariableTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/AssignResultToVariableTest.java
@@ -27,7 +27,6 @@ import org.netbeans.modules.java.hints.infrastructure.TreeRuleTestBase;
 import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.Fix;
 import org.openide.filesystems.FileObject;
-import org.netbeans.junit.RandomlyFails;
 
 /**
  *
@@ -38,15 +37,15 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
     public AssignResultToVariableTest(String testName) {
         super(testName);
     }
-    @RandomlyFails
+
     public void testDoNothingForVoidReturnType() throws Exception {
         performAnalysisTest("test/Test.java", "package test; public class Test {public void t() {get();} public void get() {}}", 51);
     }
-    @RandomlyFails
+
     public void testProposeHint() throws Exception {
         performAnalysisTest("test/Test.java", "package test; public class Test {public void t() {get();} public int get() {}}", 51, "0:51-0:51:hint:Assign Return Value To New Variable");
     }
-    @RandomlyFails
+
     public void testApplyHintGenericType() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void t() {java.util.List<String> l = null; l.get(0);}}",
@@ -55,7 +54,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test {public void t() {java.util.List<String> l = null; String get = l.get(0); }}");
     }
-    @RandomlyFails
+
     public void testApplyHintGenericType2() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void t() {java.util.List<? extends String> l = null; l.get(0);}}",
@@ -64,7 +63,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test {public void t() {java.util.List<? extends String> l = null; String get = l.get(0); }}");
     }
-    @RandomlyFails
+
     public void testApplyHintGenericType3() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test<T> {public void t() {get();} T get() {return null;}}",
@@ -73,7 +72,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test<T> {public void t() {T get = get(); } T get() {return null;}}");
     }
-    @RandomlyFails
+
     public void testApplyHintGenericType4() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void t() {test();} private Iterable<? extends CharSequence> test() {return null;}}",
@@ -82,7 +81,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test {public void t() {Iterable<? extends CharSequence> test = test(); } private Iterable<? extends CharSequence> test() {return null;}}");
     }
-    @RandomlyFails
+
     public void testApplyHintGenericType5() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void t() {test();} private Iterable<? super CharSequence> test() {return null;}}",
@@ -91,7 +90,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test {public void t() {Iterable<? super CharSequence> test = test(); } private Iterable<? super CharSequence> test() {return null;}}");
     }
-    @RandomlyFails
+
     public void testApplyHintGenericType6() throws Exception {
         performFixTest("test/Test.java",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null;l.get(0); } }",
@@ -100,7 +99,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null;Object get = l.get(0); } }");
     }
-    @RandomlyFails
+
     public void testCommentsCopied() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void t() {\n/*t*/get();\n} String get() {return null;}}",
@@ -109,7 +108,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test {public void t() { /*t*/ String get = get(); } String get() {return null;}}");
     }
-    @RandomlyFails
+
     public void testNewClass1() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void t() { new Te|st(); } private static class Test {} }",
@@ -117,7 +116,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test {public void t() { Test test = new Test(); } private static class Test {} }");
     }
-    @RandomlyFails
+
     public void testNewClass2() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void t() { new te|st(); } private static class test {} }",
@@ -125,7 +124,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test {public void t() { test test = new test(); } private static class test {} }");
     }
-    @RandomlyFails
+
     public void testNewClass133825a() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void t() { new Te|st<String>(); } private static class Test<T> {}}",
@@ -133,7 +132,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test {public void t() { Test<String> test = new Test<String>(); } private static class Test<T> {}}");
     }
-    @RandomlyFails
+
     public void testNewClass133825b() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void t() { new Test.In|ner(); } private static class Inner {} }",
@@ -141,7 +140,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test {public void t() { Inner inner = new Test.Inner(); } private static class Inner {} }");
     }
-    @RandomlyFails
+
     public void testAnonymousClass138223() throws Exception {
         performFixTest("test/Test.java",
                 "package test; public class Test {public void t() { new Run|nable() { public void run() { } }; } }",
@@ -149,7 +148,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                 "FixImpl",
                 "package test; public class Test {public void t() { Runnable runnable = new Runnable() { public void run() { } }; } }");
     }
-    @RandomlyFails
+
     public void testForgiving1() throws Exception {
         performFixTest("test/Test.java",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null;\n  l.get(0);|\n } }",
@@ -157,7 +156,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null; Object get = l.get(0); } }");
     }
-    @RandomlyFails
+
     public void testForgiving2() throws Exception {
         performFixTest("test/Test.java",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null;\n  l.get(0)|;\n } }",
@@ -165,7 +164,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null; Object get = l.get(0); } }");
     }
-    @RandomlyFails
+
     public void testForgiving3() throws Exception {
         performFixTest("test/Test.java",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null;\n  |l.get(0);\n } }",
@@ -173,7 +172,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null; Object get = l.get(0); } }");
     }
-    @RandomlyFails
+
     public void testForgiving4() throws Exception {
         performFixTest("test/Test.java",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null;\n  l.get(0);    |\n } }",
@@ -181,7 +180,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null; Object get = l.get(0); } }");
     }
-    @RandomlyFails
+
     public void testForgiving5() throws Exception {
         performFixTest("test/Test.java",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null;\n|  l.get(0);\n } }",
@@ -189,7 +188,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null; Object get = l.get(0); } }");
     }
-    @RandomlyFails
+
     public void testForgiving6() throws Exception {
         performFixTest("test/Test.java",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null;\n  l.get(0);    //tttt|\n } }",
@@ -197,7 +196,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null; Object get = l.get(0); //tttt } }");
     }
-    @RandomlyFails
+
     public void testForgiving7() throws Exception {
         performFixTest("test/Test.java",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null;/*\n|*/  l.get(0);\n } }",
@@ -205,22 +204,22 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; import java.util.List; public class Test {public Test() {List<?> l = null;/* */ Object get = l.get(0); } }");
     }
-    @RandomlyFails
+
     public void testForgivingNegative1() throws Exception {
         performAnalysisTest("test/Test.java",
                             "package test; import java.util.List; public class Test {public Test() {int i = 0;i++;| } }");
     }
-    @RandomlyFails
+
     public void testForgivingNegative2() throws Exception {
         performAnalysisTest("test/Test.java",
                             "package test; import java.util.List; public class Test {public Test() {List<?> l = null;\n  l.get(0);|l.get(0);\n } }");
     }
-    @RandomlyFails
+
     public void testForgivingNegative3() throws Exception {
         performAnalysisTest("test/Test.java",
                             "package test; import java.util.List; public class Test {public Test() {List<?> l = null;\n  l.get(0); | l.get(0);\n } }");
     }
-    @RandomlyFails
+
     public void testForgivingNegative188326() throws Exception {
         performAnalysisTest("test/Test.java",
                             "package test;\n" +
@@ -236,7 +235,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                             "    }\n" +
                             "}");
     }
-    @RandomlyFails
+
     public void testAddSemicolon1() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void t() { new Run|nable() { public void run() { } } } }",
@@ -244,7 +243,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test {public void t() { Runnable runnable = new Runnable() { public void run() { } }; } }");
     }
-    @RandomlyFails
+
     public void testAddSemicolon2() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void t() {java.util.List<String> l = null; l.ge|t(0) }}",
@@ -252,7 +251,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                        "FixImpl",
                        "package test; public class Test {public void t() {java.util.List<String> l = null; String get = l.get(0); }}");
     }
-    @RandomlyFails
+
     public void test197050() throws Exception {
         performFixTest("test/Test.java",
                             "package test;\n" +
@@ -272,7 +271,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                              "    }\n" +
                              "}").replaceAll("\\s+", " "));
     }
-    @RandomlyFails
+
     public void test235716NewVariable() throws Exception {
         performFixTest("test/Test.java",
             "package test;\n" +
@@ -293,7 +292,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
              "    }\n" +
              "}").replaceAll("\\s+", " "));
     }
-    @RandomlyFails
+
     public void testInferBounds258167() throws Exception {
         performFixTest("test/Test.java",
             "package test;\n" +
@@ -315,6 +314,7 @@ public class AssignResultToVariableTest extends TreeRuleTestBase {
                 + "}").replaceAll("\\s+", " "));
     }
 
+    @Override
     protected List<ErrorDescription> computeErrors(CompilationInfo info, TreePath path, int offset) {
         while (path != null && !new AssignResultToVariable().getTreeKinds().contains(path.getLeaf().getKind()))
             path = path.getParentPath();

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/HideFieldByVarTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/HideFieldByVarTest.java
@@ -23,11 +23,10 @@ import java.io.File;
 import java.util.List;
 import java.util.Locale;
 import org.netbeans.api.java.source.CompilationInfo;
-import org.netbeans.api.java.source.SourceUtils;
 import org.netbeans.api.java.source.SourceUtilsTestUtil;
 import org.netbeans.modules.java.hints.infrastructure.TreeRuleTestBase;
 import org.netbeans.spi.editor.hints.ErrorDescription;
-import org.netbeans.junit.RandomlyFails;
+
 /**
  *
  * @author Jaroslav Tulach
@@ -44,7 +43,7 @@ public class HideFieldByVarTest extends TreeRuleTestBase {
         SourceUtilsTestUtil.setLookup(new Object[0], getClass().getClassLoader());
     }
     
-    @RandomlyFails
+
     public void testDoesNotHideItself() throws Exception {
         String before = "package test; class Test {" +
             "  protected  int va";
@@ -53,7 +52,7 @@ public class HideFieldByVarTest extends TreeRuleTestBase {
         
         performAnalysisTest("test/Test.java", before + after, before.length());
     }
-    @RandomlyFails
+
     public void testLocaVarAgainsInstanceVar() throws Exception {
         String before = "package test; class Test {" +
             "  protected  int value;" +
@@ -68,7 +67,7 @@ public class HideFieldByVarTest extends TreeRuleTestBase {
             "0:82-0:87:verifier:Local variable hides a field"
         );
     }
-    @RandomlyFails
+
     public void testLocaVarInStaticMethod() throws Exception {
         String text = "package test; class Test {" +
             "  protected  int value;" +
@@ -83,7 +82,7 @@ public class HideFieldByVarTest extends TreeRuleTestBase {
             performAnalysisTest("test/Test.java", "// index: " + i + "\n" + text, i);
         }
     }
-    @RandomlyFails
+
     public void testLocaVarAgainsInhVar() throws Exception {
         String before = "package test; class Test {" +
             "  protected  int value;" +
@@ -100,7 +99,7 @@ public class HideFieldByVarTest extends TreeRuleTestBase {
             "0:109-0:114:verifier:Local variable hides a field"
         );
     }
-    @RandomlyFails
+
     public void testParamIsOkAgainstInhVar() throws Exception {
         String before = "package test; class Test {" +
             "  protected  int value;" +
@@ -113,12 +112,13 @@ public class HideFieldByVarTest extends TreeRuleTestBase {
         performAnalysisTest("test/Test.java", before + after, before.length());
     }
 
+    @Override
     protected List<ErrorDescription> computeErrors(CompilationInfo info, TreePath path) {
         SourceUtilsTestUtil.setSourceLevel(info.getFileObject(), sourceLevel);
         return new HideFieldByVar().run(info, path);
     }
     
-    private String sourceLevel = "1.5";
+    private final String sourceLevel = "1.5";
 
     private int workDirIndex = -1;
 

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnbalancedTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnbalancedTest.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.java.hints.bugs;
 
 import org.netbeans.junit.NbTestCase;
-import org.netbeans.junit.RandomlyFails;
 import org.netbeans.modules.java.hints.test.api.HintTest;
 
 /**
@@ -146,37 +145,6 @@ public class UnbalancedTest extends NbTestCase {
                 .assertWarnings();
     }
 
-    @RandomlyFails
-    /* ergonomics # 3604: noone holds javac:
-private static final java.util.Map org.netbeans.modules.java.hints.bugs.Unbalanced.seen->
-java.util.WeakHashMap@4ba0561d-table->
-[Ljava.util.WeakHashMap$Entry;@4dfbbcea-[5]->
-java.util.WeakHashMap$Entry@14a61465-value->
-java.util.HashMap@2a234e7e-table->
-[Ljava.util.HashMap$Entry;@6081ad10-[4]->
-java.util.HashMap$Entry@519cef33-key->
-com.sun.tools.javac.code.Symbol$VarSymbol@7756c69c-type->
-com.sun.tools.javac.code.Type$ArrayType@452719a0-elemtype->
-com.sun.tools.javac.code.Type@4bf0c8d4-tsym->
-com.sun.tools.javac.code.Symbol$ClassSymbol@1a78d426-owner->
-com.sun.tools.javac.code.Symbol$PackageSymbol@29c50e17-completer->
-org.netbeans.lib.nbjavac.services.NBClassReader@3b907285-sourceCompleter->
-com.sun.tools.javac.main.JavaCompiler@5e45ffbf-flow->
-com.sun.tools.javac.comp.Flow@576cceda-attrEnv->
-com.sun.tools.javac.comp.Env@f7e5307-toplevel->
-com.sun.tools.javac.tree.JCTree$JCCompilationUnit@40d0726d
-	at org.netbeans.junit.NbTestCase$4.run(NbTestCase.java:1390)
-	at org.netbeans.junit.internal.NbModuleLogHandler.whileIgnoringOOME(NbModuleLogHandler.java:170)
-	at org.netbeans.junit.NbTestCase.assertGC(NbTestCase.java:1348)
-	at org.netbeans.junit.NbTestCase.assertGC(NbTestCase.java:1324)
-	at org.netbeans.modules.java.hints.test.api.HintTest.run(HintTest.java:487)
-	at org.netbeans.modules.java.hints.bugs.UnbalancedTest.testNegForeach209850(UnbalancedTest.java:155)
-	at org.netbeans.junit.NbTestCase.access$200(NbTestCase.java:95)
-	at org.netbeans.junit.NbTestCase$2.doSomething(NbTestCase.java:403)
-	at org.netbeans.junit.NbTestCase$1Guard.run(NbTestCase.java:329)
-	at java.lang.Thread.run(Thread.java:662)
-     * 
-     */
     public void testNegForeach209850() throws Exception {
         HintTest
                 .create()
@@ -385,52 +353,7 @@ com.sun.tools.javac.tree.JCTree$JCCompilationUnit@40d0726d
                 .run(Unbalanced.Collection.class)
                 .assertWarnings();
     }
-    @RandomlyFails
-    /* local run #2: noone holds javac:
-private static final java.util.Map org.netbeans.modules.java.hints.bugs.Unbalanced.seen->
-java.util.WeakHashMap@4163e1-table->
-[Ljava.util.WeakHashMap$Entry;@713bd2-[8]->
-java.util.WeakHashMap$Entry@dfe4-value->
-java.util.HashMap@f8ae75-table->
-[Ljava.util.HashMap$Entry;@188b5b2-[9]->
-java.util.HashMap$Entry@2569ee-key->
-com.sun.tools.javac.code.Symbol$VarSymbol@13dff89-owner->
-com.sun.tools.javac.code.Symbol$ClassSymbol@5d529e-owner->
-com.sun.tools.javac.code.Symbol$PackageSymbol@76b9d0-owner->
-com.sun.tools.javac.code.Symbol$PackageSymbol@ec179-completer->
-org.netbeans.lib.nbjavac.services.NBClassReader@1ab1d4a-sourceCompleter->
-com.sun.tools.javac.main.JavaCompiler@9cb9f3-flow->
-com.sun.tools.javac.comp.Flow@1ebb3a4-attrEnv->
-com.sun.tools.javac.comp.Env@ade1b6-toplevel->
-com.sun.tools.javac.tree.JCTree$JCCompilationUnit@128ea3f
-junit.framework.AssertionFailedError: noone holds javac:
-private static final java.util.Map org.netbeans.modules.java.hints.bugs.Unbalanced.seen->
-java.util.WeakHashMap@4163e1-table->
-[Ljava.util.WeakHashMap$Entry;@713bd2-[8]->
-java.util.WeakHashMap$Entry@dfe4-value->
-java.util.HashMap@f8ae75-table->
-[Ljava.util.HashMap$Entry;@188b5b2-[9]->
-java.util.HashMap$Entry@2569ee-key->
-com.sun.tools.javac.code.Symbol$VarSymbol@13dff89-owner->
-com.sun.tools.javac.code.Symbol$ClassSymbol@5d529e-owner->
-com.sun.tools.javac.code.Symbol$PackageSymbol@76b9d0-owner->
-com.sun.tools.javac.code.Symbol$PackageSymbol@ec179-completer->
-org.netbeans.lib.nbjavac.services.NBClassReader@1ab1d4a-sourceCompleter->
-com.sun.tools.javac.main.JavaCompiler@9cb9f3-flow->
-com.sun.tools.javac.comp.Flow@1ebb3a4-attrEnv->
-com.sun.tools.javac.comp.Env@ade1b6-toplevel->
-com.sun.tools.javac.tree.JCTree$JCCompilationUnit@128ea3f
-	at org.netbeans.junit.NbTestCase$4.run(NbTestCase.java:1390)
-	at org.netbeans.junit.internal.NbModuleLogHandler.whileIgnoringOOME(NbModuleLogHandler.java:170)
-	at org.netbeans.junit.NbTestCase.assertGC(NbTestCase.java:1348)
-	at org.netbeans.junit.NbTestCase.assertGC(NbTestCase.java:1324)
-	at org.netbeans.modules.java.hints.test.api.HintTest.run(HintTest.java:487)
-	at org.netbeans.modules.java.hints.bugs.UnbalancedTest.testCollectionNeg4(UnbalancedTest.java:383)
-	at org.netbeans.junit.NbTestCase.access$200(NbTestCase.java:95)
-	at org.netbeans.junit.NbTestCase$2.doSomething(NbTestCase.java:403)
-	at org.netbeans.junit.NbTestCase$1Guard.run(NbTestCase.java:329)
-	at java.lang.Thread.run(Thread.java:662)
-    */
+
     public void testCollectionNeg4() throws Exception {
         HintTest
                 .create()
@@ -478,44 +401,6 @@ com.sun.tools.javac.tree.JCTree$JCCompilationUnit@128ea3f
                 .assertWarnings();
     }
 
-    @RandomlyFails
-    /** Local run #1: noone holds javac:
-private static final java.util.Map org.netbeans.modules.java.hints.bugs.Unbalanced.seen->
-java.util.WeakHashMap@1a8422e-table->
-[Ljava.util.WeakHashMap$Entry;@1ce7242-[11]->
-java.util.WeakHashMap$Entry@67ec7f-value->
-java.util.HashMap@99a269-table->
-[Ljava.util.HashMap$Entry;@d42d02-[15]->
-java.util.HashMap$Entry@56619-key->
-com.sun.tools.javac.code.Symbol$VarSymbol@ed15c7-owner->
-com.sun.tools.javac.code.Symbol$MethodSymbol@1c94b8f-owner->
-com.sun.tools.javac.code.Symbol$ClassSymbol@1c5cdac-owner->
-com.sun.tools.javac.code.Symbol$PackageSymbol@15deba3-owner->
-com.sun.tools.javac.code.Symbol$PackageSymbol@191a832-completer->
-org.netbeans.lib.nbjavac.services.NBClassReader@1e41d53-sourceCompleter->
-com.sun.tools.javac.main.JavaCompiler@9d85e0-flow->
-com.sun.tools.javac.comp.Flow@1e9150a-attrEnv->
-com.sun.tools.javac.comp.Env@7fcd7e-toplevel->
-com.sun.tools.javac.tree.JCTree$JCCompilationUnit@1b5a415
-junit.framework.AssertionFailedError: noone holds javac:
-private static final java.util.Map org.netbeans.modules.java.hints.bugs.Unbalanced.seen->
-java.util.WeakHashMap@1a8422e-table->
-[Ljava.util.WeakHashMap$Entry;@1ce7242-[11]->
-java.util.WeakHashMap$Entry@67ec7f-value->
-java.util.HashMap@99a269-table->
-[Ljava.util.HashMap$Entry;@d42d02-[15]->
-java.util.HashMap$Entry@56619-key->
-com.sun.tools.javac.code.Symbol$VarSymbol@ed15c7-owner->
-com.sun.tools.javac.code.Symbol$MethodSymbol@1c94b8f-owner->
-com.sun.tools.javac.code.Symbol$ClassSymbol@1c5cdac-owner->
-com.sun.tools.javac.code.Symbol$PackageSymbol@15deba3-owner->
-com.sun.tools.javac.code.Symbol$PackageSymbol@191a832-completer->
-org.netbeans.lib.nbjavac.services.NBClassReader@1e41d53-sourceCompleter->
-com.sun.tools.javac.main.JavaCompiler@9d85e0-flow->
-com.sun.tools.javac.comp.Flow@1e9150a-attrEnv->
-com.sun.tools.javac.comp.Env@7fcd7e-toplevel->
-com.sun.tools.javac.tree.JCTree$JCCompilationUnit@1b5a415
-*/
     public void testCollectionNegEnhForLoop() throws Exception {
         HintTest
                 .create()

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateMethodTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/CreateMethodTest.java
@@ -19,13 +19,11 @@
 package org.netbeans.modules.java.hints.errors;
 
 import com.sun.source.util.TreePath;
-import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.modules.java.hints.infrastructure.ErrorHintsTestBase;
 import org.netbeans.spi.editor.hints.Fix;
-import org.netbeans.junit.RandomlyFails;
 
 /**
  *
@@ -42,64 +40,64 @@ public class CreateMethodTest extends ErrorHintsTestBase {
     protected int timeOut() {
         return 30000;
     }
-    @RandomlyFails
+
     public void testMoreMethods() throws Exception {
         performAnalysisTest("test/Test.java", "package test; public class Test {public void test() {test(1);}}", 103 - 48, "CreateMethodFix:test(int i)void:test.Test");
     }
-    @RandomlyFails
+
     public void testConstructor() throws Exception {
         performAnalysisTest("test/Test.java", "package test; public class Test {public static void test() {new Test(1);}}", 114 - 48, "CreateConstructorFix:(int i):test.Test");
     }
-    @RandomlyFails
+
     public void testNoCreateConstructorForNonExistingClass() throws Exception {
         performAnalysisTest("test/Test.java", "package test; public class Test {public static void test() {new NonExisting(1);}}", 114 - 48);
     }
-    @RandomlyFails
+
     public void testFieldLike() throws Exception {
         performAnalysisTest("test/Test.java", "package test; public class Test {public void test() {Collections.emptyList();}}", 107 - 48);
     }
-    @RandomlyFails
+
     public void testMemberSelect1() throws Exception {
         performAnalysisTest("test/Test.java", "package test; public class Test {public void test() {emptyList().doSomething();}}", 107 - 48, "CreateMethodFix:emptyList()java.lang.Object:test.Test");
     }
-    @RandomlyFails
+
     public void testMemberSelect2() throws Exception {
         performAnalysisTest("test/Test.java", "package test; public class Test {public Test test() {test().doSomething();}}", 112 - 48, "CreateMethodFix:doSomething()void:test.Test");
     }
-    @RandomlyFails
+
     public void testAssignment() throws Exception {
         performAnalysisTest("test/Test.java", "package test; public class Test {public void test() {int i = fff();}}", 110 - 48, "CreateMethodFix:fff()int:test.Test");
     }
-    @RandomlyFails
+
     public void testNewInAnnonymousInnerclass() throws Exception {
         performAnalysisTest("test/Test.java", "package test; public class Test {public Test(){} public void test() {new Runnable() {public void run() {new Test(1);}}}}", 158 - 48, "CreateConstructorFix:(int i):test.Test");
     }
-    @RandomlyFails
+
     public void testCreateMethodInInterface() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void test() {Int i = null; i.test(1);} public static interface Int{}}", 96 - 24,
                        "CreateMethodFix:test(int i)void:test.Test.Int",
                        "package test; public class Test {public void test() {Int i = null; i.test(1);} public static interface Int{ public void test(int i); }}");
     }
-    @RandomlyFails
+
     public void testCreateMethod106255() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void test() {test2(null);}}", 82 - 25,
                        "CreateMethodFix:test2(java.lang.Object object)void:test.Test",
                        "package test; public class Test {public void test() {test2(null);} private void test2(Object object) { throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody } }");
     }
-    @RandomlyFails
+
     public void testCreateMethod77038() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public void test() {b(test2() ? true : false);} void t(boolean b){}}", 82 - 25,
                        "CreateMethodFix:test2()boolean:test.Test",
                        "package test; public class Test {public void test() {b(test2() ? true : false);} void t(boolean b){} private boolean test2() { throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody } }");
     }
-    @RandomlyFails
+
     public void testCreateMethod82923() throws Exception {
         performAnalysisTest("test/Test.java", "package test; public class Test {public void test() {int i = 0; switch (i) {case 1: fff(); break;}}}", 134 - 48, "CreateMethodFix:fff()void:test.Test");
     }
-    @RandomlyFails
+
     public void testCreateMethod82931() throws Exception {
         performFixTest("test/Test.java",
                        "package test; import java.util.Collection; public class Test {public static void test() {fff(getStrings());} private static Collection<String> getStrings() {return null;}}",
@@ -107,7 +105,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                        "CreateMethodFix:fff(java.util.Collection<java.lang.String> strings)void:test.Test",
                        "package test; import java.util.Collection; public class Test {public static void test() {fff(getStrings());} private static Collection<String> getStrings() {return null;} private static void fff(Collection<String> strings) { throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody } }");
     }
-    @RandomlyFails
+
     public void testCreateMethod74129() throws Exception {
         doRunIndexing = true;
         performFixTest("test/Test.java",
@@ -115,7 +113,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                        "CreateMethodFix:fff()void:test.TopLevel",
                        "package test; public class Test {public void test() {TopLevel.fff();}} class TopLevel { static void fff() { throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody } }");
     }
-    @RandomlyFails
+
     public void testCreateMethod76498() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {public static class T extends Test {public void test() {super.fff();}}}",
@@ -123,7 +121,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                        "CreateMethodFix:fff()void:test.Test",
                        "package test; public class Test { private void fff() { throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody } public static class T extends Test {public void test() {super.fff();}}}");
     }
-    @RandomlyFails
+
     public void testCreateMethod75069() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test<T> {public void test() {this.fff();}}",
@@ -131,35 +129,35 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                        "CreateMethodFix:fff()void:test.Test",
                        "package test; public class Test<T> {public void test() {this.fff();} private void fff() { throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody } }");
     }
-    @RandomlyFails
+
     public void testCreateMethod119037() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test {static {f|ff();}}",
                        "CreateMethodFix:fff()void:test.Test",
                        "package test; public class Test {static {fff();} private static void fff() { throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody } }");
     }
-    @RandomlyFails
+
     public void testCreateMethodWithAnonymousParameter104820() throws Exception {
         performFixTest("test/Test.java",
                        "package test;public class Test {public static void method() {final Test ac = new Test();new Runnable() {public void run() {ac.a|ction(this);}};}}",
                        "CreateMethodFix:action(java.lang.Runnable aThis)void:test.Test",
                        "package test;public class Test {public static void method() {final Test ac = new Test();new Runnable() {public void run() {ac.action(this);}};} private void action(Runnable aThis) { throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody } }");
     }
-    @RandomlyFails
+
     public void testCreateMethodWithEnumParam() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test { enum Paddle{UP, DOWN} public void foo() {f|ff(Paddle.UP);}}",
                        "CreateMethodFix:fff(test.Test.Paddle paddle)void:test.Test",
                        "package test; public class Test { private void fff(Paddle paddle) { throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody } enum Paddle{UP, DOWN} public void foo() {fff(Paddle.UP);}}");
     }
-    @RandomlyFails
+
     public void testCreateMethodWithParamOfEnumType199793() throws Exception {
         performFixTest("test/Test.java",
                        "package test; public class Test { enum Paddle{UP, DOWN} public void foo(Paddle test) {f|ff(test);}}",
                        "CreateMethodFix:fff(test.Test.Paddle test)void:test.Test",
                        "package test; public class Test { private void fff(Paddle test) { throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody } enum Paddle{UP, DOWN} public void foo(Paddle test) {fff(test);}}");
     }
-    @RandomlyFails
+
     public void test220582() throws Exception {
         performFixTest("test/Test.java",
                        "package test;\n" +
@@ -183,7 +181,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                         "    }\n" +
                         "}\n").replaceAll("[ \n\t\r]+", " "));
     }
-    @RandomlyFails
+
     public void test223011a() throws Exception {
         performFixTest("test/Test.java",
                        "package test;\n" +
@@ -205,7 +203,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                         "    }\n" +
                         "}\n").replaceAll("[ \n\t\r]+", " "));
     }
-    @RandomlyFails
+
     public void test223011b() throws Exception {
         performFixTest("test/Test.java",
                        "package test;\n" +
@@ -227,7 +225,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                         "    }\n" +
                         "}\n").replaceAll("[ \n\t\r]+", " "));
     }
-    @RandomlyFails
+
     public void test223011c() throws Exception {
         performFixTest("test/Test.java",
                        "package test;\n" +
@@ -249,7 +247,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                         "    }\n" +
                         "}\n").replaceAll("[ \n\t\r]+", " "));
     }
-    @RandomlyFails
+
     public void test203476() throws Exception {
         performFixTest("test/Test.java",
                        "package test;\n" +
@@ -278,7 +276,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                         "    public static void getName(String param) { }\n" +
                         "}\n").replaceAll("[ \n\t\r]+", " "));
     }
-    @RandomlyFails
+
     public void test233502() throws Exception {
         performFixTest("test/Test.java",
                        "package test;\n" +
@@ -301,7 +299,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                         "    }\n" +
                         "}\n").replaceAll("[ \n\t\r]+", " "));
     }
-    @RandomlyFails
+
     public void testMethodRefInstanceRefToInstance() throws Exception {
         sourceLevel = "1.8";
         performFixTest("test/Test.java",
@@ -323,7 +321,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                         "    }\n" +
                         "}\n").replaceAll("[ \n\t\r]+", " "));
     }
-    @RandomlyFails
+
     public void testMethodRefStaticRefToStatic() throws Exception {
         sourceLevel = "1.8";
         performFixTest("test/Test.java",
@@ -345,7 +343,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                         "    }\n" +
                         "}\n").replaceAll("[ \n\t\r]+", " "));
     }
-    @RandomlyFails
+
     public void testMethodRefStaticRefToInstance() throws Exception {
         sourceLevel = "1.8";
         performFixTest("test/Test.java",
@@ -375,7 +373,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                         "    }\n" +
                         "}\n").replaceAll("[ \n\t\r]+", " "));
     }
-    @RandomlyFails
+
     public void testMethodRefStaticRefToStatic2() throws Exception {
         sourceLevel = "1.8";
         performFixTest("test/Test.java",
@@ -405,7 +403,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                         "    }\n" +
                         "}\n").replaceAll("[ \n\t\r]+", " "));
     }
-    @RandomlyFails
+
     public void testMethodRefInstanceRefToInstance2() throws Exception {
         sourceLevel = "1.8";
         performFixTest("test/Test.java",
@@ -435,7 +433,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
                         "    }\n" +
                         "}\n").replaceAll("[ \n\t\r]+", " "));
     }
-    @RandomlyFails
+
     public void testErroneousMethodRef() throws Exception {
         sourceLevel = "1.8";
         performAnalysisTest("test/Test.java",
@@ -455,7 +453,7 @@ public class CreateMethodTest extends ErrorHintsTestBase {
     @Override
     protected List<Fix> computeFixes(CompilationInfo info, String diagnosticCode, int pos, TreePath path) throws Exception {
         List<Fix> fixes = new CreateElement().analyze(info, diagnosticCode, pos);
-        List<Fix> result=  new LinkedList<Fix>();
+        List<Fix> result=  new LinkedList<>();
         
         for (Fix f : fixes) {
             if (f instanceof CreateMethodFix)

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ErrorHintsTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ErrorHintsTest.java
@@ -28,7 +28,6 @@ import org.netbeans.modules.java.hints.infrastructure.HintsTestBase;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.NbBundle;
-import org.netbeans.junit.RandomlyFails;
 
 /**
  * @author Jan Lahoda
@@ -53,47 +52,47 @@ public class ErrorHintsTest extends HintsTestBase {
 //    }
         
 //
-    @RandomlyFails
+
     public void testImplementAbstractMethodsHint1() throws Exception {
         performTest("ImplementAbstractMethods1", "LBL_FIX_Impl_Abstract_Methods", 16, 60);
     }
-    @RandomlyFails
+
     public void testImplementAbstractMethodsHint2() throws Exception {
         performTest("ImplementAbstractMethods2", "LBL_FIX_Impl_Abstract_Methods", 17, 15);
     }
-    @RandomlyFails
+
     public void testImplementAbstractMethodsHint3() throws Exception {
         performTest("ImplementAbstractMethods3", "LBL_FIX_Impl_Abstract_Methods", 17, 25);
     }
-    @RandomlyFails
+
     public void testImplementAbstractMethodsHint4() throws Exception {
         performTest("ImplementAbstractMethods4", "LBL_FIX_Impl_Abstract_Methods", 16, 30);
     }
-    @RandomlyFails
+
     public void testImplementAbstractMethodsHint5() throws Exception {
         performTest("ImplementAbstractMethods5", "LBL_FIX_Impl_Abstract_Methods", 16, 30);
     }
-    @RandomlyFails
+
     public void testImplementAbstractMethodsHint6() throws Exception {
         performTest("ImplementAbstractMethods6", "LBL_FIX_Impl_Abstract_Methods", 8, 5);
     }
-    @RandomlyFails
+
     public void testImplementAbstractMethodsHint7() throws Exception {
         performTest("ImplementAbstractMethods7", "LBL_FIX_Impl_Abstract_Methods", 9, 25);
     }
-    @RandomlyFails
+
     public void testImplementAbstractMethodsHint8() throws Exception {
         performTest("ImplementAbstractMethods8", "LBL_FIX_Impl_Abstract_Methods", 12, 43);
     }
-    @RandomlyFails
+
     public void testImplementAbstractMethodsHint9() throws Exception {
         performTestDoNotPerform("ImplementAbstractMethods9", 8, 15);
     }
-    @RandomlyFails
+
     public void testImplementAbstractMethodsHint10() throws Exception {
         performTestDoNotPerform("ImplementAbstractMethods10", 8, 15);
     }
-    @RandomlyFails
+
     public void testImplementAbstractMethodsHint11() throws Exception {
         performTest("ImplementAbstractMethods11", "LBL_FIX_Impl_Abstract_Methods", 8, 15);
     }
@@ -108,7 +107,7 @@ public class ErrorHintsTest extends HintsTestBase {
         }
         return result;
     }
-    @RandomlyFails
+
     public void testImplementDefaultMethods1() throws Exception {
         ImplementGeneratorAccessor.setOverrideSelection((info, type) -> 
                 findElementHandles(info,
@@ -118,7 +117,7 @@ public class ErrorHintsTest extends HintsTestBase {
         );
         performTest("ImplementDefaultMethods1", "ImplementDefaultMethods1", "LBL_FIX_Impl_Abstract_Methods", 7, 15, true, "1.8");
     }
-    @RandomlyFails
+
     public void testImplementDefaultMethods2() throws Exception {
         ImplementGeneratorAccessor.setOverrideSelection((info, type) ->  {
                 assertEquals("Wrong number of default overridable methods", 
@@ -131,7 +130,7 @@ public class ErrorHintsTest extends HintsTestBase {
         });
         performTest("ImplementDefaultMethods2", "ImplementDefaultMethods2", "LBL_FIX_Impl_Abstract_Methods", 7, 15, true, "1.8");
     }
-    @RandomlyFails
+
     public void testImplementEnumMethods() throws Exception {
         performTest("ImplementEnumMethods", "ImplementEnumMethods", "LBL_FIX_Impl_Methods_Enum_Values2", 8, 11, true, "1.8");
     }
@@ -140,50 +139,50 @@ public class ErrorHintsTest extends HintsTestBase {
 //        performTest("org.netbeans.test.java.hints.AddSemicolon", "semicolon", 17, 15);
 //    }
 //
-    @RandomlyFails
+
     public void testAddCastHint1() throws Exception {
         performTest("org.netbeans.test.java.hints.AddCast1", "Cast", 18, 15);
     }
-    @RandomlyFails
+
     public void testAddCastHint2() throws Exception {
         performTest("org.netbeans.test.java.hints.AddCast2", "Cast", 20, 13);
     }
-    @RandomlyFails
+
     public void testAddCastHint3() throws Exception {
         performTest("org.netbeans.test.java.hints.AddCast3", "Cast", 20, 20);
     }
-    @RandomlyFails
+
     public void testAddCastHint4() throws Exception {
         performTest("org.netbeans.test.java.hints.AddCast4", "Cast", 22, 10);
     }
-    @RandomlyFails
+
     public void testAddCastHint5() throws Exception {
         performTest("org.netbeans.test.java.hints.AddCast5", "Cast", 12, 1);
     }
-    @RandomlyFails
+
     public void testAddCastHint6() throws Exception {
         performTest("org.netbeans.test.java.hints.AddCast6", "Cast", 13, 23);
     }
-    @RandomlyFails
+
     public void testAddCastHint7() throws Exception {
         performTest("org.netbeans.test.java.hints.AddCast7", "Cast", 12, 18);
     }
-    @RandomlyFails
+
     public void testAddCastHint8() throws Exception {
         performTest("org.netbeans.test.java.hints.AddCast8", "Cast", 13, 18);
     }
-    @RandomlyFails
+
     public void testAddCastHint9() throws Exception {
         //should not cause exception
         //also tests Create field hint, which should not be proposed in this case:
         performTestDoNotPerform("org.netbeans.test.java.hints.AddCast9", 11, 18);
     }
-    @RandomlyFails
+
     public void testAddCastHint10() throws Exception {
         //should not cause exception
         performTest("org.netbeans.test.java.hints.AddCast10", "Cast", 13, 18);
     }
-    @RandomlyFails
+
     public void testAddCastHint11() throws Exception {
         performTestDoNotPerform("org.netbeans.test.java.hints.AddCast11", 12, 18);
     }
@@ -194,31 +193,31 @@ public class ErrorHintsTest extends HintsTestBase {
 //        performTestDoNotPerform("org.netbeans.test.java.hints.AddCast12", 14, 18);
 //        performTestDoNotPerform("org.netbeans.test.java.hints.AddCast12", 16, 18);
 //    }
-    @RandomlyFails
+
     public void testAddCastHintDoNotPropose() throws Exception {
         //should not propose "cast to ..." hint if the actual problem is an undefined method
         performTestDoNotPerform("org.netbeans.test.java.hints.AddCastDoNotPropose", 9, 18);
     }
-    @RandomlyFails
+
     public void testAddThrowsClauseHint1() throws Exception {
         performTest("org.netbeans.test.java.hints.AddThrowsClause1", "throws", 19, 30);
     }
-    @RandomlyFails
+
     public void testAddThrowsClauseHint2() throws Exception {
         performTest("org.netbeans.test.java.hints.AddThrowsClause2", "throws", 22, 30);
     }
-    @RandomlyFails
+
     public void testAddThrowsClauseHint3() throws Exception {
         performTest("org.netbeans.test.java.hints.AddThrowsClause3", "throws", 11, 30);
     }
-    @RandomlyFails
+
     public void testAddThrowsClauseHint4() throws Exception {
         performTest("org.netbeans.test.java.hints.AddThrowsClause4", "throws", 11, 30);
     }
     
     /**tests only if an exception is thrown during hints creation of errors for this file
      */
-    @RandomlyFails 
+ 
     public void testCreateElementException() throws Exception {
         performTestDoNotPerform("org.netbeans.test.java.hints.CreateElementException", 10, 27);
     }
@@ -233,19 +232,19 @@ public class ErrorHintsTest extends HintsTestBase {
 //    public void testCreateFieldException2() throws Exception {
 //        performTestDoNotPerform("org.netbeans.test.java.hints.CreateFieldException2", 8, 15);
 //    }
-    @RandomlyFails
+
     public void testCreateFieldException3() throws Exception {
         performTestDoNotPerform("org.netbeans.test.java.hints.CreateFieldException3", 9, 15);
     }
-    @RandomlyFails
+
     public void testCreateField1() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateField1", "Field", 23, 18);
     }
-    @RandomlyFails
+
     public void testCreateField2() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateField2", "Field", 23, 20);
     }
-    @RandomlyFails
+
     public void testCreateField3() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateField3", "Field", 23, 20);
     }
@@ -253,15 +252,15 @@ public class ErrorHintsTest extends HintsTestBase {
 //    public void testCreateField4() throws Exception {
 //        performTest("org.netbeans.test.java.hints.CreateField4", "Field", 23, 20);
 //    }
-    @RandomlyFails
+
     public void testCreateField5() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateField5", "Field", 23, 18);
     }
-    @RandomlyFails
+
     public void testCreateField6() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateField6", "Field", 25, 18);
     }
-    @RandomlyFails
+
     public void testCreateField7() throws Exception {
         performTestDoNotPerform("org.netbeans.test.java.hints.CreateField7", 9, 18);
     }
@@ -270,11 +269,11 @@ public class ErrorHintsTest extends HintsTestBase {
 //    public void testCreateField8() throws Exception {
 //        performTest("org.netbeans.test.java.hints.CreateField8", "Field", 6, 18);
 //    }
-    @RandomlyFails
+
     public void testCreateField10() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateField10", "Field", 9, 10);
     }
-    @RandomlyFails
+
     public void testCreateFieldPrimitive() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateFieldPrimitive", "Field", 23, 13);
     }
@@ -282,7 +281,7 @@ public class ErrorHintsTest extends HintsTestBase {
 //    public void testCreateFieldMethod1() throws Exception {
 //        performTest("org.netbeans.test.java.hints.CreateFieldMethod1", "Field", 23, 13);
 //    }
-    @RandomlyFails
+
     public void testCreateFieldMethod2() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateFieldMethod2", "Field", 23, 13);
     }
@@ -291,7 +290,7 @@ public class ErrorHintsTest extends HintsTestBase {
 //        performTestDoNotPerform("org.netbeans.test.java.hints.DoNotProposeCreateField1",9, 18);
 //    }
 //
-    @RandomlyFails
+
     public void testDoNotProposeCreateField2() throws Exception {
         performTestDoNotPerform("org.netbeans.test.java.hints.DoNotProposeCreateField2", 7, 10);
     }
@@ -335,7 +334,7 @@ public class ErrorHintsTest extends HintsTestBase {
 //    public void testLocalAndParamIncorrect57990c() throws Exception {
 //        performTestDoNotPerform("org.netbeans.test.java.hints.LocalVarParam57990c", 23, 20);
 //    }
-    @RandomlyFails
+
     public void testCreateLocalVariable1() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateLocalVariable1", "Local Variable", 23, 15);
     }
@@ -343,55 +342,55 @@ public class ErrorHintsTest extends HintsTestBase {
 //    public void testCreateLocalVariable2() throws Exception {
 //        performTest("org.netbeans.test.java.hints.CreateLocalVariable2", "Local", 19, 20);
 //    }
-    @RandomlyFails
+
     public void testCreateLocalVariable3() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateLocalVariable3", "Local Variable ", 20, 20);
     }
-    @RandomlyFails
+
     public void testCreateLocalVariable4() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateLocalVariable4", "Local Variable", 8, 18);
     }
-    @RandomlyFails
+
     public void testCreateLocalVariable5() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateLocalVariable5", "Local Variable", 8, 18);
     }
-    @RandomlyFails
+
     public void testCreateLocalVariable6() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateLocalVariable6", "Local Variable", 8, 18);
     }
-    @RandomlyFails
+
     public void testCreateLocalVariable7() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateLocalVariable7", "Local Variable", 10, 18);
     }
-    @RandomlyFails
+
     public void testCreateLocalVariable8() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateLocalVariable8", "Local Variable", 9, 18);
     }
-    @RandomlyFails
+
     public void testCreateLocalVariable9() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateLocalVariable9", "Local Variable", 11, 18);
     }
-    @RandomlyFails
+
     public void testCreateLocalVariable10() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateLocalVariable10", "Local Variable", 10, 18);
     }
-    @RandomlyFails
+
     public void testCreateParam1() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateParam1", "Parameter", 23, 15);
     }
-    @RandomlyFails
+
     public void testCreateParam2() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateParam2", "Parameter", 20, 15);
     }
-    @RandomlyFails
+
     public void testCreateParam3() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateParam3", "Parameter", 20, 15);
     }
-    @RandomlyFails
+
     public void testCreateParam4() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateParam4", "Parameter", 9, 15);
     }
-    @RandomlyFails
+
     public void testCreateParam5() throws Exception {
         performTest("org.netbeans.test.java.hints.CreateParam5", "Parameter", 10, 15);
     }
@@ -471,19 +470,19 @@ public class ErrorHintsTest extends HintsTestBase {
 //    public void testInitializeVariable3() throws Exception {
 //        performTest("org.netbeans.test.java.hints.InitializeVariable3", "Initialize", 10, 1);
 //    }
-    @RandomlyFails
+
     public void testNonAbstractClass85806() throws Exception {
         performTestDoNotPerform("org.netbeans.test.java.hints.AbstractClass4", 8, 1);
     }
-    @RandomlyFails
+
     public void testMakeClassAbstract1() throws Exception {
         performTest("org.netbeans.test.java.hints.MakeClassAbstract1", "LBL_FIX_Make_Class_Abstract", 3, 1);
     }
-    @RandomlyFails
+
     public void testMakeClassAbstract2() throws Exception {
         performTest("org.netbeans.test.java.hints.MakeClassAbstract2", "LBL_FIX_Make_Class_Abstract", 3, 1);
     }
-    @RandomlyFails
+
     public void testMakeClassAbstract3() throws Exception {
         performTest("org.netbeans.test.java.hints.MakeClassAbstract3", "LBL_FIX_Make_Class_Abstract", 3, 1);
     }

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/VarCompDeclarationTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/VarCompDeclarationTest.java
@@ -26,7 +26,6 @@ import org.netbeans.modules.java.hints.infrastructure.ErrorHintsTestBase;
 import org.netbeans.modules.java.source.parsing.JavacParser;
 import org.netbeans.spi.editor.hints.Fix;
 import org.openide.util.NbBundle;
-import org.netbeans.junit.RandomlyFails;
 
 /**
  * Test cases for handing the 'var' compound declaration errors.
@@ -44,7 +43,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
         sourceLevel = "1.10";
         JavacParser.DISABLE_SOURCE_LEVEL_DOWNGRADE = true;
     }
-    @RandomlyFails
+
     public void testCase1() throws Exception {
         performFixTest("test/Test.java",
                        "package test; \n" +
@@ -63,7 +62,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "    } \n" +
                        "}").replaceAll("[\\s]+", " "));
     }
-    @RandomlyFails
+
     public void testCase2() throws Exception {        
         performFixTest("test/Test.java",
                        "package test; \n" +
@@ -83,7 +82,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "    } \n" +
                        "}").replaceAll("[\\s]+", " "));
     }
-    @RandomlyFails
+
     public void testCase3() throws Exception {
         performFixTest("test/Test.java",
                        "package test; \n" +
@@ -102,7 +101,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "    } \n" +
                        "}").replaceAll("[\\s]+", " "));
     }
-    @RandomlyFails
+
     public void testCase4() throws Exception {
         performFixTest("test/Test.java",
                        "package test; \n" +
@@ -122,7 +121,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "    } \n" +
                        "}").replaceAll("[\\s]+", " "));
     }
-    @RandomlyFails
+
     public void testCase5() throws Exception {
         performFixTest("test/Test.java",
                        "package test; \n" +
@@ -151,7 +150,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "    } \n" +
                        "}").replaceAll("[\\s]+", " "));       
     }
-    @RandomlyFails
+
     public void testCase6() throws Exception {
         performFixTest("test/Test.java",
                        "package test; \n" +
@@ -169,7 +168,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "        var v1 = 11;} \n" +
                        "}").replaceAll("[\\s]+", " "));       
     }
-    @RandomlyFails
+
     public void testCase7() throws Exception {
         performFixTest("test/Test.java",
                        "package test; \n" +
@@ -187,7 +186,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "        @DA final var y = 11;} \n" +
                        "}").replaceAll("[\\s]+", " "));       
     }
-    @RandomlyFails
+
     public void testCase8() throws Exception {
         performFixTest("test/Test.java",
                        "package test; \n" +
@@ -206,7 +205,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "    } \n" +
                        "}").replaceAll("[\\s]+", " "));
     }
-    @RandomlyFails
+
     public void testCase9() throws Exception {
         performFixTest("test/Test.java",
                        "package test; \n" +
@@ -233,7 +232,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "    } \n" +
                        "}").replaceAll("[\\s]+", " "));
     }
-    @RandomlyFails
+
     public void testCase10() throws Exception {
         performFixTest("test/Test.java",
                        "package test; \n" +
@@ -260,7 +259,7 @@ public class VarCompDeclarationTest extends ErrorHintsTestBase {
                        "    } \n" +
                        "}").replaceAll("[\\s]+", " "));
     }
-    @RandomlyFails
+
     public void testCase11() throws Exception {
         performFixTest("test/Test.java",
                        "package test; \n" +

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/introduce/IntroduceHintTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/introduce/IntroduceHintTest.java
@@ -60,7 +60,6 @@ import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.util.NbPreferences;
 import org.openide.util.lookup.ServiceProvider;
-import org.netbeans.junit.RandomlyFails;
 
 /**
  *
@@ -104,70 +103,70 @@ public class IntroduceHintTest extends NbTestCase {
         info = null;
         doc = null;
     }
-    @RandomlyFails
+
     public void testCorrectSelection1() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {int i = 3;}}", 110 - 49, 111 - 49, true);
     }
-    @RandomlyFails
+
     public void testCorrectSelection2() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test(int i) {|i = 3;|}}", false);
     }
-    @RandomlyFails
+
     public void testCorrectSelection3() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {int z = 0; int i = z + 2;}}", 121 - 49, 124 - 49, false);
     }
-    @RandomlyFails
+
     public void testCorrectSelection4() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {int y = 3; System.err.println((\"x=\" + y).length());}}", 83, 102, true);
     }
-    @RandomlyFails
+
     public void testCorrectSelection5() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {int y = 3; System.err.println((\"x=\" + y).length());}}", 64, 103, false);
     }
-    @RandomlyFails
+
     public void testCorrectSelection6() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {int y = 3; System.err.println((\"x=\" + y).length());}}", 64, 104, false);
     }
-    @RandomlyFails
+
     public void testCorrectSelection7() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {int y = 3; y = 2;}}", 64, 69, false);
     }
-    @RandomlyFails
+
     public void testCorrectSelection8() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {int y = (int)Math.round(1.2);}}", 111 - 49, 114 - 49, false);
     }
-    @RandomlyFails
+
     public void testCorrectSelection9() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {long y = Math.round(1.2);}}", 111 - 49, 126 - 49, true);
     }
-    @RandomlyFails
+
     public void testCorrectSelection10() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {String s = \"\"; int y = s.length();}}", 125 - 49, 135 - 49, true);
     }
-    @RandomlyFails
+
     public void testCorrectSelection11() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {System.err.println();}}", 102 - 49, 120 - 49, false);
     }
-    @RandomlyFails
+
     public void testCorrectSelection12() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test(|String|[] s) {}}", false);
     }
-    @RandomlyFails
+
     public void testCorrectSelection13() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {new |Object|();}}", false);
     }
-    @RandomlyFails
+
     public void test121420() throws Exception {
         performFixTest("package test; import java.util.ArrayList; public class Test {public void test() { |new ArrayList<String>()|; }}", "package test; import java.util.ArrayList; public class Test {public void test() { ArrayList<String> arrayList = new ArrayList<String>(); }}", new DialogDisplayerImpl(null, false, false, true), 5, 0);
     }
-    @RandomlyFails
+
     public void test142424() throws Exception {
         performFixTest("package test; public class Test {private static void bar(int i) {} public void test() {new Runnable() {public void run() {String foo = \"foo\";bar(|foo.length()|);}}.run();}}",
                        "package test; public class Test {private static void bar(int i) {} public void test() {new Runnable() {public void run() {String foo = \"foo\";int length = foo.length(); bar(length);}}.run();}}",
                        new DialogDisplayerImpl(null, false, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix1() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3; int x = y + 9;}}",
                        72, 77,
@@ -175,7 +174,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, false, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix2() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3; int x = y + 9;}}",
                        72, 77,
@@ -183,7 +182,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl("nueName", false, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix3() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3; int x = y + 9; x = y + 9;}}",
                        72, 77,
@@ -191,7 +190,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, false, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix4() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3; int x = y + 9; x = y + 9;}}",
                        72, 77,
@@ -199,7 +198,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, true, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix5() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3; int x = y + 9; x = y + 9;}}",
                        108 - 25, 113 - 25,
@@ -207,7 +206,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, true, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix6() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3; int x = y + 9; x = y + 9;}}",
                        108 - 25, 113 - 25,
@@ -215,7 +214,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, true, true, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix7() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3; if (true) y = y + 9; y = y + 9;}}",
                        103 - 25, 108 - 25,
@@ -223,7 +222,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, false, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix8() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3; if (true) y = y + 9; y = y + 9;}}",
                        114 - 25, 119 - 25,
@@ -231,7 +230,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, true, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix9() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 8 + 9;} public void test2() { int y = 8 + 9;}}",
                        86 - 25, 91 - 25,
@@ -239,7 +238,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, true, false, true),
                        5, 0);
     }
-    @RandomlyFails
+
     public void testFix10() throws Exception {
         performFixTest("package test; public class Test {public void test(int y) {while (y != 7) {y = 3 + 4;} y = 3 + 4;}}",
                        115 - 25, 120 - 25,
@@ -247,28 +246,28 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, true, false, true),
                        5, 0);
     }
-    @RandomlyFails
+
     public void testFix11() throws Exception {
         performFixTest("package test; import java.util.List; public class Test {public void test1() {List<? extends CharSequence> l = |test()|;} public List<? extends CharSequence> test() {return null;}}",
                        "package test; import java.util.List; public class Test {public void test1() {List<? extends CharSequence> name = test(); List<? extends CharSequence> l = name;} public List<? extends CharSequence> test() {return null;}}",
                        new DialogDisplayerImpl("name", true, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix12() throws Exception {
         performFixTest("package test; import java.util.List; public class Test {public void test1() {List<? extends CharSequence> l = null; CharSequence c = |l.get(0)|;} }",
                        "package test; import java.util.List; public class Test {public void test1() {List<? extends CharSequence> l = null; CharSequence name = l.get(0); CharSequence c = name;} }",
                        new DialogDisplayerImpl("name", true, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix126460() throws Exception {
         performFixTest("package test; import java.util.List; public class Test {public void test1() {List<String> l = null; assert |l.get(0)| == null;} }",
                        "package test; import java.util.List; public class Test {public void test1() {List<String> l = null; String name = l.get(0); assert name == null;} }",
                        new DialogDisplayerImpl("name", true, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix126269() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -297,7 +296,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl("name", true, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFix180164() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -321,7 +320,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl("name", true, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     public void testFixNewClassTree179766() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -338,7 +337,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl("name", true, false, true),
                        5, 0);
     }
-    @RandomlyFails
+
     public void testSwitchCase219714() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -364,7 +363,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl("name", true, false, true),
                        4, 0);
     }
-    @RandomlyFails
+
     //note the comment assignment done for this test in prepareTest
     public void testCommentVariable() throws Exception {
         performFixTest("package test;\n" +
@@ -395,43 +394,43 @@ public class IntroduceHintTest extends NbTestCase {
 //                       new DialogDisplayerImpl("name", true, null, true),
 //                       2, 0);
 //    }
-    @RandomlyFails
+
     public void testSimple4() throws Exception {
         performSimpleSelectionVerificationTest("package test; import java.util.ArrayList; public class Test {public void test() {Object o = new ArrayList<String>();}}", 141 - 49, 164 - 49, true);
     }
-    @RandomlyFails
+
     public void testConstant1() throws Exception {
         performConstantAccessTest("package test; public class Test {public void test() {int i = 1 + 2;}}", 97 - 36, 102 - 36, true);
     }
-    @RandomlyFails
+
     public void testConstant2() throws Exception {
         performConstantAccessTest("package test; public class Test {private int i = 0; public void test() {int x = 1 + i;}}", 116 - 36, 121 - 36, false);
     }
-    @RandomlyFails
+
     public void testConstant3() throws Exception {
         performConstantAccessTest("package test; public class Test {private static int i = 0; public void test() {int x = 1 + i;}}", 123 - 36, 128 - 36, false);
     }
-    @RandomlyFails
+
     public void testConstant4() throws Exception {
         performConstantAccessTest("package test; public class Test {private final int i = 0; public void test() {int x = 1 + i;}}", 122 - 36, 127 - 36, false);
     }
-    @RandomlyFails
+
     public void testConstant5() throws Exception {
         performConstantAccessTest("package test; public class Test {private static final int i = 0; public void test() {int x = 1 + i;}}", 129 - 36, 134 - 36, true);
     }
-    @RandomlyFails
+
     public void testConstant187444a() throws Exception {
         performConstantAccessTest("package test; public class Test {private static final double i = |-2.4|;}", true);
     }
-    @RandomlyFails
+
     public void testConstant187444b() throws Exception {
         performConstantAccessTest("package test; public class Test {private static final int i = |~(2 + 4)|;}", true);
     }
-    @RandomlyFails
+
     public void testConstant187444c() throws Exception {
         performConstantAccessTest("package test; public class Test {int y = 1; private final int i = |~(2 + y)|; }", false);
     }
-    @RandomlyFails
+
     public void testConstantFix1() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3 + 4;}}",
                        86 - 25, 91 - 25,
@@ -439,7 +438,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, false, null, true),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testConstantFixNoVariable() throws Exception {
         performFixTest("package test; public class Test { int y = 3 + 4;}",
                        67 - 25, 72 - 25,
@@ -447,7 +446,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, false, null, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testConstantFix2() throws Exception {
         performFixTest("package test; public class Test { int y = 3 + 4; int z = 3 + 4;}",
                        67 - 25, 72 - 25,
@@ -455,7 +454,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, true, null, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testConstantFix106490a() throws Exception {
         performFixTest("package test; public class Test { int y = 3 + 4; int z = 3 + 4;}",
                        67 - 25, 72 - 25,
@@ -464,7 +463,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PUBLIC)),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testConstantFix106490b() throws Exception {
         performFixTest("package test; public class Test { int y = 3 + 4; int z = 3 + 4;}",
                        67 - 25, 72 - 25,
@@ -473,7 +472,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .noneOf(Modifier.class)),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testConstantFix130938() throws Exception {
         performFixTest("package test;import java.util.logging.Level;import java.util.logging.Logger;public class Test {public void foo() { Logger.getLogger(Test.class.getName()).log(Level.FINEST, \"foo\");}}",
                        140 - 25,
@@ -483,13 +482,13 @@ public class IntroduceHintTest extends NbTestCase {
                 .noneOf(Modifier.class)),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix1() throws Exception {
         performCheckFixesTest("package test; public class Test {int y = 3 + 4; int z = 3 + 4;}",
                               73 - 32, 78 - 32,
                               "[IntroduceFix:NAME:2:CREATE_CONSTANT]");
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix2() throws Exception {
         performCheckFixesTest("package test; public class Test {public void test() {int y = 3 + 4; int z = 3 + 4;}}",
                               93 - 32, 98 - 32,
@@ -499,7 +498,7 @@ public class IntroduceHintTest extends NbTestCase {
                               "[IntroduceExpressionBasedMethodFix]",
                               "[Introduce Parameter Fix]");
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix3() throws Exception {
         performCheckFixesTest("package test; public class Test {public void test() {int y = 3 + 4; int z = 3 + 4;} public void test2() {int u = 3 + 4;}}",
                               93 - 32, 98 - 32,
@@ -509,7 +508,7 @@ public class IntroduceHintTest extends NbTestCase {
                               "[IntroduceExpressionBasedMethodFix]",
                               "[Introduce Parameter Fix]");
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix4() throws Exception {
         performCheckFixesTest("package test; public class Test {public void test() {int u = 0; int y = u + 4; int z = u + 4;} public void test2() {int u = 0; int a = u + 4;}}",
                               104 - 32, 109 - 32,
@@ -518,7 +517,7 @@ public class IntroduceHintTest extends NbTestCase {
                               "[IntroduceExpressionBasedMethodFix]",
                               "[Introduce Parameter Fix]");
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix5() throws Exception {
         performCheckFixesTest("package test; public class Test {int u = 0; public void test() {int y = u + 4; int z = u + 4;} public void test2() {int a = u + 4;}}",
                               104 - 32, 109 - 32,
@@ -527,7 +526,7 @@ public class IntroduceHintTest extends NbTestCase {
                               "[IntroduceExpressionBasedMethodFix]",
                               "[Introduce Parameter Fix]");
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix7() throws Exception {
         performCheckFixesTest("package test; public class Test {public void test() {int u = 0; int y = u + 4; int z = u + 4;}}",
                               104 - 32, 109 - 32,
@@ -536,7 +535,7 @@ public class IntroduceHintTest extends NbTestCase {
                               "[IntroduceExpressionBasedMethodFix]",
                               "[Introduce Parameter Fix]");
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix8() throws Exception {
         performCheckFixesTest("package test; public class Test {int u = 0; public void test() {int y = u + 4; int z = u + 4;}}",
                               104 - 32, 109 - 32,
@@ -545,7 +544,7 @@ public class IntroduceHintTest extends NbTestCase {
                               "[IntroduceExpressionBasedMethodFix]",
                               "[Introduce Parameter Fix]");
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix9() throws Exception {
         performCheckFixesTest("package test; public class Test {int u = 0; public void test() {int y = u + 4; int z = u + 4;} private int i = 4;}",
                               108 - 32, 109 - 32,
@@ -555,7 +554,7 @@ public class IntroduceHintTest extends NbTestCase {
                               "[IntroduceExpressionBasedMethodFix]",
                               "[Introduce Parameter Fix]");
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix10() throws Exception {
         performCheckFixesTest("package test; public class Test {static int u = 0; public static void test() {int y = u + 4; int z = u + 4;}}",
                               118 - 32, 123 - 32,
@@ -564,7 +563,7 @@ public class IntroduceHintTest extends NbTestCase {
                               "[IntroduceExpressionBasedMethodFix]",
                               "[Introduce Parameter Fix]");
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix11() throws Exception {
         performCheckFixesTest("package test; public class Test {public Test() {int y = 3 + 4; int z = 3 + 4;}}",
                               88 - 32, 93 - 32,
@@ -574,7 +573,7 @@ public class IntroduceHintTest extends NbTestCase {
                               "[IntroduceExpressionBasedMethodFix]",
                               "[Introduce Parameter Fix]");
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix12() throws Exception {
         performCheckFixesTest("package test; public class Test {public Test() {int y = 3 + 4; int z = 3 + 4;} public Test(int i) {}}",
                               88 - 32, 93 - 32,
@@ -584,7 +583,7 @@ public class IntroduceHintTest extends NbTestCase {
                               "[IntroduceExpressionBasedMethodFix]",
                               "[Introduce Parameter Fix]");
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix13() throws Exception {
         performFixTest("package test; public class Test {public Test() {int y = 3 + 4; int z = 3 + 4;} public Test(int i) {}}",
                        88 - 32, 93 - 32,
@@ -593,7 +592,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix14() throws Exception {
         performFixTest("package test; public class Test {public Test() {int y = 3 + 4; int z = 3 + 4;} public Test(int i) {}}",
                        88 - 32, 93 - 32,
@@ -602,7 +601,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix15() throws Exception {
         performFixTest("package test; public class Test {public Test() {int y = 3 + 4; int z = 3 + 4;} public Test(int i) {}}",
                        88 - 32, 93 - 32,
@@ -611,7 +610,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix16() throws Exception {
         performFixTest("package test; public class Test {public Test() {int y = 3 + 4; int z = 3 + 4;} public Test(int i) {}}",
                        88 - 32, 93 - 32,
@@ -620,7 +619,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix17() throws Exception {
         performFixTest("package test; public class Test {public Test() {int y = 3 + 4; int z = 3 + 4;} public Test(int i) {}}",
                        88 - 32, 93 - 32,
@@ -629,7 +628,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix18() throws Exception {
         performFixTest("package test; public class Test {public Test() {int y = 3 + 4; int z = 3 + 4;} public Test(int i) {}}",
                        88 - 32, 93 - 32,
@@ -638,7 +637,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PUBLIC), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix19() throws Exception {
         performFixTest("package test; public class Test {public Test() {int y = 3 + 4; int z = 3 + 4;} public Test(int i) {}}",
                        88 - 32, 93 - 32,
@@ -647,7 +646,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PUBLIC), true, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix20() throws Exception {
         performFixTest("package test; public class Test {public void test() { int y = 3 + 4; int z = 3 + 4;}}",
                        87 - 25, 92 - 25,
@@ -656,7 +655,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testFix21() throws Exception {
         performFixTest("package test; import java.util.List; public class Test {public void test1() {List<? extends CharSequence> l = |test()|;} public List<? extends CharSequence> test() {return null;}}",
                        "package test; import java.util.List; public class Test { private List<? extends CharSequence> name; public void test1() {name = test(); List<? extends CharSequence> l = name;} public List<? extends CharSequence> test() {return null;}}",
@@ -664,7 +663,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        4, 1);
     }
-    @RandomlyFails
+
     public void testFix22() throws Exception {
         performFixTest("package test; import java.util.List; public class Test {public void test1() {List<? extends CharSequence> l = null; CharSequence c = |l.get(0)|;} }",
                        "package test; import java.util.List; public class Test { private CharSequence name; public void test1() {List<? extends CharSequence> l = null; name = l.get(0); CharSequence c = name;} }",
@@ -672,7 +671,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        4, 1);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix114350() throws Exception {
         performFixTest("package test; public class Test {\n" +
                        "    public Test() {\n" +
@@ -688,7 +687,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix114360() throws Exception {
         performFixTest("package test; public enum Test {\n" +
                        "    A;\n" +
@@ -701,7 +700,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix120271() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -720,7 +719,6 @@ public class IntroduceHintTest extends NbTestCase {
      *
      * @throws java.lang.Exception
      */
-    @RandomlyFails 
     public void testIntroduceFieldFix106495() throws Exception {
         performFixTest("package test; public class Test {public Test() {int y = 3 + 4; int z = 3 + 4;} public Test(int i) {} public static void a() {int y = 3 + 4;}}",
                        88 - 32, 93 - 32,
@@ -729,7 +727,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE, Modifier.STATIC), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix213972() throws Exception {
         performFixTest("package test; public class Test {public void test1() {|int i = 3;|} public void test2() {int i = 3;}}",
                        "package test; public class Test { private int i = 3; public void test1() {} public void test2() {int i = 3;}}",
@@ -737,7 +735,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        3, 1);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFixNewClassTree179766() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -755,31 +753,31 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testCorrectMethodSelection1() throws Exception {
         performStatementSelectionVerificationTest("package test; public class Test {public void test() {int i = 3;}}", 105 - 52, 115 - 52, true, new int[]{0, 0});
     }
-    @RandomlyFails
+
     public void testCorrectMethodSelection2() throws Exception {
         performStatementSelectionVerificationTest("package test; public class Test {public void test() {int i = 3; i += 2; i += 3;}}", 116 - 52, 123 - 52, true, new int[]{1, 1});
     }
-    @RandomlyFails
+
     public void testCorrectMethodSelection3() throws Exception {
         performStatementSelectionVerificationTest("package test; public class Test {public void test() {int i = 3;  i += 2; i += 3;}}", 116 - 52, 125 - 52, true, new int[]{1, 1});
     }
-    @RandomlyFails
+
     public void testCorrectMethodSelection4() throws Exception {
         performStatementSelectionVerificationTest("package test; public class Test {public void test() {Object o = null;}}", 108 - 52, 121 - 52, false, new int[]{0, 0});
     }
-    @RandomlyFails
+
     public void testCorrectMethodSelection5() throws Exception {
         performStatementSelectionVerificationTest("package test; public class Test {public void test() {Object o = null;}}", 105 - 52, 105 - 52, false, new int[]{0, 0});
     }
-    @RandomlyFails
+
     public void testCorrectMethodSelection6() throws Exception {
         performStatementSelectionVerificationTest("package test; public class Test {public void test() {       Object o = null;}}", 107 - 52, 107 - 52, false, new int[]{0, 0});
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix1() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3 + 4; int z = 3 + 4;}}",
                        78 - 25, 92 - 25,
@@ -787,7 +785,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", null, true),
                        3, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix2() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3 + 4; int z = y + 4;}}",
                        93 - 25, 107 - 25,
@@ -795,21 +793,21 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", null, true),
                        2, 1);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix3() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3 + 4; y += 4; int z = y + 4;}}",
                        93 - 25, 100 - 25,
                        "package test; public class Test {public void test() {int y = 3 + 4; y = name(y); int z = y + 4;} private int name(int y) { y += 4; return y; } }",
                        new DialogDisplayerImpl3("name", null, true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix4() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3 + 4; y += 4; int a = 4; int z = y + a;}}",
                        93 - 25, 111 - 25,
                        null,
                        new DialogDisplayerImpl3("name", null, true), 0, -1);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix5() throws Exception {
         performFixTest("package test; public class Test {public void test() {int y = 3 + 4; int a = y + 4; int z = y + a;}}",
                        93 - 25, 107 - 25,
@@ -817,14 +815,14 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", null, true),
                        2, 1);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix6() throws Exception {
         performFixTest("package test; import java.io.IOException; public class Test {public void test() throws IOException {int y = 3 + 4; throw new IOException();}}",
                        140 - 25, 164 - 25,
                        "package test; import java.io.IOException; public class Test {public void test() throws IOException {int y = 3 + 4; name(); } private void name() throws IOException { throw new IOException(); } }",
                        new DialogDisplayerImpl3("name", null, true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix7() throws Exception {
         performFixTest("package test; import java.io.IOException; public class Test {public void test() {while (true) {int y = 3 + 4;}}}",
                        120 - 25, 134 - 25,
@@ -832,42 +830,42 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", null, true),
                        3, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix8() throws Exception {
         performFixTest("package test; import java.io.IOException; public class Test {public void test(int y) {while (true) {if (--y <= 0) break;}}}",
                        125 - 25, 145 - 25,
                        "package test; import java.io.IOException; public class Test {public void test(int y) {while (true) {if (name(y)) break;}} private boolean name(int y) { if (--y <= 0) { return true; } return false; } }",
                        new DialogDisplayerImpl3("name", null, true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix9() throws Exception {
         performErrorMessageTest("package test; import java.io.IOException; public class Test {public void test(int y) {while (true) {if (--y <= 0) {y = 3; break;}} int u = y;}}",
                                 134 - 34, 163 - 34,
                                 IntroduceKind.CREATE_METHOD,
                                 "ERR_Too_Many_Return_Values");
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix10() throws Exception {
         performFixTest("package test; import java.io.IOException; public class Test {public void test(int y) {while (true) {if (--y <= 0) { y = 2; break; } else { y = 3; break; }} int u = y;}}",
                        125 - 25, 179 - 25,
                        "package test; import java.io.IOException; public class Test {public void test(int y) {while (true) {y = name(y); break; } int u = y;} private int name(int y) { if (--y <= 0) { y = 2; return y; } else { y = 3; return y; } } }",
                        new DialogDisplayerImpl3("name", null, true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix11() throws Exception {
         performFixTest("package test; import java.io.IOException; public class Test {public void test(int y) {while (true) {if (--y <= 0) { break; } else { break; }}}}",
                        125 - 25, 165 - 25,
                        "package test; import java.io.IOException; public class Test {public void test(int y) {while (true) {name(y); break; }} private void name(int y) { if (--y <= 0) { return; } else { return; } } }",
                        new DialogDisplayerImpl3("name", null, true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix12() throws Exception {
         performFixTest("package test; public class Test {public int test(int y) {while (true) {if (--y <= 0) { return 1; } else { return 2; }}}}",
                        96 - 25, 142 - 25,
                        "package test; public class Test {public int test(int y) {while (true) {return name(y); }} private int name(int y) { if (--y <= 0) { return 1; } else { return 2; } } }",
                        new DialogDisplayerImpl3("name", null, true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodPosition() throws Exception {
         performFixTest("package test; public class Test {public void foo() { int i = 1; } public void foo1() {}}", 78 - 25, 88 - 25,
                        "package test; public class Test {public void foo() { name(); } public void foo1() {} private void name() { int i = 1; } }",
@@ -890,21 +888,21 @@ public class IntroduceHintTest extends NbTestCase {
                        "package test; public class Test {public void test(int y) {if (3 != 4) return ;}}",
                        new DialogDisplayerImpl3("name", null, true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFixNeverEnds1() throws Exception {
         performFixTest("package test; public class Test {}    ",
                        60 - 25, 61 - 25,
                        null,
                        new DialogDisplayerImpl(null, null, null, false));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFixNeverEnds2() throws Exception {
         performFixTest("     package test; public class Test {}",
                        26 - 25, 28 - 25,
                        null,
                        new DialogDisplayerImpl(null, null, null, false));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix106490a() throws Exception {
         performFixTest("package test; public class Test {public int test(int y) {while (true) {if (--y <= 0) { return 1; } else { return 2; }}}}",
                        96 - 25, 142 - 25,
@@ -912,7 +910,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PUBLIC), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFix106490b() throws Exception {
         performFixTest("package test; public class Test {public int test(int y) {while (true) {if (--y <= 0) { return 1; } else { return 2; }}}}",
                        96 - 25, 142 - 25,
@@ -920,7 +918,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .noneOf(Modifier.class), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFixStatic() throws Exception {
         performFixTest("package test; public class Test {public static int test(int y) {y += 5; return y;}}",
                        89 - 25, 96 - 25,
@@ -932,49 +930,48 @@ public class IntroduceHintTest extends NbTestCase {
     /**
      * Return statement inside anonymous class should not be considered
      */
-    @RandomlyFails
     public void testIntroduceMethodFix132434() throws Exception {
         performFixTest("package test;import java.awt.event.MouseAdapter;import java.awt.event.MouseEvent;import javax.swing.JPanel;public class Test {public static void main(String[] args) {JPanel p = new JPanel();|p.addMouseListener(new MouseAdapter() { public void mousePressed(MouseEvent e) { if (e.getX() > 100) { return; } else { System.out.println(e.getX()); } } });|}}",
                        "package test;import java.awt.event.MouseAdapter;import java.awt.event.MouseEvent;import javax.swing.JPanel;public class Test {public static void main(String[] args) {JPanel p = new JPanel();foo(p);} private static void foo(JPanel p) { p.addMouseListener(new MouseAdapter() { public void mousePressed(MouseEvent e) { if (e.getX() > 100) { return; } else { System.out.println(e.getX()); } } }); } }",
                        new DialogDisplayerImpl3("foo", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod109663a() throws Exception {
         performErrorMessageTest("package test; public class Test {public static void test(int y) {while (y < 10) {if (y == 0) break; else y++; int u = y;}}}",
                                 106 - 25, 134 - 25,
                                 IntroduceKind.CREATE_METHOD,
                                 "ERR_Too_Many_Return_Values");
     }
-    @RandomlyFails
+
     public void testIntroduceMethod109663b() throws Exception {
         performErrorMessageTest("package test; public class Test {public static void test(int y) {while (y < 10) {if (y == 0) break; else y++;}}}",
                                 106 - 25, 134 - 25,
                                 IntroduceKind.CREATE_METHOD,
                                 "ERR_Too_Many_Return_Values");
     }
-    @RandomlyFails
+
     public void testIntroduceMethod109663c() throws Exception {
         performErrorMessageTest("package test; public class Test {public static void test(int y) {do {if (y == 0) break; else y++;} while (y < 10); }}",
                                 103 - 34, 131 - 34,
                                 IntroduceKind.CREATE_METHOD,
                                 "ERR_Too_Many_Return_Values");
     }
-    @RandomlyFails
+
     public void testIntroduceMethod109663d() throws Exception {
         performErrorMessageTest("package test; public class Test {public static void test(int y) {for ( ; y < 10; ) {if (y == 0) break; else y++;}}}",
                                 118 - 34, 146 - 34,
                                 IntroduceKind.CREATE_METHOD,
                                 "ERR_Too_Many_Return_Values");
     }
-    @RandomlyFails
+
     public void testIntroduceMethod109663e() throws Exception {
         performErrorMessageTest("package test; public class Test {public static void test(int y) {for ( ; ; y++) {if (y == 0) break; else y++;}}}",
                                 115 - 34, 143 - 34,
                                 IntroduceKind.CREATE_METHOD,
                                 "ERR_Too_Many_Return_Values");
     }
-    @RandomlyFails
+
     public void testIntroduceMethod109663f() throws Exception {
         performFixTest("package test; public class Test {public static void test(int y) {for (int u = y ; ; ) {if (y == 0) break; else y++;}}}",
                        112 - 25, 140 - 25,
@@ -982,7 +979,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod109663g() throws Exception {
         performFixTest("package test; public class Test {public static void test(int y) {for (Integer i : java.util.Arrays.asList(y)) {if (y == 0) break; else y++;}}}",
                        136 - 25, 164 - 25,
@@ -990,12 +987,12 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void test107689() throws Exception {
         performSimpleSelectionVerificationTest("package test; import java.util.List; public class Test {}",
                                                53 - 32, 67 - 32, false);
     }
-    @RandomlyFails
+
     public void testIntroduceMethod112552a() throws Exception {
         performFixTest("package test; public class Test {public static void t() {boolean first = true; while (true) {if (first) {first = false;} else {break;}}}}",
                        130 - 25, 144 - 25,
@@ -1003,7 +1000,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod112552b() throws Exception {
         performFixTest("package test; public class Test {public static void t(int a) {boolean first = true; while (true) {if (first) {while (a != 1) {first = false;}} else {break;}}}}",
                        151 - 25, 165 - 25,
@@ -1011,7 +1008,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod112552c() throws Exception {
         performFixTest("package test; public class Test {public static void t() {boolean first = true; for (;;) {if (first) {first = false;} else {break;}}}}",
                        126 - 25, 140 - 25,
@@ -1019,7 +1016,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod112552d() throws Exception {
         performFixTest("package test; public class Test {public static void t() {boolean first = true; do {if (first) {first = false;} else {break;}} while (true);}}",
                        120 - 25, 134 - 25,
@@ -1027,7 +1024,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod112552e() throws Exception {
         performFixTest("package test; public class Test {public static void t() {boolean first = true; while (true) {first = false; while (first) {System.err.println();}}}}",
                        148 - 25, 169 - 25,
@@ -1035,7 +1032,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod111896a() throws Exception {
         performFixTest("package test; public class Test {public static void t() {new Runnable() { private  int i; public void run() { } };}}",
                        82 - 25, 139 - 25,
@@ -1043,7 +1040,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod111896b() throws Exception {
         performFixTest("package test; public class Test {public static void t() {final int a = 0; new Runnable() { private  int i; public void run() { i = a; } };}}",
                        99 - 25, 163 - 25,
@@ -1051,7 +1048,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod111896c() throws Exception {
         performFixTest("package test; public class Test {public static void t() {final int a = 0; new Runnable() { private  int i; public void run() { int a = i; } }; int b = a;}}",
                        99 - 25, 167 - 25,
@@ -1059,7 +1056,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodUselessLocalVariable() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1075,7 +1072,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod114371() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1091,7 +1088,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod179258() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1125,7 +1122,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethod116199() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1138,7 +1135,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodComments170213() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1166,7 +1163,7 @@ public class IntroduceHintTest extends NbTestCase {
 //                                IntroduceKind.CREATE_METHOD,
 //                                "");
 //    }
-    @RandomlyFails
+
     public void testIntroduceMethodFromExpression1() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1180,7 +1177,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        4, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFromExpression2() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1194,7 +1191,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        4, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFromExpressionNewClassTree179766() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1223,7 +1220,7 @@ public class IntroduceHintTest extends NbTestCase {
 //                       "package test; import java.io.IOException; public class Test { public static void test(int a) throws Exception { name(a); } private static void name(int a) throws IOException { if (a == 1) { throw new java.io.IOException(\"\"); } if (a == 2) { throw new java.io.FileNotFoundException(\"\"); } } }",
 //                       new DialogDisplayerImpl3("name", EnumSet.of(Modifier.PRIVATE), true));
 //    }
-    @RandomlyFails
+
     public void testIntroduceMethodArray162163() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1236,7 +1233,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodReplaceDuplicatesNoRemap() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1252,7 +1249,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet.of(Modifier.PRIVATE), true, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodReplaceDuplicatesSimpleRemap() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1271,7 +1268,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet.of(Modifier.PRIVATE), true, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodReplaceDuplicatesSimpleRemapNotUseAfterMethod() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1288,7 +1285,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet.of(Modifier.PRIVATE), true, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodReplaceDuplicates194622() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1305,7 +1302,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet.of(Modifier.PRIVATE), true, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodReplaceDuplicatesRemapExpression() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1324,7 +1321,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet.of(Modifier.PRIVATE), true, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodReplaceDuplicatesRemapExpression179515a() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1343,7 +1340,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet.of(Modifier.PRIVATE), true, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodReplaceDuplicatesRemapExpression179515b() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1367,7 +1364,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet.of(Modifier.PRIVATE), true, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFromExpressionDuplicatesAndRemap() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1381,7 +1378,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true, true),
                        4, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodReplaceDuplicates206193() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1418,7 +1415,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet.of(Modifier.PRIVATE), true, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFromSingleStatement153399a() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1431,7 +1428,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodFromSingleStatement153399b() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1449,13 +1446,13 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodNPE() throws Exception {
         performErrorMessageTest("package test; public class Test { |private static class F { public static void test(int y) {for ( ; ; y++) {if (y == 0) break; else y++;}}}| }",
                                 IntroduceKind.CREATE_METHOD,
                                 "ERR_Invalid_Selection");
     }
-    @RandomlyFails
+
     public void testIntroduceMethodTypeParam183435a() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1468,7 +1465,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodTypeParam183435b() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1482,7 +1479,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", EnumSet
                 .of(Modifier.PRIVATE), true));
     }
-    @RandomlyFails
+
     public void testIntroduceMethodTypeParam183435c() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1496,7 +1493,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        4, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodTypeParam183435d() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1511,7 +1508,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        4, 2);
     }
-    @RandomlyFails
+
     public void test152705() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.ArrayList;\n" +
@@ -1547,7 +1544,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testLocalVariableToField1() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.ArrayList;\n" +
@@ -1568,7 +1565,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), false, true),
                        3, 1);
     }
-    @RandomlyFails
+
     public void testLocalVariableToField201759a() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.ArrayList;\n" +
@@ -1590,7 +1587,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), false, true),
                        3, 1);
     }
-    @RandomlyFails
+
     public void testLocalVariableToField201759b() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.ArrayList;\n" +
@@ -1617,7 +1614,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), false, true),
                        3, 1);
     }
-    @RandomlyFails
+
     public void testLocalVariableToField201759c() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.ArrayList;\n" +
@@ -1641,7 +1638,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), false, true),
                        3, 1);
     }
-    @RandomlyFails
+
     public void testLocalVariableToFieldInitMethod270296() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1666,7 +1663,7 @@ public class IntroduceHintTest extends NbTestCase {
                                                 EnumSet.of(Modifier.PRIVATE), false, true),
                        3, 1);
     }
-    @RandomlyFails
+
     public void testLocalVariableToConstant1() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.ArrayList;\n" +
@@ -1687,7 +1684,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE)),
                        3, 0);
     }
-    @RandomlyFails
+
     public void test196683() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.ArrayList;\n" +
@@ -1736,7 +1733,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void test193775() throws Exception {
         performCheckFixesTest("package test; import java.util.Collection; import java.util.Map.Entry; public class Test { public void test(|Collection<Entry> e|) {} }");
     }
@@ -1762,7 +1759,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE)),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix203621a() throws Exception {
         performFixTest("package test; public class Test {\n" +
                        "    public void test() {\n" +
@@ -1774,7 +1771,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix203621b() throws Exception {
         performFixTest("package test; public class Test {\n" +
                        "    public Test() {\n" +
@@ -1788,7 +1785,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceFieldFix203621c() throws Exception {
         performFixTest("package test; public class Test {\n" +
                        "    public void test() {\n" +
@@ -1802,7 +1799,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testFieldLocation233440() throws Exception {
         Preferences prefs = CodeStylePreferences.get((FileObject) null, JavacParser.MIME_TYPE).getPreferences();
         prefs.put("classMemberInsertionPoint", InsertionPoint.CARET_LOCATION.name());
@@ -1819,7 +1816,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testIntroduceConstantFix203621() throws Exception {
         performFixTest("package test; public class Test {\n" +
                        "    public void test() {\n" +
@@ -1831,11 +1828,11 @@ public class IntroduceHintTest extends NbTestCase {
                 .noneOf(Modifier.class)),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testConstant203499() throws Exception {
         performConstantAccessTest("package test; public class Test { static String g(String s) { return s; } static String d(String s) { return |g(s)|; } }", false);
     }
-    @RandomlyFails
+
     public void testIntroduceMethod203254() throws Exception {
         performFixTest("package test;\n" +
                        "class Test {\n" +
@@ -1849,7 +1846,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethod228913() throws Exception {
         sourceLevel = "1.8";
         performFixTest("package test;\n" +
@@ -1866,7 +1863,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethod203002() throws Exception {
         performFixTest("package test;\n" +
                        "class Test {\n" +
@@ -1890,7 +1887,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testMethodUnprefixedParam() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -1916,7 +1913,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testMethodParamWithLetterPrefix() throws Exception {
         codeStylePrefs.put(FmtOptions.parameterNamePrefix, "p");
         performFixTest("package test;\n" +
@@ -1951,7 +1948,6 @@ public class IntroduceHintTest extends NbTestCase {
      * potential prefix should be ignored
      * 
      */
-    @RandomlyFails
     public void testMethodPrefixedAndUnprefixed() throws Exception {
         codeStylePrefs.put(FmtOptions.parameterNamePrefix, "p");
         performFixTest("package test;\n" +
@@ -1980,7 +1976,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void test224512() throws Exception {
         performFixTest("package test;\n" +
                        "class Test {\n" +
@@ -2023,7 +2019,7 @@ public class IntroduceHintTest extends NbTestCase {
                 .of(Modifier.PRIVATE), true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testConstantFix204373a() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.logging.Level;\n" +
@@ -2051,7 +2047,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, true, true, true, EnumSet.noneOf(Modifier.class)),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testConstantFix204373b() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.logging.Level;\n" +
@@ -2077,7 +2073,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, true, true, true, EnumSet.noneOf(Modifier.class)),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testConstantFix204373c() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.logging.Level;\n" +
@@ -2109,7 +2105,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl(null, true, true, true, EnumSet.noneOf(Modifier.class)),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testConstantFix204373d() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.logging.Level;\n" +
@@ -2141,7 +2137,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl2(null, IntroduceFieldPanel.INIT_FIELD, true, EnumSet.<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testConstantFix204373e() throws Exception {
         performFixTest("package test;\n" +
                        "import java.util.logging.Level;\n" +
@@ -2173,7 +2169,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl2(null, IntroduceFieldPanel.INIT_FIELD, true, EnumSet.<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testConstantFix208072a() throws Exception {
         Preferences prefs = CodeStylePreferences.get((FileObject) null, JavacParser.MIME_TYPE).getPreferences();
         prefs.put("classMemberInsertionPoint", "LAST_IN_CATEGORY");
@@ -2193,7 +2189,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl("ZZ", true, true, true, EnumSet.of(Modifier.PRIVATE)),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testConstantFix208072b() throws Exception {
         Preferences prefs = CodeStylePreferences.get((FileObject) null, JavacParser.MIME_TYPE).getPreferences();
         prefs.put("classMembersOrder", "STATIC_INIT;STATIC METHOD;INSTANCE_INIT;CONSTRUCTOR;METHOD;STATIC CLASS;CLASS;STATIC FIELD;FIELD");
@@ -2220,7 +2216,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl("ZZ", true, true, true, EnumSet.of(Modifier.PRIVATE)),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testConstantFix208072c() throws Exception {
         Preferences prefs = CodeStylePreferences.get((FileObject) null, JavacParser.MIME_TYPE).getPreferences();
         prefs.put("classMembersOrder", "STATIC_INIT;STATIC METHOD;INSTANCE_INIT;CONSTRUCTOR;METHOD;STATIC CLASS;CLASS;STATIC FIELD;FIELD");
@@ -2247,7 +2243,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl("ZZ", true, true, true, EnumSet.of(Modifier.PRIVATE)),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testConstantFix219771a() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2267,7 +2263,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl("C0", true, true, true, EnumSet.of(Modifier.PUBLIC)),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testConstantFix219771b() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2287,7 +2283,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl2("C0", IntroduceFieldPanel.INIT_FIELD, true, EnumSet.of(Modifier.PUBLIC), true, true),
                        4, 1);
     }
-    @RandomlyFails
+
     public void testConstantFix219771c() throws Exception {
         Preferences prefs = CodeStylePreferences.get((FileObject) null, JavacParser.MIME_TYPE).getPreferences();
         prefs.put("classMembersOrder", "STATIC_INIT;FIELD;STATIC METHOD;INSTANCE_INIT;CONSTRUCTOR;METHOD;STATIC CLASS;CLASS;STATIC FIELD");
@@ -2315,7 +2311,6 @@ public class IntroduceHintTest extends NbTestCase {
      * Checks that expressions that instantiate member classes cannot form constant
      * @throws Exception 
      */
-    @RandomlyFails
     public void testConstantFix236187() throws Exception {
         performConstantAccessTest("package test;\n" +
                         "public class Test {\n" +
@@ -2326,7 +2321,7 @@ public class IntroduceHintTest extends NbTestCase {
                         "  }\n" +
                         "}", false);
     }
-    @RandomlyFails
+
     public void testConstantFix236187Static() throws Exception {
         performFixTest("package test;\n" +
                         "public class Test {\n" +
@@ -2350,7 +2345,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl2("ZZ", IntroduceFieldPanel.INIT_FIELD, true, EnumSet.<Modifier>of(Modifier.PRIVATE), true, true),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testFieldFix208072d() throws Exception {
         Preferences prefs = CodeStylePreferences.get((FileObject) null, JavacParser.MIME_TYPE).getPreferences();
         prefs.put("classMembersOrder", "STATIC_INIT;STATIC METHOD;INSTANCE_INIT;CONSTRUCTOR;METHOD;STATIC CLASS;CLASS;STATIC FIELD;FIELD");
@@ -2377,11 +2372,11 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl2("ZZ", IntroduceFieldPanel.INIT_FIELD, false, EnumSet.<Modifier>of(Modifier.PRIVATE), false, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testWhitespace216402() throws Exception {
         performSimpleSelectionVerificationTest("package test; public class Test {public void test() {int y = 3; y =|  2   |; }}", true);
     }
-    @RandomlyFails
+
     public void testVariableNullTypeVariable221440() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2399,7 +2394,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl("name", true, false, true),
                        5, 0);
     }
-    @RandomlyFails
+
     public void testVariableNullTypeConstant221440() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2417,7 +2412,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl("name", true, null, true),
                        5, 1);
     }
-    @RandomlyFails
+
     public void testVariableNullTypeField221440() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2435,7 +2430,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl2("name", IntroduceFieldPanel.INIT_FIELD, true, null, true, true),
                        5, 2);
     }
-    @RandomlyFails
+
     public void testVariableNullTypeMethod221440() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2455,7 +2450,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", null, true),
                        5, 3);
     }
-    @RandomlyFails
+
     public void test213023() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2473,7 +2468,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", null, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testNullIntroduceMethod231050a() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2495,7 +2490,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", null, true),
                        5, 3);
     }
-    @RandomlyFails
+
     public void testNullIntroduceMethod231050b() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2517,7 +2512,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", null, true),
                        5, 3);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodLastStatement224168a() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2541,7 +2536,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", null, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodLastStatement224168b() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2569,7 +2564,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", null, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodLastStatement224168c() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +
@@ -2602,7 +2597,7 @@ public class IntroduceHintTest extends NbTestCase {
                        new DialogDisplayerImpl3("name", null, true),
                        1, 0);
     }
-    @RandomlyFails
+
     public void testIntroduceMethodReturn233433() throws Exception {
         performFixTest("package test;\n" +
                        "public class Test {\n" +


### PR DESCRIPTION
#2422 disabled many tests, lets see if we can improve coverage again.

We could try to isolate unreliable tests and wrap them in retry scripts, which is better than not running them at all.

But first.. lets turn everything on to check what happens.

edit: tests seem to be stable, didn't fail so far