### PR TITLE
Try to close Gradle Daemons on exit.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleConnectorManager.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleConnectorManager.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.logging.Logger;
+import org.gradle.tooling.GradleConnector;
+import org.netbeans.api.project.Project;
+import org.openide.modules.OnStop;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public final class GradleConnectorManager {
+    
+    private final Map<Project, GradleConnector> projectConnector = new WeakHashMap<>();
+    private final List<GradleConnector> connectors = new ArrayList<>();
+
+    private static final GradleConnectorManager INSTANCE = new GradleConnectorManager();
+    private static final Logger LOG = Logger.getLogger(GradleConnectorManager.class.getName());
+    
+    private GradleConnectorManager() {}
+    
+    public static GradleConnectorManager getDefault() {
+        return INSTANCE;
+    } 
+    
+    public GradleConnector getConnector(Project prj) {
+        synchronized (connectors) {
+            GradleConnector ret = projectConnector.computeIfAbsent(prj, p -> {
+                GradleConnector conn = GradleConnector.newConnector();
+                connectors.add(conn);
+                return conn;
+            });
+            return ret;            
+        }
+    }
+    
+    
+    public void disconnectAll() {
+        LOG.info("Disconnecting from Gradle Daemons."); //NOI18N
+        synchronized (connectors) {
+            projectConnector.clear();
+            
+            connectors.forEach(GradleConnector::disconnect);
+            connectors.clear();
+        }
+        LOG.info("Disconnecting from Gradle Daemons. Done."); //NOI18N
+    } 
+    
+    @OnStop
+    public static class DisconnectGradle implements Runnable {
+
+        @Override
+        public void run() {
+            GradleConnectorManager.getDefault().disconnectAll();
+        }
+        
+    } 
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectConnection.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectConnection.java
@@ -37,6 +37,8 @@ import org.gradle.tooling.ProjectConnection;
 import org.gradle.tooling.ResultHandler;
 import org.gradle.tooling.TestLauncher;
 import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.GradleDistributionManager;
 import org.netbeans.modules.gradle.api.execute.GradleDistributionManager.GradleDistribution;
@@ -151,8 +153,8 @@ public final class GradleProjectConnection implements ProjectConnection {
         return launcher;
     }
 
-    private static ProjectConnection createConnection(GradleDistribution dist, File projectDir) {
-        GradleConnector gconn = GradleConnector.newConnector();
+    private ProjectConnection createConnection(GradleDistribution dist, File projectDir) {
+        GradleConnector gconn = GradleConnectorManager.getDefault().getConnector(project);
         gconn = gconn.useGradleUserHomeDir(dist.getGradleUserHome());
         if (dist.isAvailable()) {
             gconn = gconn.useInstallation(dist.getDistributionDir());

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleDaemon.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleDaemon.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.gradle.loaders;
 
 import org.netbeans.modules.gradle.api.NbGradleProject;
-import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -31,12 +30,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.gradle.tooling.BuildAction;
-import org.gradle.tooling.BuildActionExecuter;
-import org.gradle.tooling.BuildController;
-import org.gradle.tooling.GradleConnectionException;
-import org.gradle.tooling.GradleConnector;
-import org.gradle.tooling.ProjectConnection;
 import org.openide.modules.InstalledFileLocator;
 import org.openide.modules.Places;
 import org.openide.util.RequestProcessor;
@@ -55,11 +48,6 @@ public final class GradleDaemon {
     private static final String PROP_TOOLING_JAR = "NETBEANS_TOOLING_JAR";
     private static final String TOOLING_JAR = InstalledFileLocator.getDefault().locate(TOOLING_JAR_NAME, NbGradleProject.CODENAME_BASE, false).getAbsolutePath().replace("\\", "\\\\");
 
-    private static final String DAEMON_LOADED = "Daemon Loaded."; //NOI18N
-    private static final String LOADER_PROJECT_NAME = "modules/gradle/daemon-loader"; //NOI18N
-    private static final File LOADER_PROJECT_DIR = InstalledFileLocator.getDefault().locate(LOADER_PROJECT_NAME, NbGradleProject.CODENAME_BASE, false);
-    private static final DummyBuildAction DUMMY_ACTION = new DummyBuildAction();
-    
     private static final Logger LOG = Logger.getLogger(GradleDaemon.class.getName());
 
     private GradleDaemon() {}
@@ -82,32 +70,4 @@ public final class GradleDaemon {
         }
         return initScript.getAbsolutePath();
     }
-    
-    private static void doLoadDaemon() {
-        GradleConnector gconn = GradleConnector.newConnector();
-        ProjectConnection pconn = gconn.forProjectDirectory(LOADER_PROJECT_DIR).connect();
-        BuildActionExecuter<String> action = pconn.action(DUMMY_ACTION);
-        GradleCommandLine cmd = new GradleCommandLine();
-        cmd.setFlag(GradleCommandLine.Flag.OFFLINE, true);
-        cmd.addParameter(GradleCommandLine.Parameter.INIT_SCRIPT, initScript());
-        cmd.configure(action);
-        try {
-            action.run();
-        } catch (GradleConnectionException | IllegalStateException ex) {
-            // Well for some reason we were  not able to load Gradle.
-            // Ignoring that for now
-        } finally {
-            pconn.close();
-        }
-    }
-
-    private static class DummyBuildAction implements BuildAction<String> {
-
-        @Override
-        public String execute(BuildController bc) {
-            return DAEMON_LOADED;
-        }
-
-    }
-
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
@@ -318,6 +318,7 @@ public final class TemplateOperation implements Runnable {
                 // Well for some reason we were  not able to load Gradle.
                 // Ignoring that for now
             }
+            gconn.disconnect();
             return Collections.singleton(FileUtil.toFileObject(target));
         }
     }
@@ -492,6 +493,7 @@ public final class TemplateOperation implements Runnable {
                 // Well for some reason we were  not able to load Gradle.
                 // Ignoring that for now
             }
+            gconn.disconnect();
             return null;
         }
 

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/GradleBaseProjectTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/GradleBaseProjectTest.java
@@ -245,6 +245,7 @@ public class GradleBaseProjectTest extends AbstractGradleProjectTestCase {
         OpenProjects.getDefault().openProjects().get();
         
         NbGradleProject.get(p).toQuality("Load data", NbGradleProject.Quality.FULL, false).toCompletableFuture().get();
+        gconn.disconnect();
         return p;
     }
     


### PR DESCRIPTION
It seems `GradleConnector` has a `disconnect()` method since 6.5. Calling that should stop daemons started by these connectors.

This one tries to fix #6303, by centralizing the previously freely created `GradleConnector`s.
