### PR TITLE
Display `Faces VERSION` instead of `JSF VERSION` 

### DIFF
--- a/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/JsfVersion.java
+++ b/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/JsfVersion.java
@@ -43,6 +43,9 @@ public enum JsfVersion {
     }
 
     public String getShortName() {
+        if (isAtLeast(JSF_4_0)) {
+            return "Faces " + version;
+        }
         return "JSF " + version;
     }
 

--- a/enterprise/web.jsfapi/test/unit/src/org/netbeans/modules/web/jsfapi/api/JsfVersionTest.java
+++ b/enterprise/web.jsfapi/test/unit/src/org/netbeans/modules/web/jsfapi/api/JsfVersionTest.java
@@ -174,7 +174,7 @@ public class JsfVersionTest {
         assertEquals("JSF 2.2", JsfVersion.JSF_2_2.getShortName());
         assertEquals("JSF 2.3", JsfVersion.JSF_2_3.getShortName());
         assertEquals("JSF 3.0", JsfVersion.JSF_3_0.getShortName());
-        assertEquals("JSF 4.0", JsfVersion.JSF_4_0.getShortName());
+        assertEquals("Faces 4.0", JsfVersion.JSF_4_0.getShortName());
     }
 
     @Test


### PR DESCRIPTION
Display `Faces VERSION` instead of `JSF VERSION` when version is at least 4.0

The name was adjusted in Jakarta Faces Specification 4.0

see #6492