### PR TITLE
Git: enable "replace invalid branch characters" by default

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/GitModuleConfig.java
+++ b/ide/git/src/org/netbeans/modules/git/GitModuleConfig.java
@@ -204,7 +204,7 @@ public final class GitModuleConfig {
     }
 
     public boolean getAutoReplaceInvalidBranchNameCharacters() {
-        return getPreferences().getBoolean(AUTO_REPLACE_INVALID_BRANCH_NAME_CHARACTERS, false);
+        return getPreferences().getBoolean(AUTO_REPLACE_INVALID_BRANCH_NAME_CHARACTERS, true);
     }
 
     public void setAutoReplaceInvalidBranchNameCharacters(boolean value) {


### PR DESCRIPTION
enables #4306 by default

discussed on the [dev list](https://lists.apache.org/thread/rdflfdbt2v0cxz9mk198tonm0hnff1bg) a while ago, I got distracted by other things and forgot to open a PR for it.