### PR TITLE
Initial draft support CSS for Markdown Preview

### DIFF
--- a/ide/editor.settings.storage/nbproject/project.xml
+++ b/ide/editor.settings.storage/nbproject/project.xml
@@ -180,6 +180,7 @@
                 <friend>org.netbeans.modules.editor.fold.nbui</friend>
                 <friend>org.netbeans.modules.parsing.indexing</friend>
                 <friend>org.netbeans.modules.parsing.nb</friend>
+                <friend>org.netbeans.modules.markdown</friend>
                 <package>org.netbeans.modules.editor.settings.storage.api</package>
                 <package>org.netbeans.modules.editor.settings.storage.spi</package>
                 <package>org.netbeans.modules.editor.settings.storage.spi.support</package>

--- a/ide/markdown/manifest.mf
+++ b/ide/markdown/manifest.mf
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: true
 OpenIDE-Module: org.netbeans.modules.markdown
+OpenIDE-Module-Layer: org/netbeans/modules/markdown/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/markdown/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.11
 

--- a/ide/markdown/nbproject/project.xml
+++ b/ide/markdown/nbproject/project.xml
@@ -51,6 +51,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.editor.settings.storage</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.75</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.textmate.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/ide/markdown/src/org/netbeans/modules/markdown/MarkdownViewerElement.java
+++ b/ide/markdown/src/org/netbeans/modules/markdown/MarkdownViewerElement.java
@@ -82,6 +82,8 @@ public class MarkdownViewerElement implements MultiViewElement {
     private static final Logger LOG = Logger.getLogger(MarkdownViewerElement.class.getName());
     private static final RequestProcessor RP = new RequestProcessor(MarkdownViewerElement.class);
     private static final int UPDATE_DELAY = 500;
+    //TODO: Might need to register this editor kit Globally
+    private static final MarkdownEditorKit EDITOR_KIT = new MarkdownEditorKit();
 
     private final MarkdownDataObject dataObject;
     private transient JToolBar toolbar;
@@ -144,7 +146,7 @@ public class MarkdownViewerElement implements MultiViewElement {
     public JComponent getVisualRepresentation() {
         if (component == null) {
             viewer = new JEditorPane();
-            viewer.setEditorKit(new MarkdownEditorKit());
+            viewer.setEditorKit(EDITOR_KIT);
             viewer.setEditable(false);
             viewer.addHyperlinkListener(this::linkHandler);
 
@@ -244,6 +246,7 @@ public class MarkdownViewerElement implements MultiViewElement {
 
                 HTMLDocument doc = (HTMLDocument) viewer.getDocument();
 
+                
                 // Would be better to create some diff and update the changed elemets
                 doc.remove(0, doc.getLength());
                 kit.read(htmlReader, doc, 0);

--- a/ide/markdown/src/org/netbeans/modules/markdown/layer.xml
+++ b/ide/markdown/src/org/netbeans/modules/markdown/layer.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
+<filesystem>
+    <folder name="Editors">
+        <folder name="text">
+            <folder name="x-markdown">
+                <folder name="FontsColors">
+                    <folder name="NetBeans">
+                        <folder name="Defaults">                            
+                            <file name="viewer.css" url="resources/viewer.css"/>
+                        </folder>
+                    </folder>
+                    <folder name="FlatLaf Light">
+                        <folder name="Defaults">                            
+                            <file name="viewer.css" url="resources/viewer.css"/>
+                        </folder>
+                    </folder>
+                    <folder name="FlatLaf Dark">
+                        <folder name="Defaults">                            
+                            <file name="viewer.css" url="resources/viewer.css"/>
+                        </folder>
+                    </folder>
+                </folder>
+            </folder>
+        </folder>
+    </folder>
+</filesystem>

--- a/ide/markdown/src/org/netbeans/modules/markdown/resources/viewer.css
+++ b/ide/markdown/src/org/netbeans/modules/markdown/resources/viewer.css
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+h1 {
+    font-size: 22px
+}

--- a/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/MarkdownEditorKit.java
+++ b/ide/markdown/src/org/netbeans/modules/markdown/ui/preview/MarkdownEditorKit.java
@@ -18,9 +18,20 @@
  */
 package org.netbeans.modules.markdown.ui.preview;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.modules.markdown.ui.preview.views.MarkdownViewFactory;
 import javax.swing.text.ViewFactory;
 import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.StyleSheet;
+import org.netbeans.modules.editor.settings.storage.api.EditorSettings;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.WeakListeners;
 
 /**
  *
@@ -29,14 +40,46 @@ import javax.swing.text.html.HTMLEditorKit;
 public class MarkdownEditorKit extends HTMLEditorKit {
 
     private final transient ViewFactory viewFactory;
-
+    private transient StyleSheet markdownStyles;
+    private final PropertyChangeListener pcl = this::colorProfileChange;
+    
     public MarkdownEditorKit() {
         super();
         this.viewFactory = new MarkdownViewFactory();
+        EditorSettings.getDefault().addPropertyChangeListener(WeakListeners.propertyChange(pcl, this));
+    }
+
+    @Override
+    public StyleSheet getStyleSheet() {
+        if (markdownStyles == null) {
+            StyleSheet defaultStyles = super.getStyleSheet();
+            StyleSheet ss = new StyleSheet();
+            ss.addStyleSheet(defaultStyles);
+            
+            String profile = EditorSettings.getDefault().getCurrentFontColorProfile();
+            String configPath = "Editors/text/x-markdown/FontsColors/" + profile + "/Defaults/viewer.css";
+            FileObject config = FileUtil.getSystemConfigFile(configPath);
+      
+            if (config != null) {
+                try (Reader rd = new InputStreamReader(config.getInputStream(), StandardCharsets.ISO_8859_1)){
+                    ss.loadRules(rd, null);
+                } catch (IOException ex) {}
+            } else {
+                
+            }
+            markdownStyles = ss;
+        }
+        return markdownStyles;
     }
 
     @Override
     public ViewFactory getViewFactory() {
         return viewFactory;
+    }
+    
+    public void colorProfileChange(PropertyChangeEvent evt) {
+        if (EditorSettings.PROP_CURRENT_FONT_COLOR_PROFILE.equals(evt.getPropertyName())) {
+            markdownStyles = null;
+        }
     }
 }


### PR DESCRIPTION
Well, I while ago I've promised to add some CSS config to the Markdown preview, if there is someone who can create a CSS for it.

Well here it is. @Chris2011 I'm pretty un-talented in this CSS, stuff. just registered the `viewer.css` on most widely used profiles. So this can be tested.

I've needed to use the Editor Settings Storage API in order to get the name of the current profile, so I've opened up that module as friend. However the API is stable enough for years, to be public.

Refinement ideas, are welcome!

Could be a solution for #6652 