### PR TITLE
fix link in apichanges for api.lsp

### DIFF
--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -60,7 +60,7 @@
         <compatibility binary="compatible" source="compatible" addition="yes" deletion="no"/>
         <description>
             A <a href="@TOP@/org/netbeans/api/lsp/SignatureInformation.html">SignatureInformation</a> class
-            and <a href="@TOP@/org/netbeans/api/lsp/SignatureInformationCollecto.html">SignatureInformationCollector</a> interface
+            and <a href="@TOP@/org/netbeans/spi/lsp/SignatureInformationCollector.html">SignatureInformationCollector</a> interface
             introduced that allows to compute and collect signature information.
         </description>
         <class package="org.netbeans.api.lsp" name="SignatureInformation"/>


### PR DESCRIPTION
as api doc build work again it show a bad link on api.lsp changes. 