### PR TITLE
Improve inline-hints settings, add keybinding, disable by default.

### DIFF
--- a/ide/editor.actions/src/org/netbeans/modules/editor/actions/ShowInlineHintsAction.java
+++ b/ide/editor.actions/src/org/netbeans/modules/editor/actions/ShowInlineHintsAction.java
@@ -29,7 +29,7 @@ import org.netbeans.api.editor.EditorActionRegistration;
                           preferencesDefault=ShowInlineHintsAction.DEF_LINES)
 public class ShowInlineHintsAction extends AbstractAction {
     public static final String KEY_LINES = "enable.inline.hints";
-    public static final boolean DEF_LINES = true;
+    public static final boolean DEF_LINES = false;
     @Override
     public void actionPerformed(ActionEvent e) {
     }

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
@@ -91,7 +91,7 @@ public final class DocumentViewOp
     private static final Logger LOG = Logger.getLogger(DocumentViewOp.class.getName());
 
     // Whether use fractional metrics rendering hint
-    static final Map<Object, Object> extraRenderingHints = new HashMap<Object, Object>();
+    static final Map<Object, Object> extraRenderingHints = new HashMap<>();
     
     static final Boolean doubleBuffered;
     
@@ -151,7 +151,7 @@ public final class DocumentViewOp
         if (contrast != null) {
             try {
                 extraRenderingHints.put(RenderingHints.KEY_TEXT_LCD_CONTRAST,
-                        Integer.parseInt(contrast));
+                        Integer.valueOf(contrast));
             } catch (NumberFormatException ex) {
                 // Do not add the key
             }
@@ -919,14 +919,13 @@ public final class DocumentViewOp
     
     /* private */ void updatePreferencesSettings(boolean nonInitialUpdate) {
         boolean nonPrintableCharactersVisibleOrig = isAnyStatusBit(NON_PRINTABLE_CHARACTERS_VISIBLE);
-        boolean nonPrintableCharactersVisible = Boolean.TRUE.equals(prefs.getBoolean(
-                SimpleValueNames.NON_PRINTABLE_CHARACTERS_VISIBLE, false));
+        boolean nonPrintableCharactersVisible = prefs.getBoolean(SimpleValueNames.NON_PRINTABLE_CHARACTERS_VISIBLE, false);
         updateStatusBits(NON_PRINTABLE_CHARACTERS_VISIBLE, nonPrintableCharactersVisible);
         // Line height correction
         float lineHeightCorrectionOrig = rowHeightCorrection;
         rowHeightCorrection = prefs.getFloat(SimpleValueNames.LINE_HEIGHT_CORRECTION, 1.0f);
         boolean inlineHintsEnableOrig = inlineHintsEnable;
-        inlineHintsEnable = Boolean.TRUE.equals(prefs.getBoolean("enable.inline.hints", true)); // NOI18N
+        inlineHintsEnable = prefs.getBoolean("enable.inline.hints", false); // NOI18N
         boolean updateMetrics = (rowHeightCorrection != lineHeightCorrectionOrig);
         boolean releaseChildren = nonInitialUpdate && 
                 ((nonPrintableCharactersVisible != nonPrintableCharactersVisibleOrig) ||
@@ -940,7 +939,7 @@ public final class DocumentViewOp
         if (releaseChildren) {
             releaseChildren(false);
         }
-        boolean currentGuideLinesEnable = Boolean.TRUE.equals(prefs.getBoolean("enable.guide.lines", true)); // NOI18N
+        boolean currentGuideLinesEnable = prefs.getBoolean("enable.guide.lines", true); // NOI18N
         if (nonInitialUpdate && guideLinesEnable != currentGuideLinesEnable) {
             docView.op.notifyRepaint(visibleRect.getMinX(), visibleRect.getMinY(), visibleRect.getMaxX(), visibleRect.getMaxY());    
         }

--- a/ide/editor/src/org/netbeans/modules/editor/resources/NetBeans-keybindings.xml
+++ b/ide/editor/src/org/netbeans/modules/editor/resources/NetBeans-keybindings.xml
@@ -177,6 +177,7 @@
     <bind actionName="toggle-highlight-search" key="OS-H"/>
     <bind actionName="toggle-rectangular-selection" key="DS-R"/>
     <bind actionName="toggle-typing-mode" key="INSERT"/>
+    <bind actionName="toggle-inline-hints" key="O-I"/>
     <bind actionName="tooltip-show" key="D-P"/>
     <bind actionName="transpose-letters" key="D-T"/>
     <bind actionName="undo" key="UNDO"/>

--- a/java/java.editor/src/org/netbeans/modules/java/editor/options/Bundle.properties
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/options/Bundle.properties
@@ -152,3 +152,4 @@ CodeCompletionPanel.javadocAutoCompletionTriggersField.text=
 InlineHintsPanel.javaInlineHintParameterNameCB.text=Show parameter names
 InlineHintsPanel.javaInlineHintChainedTypesCB.text=Show types of chained methods
 InlineHintsPanel.javaInlineHintVarTypeCB.text=Show type of var
+InlineHintsPanel.javaInlineHintsCB.text=Enable Inline Hints

--- a/java/java.editor/src/org/netbeans/modules/java/editor/options/InlineHintsPanel.form
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/options/InlineHintsPanel.form
@@ -38,10 +38,44 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,60,0,0,2,16"/>
   </AuxValues>
 
-  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
+  <Layout>
+    <DimensionLayout dim="0">
+      <Group type="103" groupAlignment="0" attributes="0">
+          <Group type="102" alignment="0" attributes="0">
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" attributes="0">
+                      <EmptySpace min="21" pref="21" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="javaInlineHintVarTypeCB" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="javaInlineHintChainedTypesCB" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="javaInlineHintParameterNameCB" alignment="0" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                  </Group>
+                  <Component id="javaInlineHintsCB" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="32767" attributes="0"/>
+          </Group>
+      </Group>
+    </DimensionLayout>
+    <DimensionLayout dim="1">
+      <Group type="103" groupAlignment="0" attributes="0">
+          <Group type="102" alignment="1" attributes="0">
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="javaInlineHintsCB" min="-2" max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <Component id="javaInlineHintParameterNameCB" min="-2" max="-2" attributes="0"/>
+              <EmptySpace min="6" pref="6" max="-2" attributes="0"/>
+              <Component id="javaInlineHintChainedTypesCB" min="-2" max="-2" attributes="0"/>
+              <EmptySpace min="6" pref="6" max="-2" attributes="0"/>
+              <Component id="javaInlineHintVarTypeCB" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
+          </Group>
+      </Group>
+    </DimensionLayout>
+  </Layout>
   <SubComponents>
     <Component class="javax.swing.JCheckBox" name="javaInlineHintParameterNameCB">
       <Properties>
@@ -49,11 +83,6 @@
           <ResourceString bundle="org/netbeans/modules/java/editor/options/Bundle.properties" key="InlineHintsPanel.javaInlineHintParameterNameCB.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
-      <Constraints>
-        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="10" weightX="1.0" weightY="0.0"/>
-        </Constraint>
-      </Constraints>
     </Component>
     <Component class="javax.swing.JCheckBox" name="javaInlineHintChainedTypesCB">
       <Properties>
@@ -61,11 +90,6 @@
           <ResourceString bundle="org/netbeans/modules/java/editor/options/Bundle.properties" key="InlineHintsPanel.javaInlineHintChainedTypesCB.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
-      <Constraints>
-        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="10" weightX="1.0" weightY="0.0"/>
-        </Constraint>
-      </Constraints>
     </Component>
     <Component class="javax.swing.JCheckBox" name="javaInlineHintVarTypeCB">
       <Properties>
@@ -73,26 +97,13 @@
           <ResourceString bundle="org/netbeans/modules/java/editor/options/Bundle.properties" key="InlineHintsPanel.javaInlineHintVarTypeCB.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
-      <Constraints>
-        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="3" insetsLeft="3" insetsBottom="3" insetsRight="3" anchor="10" weightX="1.0" weightY="0.0"/>
-        </Constraint>
-      </Constraints>
     </Component>
-    <Component class="javax.swing.Box$Filler" name="filler1">
+    <Component class="javax.swing.JCheckBox" name="javaInlineHintsCB">
       <Properties>
-        <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[32767, 32767]"/>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/java/editor/options/Bundle.properties" key="InlineHintsPanel.javaInlineHintsCB.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
-      <AuxValues>
-        <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.Glue"/>
-      </AuxValues>
-      <Constraints>
-        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="3" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="1.0"/>
-        </Constraint>
-      </Constraints>
     </Component>
   </SubComponents>
 </Form>

--- a/java/java.editor/src/org/netbeans/modules/java/editor/options/InlineHintsPanel.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/options/InlineHintsPanel.java
@@ -18,6 +18,8 @@
  */
 package org.netbeans.modules.java.editor.options;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,13 +28,14 @@ import java.util.Map;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import javax.swing.JCheckBox;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import org.netbeans.api.editor.EditorRegistry;
 import org.netbeans.modules.editor.NbEditorUtilities;
 import org.netbeans.modules.parsing.api.indexing.IndexingManager;
 import org.openide.util.Exceptions;
 
+/**
+ * UI for inline-hints settings (Tools-&gt;Options-&gt;Editor-&gt;Inline Hints).
+ */
 public class InlineHintsPanel extends javax.swing.JPanel {
 
     public static final String JAVA_INLINE_HINT_PARAMETER_NAME = "javaInlineHintParameterName"; //NOI18N
@@ -49,38 +52,41 @@ public class InlineHintsPanel extends javax.swing.JPanel {
         DEFAULT_VALUES = Collections.unmodifiableMap(defaultValuesBuilder);
     }
 
-    private List<JCheckBox> boxes;
+    private List<JCheckBox> parameterBoxes;
     private InlineHintsOptionsPanelController controller;
     private boolean changed = false;
 
-    /**
-     * Creates new form InlineHintsPanel
-     */
     public InlineHintsPanel(InlineHintsOptionsPanelController controller) {
         initComponents();
-//        if( "Windows".equals(UIManager.getLookAndFeel().getID()) ) //NOI18N
-//            setOpaque( false );
         fillBoxes();
         addListeners();
-        load(controller);
     }
 
     public void load(InlineHintsOptionsPanelController controller) {
         this.controller = controller;
 
+        javaInlineHintsCB.setSelected(InlineHintsSettings.isInlineHintsEnabled());
+
         Preferences node = InlineHintsSettings.getCurrentNode();
 
-        for (JCheckBox box : boxes) {
+        for (JCheckBox box : parameterBoxes) {
             box.setSelected(node.getBoolean(box.getActionCommand(), DEFAULT_VALUES.get(box.getActionCommand())));
         }
+
+        updateCheckBoxEnabledState(null);
 
         changed = false;
     }
 
     public void store() {
+
+        if (javaInlineHintsCB.isSelected() != InlineHintsSettings.isInlineHintsEnabled()) {
+            InlineHintsSettings.setInlineHintsEnabled(javaInlineHintsCB.isSelected());
+        }
+
         Preferences node = InlineHintsSettings.getCurrentNode();
 
-        for (javax.swing.JCheckBox box : boxes) {
+        for (JCheckBox box : parameterBoxes) {
             boolean value = box.isSelected();
             boolean original = node.getBoolean(box.getActionCommand(),
                     DEFAULT_VALUES.get(box.getActionCommand()));
@@ -117,62 +123,83 @@ public class InlineHintsPanel extends javax.swing.JPanel {
      */
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
-        java.awt.GridBagConstraints gridBagConstraints;
 
         javaInlineHintParameterNameCB = new javax.swing.JCheckBox();
         javaInlineHintChainedTypesCB = new javax.swing.JCheckBox();
         javaInlineHintVarTypeCB = new javax.swing.JCheckBox();
-        filler1 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 0), new java.awt.Dimension(0, 0), new java.awt.Dimension(32767, 32767));
+        javaInlineHintsCB = new javax.swing.JCheckBox();
 
         setBorder(javax.swing.BorderFactory.createEmptyBorder(8, 8, 8, 8));
-        setLayout(new java.awt.GridBagLayout());
 
         org.openide.awt.Mnemonics.setLocalizedText(javaInlineHintParameterNameCB, org.openide.util.NbBundle.getMessage(InlineHintsPanel.class, "InlineHintsPanel.javaInlineHintParameterNameCB.text")); // NOI18N
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.insets = new java.awt.Insets(3, 3, 3, 3);
-        add(javaInlineHintParameterNameCB, gridBagConstraints);
 
         org.openide.awt.Mnemonics.setLocalizedText(javaInlineHintChainedTypesCB, org.openide.util.NbBundle.getMessage(InlineHintsPanel.class, "InlineHintsPanel.javaInlineHintChainedTypesCB.text")); // NOI18N
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 1;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.insets = new java.awt.Insets(3, 3, 3, 3);
-        add(javaInlineHintChainedTypesCB, gridBagConstraints);
 
         org.openide.awt.Mnemonics.setLocalizedText(javaInlineHintVarTypeCB, org.openide.util.NbBundle.getMessage(InlineHintsPanel.class, "InlineHintsPanel.javaInlineHintVarTypeCB.text")); // NOI18N
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 2;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.insets = new java.awt.Insets(3, 3, 3, 3);
-        add(javaInlineHintVarTypeCB, gridBagConstraints);
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 3;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.weighty = 1.0;
-        add(filler1, gridBagConstraints);
+
+        org.openide.awt.Mnemonics.setLocalizedText(javaInlineHintsCB, org.openide.util.NbBundle.getMessage(InlineHintsPanel.class, "InlineHintsPanel.javaInlineHintsCB.text")); // NOI18N
+
+        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
+        this.setLayout(layout);
+        layout.setHorizontalGroup(
+            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(layout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(layout.createSequentialGroup()
+                        .addGap(21, 21, 21)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(javaInlineHintVarTypeCB)
+                            .addComponent(javaInlineHintChainedTypesCB)
+                            .addComponent(javaInlineHintParameterNameCB)))
+                    .addComponent(javaInlineHintsCB))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+        );
+        layout.setVerticalGroup(
+            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(javaInlineHintsCB)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(javaInlineHintParameterNameCB)
+                .addGap(6, 6, 6)
+                .addComponent(javaInlineHintChainedTypesCB)
+                .addGap(6, 6, 6)
+                .addComponent(javaInlineHintVarTypeCB)
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+        );
     }// </editor-fold>//GEN-END:initComponents
+
+    private void updateCheckBoxEnabledState(ActionEvent evt) {
+        if (javaInlineHintsCB.isSelected() && parameterBoxes.stream().noneMatch(JCheckBox::isSelected)) {
+            if (evt != null && evt.getSource() == javaInlineHintsCB) {
+                // restore default if hints are toggled on and no other parameter boxes are selected
+                // this ensures that the view aciton won't become a no-op
+                for (JCheckBox box : parameterBoxes) {
+                    box.setSelected(DEFAULT_VALUES.get(box.getActionCommand()));
+                }
+            } else {
+                // disable inline hints if none of the parameter boxes are selected
+                javaInlineHintsCB.setSelected(false);
+            }
+        }
+        // enable parameter boxes only if inline hints are active
+        parameterBoxes.forEach(box -> box.setEnabled(javaInlineHintsCB.isSelected()));
+    }
 
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    private javax.swing.Box.Filler filler1;
     private javax.swing.JCheckBox javaInlineHintChainedTypesCB;
     private javax.swing.JCheckBox javaInlineHintParameterNameCB;
     private javax.swing.JCheckBox javaInlineHintVarTypeCB;
+    private javax.swing.JCheckBox javaInlineHintsCB;
     // End of variables declaration//GEN-END:variables
-    // End of variables declaration
 
     private void fillBoxes() {
-        boxes = new ArrayList<JCheckBox>();
-        boxes.add(javaInlineHintParameterNameCB);
-        boxes.add(javaInlineHintChainedTypesCB);
-        boxes.add(javaInlineHintVarTypeCB);
+        parameterBoxes = new ArrayList<>();
+        parameterBoxes.add(javaInlineHintParameterNameCB);
+        parameterBoxes.add(javaInlineHintChainedTypesCB);
+        parameterBoxes.add(javaInlineHintVarTypeCB);
 
         javaInlineHintParameterNameCB.setActionCommand(JAVA_INLINE_HINT_PARAMETER_NAME);
         javaInlineHintChainedTypesCB.setActionCommand(JAVA_INLINE_HINT_CHAINED_TYPES);
@@ -180,31 +207,27 @@ public class InlineHintsPanel extends javax.swing.JPanel {
     }
 
     private void addListeners() {
-        ChangeListener cl = new CheckChangeListener();
-
-        for (JCheckBox box : boxes) {
-            box.addChangeListener(cl);
+        ActionListener al = e -> checkBoxChanged(e);
+        javaInlineHintsCB.addActionListener(al);
+        for (JCheckBox box : parameterBoxes) {
+            box.addActionListener(al);
         }
-
     }
 
-    private void fireChanged() {
+    private void checkBoxChanged(ActionEvent evt) {
+        updateCheckBoxEnabledState(evt);
+        if (javaInlineHintsCB.isSelected() != InlineHintsSettings.isInlineHintsEnabled()) {
+            changed = true;
+            return;
+        }        
         Preferences node = InlineHintsSettings.getCurrentNode();
-        for (JCheckBox box : boxes) {
+        for (JCheckBox box : parameterBoxes) {
             if (node.getBoolean(box.getActionCommand(), DEFAULT_VALUES.get(box.getActionCommand())) != box.isSelected()) {
                 changed = true;
                 return;
             }
         }
         changed = false;
-    }
-
-    private class CheckChangeListener implements ChangeListener {
-
-        @Override
-        public void stateChanged(ChangeEvent evt) {
-            fireChanged();
-        }
     }
 
 }

--- a/java/java.editor/src/org/netbeans/modules/java/editor/options/InlineHintsSettings.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/options/InlineHintsSettings.java
@@ -19,14 +19,16 @@ package org.netbeans.modules.java.editor.options;
  * under the License.
  */
 
-
-import org.netbeans.modules.java.editor.options.*;
 import java.util.prefs.Preferences;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.openide.util.NbPreferences;
 
 public class InlineHintsSettings {
     
     private static final String INLINE_HINTS = "InlineHints"; // NOI18N
+
+    // see org.netbeans.modules.editor.actions.ShowInlineHintsAction
+    private static final String JAVA_INLINE_HINTS_KEY = "enable.inline.hints"; // NOI18N
 
     private InlineHintsSettings() {
     }
@@ -35,7 +37,22 @@ public class InlineHintsSettings {
         Preferences preferences = NbPreferences.forModule(MarkOccurencesOptionsPanelController.class);
         return preferences.node(INLINE_HINTS).node(getCurrentProfileId());
     }
-    
+
+    private static Preferences getJavaEditorPreferences() {
+        // ShowInlineHintsAction is registering the action without setting the mime type
+        // this means this is a global toggle right now
+        return MimeLookup.getLookup("").lookup(Preferences.class);
+//        return MimeLookup.getLookup(JavaKit.JAVA_MIME_TYPE).lookup(Preferences.class);
+    }
+
+    public static boolean isInlineHintsEnabled() {
+        return getJavaEditorPreferences().getBoolean(JAVA_INLINE_HINTS_KEY, false);
+    }
+
+    public static void setInlineHintsEnabled(boolean enabled) {
+        getJavaEditorPreferences().putBoolean(JAVA_INLINE_HINTS_KEY, enabled);
+    }
+
     private static String getCurrentProfileId() {
         return "default"; // NOI18N
     }


### PR DESCRIPTION
 - inline hints options can now toggle the global on/off state too
 - fixed issue when user enabled inline hints but nothing happened since all individual options were disabled
 - added keybinding for `View -> Show Inline hints` (`ALT-I`)
 - disabled by default as discussed previously


![image](https://github.com/apache/netbeans/assets/114367/4428224e-c0a8-40d6-a679-605960fa3fef)
