### PR TITLE
[NETBEANS-6638]: Avoid adding a space after opening curly brace.

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/editor/java/TypingCompletion.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/TypingCompletion.java
@@ -168,8 +168,10 @@ class TypingCompletion {
             return;
         }
 
+        char insChr = context.getText().charAt(0);
+
         if (isString(currentToken)) {
-            if (context.getOffset() >= 1 && context.getText().charAt(0) == '{') {
+            if (context.getOffset() >= 1 && insChr == '{') {
                 char chr = context.getDocument().getText(context.getOffset() - 1, 1).charAt(0);
 
                 if (chr == '\\') {
@@ -180,10 +182,14 @@ class TypingCompletion {
             return ;
         }
 
+        if (insChr == '{') {
+            //curly brace should only be matched in string templates:
+            return ;
+        }
+
         char chr = context.getDocument().getText(context.getOffset(), 1).charAt(0);
 
         if (chr == ')' || chr == ',' || chr == '\"' || chr == '\'' || chr == ' ' || chr == ']' || chr == '}' || chr == '\n' || chr == '\t' || chr == ';') {
-            char insChr = context.getText().charAt(0);
             context.setText("" + insChr + matching(insChr), 1);  // NOI18N
         }
     }

--- a/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/TypingCompletionUnitTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/TypingCompletionUnitTest.java
@@ -1413,6 +1413,12 @@ public void testPositionInTextBlock() throws Exception {
         ctx.assertDocumentTextEquals("\"\\{}|\"");
     }
 
+    public void testX() throws Exception {
+        Context ctx = new Context(new JavaKit(), "");
+        ctx.typeChar('{');
+        ctx.assertDocumentTextEquals("{");
+    }
+
     private boolean isInsideString(String code) throws BadLocationException {
         int pos = code.indexOf('|');
 


### PR DESCRIPTION
Fix for:
https://github.com/apache/netbeans/issues/6638

When I was adding the support for String templates, I had to add call to typing completion for '{' to JavaKit:
https://github.com/apache/netbeans/blob/4a89c2b57ad9d51a613978f33767e7781bc138db/java/java.editor/src/org/netbeans/modules/editor/java/JavaKit.java#L564

I checked this condition:
https://github.com/apache/netbeans/blob/4a89c2b57ad9d51a613978f33767e7781bc138db/java/java.editor/src/org/netbeans/modules/editor/java/TypingCompletion.java#L185

and it seemed that calling the method for '{' should not change the meaning. But, I didn't realize the `chr` is not the character-to-be-inserted, but rather whatever is at the insertion offset (before insertion of the new character). And then it might go through to the then section of this if, adding a matching char - but the matching char for '{' is not known to typing completion, so it uses a space.

The proposal is to only match curly braces inside String templates, ignoring all other cases. Matching curly braces for String templates is fairly important, as not doing that typically causes large portions of the file to be miss lexed and miss parsed.

(Note the matching closing curly brace in ordinary code is normally added when a newline is inserted, not when the opening curly brace is pressed.)

closes #6638 