### PR TITLE
Fix Git show history regression.

### DIFF
--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/LogCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/LogCommand.java
@@ -210,8 +210,8 @@ public class LogCommand extends GitCommand {
                     }
                 } else {
                     usedFlags.add(flagId);
-                    if (i < 25) {
-                        i = i + 1;
+                    if (i <= 23) { // leave one spare flag for the run method, see RevWalk.newFlag()
+                        i++;
                         RevFlag flag = walk.newFlag(flagId);
                         List<GitBranch> branches = new ArrayList<>(allBranches.size());
                         branches.add(e.getValue());
@@ -253,7 +253,7 @@ public class LogCommand extends GitCommand {
     }
 
     public GitRevisionInfo[] getRevisions () {
-        return revisions.toArray(new GitRevisionInfo[revisions.size()]);
+        return revisions.toArray(new GitRevisionInfo[0]);
     }
 
     private void addRevision (GitRevisionInfo info) {


### PR DESCRIPTION
It appears RevWalk can create 24 flags, LogCommand could create 25 and
the history view would fail. This tries to maintain the limit of 24.

It is not clear why this worked in past, since the limit was there
before too. (my guess: the limit is now enforced instead of quietly ignored?)

fixes #6592