### PR TITLE
#6622: NPE check missing.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/customizer/BasicInfoPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/BasicInfoPanel.java
@@ -67,7 +67,7 @@ public class BasicInfoPanel extends javax.swing.JPanel implements DocumentListen
             NbMavenProjectImpl nbi = prj.getLookup().lookup(NbMavenProjectImpl.class);
             assert nbi != null;
             project = nbi.loadParentOf(EmbedderFactory.getProjectEmbedder(), handle.getProject());      
-            if (NbMavenProject.isErrorPlaceholder(project)) {
+            if (project != null && NbMavenProject.isErrorPlaceholder(project)) {
                 project = null;
             }
         } catch (ProjectBuildingException ex) {

--- a/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
@@ -523,7 +523,7 @@ public class MavenCommandLineExecutor extends AbstractMavenExecutor {
         if (config.getReactorStyle() != RunConfig.ReactorStyle.NONE) {
             File basedir = config.getExecutionDirectory();
             MavenProject mp = NbMavenProject.getPartialProject(config.getMavenProject());
-            File projdir = NbMavenProject.isErrorPlaceholder(mp) ? basedir : mp.getBasedir();
+            File projdir = mp == null || NbMavenProject.isErrorPlaceholder(mp) ? basedir : mp.getBasedir();
             String rel = basedir != null && projdir != null ? FileUtilities.relativizeFile(basedir, projdir) : null;
             if (!".".equals(rel)) {
                 toRet.add(config.getReactorStyle() == RunConfig.ReactorStyle.ALSO_MAKE ? "--also-make" : "--also-make-dependents");

--- a/java/maven/src/org/netbeans/modules/maven/nodes/AddDependencyPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/nodes/AddDependencyPanel.java
@@ -821,7 +821,7 @@ public class AddDependencyPanel extends javax.swing.JPanel {
             }
             try {
                 localProj = p.loadParentOf(EmbedderFactory.getProjectEmbedder(), localProj);
-                if (NbMavenProject.isErrorPlaceholder(localProj)) {
+                if (localProj == null || NbMavenProject.isErrorPlaceholder(localProj)) {
                     break;
                 }
             } catch (ProjectBuildingException x) {


### PR DESCRIPTION
Checked calls to `isErrorPlaceholder` for possible null refs. Fixes #6622 .