### PR TITLE
Avoiding crash during indexing when a record has a component with a wrong name.

### DIFF
--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -2297,6 +2297,51 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
         assertEquals(expected, file2Fixed);
     }
 
+    public void testWrongRecordComponent() throws Exception {
+        setSourceLevel("17");
+
+        Map<String, String> file2Fixed = new HashMap<>();
+        VanillaCompileWorker.fixedListener = (file, cut) -> {
+            try {
+                FileObject source = URLMapper.findFileObject(file.toUri().toURL());
+                file2Fixed.put(FileUtil.getRelativePath(getRoot(), source), cut.toString());
+            } catch (MalformedURLException ex) {
+                throw new IllegalStateException(ex);
+            }
+        };
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test.java",
+                                                                      "package test;\n" +
+                                                                      "public record Test(int wait) {\n" +
+                                                                      "}\n")),
+                                           Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
+                     createdFiles);
+        Map<String, String> expected = Collections.singletonMap("test/Test.java",
+                "package test;\n" +
+                "\n" +
+                "public class Test {\n" +
+                "    static {\n" +
+                "        throw new java.lang.RuntimeException(\"Uncompilable code - compiler.err.illegal.record.component.name\");\n" +
+                "    }\n" +
+                "    \n" +
+                "    public Test(int wait) {\n" +
+                "        super();\n" +
+                "    }\n" +
+                "    private final int wait;\n" +
+                "}");
+        assertEquals(expected, file2Fixed);
+    }
+
     public static void noop() {}
 
     @Override


### PR DESCRIPTION
Considering code like:
```
record R(int wait) {}
```

This produces an error, as `wait` is not a valid record component name. And it will leave a `Symbol.RecordComponent.accessor` empty. Which probably is OK in the front-end, but the back end expects this to be filled. As a consequence, the indexing crashes with an exception:
https://github.com/oracle/javavscode/issues/52

Generally, in `VanillaCompileWorker.dropMethodsAndErrors` we try to fix erroneous ASTs, so that classfiles/sig files can be generated for them. In this case, my proposal is to fill the `accessor` field with a dummy value - `Lower` will see is as a user-provided accessor, and do nothing. The test shows how the resulting classfile will look like (including making it unloadable).
