### PR TITLE
[NETBEANS-5659] Collection.forEach is always a read from the collection.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unbalanced.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unbalanced.java
@@ -199,8 +199,10 @@ public class Unbalanced {
         private static final Set<String> READ_METHODS = new HashSet<>(Arrays.asList(
                 "get", "getOrDefault", "contains", "remove", "containsAll", "removeAll", "removeIf", "retain", "retainAll", "containsKey",
                 "containsValue", "iterator", "listIterator", "isEmpty", "size", "toArray", "entrySet", "keySet", "values", "indexOf", "lastIndexOf",
-                "stream", "parallelStream", "spliterator", "forEach"));
-        private static final Set<String> WRITE_METHODS = new HashSet<>(Arrays.asList("add", "addAll", "set", "put", "putAll", "putIfAbsent"));
+                "stream", "parallelStream", "spliterator", "reversed", "getFirst", "getLast", "removeFirst", "removeLast"));
+        private static final Set<String> STANDALONE_READ_METHODS = new HashSet<>(Arrays.asList(
+                "forEach"));
+        private static final Set<String> WRITE_METHODS = new HashSet<>(Arrays.asList("add", "addAll", "set", "put", "putAll", "putIfAbsent", "addFirst", "addLast"));
 
         private static boolean testType(CompilationInfo info, TypeMirror actualType, String superClass) {
             TypeElement juCollection = info.getElements().getTypeElement(superClass);
@@ -243,6 +245,9 @@ public class Unbalanced {
                     if (tp.getParentPath().getParentPath().getParentPath().getLeaf().getKind() != Kind.EXPRESSION_STATEMENT) {
                         record(ctx.getInfo(), var, State.READ);
                     }
+                    return null;
+                } else if (STANDALONE_READ_METHODS.contains(methodName)) {
+                    record(ctx.getInfo(), var, State.READ);
                     return null;
                 } else if (WRITE_METHODS.contains(methodName)) {
                     if (tp.getParentPath().getParentPath().getParentPath().getLeaf().getKind() != Kind.EXPRESSION_STATEMENT) {

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnbalancedTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnbalancedTest.java
@@ -527,4 +527,53 @@ com.sun.tools.javac.tree.JCTree$JCCompilationUnit@1b5a415
                 .run(Unbalanced.Collection.class)
                 .assertWarnings();
     }
+
+    public void testListForEach() throws Exception {
+        HintTest
+                .create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void t() {\n" +
+                       "        java.util.List<String> coll = new java.util.ArrayList<String>();\n" +
+                       "        coll.add(\"\");\n" +
+                       "        coll.forEach(e -> {});\n" +
+                       "    }\n" +
+                       "}\n")
+                .run(Unbalanced.Collection.class)
+                .assertWarnings();
+    }
+
+    public void testSequencedCollection1() throws Exception {
+        HintTest
+                .create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void t() {\n" +
+                       "        java.util.List<String> coll = new java.util.ArrayList<String>();\n" +
+                       "        coll.addFirst(\"\");\n" +
+                       "        coll.addLast(\"\");\n" +
+                       "    }\n" +
+                       "}\n", false)
+                .run(Unbalanced.Collection.class)
+                .assertWarnings("3:31-3:35:verifier:ERR_UnbalancedCollectionWRITE coll");
+    }
+
+    public void testSequencedCollection2() throws Exception {
+        HintTest
+                .create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void t() {\n" +
+                       "        java.util.List<String> coll = new java.util.ArrayList<String>();\n" +
+                       "        Object sink;\n" +
+                       "        sink = coll.reversed();\n" +
+                       "        sink = coll.getFirst();\n" +
+                       "        sink = coll.getLast();\n" +
+                       "        sink = coll.removeFirst();\n" +
+                       "        sink = coll.removeLast();\n" +
+                       "    }\n" +
+                       "}\n", false)
+                .run(Unbalanced.Collection.class)
+                .assertWarnings("3:31-3:35:verifier:ERR_UnbalancedCollectionREAD coll");
+    }
 }


### PR DESCRIPTION
Having code like:

```
List<String> l = new ArrayList<>();
l.add("");
l.forEach(e -> {});
```

will mark the List as unbalanced - only written to, never read. The hint lists the `forEach` method in the list of read methods, but for (ordinary) read methods, the hint also requires the return value of the read method to be used. `forEach` is a bit different in this regard, it runs the lambda for the elements, but does not return anything.

This PR introduces a new `STANDALONE_READ_METHODS`, which do not require their return value to be used.

It also adds the JEP 431: Sequenced Collections from JDK 21 method names.

Filling with NB20 and against `delivery`, but no strong opinions on this. I am fine with moving this to `master`/NB21.