### PR TITLE
WildFly - ConcurrentHashMap over synchronized collections and some improvements

### DIFF
--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyClassLoader.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyClassLoader.java
@@ -102,9 +102,7 @@ public class WildflyClassLoader extends URLClassLoader {
     private static void findJarAddUrl(List<URL> urlList, Path folder, String pathMatcherRaw) {
         PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher(pathMatcherRaw);
 
-        Stream<Path> walk = null;
-        try {
-            walk = Files.walk(folder);
+        try (Stream<Path> walk = Files.walk(folder)) {
             Optional<Path> firstJarMatching = walk
                     .filter(pathMatcher::matches)
                     .findFirst();
@@ -115,10 +113,6 @@ public class WildflyClassLoader extends URLClassLoader {
             }
         } catch (IOException ex) {
             LOGGER.log(Level.INFO, null, ex);
-        } finally {
-            if (walk != null) {
-                walk.close();
-            }
         }
     }
 

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentManager.java
@@ -23,11 +23,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.enterprise.deploy.model.DeployableObject;
@@ -83,8 +83,8 @@ public class WildflyDeploymentManager implements DeploymentManager2 {
      * server instance bcs instance properties are also removed along with
      * instance.
      */
-    private static final Map<InstanceProperties, Boolean> PROPERTIES_TO_IS_RUNNING
-            = Collections.synchronizedMap(new WeakHashMap());
+    private static final ConcurrentMap<InstanceProperties, Boolean> PROPERTIES_TO_IS_RUNNING
+            = new ConcurrentHashMap(new WeakHashMap());
 
     private final DeploymentFactory df;
 

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/WildflyMessageDestinationManager.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/config/WildflyMessageDestinationManager.java
@@ -90,11 +90,8 @@ public final class WildflyMessageDestinationManager implements MessageDestinatio
             SAXParserFactory factory = SAXParserFactory.newInstance();
             SAXParser parser = factory.newSAXParser();
             WildflyMessageDestinationHandler handler = new WildflyMessageDestinationHandler();
-            InputStream is = new BufferedInputStream(configFile.getInputStream());
-            try {
+            try (InputStream is = new BufferedInputStream(configFile.getInputStream())) {
                 parser.parse(is, handler);
-            } finally {
-                is.close();
             }
             messageDestinations.addAll(handler.getMessageDestinations());
         } catch (IOException ex) {

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/customizer/WildflyTabVisualPanel.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/customizer/WildflyTabVisualPanel.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.enterprise.deploy.spi.DeploymentManager;
 import javax.swing.JFileChooser;
 import javax.swing.JPanel;
@@ -85,16 +86,12 @@ public final class WildflyTabVisualPanel extends JPanel {
 
     // Event handling
     //
-    private final Set<ChangeListener> listeners = new HashSet<>(1);
+    private final Set<ChangeListener> listeners = ConcurrentHashMap.newKeySet(2);
     public final void addChangeListener(ChangeListener l) {
-        synchronized (listeners) {
-            listeners.add(l);
-        }
+        listeners.add(l);
     }
     public final void removeChangeListener(ChangeListener l) {
-        synchronized (listeners) {
-            listeners.remove(l);
-        }
+        listeners.remove(l);
     }
     protected final void fireChangeEvent() {
         Iterator<ChangeListener> it;

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/JBossJaxWsStack.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/JBossJaxWsStack.java
@@ -134,21 +134,23 @@ public class JBossJaxWsStack implements WSStackImplementation<JaxWs> {
         File wsToolsJar = new File(root, JAXWS_TOOLS_JAR);
 
         if (wsToolsJar.exists()) {
-            JarFile jarFile = new JarFile(wsToolsJar);
-            JarEntry entry = jarFile.getJarEntry("com/sun/tools/ws/version.properties"); //NOI18N
-            if (entry != null) {
-                InputStream is = jarFile.getInputStream(entry);
-                BufferedReader r = new BufferedReader(new InputStreamReader(is));
-                String ln = null;
-                String ver = null;
-                while ((ln=r.readLine()) != null) {
-                    String line = ln.trim();
-                    if (line.startsWith("major-version=")) { //NOI18N
-                        ver = line.substring(14);
+            try (JarFile jarFile = new JarFile(wsToolsJar)) {
+                JarEntry entry = jarFile.getJarEntry("com/sun/tools/ws/version.properties"); //NOI18N
+                if (entry != null) {
+                    String ver = null;
+                    try (InputStream is = jarFile.getInputStream(entry);
+                            BufferedReader r = new BufferedReader(new InputStreamReader(is))) {
+                        String ln = null;
+                        while ((ln=r.readLine()) != null) {
+                            String line = ln.trim();
+                            if (line.startsWith("major-version=")) { //NOI18N
+                                ver = line.substring(14);
+                                break;
+                            }
+                        }
                     }
+                    return ver;
                 }
-                r.close();
-                return ver;
             }
         }
         return null;

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyJ2eePlatformFactory.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyJ2eePlatformFactory.java
@@ -91,7 +91,7 @@ public class WildflyJ2eePlatformFactory extends J2eePlatformFactory {
 
     public static class J2eePlatformImplImpl extends J2eePlatformImpl2 {
 
-        private static final Set<Type> MODULE_TYPES = new HashSet<Type>();
+        private static final Set<Type> MODULE_TYPES = new HashSet<Type>(8);
 
         static {
             MODULE_TYPES.add(Type.EAR);
@@ -101,7 +101,7 @@ public class WildflyJ2eePlatformFactory extends J2eePlatformFactory {
             MODULE_TYPES.add(Type.CAR);
         }
 
-        private static final Set<Profile> WILDFLY_PROFILES = new HashSet<Profile>();
+        private static final Set<Profile> WILDFLY_PROFILES = new HashSet<Profile>(16);
 
         static {
             WILDFLY_PROFILES.add(Profile.JAVA_EE_6_WEB);
@@ -112,21 +112,21 @@ public class WildflyJ2eePlatformFactory extends J2eePlatformFactory {
             WILDFLY_PROFILES.add(Profile.JAVA_EE_8_FULL);
             WILDFLY_PROFILES.add(Profile.JAKARTA_EE_8_FULL);
         }
-        private static final Set<Profile> JAKARTAEE_FULL_PROFILES = new HashSet<Profile>();
+        private static final Set<Profile> JAKARTAEE_FULL_PROFILES = new HashSet<Profile>(8);
 
         static {
             JAKARTAEE_FULL_PROFILES.add(Profile.JAKARTA_EE_9_FULL);
             JAKARTAEE_FULL_PROFILES.add(Profile.JAKARTA_EE_9_1_FULL);
             JAKARTAEE_FULL_PROFILES.add(Profile.JAKARTA_EE_10_FULL);
         }
-        private static final Set<Profile> EAP6_PROFILES = new HashSet<Profile>();
+        private static final Set<Profile> EAP6_PROFILES = new HashSet<Profile>(4);
 
         static {
             EAP6_PROFILES.add(Profile.JAVA_EE_6_WEB);
             EAP6_PROFILES.add(Profile.JAVA_EE_6_FULL);
         }
 
-        private static final Set<Profile> WILDFLY_WEB_PROFILES = new HashSet<Profile>();
+        private static final Set<Profile> WILDFLY_WEB_PROFILES = new HashSet<Profile>(16);
 
         static {
             WILDFLY_WEB_PROFILES.add(Profile.JAVA_EE_6_WEB);
@@ -138,7 +138,7 @@ public class WildflyJ2eePlatformFactory extends J2eePlatformFactory {
             WILDFLY_WEB_PROFILES.add(Profile.JAKARTA_EE_10_WEB);
         }
 
-        private static final Set<Profile> JAKARTAEE_WEB_PROFILES = new HashSet<Profile>();
+        private static final Set<Profile> JAKARTAEE_WEB_PROFILES = new HashSet<Profile>(8);
 
         static {
             JAKARTAEE_WEB_PROFILES.add(Profile.JAKARTA_EE_9_WEB);
@@ -188,7 +188,7 @@ public class WildflyJ2eePlatformFactory extends J2eePlatformFactory {
         }
 
         @Override
-        public Set/*<String>*/ getSupportedJavaPlatformVersions() {
+        public Set<String> getSupportedJavaPlatformVersions() {
             Set versions = new HashSet();
             versions.add("1.7"); // NOI18N
             versions.add("1.8"); // NOI18N
@@ -197,6 +197,9 @@ public class WildflyJ2eePlatformFactory extends J2eePlatformFactory {
             versions.add("11"); // NOI18N
             if (this.properties.getServerVersion().compareToIgnoreUpdate(WildflyPluginUtils.EAP_7_0) >= 0) {
                 versions.add("17"); // NOI18N
+            }
+            if (this.properties.getServerVersion().compareToIgnoreUpdate(WildflyPluginUtils.WILDFLY_30_0_0) >= 0) {
+                versions.add("21"); // NOI18N
             }
             return versions;
         }
@@ -383,21 +386,16 @@ public class WildflyJ2eePlatformFactory extends J2eePlatformFactory {
         }
 
         private static boolean containsService(FileObject serviceFO, String serviceName, String serviceImplName) {
-            try {
-                BufferedReader br = new BufferedReader(new InputStreamReader(serviceFO.getInputStream()));
-                try {
-                    String line;
-                    while ((line = br.readLine()) != null) {
-                        int ci = line.indexOf('#');
-                        if (ci >= 0) {
-                            line = line.substring(0, ci);
-                        }
-                        if (line.trim().equals(serviceImplName)) {
-                            return true;
-                        }
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(serviceFO.getInputStream()))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    int ci = line.indexOf('#');
+                    if (ci >= 0) {
+                        line = line.substring(0, ci);
                     }
-                } finally {
-                    br.close();
+                    if (line.trim().equals(serviceImplName)) {
+                        return true;
+                    }
                 }
             } catch (Exception ex) {
                 Exceptions.attachLocalizedMessage(ex, serviceFO.toURL().toString());

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyStartServer.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/WildflyStartServer.java
@@ -31,6 +31,7 @@ import org.netbeans.modules.j2ee.deployment.plugins.api.ServerDebugInfo;
 import org.netbeans.modules.j2ee.deployment.plugins.spi.StartServer;
 import org.openide.util.RequestProcessor;
 import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.enterprise.deploy.spi.DeploymentManager;
@@ -78,8 +79,8 @@ public class WildflyStartServer extends StartServer implements ProgressObject {
 
     private boolean consoleConfigured = false;
 
-    private static final Set<String> IS_DEBUG_MODE_URI = Collections.synchronizedSet(
-            new HashSet<String>(AVERAGE_SERVER_INSTANCES));
+    private static final Set<String> IS_DEBUG_MODE_URI = 
+            ConcurrentHashMap.newKeySet(AVERAGE_SERVER_INSTANCES);
 
     public WildflyStartServer(DeploymentManager dm) {
         this.dm = (WildflyDeploymentManager) dm;

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerLocationPanel.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerLocationPanel.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.platform.JavaPlatformManager;
@@ -43,7 +44,7 @@ public class AddServerLocationPanel implements WizardDescriptor.FinishablePanel,
 
     private AddServerLocationVisualPanel component;
     private WizardDescriptor wizard;
-    private final transient Set listeners = new HashSet(1);
+    private final transient Set listeners = ConcurrentHashMap.newKeySet(2);
 
     public AddServerLocationPanel(WildflyInstantiatingIterator instantiatingIterator) {
         this.instantiatingIterator = instantiatingIterator;
@@ -113,16 +114,12 @@ public class AddServerLocationPanel implements WizardDescriptor.FinishablePanel,
 
     @Override
     public void removeChangeListener(ChangeListener l) {
-        synchronized (listeners) {
-            listeners.remove(l);
-        }
+        listeners.remove(l);
     }
 
     @Override
     public void addChangeListener(ChangeListener l) {
-        synchronized (listeners) {
-            listeners.add(l);
-        }
+        listeners.add(l);
     }
 
     @Override

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerLocationVisualPanel.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerLocationVisualPanel.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.swing.JFileChooser;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
@@ -41,7 +42,7 @@ import org.openide.util.NbBundle;
  */
 public class AddServerLocationVisualPanel extends javax.swing.JPanel {
 
-    private final Set listeners = new HashSet();
+    private final Set listeners = ConcurrentHashMap.newKeySet();
 
     /**
      * Creates new form AddServerLocationVisualPanel
@@ -92,15 +93,11 @@ public class AddServerLocationVisualPanel extends javax.swing.JPanel {
     }
 
     public void addChangeListener(ChangeListener l) {
-        synchronized (listeners) {
-            listeners.add(l);
-        }
+        listeners.add(l);
     }
 
     public void removeChangeListener(ChangeListener l) {
-        synchronized (listeners) {
-            listeners.remove(l);
-        }
+        listeners.remove(l);
     }
 
     private void fireChangeEvent() {

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesPanel.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesPanel.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.modules.j2ee.deployment.plugins.api.InstanceProperties;
@@ -181,19 +182,15 @@ public class AddServerPropertiesPanel implements WizardDescriptor.Panel, ChangeL
         }
     }
 
-    private final transient Set listeners = new HashSet(1);
+    private final transient Set listeners = ConcurrentHashMap.newKeySet(2);
     @Override
     public void removeChangeListener(ChangeListener l) {
-        synchronized (listeners) {
-            listeners.remove(l);
-        }
+        listeners.remove(l);
     }
 
     @Override
     public void addChangeListener(ChangeListener l) {
-        synchronized (listeners) {
-            listeners.add(l);
-        }
+        listeners.add(l);
     }
 
     @Override

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesVisualPanel.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/AddServerPropertiesVisualPanel.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.swing.AbstractListModel;
 import javax.swing.ComboBoxModel;
 import javax.swing.JComboBox;
@@ -47,7 +48,7 @@ import org.openide.util.NbBundle;
  */
 public class AddServerPropertiesVisualPanel extends JPanel {
 
-    private final Set listeners = new HashSet();
+    private final Set listeners = ConcurrentHashMap.newKeySet();
 
     private javax.swing.JComboBox  domainField;  // Domain name (list of registered domains) can be edited
     private javax.swing.JTextField domainPathField;  //
@@ -77,15 +78,11 @@ public class AddServerPropertiesVisualPanel extends JPanel {
     }
 
     public void addChangeListener(ChangeListener l) {
-        synchronized (listeners) {
-            listeners.add(l);
-        }
+        listeners.add(l);
     }
 
     public void removeChangeListener(ChangeListener l ) {
-        synchronized (listeners) {
-            listeners.remove(l);
-        }
+        listeners.remove(l);
     }
 
     private void somethingChanged() {

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyInstantiatingIterator.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyInstantiatingIterator.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JComponent;
@@ -65,19 +66,15 @@ public class WildflyInstantiatingIterator implements WizardDescriptor.Instantiat
 
 
     // private InstallPanel panel;
-    private final transient Set listeners = new HashSet(1);
+    private final transient Set listeners = ConcurrentHashMap.newKeySet(2);
     @Override
     public void removeChangeListener(ChangeListener l) {
-        synchronized (listeners) {
-            listeners.remove(l);
-        }
+        listeners.remove(l);
     }
 
     @Override
     public void addChangeListener(ChangeListener l) {
-        synchronized (listeners) {
-            listeners.add(l);
-        }
+        listeners.add(l);
     }
 
     @Override

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ide/ui/WildflyPluginUtils.java
@@ -106,6 +106,10 @@ public class WildflyPluginUtils {
     public static final Version WILDFLY_27_0_0 = new Version("27.0.0", true); // NOI18N
     
     public static final Version WILDFLY_28_0_0 = new Version("28.0.0", true); // NOI18N
+    
+    public static final Version WILDFLY_29_0_0 = new Version("29.0.0", true); // NOI18N
+    
+    public static final Version WILDFLY_30_0_0 = new Version("30.0.0", true); // NOI18N
 
     private static final Logger LOGGER = Logger.getLogger(WildflyPluginUtils.class.getName());
 


### PR DESCRIPTION
NetBeans Module Notes:
- Prefer `ConcurrentMap` to `synchronizedMap`
- Prefer `ConcurrentHashMap.newKeySet` to `synchronizedSet`
- Remove synchronized blocks when using atomic and concurrent operations
  with `ConcurrentHashMap`
- Add Wildfly version 29 and 30
- Add Java 21 support for Wildfly 30+
- Close  resources with `try-with-resources` when possible
- Set initial capacity for profile sets
- Bump `source` and `target` to version 11 (will revert if tests are red)

Testing:
- Full build done
- Verify successful execution of `ant verify-libs-and-licenses`
- Verify successful execution of `ant check-sigtests-release`
- Verify successful execution of `ant -Dcluster.config=release commit-validation`
- Successfully register WildFly versions 29 and 30, create a Jakarta EE 10 WebApp and run it

[WildFly 30 Release Notes](https://www.wildfly.org/news/2023/10/18/WildFly30-Released/)