### PR TITLE
Enable JUnit output processing for failsafe:integration-test

### DIFF
--- a/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputProcessorFactory.java
+++ b/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputProcessorFactory.java
@@ -48,8 +48,9 @@ public class JUnitOutputProcessorFactory implements ContextOutputProcessorFactor
         if (config.getGoals().contains("test") //NOI18N
             || config.getGoals().contains("integration-test") //NOI18N
             || config.getGoals().contains("surefire:test") //NOI81N
+            || config.getGoals().contains("failsafe:integration-test") //NOI18N
             || config.getGoals().contains("verify")) { //NOI18N
-            Set<OutputProcessor> toReturn = new HashSet<OutputProcessor>();
+            Set<OutputProcessor> toReturn = new HashSet<>();
             if (project != null) {
                 toReturn.add(new JUnitOutputListenerProvider(config));
             }


### PR DESCRIPTION
This is a partial quick fix for showing the test output window when the Maven goals include `failsafe:integration-test`, as in the default mapping introduced in #4096 

This is possibly a fix for #6448 

While testing this I noticed that we're not calling `post-integration-test` in the default mapping, which we should probably do.  Adding that however shows another empty unit test output.  The output test result listeners probably needs some adaptation here, and possibly shouldn't open when all tests are skipped or there are none?  That is all left for NB21!