### PR TITLE
Improve error message for failure to connect to a DB

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBAddConnection.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBAddConnection.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
@@ -70,7 +72,7 @@ import org.openide.util.lookup.ServiceProvider;
     "MSG_SelectDriver=Select db driver",
     "MSG_DriverNotFound=Driver not found",
     "MSG_ConnectionAdded=Connection added",
-    "MSG_ConnectionFailed=Connection failed",
+    "MSG_ConnectionFailed=Could not connect to the database \"{0}\", user {1}:\n{2}",
     "MSG_SelectSchema=Select Database Schema"
 })
 @ServiceProvider(service = CodeActionsProvider.class)
@@ -83,6 +85,7 @@ public class DBAddConnection extends CodeActionsProvider {
     public static final String SCHEMA =  "schema"; // NOI18N
     public static final String DISPLAY_NAME =  "displayName"; // NOI18N
 
+    private static final Logger LOG = Logger.getLogger(DBAddConnection.class.getName());
     private static final Map<String, String> urlTemplates = new HashMap<> ();
     static {
         urlTemplates.put("org.postgresql.Driver", "jdbc:postgresql://<HOST>:5432/<DB>");
@@ -138,6 +141,7 @@ public class DBAddConnection extends CodeActionsProvider {
                                 ConnectionManager.getDefault().addConnection(dbconn);
                                 client.showMessage(new MessageParams(MessageType.Info, Bundle.MSG_ConnectionAdded()));
                             } catch (DatabaseException ex) {
+                                LOG.log(Level.INFO, "Add connection", ex);
                                 client.showMessage(new MessageParams(MessageType.Error, ex.getMessage()));
                             }
                         });
@@ -147,6 +151,7 @@ public class DBAddConnection extends CodeActionsProvider {
                             ConnectionManager.getDefault().addConnection(dbconn);
                             client.showMessage(new MessageParams(MessageType.Info, Bundle.MSG_ConnectionAdded()));
                         } catch (DatabaseException ex) {
+                            LOG.log(Level.INFO, "Add connection with schema", ex);
                             client.showMessage(new MessageParams(MessageType.Error, ex.getMessage()));
                         }
                     }
@@ -245,8 +250,20 @@ public class DBAddConnection extends CodeActionsProvider {
                                     ConnectionManager.getDefault().addConnection(dbconn);
                                     schemas.addAll(getSchemas(dbconn));
                                     failed = false;
-                                } catch(DatabaseException | SQLException ex) {
+                                } catch(SQLException ex) {
+                                    LOG.log(Level.INFO, "vaildate", ex);
                                     return CompletableFuture.completedFuture(ex.getMessage());
+                                } catch (DatabaseException ex) {
+                                    String message;
+                                    Throwable cause = ex.getCause();
+                                    if (cause == null) cause = ex;
+                                    if (cause.getCause() != null) {
+                                        message = Bundle.MSG_ConnectionFailed(urlData.getRight(), userData.getRight(), cause.getCause().getMessage());
+                                    } else {
+                                        message = cause.getMessage();
+                                    }
+                                    LOG.log(Level.INFO, "validate", ex);
+                                    return CompletableFuture.completedFuture(message);
                                 } finally {
                                     try {
                                         if (failed || !schemas.isEmpty()) {
@@ -273,10 +290,11 @@ public class DBAddConnection extends CodeActionsProvider {
                     DatabaseConnection dbconn = DatabaseConnection.create(driver, urlData.getRight(), userData.getRight(), schema, passwordData.getRight(), true);
                     try {
                         ConnectionManager.getDefault().addConnection(dbconn);
+                        client.showMessage(new MessageParams(MessageType.Info, Bundle.MSG_ConnectionAdded()));
                     } catch (DatabaseException ex) {
+                        LOG.log(Level.INFO, "add", ex);
                         client.showMessage(new MessageParams(MessageType.Error, ex.getMessage()));
                     }
-                    client.showMessage(new MessageParams(MessageType.Info, Bundle.MSG_ConnectionAdded()));
                 }
                 return null;
             });


### PR DESCRIPTION
When adding a new DB connection within VS Code, using our database tab in the explorer, if you enter a non-existent DB you get an error message that could be improved. 
It is now updated to something more friendly, as:
"Could not connect to the specified database: <Database connection URL>". The error message from exception is on the next line.

All exceptions from database connection are now logged.
