### PR TITLE
Terminal, Output and Syntax Coloring options UI cleanup.

### DIFF
--- a/ide/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/TermOptionsPanel.form
+++ b/ide/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/TermOptionsPanel.form
@@ -84,8 +84,8 @@
     </Component>
     <Component class="javax.swing.JTextField" name="fontText">
       <Properties>
-        <Property name="columns" type="int" value="20"/>
         <Property name="editable" type="boolean" value="false"/>
+        <Property name="columns" type="int" value="20"/>
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">

--- a/ide/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/TermOptionsPanel.java
+++ b/ide/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/TermOptionsPanel.java
@@ -28,6 +28,8 @@ import javax.swing.border.Border;
 import org.netbeans.lib.terminalemulator.LineDiscipline;
 import org.netbeans.lib.terminalemulator.Term;
 
+// TODO seems to be the older copy of ide/terminal.nb/src/org/netbeans/modules/terminal/nb/TermOptionsPanel.java
+// public via friend dependencies.
 public final class TermOptionsPanel extends javax.swing.JPanel {
 
     private TermOptions termOptions;

--- a/ide/options.editor/src/org/netbeans/modules/options/colors/SyntaxColoringPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/colors/SyntaxColoringPanel.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.options.colors;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dialog;
 import java.awt.EventQueue;
 import java.awt.Font;
 import java.awt.Insets;
@@ -51,7 +52,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.ListSelectionModel;
 import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
@@ -89,12 +89,10 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     private String              currentLanguage;
     private String              currentProfile;
     /** cache Map (String (profile name) > Map (String (language name) > List (AttributeSet))). */
-    private Map<String, Map<String, List<AttributeSet>>>
-                                profiles = new HashMap<String, Map<String, List<AttributeSet>>>();
+    private Map<String, Map<String, List<AttributeSet>>> profiles = new HashMap<>();
     /** Map (String (profile name) > Set (String (language name))) of names of changed languages. */
-    private Map<String, Set<String>>
-                                toBeSaved = new HashMap<String, Set<String>>();
-    private boolean             listen = false;
+    private Map<String, Set<String>> toBeSaved = new HashMap<>();
+    private boolean listen = false;
     private boolean changed = false;
     private static Logger log = Logger.getLogger(SyntaxColoringPanel.class.getName ());
 
@@ -122,12 +120,9 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
         lCategories.setSelectionMode (ListSelectionModel.SINGLE_SELECTION);
         lCategories.setVisibleRowCount (3);
         lCategories.setCellRenderer (new CategoryRenderer ());
-        lCategories.addListSelectionListener (new ListSelectionListener () {
-            @Override
-            public void valueChanged (ListSelectionEvent e) {
-                if (!listen) return;
-                selectTask.schedule (200);
-            }
+        lCategories.addListSelectionListener ((ListSelectionEvent e) -> {
+            if (!listen) return;
+            selectTask.schedule (200);
         });
         lCategories.setSelectedIndex(0);
         tfFont.setEditable (false);
@@ -197,7 +192,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
         lLanguage = new javax.swing.JLabel();
         lCategory = new javax.swing.JLabel();
         spCategories = new javax.swing.JScrollPane();
-        lCategories = new javax.swing.JList<AttributeSet>();
+        lCategories = new javax.swing.JList<>();
         lPreview = new javax.swing.JLabel();
         spPreview = new javax.swing.JScrollPane();
         pPreview = new javax.swing.JPanel();
@@ -208,7 +203,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
         lEffectColor = new javax.swing.JLabel();
         cbForeground = new org.openide.awt.ColorComboBox();
         cbBackground = new ColorComboBox();
-        cbEffects = new javax.swing.JComboBox<String>();
+        cbEffects = new javax.swing.JComboBox<>();
         cbEffectColor = new ColorComboBox();
         tfFont = new javax.swing.JTextField();
         bFont = new javax.swing.JButton();
@@ -332,7 +327,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     private javax.swing.JComboBox cbEffectColor;
     private javax.swing.JComboBox<String> cbEffects;
     private javax.swing.JComboBox cbForeground;
-    private final javax.swing.JComboBox<String> cbLanguage = new javax.swing.JComboBox<String>();
+    private final javax.swing.JComboBox<String> cbLanguage = new javax.swing.JComboBox<>();
     private javax.swing.JLabel lBackground;
     private javax.swing.JList<AttributeSet> lCategories;
     private javax.swing.JLabel lCategory;
@@ -360,11 +355,9 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
             }
 	    cbEffectColor.setEnabled (cbEffects.getSelectedIndex () > 0);
             updateData ();
-	} else
-	if (evt.getSource () == cbLanguage) {
+	} else if (evt.getSource () == cbLanguage) {
             updateLanguageCombobox();
-	} else
-        if (evt.getSource () == bFont) {
+	} else if (evt.getSource () == bFont) {
             PropertyEditor pe = PropertyEditorManager.findEditor (Font.class);
             AttributeSet category = getCurrentCategory ();
             if (category == null) {
@@ -381,15 +374,16 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
                 loc ("CTL_Font_Inherited"),                          // NOI18N
                 DialogDescriptor.CANCEL_OPTION
             });
-            DialogDisplayer.getDefault ().createDialog (dd).setVisible (true);
+            Dialog dialog = DialogDisplayer.getDefault().createDialog(dd);
+            dialog.setSize(460, 380);
+            dialog.setVisible (true);
             if (dd.getValue () == DialogDescriptor.OK_OPTION) {
                 f = (Font) pe.getValue ();
                 category = modifyFont (category, f);
                 replaceCurrrentCategory (category);
                 setToBeSaved (currentProfile, currentLanguage);
                 refreshUI (); // refresh font viewer
-            } else
-            if (dd.getValue ().equals (loc ("CTL_Font_Inherited"))) {
+            } else if (dd.getValue ().equals (loc ("CTL_Font_Inherited"))) {
                 String fontName = (String) getDefault (currentLanguage, category, StyleConstants.FontFamily);
                 int style = 0;
                 if (Boolean.TRUE.equals(getDefault (currentLanguage, category, StyleConstants.Bold))) {
@@ -407,8 +401,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
                 setToBeSaved (currentProfile, currentLanguage);
                 refreshUI (); // refresh font viewer
             }
-        } else
-        if (evt.getSource () instanceof JComboBox) {
+        } else if (evt.getSource () instanceof JComboBox) {
             updateData ();
         }
         fireChanged();
@@ -446,13 +439,13 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
 
         @Override
         public void run() {
-            final List<String> languages = new ArrayList<String>(colorModel.getLanguages());
+            final List<String> languages = new ArrayList<>(colorModel.getLanguages());
             EventQueue.invokeLater(new Runnable() {
 
                 @Override
                 public void run() {
                     languages.remove("text/x-all-languages");
-                    Collections.sort(languages, new LanguagesComparator());
+                    languages.sort(new LanguagesComparator());
                     Iterator<String> it = languages.iterator();
                     synchronized (cbLanguage) {
                         Object lastLanguage = cbLanguage.getSelectedItem();
@@ -495,8 +488,8 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     
     @Override
     public void cancel () {
-        toBeSaved = new HashMap<String, Set<String>>();
-        profiles = new HashMap<String, Map<String, List<AttributeSet>>>();
+        toBeSaved = new HashMap<>();
+        profiles = new HashMap<>();
         changed = false;
     }
     
@@ -515,8 +508,8 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
                 );
             }
         }
-        toBeSaved = new HashMap<String, Set<String>>();
-        profiles = new HashMap<String, Map<String, List<AttributeSet>>>();
+        toBeSaved = new HashMap<>();
+        profiles = new HashMap<>();
         changed = false;
     }
     
@@ -529,12 +522,11 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     public void setCurrentProfile (String currentProfile) {
         String oldProfile = this.currentProfile;
         this.currentProfile = currentProfile;
-        if (!colorModel.getProfiles ().contains (currentProfile) && 
-            !profiles.containsKey (currentProfile)
-        )
-            cloneScheme (oldProfile, currentProfile);
+        if (!colorModel.getProfiles().contains(currentProfile) && !profiles.containsKey(currentProfile)) {
+            cloneScheme(oldProfile, currentProfile);
+        }
         List<AttributeSet> categories = getCategories (currentProfile, currentLanguage);
-        lCategories.setListData (categories.toArray(new AttributeSet[categories.size()]));
+        lCategories.setListData (categories.toArray(new AttributeSet[0]));
         blink = false;
         lCategories.setSelectedIndex (0);
         blink = true;
@@ -544,7 +536,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
 
     @Override
     public void deleteProfile (String profile) {
-        Map<String, List<AttributeSet>> m = new HashMap<String, List<AttributeSet>> ();
+        Map<String, List<AttributeSet>> m = new HashMap<> ();
         boolean custom = colorModel.isCustomProfile (profile);
         for (String language : colorModel.getLanguages ()) {
             if (custom) {
@@ -554,7 +546,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
             }
         }
         profiles.put (profile, m);
-        toBeSaved.put (profile, new HashSet<String> (colorModel.getLanguages ()));
+        toBeSaved.put (profile, new HashSet<> (colorModel.getLanguages ()));
         if (!custom) {
             refreshUI ();
         }
@@ -569,16 +561,14 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     // other methods ...........................................................
     
     private void cloneScheme(String oldScheme, String newScheme) {
-        Map<String, List<AttributeSet>> m = new HashMap<String, List<AttributeSet>>();
+        Map<String, List<AttributeSet>> m = new HashMap<>();
         for(String language : colorModel.getLanguages()) {
             List<AttributeSet> v = getCategories(oldScheme, language);
-            List<AttributeSet> newV = new ArrayList<AttributeSet> ();
-            Iterator<AttributeSet> it = v.iterator ();
-            while (it.hasNext ()) {
-                AttributeSet attributeSet = it.next ();
+            List<AttributeSet> newV = new ArrayList<>();
+            for (AttributeSet attributeSet : v) {
                 newV.add(new SimpleAttributeSet (attributeSet));
             }
-            m.put(language, new ArrayList<AttributeSet>(newV));
+            m.put(language, newV);
             setToBeSaved(newScheme, language);
         }
         profiles.put(newScheme, m);
@@ -600,7 +590,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
         
         // setup categories list
         blink = false;
-        lCategories.setListData (getCategories (currentProfile, currentLanguage).toArray(new AttributeSet[]{}));
+        lCategories.setListData (getCategories (currentProfile, currentLanguage).toArray(new AttributeSet[0]));
         lCategories.setSelectedIndex (0);
         blink = true;
         refreshUI ();
@@ -725,7 +715,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     
     private Collection<AttributeSet> invertCategory (Collection<AttributeSet> c, AttributeSet category) {
         if (category == null) return c;
-        ArrayList<AttributeSet> result = new ArrayList<AttributeSet> (c);
+        ArrayList<AttributeSet> result = new ArrayList<> (c);
         int i = result.indexOf (category);
         SimpleAttributeSet as = new SimpleAttributeSet (category);
         Color highlight = (Color) getValue (currentLanguage, category, StyleConstants.Background);
@@ -788,28 +778,23 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
             cbEffects.setSelectedIndex (1);
             cbEffectColor.setEnabled (true);
             ((ColorComboBox)cbEffectColor).setSelectedColor((Color) category.getAttribute (StyleConstants.Underline));
-        } else
-        if (category.getAttribute (EditorStyleConstants.WaveUnderlineColor) != null) {
+        } else if (category.getAttribute (EditorStyleConstants.WaveUnderlineColor) != null) {
             cbEffects.setSelectedIndex (2);
             cbEffectColor.setEnabled (true);
             ((ColorComboBox)cbEffectColor).setSelectedColor((Color) category.getAttribute (EditorStyleConstants.WaveUnderlineColor));
-        } else
-        if (category.getAttribute (StyleConstants.StrikeThrough) != null) {
+        } else if (category.getAttribute (StyleConstants.StrikeThrough) != null) {
             cbEffects.setSelectedIndex (3);
             cbEffectColor.setEnabled (true);
             ((ColorComboBox)cbEffectColor).setSelectedColor((Color) category.getAttribute (StyleConstants.StrikeThrough));
-        } else
-        if (getDefault (currentLanguage, category, StyleConstants.Underline) != null) {
+        } else if (getDefault (currentLanguage, category, StyleConstants.Underline) != null) {
             cbEffects.setSelectedIndex (1);
             cbEffectColor.setEnabled (true);
             ((ColorComboBox)cbEffectColor).setSelectedColor((Color) getDefault (currentLanguage, category, StyleConstants.Underline));
-        } else
-        if (getDefault (currentLanguage, category, EditorStyleConstants.WaveUnderlineColor) != null) {
+        } else if (getDefault (currentLanguage, category, EditorStyleConstants.WaveUnderlineColor) != null) {
             cbEffects.setSelectedIndex (2);
             cbEffectColor.setEnabled (true);
             ((ColorComboBox)cbEffectColor).setSelectedColor((Color) getDefault (currentLanguage, category, EditorStyleConstants.WaveUnderlineColor));
-        } else
-        if (getDefault (currentLanguage, category, StyleConstants.StrikeThrough) != null) {
+        } else if (getDefault (currentLanguage, category, StyleConstants.StrikeThrough) != null) {
             cbEffects.setSelectedIndex (3);
             cbEffectColor.setEnabled (true);
             ((ColorComboBox)cbEffectColor).setSelectedColor((Color) getDefault (currentLanguage, category, StyleConstants.StrikeThrough));
@@ -823,12 +808,8 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     }
     
     private void setToBeSaved(String currentProfile, String currentLanguage) {
-        Set<String> s = toBeSaved.get(currentProfile);
-        if (s == null) {
-            s = new HashSet<String>();
-            toBeSaved.put(currentProfile, s);
-        }
-        s.add(currentLanguage);
+        toBeSaved.computeIfAbsent(currentProfile, k -> new HashSet<>())
+                 .add(currentLanguage);
     }
     
     private void fireChanged() {
@@ -897,11 +878,11 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
         if (italic == null) {
             italic = Boolean.FALSE;
         }
-        int style = bold.booleanValue() ? Font.BOLD : Font.PLAIN;
-        if (italic.booleanValue()) {
+        int style = bold ? Font.BOLD : Font.PLAIN;
+        if (italic) {
             style += Font.ITALIC;
         }
-        Font currentFont = new Font(name, style, size.intValue());
+        Font currentFont = new Font(name, style, size);
         
         name = (String) getValue(language, savedAS, StyleConstants.FontFamily);
         assert (name != null);
@@ -915,11 +896,11 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
         if (italic == null) {
             italic = Boolean.FALSE;
         }
-        style = bold.booleanValue() ? Font.BOLD : Font.PLAIN;
-        if (italic.booleanValue()) {
+        style = bold ? Font.BOLD : Font.PLAIN;
+        if (italic) {
             style += Font.ITALIC;
         }
-        Font savedFont = new Font(name, style, size.intValue());
+        Font savedFont = new Font(name, style, size);
         return !currentFont.equals(savedFont);
     }
     
@@ -940,7 +921,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     private Map<String, String> languageToMimeType;
     private Map<String, String> getLanguageToMimeTypeMap() {
         if (languageToMimeType == null) {
-            languageToMimeType = new HashMap<String, String>();
+            languageToMimeType = new HashMap<>();
             Set<String> mimeTypes = EditorSettings.getDefault().getMimeTypes();
             for(String mimeType : mimeTypes) {
                 String name = EditorSettings.getDefault().getLanguageName (mimeType);
@@ -961,7 +942,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     
     private Map<String, AttributeSet> toMap(Collection<AttributeSet> categories) {
         if (categories == null) return null;
-        Map<String, AttributeSet> result = new HashMap<String, AttributeSet>();
+        Map<String, AttributeSet> result = new HashMap<>();
         for(AttributeSet as : categories) {
             result.put((String) as.getAttribute(StyleConstants.NameAttribute), as);
         }
@@ -970,45 +951,32 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
     // end copied from ColorModel
     
     private List<AttributeSet> getCategories(String profile, String language) {
-        if (colorModel == null) return null;
-        Map<String, List<AttributeSet>> m = profiles.get(profile);
-        if (m == null) {
-            m = new HashMap<String, List<AttributeSet>>();
-            profiles.put(profile, m);
+        if (colorModel == null) {
+            return null;
         }
-        List<AttributeSet> v = m.get(language);
-        if (v == null) {
+        Map<String, List<AttributeSet>> p = profiles.computeIfAbsent(profile, k -> new HashMap<String, List<AttributeSet>>());
+        return p.computeIfAbsent(language, k -> {
+            List<AttributeSet> l = new ArrayList<>();
             Collection<AttributeSet> c = colorModel.getCategories(profile, language);
-            if (c == null) {
-                c = Collections.<AttributeSet>emptySet(); // XXX OK?
+            if (c != null) {
+                l.addAll(c);
             }
-            List<AttributeSet> l = new ArrayList<AttributeSet>(c);
-            Collections.sort(l, new CategoryComparator());
-            v = new ArrayList<AttributeSet>(l);
-            m.put(language, v);
-        }
-        return v;
+            l.sort(new CategoryComparator());
+            return l;
+        });
     }
 
-    private Map<String, Map<String, List<AttributeSet>>> defaults = new HashMap<String, Map<String, List<AttributeSet>>>();
+    private Map<String, Map<String, List<AttributeSet>>> defaults = new HashMap<>();
     /**
      * Returns original colors for given profile.
      */
     private List<AttributeSet> getDefaults(String profile, String language) {
-        Map<String, List<AttributeSet>> m = defaults.get(profile);
-        if (m == null) {
-            m = new HashMap<String, List<AttributeSet>>();
-            defaults.put(profile, m);
-        }
-        List<AttributeSet> v = m.get(language);
-        if (v == null) {
-            Collection<AttributeSet> c = colorModel.getDefaults(profile, language);
-            List<AttributeSet> l = new ArrayList<AttributeSet>(c);
-            Collections.sort(l, new CategoryComparator());
-            v = new ArrayList<AttributeSet>(l);
-            m.put(language, v);
-        }
-        return new ArrayList<AttributeSet>(v);
+        Map<String, List<AttributeSet>> m = defaults.computeIfAbsent(profile, k -> new HashMap<>());
+        return new ArrayList<>(m.computeIfAbsent(language, k -> {
+            List<AttributeSet> v = new ArrayList<>(colorModel.getDefaults(profile, language));
+            v.sort(new CategoryComparator());
+            return v;
+        }));
     }
     
     private AttributeSet getCurrentCategory () {
@@ -1082,94 +1050,88 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
         if (bold == null) bold = Boolean.FALSE;
         Boolean italic = (Boolean) getValue (currentLanguage, category, StyleConstants.Italic);
         if (italic == null) italic = Boolean.FALSE;
-        int style = bold.booleanValue () ? Font.BOLD : Font.PLAIN;
-        if (italic.booleanValue ()) style += Font.ITALIC;
-        return new Font (name, style, size.intValue ());
+        int style = bold ? Font.BOLD : Font.PLAIN;
+        if (italic) style += Font.ITALIC;
+        return new Font (name, style, size);
     }
     
     private AttributeSet modifyFont (AttributeSet category, Font f) {
-        String fontName = f.getName ();
-        Integer fontSize = new Integer (f.getSize ());
-        Boolean bold = Boolean.valueOf (f.isBold ());
-        Boolean italic = Boolean.valueOf (f.isItalic ());
+        String fontName = f.getName();
+        Integer fontSize = f.getSize();
+        Boolean bold = f.isBold();
+        Boolean italic = f.isItalic();
         boolean isDefault = "default".equals (
             category.getAttribute (StyleConstants.NameAttribute)
         );
-        if (fontName.equals (
-            getDefault (currentLanguage, category, StyleConstants.FontFamily)
-        ) && !isDefault)
+        if (fontName.equals(getDefault(currentLanguage, category, StyleConstants.FontFamily)) && !isDefault) {
             fontName = null;
-        if (fontSize.equals (
-            getDefault (currentLanguage, category, StyleConstants.FontSize)
-        ) && !isDefault)
+        }
+        if (fontSize.equals(getDefault(currentLanguage, category, StyleConstants.FontSize)) && !isDefault) {
             fontSize = null;
-        if (bold.equals (getDefault (currentLanguage, category, StyleConstants.Bold))
-        )
+        }
+        if (bold.equals(getDefault(currentLanguage, category, StyleConstants.Bold))) {
             bold = null;
-        else
-        if (bold.equals (Boolean.FALSE) &&
-            getDefault (currentLanguage, category, StyleConstants.Bold) == null
-        )
+        } else if (bold.equals(Boolean.FALSE) && getDefault(currentLanguage, category, StyleConstants.Bold) == null) {
             bold = null;
-        if (italic.equals (getDefault (currentLanguage, category, StyleConstants.Italic))
-        )
+        }
+        if (italic.equals(getDefault(currentLanguage, category, StyleConstants.Italic))) {
             italic = null;
-        else
-        if (italic.equals (Boolean.FALSE) &&
-            getDefault (currentLanguage, category, StyleConstants.Italic) == null
-        )
+        } else if (italic.equals(Boolean.FALSE) && getDefault(currentLanguage, category, StyleConstants.Italic) == null) {
             italic = null;
-        SimpleAttributeSet c = new SimpleAttributeSet (category);
-        if (fontName != null)
-            c.addAttribute (
-                StyleConstants.FontFamily,
-                fontName
+        }
+        SimpleAttributeSet c = new SimpleAttributeSet(category);
+        if (fontName != null) {
+            c.addAttribute(
+                    StyleConstants.FontFamily,
+                    fontName
             );
-        else
-            c.removeAttribute (StyleConstants.FontFamily);
-        if (fontSize != null)
-            c.addAttribute (
-                StyleConstants.FontSize,
-                fontSize
+        } else {
+            c.removeAttribute(StyleConstants.FontFamily);
+        }
+        if (fontSize != null) {
+            c.addAttribute(
+                    StyleConstants.FontSize,
+                    fontSize
             );
-        else
-            c.removeAttribute (StyleConstants.FontSize);
-        if (bold != null)
-            c.addAttribute (
-                StyleConstants.Bold,
-                bold
+        } else {
+            c.removeAttribute(StyleConstants.FontSize);
+        }
+        if (bold != null) {
+            c.addAttribute(
+                    StyleConstants.Bold,
+                    bold
             );
-        else
-            c.removeAttribute (StyleConstants.Bold);
-        if (italic != null)
-            c.addAttribute (
-                StyleConstants.Italic,
-                italic
+        } else {
+            c.removeAttribute(StyleConstants.Bold);
+        }
+        if (italic != null) {
+            c.addAttribute(
+                    StyleConstants.Italic,
+                    italic
             );
-        else
-            c.removeAttribute (StyleConstants.Italic);
+        } else {
+            c.removeAttribute(StyleConstants.Italic);
+        }
         
         return c;
     }
     
     private String fontToString (AttributeSet category) {
-        if ("default".equals (
-            category.getAttribute (StyleConstants.NameAttribute)
-        )) {
-            StringBuffer sb = new StringBuffer ();
+        if ("default".equals(category.getAttribute (StyleConstants.NameAttribute))) {
+            StringBuilder sb = new StringBuilder ();
             sb.append (getValue (currentLanguage, category, StyleConstants.FontFamily));
             sb.append (' ');
             sb.append (getValue (currentLanguage, category, StyleConstants.FontSize));
             Boolean bold = (Boolean) getValue (currentLanguage, category, StyleConstants.Bold);
-            if (bold != null && bold.booleanValue ())
+            if (bold != null && bold)
                 sb.append (' ').append (loc ("CTL_Bold"));                // NOI18N
             Boolean italic = (Boolean) getValue (currentLanguage, category, StyleConstants.Italic);
-            if (italic != null && italic.booleanValue ())
+            if (italic != null && italic)
                 sb.append (' ').append (loc ("CTL_Italic"));              // NOI18N
             return sb.toString ();
         }
         boolean def = false;
-        StringBuffer sb = new StringBuffer ();
+        StringBuilder sb = new StringBuilder();
         if (category.getAttribute (StyleConstants.FontFamily) != null)
             sb.append ('+').append (category.getAttribute (StyleConstants.FontFamily));
         else
@@ -1196,7 +1158,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
         }
     }
     
-    private static Map<String, String> convertALC = new HashMap<String, String>();
+    private static final Map<String, String> convertALC = new HashMap<>();
     
     static {
         convertALC.put("character", "char"); //NOI18N

--- a/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/TermOptionsPanel.form
+++ b/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/TermOptionsPanel.form
@@ -37,7 +37,6 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Component id="previewPanel" alignment="0" max="32767" attributes="0"/>
           <Group type="102" alignment="1" attributes="0">
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="fontLabel" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -50,7 +49,7 @@
               </Group>
               <EmptySpace min="-2" pref="16" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="1" attributes="0">
-                  <Component id="foregroundComboBox" alignment="0" pref="252" max="32767" attributes="0"/>
+                  <Component id="foregroundComboBox" alignment="0" max="32767" attributes="0"/>
                   <Component id="backgroundComboBox" alignment="0" max="32767" attributes="0"/>
                   <Component id="selectionComboBox" alignment="0" max="32767" attributes="0"/>
                   <Component id="selectByWordTextField" alignment="0" max="32767" attributes="0"/>
@@ -75,34 +74,38 @@
                   <Component id="tabSizeLabel" min="-2" max="-2" attributes="0"/>
                   <Component id="previewLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="selectByWordLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="ignoreKeymapCheckBox" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="-2" pref="86" max="-2" attributes="0"/>
-                      <Component id="altSendsEscapeCheckBox" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="scrollOnInputCheckBox" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace type="separate" max="-2" attributes="0"/>
-                      <Component id="scrollOnOutputCheckBox" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="clickToTypeCheckBox" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="-2" pref="31" max="-2" attributes="0"/>
-                      <Component id="lineWrapCheckBox" min="-2" max="-2" attributes="0"/>
-                  </Group>
               </Group>
               <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
           </Group>
+          <Group type="102" alignment="0" attributes="0">
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="scrollOnInputCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="clickToTypeCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace type="separate" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="lineWrapCheckBox" min="-2" max="-2" attributes="0"/>
+                  <Component id="scrollOnOutputCheckBox" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace type="separate" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="ignoreKeymapCheckBox" min="-2" max="-2" attributes="0"/>
+                  <Component id="altSendsEscapeCheckBox" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="32767" attributes="0"/>
+          </Group>
+          <Component id="previewPanel" alignment="0" max="32767" attributes="0"/>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="descriptionLabel" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="restoreButton" alignment="3" min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="restoreButton" min="-2" max="-2" attributes="0"/>
+                  <Component id="descriptionLabel" alignment="1" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace type="separate" max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="fontLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="fontButton" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -143,25 +146,22 @@
                   <Component id="selectByWordLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="selectByWordTextField" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace min="-2" pref="16" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="ignoreKeymapCheckBox" alignment="3" min="-2" pref="23" max="-2" attributes="0"/>
-                  <Component id="altSendsEscapeCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
-              </Group>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace type="separate" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="clickToTypeCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="lineWrapCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="ignoreKeymapCheckBox" alignment="3" min="-2" pref="23" max="-2" attributes="0"/>
               </Group>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="scrollOnInputCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="scrollOnOutputCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="altSendsEscapeCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace type="separate" max="-2" attributes="0"/>
               <Component id="previewLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
-              <Component id="previewPanel" pref="45" max="32767" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="previewPanel" pref="67" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>

--- a/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/TermOptionsPanel.java
+++ b/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/TermOptionsPanel.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.terminal.nb;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dialog;
 import java.awt.Font;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -58,12 +59,9 @@ public final class TermOptionsPanel extends JPanel {
 	"FontChooser.defaultFont.label=Default Font"
     })
     public TermOptionsPanel() {
-	propertyListener = new PropertyChangeListener() {
-	    @Override
-	    public void propertyChange(PropertyChangeEvent e) {
-		refreshView();
-	    }
-	};
+        propertyListener = (PropertyChangeEvent e) -> {
+            refreshView();
+        };
 	
 	initComponents();
 	initCustomComponents();
@@ -170,7 +168,7 @@ public final class TermOptionsPanel extends JPanel {
 
         org.openide.awt.Mnemonics.setLocalizedText(fontSizeLabel, org.openide.util.NbBundle.getMessage(TermOptionsPanel.class, "TermOptionsPanel.fontSizeLabel.text")); // NOI18N
 
-        fontSizeSpinner.setModel(new SpinnerNumberModel(12, TermOptions.MIN_FONT_SIZE, TermOptions.MAX_FONT_SIZE, 1));
+        fontSizeSpinner.setModel(new SpinnerNumberModel(12, termOptions.MIN_FONT_SIZE, termOptions.MAX_FONT_SIZE, 1));
         fontSizeSpinner.addChangeListener(new javax.swing.event.ChangeListener() {
             public void stateChanged(javax.swing.event.ChangeEvent evt) {
                 fontSizeSpinnerStateChanged(evt);
@@ -278,7 +276,6 @@ public final class TermOptionsPanel extends JPanel {
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(previewPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(fontLabel)
@@ -290,7 +287,7 @@ public final class TermOptionsPanel extends JPanel {
                     .addComponent(descriptionLabel))
                 .addGap(16, 16, 16)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addComponent(foregroundComboBox, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, 252, Short.MAX_VALUE)
+                    .addComponent(foregroundComboBox, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(backgroundComboBox, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(selectionComboBox, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(selectByWordTextField, javax.swing.GroupLayout.Alignment.LEADING)
@@ -309,28 +306,31 @@ public final class TermOptionsPanel extends JPanel {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(tabSizeLabel)
                     .addComponent(previewLabel)
-                    .addComponent(selectByWordLabel)
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(ignoreKeymapCheckBox)
-                        .addGap(86, 86, 86)
-                        .addComponent(altSendsEscapeCheckBox))
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(scrollOnInputCheckBox)
-                        .addGap(18, 18, 18)
-                        .addComponent(scrollOnOutputCheckBox))
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(clickToTypeCheckBox)
-                        .addGap(31, 31, 31)
-                        .addComponent(lineWrapCheckBox)))
+                    .addComponent(selectByWordLabel))
                 .addGap(0, 0, Short.MAX_VALUE))
+            .addGroup(layout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(scrollOnInputCheckBox)
+                    .addComponent(clickToTypeCheckBox))
+                .addGap(18, 18, 18)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(lineWrapCheckBox)
+                    .addComponent(scrollOnOutputCheckBox))
+                .addGap(18, 18, 18)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(ignoreKeymapCheckBox)
+                    .addComponent(altSendsEscapeCheckBox))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+            .addComponent(previewPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(descriptionLabel)
-                    .addComponent(restoreButton))
-                .addGap(18, 18, 18)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(restoreButton)
+                    .addComponent(descriptionLabel, javax.swing.GroupLayout.Alignment.TRAILING))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(fontLabel)
                     .addComponent(fontButton)
@@ -363,22 +363,20 @@ public final class TermOptionsPanel extends JPanel {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(selectByWordLabel)
                     .addComponent(selectByWordTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addGap(16, 16, 16)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(ignoreKeymapCheckBox, javax.swing.GroupLayout.PREFERRED_SIZE, 23, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(altSendsEscapeCheckBox))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGap(18, 18, 18)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(clickToTypeCheckBox)
-                    .addComponent(lineWrapCheckBox))
+                    .addComponent(lineWrapCheckBox)
+                    .addComponent(ignoreKeymapCheckBox, javax.swing.GroupLayout.PREFERRED_SIZE, 23, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(scrollOnInputCheckBox)
-                    .addComponent(scrollOnOutputCheckBox))
+                    .addComponent(scrollOnOutputCheckBox)
+                    .addComponent(altSendsEscapeCheckBox))
                 .addGap(18, 18, 18)
                 .addComponent(previewLabel)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addComponent(previewPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 45, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(previewPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 67, Short.MAX_VALUE)
                 .addContainerGap())
         );
     }// </editor-fold>//GEN-END:initComponents
@@ -389,7 +387,7 @@ public final class TermOptionsPanel extends JPanel {
 	}
 	Object fontSizeObj = fontSizeSpinner.getValue();
 	if (fontSizeObj instanceof Integer) {
-	    int fontSize = ((Integer) fontSizeObj).intValue();
+	    int fontSize = (Integer) fontSizeObj;
 	    termOptions.setFontSize(fontSize);
 	}
     }//GEN-LAST:event_fontSizeSpinnerStateChanged
@@ -400,7 +398,7 @@ public final class TermOptionsPanel extends JPanel {
 	}
 	Object historySizeObj = historySizeSpinner.getValue();
 	if (historySizeObj instanceof Integer) {
-	    int historySize = ((Integer) historySizeObj).intValue();
+	    int historySize = (Integer) historySizeObj;
 	    termOptions.setHistorySize(historySize);
 	}
     }//GEN-LAST:event_historySizeSpinnerStateChanged
@@ -411,7 +409,7 @@ public final class TermOptionsPanel extends JPanel {
 	}
 	Object tabSizeObj = tabSizeSpinner.getValue();
 	if (tabSizeObj instanceof Integer) {
-	    int tabSize = ((Integer) tabSizeObj).intValue();
+	    int tabSize = (Integer) tabSizeObj;
 	    termOptions.setTabSize(tabSize);
 	}
     }//GEN-LAST:event_tabSizeSpinnerStateChanged
@@ -425,7 +423,9 @@ public final class TermOptionsPanel extends JPanel {
 	    String defaultFontString = FontChooser_defaultFont_label();
 	    dd.setOptions(new Object[]{DialogDescriptor.OK_OPTION,
 		defaultFontString, DialogDescriptor.CANCEL_OPTION});  //NOI18N
-	    DialogDisplayer.getDefault().createDialog(dd).setVisible(true);
+            Dialog dialog = DialogDisplayer.getDefault().createDialog(dd);
+            dialog.setSize(460, 380);
+	    dialog.setVisible(true);
 	    if (dd.getValue() == DialogDescriptor.OK_OPTION) {
 		Font f = (Font) pe.getValue();
 		termOptions.setFont(f);

--- a/platform/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.form
+++ b/platform/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.form
@@ -37,32 +37,29 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="previewPanel" alignment="1" max="32767" attributes="0"/>
-                  <Component id="jPanel2" max="32767" attributes="0"/>
-                  <Group type="102" alignment="1" attributes="0">
-                      <Component id="lblTitle" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="32767" attributes="0"/>
-                      <Component id="btnRestore" min="-2" max="-2" attributes="0"/>
-                  </Group>
-              </Group>
+          <Component id="jPanel2" max="32767" attributes="0"/>
+          <Group type="102" alignment="1" attributes="0">
+              <Component id="lblTitle" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
+              <Component id="btnRestore" min="-2" max="-2" attributes="0"/>
           </Group>
+          <Component id="previewPanel" alignment="1" max="32767" attributes="0"/>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="lblTitle" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="btnRestore" alignment="3" min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" attributes="0">
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="lblTitle" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <Component id="btnRestore" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jPanel2" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="previewPanel" pref="51" max="32767" attributes="0"/>
+              <Component id="previewPanel" pref="57" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
@@ -82,19 +79,18 @@
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="lblErrorColor" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="lblStandardColor" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="lblLinkColor" alignment="0" min="-2" max="-2" attributes="0"/>
                       <Component id="lblFontFamily" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="lblBackgroundColor" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="lblFontSize" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="lblLinkStyle" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="lblInputColor" alignment="0" min="-2" max="-2" attributes="0"/>
+                      <Component id="lblFontSize" min="-2" max="-2" attributes="0"/>
+                      <Component id="lblBackgroundColor" min="-2" max="-2" attributes="0"/>
+                      <Component id="lblStandardColor" min="-2" max="-2" attributes="0"/>
+                      <Component id="lblErrorColor" min="-2" max="-2" attributes="0"/>
+                      <Component id="lblInputColor" min="-2" max="-2" attributes="0"/>
+                      <Component id="lblLinkColor" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
+                      <Component id="lblLinkStyle" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <EmptySpace type="separate" max="-2" attributes="0"/>
+                  <EmptySpace min="-2" pref="24" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Group type="102" alignment="0" attributes="0">
                           <Component id="fldFontFamily" max="32767" attributes="0"/>
@@ -103,17 +99,17 @@
                       </Group>
                       <Component id="lblUnwrappedOnly" alignment="0" max="32767" attributes="0"/>
                       <Group type="102" alignment="0" attributes="0">
-                          <Group type="103" groupAlignment="1" max="-2" attributes="0">
-                              <Component id="cmbLinkStyle" alignment="0" max="32767" attributes="0"/>
+                          <Group type="103" groupAlignment="1" attributes="0">
+                              <Component id="cmbLinkStyle" alignment="0" pref="113" max="32767" attributes="0"/>
                               <Component id="cmbImportantLinkColor" alignment="0" max="32767" attributes="0"/>
                               <Component id="cmbLinkColor" alignment="0" max="32767" attributes="0"/>
                               <Component id="cmbInputColor" alignment="0" max="32767" attributes="0"/>
                               <Component id="cmbErrorColor" alignment="0" max="32767" attributes="0"/>
                               <Component id="cmbStandardColor" alignment="0" max="32767" attributes="0"/>
                               <Component id="spnFontSize" alignment="0" min="-2" pref="71" max="-2" attributes="0"/>
-                              <Component id="cmbBackgroundColor" linkSize="1" alignment="0" max="32767" attributes="0"/>
+                              <Component id="cmbBackgroundColor" alignment="0" max="32767" attributes="0"/>
                           </Group>
-                          <EmptySpace type="separate" max="-2" attributes="0"/>
+                          <EmptySpace type="separate" min="-2" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
                               <Component id="jLabel2" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
@@ -121,13 +117,12 @@
                               <Component id="jLabel5" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace min="-2" pref="21" max="-2" attributes="0"/>
-                          <Group type="103" groupAlignment="1" max="-2" attributes="0">
-                              <Component id="cmbFailureColor" alignment="0" max="32767" attributes="0"/>
+                          <Group type="103" groupAlignment="1" attributes="0">
+                              <Component id="cmbFailureColor" alignment="0" pref="114" max="32767" attributes="0"/>
                               <Component id="cmbWarningColor" alignment="0" max="32767" attributes="0"/>
-                              <Component id="cmbDebugColor" linkSize="1" alignment="1" pref="238" max="32767" attributes="0"/>
+                              <Component id="cmbDebugColor" alignment="1" max="32767" attributes="0"/>
                               <Component id="cmbSuccessColor" max="32767" attributes="0"/>
                           </Group>
-                          <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                       </Group>
                   </Group>
                   <EmptySpace min="-2" pref="1" max="-2" attributes="0"/>

--- a/platform/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.java
@@ -20,9 +20,9 @@ package org.netbeans.core.output2.options;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dialog;
 import java.awt.Font;
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.beans.PropertyEditor;
 import java.beans.PropertyEditorManager;
 import java.io.IOException;
@@ -63,7 +63,7 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
     private OutputOptions outputOptions;
     private InputOutput previewInputOutput = null;
     private final OutputSettingsOptionsPanelController controller;
-    private LinkStyleModel linkStyleModel = new LinkStyleModel();
+    private final LinkStyleModel linkStyleModel = new LinkStyleModel();
 
     OutputSettingsPanel(OutputSettingsOptionsPanelController controller) {
         this.controller = controller;
@@ -247,18 +247,17 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
         jPanel2Layout.setHorizontalGroup(
             jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(jPanel2Layout.createSequentialGroup()
-                .addContainerGap()
                 .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(lblErrorColor)
-                    .addComponent(lblStandardColor)
-                    .addComponent(lblLinkColor)
                     .addComponent(lblFontFamily)
-                    .addComponent(lblBackgroundColor)
                     .addComponent(lblFontSize)
+                    .addComponent(lblBackgroundColor)
+                    .addComponent(lblStandardColor)
+                    .addComponent(lblErrorColor)
+                    .addComponent(lblInputColor)
+                    .addComponent(lblLinkColor)
                     .addComponent(jLabel1)
-                    .addComponent(lblLinkStyle)
-                    .addComponent(lblInputColor))
-                .addGap(18, 18, 18)
+                    .addComponent(lblLinkStyle))
+                .addGap(24, 24, 24)
                 .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(jPanel2Layout.createSequentialGroup()
                         .addComponent(fldFontFamily)
@@ -266,8 +265,8 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
                         .addComponent(btnSelectFont))
                     .addComponent(lblUnwrappedOnly, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addGroup(jPanel2Layout.createSequentialGroup()
-                        .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
-                            .addComponent(cmbLinkStyle, javax.swing.GroupLayout.Alignment.LEADING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                            .addComponent(cmbLinkStyle, javax.swing.GroupLayout.Alignment.LEADING, 0, 113, Short.MAX_VALUE)
                             .addComponent(cmbImportantLinkColor, javax.swing.GroupLayout.Alignment.LEADING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addComponent(cmbLinkColor, javax.swing.GroupLayout.Alignment.LEADING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addComponent(cmbInputColor, javax.swing.GroupLayout.Alignment.LEADING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
@@ -282,17 +281,13 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
                             .addComponent(jLabel4)
                             .addComponent(jLabel5))
                         .addGap(21, 21, 21)
-                        .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
-                            .addComponent(cmbFailureColor, javax.swing.GroupLayout.Alignment.LEADING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                            .addComponent(cmbFailureColor, javax.swing.GroupLayout.Alignment.LEADING, 0, 114, Short.MAX_VALUE)
                             .addComponent(cmbWarningColor, javax.swing.GroupLayout.Alignment.LEADING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                            .addComponent(cmbDebugColor, 0, 238, Short.MAX_VALUE)
-                            .addComponent(cmbSuccessColor, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                        .addGap(0, 0, Short.MAX_VALUE)))
+                            .addComponent(cmbDebugColor, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(cmbSuccessColor, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
                 .addGap(1, 1, 1))
         );
-
-        jPanel2Layout.linkSize(javax.swing.SwingConstants.HORIZONTAL, new java.awt.Component[] {cmbBackgroundColor, cmbDebugColor});
-
         jPanel2Layout.setVerticalGroup(
             jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(jPanel2Layout.createSequentialGroup()
@@ -361,27 +356,25 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(previewPanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jPanel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
-                        .addComponent(lblTitle)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .addComponent(btnRestore))))
+            .addComponent(jPanel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                .addComponent(lblTitle)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addComponent(btnRestore))
+            .addComponent(previewPanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(lblTitle)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(layout.createSequentialGroup()
+                        .addContainerGap()
+                        .addComponent(lblTitle))
                     .addComponent(btnRestore))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jPanel2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(previewPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 51, Short.MAX_VALUE)
+                .addComponent(previewPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 57, Short.MAX_VALUE)
                 .addContainerGap())
         );
     }// </editor-fold>//GEN-END:initComponents
@@ -397,7 +390,9 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
                     "BTN_Defaul_Font");                                 //NOI18N
             dd.setOptions(new Object[]{DialogDescriptor.OK_OPTION,
                         defaultFont, DialogDescriptor.CANCEL_OPTION});  //NOI18N
-            DialogDisplayer.getDefault().createDialog(dd).setVisible(true);
+            Dialog dialog = DialogDisplayer.getDefault().createDialog(dd);
+            dialog.setSize(460, 380);
+            dialog.setVisible(true);
             if (dd.getValue() == DialogDescriptor.OK_OPTION) {
                 Font f = (Font) pe.getValue();
                 outputOptions.setFont(f);
@@ -583,27 +578,21 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
         }
         previewInputOutput.getOut().close();
         previewInputOutput.getErr().close();
-        outputOptions.addPropertyChangeListener(new PropertyChangeListener() {
-            @Override
-            public void propertyChange(PropertyChangeEvent evt) {
-                if (!evt.getPropertyName().equals(OutputOptions.PROP_INITIALIZED)
-                        && outputOptions.isInitialized()) {
-                    controller.changed(outputOptions.isChanged());
-                }
-                updateControlsByModel();
+        outputOptions.addPropertyChangeListener((PropertyChangeEvent evt) -> {
+            if (!evt.getPropertyName().equals(OutputOptions.PROP_INITIALIZED)
+                    && outputOptions.isInitialized()) {
+                controller.changed(outputOptions.isChanged());
             }
+            updateControlsByModel();
         });
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                Component component = previewPanel.getComponent(0);
-                if (component instanceof AbstractOutputTab) {
-                    ((AbstractOutputTab) component).inputSent("Input from keyboard");
-                }
-                try {
-                    in.close();
-                } catch (IOException ex) {}
+        SwingUtilities.invokeLater(() -> {
+            Component component1 = previewPanel.getComponent(0);
+            if (component1 instanceof AbstractOutputTab) {
+                ((AbstractOutputTab) component1).inputSent("Input from keyboard");
             }
+            try {
+                in.close();
+            } catch (IOException ex) {}
         });
     }
 


### PR DESCRIPTION
 - made three font chooser dialogs wider so that the font columns render better
 - adjusted component gaps and layouts for consistency
 - basic code cleanup

best way to see the difference is to toggle between the terminal and output tab (misc options) in NB 20, then again with this dev build.

(sorry for the bright orange, this is just to mark my local dev build)

![font-chooser-after](https://github.com/apache/netbeans/assets/114367/0131e63d-a8bc-4a73-beee-6795a5417583)
![terminal-options-after](https://github.com/apache/netbeans/assets/114367/8c477a75-166b-4c83-bb46-eec9160b6479)
![output-options-after](https://github.com/apache/netbeans/assets/114367/b625ba85-6953-415a-90a8-f7936ec13a71)
