### PR TITLE
Fix for outline tab not loading in case package-info.java file is present in the workspace in vscode

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
@@ -65,10 +65,13 @@ public class JavaStructureProvider implements StructureProvider {
                         TreePath tp = trees.getPath(cu, cu.getPackage());
                         Element el = trees.getElement(tp);
                         if (el != null && el.getKind() == ElementKind.PACKAGE) {
-                            StructureElement jse = element2StructureElement(cc, el);
-                            if (jse != null) {
-                                result.add(jse);
-                            }
+                            Builder builder = StructureProvider.newBuilder(el.getSimpleName().toString(), ElementHeaders.javaKind2Structure(el));
+                            int start = (int) cc.getTrees().getSourcePositions().getStartPosition(cu, cu.getPackage());
+                            int end = (int) cc.getTrees().getSourcePositions().getEndPosition(cu, cu.getPackage());
+
+                            builder.expandedStartOffset(start).selectionStartOffset(start);
+                            builder.expandedEndOffset(end).selectionEndOffset(end);
+                            result.add(builder.build());
                         }
                     }
                     for (Element tel : cc.getTopLevelElements()) {


### PR DESCRIPTION
Package range was not being calculated in the object sent to the client from the server due to that error was thrown in the client of `undefined` range.

Please see:
https://github.com/oracle/javavscode/issues/23

After fix:
![outline_var2](https://github.com/apache/netbeans/assets/55803675/977b45ac-765a-43c8-b8c9-df1ea128d8ba)

---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
