### PR TITLE
Do not ask for proxies on each project.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleNetworkProxySupport.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleNetworkProxySupport.java
@@ -101,7 +101,7 @@ public class GradleNetworkProxySupport {
      * effective proxy is detected, the user is not asked again.
      */
     // @GuardedBy(this)
-    private Map<String, ProxyResult>    acknowledgedResults = new HashMap<>();
+    private static Map<String, ProxyResult>    acknowledgedResults = new HashMap<>();
     
     public GradleNetworkProxySupport(Project project) {
         this.project = project;

--- a/extide/gradle/src/org/netbeans/modules/gradle/options/GradleExperimentalSettings.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/options/GradleExperimentalSettings.java
@@ -34,6 +34,23 @@ public final class GradleExperimentalSettings {
     private static final GradleExperimentalSettings INSTANCE = new GradleExperimentalSettings(NbPreferences.forModule(GradleExperimentalSettings.class));
     private final Preferences preferences;
 
+    /**
+     * Specifies how should be proxies handled by default, if no setting is given.
+     */
+    private static final String SYSPROP_DEFAULT_PROXY_BEHAVIOUR = "netbeans.networkProxy";
+    
+    private static final NetworkProxySettings DEFAULT_PROXY_BEHAVIOUR;
+    
+    static {
+        NetworkProxySettings def;
+        try {
+            def = NetworkProxySettings.valueOf(System.getProperty(SYSPROP_DEFAULT_PROXY_BEHAVIOUR, NetworkProxySettings.ASK.name()).toUpperCase());
+        } catch (IllegalArgumentException e) {
+            def = NetworkProxySettings.ASK;
+        }
+        DEFAULT_PROXY_BEHAVIOUR = def;
+    }
+
     public static GradleExperimentalSettings getDefault() {
         return INSTANCE;
     }
@@ -71,11 +88,11 @@ public final class GradleExperimentalSettings {
     }
     
     public NetworkProxySettings getNetworkProxy() {
-        String s = getPreferences().get(PROP_NETWORK_PROXY, NetworkProxySettings.ASK.name());
+        String s = getPreferences().get(PROP_NETWORK_PROXY, DEFAULT_PROXY_BEHAVIOUR.name());
         try {
             return NetworkProxySettings.valueOf(s);
         } catch (IllegalArgumentException ex) {
-            return NetworkProxySettings.ASK;
+            return DEFAULT_PROXY_BEHAVIOUR;
         }
     }
     

--- a/java/maven/src/org/netbeans/modules/maven/execute/MavenProxySupport.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/MavenProxySupport.java
@@ -171,7 +171,7 @@ public class MavenProxySupport {
      * effective proxy is detected, the user is not asked again.
      */
     // @GuardedBy(this)
-    private Map<String, ProxyResult>    acknowledgedResults = new HashMap<>();
+    private static Map<String, ProxyResult>    acknowledgedResults = new HashMap<>();
     
     public MavenProxySupport(Project project) {
     }

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
@@ -95,6 +95,23 @@ public final class MavenSettings  {
     private static final MavenSettings INSTANCE = new MavenSettings();
     
     private final Set<PropertyChangeListener> listeners = new WeakSet<>();
+    
+    /**
+     * Specifies how should be proxies handled by default, if no setting is given.
+     */
+    private static final String SYSPROP_DEFAULT_PROXY_BEHAVIOUR = "netbeans.networkProxy";
+    
+    private static final NetworkProxySettings DEFAULT_PROXY_BEHAVIOUR;
+    
+    static {
+        NetworkProxySettings def;
+        try {
+            def = NetworkProxySettings.valueOf(System.getProperty(SYSPROP_DEFAULT_PROXY_BEHAVIOUR, NetworkProxySettings.ASK.name()).toUpperCase());
+        } catch (IllegalArgumentException e) {
+            def = NetworkProxySettings.ASK;
+        }
+        DEFAULT_PROXY_BEHAVIOUR = def;
+    }
 
     public static MavenSettings getDefault() {
         return INSTANCE;
@@ -617,11 +634,11 @@ public final class MavenSettings  {
     }
     
     public NetworkProxySettings getNetworkProxy() {
-        String s = getPreferences().get(PROP_NETWORK_PROXY, NetworkProxySettings.ASK.name());
+        String s = getPreferences().get(PROP_NETWORK_PROXY, DEFAULT_PROXY_BEHAVIOUR.name());
         try {
             return NetworkProxySettings.valueOf(s);
         } catch (IllegalArgumentException ex) {
-            return NetworkProxySettings.ASK;
+            return DEFAULT_PROXY_BEHAVIOUR;
         }
     }
     


### PR DESCRIPTION
The current implementations keep user decisions per project; so if some conflict between detected proxy and detected settings is reported to the user, it is reported again for each project: but tool setings are machine-wide, so they apply to all projects. 

This PR makes a simple (dirty) fix storing the decisions in a static variable, sharing between individual projects.  It's really annoing if there are more projects opened. Decisions are not shared between Maven and Gradle, so the IDE may ask 2 times (once for each build system). In a typical case, the developer uses either Maven or Gradle, so hopefully this will not happen frequently.

I would like to factor the detection out to core.network + add some APIs and turn maven + gradle into just some 'setting manipulators' ... but not before NB20 branching.