### PR TITLE
Update ASM from 9.5 to 9.6

### DIFF
--- a/harness/apisupport.harness/build.xml
+++ b/harness/apisupport.harness/build.xml
@@ -39,7 +39,7 @@
                 <pathelement location="${cluster}/tasks.jar"></pathelement>
             </classpath>
         </taskdef>
-        <echo file="build/binaries-list">DC6EA1875F4D64FBC85E1691C95B96A3D8569C90 org.ow2.asm:asm:9.5</echo>
+        <echo file="build/binaries-list">AA205CF0A06DBD8E04ECE91C0B37C3F5D567546A org.ow2.asm:asm:9.6</echo>
         <TestDownload>
             <manifest dir="build">
                 <include name="binaries-list"/>

--- a/java/lib.jshell.agent/nbproject/project.properties
+++ b/java/lib.jshell.agent/nbproject/project.properties
@@ -21,5 +21,5 @@ javac.compilerargs=-Xlint -Xlint:-serial
 extra.module.files=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 jnlp.indirect.jars=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 
-agentsrc.asm.cp=${libs.asm.dir}/core/asm-9.5.jar
+agentsrc.asm.cp=${libs.asm.dir}/core/asm-9.6.jar
 agentsrc.jshell.cp=${nb_all}/java/libs.jshell.compile/external/jshell-9.jar

--- a/java/maven/build.xml
+++ b/java/maven/build.xml
@@ -56,8 +56,8 @@
         <!-- we use jarjar to repackage simple json, to avoid clashes with 3rd party maven plugins possibly including it in their dependencies -->
         <taskdef name="jarjar" classname="org.pantsbuild.jarjar.JarJarTask" loaderref="lib.path.loader">
             <classpath>
-                <pathelement location="${libs.asm.dir}/core/asm-9.5.jar"/>
-                <pathelement location="${libs.asm.dir}/core/asm-commons-9.5.jar"/>
+                <pathelement location="${libs.asm.dir}/core/asm-9.6.jar"/>
+                <pathelement location="${libs.asm.dir}/core/asm-commons-9.6.jar"/>
                 <pathelement location="./external/jarjar-1.7.2.jar"/>
             </classpath>
         </taskdef>

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -79,10 +79,10 @@
         <tstamp>
             <format property="module.build.started.time" pattern="yyyy-MM-dd'T'HH:mm:ss.SSSZ"/>
         </tstamp>
-        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-9.5.jar">
-            <available file="${nbplatform.active.dir}/platform/core/asm-9.5.jar"/>
+        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-9.6.jar">
+            <available file="${nbplatform.active.dir}/platform/core/asm-9.6.jar"/>
         </condition>
-        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-9.5.jar"/>
+        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-9.6.jar"/>
         <property name="tsaurl" value=""/>
         <property name="tsacert" value=""/>
     </target>

--- a/platform/libs.asm/external/asm-9.6-license.txt
+++ b/platform/libs.asm/external/asm-9.6-license.txt
@@ -1,6 +1,6 @@
 Name: OW2 ASM
-Version: 9.5
-Files: asm-tree-9.5.jar asm-commons-9.5.jar asm-9.5.jar
+Version: 9.6
+Files: asm-tree-9.6.jar asm-commons-9.6.jar asm-9.6.jar
 License: BSD-INRIA
 Origin: OW2 Consortium
 URL: https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/

--- a/platform/libs.asm/external/binaries-list
+++ b/platform/libs.asm/external/binaries-list
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-DC6EA1875F4D64FBC85E1691C95B96A3D8569C90 org.ow2.asm:asm:9.5
-FD33C8B6373ABAA675BE407082FDFDA35021254A org.ow2.asm:asm-tree:9.5
-19AB5B5800A3910D30D3A3E64FDB00FD0CB42DE0 org.ow2.asm:asm-commons:9.5
+AA205CF0A06DBD8E04ECE91C0B37C3F5D567546A org.ow2.asm:asm:9.6
+C0CDDA9D211E965D2A4448AA3FD86110F2F8C2DE org.ow2.asm:asm-tree:9.6
+F1A9E5508EFF490744144565C47326C8648BE309 org.ow2.asm:asm-commons:9.6

--- a/platform/libs.asm/nbproject/project.properties
+++ b/platform/libs.asm/nbproject/project.properties
@@ -19,7 +19,7 @@ javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 module.jar.dir=core
 
-release.external/asm-9.5.jar=core/asm-9.5.jar
-release.external/asm-tree-9.5.jar=core/asm-tree-9.5.jar
-release.external/asm-commons-9.5.jar=core/asm-commons-9.5.jar
-license.file=../external/asm-9.5-license.txt
+release.external/asm-9.6.jar=core/asm-9.6.jar
+release.external/asm-tree-9.6.jar=core/asm-tree-9.6.jar
+release.external/asm-commons-9.6.jar=core/asm-commons-9.6.jar
+license.file=../external/asm-9.6-license.txt

--- a/platform/libs.asm/nbproject/project.xml
+++ b/platform/libs.asm/nbproject/project.xml
@@ -29,16 +29,16 @@
                 <subpackages>org</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>asm-9.5.jar</runtime-relative-path>
-                <binary-origin>external/asm-9.5.jar</binary-origin>
+                <runtime-relative-path>asm-9.6.jar</runtime-relative-path>
+                <binary-origin>external/asm-9.6.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>asm-tree-9.5.jar</runtime-relative-path>
-                <binary-origin>external/asm-tree-9.5.jar</binary-origin>
+                <runtime-relative-path>asm-tree-9.6.jar</runtime-relative-path>
+                <binary-origin>external/asm-tree-9.6.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>asm-commons-9.5.jar</runtime-relative-path>
-                <binary-origin>external/asm-commons-9.5.jar</binary-origin>
+                <runtime-relative-path>asm-commons-9.6.jar</runtime-relative-path>
+                <binary-origin>external/asm-commons-9.6.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
NetBeans Module Notes:
- Bump NetBeans project properties `javac.source` and `javac.target` to version 11

Library Notes:
- Support for Java 22
- Bug fixes:
  - 317991: Analyzer produces frames that have different locals than those detected by JRE bytecode verifier
  - 317995: Invalid stackmap generated when the instruction stream has new instruction after invokespecial to <init>
  - 317998: Analyzer can fail to catch thrown exceptions
  - 318002: asm-analysis Frame allocates an array unnecessarily inside executeInvokeInsn
  - bug in CheckFrameAnalyzer with static methods

Testing:
- Full build done
- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of `ant check-sigtests-release`
- Verify successful execution of `ant -Dcluster.config=release commit-validation`
- Verify that the jars are located in `netbeans_dir/platform/core/`
- Successfully test some projects

[ASM Web Page](https://asm.ow2.io/index.html)
[Release Notes](https://asm.ow2.io/versions.html)