### PR TITLE
Navigate to Scala classes in Analyze Stack Window

### DIFF
--- a/java/java.navigation/test/unit/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyserTest.java
+++ b/java/java.navigation/test/unit/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyserTest.java
@@ -51,6 +51,15 @@ public class StackLineAnalyserTest extends NbTestCase {
     }
 
     @Test
+    public void testMatchesScalaLines() throws Exception {
+        assertTrue(StackLineAnalyser.matches("at org.enso.compiler.core.ir.MetadataStorage.$anonfun$getUnsafe$1(MetadataStorage.scala:80)"));
+        StackLineAnalyser.Link l = StackLineAnalyser.analyse("at org.enso.compiler.core.ir.MetadataStorage.$anonfun$getUnsafe$1(MetadataStorage.scala:80)");
+        assertEquals(3, l.getStartOffset());
+        assertEquals(91, l.getEndOffset());
+        assertEquals(".scala", l.getExtension());
+    }
+
+    @Test
     public void testModuleStackTraceMatches() throws Exception {
         assertTrue(StackLineAnalyser.matches("at library.Library.init(Utilities/Library.java:24)"));
         assertTrue(StackLineAnalyser.matches("at library.Library.init(org.netbeans.api.Utilities/Library.java:24)"));


### PR DESCRIPTION
Code base of [my project](http://github.com/enso-org/enso) is full of Scala classes. While analyzing stacktraces with _Analyze Stack Window_ I'd like to jump not only to Java classes, but also to sources coming from other languages like Scala.

With this PR I can do that:

![Scala in Analyze Stack Window](https://github.com/apache/netbeans/assets/1842422/a5734dcd-6bf4-44df-abd9-bda306fd49d2)
 
Btw. to reproduce the same picture one needs [Enso 4 NetBeans plugin](https://github.com/enso-org/enso/blob/develop/tools/enso4igv/IGV.md). Tested on revision [3d23c6a8d](https://github.com/enso-org/enso/commit/3d23c6a8d0741c37af736df0c3e002cc4b58edd9).