### PR TITLE
Formatting options UI: fix naming panel layout

### DIFF
--- a/java/java.source/src/org/netbeans/modules/java/ui/FmtNaming.form
+++ b/java/java.source/src/org/netbeans/modules/java/ui/FmtNaming.form
@@ -46,12 +46,9 @@
           <Group type="102" attributes="0">
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="namingConventionsLabel" min="-2" max="-2" attributes="0"/>
-                  <Group type="102" attributes="0">
+                  <Group type="102" alignment="0" attributes="0">
                       <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="preferLongerNamesCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="jPanel1" alignment="0" min="-2" pref="274" max="-2" attributes="0"/>
-                      </Group>
+                      <Component id="jPanel1" min="-2" pref="274" max="-2" attributes="0"/>
                   </Group>
               </Group>
               <EmptySpace max="32767" attributes="0"/>
@@ -63,9 +60,7 @@
           <Group type="102" attributes="0">
               <Component id="namingConventionsLabel" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="preferLongerNamesCheckBox" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="jPanel1" min="-2" pref="144" max="-2" attributes="0"/>
+              <Component id="jPanel1" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
@@ -77,22 +72,6 @@
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/java/ui/Bundle.properties" key="LBL_gen_Naming" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
-      </Properties>
-    </Component>
-    <Component class="javax.swing.JCheckBox" name="preferLongerNamesCheckBox">
-      <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/java/ui/Bundle.properties" key="LBL_gen_PreferLongerNames" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-        <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
-          <Border info="org.netbeans.modules.form.compat2.border.EmptyBorderInfo">
-            <EmptyBorder bottom="0" left="0" right="0" top="0"/>
-          </Border>
-        </Property>
-        <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-          <Insets value="[0, 0, 0, 0]"/>
-        </Property>
-        <Property name="opaque" type="boolean" value="false"/>
       </Properties>
     </Component>
     <Container class="javax.swing.JPanel" name="jPanel1">
@@ -227,7 +206,7 @@
           </Properties>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-              <GridBagConstraints gridX="0" gridY="4" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+              <GridBagConstraints gridX="0" gridY="4" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
             </Constraint>
           </Constraints>
         </Component>

--- a/java/java.source/src/org/netbeans/modules/java/ui/FmtNaming.java
+++ b/java/java.source/src/org/netbeans/modules/java/ui/FmtNaming.java
@@ -58,8 +58,6 @@ public class FmtNaming extends javax.swing.JPanel implements Runnable {
      */
     public FmtNaming() {
         initComponents();
-        preferLongerNamesCheckBox.putClientProperty(OPTION_ID, preferLongerNames);
-        preferLongerNamesCheckBox.setVisible(false);
         fieldPrefixField.putClientProperty(OPTION_ID, fieldNamePrefix);
         fieldSuffixField.putClientProperty(OPTION_ID, fieldNameSuffix);
         staticFieldPrefixField.putClientProperty(OPTION_ID, staticFieldNamePrefix);
@@ -71,12 +69,10 @@ public class FmtNaming extends javax.swing.JPanel implements Runnable {
     }
 
     public static PreferencesCustomizer.Factory getController() {
-        return new PreferencesCustomizer.Factory() {
-            public PreferencesCustomizer create(Preferences preferences) {
-                NamingCategorySupport support = new NamingCategorySupport(preferences, new FmtNaming());
-                ((Runnable) support.panel).run();
-                return support;
-            }
+        return (Preferences preferences) -> {
+            NamingCategorySupport support = new NamingCategorySupport(preferences, new FmtNaming());
+            ((Runnable) support.panel).run();
+            return support;
         };
     }
 
@@ -90,7 +86,6 @@ public class FmtNaming extends javax.swing.JPanel implements Runnable {
         java.awt.GridBagConstraints gridBagConstraints;
 
         namingConventionsLabel = new javax.swing.JLabel();
-        preferLongerNamesCheckBox = new javax.swing.JCheckBox();
         jPanel1 = new javax.swing.JPanel();
         prefixLabel = new javax.swing.JLabel();
         suffixLabel = new javax.swing.JLabel();
@@ -111,11 +106,6 @@ public class FmtNaming extends javax.swing.JPanel implements Runnable {
         setOpaque(false);
 
         org.openide.awt.Mnemonics.setLocalizedText(namingConventionsLabel, org.openide.util.NbBundle.getMessage(FmtNaming.class, "LBL_gen_Naming")); // NOI18N
-
-        org.openide.awt.Mnemonics.setLocalizedText(preferLongerNamesCheckBox, org.openide.util.NbBundle.getMessage(FmtNaming.class, "LBL_gen_PreferLongerNames")); // NOI18N
-        preferLongerNamesCheckBox.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
-        preferLongerNamesCheckBox.setMargin(new java.awt.Insets(0, 0, 0, 0));
-        preferLongerNamesCheckBox.setOpaque(false);
 
         jPanel1.setLayout(new java.awt.GridBagLayout());
 
@@ -219,7 +209,6 @@ public class FmtNaming extends javax.swing.JPanel implements Runnable {
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 4;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
-        gridBagConstraints.insets = new java.awt.Insets(4, 0, 0, 0);
         jPanel1.add(localVarLabel, gridBagConstraints);
 
         localVarSuffixField.setColumns(5);
@@ -249,9 +238,7 @@ public class FmtNaming extends javax.swing.JPanel implements Runnable {
                     .addComponent(namingConventionsLabel)
                     .addGroup(layout.createSequentialGroup()
                         .addContainerGap()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(preferLongerNamesCheckBox)
-                            .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, 274, javax.swing.GroupLayout.PREFERRED_SIZE))))
+                        .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, 274, javax.swing.GroupLayout.PREFERRED_SIZE)))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
@@ -259,9 +246,7 @@ public class FmtNaming extends javax.swing.JPanel implements Runnable {
             .addGroup(layout.createSequentialGroup()
                 .addComponent(namingConventionsLabel)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(preferLongerNamesCheckBox)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, 144, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
@@ -277,7 +262,6 @@ public class FmtNaming extends javax.swing.JPanel implements Runnable {
     private javax.swing.JLabel parameterLabel;
     private javax.swing.JTextField parameterPrefixField;
     private javax.swing.JTextField parameterSuffixField;
-    private javax.swing.JCheckBox preferLongerNamesCheckBox;
     private javax.swing.JLabel prefixLabel;
     private javax.swing.JLabel staticFieldLabel;
     private javax.swing.JTextField staticFieldPrefixField;
@@ -297,6 +281,7 @@ public class FmtNaming extends javax.swing.JPanel implements Runnable {
                   new String[]{FmtOptions.blankLinesBeforeFields, "1"}); //NOI18N
         }
 
+        @Override
         protected void doModification(ResultIterator resultIterator) throws Exception {
             final CodeStyle codeStyle = codeStyleProducer.create(previewPrefs);
             WorkingCopy copy = WorkingCopy.get(resultIterator.getParserResult());
@@ -305,7 +290,7 @@ public class FmtNaming extends javax.swing.JPanel implements Runnable {
             GeneratorUtilities gu = GeneratorUtilities.get(copy);
             CompilationUnitTree cut = copy.getCompilationUnit();
             ClassTree ct = (ClassTree) cut.getTypeDecls().get(0);
-            List<Tree> members = new ArrayList<Tree>();
+            List<Tree> members = new ArrayList<>();
             String name = CodeStyleUtils.addPrefixSuffix("name",
                     codeStyle.getFieldNamePrefix(),
                     codeStyle.getFieldNameSuffix());


### PR DESCRIPTION
Naming panel should be set to its preferred size.

Allows the layout manager to compute its size properly,
esp when a non default font size is configured (e.g --fontsize 16)

fixes #6616

(also removes invisible and unused check box)

after (--fontsize 16 set; see issue for other screen shot):
![image](https://github.com/apache/netbeans/assets/114367/da616eee-48a6-43b3-908a-e2ef04c3806e)
