### PR TITLE
OCI ADM vulnerability audit fixes

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditOptions.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditOptions.java
@@ -28,6 +28,7 @@ import org.netbeans.modules.cloud.oracle.OCISessionInitiator;
 public final class AuditOptions {
     private boolean forceAuditExecution;
     private boolean runIfNotExists;
+    private boolean disableCache;
     private String auditName;
     private OCISessionInitiator session;
     private boolean returnData;
@@ -47,6 +48,15 @@ public final class AuditOptions {
         return this;
     }
 
+    public boolean isDisableCache() {
+        return disableCache;
+    }
+
+    public AuditOptions setDisableCache(boolean disableCache) {
+        this.disableCache = disableCache;
+        return this;
+    }
+    
     public boolean isRunIfNotExists() {
         return runIfNotExists;
     }

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -72,6 +72,7 @@ import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
+import org.openide.util.RequestProcessor.Task;
 
 /**
  *
@@ -91,10 +92,21 @@ import org.openide.util.RequestProcessor;
     "# {0} - project name",
     "MSG_AuditIsRunning=Checking for audit of project {0}",
     "MSG_NotAvailable=Not available",
+    "# {0} - Cvss V2 score",
+    "# {1} - Cvss V3 score",
+    "# {2} - Vulnerable dependency GAV",
     "MSG_Diagnostic=Vulnerability\n"
-            + "  Cvss V2 Score: %s\n"
-            + "  Cvss V3 Score: %s\n"
-            + "  Caused by dependence: %s",
+            + "  Cvss V2 Score: {0}\n"
+            + "  Cvss V3 Score: {1}\n"
+            + "  Caused by dependence: {2}",
+    "# {0} - Cvss V2 score",
+    "# {1} - Cvss V3 score",
+    "# {2} - Vulnerable dependency GAV",
+    "# {3} - Including dependency GAV",
+    "MSG_Diagnostic_Included=Vulnerability\n"
+            + "  Cvss V2 Score: {0}\n"
+            + "  Cvss V3 Score: {1}\n"
+            + "  Caused by dependence: {2}, included by {3}",
     "MSG_SearchingAuditReport=Searching for audit reports...",
     "MSG_AuditCollectDependencies=Collecting project dependencies...",
     "MSG_ExecuteAudit=Executing audit..."
@@ -206,13 +218,9 @@ public class VulnerabilityWorker implements ErrorProvider{
             DependencyResult dr = ProjectDependencies.findDependencies(project, ProjectDependencies.newQuery(Scopes.RUNTIME));
             LOG.log(Level.FINER, "{0} - dependencies refreshed", this);
             synchronized (this) {
+                // should block on this until t[0] is assigned
                 if (pendingRefresh != t) {
                     return;
-                }
-            }
-            synchronized (this) {
-                if (depChange != null) {
-                    dependencyResult.removeChangeListener(depChange);
                 }
             }
             CacheItem novy = new CacheItem( project, dr, report);
@@ -242,11 +250,14 @@ public class VulnerabilityWorker implements ErrorProvider{
                 if (LOG.isLoggable(Level.FINER)) {
                     LOG.log(Level.FINER, "{0} - scheduling refresh for {1}", new Object[] { this, project });
                 }
-                pendingRefresh = task[0] = SOURCE_REFRESH_PROCESSOR.post(() -> {
+                pendingRefresh = task[0] = SOURCE_REFRESH_PROCESSOR.create(() -> {
+                    RequestProcessor.Task t;
                     synchronized (this) {
-                        refreshDependencies(task[0]);
+                        t = task[0];
                     }
+                    refreshDependencies(t);
                 });
+                task[0].schedule(0);
             }
         }
         
@@ -259,6 +270,16 @@ public class VulnerabilityWorker implements ErrorProvider{
                 if (depChange == null) {
                     dependencyResult.addChangeListener(depChange = this::scheduleDependencyRefresh);
                     LOG.log(Level.FINER, "{0} - start listen for dependencies", this);
+                }
+            }
+        }
+        
+        void stopListening() {
+            synchronized (this) {
+                if (depChange != null) {
+                    dependencyResult.removeChangeListener(depChange);
+                    // intentionally does not clean depChange, to make a subsequent startListening no-op.
+                    LOG.log(Level.FINER, "{0} - stop listen for dependencies", this);
                 }
             }
         }
@@ -313,11 +334,23 @@ public class VulnerabilityWorker implements ErrorProvider{
 
                     if (declarationRange != null && declarationRange.hasPosition() && declarationRange.getFile().equals(file)) {
                         final SourceLocation fDeclarationRange = declarationRange;
+                        String ownerGav = null;
+                        if (fDeclarationRange.getImpliedBy() instanceof Dependency) {
+                            Dependency owner = (Dependency)fDeclarationRange.getImpliedBy();
+                            ownerGav = createGAV(owner.getArtifact());
+                        }
                         for(Vulnerability vulnerability: vulnerabilities) {
-                            String message = String.format(Bundle.MSG_Diagnostic(), 
-                                    formatCvssScore(vulnerability.getCvssV2Score()), 
-                                    formatCvssScore(vulnerability.getCvssV3Score()), 
-                                    createGAV(dependency.getArtifact()));
+                            String message = 
+                                    ownerGav == null ? 
+                                        Bundle.MSG_Diagnostic(
+                                            formatCvssScore(vulnerability.getCvssV2Score()), 
+                                            formatCvssScore(vulnerability.getCvssV3Score()), 
+                                            createGAV(dependency.getArtifact())) :
+                                        Bundle.MSG_Diagnostic_Included(
+                                            formatCvssScore(vulnerability.getCvssV2Score()), 
+                                            formatCvssScore(vulnerability.getCvssV3Score()), 
+                                            createGAV(dependency.getArtifact()),
+                                            ownerGav);
                             Diagnostic.Builder builder = Diagnostic.Builder.create(() -> fDeclarationRange.getStartOffset(), () -> fDeclarationRange.getEndOffset(), message);
                             builder.setSeverity(Diagnostic.Severity.Warning).setCode(vulnerability.getId());
                             try {
@@ -345,10 +378,14 @@ public class VulnerabilityWorker implements ErrorProvider{
     private static boolean replaceCacheItem(CacheItem old, CacheItem novy) {
         synchronized (cache) {
             CacheItem registered = cache.get(old.project);
-            if (registered != old) {
+            if (old != null && registered != old) {
+                old.stopListening();
                 return false;
             }
             cache.put(novy.project, novy);
+        }
+        if (old != null) {
+            old.stopListening();
         }
         return true;
     }
@@ -416,11 +453,13 @@ public class VulnerabilityWorker implements ErrorProvider{
         DependencyResult dr = null;
         
         if (!auditOptions.isForceAuditExecution()) {
-            try {
-                savedAudit = AuditCache.getInstance().loadAudit(knowledgeBaseId);
-            } catch (IOException ex) {
-                LOG.log(Level.WARNING, "Could not load cached audit data", ex); 
-           }
+            if (!auditOptions.isDisableCache()) {
+                try {
+                    savedAudit = AuditCache.getInstance().loadAudit(knowledgeBaseId);
+                } catch (IOException ex) {
+                    LOG.log(Level.WARNING, "Could not load cached audit data", ex); 
+                }
+            }
 
             if (savedAudit == null) {
                 // attempt to find an active most recent audit:
@@ -497,6 +536,10 @@ public class VulnerabilityWorker implements ErrorProvider{
             }
         } else if (savedAudit != null && cacheItem == null) {
             if (dr == null) {
+                // not really a remote call, but lengthy anyway...
+                if (remoteCall.compareAndSet(false, true)) {
+                    progressHandle.start();
+                }
                 progressHandle.progress(Bundle.MSG_AuditCollectDependencies());
                 dr = ProjectDependencies.findDependencies(project, ProjectDependencies.newQuery(Scopes.RUNTIME));
                 convert(dr.getRoot(), new HashMap<>(), result);
@@ -670,6 +713,9 @@ public class VulnerabilityWorker implements ErrorProvider{
     
     @Override
     public List<? extends Diagnostic> computeErrors(Context context) {
+        if (context.errorKind() != ErrorProvider.Kind.ERRORS) {
+            return Collections.emptyList();
+        }
         List<Diagnostic> result = new ArrayList<>();
         Collection<CacheItem> items;
         

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependencyResult.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleDependencyResult.java
@@ -58,7 +58,7 @@ public final class GradleDependencyResult implements DependencyResult, PropertyC
     private final NbGradleProject gp;
     private final Project gradleProject;
     private final Dependency root;
-    private boolean valid;
+    private boolean valid = true;
 
     // @GuardedBy(this)
     PropertyChangeListener wL;
@@ -135,6 +135,7 @@ public final class GradleDependencyResult implements DependencyResult, PropertyC
         List<ChangeListener> ll;
         synchronized (this) {
             valid = false;
+            sourceMapping = null;
             if (listeners == null || listeners.isEmpty()) {
                 return;
             }

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/ProjectAuditCommand.java
@@ -97,6 +97,30 @@ public class ProjectAuditCommand extends CodeActionsProvider {
         gson = new Gson();
     }
 
+    /**
+     * Implements commands {@code nbls.projectAudit.execute} and {@code nbls.projectAudit.display}. The command accepts parameters
+     * <ol>
+     * <li>URI that identifies the project or a file within a project. If the file is not a part of a project, an exception is thrown
+     * <li>knowledgebase OCID. It must not be empty and the knowledgebase must exist.
+     * <li>options structure, optional.
+     * </ol>
+     * If the project does not support vulnerability audits, an exception is thrown. The following options are supported:
+     * <ul>
+     * <li><b>profile</b> : string - OCI profile to use for communication (default: null = default profile)
+     * <li><b>force</b> : boolean - forces audit execution in OCI, bypasses local caches and older audit results (default: false).
+     * <li><b>compute</b> : boolean - for .display, computes the audit, if there are no results in OCI (default: true)
+     * <li><b>disableCache</b> : boolean - do not load from local cache (default: false)
+     * <li><b>suppressErrors</b> : boolean - suppresses displaying errors by NBLS, only fails the Future with an exception (default: false)
+     * <li><b>configPath</b> : string - custom OCI config path (default: null)
+     * <li><b>returnData</b> : boolean - if true, summary data is returned from the command. If false, the command just indicates success, returns audit OCID (default: false).
+     * <li><b>displaySummary</b> : boolean - if true, NBLS displays audit summary at completion of the command (default: true)
+     * </ul>
+     * The .execute command defaults to {@code force = true}.
+     * @param client the LSP client to communicate with
+     * @param command the command name
+     * @param arguments arguments to the command
+     * @return Future that contains audit ID or response structure {@link AuditResult}.
+     */
     @NbBundle.Messages({
         "# {0} - project name",
         "# {1} - cause message",
@@ -104,7 +128,7 @@ public class ProjectAuditCommand extends CodeActionsProvider {
     })
     @Override
     public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
-        if (arguments.size() < 3) {
+        if (arguments.size() < 2) {
             throw new IllegalArgumentException("Expected 3 parameters: resource, compartment, knowledgebase");
         }
         
@@ -131,7 +155,7 @@ public class ProjectAuditCommand extends CodeActionsProvider {
         }
         
         String knowledgeBase = ((JsonPrimitive) arguments.get(1)).getAsString();
-        Object o = arguments.get(2);
+        Object o = arguments.size() > 2 ? arguments.get(2) : new JsonObject();
         if (!(o instanceof JsonObject)) {
             throw new IllegalArgumentException("Expected structure, got  " + o);
         }
@@ -142,6 +166,8 @@ public class ProjectAuditCommand extends CodeActionsProvider {
         LOG.log(Level.FINE, "Running audit command with context: {0}", ctx);
         
         boolean forceAudit = options.has("force") && options.get("force").getAsBoolean();
+        boolean executeIfNotExists = forceAudit || !options.has("compute") ||  options.get("compute").getAsBoolean();
+        boolean disableCache = forceAudit || (options.has("disableCache") && options.get("disableCache").getAsBoolean());
         String preferredName = options.has("auditName") ? options.get("auditName").getAsString() : null;
         
         final OCIProfile auditWithProfile;
@@ -210,7 +236,11 @@ public class ProjectAuditCommand extends CodeActionsProvider {
                     break;
                 case COMMAND_LOAD_AUDIT:
                 case COMMAND_LOAD_AUDIT_OLD: {
-                    exec = v.runProjectAudit(kb, auditOpts.setRunIfNotExists(forceAudit).setAuditName(preferredName));
+                    exec = v.runProjectAudit(kb, 
+                            auditOpts.
+                                    setRunIfNotExists(executeIfNotExists).
+                                    setForceAuditExecution(forceAudit).
+                                    setDisableCache(disableCache));
                     break;
                 }
                 default:

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -827,7 +827,9 @@ public final class Server {
                         NATIVE_IMAGE_FIND_DEBUG_PROCESS_TO_ATTACH,
                         NBLS_PROJECT_INFO,
                         JAVA_ENABLE_PREVIEW,
-                        NBLS_DOCUMENT_SYMBOLS
+                        NBLS_DOCUMENT_SYMBOLS,
+                        NBLS_GET_DIAGNOSTICS,
+                        NBLS_GET_SERVER_DIRECTORIES
                 ));
                 for (CodeActionsProvider codeActionsProvider : Lookup.getDefault().lookupAll(CodeActionsProvider.class)) {
                     commands.addAll(codeActionsProvider.getCommands());
@@ -1099,6 +1101,17 @@ public final class Server {
      * Provides symbols for the given document
      */
     public static final String NBLS_DOCUMENT_SYMBOLS =  "nbls.document.symbols";
+    
+    /**
+     * Returns diagnostics as they would be published by the asynchronous diagnotic task triggered by
+     * text changes.
+     */
+    public static final String NBLS_GET_DIAGNOSTICS = "nbls.get.diagnostics";
+    
+    /**
+     * Returns the directories of NBLS. Returns userdir and the cluster directories.
+     */
+    public static final String NBLS_GET_SERVER_DIRECTORIES = "nbls.server.directories";
 
     static final String INDEXING_COMPLETED = "Indexing completed.";
     static final String NO_JAVA_SUPPORT = "Cannot initialize Java support on JDK ";


### PR DESCRIPTION
During testing, I've found some subtle bugs including bad synchronization. The main changes are:
- changed wording of the audit diagnostic: if the vulnerable dependency is indirect, the message indicates the direct dependency that brought the vulnerability into the project
- audit request has an option to disable the local cache

There's a very light bug in Gradle dependencies implementation: the valid flag was not set up at the start; 

Unrelated features, but possibly important for integration testing:
- NBLS command that gets diagnostic for a given file. It's not much possible to hook on LSP diagnostic stream on LSP client side.
- NBLS command that informs about directories the server uses; useful for on-disk settings inspection