### PR TITLE
CI: Add build-from-src-zip job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -361,10 +361,10 @@ jobs:
 
 
   build-nbms:
-    name: Build NBMs, Source zips and Javadoc on JDK ${{ matrix.java }}
+    name: Build NBMs and Javadoc on JDK ${{ matrix.java }}
     needs: base-build
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       matrix:
         java: [ '11' ]
@@ -387,12 +387,70 @@ jobs:
       - name: Build nbms
         run: ant $OPTS build-nbms
 
-      - name: Build source zips
-        run: ant $OPTS build-source-zips
-
       - name: Build javadoc
         if: env.test_javadoc == 'true' && success()
         run: ant $OPTS build-javadoc
+
+
+  build-from-src-zip:
+    name: Build ${{ matrix.config }} from src.zip on JDK ${{ matrix.java }}
+    # equals env.test_platform == 'true' || test_vscode_extension == 'true'
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'Platform') || contains(github.event.pull_request.labels.*.name, 'VSCode Extension') || contains(github.event.pull_request.labels.*.name, 'ci:all-tests') || github.event_name != 'pull_request' }}
+    needs: base-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        java: [ '11' ]
+        config: [ 'platform', 'release' ]
+    steps:
+
+      - name: Set up JDK ${{ matrix.java }} 
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java }} 
+          distribution: ${{ env.default_java_distribution }}
+
+      - name: Download Build
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+
+      - name: Extract
+        run: tar --zstd -xf build.tar.zst
+
+      - name: Restoring Cache
+        uses: actions/cache/restore@v3
+        with:
+          path: ~/.hgexternalcache
+          key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
+          restore-keys: ${{ runner.os }}-
+
+      - name: Create ${{ matrix.config }}-src zip
+        run: ant $OPTS -quiet build-source-config -Dcluster.config=${{ matrix.config }}
+
+      - name: Extract ${{ matrix.config }}-src zip
+        run: |
+          mkdir tmpbuild && cd tmpbuild
+          unzip -qq ../nbbuild/build/${{ matrix.config }}-src*
+
+      - name: Build from ${{ matrix.config }}-src zip
+        run: |
+          cd tmpbuild
+          ant $OPTS -quiet build -Dcluster.config=${{ matrix.config }}
+
+      # extra round for VSCodeExt which is built with 'release' config
+      - name: Set up node
+        if: ${{ (matrix.config == 'release') && success() }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Build NBVSCodeExt from ${{ matrix.config }}-src zip
+        if: ${{ (matrix.config == 'release') && success() }}
+        run: |
+          cd tmpbuild/java/java.lsp.server
+          ant $OPTS build-vscode-ext -D3rdparty.modules=.*externalcodeformatter.*
 
 
   ide-modules-test:
@@ -867,12 +925,6 @@ jobs:
         java: [ '8' ]
     steps:
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: ${{ env.default_java_distribution }}
-
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
@@ -1008,32 +1060,6 @@ jobs:
 
       - name: platform/o.n.swing.tabcontrol
         run: ant $OPTS -Dvanilla.javac.exists=true -f platform/o.n.swing.tabcontrol test
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: ${{ env.default_java_distribution }}
-
-      # use cache so that the platform build doesn't have to download dependencies again
-      - name: Caching dependencies
-        uses: actions/cache/restore@v3
-        with:
-          path: ~/.hgexternalcache
-          key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
-          restore-keys: ${{ runner.os }}-
-
-      - name: platform build from platform-src zip
-        run: |
-          ant $OPTS -quiet build-source-config -Dcluster.config=platform
-          mkdir tmpplatform && cd tmpplatform && unzip -qq ../nbbuild/build/platform-src*
-          ant $OPTS build -Dcluster.config=platform
-
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: ${{ env.default_java_distribution }}
 
       # required by netbinox tests
       - name: isolate platform build
@@ -2593,7 +2619,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.2
+          node-version: 18
 
       - name: Setup Xvfb
         run: |
@@ -2628,6 +2654,7 @@ jobs:
       - paperwork
       - build-system-test
       - build-nbms
+      - build-from-src-zip
       - ide-modules-test
       - platform-modules-test1
       - platform-modules-test2


### PR DESCRIPTION
Build from src zip for release and platform in a separate job. This simplifies the platform job too as side effect.

Do we want to do this every time or only when certain labels are set? (https://github.com/apache/netbeans/labels/Platform, https://github.com/apache/netbeans/labels/VSCode%20Extension, https://github.com/apache/netbeans/labels/ci%3Aall-tests and on master?)

this PR is intended to fail until #6583 made it back to master