### PR TITLE
Assignments to parameters to record compact constructors should not be marked as unused.

### DIFF
--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnusedAssignmentOrBranchTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnusedAssignmentOrBranchTest.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.java.hints.bugs;
 
+import org.junit.Assume;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.hints.test.api.HintTest;
 
@@ -210,5 +211,31 @@ public class UnusedAssignmentOrBranchTest extends NbTestCase {
                        "}")
                 .run(UnusedAssignmentOrBranch.class)
                 .assertWarnings();
+    }
+
+    public void testRecordCompactConstructor() throws Exception {
+        Assume.assumeTrue(isRecordClassPresent());
+
+        HintTest
+                .create()
+                .input("package test;\n" +
+                       "\n" +
+                       "public record Test(int i, int j) {\n" +
+                       "    public Test {\n" +
+                       "        i = -i;\n" +
+                       "    }\n" +
+                       "}")
+                .sourceLevel("21")
+                .run(UnusedAssignmentOrBranch.class)
+                .assertWarnings();
+    }
+
+    private boolean isRecordClassPresent() {
+        try {
+            Class.forName("java.lang.Record");
+            return true;
+        } catch (ClassNotFoundException ex) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
The parameters (and hence the assigned values) are implicitly used at the end of the compact constructors.

Please see:
https://github.com/oracle/javavscode/issues/53

---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
