### PR TITLE
JDK Downloader: fix current GA/EA values

### DIFF
--- a/java/java.disco/src/org/netbeans/modules/java/disco/SelectPackagePanel.java
+++ b/java/java.disco/src/org/netbeans/modules/java/disco/SelectPackagePanel.java
@@ -128,11 +128,11 @@ public class SelectPackagePanel extends FirstPanel {
         //loading stuff when ui shown
         submit(() -> {
             int minVersion = 6;
-            int maxVersion = discoClient.getLatestSts(true).getAsInt();
-            int current    = discoClient.getLatestSts(false).getAsInt();
+            int maxVersion = discoClient.getLatestEAVersion().getAsInt();
+            int current    = discoClient.getLatestGAVersion().getAsInt();
 
             // limit to LTS + current
-            Map<Integer, TermOfSupport> maintainedVersions = discoClient.getAllMaintainedMajorVersions().stream()
+            Map<Integer, TermOfSupport> maintainedVersions = discoClient.getAllMaintainedMajorVersions()
                     .filter(v -> v.getAsInt() >= minVersion && v.getAsInt() <= current)   // defensive filter, the API returned an EA JDK as released
                     .filter(v -> v.getAsInt() == current || v.getTermOfSupport() == TermOfSupport.LTS)
                     .collect(Collectors.toMap(MajorVersion::getAsInt, MajorVersion::getTermOfSupport));


### PR DESCRIPTION
`getLatestSts` does not include LTS (obviously :)), which means the downloader thought the latest JDK was still 20 and 21 was still in EA.

(trying to find a more efficient way of running this query before RC2, since this doubles the latency)

targets delivery

before:
![image](https://github.com/apache/netbeans/assets/114367/9b60390e-f499-4884-b15c-5cffa837f696)

after:
![image](https://github.com/apache/netbeans/assets/114367/632cb4b7-600d-4e33-bed1-5fe72c8e32ee)
