### PR TITLE
Move platform jobs to 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -808,7 +808,7 @@ jobs:
 
 
   build-tools:
-    name: Build Tools on Linux/JDK ${{ matrix.java }}
+    name: Build Tools on Linux/JDK ${{ matrix.java }} (some on 17)
     # label triggers: Ant, Gradle, Maven, MX
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Ant') || contains(github.event.pull_request.labels.*.name, 'Gradle') || contains(github.event.pull_request.labels.*.name, 'Maven') || contains(github.event.pull_request.labels.*.name, 'MX') || contains(github.event.pull_request.labels.*.name, 'ci:all-tests') || github.event_name != 'pull_request' }}
     needs: base-build
@@ -816,7 +816,8 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '11', '17' ]
+        java: [ '11', '21' ]
+      fail-fast: false
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
@@ -837,17 +838,6 @@ jobs:
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
-
-      # run unreliable steps first to fail early
-      - name: java/java.mx.project
-        continue-on-error: ${{ github.event_name != 'pull_request' }}
-        run: .github/retry.sh ant $OPTS -f java/java.mx.project test
-        
-      - name: java/gradle.java
-        run: .github/retry.sh ant $OPTS -f java/gradle.java test
-
-      - name: extide/gradle
-        run: ant $OPTS -f extide/gradle test
 
       - name: java/maven
         run: ant $OPTS -f java/maven test
@@ -903,6 +893,24 @@ jobs:
 #      - name: java/ant.grammar
 #        run: ant $OPTS -f java/ant.grammar test
 
+      - name: Set up JDK 17 for JDK 21 incompatible tests
+        if: ${{ matrix.java == '21' }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: ${{ env.default_java_distribution }}
+
+      # TODO fix JDK 21 incompatibilites
+      - name: java/java.mx.project
+        continue-on-error: ${{ github.event_name != 'pull_request' }}
+        run: .github/retry.sh ant $OPTS -f java/java.mx.project test
+
+      - name: java/gradle.java
+        run: .github/retry.sh ant $OPTS -f java/gradle.java test
+
+      - name: extide/gradle
+        run: ant $OPTS -f extide/gradle test
+
       - name: extide/o.apache.tools.ant.module
         run: ant $OPTS -f extide/o.apache.tools.ant.module test
 
@@ -914,7 +922,7 @@ jobs:
 
 
   platform-modules-test1:
-    name: Platform Modules batch1 on Linux/JDK ${{ matrix.java }}
+    name: Platform Modules batch1 on Linux/JDK ${{ matrix.java }} (some on 8)
     # equals env.test_platform == 'true'
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Platform') || contains(github.event.pull_request.labels.*.name, 'ci:all-tests') || github.event_name != 'pull_request' }}
     needs: base-build
@@ -922,7 +930,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '11' ]
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
@@ -945,123 +953,136 @@ jobs:
         run: tar --zstd -xf build.tar.zst
 
       - name: platform/api.htmlui
-        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/api.htmlui test
+        run: .github/retry.sh ant $OPTS -f platform/api.htmlui test
   
       - name: platform/htmlui
-        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/htmlui test
+        run: .github/retry.sh ant $OPTS -f platform/htmlui test
 
       - name: platform/api.intent
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/api.intent test
+        run: ant $OPTS -f platform/api.intent test
 
       - name: platform/api.io
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/api.io test
+        run: ant $OPTS -f platform/api.io test
 
       - name: platform/api.progress
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/api.progress test
+        run: ant $OPTS -f platform/api.progress test
 
       - name: platform/api.progress.nb
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/api.progress.nb test
+        run: ant $OPTS -f platform/api.progress.nb test
 
       - name: platform/api.scripting
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/api.scripting test
+        run: ant $OPTS -f platform/api.scripting test
 
       - name: platform/api.search
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/api.search test
+        run: ant $OPTS -f platform/api.search test
 
       - name: platform/api.templates
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/api.templates test
+        run: ant $OPTS -f platform/api.templates test
 
       - name: platform/api.visual
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/api.visual test
+        run: ant $OPTS -f platform/api.visual test
 
       - name: platform/applemenu
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/applemenu test
+        run: ant $OPTS -f platform/applemenu test
 
       - name: platform/autoupdate.cli
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/autoupdate.cli test
+        run: ant $OPTS -f platform/autoupdate.cli test
 
       - name: platform/autoupdate.services
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/autoupdate.services test
+        run: ant $OPTS -f platform/autoupdate.services test
 
       - name: platform/autoupdate.ui
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/autoupdate.ui test
+        run: ant $OPTS -f platform/autoupdate.ui test
 
       - name: platform/core.execution
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.execution test
+        run: ant $OPTS -f platform/core.execution test
 
       - name: platform/core.io.ui
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.io.ui test
+        run: ant $OPTS -f platform/core.io.ui test
 
       - name: platform/core.kit
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.kit test
+        run: ant $OPTS -f platform/core.kit test
 
       - name: platform/core.multiview
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.multiview test
+        run: ant $OPTS -f platform/core.multiview test
 
       - name: platform/core.netigso
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.netigso test
+        run: ant $OPTS -f platform/core.netigso test
 
       - name: platform/core.osgi
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.osgi test
+        run: ant $OPTS -f platform/core.osgi test
 
       - name: platform/core.output2
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.output2 test
+        run: ant $OPTS -f platform/core.output2 test
 
       - name: platform/core.startup
-        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/core.startup test
+        run: .github/retry.sh ant $OPTS -f platform/core.startup test
 
       - name: platform/core.startup.base
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.startup.base test
+        run: ant $OPTS -f platform/core.startup.base test
 
       - name: platform/core.ui
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/core.ui test
+        run: ant $OPTS -f platform/core.ui test
 
       - name: platform/core.windows
-        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/core.windows test
+        run: .github/retry.sh ant $OPTS -f platform/core.windows test
 
       - name: platform/editor.mimelookup
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/editor.mimelookup test
+        run: ant $OPTS -f platform/editor.mimelookup test
 
       - name: platform/editor.mimelookup.impl
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/editor.mimelookup.impl test
+        run: ant $OPTS -f platform/editor.mimelookup.impl test
 
       - name: platform/favorites
-        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/favorites test
+        run: .github/retry.sh ant $OPTS -f platform/favorites test
 
       - name: platform/javahelp
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/javahelp test-unit
+        run: ant $OPTS -f platform/javahelp test-unit
 
       - name: platform/keyring.fallback
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/keyring.fallback test
+        run: ant $OPTS -f platform/keyring.fallback test
 
       - name: platform/keyring.impl
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/keyring.impl test
-
-      - name: platform/lib.uihandler
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/lib.uihandler test
+        run: ant $OPTS -f platform/keyring.impl test
 
       - name: platform/libs.javafx
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/libs.javafx test
+        run: ant $OPTS -f platform/libs.javafx test
 
       - name: platform/libs.junit4
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/libs.junit4 test
+        run: ant $OPTS -f platform/libs.junit4 test
 
       - name: platform/masterfs
-        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/masterfs test
+        run: .github/retry.sh ant $OPTS -f platform/masterfs test
 
       - name: platform/masterfs.linux
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/masterfs.linux test
+        run: ant $OPTS -f platform/masterfs.linux test
 
       - name: platform/o.n.core
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/o.n.core test-unit
+        run: ant $OPTS -f platform/o.n.core test-unit
 
       - name: platform/o.n.swing.outline
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/o.n.swing.outline test
+        run: ant $OPTS -f platform/o.n.swing.outline test
 
       - name: platform/o.n.swing.tabcontrol
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/o.n.swing.tabcontrol test
+        run: ant $OPTS -f platform/o.n.swing.tabcontrol test
 
-      # required by netbinox tests
+      - name: Set up JDK 8 for incompatibe tests
+        uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: ${{ env.default_java_distribution }}
+
+      # TODO fix JDK 11 incompatibilities
+      - name: platform/lib.uihandler
+        run: ant $OPTS -f platform/lib.uihandler test
+
+      - name: platform/openide.text
+        run: .github/retry.sh ant $OPTS -f platform/openide.text test
+
+      - name: platform/openide.util.ui
+        run: ant $OPTS -f platform/openide.util.ui test
+
+      # isolation required by netbinox tests
       - name: isolate platform build
         run: |
           cp -r platform/ _platform/ && cp -r harness/ _harness/ && cp nbbuild/build/nbantext.jar .
@@ -1072,7 +1093,7 @@ jobs:
           mv _nb_platform/ nbbuild/netbeans/platform/ && mv _nb_harness/ nbbuild/netbeans/harness/
 
       - name: platform/netbinox
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/netbinox test -Dtest.config=stableBTD
+        run: ant $OPTS -f platform/netbinox test -Dtest.config=stableBTD
 
       - name: Create Test Summary
         uses: test-summary/action@v2
@@ -1082,7 +1103,7 @@ jobs:
 
 
   platform-modules-test2:
-    name: Platform Modules batch2 on Linux/JDK ${{ matrix.java }} (some on 11)
+    name: Platform Modules batch2 on Linux/JDK ${{ matrix.java }}
     # equals env.test_platform == 'true'
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Platform') || contains(github.event.pull_request.labels.*.name, 'ci:all-tests') || github.event_name != 'pull_request' }}
     needs: base-build
@@ -1090,7 +1111,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '11' ]
     steps:
 
       - name: Set up JDK 11
@@ -1119,113 +1140,101 @@ jobs:
         run: tar --zstd -xf build.tar.zst
 
       - name: platform/openide.actions
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.actions test
+        run: ant $OPTS -f platform/openide.actions test
 
       - name: platform/openide.awt
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.awt test
+        run: ant $OPTS -f platform/openide.awt test
 
       - name: platform/openide.compat
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.compat test
+        run: ant $OPTS -f platform/openide.compat test
 
       - name: platform/openide.dialogs
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.dialogs test
+        run: ant $OPTS -f platform/openide.dialogs test
 
       - name: platform/openide.execution
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.execution test
+        run: ant $OPTS -f platform/openide.execution test
 
       - name: platform/openide.execution.compat8
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.execution.compat8 test
+        run: ant $OPTS -f platform/openide.execution.compat8 test
 
       - name: platform/openide.explorer
-        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.explorer test
+        run: .github/retry.sh ant $OPTS -f platform/openide.explorer test
 
       - name: platform/openide.filesystems
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.filesystems test
+        run: ant $OPTS -f platform/openide.filesystems test
 
       - name: platform/openide.filesystems.compat8
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.filesystems.compat8 test
+        run: ant $OPTS -f platform/openide.filesystems.compat8 test
 
       - name: platform/openide.filesystems.nb
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.filesystems.nb test
+        run: ant $OPTS -f platform/openide.filesystems.nb test
 
       - name: platform/openide.io
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.io test
+        run: ant $OPTS -f platform/openide.io test
 
       - name: platform/openide.loaders
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.loaders test
+        run: ant $OPTS -f platform/openide.loaders test
 
       - name: platform/openide.modules
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.modules test
+        run: ant $OPTS -f platform/openide.modules test
 
       - name: platform/openide.nodes
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.nodes test
+        run: ant $OPTS -f platform/openide.nodes test
 
       - name: platform/openide.options
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.options test
-
-      - name: platform/openide.text
-        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.text test
+        run: ant $OPTS -f platform/openide.options test
 
       - name: platform/openide.util
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.util test
+        run: ant $OPTS -f platform/openide.util test
 
       - name: platform/openide.util.lookup
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.util.lookup test
-
-      - name: platform/openide.util.ui
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.util.ui test
+        run: ant $OPTS -f platform/openide.util.lookup test
 
       - name: platform/openide.windows
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/openide.windows test
+        run: ant $OPTS -f platform/openide.windows test
 
       - name: platform/options.api
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/options.api test-unit
+        run: ant $OPTS -f platform/options.api test-unit
 
       - name: platform/options.keymap
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/options.keymap test
+        run: ant $OPTS -f platform/options.keymap test
 
       - name: platform/print
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/print test
+        run: ant $OPTS -f platform/print test
 
       - name: platform/progress.ui
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/progress.ui test
+        run: ant $OPTS -f platform/progress.ui test
 
       - name: platform/queries
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/queries test
+        run: ant $OPTS -f platform/queries test
 
       - name: platform/sampler
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/sampler test
+        run: ant $OPTS -f platform/sampler test
 
       - name: platform/sendopts
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/sendopts test
+        run: ant $OPTS -f platform/sendopts test
 
       - name: platform/settings
-        run: .github/retry.sh ant $OPTS -Dvanilla.javac.exists=true -f platform/settings test
+        run: .github/retry.sh ant $OPTS -f platform/settings test
 
       - name: platform/spi.actions
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/spi.actions test
+        run: ant $OPTS -f platform/spi.actions test
 
       - name: platform/spi.quicksearch
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/spi.quicksearch test
+        run: ant $OPTS -f platform/spi.quicksearch test
 
       - name: platform/templates
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/templates test
+        run: ant $OPTS -f platform/templates test
 
       - name: platform/templatesui
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/templatesui test
+        run: ant $OPTS -f platform/templatesui test
 
       - name: platform/uihandler
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/uihandler test
+        run: ant $OPTS -f platform/uihandler test
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: ${{ env.default_java_distribution }}
-        
-      - name: platform/o.n.bootstrap on 11
-        run: ant $OPTS -Dvanilla.javac.exists=true -f platform/o.n.bootstrap test
- 
+      - name: platform/o.n.bootstrap
+        run: ant $OPTS -f platform/o.n.bootstrap test
+
       - name: Create Test Summary
         uses: test-summary/action@v2
         if: failure()
@@ -1265,16 +1274,16 @@ jobs:
         run: tar --zstd -xf build.tar.zst
 
       - name: harness/o.n.insane
-        run: ant $OPTS -Dvanilla.javac.exists=true -f harness/o.n.insane test
+        run: ant $OPTS -f harness/o.n.insane test
 
       - name: harness/apisupport.harness
-        run: ant $OPTS -Dvanilla.javac.exists=true -f harness/apisupport.harness test
+        run: ant $OPTS -f harness/apisupport.harness test
 
       - name: harness/harness/nbjunit
-        run: ant $OPTS -Dvanilla.javac.exists=true -f harness/nbjunit test
+        run: ant $OPTS -f harness/nbjunit test
 
       - name: harness/jellytools.platform
-        run: ant $OPTS -Dvanilla.javac.exists=true -f harness/jellytools.platform test -Dtest.config=stable
+        run: ant $OPTS -f harness/jellytools.platform test -Dtest.config=stable
 
       - name: ergonomics/ide.ergonomics
         run: ant $OPTS -f ergonomics/ide.ergonomics test -Dtest.config=commit
@@ -1600,7 +1609,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '11', '17' ]
+        java: [ '11', '21' ]
       fail-fast: false
     steps:
 

--- a/platform/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewProcessorTest.java
+++ b/platform/core.multiview/test/unit/src/org/netbeans/core/multiview/MultiViewProcessorTest.java
@@ -343,10 +343,6 @@ public class MultiViewProcessorTest extends NbTestCase {
         AnnotationProcessorTestUtils.makeSource(getWorkDir(), "pkg.Test", src);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         boolean res = AnnotationProcessorTestUtils.runJavac(getWorkDir(), null, getWorkDir(), null, os);
-        if (AnnotationProcessorTestUtils.searchClasspathBroken()) {
-            assertTrue("Alas, compilation succeded", res);
-            return;
-        }
         assertFalse("Compilation should fail:\n" + os.toString(), res);
         assertTrue("because of missing icon:\n" + os.toString(), os.toString().contains("iconBase"));
         assertTrue("because of missing icon:\n" + os.toString(), os.toString().contains("Cannot find resource pkg/none-existing.png"));

--- a/platform/favorites/src/org/netbeans/modules/favorites/Actions.java
+++ b/platform/favorites/src/org/netbeans/modules/favorites/Actions.java
@@ -414,23 +414,24 @@ public final class Actions extends Object {
             return null;
         }
 
+        // what order is this? requires comment
         public static void reorderAfterAddition(final DataFolder favourities, final DataObject[] children, final List<? extends DataObject> listAdd) {
             List<DataObject> listDest = new ArrayList<>();
             if (listAdd.size() > 0) {
                 //Insert new nodes just before last (root) node
                 DataObject root = null;
                 //Find root
-                for (DataObject children1 : children) {
-                    FileObject fo = children1.getPrimaryFile();
-                    if ("Favorites/Root.instance".equals(fo.getPath())) {
-                        //NOI18N
-                        root = children1;
+                for (DataObject child : children) {
+                    FileObject fo = child.getPrimaryFile();
+                    if ("Favorites/Root.instance".equals(fo.getPath())) { //NOI18N
+                        root = child;
+                        break;
                     }
                 }
                 if (root != null) {
-                    for (DataObject children1 : children) {
-                        if (!root.equals(children1)) {
-                            listDest.add(children1);
+                    for (DataObject child : children) {
+                        if (!root.equals(child)) {
+                            listDest.add(child);
                         }
                     }
                     listDest.addAll(listAdd);
@@ -440,7 +441,7 @@ public final class Actions extends Object {
                     listDest.addAll(listAdd);
                 }
                 //Set desired order
-                DataObject [] newOrder = listDest.toArray(new DataObject[listDest.size()]);
+                DataObject [] newOrder = listDest.toArray(new DataObject[0]);
                 try {
                     favourities.setOrder(newOrder);
                 } catch (IOException ex) {

--- a/platform/openide.awt/test/unit/src/org/netbeans/modules/openide/awt/ActionProcessorTest.java
+++ b/platform/openide.awt/test/unit/src/org/netbeans/modules/openide/awt/ActionProcessorTest.java
@@ -863,10 +863,6 @@ public class ActionProcessorTest extends NbTestCase {
 
     public void testWrongPointerToIcon() throws IOException {
         clearWorkDir();
-        if (AnnotationProcessorTestUtils.searchClasspathBroken()) {
-            System.err.println("#196933: testWrongPointerToIcon will only pass when using JDK 7 javac, skipping");
-            return;
-        }
         AnnotationProcessorTestUtils.makeSource(getWorkDir(), "test.A", 
             "import org.openide.awt.ActionRegistration;\n" +
             "import org.openide.awt.ActionReference;\n" +

--- a/platform/openide.awt/test/unit/src/org/netbeans/modules/openide/openide/awt/StatefulActionProcessorTest.java
+++ b/platform/openide.awt/test/unit/src/org/netbeans/modules/openide/openide/awt/StatefulActionProcessorTest.java
@@ -500,8 +500,9 @@ public class StatefulActionProcessorTest extends NbTestCase implements ContextGl
         );
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         boolean r = AnnotationProcessorTestUtils.runJavac(getWorkDir(), null, getWorkDir(), null, os);
-        if (!os.toString().contains("is not public")) {
-            fail("Nonpublic listener type must be reported" + os);
+        String msg = os.toString();
+        if (!msg.contains("cannot find symbol") && !msg.contains("is not public")) {
+            fail("Nonpublic listener type must be reported" + msg);
         }
     }
 

--- a/platform/openide.filesystems/src/org/openide/filesystems/annotations/LayerBuilder.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/annotations/LayerBuilder.java
@@ -301,11 +301,7 @@ public final class LayerBuilder {
 
     /**
      * Validates a resource named in an annotation.
-     * <p>Note that resources found in the binary classpath (if permitted)
-     * cannot actually be located when running inside javac on JDK 6 (see #196933 for discussion), in which case
-     * no exception is thrown but the return value may not permit {@link FileObject#openInputStream}.
-     * <span class="nonnormative">{@code AnnotationProcessorTestUtils.searchClasspathBroken} should be used in unit tests affected by this bug.</span>
-     * <p>Also remember that the binary compilation classpath for an Ant-based NetBeans module does
+     * <p>Note that the binary compilation classpath for an Ant-based NetBeans module does
      * not include non-public packages.
      * (As of the 7.1 harness it does include non-classfile resources from public packages of module dependencies.)
      * The processorpath does contain all of these but it is not consulted.

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerBuilderTest.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerBuilderTest.java
@@ -322,7 +322,7 @@ public class LayerBuilderTest extends NbTestCase {
         boolean status = AnnotationProcessorTestUtils.runJavac(src, null, dest, new File[] {j, BaseUtilities.toFile(LayerBuilderTest.class.getProtectionDomain().getCodeSource().getLocation().toURI())}, err);
         String msgs = err.toString();
         assertTrue(msgs, status);
-        assertTrue(msgs, msgs.contains("r1=x1") ^ AnnotationProcessorTestUtils.searchClasspathBroken());
+        assertTrue(msgs, msgs.contains("r1=x1"));
         assertTrue(msgs, msgs.contains("r2=x2"));
         FileObject f = new XMLFileSystem(BaseUtilities.toURI(new File(dest, "META-INF/generated-layer.xml")).toURL()).findResource("f");
         assertNotNull(f);
@@ -339,13 +339,13 @@ public class LayerBuilderTest extends NbTestCase {
         String msgs = err.toString();
         assertFalse(msgs, status);
         assertTrue(msgs, msgs.contains("resourcez"));
-        assertTrue(msgs, msgs.contains("r1=x1") ^ AnnotationProcessorTestUtils.searchClasspathBroken());
+        assertTrue(msgs, msgs.contains("r1=x1"));
         AnnotationProcessorTestUtils.makeSource(src, "p.C", "@" + V.class.getCanonicalName() + "(r1=\"othr/x1\", r2=\"resources/x2\") public class C {}");
         err = new ByteArrayOutputStream();
         status = AnnotationProcessorTestUtils.runJavac(src, null, dest, new File[] {j, BaseUtilities.toFile(LayerBuilderTest.class.getProtectionDomain().getCodeSource().getLocation().toURI())}, err);
         msgs = err.toString();
-        assertFalse(msgs, status ^ AnnotationProcessorTestUtils.searchClasspathBroken());
-        assertTrue(msgs, msgs.contains("othr") ^ AnnotationProcessorTestUtils.searchClasspathBroken());
+        assertFalse(msgs, status);
+        assertTrue(msgs, msgs.contains("othr"));
     }
 
     // XXX verify that CLASS_OUTPUT may be used as well

--- a/platform/openide.util.lookup/test/unit/src/org/openide/util/test/AnnotationProcessorTestUtils.java
+++ b/platform/openide.util.lookup/test/unit/src/org/openide/util/test/AnnotationProcessorTestUtils.java
@@ -25,9 +25,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.security.CodeSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -58,9 +55,7 @@ public class AnnotationProcessorTestUtils {
     public static void makeSource(File dir, String clazz, String... content) throws IOException {
         File f = new File(dir, clazz.replace('.', File.separatorChar) + ".java");
         f.getParentFile().mkdirs();
-        Writer w = new FileWriter(f);
-        try {
-            PrintWriter pw = new PrintWriter(w);
+        try (Writer w = new FileWriter(f); PrintWriter pw = new PrintWriter(w)) {
             String pkg = clazz.replaceFirst("\\.[^.]+$", "");
             if (!pkg.equals(clazz) && !clazz.endsWith(".package-info")) {
                 pw.println("package " + pkg + ";");
@@ -69,8 +64,6 @@ public class AnnotationProcessorTestUtils {
                 pw.println(line);
             }
             pw.flush();
-        } finally {
-            w.close();
         }
     }
 
@@ -137,7 +130,7 @@ public class AnnotationProcessorTestUtils {
                 ),
             compiler);
         //System.err.println("running javac with args: " + args);
-        return compiler.run(null, null, stderr, args.toArray(new String[args.size()])) == 0;
+        return compiler.run(null, null, stderr, args.toArray(new String[0])) == 0;
     }
     private static void scan(List<String> names, File f, String includes) {
         if (f.isDirectory()) {
@@ -146,27 +139,6 @@ public class AnnotationProcessorTestUtils {
             }
         } else if (f.getName().endsWith(".java") && (includes == null || Pattern.compile(includes).matcher(f.getName()).find())) {
             names.add(f.getAbsolutePath());
-        }
-    }
-
-    /**
-     * Checks whether the version of javac in use suffers from #6929404.
-     * If so, calls to {@code LayerBuilder.validateResource(..., true)} will return normally
-     * even if the resource path does not exist, so tests must be more lenient.
-     */
-    public static boolean searchClasspathBroken() {
-        // Cannot just check for e.g. SourceVersion.RELEASE_7 because we might be running JDK 6 javac w/ JDK 7 boot CP, and that is in JRE.
-        // (Anyway libs.javacapi/external/nb-javac-api.jar, in the test's normal boot CP, has this!)
-        // Filter.class added in 7ae4016c5938, not long after f3323b1c65ee which we rely on for this to work.
-        // Also cannot just check Class.forName(...) since tools.jar not in CP but ToolProvider loads it specially - not true anymore since JDK 9 ToolProvider does not look for tools.jar.
-        final String res = "com/sun/tools/javac/util/Filter.class"; //NOI18N
-        final CodeSource codeSource = ToolProvider.getSystemJavaCompiler().getClass().getProtectionDomain().getCodeSource();
-        if (codeSource != null) {
-            //Compiler from URLClassLoader - JDK7, JDK8 javac
-            return new URLClassLoader(new URL[] {codeSource.getLocation()}).findResource(res) == null;
-        } else {
-            //Compiler from Boot, Ext, System ClassLoader - JDK9 javac
-            return ClassLoader.getSystemClassLoader().getResource(res) == null;
         }
     }
 

--- a/platform/options.api/test/unit/src/org/netbeans/modules/options/OptionsPanelControllerProcessorTest.java
+++ b/platform/options.api/test/unit/src/org/netbeans/modules/options/OptionsPanelControllerProcessorTest.java
@@ -52,8 +52,8 @@ public class OptionsPanelControllerProcessorTest extends NbTestCase {
                 "    public void removePropertyChangeListener(java.beans.PropertyChangeListener l) {}",
                 "}");
         ByteArrayOutputStream err = new ByteArrayOutputStream();
-        assertFalse(AnnotationProcessorTestUtils.runJavac(src, null, dest, null, err) ^ AnnotationProcessorTestUtils.searchClasspathBroken());
-        assertTrue(err.toString(), err.toString().contains("no/such/icon") ^ AnnotationProcessorTestUtils.searchClasspathBroken());
+        assertFalse(AnnotationProcessorTestUtils.runJavac(src, null, dest, null, err));
+        assertTrue(err.toString(), err.toString().contains("no/such/icon"));
         TestFileUtils.writeFile(new File(src, "no/such/icon"), "whatever");
         assertTrue(AnnotationProcessorTestUtils.runJavac(src, null, dest, null, null));
     }


### PR DESCRIPTION
platform jobs:
 - test everything on JDK 11 which can run on JDK 11
 - fix some of the tests which are "easily" fixable 
   - `openide.filesystems`
   - `options.api`
   - `openide.awt` 
   - `core.multiview`
   - `platform/favorites`
 - leave the rest in a JDK 8 section of the platform job for now (makes it easy to see what still needs work)
 - remove relict from travis times: can't find any references to `-Dvanilla.javac.exists=true` 

misc jobs:
 - bump build-tools job from `[11, 17]` to `[11, 21]`, isolate tests which can't run on JDK 21 yet (discussed in https://github.com/apache/netbeans/pull/6514#issuecomment-1774691147)
 - bump java debugger job `[11, 17]` to `[11, 21]`

meta issue #4904 
rebase after #6579 is merged (done)