### PR TITLE
Update FlatLaf from 3.2.1 to 3.2.5

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-90F4BD7E9208C38CC065E84555A423E871AADE18 com.formdev:flatlaf:3.2.1
+A180D2525801750F8BE57A1FAE71181593C9BB36 com.formdev:flatlaf:3.2.5

--- a/platform/libs.flatlaf/external/flatlaf-3.2.5-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-3.2.5-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 3.2.1
-Files: flatlaf-3.2.1.jar
+Version: 3.2.5
+Files: flatlaf-3.2.5.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/manifest.mf
+++ b/platform/libs.flatlaf/manifest.mf
@@ -4,4 +4,4 @@ OpenIDE-Module: org.netbeans.libs.flatlaf/1
 OpenIDE-Module-Install: org/netbeans/libs/flatlaf/Installer.class
 OpenIDE-Module-Specification-Version: 1.16
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Implementation-Version: 3.2.1
+OpenIDE-Module-Implementation-Version: 3.2.5

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -31,12 +31,12 @@ spec.version.base.fatal.warning=false
 #
 # So when FlatLaf is updated, the OpenIDE-Module-Implementation-Version entry
 # in manifest.mf needs to be updated to match the new FlatLaf version.
-release.external/flatlaf-3.2.1.jar=modules/ext/flatlaf-3.2.1.jar
+release.external/flatlaf-3.2.5.jar=modules/ext/flatlaf-3.2.5.jar
 
-release.external/flatlaf-3.2.1.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
-release.external/flatlaf-3.2.1.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
-release.external/flatlaf-3.2.1.jar!/com/formdev/flatlaf/natives/flatlaf-windows-arm64.dll=modules/lib/flatlaf-windows-arm64.dll
-release.external/flatlaf-3.2.1.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
+release.external/flatlaf-3.2.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
+release.external/flatlaf-3.2.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
+release.external/flatlaf-3.2.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-arm64.dll=modules/lib/flatlaf-windows-arm64.dll
+release.external/flatlaf-3.2.5.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
 jnlp.verify.excludes=\
     modules/lib/flatlaf-windows-x86.dll,\
     modules/lib/flatlaf-windows-x86_64.dll,\

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -48,8 +48,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-3.2.1.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-3.2.1.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-3.2.5.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-3.2.5.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Changes: https://github.com/JFormDesigner/FlatLaf/releases/tag/3.2.5
and: https://github.com/JFormDesigner/FlatLaf/releases/tag/3.2.4
and: https://github.com/JFormDesigner/FlatLaf/releases/tag/3.2.3
and: https://github.com/JFormDesigner/FlatLaf/releases/tag/3.2.2

fixes issue #6587: "document list" popup not shown on Linux with Wayland and Java 21
