### PR TITLE
ConvertToLambda hint should ignore default methods.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambda.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambda.java
@@ -21,7 +21,6 @@
  */
 package org.netbeans.modules.java.hints.jdk;
 
-import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
@@ -29,7 +28,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import javax.tools.Diagnostic;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.JavaSource.Phase;
 import org.netbeans.api.java.source.WorkingCopy;
@@ -56,7 +54,7 @@ import org.openide.util.NbBundle;
 public class ConvertToLambda {
 
     public static final String ID = "Javac_canUseLambda"; //NOI18N
-    public static final Set<String> CODES = new HashSet<String>(Arrays.asList("compiler.warn.potential.lambda.found")); //NOI18N
+    public static final Set<String> CODES = new HashSet<>(Arrays.asList("compiler.warn.potential.lambda.found")); //NOI18N
 
     static final boolean DEF_PREFER_MEMBER_REFERENCES = true;
 
@@ -68,7 +66,6 @@ public class ConvertToLambda {
     })
     @NbBundle.Messages("MSG_AnonymousConvertibleToLambda=This anonymous inner class creation can be turned into a lambda expression.")
     public static ErrorDescription computeAnnonymousToLambda(HintContext ctx) {
-        ClassTree clazz = ((NewClassTree) ctx.getPath().getLeaf()).getClassBody();
         ConvertToLambdaPreconditionChecker preconditionChecker =
                 new ConvertToLambdaPreconditionChecker(ctx.getPath(), ctx.getInfo());
         if (!preconditionChecker.passesFatalPreconditions()) {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambdaConverter.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToLambdaConverter.java
@@ -21,7 +21,6 @@
  */
 package org.netbeans.modules.java.hints.jdk;
 
-import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
@@ -48,9 +47,7 @@ import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.ReturnTree;
 import java.util.List;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
-import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.TreeMaker;
 import org.netbeans.api.java.source.WorkingCopy;
 import org.netbeans.api.java.source.matching.Matcher;


### PR DESCRIPTION
Default methods don't qualify for functional interfaces since they are not abstract and can therefore not be converted into lambdas.

The hint has to go through the interface hierarchy and check if the implemented method was a `default` method.

example:
    
```java
    private interface NotFunctional1 {
        default void a(int i) {};
    }
    
    // can't be converted to lambda
    NotFunctional1 nf = new NotFunctional1() { 
        @Override
        public void a(int i) {
        }
    };
```
real world example: `com.sun.source.util.TaskListener`