### PR TITLE
GlassFish modules cleaning and some fixes

### DIFF
--- a/enterprise/glassfish.common/nbproject/org-netbeans-modules-glassfish-common.sig
+++ b/enterprise/glassfish.common/nbproject/org-netbeans-modules-glassfish-common.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.96
+#Version 1.97
 
 CLSS public abstract java.awt.Component
 cons protected init()
@@ -1513,6 +1513,7 @@ supr java.lang.Object
 hfds delegate
 
 CLSS public final org.netbeans.modules.glassfish.common.GlassfishInstanceProvider
+fld public final static java.lang.String EE6WC_DEFAULT_NAME = "GlassFish_Server_3.1"
 fld public final static java.lang.String EE6WC_DEPLOYER_FRAGMENT = "deployer:gfv3ee6wc"
 fld public final static java.lang.String EE6_DEPLOYER_FRAGMENT = "deployer:gfv3ee6"
 fld public final static java.lang.String EE7_DEPLOYER_FRAGMENT = "deployer:gfv4ee7"
@@ -1522,10 +1523,9 @@ fld public final static java.lang.String JAKARTAEE10_DEPLOYER_FRAGMENT = "deploy
 fld public final static java.lang.String JAKARTAEE8_DEPLOYER_FRAGMENT = "deployer:gfv510ee8"
 fld public final static java.lang.String JAKARTAEE91_DEPLOYER_FRAGMENT = "deployer:gfv610ee9"
 fld public final static java.lang.String JAKARTAEE9_DEPLOYER_FRAGMENT = "deployer:gfv6ee9"
+fld public final static java.lang.String PRELUDE_DEFAULT_NAME = "GlassFish_v3_Prelude"
 fld public final static java.lang.String PRELUDE_DEPLOYER_FRAGMENT = "deployer:gfv3"
 fld public final static java.util.Set<java.lang.String> activeRegistrationSet
-fld public static java.lang.String EE6WC_DEFAULT_NAME
-fld public static java.lang.String PRELUDE_DEFAULT_NAME
 intf org.netbeans.spi.server.ServerInstanceProvider
 intf org.openide.util.LookupListener
 meth public <%0 extends java.lang.Object> java.util.List<{%%0}> getInstancesByCapability(java.lang.Class<{%%0}>)
@@ -1657,7 +1657,7 @@ meth public static org.netbeans.modules.glassfish.common.ServerDetails valueOf(j
 meth public static org.netbeans.modules.glassfish.common.ServerDetails[] values()
 meth public static org.openide.WizardDescriptor$InstantiatingIterator getInstantiatingIterator()
 supr java.lang.Enum<org.netbeans.modules.glassfish.common.ServerDetails>
-hfds directUrl,displayName,indirectUrl,licenseUrl,serverDetails,uriFragment,versionInt
+hfds directUrl,displayName,glassFishVersion,indirectUrl,licenseUrl,serverDetails,uriFragment
 hcls DomainParser
 
 CLSS public org.netbeans.modules.glassfish.common.SimpleIO

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassFishLogger.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassFishLogger.java
@@ -33,12 +33,11 @@ public class GlassFishLogger {
 
     /**
      * Get logger for given class.
-     * <p/>
-     * @param  c Target class for logger.
+     * @param c Target class for logger.
      * @return Logger for given class.
      */
     public static Logger get(Class c) {
-        return Logger.getLogger("glassfish");
+        return Logger.getLogger(c.getName());
     }
     
 }

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassfishInstance.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassfishInstance.java
@@ -695,7 +695,7 @@ public class GlassfishInstance implements ServerInstanceImplementation,
     ////////////////////////////////////////////////////////////////////////////
 
     // Server properties
-    private boolean removable = true;
+    private final boolean removable = true;
     
     /** GlassFish server properties. */
     private transient Map<String, String> properties;
@@ -716,8 +716,8 @@ public class GlassfishInstance implements ServerInstanceImplementation,
     /** Configuration changes listener watching <code>domain.xml</code> file. */
     private final transient DomainXMLChangeListener domainXMLListener;
 
-    private transient InstanceContent ic;
-    private transient Lookup localLookup;
+    private final transient InstanceContent ic;
+    private final transient Lookup localLookup;
     private transient Lookup full;
     private final transient Lookup.Result<GlassfishModuleFactory>
             lookupResult = Lookups.forPath(Util.GF_LOOKUP_PATH).lookupResult(
@@ -729,7 +729,7 @@ public class GlassfishInstance implements ServerInstanceImplementation,
     private final transient CommonServerSupport commonSupport;
     // API instance
     private ServerInstance commonInstance;
-    private GlassfishInstanceProvider instanceProvider;
+    private final GlassfishInstanceProvider instanceProvider;
 
     // GuardedBy("lookupResult")
     private Node fullNode;
@@ -1185,7 +1185,7 @@ public class GlassfishInstance implements ServerInstanceImplementation,
      * Method {@see #writeInstanceToFile(GlassfishInstance)} must be called
      * to persist value.
      * <p/>
-     * @param usern GlassFish server administration user name.
+     * @param user GlassFish server administration user name.
      */
     public void setAdminUser(final String user) {
         properties.put(GlassfishModule.USERNAME_ATTR, user);
@@ -1317,7 +1317,7 @@ public class GlassfishInstance implements ServerInstanceImplementation,
     /**
      * Check if local running server started from IDE is still running.
      * <p/>
-     * @returns Value of <code>true</code> when process information is stored
+     * @return Value of <code>true</code> when process information is stored
      *          and process is still running or <code>false</code> otherwise.
      */
     public boolean isProcessRunning() {

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassfishInstance.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassfishInstance.java
@@ -203,13 +203,10 @@ public class GlassfishInstance implements ServerInstanceImplementation,
         public String get(Object key) {
             if (GlassfishModule.PASSWORD_ATTR.equals(key)) {
                 String value;
-                value = delegate.computeIfPresent((String)key, (k, v) -> v);
-                if (value == null) {
-                    value = getPasswordFromKeyring(
-                            delegate.get(GlassfishModule.DISPLAY_NAME_ATTR),
-                            delegate.get(GlassfishModule.USERNAME_ATTR));
-                    delegate.put((String)key, value);
-                }
+                value = delegate.computeIfAbsent((String)key, k -> 
+                            getPasswordFromKeyring(
+                                delegate.get(GlassfishModule.DISPLAY_NAME_ATTR),
+                                delegate.get(GlassfishModule.USERNAME_ATTR)));
                 return value;
             } else {
                 return delegate.computeIfPresent((String)key, (k, v) -> v);

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassfishInstanceProvider.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassfishInstanceProvider.java
@@ -20,7 +20,14 @@
 package org.netbeans.modules.glassfish.common;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
@@ -71,17 +78,17 @@ public final class GlassfishInstanceProvider implements ServerInstanceProvider, 
     public static final String JAKARTAEE10_DEPLOYER_FRAGMENT = "deployer:gfv700ee10";
     public static final String EE6WC_DEPLOYER_FRAGMENT = "deployer:gfv3ee6wc"; // NOI18N
     public static final String PRELUDE_DEPLOYER_FRAGMENT = "deployer:gfv3"; // NOI18N
-    private static String EE6_INSTANCES_PATH = "/GlassFishEE6/Instances"; // NOI18N
-    private static String EE7_INSTANCES_PATH = "/GlassFishEE7/Instances"; // NOI18N
-    private static String EE8_INSTANCES_PATH = "/GlassFishEE8/Instances"; // NOI18N
-    private static String JAKARTAEE8_INSTANCES_PATH = "/GlassFishJakartaEE8/Instances"; // NOI18N
-    private static String JAKARTAEE9_INSTANCES_PATH = "/GlassFishJakartaEE9/Instances"; // NOI18N
-    private static String JAKARTAEE91_INSTANCES_PATH = "/GlassFishJakartaEE91/Instances"; // NOI18N
-    private static String JAKARTAEE10_INSTANCES_PATH = "/GlassFishJakartaEE10/Instances"; // NOI18N
-    private static String EE6WC_INSTANCES_PATH = "/GlassFishEE6WC/Instances"; // NOI18N
+    private static final String EE6_INSTANCES_PATH = "/GlassFishEE6/Instances"; // NOI18N
+    private static final String EE7_INSTANCES_PATH = "/GlassFishEE7/Instances"; // NOI18N
+    private static final String EE8_INSTANCES_PATH = "/GlassFishEE8/Instances"; // NOI18N
+    private static final String JAKARTAEE8_INSTANCES_PATH = "/GlassFishJakartaEE8/Instances"; // NOI18N
+    private static final String JAKARTAEE9_INSTANCES_PATH = "/GlassFishJakartaEE9/Instances"; // NOI18N
+    private static final String JAKARTAEE91_INSTANCES_PATH = "/GlassFishJakartaEE91/Instances"; // NOI18N
+    private static final String JAKARTAEE10_INSTANCES_PATH = "/GlassFishJakartaEE10/Instances"; // NOI18N
+    private static final String EE6WC_INSTANCES_PATH = "/GlassFishEE6WC/Instances"; // NOI18N
 
-    public static String PRELUDE_DEFAULT_NAME = "GlassFish_v3_Prelude"; //NOI18N
-    public static String EE6WC_DEFAULT_NAME = "GlassFish_Server_3.1"; // NOI18N
+    public static final String PRELUDE_DEFAULT_NAME = "GlassFish_v3_Prelude"; //NOI18N
+    public static final String EE6WC_DEFAULT_NAME = "GlassFish_Server_3.1"; // NOI18N
 
     // GlassFish Tooling SDK configuration should be done before any server
     // instance is created and used.

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/spi/RegisteredDDCatalog.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/spi/RegisteredDDCatalog.java
@@ -26,7 +26,6 @@ import org.netbeans.spi.server.ServerInstanceProvider;
  * @author raccah
  */
 public interface RegisteredDDCatalog {
-//    public void registerPreludeRunTimeDDCatalog(ServerInstanceProvider gip);
     public void registerEE6RunTimeDDCatalog(ServerInstanceProvider gip);
     public void refreshRunTimeDDCatalog(ServerInstanceProvider gip, String installRoot);
 }

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/LogHyperLinkSupport.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/LogHyperLinkSupport.java
@@ -19,9 +19,8 @@
 package org.netbeans.modules.glassfish.eecommon.api;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import org.netbeans.modules.glassfish.tooling.utils.StringPrefixTree;
 import org.netbeans.api.java.classpath.GlobalPathRegistry;
 import org.netbeans.api.java.classpath.GlobalPathRegistryEvent;
@@ -45,7 +44,7 @@ import org.openide.windows.OutputListener;
  */
 public class LogHyperLinkSupport {
 
-    private Map<Link, Link> links = Collections.synchronizedMap(new HashMap<Link, Link>());
+    private final ConcurrentMap<Link, Link> links = new ConcurrentHashMap<>();
     private Annotation errAnnot;
 
     /**
@@ -80,11 +79,11 @@ public class LogHyperLinkSupport {
      */
     public static class LineInfo {
 
-        private String path;
-        private int line;
-        private String message;
-        private boolean error;
-        private boolean accessible;
+        private final String path;
+        private final int line;
+        private final String message;
+        private final boolean error;
+        private final boolean accessible;
 
         /**
          * <code>LineInfo</code> is used to store info about the parsed line.
@@ -159,9 +158,9 @@ public class LogHyperLinkSupport {
      */
     public class Link implements OutputListener {
 
-        private String msg;
-        private String path;
-        private int line;
+        private final String msg;
+        private final String path;
+        private final int line;
         private int hashCode = 0;
 
         Link(String msg, String path, int line) {

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/config/GlassfishConfiguration.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/config/GlassfishConfiguration.java
@@ -124,7 +124,7 @@ public abstract class GlassfishConfiguration implements
      * server version.
      * <br/>
      * <i>Internal {@link #getExistingResourceFile(J2eeModule, GlassFishVersion)
-     * helper method.</i>
+     * } helper method.</i>
      * <p/>
      * @param version GlassFish server version.
      * @return An array of {@code RESOURCE_FILES} array indexes pointing
@@ -136,19 +136,7 @@ public abstract class GlassfishConfiguration implements
         if (version == null) {
             return new int[]{0,1};
         }
-        // glassfish-resources.xml for v7
-        if (GlassFishVersion.ge(version, GlassFishVersion.GF_7_0_0)) {
-            return new int[]{0};
-        }
-        // glassfish-resources.xml for v6
-        if (GlassFishVersion.ge(version, GlassFishVersion.GF_6) || GlassFishVersion.ge(version, GlassFishVersion.GF_6_1_0)) {
-            return new int[]{0};
-        }
-        // glassfish-resources.xml for v5
-        if (GlassFishVersion.ge(version, GlassFishVersion.GF_5) || GlassFishVersion.ge(version, GlassFishVersion.GF_5_1_0)) {
-            return new int[]{0};
-        }
-        // glassfish-resources.xml for v4
+        // glassfish-resources.xml for v4 or greater
         if (GlassFishVersion.ge(version, GlassFishVersion.GF_4)) {
             return new int[]{0};
         }
@@ -195,7 +183,7 @@ public abstract class GlassfishConfiguration implements
      * <li><i>GlassFish v2:</i> Only {@code sun-resources.xml} is checked.</li>
      * <li><i>GlassFish v3:</i> {@code glassfish-resources.xml} is checked first,
      *                          {@code sun-resources.xml} as fallback.</li>
-     * <li><i>GlassFish v4:</i> Only {@code glassfish-resources.xml} is checked.</li>
+     * <li><i>GlassFish v4 or greater:</i> Only {@code glassfish-resources.xml} is checked.</li>
      * <li><i>Configuration directory</i> is checked first, <i>resources directory</i>
      *        as fallback.</li>
      * </ul>

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
@@ -961,6 +961,9 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
                         case "text/x-dd-ejbjar2.1":  // NOI18N
                             inputSource = resolver.resolveEntity(EJBJAR_2_1_ID, "");
                             break;
+                        case "text/x-dd-application10.0":  // NOI18N
+                            inputSource = resolver.resolveEntity(APP_10_ID, "");
+                            break;
                         case "text/x-dd-application9.0":  // NOI18N
                             inputSource = resolver.resolveEntity(APP_9_ID, "");
                             break;
@@ -978,6 +981,9 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
                             break;
                         case "text/x-dd-application1.4":  // NOI18N
                             inputSource = resolver.resolveEntity(APP_1_4_ID, "");
+                            break;
+                        case "text/x-dd-client10.0":  // NOI18N
+                            inputSource = resolver.resolveEntity(APPCLIENT_10_ID, "");
                             break;
                         case "text/x-dd-client9.0":  // NOI18N
                             inputSource = resolver.resolveEntity(APPCLIENT_9_ID, "");
@@ -1073,7 +1079,7 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
                     if (inputSource != null) {
                         return DTDUtil.parseDTD(true, inputSource);
                     }
-                    
+                    // TODO: Validate all webservices versions not only 1.1
                     if (is.getSystemId().endsWith("webservices.xml") ) {  // NOI18N
                         // System.out.println("webservices tag");
                         inputSource = resolver.resolveEntity(WEBSERVICES_1_1_ID, "");
@@ -1099,6 +1105,7 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
     @Override
     public String resolveURI(String name) {
         // System.out.println("resolveURI(String name)="+name);
+        // TODO: Validate all webservices versions
         if (platformRootDir == null) {
             return null;
         }

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
@@ -204,7 +204,7 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
         "SCHEMA:http://xmlns.oracle.com/weblogic/jdbc-data-source/1.0/jdbc-data-source.xsd", "jdbc-data-source",
     };
 
-    private static Map<ServerInstanceProvider, RunTimeDDCatalog> ddCatalogMap = new HashMap<>();
+    private static final Map<ServerInstanceProvider, RunTimeDDCatalog> ddCatalogMap = new HashMap<>();
 //    private static RunTimeDDCatalog preludeDDCatalog;
     private static RunTimeDDCatalog javaEE6DDCatalog;
 

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/ide/RegisteredDDCatalogImpl.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/ide/RegisteredDDCatalogImpl.java
@@ -36,10 +36,7 @@ public class RegisteredDDCatalogImpl implements RegisteredDDCatalog {
             catalog.setInstanceProvider(gip);
         }
     }
-//    @Override
-//    public void registerPreludeRunTimeDDCatalog(ServerInstanceProvider gip) {
-//        registerRunTimeDDCatalog(RunTimeDDCatalog.getPreludeRunTimeDDCatalog(), gip);
-//    }
+    
     @Override
     public void registerEE6RunTimeDDCatalog(ServerInstanceProvider gip) {
         registerRunTimeDDCatalog(RunTimeDDCatalog.getEE6RunTimeDDCatalog(), gip);

--- a/enterprise/glassfish.tooling/nbproject/project.xml
+++ b/enterprise/glassfish.tooling/nbproject/project.xml
@@ -60,6 +60,14 @@
                         <specification-version>9.20</specification-version>
                     </run-dependency>
                 </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.31</specification-version>
+                    </run-dependency>
+                </dependency>
             </module-dependencies>
             <test-dependencies>
                 <test-type>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/ConfigBuilderProvider.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/ConfigBuilderProvider.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.netbeans.modules.glassfish.tooling.data.GlassFishServer;
 import org.netbeans.modules.glassfish.tooling.data.GlassFishVersion;
+import org.openide.util.Utilities;
 
 /**
  * Configuration builder provider.
@@ -209,8 +210,11 @@ public class ConfigBuilderProvider {
                     "GlassFish server entity shall not be null");
         }
         String serverHome = server.getServerHome();
+        String javadocsHome = Utilities.isWindows() 
+                ? serverHome + "\\docs" 
+                : serverHome + "/docs";
         return builders.computeIfAbsent(server, key -> 
-                new ConfigBuilder(config, serverHome, serverHome, serverHome));
+                new ConfigBuilder(config, serverHome, javadocsHome, serverHome));
     }
     
 


### PR DESCRIPTION
NetBeans GlassFish module notes:

- Use `ConcurrentHashMap` insted of `Collections.synchronizedMap`
- Use `ConcurrentHashMap.newKeySet` instead of `Collections.synchronizedMap`
- When using `ConcurrentHashMap` remove some synchronized blocks when using
  atomic and concurrent operations (remove, put, containsKey, and get).
- Refactor to `computeIfAbsent` pattern when possible.
- Add javadoc support for JAKARTA EE 9 and JAKARTA EE 10
- Add missing validations for Jakarta EE 10
- Close resource with try-with-resources
- Remove redundant calls to si.getDeployerUri() and this.getClass()
- Remove redundant call to some methods getConfigRoot(), getDeployerUri()
- Use `GlassFishLogger` instead of generic `glassfish-ee` logger
- Use target class for logger instead of "glassfish"
- Regen sig file because `ant check-sigtests-release` failed
- Fix path to javadocs when creating a new `ConfigBuilder`
- Make final some class instances
- Refactor method `versionToResourceFilesIndexes()`
- Fix some javadoc comments
- Make final some class instances
- Add imports and remove commented code
- Add TODO comments
- Change inefficient creation of new Array
- Remove commented code
- Fix some typos

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of `ant -Dcluster.config=release commit-validation`
- Verify successful execution of unit tests for modules `glassfish.common`, `glassfish.javaee`, `glassfish.tooling`, 
  and `glassfish.eecommon`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Successfully register GlassFish versions 4, 5, 5.1, 6, 6.2, and 7. Then create a web app for each version 
  and verify that they work.