### PR TITLE
The list of tests should include TestNG tests.

### DIFF
--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodFinderImpl.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodFinderImpl.java
@@ -56,7 +56,7 @@ import org.openide.util.WeakSet;
 public final class TestMethodFinderImpl extends EmbeddingIndexer {
 
     public static final String NAME = "tests"; // NOI18N
-    public static final int VERSION = 1;
+    public static final int VERSION = 2;
     public static final TestMethodFinderImpl INSTANCE = new TestMethodFinderImpl();
 
     private final WeakSet<BiConsumer<FileObject, Collection<TestMethodController.TestMethod>>> listeners = new WeakSet<>();

--- a/java/java.lsp.server/vscode/README.md
+++ b/java/java.lsp.server/vscode/README.md
@@ -42,7 +42,7 @@ When running this extension on GraalVM, as its runtime JDK, behind proxy it requ
 * __Java: New Project...__ allows creation of new Maven or Gradle project 
 * __Java: New from Template...__ add various files to currently selected open project. Files are:
     * Java - broad selection of various predefined Java classes
-    * Unit tests - JUnit and TestNB templates for test suites and test cases
+    * Unit tests - JUnit and TestNG templates for test suites and test cases
     * HTML5/JavaScript - Templates for JS, HTML, CSS,... files
     * Other - various templates for JSON, YAML, properties, ... files
 * __Java: Compile Workspace__ - invoke Maven or Gradle build

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestClassInfoTask.java
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestClassInfoTask.java
@@ -281,7 +281,7 @@ public final class TestClassInfoTask implements Task<CompilationController> {
     }
 
     @MimeRegistration(mimeType="text/x-java", service=org.netbeans.modules.gsf.testrunner.ui.spi.ComputeTestMethods.class)
-    public static final class GenericComputeTestMethodsImpl implements org.netbeans.modules.gsf.testrunner.ui.spi.ComputeTestMethods {
+    public static final class JUnitComputeTestMethodsImpl implements org.netbeans.modules.gsf.testrunner.ui.spi.ComputeTestMethods {
 
         @Override
         public List<TestMethod> computeTestMethods(Parser.Result parserResult, AtomicBoolean cancel) {

--- a/java/testng.ui/nbproject/project.xml
+++ b/java/testng.ui/nbproject/project.xml
@@ -35,6 +35,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.api.java.classpath</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.77</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>


### PR DESCRIPTION
Please see here:
https://github.com/oracle/javavscode/issues/28

The test indexer uses providers to detect tests, and the provider for TestNG tests seems to be missing. So, this PR adds the provider.
