### PR TITLE
Fix php tag fold test (attempt 2)

### DIFF
--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -2146,13 +2146,6 @@ public abstract class CslTestBase extends NbTestCase {
         ParserManager.parse(Collections.singleton(testSource), new UserTask() {
             public @Override void run(ResultIterator resultIterator) throws Exception {
 
-                // FoldingScanner#folds calls source.getDocument(false) and receive non null values on JDK 8.
-                // On JDK 11+ however the document is null which leads to test failures in FoldingTest#testPHPTags.
-                // This is likely a race condition which is more likely to occur on JDK 11+ since the test can be
-                // brute forced to passing on linux if restarted often enough. 
-                // This fixes it by making sure the document is open before folds are computed
-                assertNotNull(resultIterator.getSnapshot().getSource().getDocument(true));
-                
                 StructureScanner analyzer = getStructureScanner();
                 assertNotNull("getStructureScanner must be implemented", analyzer);
 

--- a/php/php.editor/src/org/netbeans/modules/php/editor/csl/FoldingScanner.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/csl/FoldingScanner.java
@@ -179,7 +179,7 @@ public final class FoldingScanner {
             program.accept(new FoldingVisitor(folds));
             Source source = phpParseResult.getSnapshot().getSource();
             assert source != null : "source was null";
-            Document doc = source.getDocument(false);
+            Document doc = source.getDocument(true);
             if (FOLD_PHPTAG) {
                 processPHPTags(folds, doc);
             }


### PR DESCRIPTION
The race condition strikes back!

This particular php tests requires too many restarts, I can't stabilize master at all atm:
https://github.com/apache/netbeans/blob/0c8313ebfd62638da8933c5d6a3347fe1a8d189e/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/FoldingTest.java#L88

So I took another look at #5658, and I believe all I did back then was to change the timing without fixing the underlying issue. My mistake was to think that [`getSource().getDocument(true)`](https://github.com/apache/netbeans/blob/0c8313ebfd62638da8933c5d6a3347fe1a8d189e/ide/parsing.api/src/org/netbeans/modules/parsing/api/Source.java#L266-L289) would hold the document internally for the next `getDocument(false)` call - but this is not the case. So all the last "fix" did was to read a document and forget about it again, the timing however helped the tests to pass. 

This is also annoying to debug since this usually works when the debugger is attached.

So I think there are two obvious ways how to fix this:
 - actually cache the document in `Source.getDocument(true)` for subsequent `Source.getDocument(false)` calls, and eager load the document in the test like attempted in 5658
 - or call `Source.getDocument(true)` in `FoldingScanner` (might potentially have an performance impact)
 
 PR implements currently the second option