### PR TITLE
Database dialect not detected 

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/db/MicronautRepository.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/db/MicronautRepository.java
@@ -117,6 +117,11 @@ public class MicronautRepository implements TemplateWizard.Iterator {
                         DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(Bundle.MSG_NoDdSupport(folder.getPath()), NotifyDescriptor.ERROR_MESSAGE));
                         return Collections.emptyList();
                     }
+                    DatabaseConnection connection = ConnectionManager.getDefault().getPreferredConnection(true);
+                    if (connection == null) {
+                        DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(Bundle.MSG_NoDbConn(), NotifyDescriptor.ERROR_MESSAGE));
+                        return Collections.emptyList();
+                    }
                     final boolean jpaSupported = Utils.isJPASupported(sourceGroup);
                     final Map<String, String> entity2idTypes = getEntityClasses(sourceGroup, jpaSupported);
                     final List<NotifyDescriptor.QuickPick.Item> entities = new ArrayList<>();


### PR DESCRIPTION
Without databse connection, dialect in generated @JdbcRepository annotation is missing. 

Make sure there is databse connection when generationg Repository class from Micronut template. 

