### PR TITLE
Drop horizontal scroll mouse button events on Linux

### DIFF
--- a/ide/editor/src/org/netbeans/modules/editor/resources/NetBeans-keybindings.xml
+++ b/ide/editor/src/org/netbeans/modules/editor/resources/NetBeans-keybindings.xml
@@ -97,11 +97,9 @@
     <bind actionName="jump-list-next" key="O-RIGHT"/>
     <bind actionName="jump-list-next" key="O-KP_RIGHT"/>
     <bind actionName="jump-list-next" key="MOUSE_BUTTON5"/>
-    <bind actionName="jump-list-next" key="MOUSE_BUTTON7"/>
     <bind actionName="jump-list-prev" key="O-LEFT"/>
     <bind actionName="jump-list-prev" key="O-KP_LEFT"/>
     <bind actionName="jump-list-prev" key="MOUSE_BUTTON4"/>
-    <bind actionName="jump-list-prev" key="MOUSE_BUTTON6"/>
     <bind actionName="page-down" key="PAGE_DOWN"/>
     <bind actionName="page-up" key="PAGE_UP"/>
     <bind actionName="paste-formated" key="DS-V"/>

--- a/platform/core.windows/src/org/netbeans/core/windows/ShortcutAndMenuKeyEventProcessor.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/ShortcutAndMenuKeyEventProcessor.java
@@ -318,11 +318,20 @@ final class ShortcutAndMenuKeyEventProcessor implements KeyEventDispatcher, KeyE
                 || mev.isConsumed()) {
             return;
         }
+        int button = mev.getButton();
+        if (Utilities.getOperatingSystem() == Utilities.OS_LINUX) {
+            // the JDK drops buttons for vertical scroll
+            // drop buttons for horizontal scroll here.
+            button -= 2;
+            if (button <= 3) {
+                return;
+            }
+        }
         //ignore when the IDE is shutting down
         if (NbLifecycleManager.isExiting()) {
             return;
         }
-        int keycode = Utilities.mouseButtonKeyCode(mev.getButton());
+        int keycode = Utilities.mouseButtonKeyCode(button);
         if (keycode == KeyEvent.VK_UNDEFINED) {
             return;
         }

--- a/platform/openide.util.ui/src/org/openide/util/Utilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/Utilities.java
@@ -842,7 +842,13 @@ public final class Utilities {
      * {@link KeyEvent#VK_UNDEFINED} if not available.
      * <p>
      * Implementation note : only extended mouse buttons in the range BUTTON4 to
-     * BUTTON9 are currently mapped to keycodes.
+     * BUTTON9 are currently mapped to keycodes. The caller may pass in values
+     * that best reflect the desired mouse button rather than the actual value
+     * from the OS or MouseEvent. eg. on Linux, the JDK excludes X button values
+     * for vertical scrolling when generating the range of buttons, and the
+     * default NetBeans window system further excludes the horizontal scroll
+     * button values - button 4 passed in here might be JDK button 6 and X event
+     * button 8.
      *
      * @param button mouse button
      * @return keycode if defined


### PR DESCRIPTION
Drop horizontal scroll mouse button events on Linux to fix issues reported with trackpads triggering code navigation.  The JDK already drops the X event button number by 2 to skip vertical scroll.  This skips the horizontal scroll button values and drops the value another 2 before passing to the keymap, which should also bring Linux in line with other OS button values.

This is an alternative to #6636 

Added a build for easier testing.  Ideally we should check that Windows and macOS don't need the button 6&7 mappings anywhere.