### PR TITLE
PHP: Fix autocomplete for exception class when adding exception breakpoint.

### DIFF
--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/ui/completion/ExceptionCompletionItem.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/ui/completion/ExceptionCompletionItem.java
@@ -155,7 +155,7 @@ public class ExceptionCompletionItem implements CompletionItem {
 
     @Override
     public CharSequence getSortText() {
-        return getName();
+        return element.getName();
     }
 
     @Override
@@ -164,7 +164,7 @@ public class ExceptionCompletionItem implements CompletionItem {
     }
 
     public String getName() {
-        return element.getName();
+        return element.getNamespaceName().append(element.getName()).toString();
     }
 
     public static class Builtin extends ExceptionCompletionItem {
@@ -199,6 +199,11 @@ public class ExceptionCompletionItem implements CompletionItem {
         @Override
         public int getSortPriority() {
             return -1;
+        }
+
+        @Override
+        public CharSequence getSortText() {
+            return this.element;
         }
 
         @Override


### PR DESCRIPTION
A qualified exception class name is required for the exception breakpoint to work correctly. The current implementation of autocomplete completes an unqualified exception class name.

Before:

https://github.com/apache/netbeans/assets/9607501/ccc198b2-eeb1-4bc6-a8e0-70d7f02cb402


After:

https://github.com/apache/netbeans/assets/9607501/77a69820-a73f-4cb5-ab41-7ce6815de711



