### PR TITLE
Fix LSP/Micronaut tests + don't ignore exception in gradle spi

### DIFF
--- a/enterprise/micronaut/test/unit/data/gradle/artifacts/multi/app/build.gradle
+++ b/enterprise/micronaut/test/unit/data/gradle/artifacts/multi/app/build.gradle
@@ -8,7 +8,6 @@ group = "com.example"
 
 repositories {
     mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
 }
 
 dependencies {

--- a/enterprise/micronaut/test/unit/data/gradle/artifacts/multi/gradle.properties
+++ b/enterprise/micronaut/test/unit/data/gradle/artifacts/multi/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=3.10.1
+micronautVersion=3.10.2

--- a/enterprise/micronaut/test/unit/data/gradle/artifacts/multi/oci/build.gradle
+++ b/enterprise/micronaut/test/unit/data/gradle/artifacts/multi/oci/build.gradle
@@ -8,7 +8,6 @@ group = "com.example"
 
 repositories {
     mavenCentral()
-    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
 }
 
 dependencies {

--- a/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/gradle/MicronautGradleArtifactsImplTest.java
+++ b/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/gradle/MicronautGradleArtifactsImplTest.java
@@ -19,13 +19,17 @@
 package org.netbeans.modules.micronaut.gradle;
 
 import java.io.File;
+import java.util.Set;
+import java.util.stream.Collectors;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectActionContext;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.gradle.NbGradleProjectImpl;
 import org.netbeans.modules.gradle.ProjectTrust;
+import org.netbeans.modules.gradle.api.GradleReport;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.project.dependency.ArtifactSpec;
 import org.netbeans.modules.project.dependency.ProjectArtifactsQuery;
@@ -51,8 +55,7 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         return new File(destDir);
     }
     
-    FileObject d;
-    FileObject dataFO;
+    private FileObject dataFO;
 
     @org.openide.util.lookup.ServiceProvider(service=org.openide.modules.InstalledFileLocator.class, position = 1000)
     public static class InstalledFileLocator extends DummyInstalledFileLocator {
@@ -66,7 +69,6 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         // it back to System.err - loop is formed. Initialize IOProvider first, it gets
         // the real System.err/out references.
         IOProvider p = IOProvider.getDefault();
-        d = FileUtil.toFileObject(getWorkDir());
         System.setProperty("test.reload.sync", "true");
         dataFO = FileUtil.toFileObject(getDataDir());
         
@@ -83,7 +85,9 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         
         Project p = ProjectManager.getDefault().findProject(prjCopy);
         ProjectTrust.getDefault().trustProject(p);
+
         NbGradleProject.get(p).toQuality("Test", NbGradleProject.Quality.FULL, true).toCompletableFuture().get();
+        assertNoProblems(p);
         ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, ProjectArtifactsQuery.newQuery(null));
         
         assertNotNull(ar);
@@ -100,7 +104,9 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         
         Project p = ProjectManager.getDefault().findProject(prjCopy);
         ProjectTrust.getDefault().trustProject(p);
+        
         NbGradleProject.get(p).toQuality("Test", NbGradleProject.Quality.FULL, true).toCompletableFuture().get();
+        assertNoProblems(p);
         ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, ProjectArtifactsQuery.newQuery("exe"));
         
         assertNotNull(ar);
@@ -115,7 +121,9 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         
         Project p = ProjectManager.getDefault().findProject(prjCopy);
         ProjectTrust.getDefault().trustProject(p);
+
         NbGradleProject.get(p).toQuality("Test", NbGradleProject.Quality.FULL, true).toCompletableFuture().get();
+        assertNoProblems(p);
         ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
                 ProjectArtifactsQuery.newQuery(null, null, 
                         ProjectActionContext.newBuilder(p).forProjectAction("native-build").context()
@@ -136,7 +144,9 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         
         Project p = ProjectManager.getDefault().findProject(prjCopy);
         ProjectTrust.getDefault().trustProject(p);
+
         NbGradleProject.get(p).toQuality("Test", NbGradleProject.Quality.FULL, true).toCompletableFuture().get();
+        assertNoProblems(p);
         ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
                 ProjectArtifactsQuery.newQuery(null, null, 
                         ProjectActionContext.newBuilder(p).forProjectAction("native-build").context()
@@ -157,7 +167,9 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         
         Project p = ProjectManager.getDefault().findProject(prjCopy);
         ProjectTrust.getDefault().trustProject(p);
-        NbGradleProject.get(p).toQuality("TEst", NbGradleProject.Quality.FULL, true).toCompletableFuture().get();
+
+        NbGradleProject.get(p).toQuality("Test", NbGradleProject.Quality.FULL, true).toCompletableFuture().get();
+        assertNoProblems(p);
         ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
                 ProjectArtifactsQuery.newQuery("jar", null, 
                         ProjectActionContext.newBuilder(p).forProjectAction("native-build").context()
@@ -178,7 +190,9 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         
         Project p = ProjectManager.getDefault().findProject(prjCopy);
         ProjectTrust.getDefault().trustProject(p);
+
         NbGradleProject.get(p).toQuality("Test", NbGradleProject.Quality.FULL, true).toCompletableFuture().get();
+        assertNoProblems(p);
         ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
                 ProjectArtifactsQuery.newQuery("exe", null, 
                         ProjectActionContext.newBuilder(p).forProjectAction("native-build").context()
@@ -203,6 +217,7 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         ProjectTrust.getDefault().trustProject(p);
 
         NbGradleProject.get(p).toQuality("Test", NbGradleProject.Quality.FULL, true).toCompletableFuture().get();
+        assertNoProblems(p);
         ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, ProjectArtifactsQuery.newQuery(null));
         
         assertNotNull(ar);
@@ -223,6 +238,7 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         ProjectTrust.getDefault().trustProject(p);
 
         NbGradleProject.get(p).toQuality("Test", NbGradleProject.Quality.FULL, true).toCompletableFuture().get();
+        assertNoProblems(p);
         ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
                 ProjectArtifactsQuery.newQuery(null, null, null, ArtifactSpec.TAG_SHADED)
         );
@@ -242,7 +258,9 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         
         Project p = ProjectManager.getDefault().findProject(prjCopy.getFileObject("oci"));
         ProjectTrust.getDefault().trustProject(p);
+
         NbGradleProject.get(p).toQuality("Test", NbGradleProject.Quality.FULL, true).toCompletableFuture().get();
+        assertNoProblems(p);
         ProjectArtifactsQuery.ArtifactsResult ar = ProjectArtifactsQuery.findArtifacts(p, 
                 ProjectArtifactsQuery.newQuery("exe", null, 
                         ProjectActionContext.newBuilder(p).forProjectAction("native-build").context()
@@ -253,6 +271,19 @@ public class MicronautGradleArtifactsImplTest extends NbTestCase {
         assertEquals(1, ar.getArtifacts().size());
         ArtifactSpec spec = ar.getArtifacts().get(0);
         assertEquals("exe", spec.getType());
+    }
+
+    private static void assertNoProblems(Project project) {
+        assertNotNull(project);
+        Set<GradleReport> problems = ((NbGradleProjectImpl)project).getGradleProject().getBaseProject().getProblems();
+        assertTrue(
+            problems.size()+" problem(s) found>>>\n"+
+            problems.stream()
+                .map(p -> p.toString())
+                .collect(Collectors.joining("\n"))
+            +"\n<<<end of problems",
+            problems.isEmpty()
+        );
     }
 }
 

--- a/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/gradle/MicronautGradleArtifactsImplTest.java
+++ b/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/gradle/MicronautGradleArtifactsImplTest.java
@@ -44,6 +44,14 @@ import org.openide.windows.IOProvider;
  */
 public class MicronautGradleArtifactsImplTest extends NbTestCase {
 
+    static {
+        // TODO remove ASAP from MicronautGradleArtifactsImplTest and ProjectViewTest
+        // investigate "javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure"
+        // during gradle download "at org.netbeans.modules.gradle.spi.newproject.TemplateOperation$InitStep.execute(TemplateOperation.java:317)"
+        // this looks like a misconfigured webserver to me
+        System.setProperty("https.protocols", "TLSv1.2");
+    }
+
     public MicronautGradleArtifactsImplTest(String name) {
         super(name);
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
@@ -59,6 +59,7 @@ import org.netbeans.modules.gradle.api.GradleProjects;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
 import org.openide.loaders.DataFolder;
 import org.openide.loaders.DataObject;
+import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 
 /**
@@ -315,8 +316,7 @@ public final class TemplateOperation implements Runnable {
 
                 pconn.newBuild().withArguments("--offline").forTasks(args.toArray(new String[0])).run(); //NOI18N
             } catch (GradleConnectionException | IllegalStateException ex) {
-                // Well for some reason we were  not able to load Gradle.
-                // Ignoring that for now
+                Exceptions.printStackTrace(ex);
             }
             gconn.disconnect();
             return Collections.singleton(FileUtil.toFileObject(target));

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
@@ -98,6 +98,14 @@ public class ProjectViewTest extends NbTestCase {
     private final Gson gson = new Gson();
     private Socket clientSocket;
     private Thread serverThread;
+    
+    static {
+        // TODO remove ASAP from MicronautGradleArtifactsImplTest and ProjectViewTest
+        // investigate "javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure"
+        // during gradle download "at org.netbeans.modules.gradle.spi.newproject.TemplateOperation$InitStep.execute(TemplateOperation.java:317)"
+        // this looks like a misconfigured webserver to me
+        System.setProperty("https.protocols", "TLSv1.2");
+    }
 
     public ProjectViewTest(String name) {
         super(name);
@@ -317,7 +325,8 @@ public class ProjectViewTest extends NbTestCase {
         List<FileObject> projectFiles = b.build();
         // the template will create a parent project with 'app' application subproject.
         projectDir = projectFiles.get(0).getFileObject("app");
-                
+        assertNotNull(projectDir);
+
         deepCopy(from, projectDir.getParent());
         project = FileOwnerQuery.getOwner(projectDir);
         OpenProjects.getDefault().open(new Project[] { project } , true);


### PR DESCRIPTION
targets delivery

This attempts to fix the failing LSP and Micronaut jobs. 

This took a while to find due to several reasons (not going to write everything down here), two of them being that a key gradle exception was swallowed deep in setup code and that this wasn't reproducible locally unless the `.gradle` cache was cleared - which lead me to the wrong paths during investigation. (also the tests are difficult to work with since they throw exceptions even when green!)

Initially it wasn't even clear that this was a gradle issue, but after trying other JDK vendors, reverting commits until the last green master build and double checking that nothing else changed in the CI environment, this was the only path left.

tested locally. lets see if CI is ok with it

exception:
<details>

```
org.gradle.tooling.GradleConnectionException: Could not install Gradle distribution from 'https://services.gradle.org/distributions/gradle-8.4-bin.zip'.
	at org.gradle.tooling.internal.consumer.DistributionFactory$ZippedDistribution.getToolingImplementationClasspath(DistributionFactory.java:135)
	at org.gradle.tooling.internal.consumer.loader.CachingToolingImplementationLoader.create(CachingToolingImplementationLoader.java:41)
	at org.gradle.tooling.internal.consumer.loader.SynchronizedToolingImplementationLoader.create(SynchronizedToolingImplementationLoader.java:44)
	at org.gradle.tooling.internal.consumer.connection.LazyConsumerActionExecutor.onStartAction(LazyConsumerActionExecutor.java:160)
	at org.gradle.tooling.internal.consumer.connection.LazyConsumerActionExecutor.run(LazyConsumerActionExecutor.java:142)
	at org.gradle.tooling.internal.consumer.connection.CancellableConsumerActionExecutor.run(CancellableConsumerActionExecutor.java:45)
	at org.gradle.tooling.internal.consumer.connection.ProgressLoggingConsumerActionExecutor.run(ProgressLoggingConsumerActionExecutor.java:61)
	at org.gradle.tooling.internal.consumer.connection.RethrowingErrorsConsumerActionExecutor.run(RethrowingErrorsConsumerActionExecutor.java:38)
	at org.gradle.tooling.internal.consumer.async.DefaultAsyncConsumerActionExecutor$1$1.run(DefaultAsyncConsumerActionExecutor.java:67)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
	at org.gradle.tooling.internal.consumer.BlockingResultHandler.getResult(BlockingResultHandler.java:46)
	at org.gradle.tooling.internal.consumer.DefaultBuildLauncher.run(DefaultBuildLauncher.java:83)
	at org.netbeans.modules.gradle.spi.newproject.TemplateOperation$InitStep.execute(TemplateOperation.java:317)
	at org.netbeans.modules.gradle.spi.newproject.TemplateOperation.run(TemplateOperation.java:116)
	at org.netbeans.modules.gradle.newproject.GradleProjectFromTemplateHandler.createFromTemplate(GradleProjectFromTemplateHandler.java:62)
	at org.netbeans.api.templates.CreateFromTemplateImpl.build(CreateFromTemplateImpl.java:146)
	at org.netbeans.api.templates.CreateFromTemplateImpl.lambda$build$0(CreateFromTemplateImpl.java:86)
	at org.openide.filesystems.EventControl.runAtomicAction(EventControl.java:102)
	at org.openide.filesystems.FileSystem.runAtomicAction(FileSystem.java:494)
	at org.netbeans.api.templates.CreateFromTemplateImpl.build(CreateFromTemplateImpl.java:84)
	at org.netbeans.api.templates.FileBuilder.build(FileBuilder.java:267)
	at org.netbeans.modules.java.lsp.server.explorer.ProjectViewTest.createSimpleProject(ProjectViewTest.java:325)
	at org.netbeans.modules.java.lsp.server.explorer.ProjectViewTest.createAndFindProjectNode(ProjectViewTest.java:361)
	at org.netbeans.modules.java.lsp.server.explorer.ProjectViewTest.testEmptyInterimPackageRemoved(ProjectViewTest.java:578)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at org.netbeans.junit.NbTestCase.access$200(NbTestCase.java:79)
	at org.netbeans.junit.NbTestCase$2.doSomething(NbTestCase.java:484)
	at org.netbeans.junit.NbTestCase$1Guard.run(NbTestCase.java:405)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:131)
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:117)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:347)
	at java.base/sun.security.ssl.Alert$AlertConsumer.consume(Alert.java:293)
	at java.base/sun.security.ssl.TransportContext.dispatch(TransportContext.java:186)
	at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:172)
	at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1511)
	at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1421)
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:456)
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:427)
	at java.base/sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:580)
	at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:201)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.followRedirect0(HttpURLConnection.java:2830)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.followRedirect(HttpURLConnection.java:2742)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1869)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1525)
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:250)
	at org.gradle.wrapper.Download.downloadInternal(Download.java:129)
	at org.gradle.wrapper.Download.download(Download.java:109)

```

</details>