### PR TITLE
[NETBEANS-6599] Do not throw a CompletionFailure for empty java.lang package outside of java.base.

### DIFF
--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBClassFinder.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBClassFinder.java
@@ -24,6 +24,8 @@ import com.sun.tools.javac.code.Kinds.Kind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.Completer;
 import com.sun.tools.javac.code.Symbol.CompletionFailure;
+import com.sun.tools.javac.code.Symbol.PackageSymbol;
+import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.JCDiagnostic;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticInfo;
@@ -54,6 +56,7 @@ public class NBClassFinder extends ClassFinder {
 
     private final Context context;
     private final Names names;
+    private final Symtab syms;
     private final JCDiagnostic.Factory diagFactory;
     private final Log log;
 
@@ -61,6 +64,7 @@ public class NBClassFinder extends ClassFinder {
         super(context);
         this.context = context;
         this.names = Names.instance(context);
+        this.syms = Symtab.instance(context);
         this.diagFactory = JCDiagnostic.Factory.instance(context);
         this.log = Log.instance(context);
     }
@@ -95,6 +99,7 @@ public class NBClassFinder extends ClassFinder {
                     delegate.complete(sym);
                     if (sym.kind == Kind.PCK &&
                         sym.flatName() == names.java_lang &&
+                        ((PackageSymbol) sym).modle == syms.java_base &&
                         sym.members().isEmpty()) {
                         sym.flags_field |= Flags.EXISTS;
                         try {

--- a/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBClassFinderTest.java
+++ b/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBClassFinderTest.java
@@ -69,6 +69,15 @@ public class NBClassFinderTest extends NbTestCase {
         assertEquals(expectedErrors, actualErrors);
     }
 
+    public void testEmptyClassPath2() throws Exception {
+        String code = "package java.lang.nb.test; public class Test { String t(String s) { return s.toString(); } }";
+        List<String> expectedErrors;
+        expectedErrors = Arrays.asList("");
+        List<String> actualErrors;
+        actualErrors = compile(code, "-XDrawDiagnostics", "-XDide", "-Xlint:-options");
+        assertEquals(expectedErrors, actualErrors);
+    }
+
     private static class MyFileObject extends SimpleJavaFileObject {
         private String text;
 


### PR DESCRIPTION
`NBClassFinder` throws a customized `CompletionFailure` when empty `java.lang` is seen. This is to prevent hard `Abort` later in case there are no system classes. But, the exception is also thrown when the `java.lang` that is being completed is not in the `java.base` module, which leads to false positives. So, the proposal is to limit the CF to only cases where the package is from java.base.


closes #6599


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
