### PR TITLE
Be more friendly on 'runSingle' when 'run' task is missing.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
@@ -30,8 +30,8 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.process.CommandLineArgumentProvider;
-import org.gradle.tooling.BuildException;
 import org.gradle.util.GradleVersion;
 /**
  *
@@ -47,6 +47,8 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
     private static final String RUN_SINGLE_JVM_ARGS = "runJvmArgs";
     private static final String RUN_SINGLE_CWD = "runWorkingDir";
 
+    private static final String DEPRECATE_RUN_SINGLE = 
+            "runSingle task is deprecated. Inspect your configuration and use just 'run' task instead of 'runSingle'";
     @Override
     public void apply(Project project) {
         project.afterEvaluate(p -> {
@@ -55,61 +57,58 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
                     && project.hasProperty(RUN_SINGLE_MAIN)) {
                 Set<Task> runTasks = p.getTasksByName("run", false);
                 Task r = runTasks.isEmpty() ? null : runTasks.iterator().next();
-                String mainClass = project.property(RUN_SINGLE_MAIN).toString();
-                p.getTasks().withType(JavaExec.class).configureEach(je -> {
-                    if (GRADLE_VERSION.compareTo(GradleVersion.version("6.4")) < 0) {
-                        // Using setMain to keep the backward compatibility before Gradle 6.4
-                        je.setMain(mainClass);
-                    } else {
-                        je.getMainClass().set(mainClass);
-                    }
-                    if (project.hasProperty(RUN_SINGLE_ARGS)) {
-                        je.setArgs(asList(project.property(RUN_SINGLE_ARGS).toString().split(" ")));
-                    }
-                    if (p.hasProperty(RUN_SINGLE_JVM_ARGS)) {
-                        // Property jvmArgumentProviders should not be implemented as a lambda to allow execution optimizations.
-                        // See https://docs.gradle.org/current/userguide/validation_problems.html#implementation_unknown
-                        je.getJvmArgumentProviders().add(new CommandLineArgumentProvider() {
-                            // Do not convert to lambda.
-                            @Override
-                            public Iterable<String> asArguments() {
-                                return asList(p.property(RUN_SINGLE_JVM_ARGS).toString().split(" "));
-                            }
-                        });
-                    }
-                    try {
-                        je.setStandardInput(System.in);
-                    } catch (RuntimeException ex) {
-                        if(LOG.isEnabled(LogLevel.DEBUG)) {
-                            LOG.debug("Failed to set STDIN for Plugin: " + je.toString(), ex);
-                        } else {
-                            LOG.info("Failed to set STDIN for Plugin: " + je.toString());
-                        }
-                    }
-                    if (project.hasProperty(RUN_SINGLE_CWD)) {
-                        je.setWorkingDir(project.property(RUN_SINGLE_CWD).toString());
-                    }
-                });
+                p.getTasks().withType(JavaExec.class).configureEach(je -> configureJavaExec(project, je));
                 addTask(project, r);
             }
         });
     }
     
-    public static class JE extends JavaExec {
-        @Override
-        public void exec() {
+    private void configureJavaExec(Project project, JavaExec je) {
+        String mainClass = project.property(RUN_SINGLE_MAIN).toString();
+        if (GRADLE_VERSION.compareTo(GradleVersion.version("6.4")) < 0) {
+            // Using setMain to keep the backward compatibility before Gradle 6.4
+            je.setMain(mainClass);
+        } else {
+            je.getMainClass().set(mainClass);
         }
-    }
-    
-    private void addTask(Project project, Task runTask) {
-        project.getTasks().register(RUN_SINGLE_TASK, JE.class, (je) -> {
-            if (runTask == null) {
-                throw new BuildException("Could not find \"run\" task to execute. Please upgrade your configuration to use standard run-style tasks instead of deprecated runSingle", null);
+        if (project.hasProperty(RUN_SINGLE_ARGS)) {
+            je.setArgs(asList(project.property(RUN_SINGLE_ARGS).toString().split(" ")));
+        }
+        if (project.hasProperty(RUN_SINGLE_JVM_ARGS)) {
+            // Property jvmArgumentProviders should not be implemented as a lambda to allow execution optimizations.
+            // See https://docs.gradle.org/current/userguide/validation_problems.html#implementation_unknown
+            je.getJvmArgumentProviders().add(new CommandLineArgumentProvider() {
+                // Do not convert to lambda.
+                @Override
+                public Iterable<String> asArguments() {
+                    return asList(project.property(RUN_SINGLE_JVM_ARGS).toString().split(" "));
+                }
+            });
+        }
+        try {
+            je.setStandardInput(System.in);
+        } catch (RuntimeException ex) {
+            if(LOG.isEnabled(LogLevel.DEBUG)) {
+                LOG.debug("Failed to set STDIN for Plugin: " + je.toString(), ex);
             } else {
-                LOG.warn("runSingle task is deprecated. Inspect your configuration and use just 'run' task instead of 'runSingle'");
-                je.finalizedBy(runTask);
+                LOG.info("Failed to set STDIN for Plugin: " + je.toString());
             }
-        });
+        }
+        if (project.hasProperty(RUN_SINGLE_CWD)) {
+            je.setWorkingDir(project.property(RUN_SINGLE_CWD).toString());
+        }
+    } 
+
+    private void addTask(Project project, Task runTask) {
+        TaskProvider<? extends DefaultTask> runSingle = runTask == null 
+                ? project.getTasks().register(RUN_SINGLE_TASK, JavaExec.class, (je) -> {
+                    SourceSetContainer sourceSets = project.getExtensions().findByType(SourceSetContainer.class);
+                    je.setClasspath(sourceSets.findByName("main").getRuntimeClasspath());
+                    configureJavaExec(project, je);
+                  })
+                : project.getTasks().register(RUN_SINGLE_TASK, DefaultTask.class, (task) -> task.finalizedBy(runTask));
+        
+        runSingle.configure((task) -> task.doFirst((action) -> project.getLogger().warn(DEPRECATE_RUN_SINGLE)));
     }
 
 }


### PR DESCRIPTION

While #6003 was addressing issues with the Gradle setup of running single classes, the backward compatibility, providing a `runSingle` task throwing an exception in the absence of `run` task is not nice. This PR adds back the `runSingle` functionality in those cases.

Fixes: #6586 